### PR TITLE
SGLang cu132 refresh: torch 2.12 wheels, patched NCCL 2.30.4, b12x 0.20 fixes, guarded builds

### DIFF
--- a/Dockerfile.sglang-cu132
+++ b/Dockerfile.sglang-cu132
@@ -1,60 +1,268 @@
 # =============================================================================
-# SGLang inference stack for RTX Blackwell (sm_120a)
+# SGLang inference stack for RTX PRO 6000 Blackwell (sm_120a) — June 2026
+# CUDA 13.2.1 + torch 2.12.0+cu132 wheels + patched NCCL 2.30.4 + b12x 0.20.0
 #
-# Based on voipmonitor/torch:cu132 (torch + FlashInfer compiled from source,
-# system CUDA libs, no pip nvidia-cublas/cudnn/nccl version conflicts).
+# Replaces voipmonitor/sglang:cu130 (CUDA 13.0.1, torch 2.11, b12x 0.7.2-0.10).
+# Platform modernization based on Dockerfile.vllm-b12x-cu132 (June 2026);
+# SGLang source = voipmonitor/sglang @ blackwell-cu130 260194aa (2026-04-13
+# rebuild: upstream main 2026-04-08 + 14 PR cherry-picks + lukealonso b12x
+# integration incl. the "MoE path via apply" modelopt fix — never shipped).
 #
-# Contains all cherry-picks and patches from Dockerfile.cu130:
-#   - PCIe allreduce + b12x NVFP4 MoE backend (lukealonso)
-#   - PR #21314: CUTLASS NVFP4 GEMM for SM120
-#   - PR #21599: Adaptive speculative decoding (EAGLE topk=1)
-#   - PR #21601: FP4 KV cache SM120
-#   - PR #20059, #20114, #20182, #20275, #20433, #20439, #20445, #20448,
-#     #20460, #20479, #20534, #20949
-#   - Runtime patches (KLD logit capture, GLM MoE strip whitespace,
-#     FlashInfer backend assert, Triton SMEM autotuning, NVFP4 dual gencode)
+# Why NOT current upstream main: the June upstream refactored the CUDA-graph /
+# attention-replay architecture (#23906, #27192, #27193) — the b12x attention
+# backend would need a full port, not a rebase. Audit 2026-06-11:
+#   merged upstream since April: #20479 #21599 #20114 #20460 #21314 (+#20439
+#   superseded); obsolete runtime patches: fix-blackwell-flashinfer-backend-
+#   assert, fix-glm-moe-strip-whitespace, apply-indexcache, (all upstreamed) —
+#   but still REQUIRED here because the 260194aa tree predates those merges.
 #
-# Build:
-#   docker build --build-arg CACHEBUST=$(date +%s) \
-#     -f Dockerfile.sglang-cu132 -t voipmonitor/sglang:test-cu132 .
+# Build (cap sgl-kernel parallelism — see KERNEL_MAX_JOBS — and avoid
+# building while a co-located inference service is loading weights):
+#   podman build -f Dockerfile.sglang-cu132 -t voipmonitor/sglang:cu132 .
 # =============================================================================
 
-FROM voipmonitor/torch:cu132
+ARG CUDA_VERSION=13.2.1
+ARG UBUNTU_VERSION=24.04
+ARG PYTHON_VERSION=3.12
+ARG CUBLAS_CUDA13_VERSION=13.4.1.2-1
+ARG CUDNN_CUDA13_VERSION=9.22.0.52-1
 
-ARG MAX_JOBS=128
-ARG NVCC_THREADS=8
+ARG NCCL_REPO=https://github.com/local-inference-lab/nccl-canonical.git
+ARG NCCL_REF=canonical/cu132-nccl2304-amd-noxml
+ARG NCCL_COMMIT=dfab7c1ace32da250ba97757879429c341b7bcf9
+ARG NCCL_SONAME=libnccl.so.2.30.4
+
+ARG SGLANG_REPO=https://github.com/voipmonitor/sglang.git
+ARG SGLANG_COMMIT=260194aafb4f90b948140acce4a83b925fe78df3
+
+ARG TORCH_VERSION=2.12.0+cu132
+ARG TORCHVISION_VERSION=0.27.0+cu132
+ARG CUTLASS_DSL_VERSION=4.5.2
+ARG B12X_VERSION=0.20.0
+ARG FLASHINFER_VERSION=0.6.12
+
 ARG TORCH_CUDA_ARCH_LIST="12.0a"
 ARG CMAKE_CUDA_ARCHITECTURES="120a"
 ARG FLASHINFER_CUDA_ARCH_LIST="12.0a"
-ARG CACHEBUST=0
+# sgl-kernel compile parallelism. 48 jobs OOMed a 251GB host (and killed the
+# production service); 12 peaks ~100GB alongside a loaded serving stack.
+ARG KERNEL_MAX_JOBS=12
 
-ENV TORCH_CUDA_ARCH_LIST=${TORCH_CUDA_ARCH_LIST} \
-    FLASHINFER_CUDA_ARCH_LIST=${FLASHINFER_CUDA_ARCH_LIST} \
-    MAX_JOBS=${MAX_JOBS} \
-    NVCC_THREADS=${NVCC_THREADS} \
-    FLASHINFER_DISABLE_VERSION_CHECK=1
+# =============================================================================
+# Stage 0: patched NCCL 2.30.4 (local-inference-lab PCIe-tuned canonical)
+# =============================================================================
+FROM nvidia/cuda:${CUDA_VERSION}-cudnn-devel-ubuntu${UBUNTU_VERSION} AS nccl-build
+
+ARG NCCL_REPO
+ARG NCCL_REF
+ARG NCCL_COMMIT
+ARG NCCL_SONAME
+ARG DEBIAN_FRONTEND=noninteractive
+
+
+RUN for attempt in 1 2 3 4 5; do \
+      if apt-get update; then break; fi; \
+      if [ "${attempt}" = "5" ]; then exit 1; fi; \
+      rm -rf /var/lib/apt/lists/*; \
+      sleep $((attempt * 10)); \
+    done \
+    && apt-get install -y --no-install-recommends \
+    git python3 build-essential make g++ ca-certificates \
+    && rm -rf /var/lib/apt/lists/*
 
 WORKDIR /build
+RUN git clone "${NCCL_REPO}" nccl \
+ && cd nccl \
+ && git checkout "${NCCL_REF}" \
+ && test "$(git rev-parse HEAD)" = "${NCCL_COMMIT}" \
+ && make -j"$(nproc)" src.build CUDA_HOME=/usr/local/cuda \
+ && strings "build/lib/${NCCL_SONAME}" | grep -F "NCCL version 2.30.4 compiled with CUDA 13.2"
 
 # =============================================================================
-# CUTLASS headers from git (latest, needed for blockscaled_layout.py)
+# Stage 1: base — CUDA 13.2.1 + latest 13.2-compatible cuBLAS/cuDNN + Python
 # =============================================================================
-RUN git clone --depth 1 https://github.com/NVIDIA/cutlass.git /build/cutlass && \
-    grep "CUTLASS_MAJOR\|CUTLASS_MINOR\|CUTLASS_PATCH" /build/cutlass/include/cutlass/version.h | head -3
+FROM nvidia/cuda:${CUDA_VERSION}-cudnn-devel-ubuntu${UBUNTU_VERSION} AS base
 
-# Patch cutlass-dsl: copy blockscaled_layout.py from git main (adds sm120_make_smem_layout_sfa)
-RUN CUTLASS_DSL=$(python -c 'import cutlass.utils.blockscaled_layout as m; print(m.__file__)') && \
-    cp /build/cutlass/python/CuTeDSL/cutlass/utils/blockscaled_layout.py "$CUTLASS_DSL" && \
-    python -c 'from cutlass.utils.blockscaled_layout import sm120_make_smem_layout_sfa; print("OK: sm120_make_smem_layout_sfa available")'
+ARG PYTHON_VERSION
+ARG CUBLAS_CUDA13_VERSION
+ARG CUDNN_CUDA13_VERSION
+ARG CUDA_VERSION
+ARG NCCL_SONAME
+ARG DEBIAN_FRONTEND=noninteractive
+
+
+ENV LANG=C.UTF-8 \
+    LC_ALL=C.UTF-8 \
+    PYTHONDONTWRITEBYTECODE=1 \
+    PYTHONUNBUFFERED=1 \
+    PIP_DISABLE_PIP_VERSION_CHECK=1
+
+# Toolkit stays 13.2.1; overlay the newest CUDA-13.2-compatible cuBLAS/cuDNN
+RUN for attempt in 1 2 3 4 5; do \
+      if apt-get update; then break; fi; \
+      if [ "${attempt}" = "5" ]; then exit 1; fi; \
+      rm -rf /var/lib/apt/lists/*; \
+      sleep $((attempt * 10)); \
+    done \
+    && apt-get install -y --allow-change-held-packages --no-install-recommends \
+    python${PYTHON_VERSION} \
+    python${PYTHON_VERSION}-dev \
+    python${PYTHON_VERSION}-venv \
+    python3-pip \
+    git git-lfs wget curl ca-certificates \
+    build-essential cmake ninja-build ccache pkg-config patchelf \
+    libssl-dev libffi-dev libjpeg-dev libpng-dev \
+    libgomp1 numactl libnuma-dev libibverbs-dev pciutils \
+    libcublas13-cuda-13=${CUBLAS_CUDA13_VERSION} \
+    libcublas13-dev-cuda-13=${CUBLAS_CUDA13_VERSION} \
+    cublas-cuda-13=${CUBLAS_CUDA13_VERSION} \
+    libcudnn9-cuda-13=${CUDNN_CUDA13_VERSION} \
+    libcudnn9-dev-cuda-13=${CUDNN_CUDA13_VERSION} \
+    libcudnn9-headers-cuda-13=${CUDNN_CUDA13_VERSION} \
+    && ldconfig \
+    && rm -rf /var/lib/apt/lists/*
+
+# Point the CUDA toolkit dir at the overlaid cuBLAS (same trick as the
+# vllm-b12x-cu132 base — toolkit libs would otherwise shadow the new ones)
+RUN cublas="$(readlink -f /usr/lib/x86_64-linux-gnu/libcublas/13/libcublas.so.13)" \
+ && cublas_lt="$(readlink -f /usr/lib/x86_64-linux-gnu/libcublas/13/libcublasLt.so.13)" \
+ && cublas_name="$(basename "${cublas}")" \
+ && cublas_lt_name="$(basename "${cublas_lt}")" \
+ && test -f "${cublas}" && test -f "${cublas_lt}" \
+ && for cuda_libdir in /usr/local/cuda/targets/x86_64-linux/lib /usr/local/cuda-${CUDA_VERSION}/targets/x86_64-linux/lib; do \
+      if [ -d "${cuda_libdir}" ]; then \
+        cuda_libdir="$(readlink -f "${cuda_libdir}")"; \
+        rm -f "${cuda_libdir}"/libcublas.so "${cuda_libdir}"/libcublas.so.13 "${cuda_libdir}"/libcublas.so.13.*; \
+        rm -f "${cuda_libdir}"/libcublasLt.so "${cuda_libdir}"/libcublasLt.so.13 "${cuda_libdir}"/libcublasLt.so.13.*; \
+        ln -s "${cublas}" "${cuda_libdir}/${cublas_name}"; \
+        ln -s "${cublas_name}" "${cuda_libdir}/libcublas.so.13"; \
+        ln -s libcublas.so.13 "${cuda_libdir}/libcublas.so"; \
+        ln -s "${cublas_lt}" "${cuda_libdir}/${cublas_lt_name}"; \
+        ln -s "${cublas_lt_name}" "${cuda_libdir}/libcublasLt.so.13"; \
+        ln -s libcublasLt.so.13 "${cuda_libdir}/libcublasLt.so"; \
+      fi; \
+    done \
+ && ldconfig
+
+RUN update-alternatives --install /usr/bin/python3 python3 /usr/bin/python${PYTHON_VERSION} 1 \
+ && update-alternatives --install /usr/bin/python python /usr/bin/python${PYTHON_VERSION} 1
+
+RUN python${PYTHON_VERSION} -m venv /opt/venv
+ENV VIRTUAL_ENV=/opt/venv \
+    PATH="/opt/venv/bin:${PATH}"
+RUN pip install --upgrade pip setuptools wheel
+
+ENV CCACHE_DIR=/root/.ccache \
+    CMAKE_C_COMPILER_LAUNCHER=ccache \
+    CMAKE_CXX_COMPILER_LAUNCHER=ccache \
+    CMAKE_CUDA_COMPILER_LAUNCHER=ccache
+
+COPY --from=nccl-build /build/nccl/build/lib/${NCCL_SONAME} /opt/${NCCL_SONAME}
 
 # =============================================================================
-# Python dependencies (no torch/nvidia reinstalls — all from base image)
+# Stage 2: deps — torch 2.12 cu132 + cutlass-dsl + b12x + flashinfer
 # =============================================================================
+FROM base AS deps
 
-# transformers (pinned — 5.4+ breaks Qwen3.5 composite config)
+ARG TORCH_VERSION
+ARG TORCHVISION_VERSION
+ARG CUTLASS_DSL_VERSION
+ARG B12X_VERSION
+ARG FLASHINFER_VERSION
+ARG NCCL_SONAME
+ARG TORCH_CUDA_ARCH_LIST
+ARG FLASHINFER_CUDA_ARCH_LIST
+
+
+ENV TORCH_CUDA_ARCH_LIST=${TORCH_CUDA_ARCH_LIST} \
+    FLASHINFER_CUDA_ARCH_LIST=${FLASHINFER_CUDA_ARCH_LIST}
+
+# -- PyTorch 2.12.0 cu132 official wheels --------------------------------------
+RUN pip install \
+    --index-url https://download.pytorch.org/whl/cu132 \
+    "torch==${TORCH_VERSION}" \
+    "torchvision==${TORCHVISION_VERSION}"
+
+# -- Patched NCCL 2.30.4: replace the pip wheel's lib so torch loads it --------
+# (sglang's pynccl additionally honors SGLANG_NCCL_SO_PATH, set in final stage)
+# NOTE: 'nvidia' is a namespace package (find_spec origin is None) — locate the
+# libs by searching site-packages directly. Fail the build if none found, and
+# verify the replaced libs really report >= 2.30.4 (encoded 23004) via ctypes.
+RUN SITE=$(python -c "import sysconfig; print(sysconfig.get_paths()['purelib'])") \
+ && FOUND=0 \
+ && for f in $(find "$SITE" -name 'libnccl.so.2*' -not -name '*.orig' -type f); do \
+      cp "$f" "$f.orig"; \
+      cp /opt/${NCCL_SONAME} "$f"; \
+      FOUND=1; \
+      echo "OK: replaced $f with patched 2.30.4"; \
+    done \
+ && if [ "$FOUND" = "0" ]; then echo "ERROR: no pip libnccl.so found to replace"; exit 1; fi \
+ && python -c "import ctypes,glob,sysconfig; site=sysconfig.get_paths()['purelib']; \
+libs=[p for p in glob.glob(site+'/**/libnccl.so.2*', recursive=True) if not p.endswith('.orig')]; \
+assert libs, 'no libnccl found'; \
+vals={p: (lambda l,v: (l.ncclGetVersion(ctypes.byref(v)), v.value)[1])(ctypes.CDLL(p), ctypes.c_int()) for p in libs}; \
+print(vals); \
+assert all(v >= 23004 for v in vals.values()), f'patched NCCL not active: {vals}'"
+
+# -- CUTLASS DSL 4.5.2 (libs-cu13 reinstalled LAST — NVVM/ptxas 13.x must win) --
+RUN pip install "nvidia-cutlass-dsl[cu13]==${CUTLASS_DSL_VERSION}" \
+ && pip install --force-reinstall --no-deps "nvidia-cutlass-dsl-libs-cu13==${CUTLASS_DSL_VERSION}" \
+ && python -c "from cutlass._mlir._mlir_libs import _cutlass_ir; print('OK: cutlass MLIR loaded')"
+
+# sm120 blockscaled layout helper must exist (cutlass-dsl >= 4.5 ships it;
+# the 4.4.2-era git-overlay hack is no longer needed)
+RUN python -c 'from cutlass.utils.blockscaled_layout import sm120_make_smem_layout_sfa; print("OK: sm120_make_smem_layout_sfa available")'
+
+# -- b12x (SM120 CuTe-DSL NVFP4 GEMM/MoE + paged attention) --------------------
+# deps installed explicitly above/below; --no-deps keeps torch untouched
+RUN pip install "apache-tvm-ffi>=0.1.6,!=0.1.8,!=0.1.8.post0,<0.2" rich \
+ && pip install "b12x==${B12X_VERSION}" --no-deps \
+ && python -c "import b12x; print('b12x', getattr(b12x,'__version__','?'))"
+
+# -- FlashInfer (JIT mode, kernels compile at runtime into /cache/jit) ---------
+RUN pip install "nvidia-cudnn-frontend>=1.13.0" pynvml nvidia-ml-py packaging numpy einops \
+        requests click tabulate tqdm \
+ && pip install "flashinfer-python==${FLASHINFER_VERSION}" --no-deps \
+ && pip install "flashinfer-cubin==${FLASHINFER_VERSION}" --no-deps || true
+ENV FLASHINFER_DISABLE_VERSION_CHECK=1
+RUN python -c "import flashinfer; print('FlashInfer:', flashinfer.__version__)"
+
+# -- transformers pinned: 5.4+ breaks Qwen3.5 composite config -----------------
 RUN pip install "transformers>=5.3.0,<5.4"
 
-# Safe packages (no torch dependency)
+RUN python -c "import torch; v=torch.__version__; print('torch', v); assert v.startswith('2.12.0+cu132'), v"
+
+# =============================================================================
+# Stage 3: SGLang fork @ 260194aa + sgl-kernel
+# =============================================================================
+FROM deps AS sglang-build
+
+ARG SGLANG_REPO
+ARG SGLANG_COMMIT
+ARG KERNEL_MAX_JOBS
+ARG TORCH_CUDA_ARCH_LIST
+ARG CMAKE_CUDA_ARCHITECTURES
+
+
+RUN git clone "${SGLANG_REPO}" /opt/sglang \
+ && cd /opt/sglang \
+ && git checkout "${SGLANG_COMMIT}" \
+ && git submodule update --init --recursive \
+ && git log -1 --format='sglang fork @ %H %s'
+
+# Apply the full local pick set (python + sgl-kernel) BEFORE the kernel build
+# so sgl-kernel compiles with #25775 (case-512 topk gating softmax) included.
+# Same diff the runtime hotfix layer uses, unfiltered here.
+COPY patches/cherry-picks-20260611.diff /tmp/picks.diff
+RUN cd /opt/sglang \
+ && git apply --stat /tmp/picks.diff | tail -2 \
+ && git apply /tmp/picks.diff \
+ && rm /tmp/picks.diff \
+ && echo "OK: pick set applied to source tree (incl. sgl-kernel)"
+
+WORKDIR /opt/sglang
+
+# -- SGLang runtime deps (no torch reinstalls) ---------------------------------
 RUN pip install \
         ipython orjson \
         aiohttp fastapi uvicorn uvloop \
@@ -63,157 +271,84 @@ RUN pip install \
         multipart python-multipart decord soundfile librosa \
         prometheus-client prometheus-fastapi-instrumentator \
         partial_json_parser tiktoken modelscope pybase64 \
-        huggingface_hub \
-        setproctitle gguf dill pyzmq \
+        huggingface_hub hf_transfer \
+        setproctitle gguf dill pyzmq einops \
         lark-parser \
         sniffio distro loguru jsonschema \
         accelerate safetensors tokenizers sentencepiece bitsandbytes \
-        rich click tabulate \
-    2>/dev/null || true
-
-# Packages that might pull torch — install with --no-deps
+        click tabulate \
+    || true
 RUN pip install --no-deps \
         xgrammar outlines compressed-tensors interegular \
-    2>/dev/null || true
+        openai anthropic openai-harmony fastsafetensors \
+    || true
+RUN pip install --no-deps xformers || true
 
-# fastsafetensors + xformers (optional, --no-deps)
-RUN pip install fastsafetensors || true
-RUN pip install xformers --no-deps || true
+# cmake >= 3.26 for sgl-kernel; scikit-build-core + uv for its Makefile
+RUN pip install --upgrade cmake scikit-build-core uv
 
-# b12x: TP-only NVFP4 MoE/GEMM backend for SM120 (--no-deps to avoid torch conflicts)
-RUN pip install b12x --no-deps
-
-# Upgrade cmake (sgl-kernel needs cmake >= 3.26)
-RUN pip install --upgrade cmake scikit-build-core
-
-# =============================================================================
-# SGLang from source + cherry-picks
-# =============================================================================
-RUN git clone --recursive https://github.com/sgl-project/sglang.git /opt/sglang
-WORKDIR /opt/sglang
-
-# -- Copy conflict resolution scripts -----------------------------------------
-COPY patches/fix-cuda-arch-suffix.py /tmp/patches/fix-cuda-arch-suffix.py
-COPY patches/fix-mamba-leak-conflict.py /tmp/patches/fix-mamba-leak-conflict.py
-COPY patches/fix-fp4-kvcache-conflict.py /tmp/patches/fix-fp4-kvcache-conflict.py
-
-# -- Cherry-pick unmerged PRs --------------------------------------------------
-RUN git config user.email "build@docker" && git config user.name "build" && \
-    git fetch origin \
-        pull/20059/head:pr-20059 \
-        pull/20114/head:pr-20114 \
-        pull/20182/head:pr-20182 \
-        pull/20275/head:pr-20275 \
-        pull/20433/head:pr-20433 \
-        pull/20439/head:pr-20439 \
-        pull/20445/head:pr-20445 \
-        pull/20448/head:pr-20448 \
-        pull/20460/head:pr-20460 \
-        pull/20479/head:pr-20479 \
-        pull/20534/head:pr-20534 \
-        pull/20949/head:pr-20949 \
-        pull/21599/head:pr-21599 \
-        pull/21601/head:pr-21601 && \
-    echo "=== PR #19963: Fix arch suffix (adapted for refactored code) ===" && \
-    python3 /tmp/patches/fix-cuda-arch-suffix.py && \
-    echo "=== PR #20439: Fix AWQ modules_to_not_convert for FusedMoE ===" && \
-    git cherry-pick --no-commit 23aa58fa1b7c && \
-    echo "=== PR #20059: Fuse normal_decode_set_metadata into Triton kernel ===" && \
-    git cherry-pick --no-commit 1e5d20c64aac e0137cc66274 3345601bab22 556f00b70aec 39f312d94c5e && \
-    echo "=== PR #20114: support HybridLinearAttnBackend in TboAttnBackend ===" && \
-    git cherry-pick --no-commit b961a4124855 && \
-    echo "=== PR #20275: GLM-5 thinking budget logit processor ===" && \
-    git cherry-pick --no-commit 45baf2e56ab5 42b872677423 && \
-    echo "=== PR #20448: mm_input_embeds in piecewise graph replay ===" && \
-    git cherry-pick --no-commit 6bcb570f95a8 && \
-    echo "=== PR #20460: HiCache synchronization for context parallelism ===" && \
-    git cherry-pick --no-commit 614b7815b53f && \
-    echo "=== PR #20479: Triton MLA FP8 KV cache (SM120) ===" && \
-    git cherry-pick --no-commit 3019db47e505 64cc6ffa1d4d 3e8774f6f6d1 0e25a1cb74c4 b6551f2ba4af c69aa5debd47 75d4edbbadf9 && \
-    echo "=== PR #20534: FP8 K/K_scale for CP indexer prefill gather ===" && \
-    git cherry-pick --no-commit 4578257732bf f695b901400833 && \
-    echo "=== PR #20949: cuBLAS/cuBLASLt warmup for BF16 ===" && \
-    git cherry-pick --no-commit f6c25c12c && \
-    echo "=== PR #21599: Adaptive speculative decoding for EAGLE topk=1 ===" && \
-    git cherry-pick --no-commit 06488d367 5f9b9554a 0fc903cc5 6e8f2abe4 e486262df 3200fa2f9 3bd9c1e15 && \
-    echo "=== PR #20445: Avoid GPU syncs in mamba/GDN track metadata ===" && \
-    git cherry-pick --no-commit cc4a43a1698bd61acbe03af6656f366d963476ce && \
-    echo "=== PR #20433: Async extra buffer track indices (+15% MTP throughput) ===" && \
-    git cherry-pick --no-commit 0433bc88b5ae59b397113fa297b3948fc0910a8a dc0a80235e9175cc4fdb16de900c97134ab408f7 && \
-    echo "=== PR #20182: Fix mamba memory leak (conflict: hisparse_coordinator) ===" && \
-    git cherry-pick --no-commit a38e09ac8ace2676de23d6b646bd15312a3afa6e; \
-    python3 /tmp/patches/fix-mamba-leak-conflict.py && \
-    git add -A && \
-    git cherry-pick --no-commit 6be4ccd441fb588f53cbc474f774c34dde9b571a 27d36e52e1eed766b41b00576e2f081e2fc5e87a && \
-    echo "=== PR #21601: FP4 KV cache SM120 (conflict: flashinfer+trtllm backends) ===" && \
-    git cherry-pick --no-commit 4473ed79fa3054c7fa40ae74717c2cd21d530a15; \
-    python3 /tmp/patches/fix-fp4-kvcache-conflict.py && \
-    git add -A && \
-    echo "=== All cherry-picks applied ==="
-
-# -- PR #21314: CUTLASS NVFP4 GEMM for SM120 (git diff to avoid conflicts) ----
-RUN git fetch origin pull/21314/head:pr-21314 && \
-    git diff $(git merge-base HEAD pr-21314)..pr-21314 -- \
-        python/sglang/jit_kernel/csrc/gemm/nvfp4/ \
-        python/sglang/srt/layers/quantization/ \
-        python/sglang/srt/server_args.py \
-    | git apply --3way --allow-empty && \
-    git add -A
-
-# -- b12x integration (lukealonso fork, no PCIe allreduce) ---------------------
-COPY patches/fix-pcie-allreduce-conflict.py /tmp/patches/fix-pcie-allreduce-conflict.py
-COPY patches/fix-modelopt-merge.py /tmp/patches/fix-modelopt-merge.py
-RUN git remote add lukealonso https://github.com/lukealonso/sglang.git && \
-    git fetch lukealonso c70c22a15a16961c65b8c61f7f18fae07995ec38
-RUN echo "=== b12x backend (c70c22a1) ===" && \
-    git cherry-pick --no-commit c70c22a15a16961c65b8c61f7f18fae07995ec38; \
-    python /tmp/patches/fix-pcie-allreduce-conflict.py && \
-    python /tmp/patches/fix-modelopt-merge.py && \
-    git add -A && \
-    python3 -c "import ast,glob; [ast.parse(open(f,encoding='utf-8-sig').read(),f) for f in glob.glob('python/sglang/srt/**/*.py',recursive=True)]" && \
-    echo "=== b12x applied, syntax verified ==="
-
-# =============================================================================
-# Triton MoE configs for Blackwell GPUs
-# =============================================================================
+# -- Triton MoE tuned configs for RTX PRO 6000 Blackwell -----------------------
 COPY configs/ /tmp/triton-configs/
-RUN SGLANG_PKG="/opt/sglang/python" && \
-    TRITON_CONFIGS_DIR="${SGLANG_PKG}/sglang/srt/layers/moe/fused_moe_triton/configs/triton_3_6_0" && \
-    mkdir -p "$TRITON_CONFIGS_DIR" && \
-    for f in /tmp/triton-configs/*.json; do \
+RUN SGLANG_PKG="/opt/sglang/python" \
+ && TRITON_VER=$(python -c "import triton; print(triton.__version__.replace('.','_'))") \
+ && TRITON_CONFIGS_DIR="${SGLANG_PKG}/sglang/srt/layers/moe/fused_moe_triton/configs/triton_${TRITON_VER}" \
+ && mkdir -p "$TRITON_CONFIGS_DIR" \
+ && for f in /tmp/triton-configs/*.json; do \
         base=$(basename "$f"); \
         cp "$f" "$TRITON_CONFIGS_DIR/$base"; \
         cp "$f" "${TRITON_CONFIGS_DIR}/$(echo "$base" | sed 's/\.json$/_down.json/')"; \
         nodt=$(echo "$base" | sed 's/,dtype=[^.]*//'); \
         cp "$f" "$TRITON_CONFIGS_DIR/$nodt"; \
         cp "$f" "${TRITON_CONFIGS_DIR}/$(echo "$nodt" | sed 's/\.json$/_down.json/')"; \
-    done && \
-    rm -rf /tmp/triton-configs && \
-    ls -la "$TRITON_CONFIGS_DIR/"
+    done \
+ && rm -rf /tmp/triton-configs \
+ && echo "MoE configs installed to ${TRITON_CONFIGS_DIR}" && ls "$TRITON_CONFIGS_DIR" | head -4
 
-# =============================================================================
-# Build sgl-kernel LAST (after all pip deps are finalized)
-# =============================================================================
+# -- Build sgl-kernel (memory-capped parallelism — see KERNEL_MAX_JOBS note) ---
 WORKDIR /opt/sglang/sgl-kernel
 RUN --mount=type=cache,target=/root/.ccache \
-    TORCH_CUDA_ARCH_LIST="12.0a" \
-    CMAKE_CUDA_ARCHITECTURES="120a" \
-    MAX_JOBS=${MAX_JOBS} \
+    TORCH_CUDA_ARCH_LIST="${TORCH_CUDA_ARCH_LIST}" \
+    CMAKE_CUDA_ARCHITECTURES="${CMAKE_CUDA_ARCHITECTURES}" \
+    MAX_JOBS=${KERNEL_MAX_JOBS} \
     make build CMAKE_ARGS="-DCMAKE_C_COMPILER_LAUNCHER=ccache -DCMAKE_CXX_COMPILER_LAUNCHER=ccache -DENABLE_BELOW_SM90=0"
 
-# Install SGLang Python package (editable)
+# -- SGLang editable install ----------------------------------------------------
 WORKDIR /opt/sglang
 RUN pip install --no-build-isolation --no-deps -e "./python[all]"
+RUN python -c "import sglang; print('SGLang', getattr(sglang,'__version__','editable'))"
+
+# Clean caches
+RUN pip cache purge 2>/dev/null || true \
+ && rm -rf /root/.cache/pip /tmp/pip-* \
+ && find /opt/venv -type d -name "__pycache__" -exec rm -rf {} + 2>/dev/null || true \
+ && find /opt/venv -name "*.pyc" -delete 2>/dev/null || true
 
 # =============================================================================
-# Runtime env
+# Stage 4: final — runtime image (devel base: FlashInfer JIT needs nvcc)
 # =============================================================================
-ENV NCCL_P2P_DISABLE=0 \
+FROM base AS final
+
+ARG TORCH_CUDA_ARCH_LIST
+ARG FLASHINFER_CUDA_ARCH_LIST
+ARG NCCL_SONAME
+ARG BUILD_ID=unknown
+
+
+COPY --from=sglang-build /opt/venv /opt/venv
+COPY --from=sglang-build /opt/sglang /opt/sglang
+
+ENV TORCH_CUDA_ARCH_LIST=${TORCH_CUDA_ARCH_LIST} \
+    FLASHINFER_CUDA_ARCH_LIST=${FLASHINFER_CUDA_ARCH_LIST} \
+    FLASHINFER_DISABLE_VERSION_CHECK=1 \
+    SGLANG_SKIP_SGL_KERNEL_VERSION_CHECK=1 \
+    NCCL_P2P_DISABLE=0 \
     NCCL_IB_DISABLE=0 \
-    CUDA_DEVICE_MAX_CONNECTIONS=32
+    CUDA_DEVICE_MAX_CONNECTIONS=32 \
+    SGLANG_NCCL_SO_PATH=/opt/${NCCL_SONAME}
 
-# JIT cache directories
-ENV TRITON_CACHE_DIR=/cache/jit/triton \
+RUN echo "${BUILD_ID}" > /etc/jit-build-id
+ENV JIT_BUILD_ID=${BUILD_ID} \
+    TRITON_CACHE_DIR=/cache/jit/triton \
     TORCH_EXTENSIONS_DIR=/cache/jit/torch_extensions \
     FLASHINFER_WORKSPACE_BASE=/cache/jit/flashinfer \
     TVM_FFI_CACHE_DIR=/cache/jit/tvm-ffi \
@@ -222,53 +357,64 @@ ENV TRITON_CACHE_DIR=/cache/jit/triton \
 
 RUN mkdir -p /cache/jit/triton /cache/jit/torch_extensions
 
-# =============================================================================
-# Runtime patches
-# =============================================================================
+ENV LD_LIBRARY_PATH="/opt/venv/lib/python3.12/site-packages/nvidia/cu13/lib:/usr/local/cuda/lib64:${LD_LIBRARY_PATH}"
+
+# CCCL symlink (CUDA 13.2 moved headers under cccl/ prefix)
+RUN if [ -d /usr/local/cuda/targets/x86_64-linux/include/cccl ] && \
+       [ ! -e /usr/local/cuda/targets/x86_64-linux/include/cccl/cuda ]; then \
+        ln -sf /usr/local/cuda/targets/x86_64-linux/include/cuda \
+               /usr/local/cuda/targets/x86_64-linux/include/cccl/cuda; \
+    fi; \
+    test -d /usr/local/cuda/targets/x86_64-linux/include/cccl/cuda && \
+    ln -sf /usr/local/cuda/targets/x86_64-linux/include/cccl/cuda /usr/local/cuda/include/cuda || true
+
+# libcudart.so.12 compat symlink (prebuilt JIT-cache binaries may want it)
+RUN CUDA_LIB=$(find /usr/local/cuda/targets -name 'libcudart.so' -print -quit 2>/dev/null) \
+ && if [ -n "$CUDA_LIB" ]; then \
+        ln -sf "$CUDA_LIB" "$(dirname $CUDA_LIB)/libcudart.so.12"; \
+    fi
+
+COPY jit-cache-invalidate.sh /usr/local/bin/jit-cache-invalidate.sh
+RUN chmod +x /usr/local/bin/jit-cache-invalidate.sh \
+ && echo 'source /usr/local/bin/jit-cache-invalidate.sh' >> /root/.bashrc
+ENV BASH_ENV=/usr/local/bin/jit-cache-invalidate.sh
+
+COPY entrypoint-sglang.sh /entrypoint.sh
+COPY scripts/sglang_kld_eval.py /workspace/sglang_kld_eval.py
+RUN chmod +x /entrypoint.sh
+
+WORKDIR /workspace
+
+# -- Runtime patches -------------------------------------------------------------
+# Still needed on the 260194aa tree (upstream merged equivalents only AFTER it):
+#   fix-blackwell-flashinfer-backend-assert (required: --prefill-attention-backend
+#     flashinfer on Blackwell hybrid GDN), fix-glm-moe-strip-whitespace,
+#   apply-indexcache, fix-nvfp4-dual-gencode, sglang-kld-logit-capture (eval).
+# fix-triton-smem-autotuning-sm120 targets torch._inductor — validated against
+#   the installed torch (script skips gracefully if torch 2.12 moved the marker).
+# fix-pcie-allreduce-conflict is a no-op on a committed tree (kept for parity).
 COPY patches/sglang-kld-logit-capture.py /tmp/patches/
 COPY patches/fix-glm-moe-strip-whitespace.py /tmp/patches/
 COPY patches/apply-indexcache.py /tmp/patches/
 COPY patches/fix-blackwell-flashinfer-backend-assert.py /tmp/patches/
-COPY patches/fix-pcie-allreduce-conflict.py /tmp/patches/
 COPY patches/fix-triton-smem-autotuning-sm120.py /tmp/patches/
 COPY patches/fix-nvfp4-dual-gencode.py /tmp/patches/
-RUN python /tmp/patches/sglang-kld-logit-capture.py && \
-    python /tmp/patches/fix-glm-moe-strip-whitespace.py && \
-    python /tmp/patches/apply-indexcache.py && \
-    python /tmp/patches/fix-blackwell-flashinfer-backend-assert.py && \
-    python /tmp/patches/fix-pcie-allreduce-conflict.py && \
-    python /tmp/patches/fix-triton-smem-autotuning-sm120.py && \
-    python /tmp/patches/fix-nvfp4-dual-gencode.py && \
-    rm -rf /tmp/patches
+COPY patches/fix-pcie-oneshot-nccl-group.py /tmp/patches/
+RUN python /tmp/patches/sglang-kld-logit-capture.py \
+ && python /tmp/patches/fix-glm-moe-strip-whitespace.py \
+ && python /tmp/patches/apply-indexcache.py \
+ && python /tmp/patches/fix-blackwell-flashinfer-backend-assert.py \
+ && python /tmp/patches/fix-triton-smem-autotuning-sm120.py \
+ && python /tmp/patches/fix-nvfp4-dual-gencode.py \
+ && python /tmp/patches/fix-pcie-oneshot-nccl-group.py \
+ && rm -rf /tmp/patches
 
-# =============================================================================
-# Entrypoint + scripts
-# =============================================================================
-COPY entrypoint-sglang.sh /entrypoint.sh
-COPY scripts/sglang_kld_eval.py /workspace/sglang_kld_eval.py
-COPY jit-cache-invalidate.sh /usr/local/bin/jit-cache-invalidate.sh
-RUN chmod +x /entrypoint.sh /usr/local/bin/jit-cache-invalidate.sh && \
-    echo 'source /usr/local/bin/jit-cache-invalidate.sh' >> /root/.bashrc
-ENV BASH_ENV=/usr/local/bin/jit-cache-invalidate.sh
+# -- Smoke test (no GPU at build time) -------------------------------------------
+# NOTE: plain COPY, not a heredoc — podman/buildah 1.33 lacks heredoc support
+COPY smoke_test_cu132.py /tmp/smoke_test.py
+RUN python /tmp/smoke_test.py && rm /tmp/smoke_test.py
 
-WORKDIR /workspace
-
-# Reinstall cutlass-dsl-libs-cu13 LAST (in case anything overwrote it)
-RUN pip install --force-reinstall --no-deps nvidia-cutlass-dsl-libs-cu13
-
-# =============================================================================
-# Smoke test
-# =============================================================================
-RUN python -c "\
-import torch; \
-import flashinfer; \
-import transformers; \
-import sglang; \
-print(f'PyTorch:      {torch.__version__}'); \
-print(f'CUDA:         {torch.version.cuda}'); \
-print(f'FlashInfer:   {flashinfer.__version__}'); \
-print(f'Transformers: {transformers.__version__}'); \
-print(f'SGLang:       {getattr(sglang, \"__version__\", \"editable-install\")}'); \
-"
+COPY profiles/ /profiles/
+COPY configs/nccl_graph_opt.xml /etc/nccl_graph_opt.xml
 
 ENTRYPOINT ["/entrypoint.sh"]

--- a/Dockerfile.sglang-cu132
+++ b/Dockerfile.sglang-cu132
@@ -359,14 +359,18 @@ RUN mkdir -p /cache/jit/triton /cache/jit/torch_extensions
 
 ENV LD_LIBRARY_PATH="/opt/venv/lib/python3.12/site-packages/nvidia/cu13/lib:/usr/local/cuda/lib64:${LD_LIBRARY_PATH}"
 
-# CCCL symlink (CUDA 13.2 moved headers under cccl/ prefix)
-RUN if [ -d /usr/local/cuda/targets/x86_64-linux/include/cccl ] && \
-       [ ! -e /usr/local/cuda/targets/x86_64-linux/include/cccl/cuda ]; then \
-        ln -sf /usr/local/cuda/targets/x86_64-linux/include/cuda \
-               /usr/local/cuda/targets/x86_64-linux/include/cccl/cuda; \
+# CCCL symlink (CUDA 13.2 moved headers under cccl/ prefix). Skipping when the
+# layout doesn't need it is fine; a FAILED ln is not — don't mask it (CodeRabbit).
+RUN CCCL=/usr/local/cuda/targets/x86_64-linux/include/cccl; \
+    if [ -d "$CCCL" ] && [ ! -e "$CCCL/cuda" ]; then \
+        ln -sf /usr/local/cuda/targets/x86_64-linux/include/cuda "$CCCL/cuda"; \
     fi; \
-    test -d /usr/local/cuda/targets/x86_64-linux/include/cccl/cuda && \
-    ln -sf /usr/local/cuda/targets/x86_64-linux/include/cccl/cuda /usr/local/cuda/include/cuda || true
+    if [ -d "$CCCL/cuda" ]; then \
+        ln -sf "$CCCL/cuda" /usr/local/cuda/include/cuda \
+        && echo "OK: CCCL include symlink in place"; \
+    else \
+        echo "OK: CUDA layout has no cccl prefix — symlink not needed"; \
+    fi
 
 # libcudart.so.12 compat symlink (prebuilt JIT-cache binaries may want it)
 RUN CUDA_LIB=$(find /usr/local/cuda/targets -name 'libcudart.so' -print -quit 2>/dev/null) \

--- a/Dockerfile.sglang-cu132-picks
+++ b/Dockerfile.sglang-cu132-picks
@@ -1,0 +1,33 @@
+# Cherry-pick layer on the cu132 image (2026-06-11):
+#   #21593 tool-call constrained decoding fixes for native-format models
+#   #21722 structural tags for strict tool calling (needs xgrammar>=0.2.0)
+#   #23953 two-phase reasoning grammar + --enable-strict-thinking
+#   #23476/#26433 JSON Schema type normalization for tool params
+#   #27463 topk>1 tree drafting for mamba/hybrid models (EXPERIMENTAL on this
+#          tree at topk>1 — identical behavior at production topk=1)
+# Source branch: sglang-fork blackwell-cu132-picks (260194aa + 6 picks);
+# patch generated via `git diff 260194aa..blackwell-cu132-picks`.
+FROM localhost/voipmonitor/sglang:cu132
+
+COPY patches/cherry-picks-20260611.diff /tmp/picks.diff
+# plain apply (no --3way: the tree is intentionally dirty from runtime patches,
+# so the index can't be used); only runtime package paths matter in the image
+RUN cd /opt/sglang \
+ && git apply --include='python/sglang/*' --stat /tmp/picks.diff | tail -2 \
+ && git apply --include='python/sglang/*' /tmp/picks.diff \
+ && rm /tmp/picks.diff \
+ && python -c "import ast,glob; [ast.parse(open(f,encoding='utf-8-sig').read(),f) for f in glob.glob('python/sglang/srt/**/*.py',recursive=True)]" \
+ && echo "OK: picks applied, full srt syntax check passed"
+
+# 21722 needs xgrammar>=0.2.0; the cu132 base already ships 0.2.1 — verify only
+RUN python -c "from importlib.metadata import version; v=version('xgrammar'); print('xgrammar', v); assert tuple(map(int, v.split('.')[:2])) >= (0,2), v"
+
+COPY smoke_test_cu132.py /tmp/smoke_test.py
+# from_cli_args is the real gate: it maps EVERY dataclass field from the
+# argparse namespace, so an orphaned field (added without its CLI arg)
+# crashes here — exactly the failure mode that broke the first deploy.
+RUN python /tmp/smoke_test.py && rm /tmp/smoke_test.py \
+ && python -c "import argparse; from sglang.srt.server_args import ServerArgs; \
+p=argparse.ArgumentParser(); ServerArgs.add_cli_args(p); \
+a=p.parse_args(['--model-path','x','--enable-strict-thinking']); \
+exec('''try:\n ServerArgs.from_cli_args(a)\nexcept AttributeError as e:\n raise SystemExit(f\"FATAL orphaned field: {e}\")\nexcept Exception as e:\n print(f\"OK: field mapping passed (post-init stopped at expected {type(e).__name__})\")\nelse:\n print(\"OK: from_cli_args full round-trip\")''')"

--- a/Dockerfile.sglang-cu132-picks
+++ b/Dockerfile.sglang-cu132-picks
@@ -4,7 +4,11 @@
 # tools = port of open PR #25881, tree-drafting #27463, EAGLE #27390 #26397
 # #26800 #26424, mamba leaks #24244 #25770 #26941, detok #25309 #24659, #25155
 # #24627, GDN #26206, sgl-kernel case-512 #25775 — the kernel pick is inert in
-# this layer and takes effect via the main Dockerfile's in-tree apply).
+# this layer and takes effect via the main Dockerfile's in-tree apply.
+# Also: port of open PR #27983 — rope overrides reach text_config, fixes the
+# --json-model-override-args silent no-op/crash on VLM-format models (issue
+# #27974); and the open PR #27324 guard — None mamba_next_track_idx crash in
+# spec v2 verify under extra_buffer (issue #27325, hit 5x in production)).
 # Source branch: sglang-fork blackwell-cu132-picks;
 # patch generated via `git diff 260194aa..blackwell-cu132-picks`.
 FROM localhost/voipmonitor/sglang:cu132

--- a/Dockerfile.sglang-cu132-picks
+++ b/Dockerfile.sglang-cu132-picks
@@ -1,33 +1,31 @@
-# Cherry-pick layer on the cu132 image (2026-06-11):
-#   #21593 tool-call constrained decoding fixes for native-format models
-#   #21722 structural tags for strict tool calling (needs xgrammar>=0.2.0)
-#   #23953 two-phase reasoning grammar + --enable-strict-thinking
-#   #23476/#26433 JSON Schema type normalization for tool params
-#   #27463 topk>1 tree drafting for mamba/hybrid models (EXPERIMENTAL on this
-#          tree at topk>1 — identical behavior at production topk=1)
-# Source branch: sglang-fork blackwell-cu132-picks (260194aa + 6 picks);
+# Cherry-pick layer on the cu132 image — validated upstream backports.
+# Full pick list: see the commit message for patches/cherry-picks-20260611.diff
+# (tool-call/grammar #21593 #23476 #21722 #23953 #26433, Responses-API function
+# tools = port of open PR #25881, tree-drafting #27463, EAGLE #27390 #26397
+# #26800 #26424, mamba leaks #24244 #25770 #26941, detok #25309 #24659, #25155
+# #24627, GDN #26206, sgl-kernel case-512 #25775 — the kernel pick is inert in
+# this layer and takes effect via the main Dockerfile's in-tree apply).
+# Source branch: sglang-fork blackwell-cu132-picks;
 # patch generated via `git diff 260194aa..blackwell-cu132-picks`.
 FROM localhost/voipmonitor/sglang:cu132
 
 COPY patches/cherry-picks-20260611.diff /tmp/picks.diff
 # plain apply (no --3way: the tree is intentionally dirty from runtime patches,
-# so the index can't be used); only runtime package paths matter in the image
+# so the index can't be used); only runtime package paths matter in the image.
+# Syntax check covers the SAME scope as the apply (python/sglang/**, not just
+# srt/ — picks touch e.g. jit_kernel/ too).
 RUN cd /opt/sglang \
  && git apply --include='python/sglang/*' --stat /tmp/picks.diff | tail -2 \
  && git apply --include='python/sglang/*' /tmp/picks.diff \
  && rm /tmp/picks.diff \
- && python -c "import ast,glob; [ast.parse(open(f,encoding='utf-8-sig').read(),f) for f in glob.glob('python/sglang/srt/**/*.py',recursive=True)]" \
- && echo "OK: picks applied, full srt syntax check passed"
+ && python -c "import ast,glob; [ast.parse(open(f,encoding='utf-8-sig').read(),f) for f in glob.glob('python/sglang/**/*.py',recursive=True)]" \
+ && echo "OK: picks applied, full python/sglang syntax check passed"
 
 # 21722 needs xgrammar>=0.2.0; the cu132 base already ships 0.2.1 — verify only
 RUN python -c "from importlib.metadata import version; v=version('xgrammar'); print('xgrammar', v); assert tuple(map(int, v.split('.')[:2])) >= (0,2), v"
 
+# smoke_test_cu132.py includes the ServerArgs.from_cli_args gate: it maps EVERY
+# dataclass field from the argparse namespace, so an orphaned field (added
+# without its CLI arg) fails the build here instead of crashing at server start.
 COPY smoke_test_cu132.py /tmp/smoke_test.py
-# from_cli_args is the real gate: it maps EVERY dataclass field from the
-# argparse namespace, so an orphaned field (added without its CLI arg)
-# crashes here — exactly the failure mode that broke the first deploy.
-RUN python /tmp/smoke_test.py && rm /tmp/smoke_test.py \
- && python -c "import argparse; from sglang.srt.server_args import ServerArgs; \
-p=argparse.ArgumentParser(); ServerArgs.add_cli_args(p); \
-a=p.parse_args(['--model-path','x','--enable-strict-thinking']); \
-exec('''try:\n ServerArgs.from_cli_args(a)\nexcept AttributeError as e:\n raise SystemExit(f\"FATAL orphaned field: {e}\")\nexcept Exception as e:\n print(f\"OK: field mapping passed (post-init stopped at expected {type(e).__name__})\")\nelse:\n print(\"OK: from_cli_args full round-trip\")''')"
+RUN python /tmp/smoke_test.py && rm /tmp/smoke_test.py

--- a/configs/E=512,N=256,device_name=NVIDIA_RTX_PRO_6000_Blackwell_Workstation_Edition.json
+++ b/configs/E=512,N=256,device_name=NVIDIA_RTX_PRO_6000_Blackwell_Workstation_Edition.json
@@ -1,0 +1,146 @@
+{
+    "1": {
+        "BLOCK_SIZE_M": 16,
+        "BLOCK_SIZE_N": 32,
+        "BLOCK_SIZE_K": 64,
+        "GROUP_SIZE_M": 16,
+        "num_warps": 4,
+        "num_stages": 4
+    },
+    "2": {
+        "BLOCK_SIZE_M": 16,
+        "BLOCK_SIZE_N": 32,
+        "BLOCK_SIZE_K": 128,
+        "GROUP_SIZE_M": 32,
+        "num_warps": 4,
+        "num_stages": 3
+    },
+    "4": {
+        "BLOCK_SIZE_M": 16,
+        "BLOCK_SIZE_N": 64,
+        "BLOCK_SIZE_K": 64,
+        "GROUP_SIZE_M": 32,
+        "num_warps": 8,
+        "num_stages": 4
+    },
+    "8": {
+        "BLOCK_SIZE_M": 16,
+        "BLOCK_SIZE_N": 64,
+        "BLOCK_SIZE_K": 64,
+        "GROUP_SIZE_M": 16,
+        "num_warps": 4,
+        "num_stages": 3
+    },
+    "16": {
+        "BLOCK_SIZE_M": 16,
+        "BLOCK_SIZE_N": 32,
+        "BLOCK_SIZE_K": 64,
+        "GROUP_SIZE_M": 32,
+        "num_warps": 4,
+        "num_stages": 2
+    },
+    "24": {
+        "BLOCK_SIZE_M": 16,
+        "BLOCK_SIZE_N": 32,
+        "BLOCK_SIZE_K": 64,
+        "GROUP_SIZE_M": 1,
+        "num_warps": 4,
+        "num_stages": 2
+    },
+    "32": {
+        "BLOCK_SIZE_M": 16,
+        "BLOCK_SIZE_N": 32,
+        "BLOCK_SIZE_K": 64,
+        "GROUP_SIZE_M": 1,
+        "num_warps": 4,
+        "num_stages": 2
+    },
+    "48": {
+        "BLOCK_SIZE_M": 16,
+        "BLOCK_SIZE_N": 32,
+        "BLOCK_SIZE_K": 64,
+        "GROUP_SIZE_M": 1,
+        "num_warps": 4,
+        "num_stages": 2
+    },
+    "64": {
+        "BLOCK_SIZE_M": 16,
+        "BLOCK_SIZE_N": 128,
+        "BLOCK_SIZE_K": 64,
+        "GROUP_SIZE_M": 32,
+        "num_warps": 4,
+        "num_stages": 3
+    },
+    "96": {
+        "BLOCK_SIZE_M": 16,
+        "BLOCK_SIZE_N": 128,
+        "BLOCK_SIZE_K": 64,
+        "GROUP_SIZE_M": 16,
+        "num_warps": 8,
+        "num_stages": 2
+    },
+    "128": {
+        "BLOCK_SIZE_M": 16,
+        "BLOCK_SIZE_N": 128,
+        "BLOCK_SIZE_K": 128,
+        "GROUP_SIZE_M": 32,
+        "num_warps": 4,
+        "num_stages": 2
+    },
+    "256": {
+        "BLOCK_SIZE_M": 16,
+        "BLOCK_SIZE_N": 128,
+        "BLOCK_SIZE_K": 64,
+        "GROUP_SIZE_M": 16,
+        "num_warps": 4,
+        "num_stages": 4
+    },
+    "512": {
+        "BLOCK_SIZE_M": 16,
+        "BLOCK_SIZE_N": 32,
+        "BLOCK_SIZE_K": 64,
+        "GROUP_SIZE_M": 1,
+        "num_warps": 4,
+        "num_stages": 2
+    },
+    "1024": {
+        "BLOCK_SIZE_M": 32,
+        "BLOCK_SIZE_N": 128,
+        "BLOCK_SIZE_K": 128,
+        "GROUP_SIZE_M": 32,
+        "num_warps": 4,
+        "num_stages": 2
+    },
+    "1536": {
+        "BLOCK_SIZE_M": 32,
+        "BLOCK_SIZE_N": 128,
+        "BLOCK_SIZE_K": 128,
+        "GROUP_SIZE_M": 1,
+        "num_warps": 4,
+        "num_stages": 2
+    },
+    "2048": {
+        "BLOCK_SIZE_M": 64,
+        "BLOCK_SIZE_N": 128,
+        "BLOCK_SIZE_K": 128,
+        "GROUP_SIZE_M": 1,
+        "num_warps": 4,
+        "num_stages": 2
+    },
+    "3072": {
+        "BLOCK_SIZE_M": 64,
+        "BLOCK_SIZE_N": 128,
+        "BLOCK_SIZE_K": 128,
+        "GROUP_SIZE_M": 1,
+        "num_warps": 4,
+        "num_stages": 2
+    },
+    "4096": {
+        "BLOCK_SIZE_M": 128,
+        "BLOCK_SIZE_N": 128,
+        "BLOCK_SIZE_K": 64,
+        "GROUP_SIZE_M": 1,
+        "num_warps": 4,
+        "num_stages": 2
+    }
+}

--- a/patches/cherry-picks-20260611.diff
+++ b/patches/cherry-picks-20260611.diff
@@ -5076,6 +5076,89 @@ index ecaab3cc0e..c805502306 100644
          # Set constant
          from sglang.srt.speculative.eagle_info import EagleDraftInput
  
+diff --git a/python/sglang/srt/utils/hf_transformers_utils.py b/python/sglang/srt/utils/hf_transformers_utils.py
+index b928b08d4d..c2cf0b9a31 100644
+--- a/python/sglang/srt/utils/hf_transformers_utils.py
++++ b/python/sglang/srt/utils/hf_transformers_utils.py
+@@ -475,6 +475,69 @@ def _ensure_gguf_version():
+         pass
+ 
+ 
++_ROPE_OVERRIDE_KEYS = ("rope_scaling", "rope_parameters")
++
++# Sub-config attributes that may hold the language-model config of a
++# composite (VLM / omni) model. Mirrors get_hf_text_config priority.
++# (Ported from upstream PR #27983, issue #27974.)
++_TEXT_SUB_CONFIG_ATTRS = (
++    "thinker_config",
++    "llm_config",
++    "language_config",
++    "text_config",
++)
++
++
++def _resolve_text_sub_config(config):
++    for attr in _TEXT_SUB_CONFIG_ATTRS:
++        sub = getattr(config, attr, None)
++        if isinstance(sub, PretrainedConfig):
++            if attr == "thinker_config":
++                inner = getattr(sub, "text_config", None)
++                if isinstance(inner, PretrainedConfig):
++                    return inner
++            return sub
++    return None
++
++
++def _merged_rope_override(config, key, value):
++    existing = getattr(config, key, None)
++    if isinstance(value, dict) and isinstance(existing, dict):
++        return {**existing, **value}
++    return value
++
++
++def apply_model_override_args(config, model_override_args: dict) -> None:
++    """Apply --json-model-override-args to a (possibly composite) config.
++
++    Ported from upstream PR #27983 (issue #27974): recurse into sub-configs
++    for the nested form (was: crash), merge partial rope dicts, and mirror
++    flat rope overrides onto the text sub-config (was: silent no-op).
++    """
++    flat_overrides = {}
++    for key, value in model_override_args.items():
++        existing = getattr(config, key, None)
++        if isinstance(value, dict) and isinstance(existing, PretrainedConfig):
++            apply_model_override_args(existing, value)
++        elif key in _ROPE_OVERRIDE_KEYS:
++            flat_overrides[key] = _merged_rope_override(config, key, value)
++        else:
++            flat_overrides[key] = value
++    if flat_overrides:
++        config.update(flat_overrides)
++
++    rope_keys = [k for k in _ROPE_OVERRIDE_KEYS if k in flat_overrides]
++    if rope_keys:
++        text_config = _resolve_text_sub_config(config)
++        if text_config is not None:
++            text_config.update(
++                {
++                    k: _merged_rope_override(text_config, k, model_override_args[k])
++                    for k in rope_keys
++                }
++            )
++
++
+ @lru_cache_frozenset(maxsize=32)
+ def get_config(
+     model: str,
+@@ -652,7 +715,7 @@ def get_config(
+         config.update({"architectures": ["LongcatFlashForCausalLM"]})
+ 
+     if model_override_args:
+-        config.update(model_override_args)
++        apply_model_override_args(config, model_override_args)
+ 
+     # Special architecture mapping check for GGUF models
+     if is_gguf:
 diff --git a/python/sglang/srt/utils/patch_tokenizer.py b/python/sglang/srt/utils/patch_tokenizer.py
 index 7ad1114da8..1d083180f4 100644
 --- a/python/sglang/srt/utils/patch_tokenizer.py

--- a/patches/cherry-picks-20260611.diff
+++ b/patches/cherry-picks-20260611.diff
@@ -4694,6 +4694,30 @@ index c1eee12985..9c81b7fc9f 100644
  from dataclasses import dataclass
  from typing import List, Optional, Tuple
  
+diff --git a/python/sglang/srt/speculative/eagle_info_v2.py b/python/sglang/srt/speculative/eagle_info_v2.py
+index cec0857d6c..358348a639 100644
+--- a/python/sglang/srt/speculative/eagle_info_v2.py
++++ b/python/sglang/srt/speculative/eagle_info_v2.py
+@@ -265,8 +265,18 @@ class EagleVerifyInputV2Mixin:
+                 req_pool_idx_tensor = batch.req_pool_indices.to(
+                     device=mapping.device, dtype=torch.int64
+                 )
++                # Guard (upstream PR #27324, issue #27325): mamba_next_track_idx
++                # may be None for requests that haven't allocated a ping-pong
++                # buffer yet (spec v2 verify path). Default to slot 0 — the
++                # mapping yields the no-allocation marker and downstream
++                # track-masking skips the request instead of crashing.
+                 track_col_idx = torch.tensor(
+-                    [req.mamba_next_track_idx for req in batch.reqs],
++                    [
++                        req.mamba_next_track_idx
++                        if req.mamba_next_track_idx is not None
++                        else 0
++                        for req in batch.reqs
++                    ],
+                     dtype=torch.int64,
+                     pin_memory=True,
+                 ).to(mapping.device, non_blocking=True)
 diff --git a/python/sglang/srt/speculative/eagle_utils.py b/python/sglang/srt/speculative/eagle_utils.py
 index f41a92523e..8742fb10e3 100644
 --- a/python/sglang/srt/speculative/eagle_utils.py

--- a/patches/cherry-picks-20260611.diff
+++ b/patches/cherry-picks-20260611.diff
@@ -1,0 +1,8541 @@
+diff --git a/.github/workflows/nightly-test-npu.yml b/.github/workflows/nightly-test-npu.yml
+index 205dcc02e3..44071afc7e 100644
+--- a/.github/workflows/nightly-test-npu.yml
++++ b/.github/workflows/nightly-test-npu.yml
+@@ -131,7 +131,7 @@ jobs:
+           pip install sentence_transformers torchaudio==2.8.0
+           pip install protobuf==6.31.1 zss pre-commit wandb>=0.16.0 tenacity==8.3.0 loguru openpyxl latex2sympy2 zstandard transformers-stream-generator tqdm-multiprocess pycocoevalcap
+           pip install yt-dlp sentencepiece==0.1.99 nltk av ftfy sqlitedict==2.1.0 sacrebleu>=1.5.0 pytablewriter black==24.1.0 isort==5.13.2 peft>=0.2.0 accelerate>=0.29.1
+-          pip install jsonlines httpx==0.25.0 evaluate>=0.4.0 datasets==2.16.1 numexpr xgrammar==0.1.32 numpy==1.26.4 dotenv
++          pip install jsonlines httpx==0.25.0 evaluate>=0.4.0 datasets==2.16.1 numexpr xgrammar==0.2.0 numpy==1.26.4 dotenv
+           git clone --branch v0.3.3 --depth 1 https://github.com/EvolvingLMMs-Lab/lmms-eval.git
+           cd ./lmms-eval
+           nohup pip install . > lmmslog.txt 2>&1 &
+@@ -197,7 +197,7 @@ jobs:
+           pip install sentence_transformers torchaudio==2.8.0
+           pip install protobuf==6.31.1 zss pre-commit wandb>=0.16.0 tenacity==8.3.0 loguru openpyxl latex2sympy2 zstandard transformers-stream-generator tqdm-multiprocess pycocoevalcap
+           pip install yt-dlp sentencepiece==0.1.99 nltk av ftfy sqlitedict==2.1.0 sacrebleu>=1.5.0 pytablewriter black==24.1.0 isort==5.13.2 peft>=0.2.0 accelerate>=0.29.1
+-          pip install jsonlines httpx==0.25.0 evaluate>=0.4.0 datasets==2.16.1 numexpr xgrammar==0.1.32 numpy==1.26.4 dotenv
++          pip install jsonlines httpx==0.25.0 evaluate>=0.4.0 datasets==2.16.1 numexpr xgrammar==0.2.0 numpy==1.26.4 dotenv
+           git clone --branch v0.3.3 --depth 1 https://github.com/EvolvingLMMs-Lab/lmms-eval.git
+           cd ./lmms-eval
+           nohup pip install . > lmmslog.txt 2>&1 &
+@@ -264,7 +264,7 @@ jobs:
+           pip install sentence_transformers torchaudio==2.8.0
+           pip install protobuf==6.31.1 zss pre-commit wandb>=0.16.0 tenacity==8.3.0 loguru openpyxl latex2sympy2 zstandard transformers-stream-generator tqdm-multiprocess pycocoevalcap
+           pip install yt-dlp sentencepiece==0.1.99 nltk av ftfy sqlitedict==2.1.0 sacrebleu>=1.5.0 pytablewriter black==24.1.0 isort==5.13.2 peft>=0.2.0 accelerate>=0.29.1
+-          pip install jsonlines httpx==0.25.0 evaluate>=0.4.0 datasets==2.16.1 numexpr xgrammar==0.1.32 numpy==1.26.4 dotenv
++          pip install jsonlines httpx==0.25.0 evaluate>=0.4.0 datasets==2.16.1 numexpr xgrammar==0.2.0 numpy==1.26.4 dotenv
+           git clone --branch v0.3.3 --depth 1 https://github.com/EvolvingLMMs-Lab/lmms-eval.git
+           cd ./lmms-eval
+           nohup pip install . > lmmslog.txt 2>&1 &
+@@ -331,7 +331,7 @@ jobs:
+           pip install sentence_transformers torchaudio==2.8.0
+           pip install protobuf==6.31.1 zss pre-commit wandb>=0.16.0 tenacity==8.3.0 loguru openpyxl latex2sympy2 zstandard transformers-stream-generator tqdm-multiprocess pycocoevalcap
+           pip install yt-dlp sentencepiece==0.1.99 nltk av ftfy sqlitedict==2.1.0 sacrebleu>=1.5.0 pytablewriter black==24.1.0 isort==5.13.2 peft>=0.2.0 accelerate>=0.29.1
+-          pip install jsonlines httpx==0.25.0 evaluate>=0.4.0 datasets==2.16.1 numexpr xgrammar==0.1.32 numpy==1.26.4 dotenv
++          pip install jsonlines httpx==0.25.0 evaluate>=0.4.0 datasets==2.16.1 numexpr xgrammar==0.2.0 numpy==1.26.4 dotenv
+           git clone --branch v0.3.3 --depth 1 https://github.com/EvolvingLMMs-Lab/lmms-eval.git
+           cd ./lmms-eval
+           nohup pip install . > lmmslog.txt 2>&1 &
+@@ -398,7 +398,7 @@ jobs:
+           pip install sentence_transformers torchaudio==2.8.0
+           pip install protobuf==6.31.1 zss pre-commit wandb>=0.16.0 tenacity==8.3.0 loguru openpyxl latex2sympy2 zstandard transformers-stream-generator tqdm-multiprocess pycocoevalcap
+           pip install yt-dlp sentencepiece==0.1.99 nltk av ftfy sqlitedict==2.1.0 sacrebleu>=1.5.0 pytablewriter black==24.1.0 isort==5.13.2 peft>=0.2.0 accelerate>=0.29.1
+-          pip install jsonlines httpx==0.25.0 evaluate>=0.4.0 datasets==2.16.1 numexpr xgrammar==0.1.32 numpy==1.26.4 dotenv
++          pip install jsonlines httpx==0.25.0 evaluate>=0.4.0 datasets==2.16.1 numexpr xgrammar==0.2.0 numpy==1.26.4 dotenv
+           git clone --branch v0.3.3 --depth 1 https://github.com/EvolvingLMMs-Lab/lmms-eval.git
+           cd ./lmms-eval
+           nohup pip install . > lmmslog.txt 2>&1 &
+diff --git a/3rdparty/amd/wheel/sglang/pyproject.toml b/3rdparty/amd/wheel/sglang/pyproject.toml
+index 9b9c24fd22..1df32e7d57 100644
+--- a/3rdparty/amd/wheel/sglang/pyproject.toml
++++ b/3rdparty/amd/wheel/sglang/pyproject.toml
+@@ -62,7 +62,7 @@ runtime_common = [
+   "transformers==4.57.1",
+   "uvicorn",
+   "uvloop",
+-  "xgrammar==0.1.32",
++  "xgrammar==0.2.0",
+   "smg-grpc-servicer>=0.5.0",
+ ]
+ 
+diff --git a/benchmark/bench_linear_attention/bench_gdn_qkv_split.py b/benchmark/bench_linear_attention/bench_gdn_qkv_split.py
+new file mode 100644
+index 0000000000..30aaf9e26b
+--- /dev/null
++++ b/benchmark/bench_linear_attention/bench_gdn_qkv_split.py
+@@ -0,0 +1,139 @@
++from __future__ import annotations
++
++import argparse
++
++import torch
++
++from sglang.jit_kernel.triton.gdn_fused_proj import fused_qkv_split_gdn_prefill
++
++DTYPES = {
++    "bf16": torch.bfloat16,
++    "fp16": torch.float16,
++    "fp32": torch.float32,
++}
++
++
++def parse_args():
++    parser = argparse.ArgumentParser(
++        description="Benchmark GDN prefill QKV split fallback vs fused Triton path."
++    )
++    parser.add_argument("--seq-len", type=int, default=8192)
++    parser.add_argument("--num-q-heads", type=int, default=16)
++    parser.add_argument("--num-k-heads", type=int, default=16)
++    parser.add_argument("--num-v-heads", type=int, default=16)
++    parser.add_argument("--head-q", type=int, default=128)
++    parser.add_argument("--head-k", type=int, default=128)
++    parser.add_argument("--head-v", type=int, default=128)
++    parser.add_argument("--dtype", choices=DTYPES.keys(), default="bf16")
++    parser.add_argument("--warmup", type=int, default=20)
++    parser.add_argument("--iters", type=int, default=100)
++    return parser.parse_args()
++
++
++def make_non_contiguous_view(src: torch.Tensor) -> torch.Tensor:
++    backing = torch.empty(
++        src.shape[1],
++        src.shape[0],
++        dtype=src.dtype,
++        device=src.device,
++    )
++    view = backing.transpose(0, 1)
++    view.copy_(src)
++    return view
++
++
++def split_reference(
++    mixed_qkv: torch.Tensor,
++    num_q_heads: int,
++    num_k_heads: int,
++    num_v_heads: int,
++    head_q: int,
++    head_k: int,
++    head_v: int,
++):
++    q_dim = num_q_heads * head_q
++    k_dim = num_k_heads * head_k
++    v_dim = num_v_heads * head_v
++    actual_seq_len = mixed_qkv.shape[0]
++    query, key, value = torch.split(mixed_qkv, [q_dim, k_dim, v_dim], dim=-1)
++    query = query.reshape(1, actual_seq_len, num_q_heads, head_q).contiguous()
++    key = key.reshape(1, actual_seq_len, num_k_heads, head_k).contiguous()
++    value = value.reshape(1, actual_seq_len, num_v_heads, head_v).contiguous()
++    return query, key, value
++
++
++@torch.inference_mode()
++def benchmark(fn, warmup: int, iters: int) -> float:
++    for _ in range(warmup):
++        fn()
++    torch.cuda.synchronize()
++
++    start = torch.cuda.Event(enable_timing=True)
++    end = torch.cuda.Event(enable_timing=True)
++    start.record()
++    for _ in range(iters):
++        fn()
++    end.record()
++    torch.cuda.synchronize()
++    return start.elapsed_time(end) * 1000.0 / iters
++
++
++def check_close(actual, expected):
++    for actual_tensor, expected_tensor in zip(actual, expected):
++        torch.testing.assert_close(actual_tensor, expected_tensor, rtol=0, atol=0)
++
++
++def run_case(name: str, mixed_qkv: torch.Tensor, args):
++    shape_args = (
++        args.num_q_heads,
++        args.num_k_heads,
++        args.num_v_heads,
++        args.head_q,
++        args.head_k,
++        args.head_v,
++    )
++    expected = split_reference(mixed_qkv, *shape_args)
++    actual = fused_qkv_split_gdn_prefill(mixed_qkv, *shape_args)
++    check_close(actual, expected)
++
++    baseline_us = benchmark(
++        lambda: split_reference(mixed_qkv, *shape_args),
++        args.warmup,
++        args.iters,
++    )
++    fused_us = benchmark(
++        lambda: fused_qkv_split_gdn_prefill(mixed_qkv, *shape_args),
++        args.warmup,
++        args.iters,
++    )
++    speedup = baseline_us / fused_us
++    print(f"{name:>12} {baseline_us:12.2f} {fused_us:12.2f} {speedup:10.2f}x")
++
++
++def main():
++    args = parse_args()
++    if not torch.cuda.is_available():
++        raise RuntimeError("CUDA is required for this benchmark")
++
++    torch.manual_seed(0)
++    device = torch.device("cuda")
++    dtype = DTYPES[args.dtype]
++    qkv_dim = (
++        args.num_q_heads * args.head_q
++        + args.num_k_heads * args.head_k
++        + args.num_v_heads * args.head_v
++    )
++    mixed_qkv = torch.randn(args.seq_len, qkv_dim, dtype=dtype, device=device)
++    mixed_qkv_strided = make_non_contiguous_view(mixed_qkv)
++
++    print(
++        f"seq_len={args.seq_len} qkv_dim={qkv_dim} dtype={args.dtype} "
++        f"warmup={args.warmup} iters={args.iters}"
++    )
++    print(f"{'layout':>12} {'baseline_us':>12} {'fused_us':>12} {'speedup':>11}")
++    run_case("contiguous", mixed_qkv, args)
++    run_case("strided", mixed_qkv_strided, args)
++
++
++if __name__ == "__main__":
++    main()
+diff --git a/python/pyproject.toml b/python/pyproject.toml
+index 538ad4908d..4af0fdd55a 100755
+--- a/python/pyproject.toml
++++ b/python/pyproject.toml
+@@ -75,7 +75,7 @@ dependencies = [
+   "uvicorn",
+   "uvloop",
+   "watchfiles",
+-  "xgrammar==0.1.32",
++  "xgrammar==0.2.0",
+   "smg-grpc-servicer>=0.5.0",
+   "kernels",
+ ]
+diff --git a/python/pyproject_cpu.toml b/python/pyproject_cpu.toml
+index 550780ffc7..7835b18aa8 100644
+--- a/python/pyproject_cpu.toml
++++ b/python/pyproject_cpu.toml
+@@ -65,7 +65,7 @@ dependencies = [
+   "triton==3.5.0",
+   "uvicorn",
+   "uvloop",
+-  "xgrammar==0.1.32",
++  "xgrammar==0.2.0",
+   "smg-grpc-servicer>=0.5.0",
+ ]
+ 
+diff --git a/python/pyproject_npu.toml b/python/pyproject_npu.toml
+index 704df6e3e9..7a6ce70872 100644
+--- a/python/pyproject_npu.toml
++++ b/python/pyproject_npu.toml
+@@ -61,7 +61,7 @@ dependencies = [
+   "transformers==5.3.0",
+   "uvicorn",
+   "uvloop",
+-  "xgrammar==0.1.32",
++  "xgrammar==0.2.0",
+   "smg-grpc-servicer>=0.5.0",
+ ]
+ 
+diff --git a/python/pyproject_other.toml b/python/pyproject_other.toml
+index b7f4411cff..f7fa38bd5a 100755
+--- a/python/pyproject_other.toml
++++ b/python/pyproject_other.toml
+@@ -61,7 +61,7 @@ runtime_common = [
+   "transformers==5.3.0",
+   "uvicorn",
+   "uvloop",
+-  "xgrammar==0.1.32",
++  "xgrammar==0.2.0",
+   "smg-grpc-servicer>=0.5.0",
+ ]
+ 
+diff --git a/python/pyproject_xpu.toml b/python/pyproject_xpu.toml
+index 5a25320363..af4acb9bd8 100644
+--- a/python/pyproject_xpu.toml
++++ b/python/pyproject_xpu.toml
+@@ -15,10 +15,10 @@ classifiers = [
+ ]
+ 
+ dependencies = [
+-  "torch==2.10.0+xpu",
+-  "torchcodec==0.10.0 ; sys_platform != 'linux' or (sys_platform == 'linux' and platform_machine != 'aarch64' and platform_machine != 'arm64' and platform_machine != 'armv7l')", # torchcodec does not exist in those systems. torch==2.10.0 on XPU uses 0.10.0
++  "torch==2.11.0+xpu",
++  "torchcodec==0.11.0 ; sys_platform != 'linux' or (sys_platform == 'linux' and platform_machine != 'aarch64' and platform_machine != 'arm64' and platform_machine != 'armv7l')", # torchcodec does not exist in those systems. torch==2.11.0 on XPU uses 0.11.0
+   "av ; sys_platform == 'linux' and (platform_machine == 'aarch64' or platform_machine == 'arm64' or platform_machine == 'armv7l')",
+-  "torchaudio==2.10.0+xpu",
++  "torchaudio==2.11.0+xpu",
+   "torchvision",
+   "sgl-kernel @ git+https://github.com/sgl-project/sgl-kernel-xpu.git",
+   "IPython",
+@@ -27,7 +27,9 @@ dependencies = [
+   "blobfile==3.0.0",
+   "build",
+   "compressed-tensors",
++  "addict",
+   "datasets",
++  "easydict",
+   "einops",
+   "fastapi",
+   "gguf",
+@@ -58,17 +60,36 @@ dependencies = [
+   "soundfile==0.13.1",
+   "tiktoken",
+   "timm==1.0.16",
+-  "torchao==0.9.0",
++  "torchao==0.9.0+xpu",
+   "tqdm",
+-  "mistral_common>=1.9.0",
+-  "transformers==5.3.0",
++  "mistral_common>=1.11.0",
++  "transformers==5.6.0",
+   "uvicorn",
+   "uvloop",
+-  # "xgrammar==0.1.24", , xgrammar depends on CUDA PyTorch and Triton only
++  # "xgrammar==0.2.0", xgrammar depends on CUDA PyTorch and Triton only
+   "smg-grpc-servicer>=0.5.0",
+ ]
+ 
+ [project.optional-dependencies]
++diffusion = [
++  "PyYAML==6.0.1",
++  "cloudpickle==3.1.2",
++  "diffusers==0.36.0",
++  "imageio==2.36.0",
++  "imageio-ffmpeg==0.5.1",
++  "moviepy>=2.0.0",
++  "opencv-python==4.10.0.84",
++  "remote-pdb==2.1.0",
++  "st_attn==0.0.7 ; platform_machine != 'aarch64' and platform_machine != 'arm64'",
++  "runai_model_streamer>=0.15.5",
++  "cache-dit==1.3.0",
++  "addict==2.4.0",
++  "av==16.1.0",
++  "scikit-image==0.25.2",
++  "trimesh>=4.0.0",
++  "xatlas",
++]
++
+ tracing = [
+   "opentelemetry-api",
+   "opentelemetry-exporter-otlp",
+@@ -93,6 +114,7 @@ test = [
+ dev = ["sglang[test]"]
+ 
+ all = [
++  "sglang[diffusion]",
+   "sglang[tracing]",
+ ]
+ 
+@@ -134,6 +156,6 @@ exclude = [
+ [tool.setuptools_scm]
+ root = ".."
+ version_file = "sglang/_version.py"
+-git_describe_command = ["python3", "python/tools/get_version_tag.py", "--tag-only"]
++git_describe_command = ["python3", "python/tools/get_version_tag.py"]
+ # Allow editable installs even when .git metadata is not available.
+ fallback_version = "0.0.0.dev0"
+diff --git a/python/sglang/jit_kernel/triton/gdn_fused_proj.py b/python/sglang/jit_kernel/triton/gdn_fused_proj.py
+index d7d07da739..076a1cc3f7 100644
+--- a/python/sglang/jit_kernel/triton/gdn_fused_proj.py
++++ b/python/sglang/jit_kernel/triton/gdn_fused_proj.py
+@@ -308,3 +308,100 @@ def fused_qkvzba_split_reshape_cat_contiguous(
+         num_stages=3,
+     )
+     return mixed_qkv, z, b, a
++
++
++@triton.jit
++def fused_qkv_split_gdn_prefill_kernel(
++    q,
++    k,
++    v,
++    mixed_qkv,
++    MIXED_QKV_STRIDE_T: tl.constexpr,
++    MIXED_QKV_STRIDE_D: tl.constexpr,
++    NUM_Q_HEADS: tl.constexpr,
++    NUM_K_HEADS: tl.constexpr,
++    NUM_V_HEADS: tl.constexpr,
++    HEAD_Q: tl.constexpr,
++    HEAD_K: tl.constexpr,
++    HEAD_V: tl.constexpr,
++    BLOCK_SIZE: tl.constexpr,
++):
++    i_t = tl.program_id(0)
++    offsets = tl.arange(0, BLOCK_SIZE)
++
++    q_dim: tl.constexpr = NUM_Q_HEADS * HEAD_Q
++    k_dim: tl.constexpr = NUM_K_HEADS * HEAD_K
++    v_dim: tl.constexpr = NUM_V_HEADS * HEAD_V
++    qk_dim: tl.constexpr = q_dim + k_dim
++    qkv_dim: tl.constexpr = qk_dim + v_dim
++
++    mask = offsets < qkv_dim
++    values = tl.load(
++        mixed_qkv + i_t * MIXED_QKV_STRIDE_T + offsets * MIXED_QKV_STRIDE_D,
++        mask=mask,
++    )
++
++    q_mask = offsets < q_dim
++    tl.store(q + i_t * q_dim + offsets, values, mask=q_mask)
++
++    k_offsets = offsets - q_dim
++    k_mask = (offsets >= q_dim) & (offsets < qk_dim)
++    tl.store(k + i_t * k_dim + k_offsets, values, mask=k_mask)
++
++    v_offsets = offsets - qk_dim
++    v_mask = (offsets >= qk_dim) & (offsets < qkv_dim)
++    tl.store(v + i_t * v_dim + v_offsets, values, mask=v_mask)
++
++
++def fused_qkv_split_gdn_prefill(
++    mixed_qkv: torch.Tensor,
++    num_q_heads: int,
++    num_k_heads: int,
++    num_v_heads: int,
++    head_q: int,
++    head_k: int,
++    head_v: int,
++):
++    """Split packed post-conv GDN QKV into contiguous FLA prefill tensors.
++
++    `mixed_qkv` is laid out per token as `[all_q | all_k | all_v]`. The FLA
++    chunk kernels consume separate contiguous `[1, T, H, D]` tensors, so this
++    fused split replaces three independent `aten::copy_` kernels from the
++    generic FLA input guard. `mixed_qkv` may be a strided `[T, qkv_dim]` view.
++    """
++    seq_len = mixed_qkv.shape[0]
++    q = torch.empty(
++        (1, seq_len, num_q_heads, head_q),
++        dtype=mixed_qkv.dtype,
++        device=mixed_qkv.device,
++    )
++    k = torch.empty(
++        (1, seq_len, num_k_heads, head_k),
++        dtype=mixed_qkv.dtype,
++        device=mixed_qkv.device,
++    )
++    v = torch.empty(
++        (1, seq_len, num_v_heads, head_v),
++        dtype=mixed_qkv.dtype,
++        device=mixed_qkv.device,
++    )
++
++    qkv_dim = num_q_heads * head_q + num_k_heads * head_k + num_v_heads * head_v
++    fused_qkv_split_gdn_prefill_kernel[(seq_len,)](
++        q,
++        k,
++        v,
++        mixed_qkv,
++        mixed_qkv.stride(0),
++        mixed_qkv.stride(1),
++        num_q_heads,
++        num_k_heads,
++        num_v_heads,
++        head_q,
++        head_k,
++        head_v,
++        BLOCK_SIZE=triton.next_power_of_2(qkv_dim),
++        num_warps=8,
++        num_stages=3,
++    )
++    return q, k, v
+diff --git a/python/sglang/srt/constrained/base_grammar_backend.py b/python/sglang/srt/constrained/base_grammar_backend.py
+index 3704e6d0d2..4f907b983a 100644
+--- a/python/sglang/srt/constrained/base_grammar_backend.py
++++ b/python/sglang/srt/constrained/base_grammar_backend.py
+@@ -21,6 +21,7 @@ from typing import Dict, List, Optional, Tuple
+ 
+ import torch
+ 
++from sglang.srt.parser.reasoning_parser import ReasoningParser
+ from sglang.srt.server_args import ServerArgs
+ 
+ logger = logging.getLogger(__name__)
+@@ -128,6 +129,8 @@ class InvalidGrammarObject(BaseGrammarObject):
+ 
+ 
+ class BaseGrammarBackend:
++    _enable_strict_thinking: bool = False
++
+     def __init__(self):
+         self.executor = ThreadPoolExecutor()
+         self.cache: Dict[Tuple[str, str], BaseGrammarObject] = {}
+@@ -136,6 +139,24 @@ class BaseGrammarBackend:
+         logger.warning(f"Skip unsupported {key_type=}, {key_string=}")
+         return InvalidGrammarObject()
+ 
++    @property
++    def enable_strict_thinking(self):
++        return self._enable_strict_thinking
++
++    @property
++    def is_support_token_filter(self):
++        return False
++
++    def set_token_filter(
++        self, vocab_mask, token_ids, batch_idx, is_allowed=True, reset_vocab_mask=True
++    ):
++        """Set or clear specific tokens in the vocab mask. No-op by default."""
++        pass
++
++    def init_strict_reasoning_grammar(self, reasoning: bool):
++        """Create a grammar object for strict token filtering only. Returns None by default."""
++        return None
++
+     def dispatch_fallback(self, key_type: str, key_string: str) -> BaseGrammarObject:
+         """
+         This function should not be reached in any case.
+@@ -239,6 +260,13 @@ def create_grammar_backend(
+                 any_whitespace=not server_args.constrained_json_disable_any_whitespace,
+             )
+         except TokenizerNotSupportedError as e:
++            if server_args.enable_strict_thinking:
++                raise ValueError(
++                    f"--enable-strict-thinking requires a grammar backend with "
++                    f"token filtering support, but XGrammar failed to initialize: "
++                    f"{e}. Cannot fall back to grammar_backend='none' with strict "
++                    f"thinking enabled."
++                ) from e
+             logger.warning(
+                 f"Grammar backend disabled because tokenizer is not supported by XGrammar: {e}. "
+                 "Falling back to grammar_backend='none'. "
+@@ -255,6 +283,13 @@ def create_grammar_backend(
+             whitespace_pattern=server_args.constrained_json_whitespace_pattern,
+         )
+     elif name == "none":
++        if server_args.enable_strict_thinking:
++            raise ValueError(
++                "--enable-strict-thinking requires a grammar backend that supports "
++                "token filtering, but grammar_backend='none' was specified. Use "
++                "--grammar-backend xgrammar or another backend that supports token "
++                "filtering."
++            )
+         return None
+     else:
+         raise ValueError(f"Invalid grammar backend: {name}")
+@@ -264,6 +299,15 @@ def create_grammar_backend(
+             ReasonerGrammarBackend,
+         )
+ 
+-        grammar_backend = ReasonerGrammarBackend(grammar_backend, think_end_id)
++        reasoning_parser = ReasoningParser(
++            model_type=server_args.reasoning_parser, stream_reasoning=False
++        )
++
++        grammar_backend = ReasonerGrammarBackend(
++            grammar_backend,
++            reasoning_parser,
++            tokenizer,
++            enable_strict_thinking=server_args.enable_strict_thinking,
++        )
+ 
+     return grammar_backend
+diff --git a/python/sglang/srt/constrained/grammar_manager.py b/python/sglang/srt/constrained/grammar_manager.py
+index 8b1e796587..5442cb5d30 100644
+--- a/python/sglang/srt/constrained/grammar_manager.py
++++ b/python/sglang/srt/constrained/grammar_manager.py
+@@ -11,6 +11,7 @@ from sglang.srt.constrained.base_grammar_backend import (
+     InvalidGrammarObject,
+     create_grammar_backend,
+ )
++from sglang.srt.constrained.reasoner_grammar_backend import ReasonerGrammarObject
+ from sglang.srt.environ import envs
+ 
+ if TYPE_CHECKING:
+@@ -37,6 +38,12 @@ class GrammarManager:
+         else:
+             self.grammar_backend = None
+ 
++        self._enable_strict_thinking = (
++            self.grammar_backend.enable_strict_thinking
++            if self.grammar_backend is not None
++            else False
++        )
++
+         self.grammar_sync_group = scheduler.dp_tp_cpu_group
+         self.grammar_sync_size = scheduler.dp_tp_group.world_size
+         self.grammar_sync_entry = scheduler.dp_tp_group.first_rank
+@@ -65,6 +72,20 @@ class GrammarManager:
+                     req.grammar.cancel()
+                 req.set_finish_with_abort("Aborted by AbortReq.")
+ 
++    def _get_request_thinking_budget(self, req: Req) -> int | None:
++        custom_params = req.sampling_params.custom_params
++        if not isinstance(custom_params, dict):
++            return None
++        thinking_budget = custom_params.get("thinking_budget")
++        return thinking_budget if isinstance(thinking_budget, int) else None
++
++    def _apply_request_reasoning_budget(self, req: Req) -> None:
++        thinking_budget = self._get_request_thinking_budget(req)
++        if thinking_budget is None:
++            return
++        if isinstance(req.grammar, ReasonerGrammarObject):
++            req.grammar.max_think_tokens = thinking_budget
++
+     def process_req_with_grammar(self, req: Req) -> bool:
+         # Init grammar cache for this request
+         add_to_grammar_queue = False
+@@ -103,6 +124,15 @@ class GrammarManager:
+                             f"Failed to compile {key[0]} grammar: {value.error_message}"
+                         )
+                         req.set_finish_with_abort(error_msg)
++                    else:
++                        self._apply_request_reasoning_budget(req)
++        elif self._enable_strict_thinking:
++            grammar_obj = self.grammar_backend.init_strict_reasoning_grammar(
++                req.require_reasoning
++            )
++            if grammar_obj is not None:
++                req.grammar = grammar_obj
++                self._apply_request_reasoning_budget(req)
+ 
+         if add_to_grammar_queue:
+             self.grammar_queue.append(req)
+@@ -177,8 +207,16 @@ class GrammarManager:
+                 continue
+ 
+             assert isinstance(req.grammar, futures.Future) and req.grammar_key
+-            req.grammar = req.grammar.result()
++            try:
++                req.grammar = req.grammar.result()
++            except Exception as e:
++                logger.error(
++                    f"Grammar compilation raised an exception: {e}, "
++                    f"grammar_key={req.grammar_key}"
++                )
++                req.grammar = InvalidGrammarObject(f"Grammar compilation failed: {e}")
+             self.grammar_backend.set_cache(req.grammar_key, req.grammar.copy())
++            self._apply_request_reasoning_budget(req)
+             if isinstance(req.grammar, InvalidGrammarObject):
+                 error_msg = f"Failed to compile {req.grammar_key[0]} grammar: {req.grammar.error_message}"
+                 req.set_finish_with_abort(error_msg)
+diff --git a/python/sglang/srt/constrained/reasoner_grammar_backend.py b/python/sglang/srt/constrained/reasoner_grammar_backend.py
+index d204bdd9ed..57d0f65d58 100644
+--- a/python/sglang/srt/constrained/reasoner_grammar_backend.py
++++ b/python/sglang/srt/constrained/reasoner_grammar_backend.py
+@@ -13,9 +13,14 @@
+ # ==============================================================================
+ """The baseclass of a backend for reasoner grammar-guided constrained decoding."""
+ 
+-from typing import List, Optional, Tuple
++import logging
++from typing import List, Optional, Tuple, Union
+ 
+ import torch
++from transformers import PreTrainedTokenizer, PreTrainedTokenizerFast
++
++from sglang.srt.environ import envs
++from sglang.srt.parser.reasoning_parser import ReasoningParser
+ 
+ from .base_grammar_backend import (
+     BaseGrammarBackend,
+@@ -23,102 +28,291 @@ from .base_grammar_backend import (
+     InvalidGrammarObject,
+ )
+ 
++logger = logging.getLogger(__name__)
++
+ 
+ class ReasonerGrammarObject(BaseGrammarObject):
+-    def __init__(self, grammar: BaseGrammarObject, think_end_id: int):
++    """Wraps a grammar object to handle reasoning (think/generation) phases.
++
++    State machine (must call maybe_init_reasoning before use):
++      THINKING (tokens_in_think >= 0, tokens_after_end == -1)
++        -> grammar not consulted, optional token filtering
++      GENERATION (tokens_after_end >= 0)
++        -> grammar consulted for accept/fill/rollback
++
++    When enable_token_filter=True (strict mode), fill_vocab_mask filters
++    excluded tokens during THINKING and enforces max_think_tokens budget.
++    When the budget is exhausted, only think_end_id is allowed, forcing the
++    model to exit the thinking phase.
++    When enable_token_filter=False (non-strict mode), fill_vocab_mask is
++    a no-op during THINKING.
++    """
++
++    def __init__(
++        self,
++        grammar: Optional[BaseGrammarObject],
++        think_end_id: int,
++        think_excluded_token_ids: Optional[List[int]] = None,
++        max_think_tokens: int = -1,
++        enable_token_filter: bool = False,
++        token_filter_fn=None,
++        allocate_vocab_mask_fn=None,
++        move_vocab_mask_fn=None,
++        apply_vocab_mask_fn=None,
++    ):
+         super().__init__()
+         self.grammar = grammar
+         self.think_end_id = think_end_id
+-        # -1    means thinking has not ended yet
+-        # 0     means just ended thinking in the last token
+-        # +     means number of tokens after thinking ended
+-        self.tokens_after_think_end = -1
++        self.think_excluded_token_ids = think_excluded_token_ids
++        self.max_think_tokens = max_think_tokens
++        self.enable_token_filter = enable_token_filter
++        self.token_filter_fn = token_filter_fn
++        self.allocate_vocab_mask_fn = allocate_vocab_mask_fn
++        self.move_vocab_mask_fn = move_vocab_mask_fn
++        self.apply_vocab_mask_fn = apply_vocab_mask_fn
++        self._think_end_id_list = [think_end_id]
++
++        self.tokens_in_think = -1
++        self.tokens_after_end = -1
+ 
+     def maybe_init_reasoning(self, reasoning: bool):
+-        self.tokens_after_think_end = -1 if reasoning else 0
++        if reasoning:
++            self.tokens_in_think = 0
++        else:
++            self.tokens_in_think = -1
++            self.tokens_after_end = 0
++
++    def _is_thinking(self):
++        return self.tokens_in_think >= 0 and self.tokens_after_end == -1
+ 
+-    def transfer_state(self, token: int) -> int:
+-        if self.tokens_after_think_end == -1 and token == self.think_end_id:
+-            self.tokens_after_think_end = 0
+-        elif self.tokens_after_think_end >= 0:
+-            self.tokens_after_think_end += 1
++    def _is_generation(self):
++        return self.tokens_after_end >= 0
++
++    def transfer_state(self, token: int) -> None:
++        if self._is_thinking():
++            if token == self.think_end_id:
++                self.tokens_after_end = 0
++            else:
++                self.tokens_in_think += 1
++        elif self._is_generation():
++            self.tokens_after_end += 1
+ 
+     def rollback_state(self):
+-        if self.tokens_after_think_end == 0:
+-            self.tokens_after_think_end = -1
+-        elif self.tokens_after_think_end > 0:
+-            self.tokens_after_think_end -= 1
++        if self._is_thinking():
++            if self.tokens_in_think > 0:
++                self.tokens_in_think -= 1
++        elif self._is_generation():
++            if self.tokens_after_end == 0:
++                self.tokens_after_end = -1
++            elif self.tokens_after_end > 0:
++                self.tokens_after_end -= 1
+ 
+     def accept_token(self, token: int):
+-        if self.tokens_after_think_end >= 0:
++        if self._is_generation() and self.grammar is not None:
+             self.grammar.accept_token(token)
+         self.transfer_state(token)
+ 
+     def is_terminated(self):
+-        return self.grammar.is_terminated()
++        if self.grammar is not None:
++            return self.grammar.is_terminated()
++        return False
+ 
+     def rollback(self, k):
+-        steps_after_think = min(k, self.tokens_after_think_end)
+-        if steps_after_think > 0:
+-            self.grammar.rollback(steps_after_think)
+-
++        if self.grammar is not None:
++            steps_after = min(k, max(0, self.tokens_after_end))
++            if steps_after > 0:
++                self.grammar.rollback(steps_after)
+         for _ in range(k):
+             self.rollback_state()
+ 
+-    def allocate_vocab_mask(
+-        self, vocab_size: int, batch_size: int, device
+-    ) -> torch.Tensor:
+-        return self.grammar.allocate_vocab_mask(vocab_size, batch_size, device)
++    def _can_think_more(self):
++        return self.max_think_tokens < 0 or self.tokens_in_think < self.max_think_tokens
++
++    def _do_token_filter(self, vocab_mask, token_ids, idx, is_allowed=True):
++        if self.token_filter_fn is not None:
++            self.token_filter_fn(vocab_mask, token_ids, idx, is_allowed)
+ 
+     def fill_vocab_mask(self, vocab_mask: torch.Tensor, idx: int) -> None:
+-        if self.tokens_after_think_end >= 0:
++        if self._is_thinking():
++            if not self.enable_token_filter:
++                return
++            if self._can_think_more():
++                self._do_token_filter(
++                    vocab_mask, self.think_excluded_token_ids, idx, is_allowed=False
++                )
++            else:
++                self._do_token_filter(
++                    vocab_mask, self._think_end_id_list, idx, is_allowed=True
++                )
++            return
++        if self._is_generation() and self.grammar is not None:
+             self.grammar.fill_vocab_mask(vocab_mask, idx)
+ 
+-    def move_vocab_mask(self, vocab_mask: torch.Tensor, device) -> torch.Tensor:
+-        return self.grammar.move_vocab_mask(vocab_mask, device)
++    def allocate_vocab_mask(self, vocab_size, batch_size, device):
++        if self.grammar is not None:
++            return self.grammar.allocate_vocab_mask(vocab_size, batch_size, device)
++        if self.allocate_vocab_mask_fn is not None:
++            return self.allocate_vocab_mask_fn(vocab_size, batch_size, device)
++        return None
++
++    def move_vocab_mask(self, vocab_mask, device):
++        if self.grammar is not None:
++            return self.grammar.move_vocab_mask(vocab_mask, device)
++        if self.move_vocab_mask_fn is not None:
++            return self.move_vocab_mask_fn(vocab_mask, device)
++        return vocab_mask
+ 
+     @property
+     def apply_vocab_mask(self):
+-        return self.grammar.apply_vocab_mask
++        if self.grammar is not None:
++            return self.grammar.apply_vocab_mask
++        return self.apply_vocab_mask_fn
+ 
+-    def copy(self) -> BaseGrammarObject:
+-        return ReasonerGrammarObject(self.grammar.copy(), self.think_end_id)
++    def copy(self):
++        new_obj = ReasonerGrammarObject(
++            self.grammar.copy() if self.grammar is not None else None,
++            self.think_end_id,
++            self.think_excluded_token_ids,
++            self.max_think_tokens,
++            self.enable_token_filter,
++            self.token_filter_fn,
++            self.allocate_vocab_mask_fn,
++            self.move_vocab_mask_fn,
++            self.apply_vocab_mask_fn,
++        )
++        new_obj.tokens_in_think = self.tokens_in_think
++        new_obj.tokens_after_end = self.tokens_after_end
++        new_obj._finished = self._finished
++        return new_obj
+ 
+     @property
+     def finished(self):
+-        return self.grammar.finished
++        if self.grammar is not None:
++            return self.grammar.finished
++        return self._finished
+ 
+     @finished.setter
+     def finished(self, finished):
+-        self.grammar.finished = finished
++        if self.grammar is not None:
++            self.grammar.finished = finished
++        else:
++            self._finished = finished
+ 
+     def try_jump_forward(self, tokenizer):
+-        return self.grammar.try_jump_forward(tokenizer)
++        if self.grammar is not None:
++            return self.grammar.try_jump_forward(tokenizer)
++        return None
+ 
+     def jump_forward_str_state(self, helper):
+-        return self.grammar.jump_forward_str_state(helper)
++        if self.grammar is not None:
++            return self.grammar.jump_forward_str_state(helper)
++        return None
+ 
+-    def jump_and_retokenize(
+-        self, old_output_ids: List[int], new_output_ids: List[int], next_state: int
+-    ):
+-        return self.grammar.jump_and_retokenize(
+-            old_output_ids, new_output_ids, next_state
+-        )
++    def jump_and_retokenize(self, old_output_ids, new_output_ids, next_state):
++        if self.grammar is not None:
++            return self.grammar.jump_and_retokenize(
++                old_output_ids, new_output_ids, next_state
++            )
+ 
+ 
+ class ReasonerGrammarBackend(BaseGrammarBackend):
+-    def __init__(self, grammar_backend: BaseGrammarBackend, think_end_id):
++    def __init__(
++        self,
++        grammar_backend: BaseGrammarBackend,
++        reasoning_parser: ReasoningParser,
++        tokenizer: Union[PreTrainedTokenizer, PreTrainedTokenizerFast],
++        enable_strict_thinking: bool = False,
++    ):
+         super().__init__()
+         self.grammar_backend = grammar_backend
+-        self.think_end_id = think_end_id
++        think_end_ids = tokenizer.encode(
++            reasoning_parser.detector.think_end_token, add_special_tokens=False
++        )
++        if not think_end_ids:
++            raise ValueError(
++                f"think_end_token '{reasoning_parser.detector.think_end_token}' "
++                f"could not be encoded by the tokenizer."
++            )
++        if len(think_end_ids) != 1:
++            raise ValueError(
++                f"think_end_token '{reasoning_parser.detector.think_end_token}' "
++                "must encode to exactly one token for constrained reasoning."
++            )
++        self.think_end_id = think_end_ids[0]
++        self._enable_strict_thinking = enable_strict_thinking
++        self.think_excluded_token_ids = self._get_think_excluded_token_ids(
++            reasoning_parser, tokenizer
++        )
++        self.max_think_tokens = envs.SGLANG_MAX_THINK_TOKENS.get()
++        if (
++            self.enable_strict_thinking
++            and self.think_excluded_token_ids is not None
++            and not self.grammar_backend.is_support_token_filter
++        ):
++            raise ValueError(
++                "Strict reasoning format requested but the grammar backend does not "
++                "support token filtering. Use a grammar backend that supports token "
++                "filtering (e.g., xgrammar) or disable strict reasoning mode."
++            )
++        self.enable_token_filter = (
++            self.enable_strict_thinking
++            and self.think_excluded_token_ids is not None
++            and self.grammar_backend.is_support_token_filter
++        )
++        self._token_filter_fn = (
++            self.grammar_backend.set_token_filter if self.enable_token_filter else None
++        )
++
++    def _get_think_excluded_token_ids(
++        self,
++        reasoning_parser: ReasoningParser,
++        tokenizer: Union[PreTrainedTokenizer, PreTrainedTokenizerFast],
++    ) -> Optional[List[int]]:
++        excluded_ids = []
++        if (not self.enable_strict_thinking) or (
++            not reasoning_parser.detector.think_excluded_tokens
++        ):
++            return None
++        for token in reasoning_parser.detector.think_excluded_tokens:
++            new_ids = tokenizer.encode(token, add_special_tokens=False)
++            if not new_ids:
++                raise ValueError(
++                    f"think_excluded_token '{token}' could not be encoded by the "
++                    f"tokenizer. All excluded tokens must be encodable for strict "
++                    f"reasoning mode to function correctly."
++                )
++            excluded_ids += new_ids
++        return excluded_ids
++
++    def _make_grammar_object(
++        self, grammar: Optional[BaseGrammarObject], reasoning: bool
++    ) -> ReasonerGrammarObject:
++        obj = ReasonerGrammarObject(
++            grammar=grammar,
++            think_end_id=self.think_end_id,
++            think_excluded_token_ids=self.think_excluded_token_ids,
++            max_think_tokens=self.max_think_tokens,
++            enable_token_filter=self.enable_token_filter,
++            token_filter_fn=self._token_filter_fn,
++            allocate_vocab_mask_fn=self.grammar_backend.allocate_vocab_mask,
++            move_vocab_mask_fn=self.grammar_backend.move_vocab_mask,
++            apply_vocab_mask_fn=self.grammar_backend.apply_vocab_mask,
++        )
++        obj.maybe_init_reasoning(reasoning)
++        return obj
++
++    def init_strict_reasoning_grammar(
++        self, reasoning: bool
++    ) -> Optional[BaseGrammarObject]:
++        """Create a grammar object for strict token filtering only (no inner grammar)."""
++        if not self.enable_strict_thinking:
++            return None
++        return self._make_grammar_object(None, reasoning)
+ 
+     def _init_value_dispatch(
+         self, key: Tuple[str, str], reasoning: bool
+     ) -> Optional[BaseGrammarObject]:
+         ret = self.grammar_backend._init_value_dispatch(key, reasoning)
+-        # avoid wrapping invalid grammar, so that the scheduler can detect it
+         if ret is None or isinstance(ret, InvalidGrammarObject):
+             return ret
+-        obj = ReasonerGrammarObject(ret, self.think_end_id)
+-        obj.maybe_init_reasoning(reasoning)
+-        return obj
++        return self._make_grammar_object(ret, reasoning)
+diff --git a/python/sglang/srt/constrained/torch_ops/token_filter_torch_ops.py b/python/sglang/srt/constrained/torch_ops/token_filter_torch_ops.py
+new file mode 100644
+index 0000000000..f12d62b46f
+--- /dev/null
++++ b/python/sglang/srt/constrained/torch_ops/token_filter_torch_ops.py
+@@ -0,0 +1,63 @@
++# Copyright 2026 SGLang Team
++# Licensed under the Apache License, Version 2.0 (the "License");
++# you may not use this file except in compliance with the License.
++# You may obtain a copy of the License at
++#
++#     http://www.apache.org/licenses/LICENSE-2.0
++#
++# Unless required by applicable law or agreed to in writing, software
++# distributed under the License is distributed on an "AS IS" BASIS,
++# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
++# See the License for the specific language governing permissions and
++# limitations under the License.
++# ==============================================================================
++"""Torch fallback for token filter operations (non-CUDA devices and HIP).
++
++Sets or clears specific bits in an int32 bitmask by token ID.  The token list
++is typically tiny (< 10 entries); aggregation is done in Python with the actual
++bitmask operations using torch tensor indexing.
++"""
++
++import ctypes
++from typing import List
++
++import torch
++
++
++def set_token_filter_torch(
++    vocab_mask: torch.Tensor,
++    token_ids: List[int],
++    batch_idx: int,
++    is_allowed: bool = True,
++    reset_vocab_mask: bool = True,
++):
++    if reset_vocab_mask:
++        vocab_mask[batch_idx].fill_(-1 if (not is_allowed) else 0)
++
++    if not token_ids:
++        return
++
++    # Aggregate bit masks per int32 element to handle duplicate indices.
++    aggregated: dict[int, int] = {}
++    for token_id in token_ids:
++        element_idx = token_id // 32
++        bit_idx = token_id % 32
++        aggregated[element_idx] = aggregated.get(element_idx, 0) | (1 << bit_idx)
++
++    row = vocab_mask[batch_idx]
++    element_indices = torch.tensor(
++        list(aggregated.keys()), dtype=torch.long, device=row.device
++    )
++    bitmasks = torch.tensor(
++        [
++            ctypes.c_int32(mask if is_allowed else ~mask).value
++            for mask in aggregated.values()
++        ],
++        dtype=row.dtype,
++        device=row.device,
++    )
++
++    if is_allowed:
++        row[element_indices] = torch.bitwise_or(row[element_indices], bitmasks)
++    else:
++        row[element_indices] = torch.bitwise_and(row[element_indices], bitmasks)
+diff --git a/python/sglang/srt/constrained/triton_ops/token_filter_ops.py b/python/sglang/srt/constrained/triton_ops/token_filter_ops.py
+new file mode 100644
+index 0000000000..f8d6b6cfc6
+--- /dev/null
++++ b/python/sglang/srt/constrained/triton_ops/token_filter_ops.py
+@@ -0,0 +1,175 @@
++# Copyright 2026 SGLang Team
++# Licensed under the Apache License, Version 2.0 (the "License");
++# you may not use this file except in compliance with the License.
++# You may obtain a copy of the License at
++#
++#     http://www.apache.org/licenses/LICENSE-2.0
++#
++# Unless required by applicable law or agreed to in writing, software
++# distributed under the License is distributed on an "AS IS" BASIS,
++# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
++# See the License for the specific language governing permissions and
++# limitations under the License.
++# ==============================================================================
++"""Triton kernels for token filter operations."""
++
++from collections import OrderedDict
++from typing import List
++
++import torch
++import triton
++import triton.language as tl
++
++from sglang.srt.utils import get_device_core_count
++
++
++@triton.jit
++def reset_vocab_mask_kernel(
++    vocab_mask_ptr,
++    batch_idx: int,
++    num_elements: int,
++    reset_value: tl.constexpr,
++):
++    """Reset the vocab mask for a specific batch index to a given value.
++
++    Parameters
++    ----------
++    vocab_mask_ptr : tl.tensor
++        Pointer to the vocab mask tensor.
++
++    batch_idx : int
++        The batch index to reset.
++
++    num_elements : int
++        Number of int32 elements in the vocab mask for each batch.
++
++    reset_value : int
++        The value to reset the vocab mask to (typically -1 or 0).
++    """
++    pid = tl.program_id(0)
++    num_threads = tl.num_programs(0)
++
++    for i in tl.range(pid, num_elements, num_threads):
++        offset = batch_idx * num_elements + i
++        tl.store(vocab_mask_ptr + offset, reset_value)
++
++
++@triton.jit
++def set_token_filter_batch_kernel(
++    vocab_mask_ptr,
++    token_ids_ptr,
++    batch_idx: int,
++    num_tokens: int,
++    num_elements: int,
++    is_allowed: tl.constexpr,
++):
++    """Set or clear specific tokens in the vocab mask for a batch.
++
++    Each token ID maps to a specific bit in the int32 bitmask array.
++    The kernel sets or clears those bits using atomic operations.
++
++    Parameters
++    ----------
++    vocab_mask_ptr : tl.tensor
++        Pointer to the vocab mask tensor.
++
++    token_ids_ptr : tl.tensor
++        Pointer to the token IDs to set/clear.
++
++    batch_idx : int
++        The batch index to modify.
++
++    num_tokens : int
++        Number of tokens to process.
++
++    num_elements : int
++        Number of int32 elements in the vocab mask for each batch.
++
++    is_allowed : bool
++        If True, set the bit to 1 (allow token).
++        If False, clear the bit to 0 (block token).
++    """
++    pid = tl.program_id(0)
++    num_threads = tl.num_programs(0)
++
++    for i in tl.range(pid, num_tokens, num_threads):
++        token_id = tl.load(token_ids_ptr + i)
++        element_idx = token_id // 32
++        bit_idx = token_id % 32
++
++        offset = batch_idx * num_elements + element_idx
++
++        if is_allowed:
++            tl.atomic_or(vocab_mask_ptr + offset, 1 << bit_idx)
++        else:
++            tl.atomic_and(vocab_mask_ptr + offset, ~(1 << bit_idx))
++
++
++_cached_num_sms = None
++_cached_token_id_tensors: OrderedDict[tuple[int, tuple[int, ...]], torch.Tensor] = (
++    OrderedDict()
++)
++_MAX_TOKEN_ID_TENSOR_CACHE_SIZE = 32
++
++
++def _compute_grid(work_items: int):
++    global _cached_num_sms
++    if _cached_num_sms is None:
++        _cached_num_sms = get_device_core_count()
++    if _cached_num_sms > 0:
++        return (min(_cached_num_sms, work_items),)
++    return (work_items,)
++
++
++def _get_cached_token_ids_tensor(
++    token_ids: List[int], device: torch.device
++) -> torch.Tensor:
++    key = (device.index or 0, tuple(token_ids))
++    cached = _cached_token_id_tensors.get(key)
++    if cached is not None:
++        _cached_token_id_tensors.move_to_end(key)
++        return cached
++
++    token_ids_tensor = torch.tensor(token_ids, dtype=torch.int32, device=device)
++    _cached_token_id_tensors[key] = token_ids_tensor
++    if len(_cached_token_id_tensors) > _MAX_TOKEN_ID_TENSOR_CACHE_SIZE:
++        _cached_token_id_tensors.popitem(last=False)
++    return token_ids_tensor
++
++
++def set_token_filter_triton(
++    vocab_mask: torch.Tensor,
++    token_ids: List[int],
++    batch_idx: int,
++    is_allowed: bool = True,
++    reset_vocab_mask: bool = True,
++):
++    """Set or clear specific tokens in the vocab mask using Triton."""
++    assert vocab_mask.device.type == "cuda"
++
++    num_elements = vocab_mask.shape[1]
++
++    if reset_vocab_mask:
++        reset_value = 0 if is_allowed else -1
++        reset_vocab_mask_kernel[_compute_grid(num_elements)](
++            vocab_mask,
++            batch_idx,
++            num_elements,
++            reset_value,
++            num_warps=4,
++        )
++
++    if not token_ids:
++        return
++
++    num_tokens = len(token_ids)
++    token_ids_tensor = _get_cached_token_ids_tensor(token_ids, vocab_mask.device)
++    set_token_filter_batch_kernel[_compute_grid(num_tokens)](
++        vocab_mask,
++        token_ids_tensor,
++        batch_idx,
++        num_tokens,
++        num_elements,
++        is_allowed,
++        num_warps=4,
++    )
+diff --git a/python/sglang/srt/constrained/xgrammar_backend.py b/python/sglang/srt/constrained/xgrammar_backend.py
+index 0e9e586220..df0c5cf943 100644
+--- a/python/sglang/srt/constrained/xgrammar_backend.py
++++ b/python/sglang/srt/constrained/xgrammar_backend.py
+@@ -23,6 +23,7 @@ from xgrammar import (
+     CompiledGrammar,
+     GrammarCompiler,
+     GrammarMatcher,
++    StructuralTag,
+     StructuralTagItem,
+     TokenizerInfo,
+     allocate_token_bitmask,
+@@ -45,6 +46,10 @@ else:
+         apply_token_bitmask_inplace_triton,
+     )
+ 
++from sglang.srt.constrained.torch_ops.token_filter_torch_ops import (
++    set_token_filter_torch,
++)
++from sglang.srt.constrained.triton_ops.token_filter_ops import set_token_filter_triton
+ 
+ logger = logging.getLogger(__name__)
+ MAX_ROLLBACK_TOKENS = 200
+@@ -58,7 +63,7 @@ class XGrammarGrammar(BaseGrammarObject):
+         vocab_size: int,
+         ctx: CompiledGrammar,
+         override_stop_tokens: Optional[Union[List[int], int]],
+-        key_string: Optional[str] = None,  # TODO (sk): for debugging, remove later
++        key_string: Optional[str] = None,
+         grammar_stats: Optional[GrammarStats] = GrammarStats(),
+     ) -> None:
+         super().__init__()
+@@ -156,7 +161,14 @@ class XGrammarGrammar(BaseGrammarObject):
+             self.matcher.rollback(len(old_output_ids) - k)
+ 
+         for i in range(k, len(new_output_ids)):
+-            assert self.matcher.accept_token(new_output_ids[i])
++            if not self.matcher.accept_token(new_output_ids[i]):
++                raise ValueError(
++                    f"Token not accepted during retokenization: {new_output_ids[i]} "
++                    f"at position {i}\n"
++                    f"Old output IDs: {old_output_ids}\n"
++                    f"New output IDs: {new_output_ids}\n"
++                    f"Key string: {self.key_string}"
++                )
+ 
+     def __repr__(self):
+         return f"XGrammarGrammar({self.key_string=}, {self.accepted_tokens=}, {self.current_token=})"
+@@ -205,6 +217,53 @@ class XGrammarGrammarBackend(BaseGrammarBackend):
+         self.override_stop_tokens = override_stop_tokens
+         self.any_whitespace = any_whitespace
+ 
++    @property
++    def is_support_token_filter(self):
++        return True
++
++    @staticmethod
++    def allocate_vocab_mask(vocab_size: int, batch_size: int, device) -> torch.Tensor:
++        return allocate_token_bitmask(batch_size, vocab_size)
++
++    @staticmethod
++    def move_vocab_mask(vocab_mask: torch.Tensor, device) -> torch.Tensor:
++        return vocab_mask.to(device, non_blocking=True)
++
++    @staticmethod
++    def apply_vocab_mask(logits: torch.Tensor, vocab_mask: torch.Tensor) -> None:
++        if logits.device.type in {"cuda", "npu", "xpu", "musa"}:
++            if _is_hip:
++                apply_token_bitmask_inplace_cuda(logits, vocab_mask)
++            else:
++                apply_token_bitmask_inplace_triton(logits, vocab_mask)
++        else:
++            raise RuntimeError(f"Unsupported device: {logits.device.type}")
++
++    @staticmethod
++    def set_token_filter(
++        vocab_mask: torch.Tensor,
++        token_ids: List[int],
++        batch_idx: int,
++        is_allowed: bool = True,
++        reset_vocab_mask: bool = True,
++    ):
++        if _is_hip or (vocab_mask.device.type != "cuda"):
++            set_token_filter_torch(
++                vocab_mask,
++                token_ids,
++                batch_idx,
++                is_allowed=is_allowed,
++                reset_vocab_mask=reset_vocab_mask,
++            )
++        else:
++            set_token_filter_triton(
++                vocab_mask,
++                token_ids,
++                batch_idx,
++                is_allowed=is_allowed,
++                reset_vocab_mask=reset_vocab_mask,
++            )
++
+     @staticmethod
+     def _sanitize_structural_format(structural_format):
+         """Recursively replace missing json_schema fields with an empty schema."""
+@@ -295,9 +354,11 @@ class XGrammarGrammarBackend(BaseGrammarBackend):
+                     )
+                     for structure in structural_tag["structures"]
+                 ]
+-                ctx = self.grammar_compiler.compile_structural_tag(
++                new_tag = StructuralTag.from_legacy_structural_tag(
+                     tags, structural_tag["triggers"]
+                 )
++                new_tag.format.at_least_one = structural_tag.get("at_least_one", False)
++                ctx = self.grammar_compiler.compile_structural_tag(new_tag)
+             else:
+                 format_dict = structural_tag.get("format")
+                 if isinstance(format_dict, dict):
+diff --git a/python/sglang/srt/disaggregation/decode.py b/python/sglang/srt/disaggregation/decode.py
+index ccf842ac00..d6860a4de8 100644
+--- a/python/sglang/srt/disaggregation/decode.py
++++ b/python/sglang/srt/disaggregation/decode.py
+@@ -212,7 +212,7 @@ class HybridMambaDecodeReqToTokenPool(HybridReqToTokenPool):
+         self.start_layer = start_layer if start_layer is not None else 0
+         self.layer_transfer_counter = None
+         self._init_mamba_pool(
+-            size=effective_mamba_size,
++            mamba_size=effective_mamba_size,
+             mamba_spec_state_size=size + pre_alloc_size,
+             cache_params=cache_params,
+             mamba_layer_ids=mamba_layer_ids,
+diff --git a/python/sglang/srt/entrypoints/harmony_utils.py b/python/sglang/srt/entrypoints/harmony_utils.py
+index 86d4356dc8..33bd887838 100644
+--- a/python/sglang/srt/entrypoints/harmony_utils.py
++++ b/python/sglang/srt/entrypoints/harmony_utils.py
+@@ -3,6 +3,7 @@
+ # Adapted from vLLM: https://github.com/vllm-project/vllm/blob/1b9902806915040ac9b3029f2ab7522ec505afc3/vllm/entrypoints/harmony_utils.py
+ # Slight differences in processing chat messages
+ import datetime
++import logging
+ from collections.abc import Iterable
+ from typing import Literal, Optional, Union
+ 
+@@ -42,6 +43,8 @@ from openai_harmony import (
+ from sglang.srt.entrypoints.openai.protocol import ResponseInputOutputItem
+ from sglang.srt.utils import random_uuid
+ 
++logger = logging.getLogger(__name__)
++
+ REASONING_EFFORT = {
+     "high": ReasoningEffort.HIGH,
+     "medium": ReasoningEffort.MEDIUM,
+@@ -92,13 +95,22 @@ def get_developer_message(
+     if tools is not None:
+         function_tools = []
+         for tool in tools:
+-            if tool.type in ("web_search_preview", "code_interpreter"):
++            if tool.type in (
++                "web_search",
++                "web_search_preview",
++                "code_interpreter",
++            ):
+                 # These are built-in tools that are added to the system message.
+                 pass
+             elif tool.type == "function":
+                 function_tools.append(tool)
+             else:
+-                raise ValueError(f"tool type {tool.type} not supported")
++                # No harmony prompt template for the remaining built-ins;
++                # drop them so the request still runs.
++                logger.debug(
++                    "harmony: ignoring unsupported response tool type %r",
++                    tool.type,
++                )
+         if function_tools:
+             function_tool_descriptions = [
+                 ToolDescription.new(
+@@ -139,7 +151,16 @@ def parse_response_input(
+         if isinstance(content, str):
+             msg = Message.from_role_and_content(role, text_prefix + content)
+         else:
+-            contents = [TextContent(text=text_prefix + c["text"]) for c in content]
++            # Filter to text parts first, then enumerate, so the surviving first
++            # text chunk always carries the system→developer text_prefix even if
++            # earlier parts were non-text (image/audio) and got dropped.
++            text_chunks = [
++                c for c in content if c.get("type") in ("text", "input_text")
++            ]
++            contents = [
++                TextContent(text=(text_prefix if i == 0 else "") + c.get("text", ""))
++                for i, c in enumerate(text_chunks)
++            ]
+             msg = Message.from_role_and_contents(role, contents)
+     elif response_msg["type"] == "function_call_output":
+         call_id = response_msg["call_id"]
+diff --git a/python/sglang/srt/entrypoints/http_server.py b/python/sglang/srt/entrypoints/http_server.py
+index c460141c32..815cccb16a 100644
+--- a/python/sglang/srt/entrypoints/http_server.py
++++ b/python/sglang/srt/entrypoints/http_server.py
+@@ -1649,12 +1649,11 @@ async def v1_score_request(request: ScoringRequest, raw_request: Request):
+ 
+ 
+ @app.post("/v1/responses", dependencies=[Depends(validate_json_request)])
+-async def v1_responses_request(request: dict, raw_request: Request):
++async def v1_responses_request(request: ResponsesRequest, raw_request: Request):
+     """Endpoint for the responses API with reasoning support."""
+ 
+-    request_obj = ResponsesRequest(**request)
+     result = await raw_request.app.state.openai_serving_responses.create_responses(
+-        request_obj, raw_request
++        request, raw_request
+     )
+ 
+     # Handle streaming responses
+diff --git a/python/sglang/srt/entrypoints/openai/protocol.py b/python/sglang/srt/entrypoints/openai/protocol.py
+index 165850075d..e4a2579d54 100644
+--- a/python/sglang/srt/entrypoints/openai/protocol.py
++++ b/python/sglang/srt/entrypoints/openai/protocol.py
+@@ -166,6 +166,7 @@ class LegacyStructuralTagResponseFormat(BaseModel):
+     type: Literal["structural_tag"]
+     structures: List[StructuresResponseFormat]
+     triggers: List[str]
++    at_least_one: bool = False
+ 
+ 
+ StructuralTagResponseFormat: TypeAlias = Union[
+@@ -1140,14 +1141,46 @@ class ResponseReasoningParam(BaseModel):
+         default="medium",
+         description="Constrains effort on reasoning for reasoning models.",
+     )
++    summary: Optional[Literal["auto", "concise", "detailed"]] = Field(
++        default=None,
++        description="Include a summary of the model's reasoning trace on the response.",
++    )
++
++
++# Only ``function`` / ``web_search*`` / ``code_interpreter`` are wired to
++# execution paths; the rest pass validation so clients aren't rejected.
++RESPONSE_TOOL_TYPES = Literal[
++    "function",
++    "web_search",
++    "web_search_preview",
++    "code_interpreter",
++    "file_search",
++    "image_generation",
++    "computer_use_preview",
++    "local_shell",
++    "mcp",
++    "custom",
++    "namespace",
++    "tool_search",
++]
+ 
+ 
+ class ResponseTool(BaseModel):
+     """Tool definition for responses."""
+ 
+-    type: Literal["web_search_preview", "code_interpreter"] = Field(
+-        description="Type of tool to enable"
+-    )
++    type: RESPONSE_TOOL_TYPES = Field(description="Type of tool to enable")
++    name: Optional[str] = None
++    description: Optional[str] = None
++    parameters: Optional[Dict[str, Any]] = None
++    strict: bool = False
++    # Inner schemas for ``namespace`` tools.
++    tools: Optional[List[Dict[str, Any]]] = None
++
++    @model_validator(mode="after")
++    def validate_function_tool(self) -> "ResponseTool":
++        if self.type == "function" and not self.name:
++            raise ValueError("Function tools must include a name.")
++        return self
+ 
+ 
+ ResponseInputOutputItem: TypeAlias = Union[
+@@ -1174,7 +1207,9 @@ class ResponsesRequest(BaseModel):
+             ]
+         ]
+     ] = None
+-    input: Union[str, List[ResponseInputOutputItem]]
++    # Accept dict-shaped items as the loose arm; downstream normalization
++    # handles replayed shapes that don't satisfy every openai TypedDict.
++    input: Union[str, List[ResponseInputOutputItem], List[Dict[str, Any]]]
+     instructions: Optional[str] = None
+     max_output_tokens: Optional[int] = None
+     max_tool_calls: Optional[int] = None
+@@ -1208,13 +1243,13 @@ class ResponsesRequest(BaseModel):
+         default=None, description="Cache salt for request caching"
+     )
+ 
+-    # SGLang-specific sampling parameters
++    # SGLang sampling extras. ``None`` defers to ``--preferred-sampling-params``.
+     frequency_penalty: float = 0.0
+     presence_penalty: float = 0.0
+     stop: Optional[Union[str, List[str]]] = None
+-    top_k: int = -1
+-    min_p: float = 0.0
+-    repetition_penalty: float = 1.0
++    top_k: Optional[int] = None
++    min_p: Optional[float] = None
++    repetition_penalty: Optional[float] = None
+ 
+     # Default sampling parameters
+     _DEFAULT_SAMPLING_PARAMS = {
+@@ -1225,8 +1260,57 @@ class ResponsesRequest(BaseModel):
+         "repetition_penalty": 1.0,
+     }
+ 
++    @model_validator(mode="before")
++    @classmethod
++    def normalize_responses_input(cls, values):
++        if not isinstance(values, dict):
++            return values
++
++        input_value = values.get("input")
++        if not isinstance(input_value, list):
++            return values
++
++        values = values.copy()
++        values["input"] = [
++            cls._normalize_input_item_for_validation(item) for item in input_value
++        ]
++        return values
++
++    @staticmethod
++    def _normalize_input_item_for_validation(item):
++        if not isinstance(item, dict):
++            return item
++
++        content = item.get("content")
++        if not isinstance(content, list):
++            return item
++
++        item = item.copy()
++        item["content"] = [
++            ResponsesRequest._normalize_content_part_for_validation(part)
++            for part in content
++        ]
++        return item
++
++    @staticmethod
++    def _normalize_content_part_for_validation(part):
++        if not isinstance(part, dict):
++            return part
++
++        part_type = part.get("type")
++        if part_type != "input_image" or part.get("detail") is not None:
++            return part
++
++        part = part.copy()
++        part["detail"] = "auto"
++        return part
++
+     def to_sampling_params(
+-        self, default_max_tokens: int, default_params: Optional[Dict] = None
++        self,
++        default_max_tokens: int,
++        default_params: Optional[Dict] = None,
++        stop: Optional[Union[str, List[str]]] = None,
++        tool_call_constraint: Optional[ToolCallConstraint] = None,
+     ) -> Dict[str, Any]:
+         """Convert to sampling parameters for generation."""
+         if default_params is None:
+@@ -1238,10 +1322,9 @@ class ResponsesRequest(BaseModel):
+         else:
+             max_tokens = default_max_tokens
+ 
+-        # Avoid exceed the context length by minus 2 token
++        # Headroom for BOS/EOS the engine appends on top of prompt+budget.
+         max_tokens -= 2
+ 
+-        # Get parameters with defaults
+         temperature = self.temperature
+         if temperature is None:
+             temperature = default_params.get(
+@@ -1252,23 +1335,51 @@ class ResponsesRequest(BaseModel):
+         if top_p is None:
+             top_p = default_params.get("top_p", self._DEFAULT_SAMPLING_PARAMS["top_p"])
+ 
+-        params = {
++        # Omit None entries so they fall through to ``--preferred-sampling-params``
++        # rather than overriding it with a literal default.
++        params: dict[str, Any] = {
+             "max_new_tokens": max_tokens,
+             "temperature": temperature,
+             "top_p": top_p,
+             "frequency_penalty": self.frequency_penalty,
+             "presence_penalty": self.presence_penalty,
+-            "stop": self.stop,
+-            "top_k": self.top_k,
+-            "min_p": self.min_p,
+-            "repetition_penalty": self.repetition_penalty,
++            "stop": self.stop if stop is None else stop,
+         }
++        if self.top_k is not None:
++            params["top_k"] = self.top_k
++        if self.min_p is not None:
++            params["min_p"] = self.min_p
++        if self.repetition_penalty is not None:
++            params["repetition_penalty"] = self.repetition_penalty
+ 
+         # Apply any additional default parameters
+         for key, value in default_params.items():
+             if key not in params or params[key] is None:
+                 params[key] = value
+ 
++        has_existing_constraints = (
++            params.get("regex")
++            or params.get("ebnf")
++            or params.get("structural_tag")
++            or params.get("json_schema")
++        )
++        if tool_call_constraint and has_existing_constraints:
++            # Refuse rather than silently drop the tool-call grammar.
++            raise ValueError(
++                "Cannot combine tool calls with constrained decoding "
++                "(regex / ebnf / structural_tag / json_schema). Remove one."
++            )
++        if tool_call_constraint:
++            constraint_type, constraint_value = tool_call_constraint
++            if constraint_type in ("structural_tag", "json_schema"):
++                params[constraint_type] = convert_json_schema_to_str(
++                    constraint_value.model_dump(by_alias=True)
++                    if hasattr(constraint_value, "model_dump")
++                    else constraint_value
++                )
++            else:
++                params[constraint_type] = constraint_value
++
+         return params
+ 
+ 
+@@ -1371,7 +1482,11 @@ class ResponsesResponse(BaseModel):
+             output=output,
+             status=status,
+             usage=usage,
+-            parallel_tool_calls=request.parallel_tool_calls or True,
++            parallel_tool_calls=(
++                request.parallel_tool_calls
++                if request.parallel_tool_calls is not None
++                else True
++            ),
+             tool_choice=request.tool_choice,
+             tools=request.tools,
+             # fields for parity with v1/responses
+diff --git a/python/sglang/srt/entrypoints/openai/serving_chat.py b/python/sglang/srt/entrypoints/openai/serving_chat.py
+index 6bfd678f96..66088be961 100644
+--- a/python/sglang/srt/entrypoints/openai/serving_chat.py
++++ b/python/sglang/srt/entrypoints/openai/serving_chat.py
+@@ -47,7 +47,10 @@ from sglang.srt.entrypoints.openai.utils import (
+ from sglang.srt.function_call.core_types import ToolCallItem
+ from sglang.srt.function_call.function_call_parser import FunctionCallParser
+ from sglang.srt.function_call.json_array_parser import JsonArrayParser
+-from sglang.srt.function_call.utils import get_json_schema_constraint
++from sglang.srt.function_call.utils import (
++    get_json_schema_constraint,
++    normalize_json_schema_types,
++)
+ from sglang.srt.managers.io_struct import GenerateReqInput
+ from sglang.srt.parser.conversation import generate_chat_conv
+ from sglang.srt.parser.jinja_template_utils import process_content_for_template_format
+@@ -221,9 +224,19 @@ class OpenAIServingChat(OpenAIServingBase):
+             if tool.function.parameters is None:
+                 continue
+             try:
++                # Rewrite DB/ORM-style aliases (e.g. "varchar", "enum", "int")
++                # to standard JSON Schema types before validation. RecursionError
++                # guards against hand-crafted cyclic schemas so the request gets
++                # a 400 instead of crashing into a 500.
++                normalize_json_schema_types(tool.function.parameters)
+                 Draft202012Validator.check_schema(tool.function.parameters)
+             except SchemaError as e:
+                 return f"Tool {i} function has invalid 'parameters' schema: {str(e)}"
++            except RecursionError:
++                return (
++                    f"Tool {i} function 'parameters' schema is too deeply nested "
++                    "or contains a cycle."
++                )
+ 
+         max_output_tokens = request.max_completion_tokens or request.max_tokens
+         server_context_length = self.tokenizer_manager.server_args.context_length
+@@ -341,6 +354,13 @@ class OpenAIServingChat(OpenAIServingBase):
+ 
+         self._patch_mistral_skip_special_tokens(request)
+ 
++        thinking_mode = self._get_reasoning_from_request(request)
++        # SGLang's ReasonerGrammarBackend owns the reasoning prefix
++        # when --reasoning-parser is configured, so builtin xgrammar
++        # tags must describe only the post-reasoning tool-call suffix.
++        xgrammar_reasoning = thinking_mode and (
++            self.tokenizer_manager.server_args.reasoning_parser is not None
++        )
+         tool_call_constraint = None
+ 
+         # Apply chat template and its stop strings
+@@ -360,10 +380,13 @@ class OpenAIServingChat(OpenAIServingBase):
+                 tool_call_constraint = parser.get_structure_constraint(
+                     request.tool_choice,
+                     parallel_tool_calls=request.parallel_tool_calls,
++                    thinking_mode=xgrammar_reasoning,
+                 )
+-            # Handle JSON schema constraint directly for required or named tool choice
+-            if request.tool_choice == "required" or isinstance(
+-                request.tool_choice, ToolChoice
++            # Fallback: use generic JSON schema for required/named tool choice
++            # only when no parser-specific constraint was set
++            if tool_call_constraint is None and (
++                request.tool_choice == "required"
++                or isinstance(request.tool_choice, ToolChoice)
+             ):
+                 json_schema = get_json_schema_constraint(
+                     request.tools,
+@@ -1136,22 +1159,56 @@ class OpenAIServingChat(OpenAIServingBase):
+     ) -> ToolCallProcessingResult:
+         """Process tool calls in the response"""
+ 
+-        # Handle required or named tool choice
+-        if tool_choice == "required" or (
+-            isinstance(tool_choice, ToolChoice) and tool_choice.type == "function"
+-        ):
+-            # Set finish reason to tool_calls since we're processing tool calls
++        is_required = tool_choice == "required" or isinstance(tool_choice, ToolChoice)
++
++        # Try model-specific parser when output is in native format.
++        # For required/named: only use parser when structural_tag was used
++        # as constraint (mirrors the streaming path). For auto: always try.
++        if self.tool_call_parser:
++            parser = FunctionCallParser(tools, self.tool_call_parser)
++            should_try_parser = (
++                not is_required or parser.detector.supports_structural_tag()
++            )
++            if should_try_parser and parser.has_tool_call(text):
++                original_finish_type = finish_reason["type"]
++                if finish_reason["type"] == "stop":
++                    finish_reason["type"] = "tool_calls"
++                    finish_reason["matched"] = None
++                try:
++                    text, call_info_list = parser.parse_non_stream(text)
++                    tool_calls = []
++                    for call_info in call_info_list:
++                        tool_id = self._process_tool_call_id(
++                            call_info, history_tool_calls_cnt
++                        )
++                        tool_calls.append(
++                            ToolCall(
++                                id=tool_id,
++                                index=getattr(call_info, "tool_index", None),
++                                function=FunctionResponse(
++                                    name=call_info.name,
++                                    arguments=call_info.parameters,
++                                ),
++                            )
++                        )
++                    return ToolCallProcessingResult(tool_calls, text, finish_reason)
++                except Exception as e:
++                    logger.error(f"Tool call parsing error: {e}")
++                    finish_reason["type"] = original_finish_type
++                    return ToolCallProcessingResult(None, text, finish_reason)
++
++        # json_schema constraint → JSON array output for required/named
++        if is_required:
++            original_finish_type = finish_reason["type"]
+             if finish_reason["type"] == "stop":
+                 finish_reason["type"] = "tool_calls"
+                 finish_reason["matched"] = None
+             try:
+-                # For required tool choice, we expect a JSON array of tool calls
+                 tool_call_data = orjson.loads(text)
+                 tool_calls = []
+                 for i, tool in enumerate(tool_call_data):
+-                    # Create a ToolCallItem from the JSON data
+                     call_info = ToolCallItem(
+-                        tool_index=i,  # Use the loop index as tool_index
++                        tool_index=i,
+                         name=tool["name"],
+                         parameters=json.dumps(tool["parameters"], ensure_ascii=False),
+                     )
+@@ -1171,36 +1228,9 @@ class OpenAIServingChat(OpenAIServingBase):
+                         )
+                     )
+                 return ToolCallProcessingResult(tool_calls, "", finish_reason)
+-            except json.JSONDecodeError as e:
+-                logger.error(f"Tool call parsing error: {e}")
+-                return ToolCallProcessingResult(None, text, finish_reason)
+-
+-        # Use parser since output is not constrained by JSON schema
+-        parser = FunctionCallParser(tools, self.tool_call_parser)
+-        if parser.has_tool_call(text):
+-            if finish_reason["type"] == "stop":
+-                finish_reason["type"] = "tool_calls"
+-                finish_reason["matched"] = None
+-            try:
+-                text, call_info_list = parser.parse_non_stream(text)
+-                tool_calls = []
+-                for call_info in call_info_list:
+-                    tool_id = self._process_tool_call_id(
+-                        call_info, history_tool_calls_cnt
+-                    )
+-                    tool_calls.append(
+-                        ToolCall(
+-                            id=tool_id,
+-                            index=getattr(call_info, "tool_index", None),
+-                            function=FunctionResponse(
+-                                name=call_info.name, arguments=call_info.parameters
+-                            ),
+-                        )
+-                    )
+-                return ToolCallProcessingResult(tool_calls, text, finish_reason)
+             except Exception as e:
+                 logger.error(f"Tool call parsing error: {e}")
+-                # Return error but don't fail the whole request
++                finish_reason["type"] = original_finish_type
+                 return ToolCallProcessingResult(None, text, finish_reason)
+ 
+         return ToolCallProcessingResult(None, text, finish_reason)
+@@ -1341,11 +1371,26 @@ class OpenAIServingChat(OpenAIServingBase):
+     ):
+         """Process tool calls in streaming response"""
+         if index not in parser_dict:
+-            # Use JSON detector directly for required or named tool choice
+-            if request.tool_choice == "required" or isinstance(
++            is_required = request.tool_choice == "required" or isinstance(
+                 request.tool_choice, ToolChoice
+-            ):
+-                parser_dict[index] = JsonArrayParser()
++            )
++            # For required/named tool choice: use JsonArrayParser when the
++            # constrained output is plain JSON (detector doesn't support
++            # structural_tag or no parser configured). Use FunctionCallParser
++            # only when the detector supports structural_tag and will produce
++            # native format output.
++            if is_required:
++                use_native_parser = False
++                if self.tool_call_parser:
++                    probe = FunctionCallParser(
++                        tools=request.tools,
++                        tool_call_parser=self.tool_call_parser,
++                    )
++                    use_native_parser = probe.detector.supports_structural_tag()
++                if use_native_parser:
++                    parser_dict[index] = probe
++                else:
++                    parser_dict[index] = JsonArrayParser()
+             else:
+                 parser_dict[index] = FunctionCallParser(
+                     tools=request.tools,
+diff --git a/python/sglang/srt/entrypoints/openai/serving_responses.py b/python/sglang/srt/entrypoints/openai/serving_responses.py
+index 41aefac686..59d23b67ae 100644
+--- a/python/sglang/srt/entrypoints/openai/serving_responses.py
++++ b/python/sglang/srt/entrypoints/openai/serving_responses.py
+@@ -5,7 +5,6 @@
+ from __future__ import annotations
+ 
+ import asyncio
+-import copy
+ import json
+ import logging
+ import time
+@@ -27,6 +26,15 @@ from openai.types.responses.response_function_tool_call import ResponseFunctionT
+ from openai.types.responses.response_reasoning_item import (
+     Content as ResponseReasoningTextContent,
+ )
++from openai.types.responses.response_reasoning_item import (
++    Summary as ResponseReasoningSummary,
++)
++from openai.types.responses.response_reasoning_summary_part_added_event import (
++    Part as ResponseReasoningSummaryAddedPart,
++)
++from openai.types.responses.response_reasoning_summary_part_done_event import (
++    Part as ResponseReasoningSummaryDonePart,
++)
+ from openai_harmony import Message as OpenAIMessage
+ 
+ from sglang.srt.entrypoints.context import (
+@@ -48,14 +56,19 @@ from sglang.srt.entrypoints.harmony_utils import (
+ from sglang.srt.entrypoints.openai.protocol import (
+     ChatCompletionMessageParam,
+     ChatCompletionRequest,
++    Function,
++    MessageProcessingResult,
+     PromptTokenUsageInfo,
+     RequestResponseMetadata,
+     ResponsesRequest,
+     ResponsesResponse,
++    Tool,
+     UsageInfo,
+ )
+ from sglang.srt.entrypoints.openai.serving_chat import OpenAIServingChat
+ from sglang.srt.entrypoints.openai.tool_server import MCPToolServer, ToolServer
++from sglang.srt.function_call.function_call_parser import FunctionCallParser
++from sglang.srt.function_call.json_array_parser import JsonArrayParser
+ from sglang.srt.managers.io_struct import GenerateReqInput
+ from sglang.srt.parser.reasoning_parser import ReasoningParser
+ from sglang.srt.utils import random_uuid
+@@ -84,8 +97,9 @@ class OpenAIServingResponses(OpenAIServingChat):
+         self.reasoning_parser = self.tokenizer_manager.server_args.reasoning_parser
+         self.enable_prompt_tokens_details = enable_prompt_tokens_details
+ 
+-        # Get default sampling params from model config if available
+-        self.default_sampling_params = {}
++        # Parent OpenAIServingChat.__init__ already populated default_sampling_params.
++        if not isinstance(self.default_sampling_params, dict):
++            self.default_sampling_params = {}
+ 
+         self.supports_browsing = (
+             tool_server.has_tool("browser") if tool_server else False
+@@ -171,6 +185,15 @@ class OpenAIServingResponses(OpenAIServingChat):
+         # FIXME: If the engine is dead, raise an error
+         # This is required for the streaming case
+ 
++        # ``tool_choice="required"`` only works with ``function`` tools.
++        if request.tool_choice == "required" and not any(
++            tool.type == "function" for tool in (request.tools or [])
++        ):
++            return self.create_error_response(
++                'tool_choice="required" requires at least one tool with '
++                'type="function"; other built-in tool types cannot be forced.'
++            )
++
+         # Handle the previous response ID
+         prev_response_id = request.previous_response_id
+         if prev_response_id is not None:
+@@ -186,15 +209,19 @@ class OpenAIServingResponses(OpenAIServingChat):
+         try:
+             model_name = request.model
+             tokenizer = self.tokenizer_manager.tokenizer
++            processed_messages: Optional[MessageProcessingResult] = None
+ 
+             if self.use_harmony:
+                 messages, request_prompts, engine_prompts = (
+                     self._make_request_with_harmony(request, prev_response)
+                 )
+             else:
+-                messages, request_prompts, engine_prompts = await self._make_request(
+-                    request, prev_response, tokenizer
+-                )
++                (
++                    messages,
++                    request_prompts,
++                    engine_prompts,
++                    processed_messages,
++                ) = await self._make_request(request, prev_response, tokenizer)
+ 
+         except (ValueError, TypeError, RuntimeError, jinja2.TemplateError) as e:
+             logger.exception("Error in preprocessing prompt inputs")
+@@ -210,7 +237,7 @@ class OpenAIServingResponses(OpenAIServingChat):
+             and (request.background or request.stream)
+             and request.tools
+             and any(
+-                tool.type in ["web_search_preview", "code_interpreter"]
++                tool.type in ("web_search", "web_search_preview", "code_interpreter")
+                 for tool in request.tools
+             )
+         ):
+@@ -244,10 +271,10 @@ class OpenAIServingResponses(OpenAIServingChat):
+                     tool_sessions = {}
+                 for i, engine_prompt in enumerate(engine_prompts):
+                     # Calculate default max tokens from context length minus prompt length
+-                    if hasattr(engine_prompt, "__len__"):
+-                        prompt_length = len(engine_prompt)
+-                    elif isinstance(engine_prompt, list):
++                    if isinstance(engine_prompt, list):
+                         prompt_length = len(engine_prompt)
++                    elif isinstance(engine_prompt, str):
++                        prompt_length = len(tokenizer.encode(engine_prompt))
+                     else:
+                         prompt_length = 0
+ 
+@@ -263,7 +290,18 @@ class OpenAIServingResponses(OpenAIServingChat):
+                         context_len - prompt_length - num_reserved_tokens, 512
+                     )  # Ensure minimum 512 tokens
+                     sampling_params = request.to_sampling_params(
+-                        default_max_tokens, self.default_sampling_params
++                        default_max_tokens,
++                        self.default_sampling_params,
++                        stop=(
++                            processed_messages.stop
++                            if processed_messages
++                            else request.stop
++                        ),
++                        tool_call_constraint=(
++                            processed_messages.tool_call_constraint
++                            if processed_messages
++                            else None
++                        ),
+                     )
+ 
+                     context: ConversationContext
+@@ -276,8 +314,33 @@ class OpenAIServingResponses(OpenAIServingChat):
+                         context = SimpleContext()
+ 
+                     # Create GenerateReqInput for SGLang
++                    if isinstance(engine_prompt, str):
++                        prompt_kwargs = {"text": engine_prompt}
++                    else:
++                        prompt_kwargs = {"input_ids": engine_prompt}
++
+                     adapted_request = GenerateReqInput(
+-                        input_ids=engine_prompt,
++                        **prompt_kwargs,
++                        image_data=(
++                            processed_messages.image_data
++                            if processed_messages
++                            else None
++                        ),
++                        video_data=(
++                            processed_messages.video_data
++                            if processed_messages
++                            else None
++                        ),
++                        audio_data=(
++                            processed_messages.audio_data
++                            if processed_messages
++                            else None
++                        ),
++                        modalities=(
++                            processed_messages.modalities
++                            if processed_messages
++                            else None
++                        ),
+                         sampling_params=sampling_params,
+                         stream=request.stream,
+                         rid=request.request_id,
+@@ -342,11 +405,20 @@ class OpenAIServingResponses(OpenAIServingChat):
+                 return response
+ 
+             if request.stream:
+-                return self.responses_stream_generator(
++                if self.use_harmony:
++                    return self.responses_stream_generator(
++                        request,
++                        sampling_params,
++                        result_generator,
++                        context,
++                        model_name,
++                        tokenizer,
++                        request_metadata,
++                    )
++                return self.responses_stream_generator_non_harmony(
+                     request,
+                     sampling_params,
+                     result_generator,
+-                    context,
+                     model_name,
+                     tokenizer,
+                     request_metadata,
+@@ -374,43 +446,34 @@ class OpenAIServingResponses(OpenAIServingChat):
+         prev_response: Optional[ResponsesResponse],
+         tokenizer: Any,
+     ):
+-        # Construct the input messages
+         messages = self._construct_input_messages(request, prev_response)
+ 
+-        # Follow SGLang's pattern: create a ChatCompletionRequest and process messages
+-        try:
+-            # Convert ResponsesRequest to ChatCompletionRequest for processing
+-            chat_request = ChatCompletionRequest(
+-                model=request.model,
+-                messages=messages,
+-                stream=request.stream,
+-            )
++        chat_tools = self._response_tools_to_chat_tools(request)
++        chat_request = ChatCompletionRequest(
++            model=request.model,
++            messages=messages,
++            stream=request.stream,
++            tools=chat_tools or None,
++            tool_choice=request.tool_choice if chat_tools else "none",
++            parallel_tool_calls=(
++                request.parallel_tool_calls
++                if request.parallel_tool_calls is not None
++                else True
++            ),
++            stop=request.stop,
++        )
+ 
+-            # Follow SGLang's _process_messages pattern
+-            is_multimodal = self.tokenizer_manager.model_config.is_multimodal
+-            processed_messages = self._process_messages(chat_request, is_multimodal)
++        is_multimodal = self.tokenizer_manager.model_config.is_multimodal
++        processed_messages = self._process_messages(chat_request, is_multimodal)
+ 
+-            # Extract the results
+-            if is_multimodal:
+-                request_prompts = [processed_messages.prompt]
+-                engine_prompts = [processed_messages.prompt]
+-            else:
+-                request_prompts = [processed_messages.prompt_ids]
+-                engine_prompts = [processed_messages.prompt_ids]
++        if is_multimodal:
++            request_prompts = [processed_messages.prompt]
++            engine_prompts = [processed_messages.prompt]
++        else:
++            request_prompts = [processed_messages.prompt_ids]
++            engine_prompts = [processed_messages.prompt_ids]
+ 
+-        except Exception as e:
+-            logger.warning(f"Chat processing failed, using fallback: {e}")
+-            # Fallback to simple encoding
+-            prompt_text = ""
+-            for msg in messages:
+-                role = msg.get("role", "user")
+-                content = msg.get("content", "")
+-                prompt_text += f"{role}: {content}\n"
+-            prompt_ids = tokenizer.encode(prompt_text)
+-            request_prompts = [prompt_ids]
+-            engine_prompts = [prompt_ids]
+-
+-        return messages, request_prompts, engine_prompts
++        return messages, request_prompts, engine_prompts, processed_messages
+ 
+     def _make_request_with_harmony(
+         self,
+@@ -451,7 +514,7 @@ class OpenAIServingResponses(OpenAIServingChat):
+         if self.use_harmony:
+             assert isinstance(context, HarmonyContext)
+             output = self._make_response_output_items_with_harmony(context)
+-            # TODO: these are all 0 for now!
++            # num_reasoning_tokens isn't wired through HarmonyContext yet; stays 0.
+             num_prompt_tokens = context.num_prompt_tokens
+             num_generated_tokens = context.num_output_tokens
+             num_cached_tokens = context.num_cached_tokens
+@@ -466,10 +529,29 @@ class OpenAIServingResponses(OpenAIServingChat):
+             )
+ 
+             # Calculate usage from actual output
+-            if hasattr(final_res, "meta_info"):
+-                num_prompt_tokens = final_res.meta_info.get("prompt_tokens", 0)
+-                num_generated_tokens = final_res.meta_info.get("completion_tokens", 0)
+-                num_cached_tokens = final_res.meta_info.get("cached_tokens", 0)
++            num_reasoning_tokens = 0
++            meta_info = None
++            if isinstance(final_res, dict) and isinstance(
++                final_res.get("meta_info"), dict
++            ):
++                meta_info = final_res["meta_info"]
++            elif hasattr(final_res, "meta_info"):
++                meta_info = final_res.meta_info
++
++            if meta_info is not None:
++                num_prompt_tokens = meta_info.get("prompt_tokens", 0)
++                num_generated_tokens = meta_info.get("completion_tokens", 0)
++                num_cached_tokens = meta_info.get("cached_tokens", 0)
++                num_reasoning_tokens = meta_info.get("reasoning_tokens", 0)
++            elif isinstance(final_res, dict) and (
++                final_res.get("prompt_token_ids") is not None
++                or final_res.get("output_ids") is not None
++            ):
++                prompt_token_ids = final_res.get("prompt_token_ids") or []
++                output_token_ids = final_res.get("output_ids") or []
++                num_prompt_tokens = len(prompt_token_ids)
++                num_generated_tokens = len(output_token_ids)
++                num_cached_tokens = final_res.get("num_cached_tokens", 0)
+             elif hasattr(final_res, "prompt_token_ids") and hasattr(
+                 final_res, "outputs"
+             ):
+@@ -483,7 +565,6 @@ class OpenAIServingResponses(OpenAIServingChat):
+                     else 0
+                 )
+                 num_cached_tokens = getattr(final_res, "num_cached_tokens", 0)
+-                num_reasoning_tokens = 0
+             else:
+                 # Final fallback
+                 num_prompt_tokens = 0
+@@ -522,18 +603,59 @@ class OpenAIServingResponses(OpenAIServingChat):
+ 
+         return response
+ 
++    @staticmethod
++    def _wants_reasoning_summary(request: ResponsesRequest) -> bool:
++        return request.reasoning is not None and request.reasoning.summary is not None
++
++    def _is_thinking_enabled_for_request(self, request: ResponsesRequest) -> bool:
++        """Whether to start the reasoning detector in thinking mode."""
++        if not self.reasoning_parser:
++            return False
++        effort = request.reasoning.effort if request.reasoning is not None else None
++        if self.reasoning_parser == "hunyuan":
++            return effort not in (None, "none", "no_think")
++        if self.template_manager.force_reasoning:
++            return True
++        # April-tree TemplateManager has no reasoning_config (template-based
++        # thinking-toggle detection landed later); None takes the parser-only path
++        config = getattr(self.template_manager, "reasoning_config", None)
++        if config is None:
++            # Parser-only models (DeepSeek-R1, …) carry the thinking default in
++            # the detector itself.
++            detector = getattr(self, "_reasoning_detector", None)
++            mode = getattr(detector, "reasoning_default", None) if detector else None
++            if mode is None or mode == "always":
++                return mode == "always"
++            if mode == "mistral":
++                return effort is not None and effort != "none"
++            if mode in ("thinking", "enable_thinking"):
++                return effort != "none"
++            if mode in ("explicit_thinking", "explicit_enable_thinking"):
++                return False
++            return False
++        if config.special_case == "always":
++            return True
++        if config.special_case == "mistral":
++            return effort is not None and effort != "none"
++        if config.toggle_param is None or config.default_enabled is None:
++            return False
++        if effort == "none":
++            return False
++        return bool(config.default_enabled)
++
+     def _make_response_output_items(
+         self,
+         request: ResponsesRequest,
+         final_output: Any,
+         tokenizer: Any,
+     ):
+-        # Handle reasoning parsing if enabled
+         if self.reasoning_parser:
+-            # Use standard reasoning parser (openai maps to T4Detector internally)
++            # Templates that prefill ``<think>`` only emit the close tag, so
++            # start the detector in thinking mode.
+             reasoning_parser = ReasoningParser(
+                 model_type=self.reasoning_parser,
+                 stream_reasoning=False,
++                force_reasoning=self._is_thinking_enabled_for_request(request),
+                 request=request,
+             )
+             reasoning_content, content = reasoning_parser.parse_non_stream(final_output)
+@@ -543,10 +665,21 @@ class OpenAIServingResponses(OpenAIServingChat):
+ 
+         output_items = []
+         if reasoning_content:
++            # Mirror the single parsed blob into ``summary`` when the caller opts
++            # in via ``reasoning.summary``; full trace stays in ``content``.
++            wants_summary = self._wants_reasoning_summary(request)
+             reasoning_item = ResponseReasoningItem(
+                 id=f"rs_{random_uuid()}",
+                 type="reasoning",
+-                summary=[],
++                summary=(
++                    [
++                        ResponseReasoningSummary(
++                            type="summary_text", text=reasoning_content
++                        )
++                    ]
++                    if wants_summary
++                    else []
++                ),
+                 content=[
+                     ResponseReasoningTextContent(
+                         type="reasoning_text", text=reasoning_content
+@@ -555,6 +688,65 @@ class OpenAIServingResponses(OpenAIServingChat):
+                 status=None,
+             )
+             output_items.append(reasoning_item)
++
++        chat_tools = self._response_tools_to_chat_tools(request)
++        is_required = request.tool_choice == "required"
++        tool_call_items: list[ResponseFunctionToolCall] = []
++        parsed_via_native = False
++        if (
++            content
++            and chat_tools
++            and self.tool_call_parser
++            and request.tool_choice != "none"
++        ):
++            parser = FunctionCallParser(chat_tools, self.tool_call_parser)
++            should_try_native = (
++                not is_required or parser.detector.supports_structural_tag()
++            )
++            if should_try_native and parser.has_tool_call(content):
++                try:
++                    content, call_info_list = parser.parse_non_stream(content)
++                    for call_info in call_info_list:
++                        tool_call_items.append(
++                            ResponseFunctionToolCall(
++                                arguments=call_info.parameters or "",
++                                call_id=f"call_{random_uuid()[:24]}",
++                                type="function_call",
++                                name=call_info.name,
++                                id=f"fc_{random_uuid()[:8]}",
++                                status="completed",
++                            )
++                        )
++                    parsed_via_native = bool(call_info_list)
++                except Exception as e:
++                    logger.error("Tool call parsing error: %s", e)
++
++        if content and chat_tools and is_required and not parsed_via_native:
++            try:
++                tool_call_data = orjson.loads(content)
++                if isinstance(tool_call_data, dict):
++                    tool_call_data = [tool_call_data]
++                if isinstance(tool_call_data, list):
++                    for tool in tool_call_data:
++                        if not isinstance(tool, dict) or "name" not in tool:
++                            continue
++                        arguments = json.dumps(
++                            tool.get("parameters", {}), ensure_ascii=False
++                        )
++                        tool_call_items.append(
++                            ResponseFunctionToolCall(
++                                arguments=arguments,
++                                call_id=f"call_{random_uuid()[:24]}",
++                                type="function_call",
++                                name=tool["name"],
++                                id=f"fc_{random_uuid()[:8]}",
++                                status="completed",
++                            )
++                        )
++                    content = ""
++            except Exception as e:
++                logger.error("Required tool JSON parse error: %s", e)
++
+         if content:
+             output_text = ResponseOutputText(
+                 text=content,
+@@ -570,6 +762,7 @@ class OpenAIServingResponses(OpenAIServingChat):
+                 type="message",
+             )
+             output_items.append(message)
++        output_items.extend(tool_call_items)
+         return output_items
+ 
+     def _make_response_output_items_with_harmony(
+@@ -586,6 +779,247 @@ class OpenAIServingResponses(OpenAIServingChat):
+             output_items.extend(last_items)
+         return output_items
+ 
++    @staticmethod
++    def _response_tools_to_chat_tools(request: ResponsesRequest) -> list[Tool]:
++        # Only ``function`` tools flow to chat; built-ins go through harmony.
++        chat_tools = []
++        for tool in request.tools:
++            if tool.type != "function":
++                continue
++            chat_tools.append(
++                Tool(
++                    type="function",
++                    function=Function(
++                        name=tool.name,
++                        description=tool.description,
++                        parameters=tool.parameters,
++                        strict=tool.strict,
++                    ),
++                )
++            )
++        return chat_tools
++
++    @staticmethod
++    def _normalize_response_content_part_for_chat(content_part: Any) -> Any:
++        # Default detail=\"auto\" and lift flat min/max_dynamic_patch onto
++        # image_url so the image preprocessor sees them.
++        if hasattr(content_part, "model_dump"):
++            content_part = content_part.model_dump(exclude_none=True)
++        if not isinstance(content_part, dict):
++            return content_part
++
++        part_type = content_part.get("type")
++        if part_type in ("input_text", "output_text"):
++            return {"type": "text", "text": content_part.get("text", "")}
++
++        if part_type == "input_image":
++            image_url = content_part.get("image_url")
++            if isinstance(image_url, dict):
++                image_url_obj = image_url.copy()
++            else:
++                image_url_obj = {"url": image_url}
++            if not image_url_obj.get("detail"):
++                image_url_obj["detail"] = content_part.get("detail") or "auto"
++            for key in ("min_dynamic_patch", "max_dynamic_patch"):
++                if key in content_part and key not in image_url_obj:
++                    image_url_obj[key] = content_part[key]
++            return {"type": "image_url", "image_url": image_url_obj}
++
++        if part_type == "text":
++            return content_part
++
++        if part_type == "image_url":
++            image_url = content_part.get("image_url")
++            if isinstance(image_url, str):
++                image_url = {
++                    "url": image_url,
++                    "detail": content_part.get("detail", "auto"),
++                }
++            elif isinstance(image_url, dict):
++                image_url = image_url.copy()
++                if not image_url.get("detail"):
++                    image_url["detail"] = content_part.get("detail") or "auto"
++            return {**content_part, "image_url": image_url}
++
++        return content_part
++
++    @classmethod
++    def _normalize_response_message_for_chat(cls, message: Any) -> Any:
++        """Convert one Responses-API input item to a chat-completions message."""
++        if hasattr(message, "model_dump"):
++            message = message.model_dump(exclude_none=True)
++        if not isinstance(message, dict):
++            return message
++
++        # Most chat templates only recognize system/user/assistant/tool;
++        # collapse ``developer`` to ``system`` at the boundary.
++        if message.get("role") == "developer":
++            message = {**message, "role": "system"}
++
++        msg_type = message.get("type")
++        if msg_type == "function_call":
++            # Coerce ``arguments`` to a valid JSON-object string so the chat
++            # template's unconditional ``orjson.loads`` survives truncated or
++            # dict-shaped echoes.
++            raw = message.get("arguments")
++            if isinstance(raw, str):
++                try:
++                    parsed = orjson.loads(raw) if raw else None
++                except orjson.JSONDecodeError:
++                    parsed = None
++                if not isinstance(parsed, dict):
++                    raw = "{}"
++            elif isinstance(raw, dict):
++                raw = orjson.dumps(raw).decode("utf-8")
++            else:
++                raw = "{}"
++            return {
++                "role": "assistant",
++                "tool_calls": [
++                    {
++                        "id": message.get("call_id") or message.get("id"),
++                        "type": "function",
++                        "function": {
++                            "name": message.get("name"),
++                            "arguments": raw,
++                        },
++                    }
++                ],
++            }
++        if msg_type == "function_call_output":
++            return {
++                "role": "tool",
++                "tool_call_id": message.get("call_id"),
++                "content": message.get("output", ""),
++            }
++        # Reasoning items render as {role: assistant, reasoning_content};
++        # empty ones drop instead of injecting an empty assistant block.
++        if msg_type == "reasoning":
++            # Prefer ``summary``; fall back to ``content`` only when summary
++            # is empty, since clients often populate both with the same text.
++            def _collect(parts):
++                out: list[str] = []
++                for entry in parts or []:
++                    if isinstance(entry, dict):
++                        text = entry.get("text")
++                        if text:
++                            out.append(text)
++                return out
++
++            text_parts = _collect(message.get("summary"))
++            if not text_parts:
++                text_parts = _collect(message.get("content"))
++            if not text_parts:
++                return None
++            return {
++                "role": "assistant",
++                "reasoning_content": "\n".join(text_parts),
++            }
++        if msg_type not in (None, "message"):
++            raise ValueError(f"Unsupported Responses API input item type: {msg_type!r}")
++
++        content = message.get("content")
++        if not isinstance(content, list):
++            return {
++                k: v
++                for k, v in message.items()
++                if v is not None and k not in ("id", "status", "type")
++            }
++
++        return {
++            k: v
++            for k, v in {
++                **message,
++                "content": [
++                    cls._normalize_response_content_part_for_chat(part)
++                    for part in content
++                ],
++            }.items()
++            if v is not None and k not in ("id", "status", "type")
++        }
++
++    @staticmethod
++    def _output_message_text(output_item: Any) -> Optional[str]:
++        """Return assistant text from a ``message`` output item (joining
++        ``output_text`` parts with newlines), or None for non-message items."""
++        if isinstance(output_item, ResponseReasoningItem):
++            return None
++        if hasattr(output_item, "model_dump"):
++            output_item = output_item.model_dump(exclude_none=True)
++        if not isinstance(output_item, dict):
++            return None
++        if output_item.get("type") != "message":
++            return None
++
++        text_parts = []
++        for content in output_item.get("content") or []:
++            if isinstance(content, ResponseOutputText):
++                text_parts.append(content.text)
++                continue
++            if hasattr(content, "model_dump"):
++                content = content.model_dump(exclude_none=True)
++            if isinstance(content, dict) and content.get("type") == "output_text":
++                text = content.get("text")
++                if text is not None:
++                    text_parts.append(text)
++
++        return "\n".join(text_parts) if text_parts else None
++
++    @staticmethod
++    def _merge_consecutive_assistant_messages(
++        messages: list,
++    ) -> list:
++        """Collapse runs of consecutive ``assistant`` dicts into one entry,
++        joining ``content`` and concatenating ``tool_calls`` and
++        ``reasoning_content`` so a logical turn renders as a single block."""
++        merged: list = []
++        for msg in messages:
++            if (
++                isinstance(msg, dict)
++                and msg.get("role") == "assistant"
++                and merged
++                and isinstance(merged[-1], dict)
++                and merged[-1].get("role") == "assistant"
++            ):
++                prev = merged[-1] = dict(merged[-1])
++                # Lift mixed str/list content to list parts so non-text parts
++                # (e.g. image_url) survive when the two sides differ in shape.
++                new_content = msg.get("content")
++                if new_content is not None and new_content != "":
++                    prev_content = prev.get("content")
++                    if prev_content is None or prev_content == "":
++                        prev["content"] = new_content
++                    elif isinstance(prev_content, str) and isinstance(new_content, str):
++                        sep = "\n\n" if prev_content and new_content else ""
++                        prev["content"] = prev_content + sep + new_content
++                    else:
++
++                        def _as_parts(c):
++                            if isinstance(c, list):
++                                return list(c)
++                            if isinstance(c, str) and c:
++                                return [{"type": "text", "text": c}]
++                            return []
++
++                        prev["content"] = _as_parts(prev_content) + _as_parts(
++                            new_content
++                        )
++                new_calls = msg.get("tool_calls")
++                if new_calls:
++                    prev_calls = prev.get("tool_calls") or []
++                    prev["tool_calls"] = prev_calls + list(new_calls)
++                new_reasoning = msg.get("reasoning_content")
++                if new_reasoning:
++                    prev_reasoning = prev.get("reasoning_content")
++                    prev["reasoning_content"] = (
++                        f"{prev_reasoning}\n{new_reasoning}"
++                        if prev_reasoning
++                        else new_reasoning
++                    )
++                continue
++            merged.append(msg)
++        return merged
++
+     def _construct_input_messages(
+         self,
+         request: ResponsesRequest,
+@@ -606,26 +1040,49 @@ class OpenAIServingResponses(OpenAIServingChat):
+             prev_msg = self.msg_store[prev_response.id]
+             messages.extend(prev_msg)
+ 
+-            # Add the previous output
+             for output_item in prev_response.output:
+-                # NOTE: We skip the reasoning output of the previous response
+-                if isinstance(output_item, ResponseReasoningItem):
++                assistant_text = self._output_message_text(output_item)
++                if assistant_text is None:
+                     continue
+-                for content in output_item.content:
+-                    messages.append(
+-                        {
+-                            "role": "system",
+-                            "content": request.instructions,
+-                        }
+-                    )
++                messages.append({"role": "assistant", "content": assistant_text})
+ 
+         # Append the new input
+         # Responses API supports simple text inputs without chat format
+         if isinstance(request.input, str):
+             messages.append({"role": "user", "content": request.input})
+         else:
+-            messages.extend(request.input)  # type: ignore
+-        return messages
++            for input_item in request.input:
++                normalized = self._normalize_response_message_for_chat(input_item)
++                if normalized is not None:
++                    messages.append(normalized)  # type: ignore
++
++        # One Responses-API assistant turn maps to multiple input items
++        # (message + function_call(s)); collapse them into one chat message
++        # so chat templates render a single assistant block per turn.
++        messages = self._merge_consecutive_assistant_messages(messages)
++
++        # Most chat templates expect a single leading ``system`` message;
++        # coalesce any ``instructions`` + interleaved ``developer`` entries.
++        system_chunks: list[str] = []
++        other_msgs: list = []
++        for m in messages:
++            if isinstance(m, dict) and m.get("role") == "system":
++                content = m.get("content")
++                if isinstance(content, str):
++                    system_chunks.append(content)
++                elif isinstance(content, list):
++                    for part in content:
++                        if isinstance(part, dict):
++                            text = part.get("text")
++                            if isinstance(text, str):
++                                system_chunks.append(text)
++            else:
++                other_msgs.append(m)
++        if system_chunks:
++            return [
++                {"role": "system", "content": "\n\n".join(system_chunks)}
++            ] + other_msgs
++        return other_msgs
+ 
+     def _construct_input_messages_with_harmony(
+         self,
+@@ -638,7 +1095,8 @@ class OpenAIServingResponses(OpenAIServingChat):
+             reasoning_effort = request.reasoning.effort if request.reasoning else None
+             tool_types = [tool.type for tool in request.tools]
+             enable_browser = (
+-                "web_search_preview" in tool_types and self.tool_server is not None
++                any(t in tool_types for t in ("web_search", "web_search_preview"))
++                and self.tool_server is not None
+             )
+             enable_code_interpreter = (
+                 "code_interpreter" in tool_types and self.tool_server is not None
+@@ -693,7 +1151,7 @@ class OpenAIServingResponses(OpenAIServingChat):
+             messages.append(get_user_message(request.input))
+         else:
+             if prev_response is not None:
+-                prev_outputs = copy(prev_response.output)
++                prev_outputs = list(prev_response.output)
+             else:
+                 prev_outputs = []
+             for response_msg in request.input:
+@@ -1231,6 +1689,8 @@ class OpenAIServingResponses(OpenAIServingChat):
+         )
+         # Convert final_response to the format expected by ResponseCompletedEvent
+         response_dict = final_response.model_dump()
++        # OpenAI SDK's Tool union may not know extended types; drop echo.
++        response_dict["tools"] = []
+ 
+         # Convert UsageInfo to ResponseUsage format
+         if response_dict.get("usage"):
+@@ -1255,6 +1715,596 @@ class OpenAIServingResponses(OpenAIServingChat):
+             )
+         )
+ 
++    async def responses_stream_generator_non_harmony(
++        self,
++        request: ResponsesRequest,
++        sampling_params: Any,
++        result_generator: AsyncIterator[Any],
++        model_name: str,
++        tokenizer: Any,
++        request_metadata: RequestResponseMetadata,
++        created_time: Optional[int] = None,
++    ) -> AsyncGenerator[str, None]:
++        """Stream a /v1/responses response as typed OpenAI SSE events for
++        non-harmony models. Each engine chunk is run through the reasoning
++        and function-call parsers; leftover text becomes
++        ``response.output_text.delta``.
++        """
++
++        created_time = created_time or int(time.time())
++        sequence_number = 0
++
++        def _send_event(event):
++            nonlocal sequence_number
++            if hasattr(event, "sequence_number"):
++                event.sequence_number = sequence_number
++            sequence_number += 1
++            event_type = getattr(event, "type", "unknown")
++            return (
++                f"event: {event_type}\n"
++                f"data: {event.model_dump_json(indent=None)}\n\n"
++            )
++
++        # The streaming Response* event models echo ``tools`` through a
++        # narrower OpenAI SDK Tool union; strip it to avoid pydantic
++        # validation failures on extended tool types.
++        def _sanitize_response_dict(d: dict) -> dict:
++            d["tools"] = []
++            return d
++
++        initial_response = _sanitize_response_dict(
++            ResponsesResponse.from_request(
++                request,
++                sampling_params,
++                model_name=model_name,
++                created_time=created_time,
++                output=[],
++                status="in_progress",
++                usage=None,
++            ).model_dump()
++        )
++        yield _send_event(
++            openai_responses_types.ResponseCreatedEvent(
++                type="response.created",
++                sequence_number=-1,
++                response=initial_response,
++            )
++        )
++        yield _send_event(
++            openai_responses_types.ResponseInProgressEvent(
++                type="response.in_progress",
++                sequence_number=-1,
++                response=initial_response,
++            )
++        )
++
++        chat_tools = self._response_tools_to_chat_tools(request)
++        is_required = request.tool_choice == "required"
++        tool_parser: Optional[Union[FunctionCallParser, JsonArrayParser]] = None
++        if chat_tools and request.tool_choice != "none":
++            native_supports_structural_tag = False
++            if self.tool_call_parser:
++                probe = FunctionCallParser(chat_tools, self.tool_call_parser)
++                native_supports_structural_tag = (
++                    probe.detector.supports_structural_tag()
++                )
++            if is_required and not native_supports_structural_tag:
++                tool_parser = JsonArrayParser()
++            elif self.tool_call_parser:
++                tool_parser = FunctionCallParser(chat_tools, self.tool_call_parser)
++        reasoning_parser_obj: Optional[ReasoningParser] = None
++        if self.reasoning_parser:
++            reasoning_parser_obj = ReasoningParser(
++                model_type=self.reasoning_parser,
++                stream_reasoning=True,
++                force_reasoning=self._is_thinking_enabled_for_request(request),
++                request=request,
++            )
++
++        current_output_index = -1
++        reasoning_state = {
++            "open": False,
++            "item_id": "",
++            "output_index": -1,
++            "text": "",
++        }
++        message_state = {
++            "open": False,
++            "item_id": "",
++            "output_index": -1,
++            "text": "",
++        }
++        tool_call_states: dict[int, dict[str, Any]] = {}
++        # Items closed during the stream, in wire order. Feeds the final
++        # ``response.completed`` snapshot and the stored response.
++        emitted_items: list = []
++
++        prompt_tokens = 0
++        completion_tokens = 0
++        cached_tokens = 0
++        total_tokens_meta = 0
++        reasoning_tokens_meta = 0
++        finish_reason: Optional[dict[str, Any]] = None
++        stream_offset = 0
++        incremental = self.tokenizer_manager.server_args.incremental_streaming_output
++
++        def _open_reasoning_item() -> str:
++            nonlocal current_output_index
++            current_output_index += 1
++            item_id = f"rs_{random_uuid()}"
++            reasoning_state.update(
++                open=True, item_id=item_id, output_index=current_output_index, text=""
++            )
++            return item_id
++
++        wants_summary = self._wants_reasoning_summary(request)
++
++        def _close_reasoning_item():
++            if not reasoning_state["open"]:
++                return []
++            text = reasoning_state["text"]
++            completed_item = ResponseReasoningItem(
++                id=reasoning_state["item_id"],
++                type="reasoning",
++                summary=(
++                    [ResponseReasoningSummary(type="summary_text", text=text)]
++                    if wants_summary
++                    else []
++                ),
++                content=[
++                    ResponseReasoningTextContent(type="reasoning_text", text=text),
++                ],
++                status="completed",
++            )
++            events: list = []
++            if wants_summary:
++                events.append(
++                    _send_event(
++                        openai_responses_types.ResponseReasoningSummaryTextDoneEvent(
++                            type="response.reasoning_summary_text.done",
++                            item_id=reasoning_state["item_id"],
++                            sequence_number=-1,
++                            output_index=reasoning_state["output_index"],
++                            summary_index=0,
++                            text=text,
++                        )
++                    )
++                )
++                events.append(
++                    _send_event(
++                        openai_responses_types.ResponseReasoningSummaryPartDoneEvent(
++                            type="response.reasoning_summary_part.done",
++                            item_id=reasoning_state["item_id"],
++                            sequence_number=-1,
++                            output_index=reasoning_state["output_index"],
++                            summary_index=0,
++                            part=ResponseReasoningSummaryDonePart(
++                                type="summary_text", text=text
++                            ),
++                        )
++                    )
++                )
++            else:
++                events.append(
++                    _send_event(
++                        openai_responses_types.ResponseReasoningTextDoneEvent(
++                            type="response.reasoning_text.done",
++                            item_id=reasoning_state["item_id"],
++                            sequence_number=-1,
++                            output_index=reasoning_state["output_index"],
++                            content_index=0,
++                            text=text,
++                        )
++                    )
++                )
++            events += [
++                _send_event(
++                    openai_responses_types.ResponseOutputItemDoneEvent(
++                        type="response.output_item.done",
++                        sequence_number=-1,
++                        output_index=reasoning_state["output_index"],
++                        item=completed_item,
++                    )
++                ),
++            ]
++            emitted_items.append(completed_item)
++            reasoning_state["open"] = False
++            return events
++
++        def _open_message_item() -> str:
++            nonlocal current_output_index
++            current_output_index += 1
++            item_id = f"msg_{random_uuid()}"
++            message_state.update(
++                open=True, item_id=item_id, output_index=current_output_index, text=""
++            )
++            return item_id
++
++        def _close_message_item():
++            if not message_state["open"]:
++                return []
++            text = message_state["text"]
++            text_content = openai_responses_types.ResponseOutputText(
++                type="output_text", text=text, annotations=[], logprobs=None
++            )
++            completed_item = ResponseOutputMessage(
++                id=message_state["item_id"],
++                type="message",
++                role="assistant",
++                content=[text_content],
++                status="completed",
++            )
++            events = [
++                _send_event(
++                    openai_responses_types.ResponseTextDoneEvent(
++                        type="response.output_text.done",
++                        sequence_number=-1,
++                        output_index=message_state["output_index"],
++                        content_index=0,
++                        text=text,
++                        logprobs=[],
++                        item_id=message_state["item_id"],
++                    )
++                ),
++                _send_event(
++                    openai_responses_types.ResponseContentPartDoneEvent(
++                        type="response.content_part.done",
++                        sequence_number=-1,
++                        item_id=message_state["item_id"],
++                        output_index=message_state["output_index"],
++                        content_index=0,
++                        part=text_content,
++                    )
++                ),
++                _send_event(
++                    openai_responses_types.ResponseOutputItemDoneEvent(
++                        type="response.output_item.done",
++                        sequence_number=-1,
++                        output_index=message_state["output_index"],
++                        item=completed_item,
++                    )
++                ),
++            ]
++            emitted_items.append(completed_item)
++            message_state["open"] = False
++            return events
++
++        def _close_tool_call_state(tool_index: int):
++            state = tool_call_states.get(tool_index)
++            if state is None or state.get("done"):
++                return []
++            arguments = state["arguments"]
++            completed_item = ResponseFunctionToolCall(
++                arguments=arguments,
++                call_id=state["call_id"],
++                name=state["name"] or "",
++                type="function_call",
++                id=state["item_id"],
++                status="completed",
++            )
++            events = [
++                _send_event(
++                    openai_responses_types.ResponseFunctionCallArgumentsDoneEvent(
++                        type="response.function_call_arguments.done",
++                        sequence_number=-1,
++                        item_id=state["item_id"],
++                        output_index=state["output_index"],
++                        arguments=arguments,
++                        name=state["name"] or "",
++                    )
++                ),
++                _send_event(
++                    openai_responses_types.ResponseOutputItemDoneEvent(
++                        type="response.output_item.done",
++                        sequence_number=-1,
++                        output_index=state["output_index"],
++                        item=completed_item,
++                    )
++                ),
++            ]
++            emitted_items.append(completed_item)
++            state["done"] = True
++            return events
++
++        try:
++            async for ctx in result_generator:
++                if isinstance(ctx, dict):
++                    chunk = ctx
++                else:
++                    chunk = getattr(ctx, "last_output", None)
++                if not isinstance(chunk, dict):
++                    continue
++                meta = chunk.get("meta_info") or {}
++                prompt_tokens = meta.get("prompt_tokens", prompt_tokens)
++                completion_tokens = meta.get("completion_tokens", completion_tokens)
++                cached_tokens = meta.get("cached_tokens", cached_tokens)
++                total_tokens_meta = meta.get("total_tokens", total_tokens_meta)
++                reasoning_tokens_meta = meta.get(
++                    "reasoning_tokens", reasoning_tokens_meta
++                )
++                finish_reason = meta.get("finish_reason") or finish_reason
++
++                text = chunk.get("text", "") or ""
++                if incremental:
++                    delta = text
++                else:
++                    delta = text[stream_offset:]
++                    stream_offset = len(text)
++                if not delta and finish_reason is None:
++                    continue
++
++                if reasoning_parser_obj is not None:
++                    reasoning_chunk, delta = reasoning_parser_obj.parse_stream_chunk(
++                        delta
++                    )
++                else:
++                    reasoning_chunk = None
++
++                if reasoning_chunk:
++                    if message_state["open"]:
++                        for ev in _close_message_item():
++                            yield ev
++                    if not reasoning_state["open"]:
++                        item_id = _open_reasoning_item()
++                        yield _send_event(
++                            openai_responses_types.ResponseOutputItemAddedEvent(
++                                type="response.output_item.added",
++                                sequence_number=-1,
++                                output_index=reasoning_state["output_index"],
++                                item=ResponseReasoningItem(
++                                    id=item_id,
++                                    type="reasoning",
++                                    summary=[],
++                                    content=[],
++                                    status="in_progress",
++                                ),
++                            )
++                        )
++                        # Clients that opt into ``reasoning.summary`` render
++                        # off the ``reasoning_summary_text.*`` event stream,
++                        # so mirror the trace into a summary part.
++                        if wants_summary:
++                            yield _send_event(
++                                openai_responses_types.ResponseReasoningSummaryPartAddedEvent(
++                                    type="response.reasoning_summary_part.added",
++                                    item_id=item_id,
++                                    output_index=reasoning_state["output_index"],
++                                    summary_index=0,
++                                    part=ResponseReasoningSummaryAddedPart(
++                                        type="summary_text", text=""
++                                    ),
++                                    sequence_number=-1,
++                                )
++                            )
++                    reasoning_state["text"] += reasoning_chunk
++                    if wants_summary:
++                        yield _send_event(
++                            openai_responses_types.ResponseReasoningSummaryTextDeltaEvent(
++                                type="response.reasoning_summary_text.delta",
++                                item_id=reasoning_state["item_id"],
++                                output_index=reasoning_state["output_index"],
++                                summary_index=0,
++                                delta=reasoning_chunk,
++                                sequence_number=-1,
++                            )
++                        )
++                    else:
++                        yield _send_event(
++                            openai_responses_types.ResponseReasoningTextDeltaEvent(
++                                type="response.reasoning_text.delta",
++                                item_id=reasoning_state["item_id"],
++                                output_index=reasoning_state["output_index"],
++                                content_index=0,
++                                delta=reasoning_chunk,
++                                sequence_number=-1,
++                            )
++                        )
++
++                if not delta:
++                    continue
++
++                if isinstance(tool_parser, JsonArrayParser):
++                    sp = tool_parser.parse_streaming_increment(delta, chat_tools)
++                    normal_text, tool_calls = sp.normal_text or "", sp.calls
++                elif tool_parser is not None:
++                    normal_text, tool_calls = tool_parser.parse_stream_chunk(delta)
++                else:
++                    normal_text, tool_calls = delta, []
++
++                # Close any open tool-call item before opening a message so
++                # ``output_item.done`` lands before the next ``added``.
++                if normal_text:
++                    if reasoning_state["open"]:
++                        for ev in _close_reasoning_item():
++                            yield ev
++                    for tool_index in list(tool_call_states):
++                        for ev in _close_tool_call_state(tool_index):
++                            yield ev
++                    if not message_state["open"]:
++                        item_id = _open_message_item()
++                        yield _send_event(
++                            openai_responses_types.ResponseOutputItemAddedEvent(
++                                type="response.output_item.added",
++                                sequence_number=-1,
++                                output_index=message_state["output_index"],
++                                item=ResponseOutputMessage(
++                                    id=item_id,
++                                    type="message",
++                                    role="assistant",
++                                    content=[],
++                                    status="in_progress",
++                                ),
++                            )
++                        )
++                        yield _send_event(
++                            openai_responses_types.ResponseContentPartAddedEvent(
++                                type="response.content_part.added",
++                                sequence_number=-1,
++                                output_index=message_state["output_index"],
++                                item_id=message_state["item_id"],
++                                content_index=0,
++                                part=openai_responses_types.ResponseOutputText(
++                                    type="output_text",
++                                    text="",
++                                    annotations=[],
++                                    logprobs=None,
++                                ),
++                            )
++                        )
++                    message_state["text"] += normal_text
++                    yield _send_event(
++                        openai_responses_types.ResponseTextDeltaEvent(
++                            type="response.output_text.delta",
++                            sequence_number=-1,
++                            content_index=0,
++                            output_index=message_state["output_index"],
++                            item_id=message_state["item_id"],
++                            delta=normal_text,
++                            logprobs=[],
++                        )
++                    )
++
++                if not tool_calls:
++                    continue
++
++                if reasoning_state["open"]:
++                    for ev in _close_reasoning_item():
++                        yield ev
++                if message_state["open"]:
++                    for ev in _close_message_item():
++                        yield ev
++
++                for call in tool_calls:
++                    tool_index = call.tool_index
++                    state = tool_call_states.get(tool_index)
++                    if state is None or state.get("done"):
++                        current_output_index += 1
++                        item_id = f"fc_{random_uuid()[:8]}"
++                        call_id = f"call_{random_uuid()[:24]}"
++                        state = {
++                            "item_id": item_id,
++                            "call_id": call_id,
++                            "output_index": current_output_index,
++                            "name": call.name or "",
++                            "arguments": "",
++                            "added": False,
++                            "done": False,
++                        }
++                        tool_call_states[tool_index] = state
++                    if not state["added"]:
++                        state["added"] = True
++                        # Capture ``call.name`` before the ``added`` event so
++                        # the name is set on the first emitted item.
++                        if call.name and not state["name"]:
++                            state["name"] = call.name
++                        yield _send_event(
++                            openai_responses_types.ResponseOutputItemAddedEvent(
++                                type="response.output_item.added",
++                                sequence_number=-1,
++                                output_index=state["output_index"],
++                                item=ResponseFunctionToolCall(
++                                    arguments="",
++                                    call_id=state["call_id"],
++                                    name=state["name"],
++                                    type="function_call",
++                                    id=state["item_id"],
++                                    status="in_progress",
++                                ),
++                            )
++                        )
++                    if call.parameters:
++                        state["arguments"] += call.parameters
++                        yield _send_event(
++                            openai_responses_types.ResponseFunctionCallArgumentsDeltaEvent(
++                                type="response.function_call_arguments.delta",
++                                sequence_number=-1,
++                                item_id=state["item_id"],
++                                output_index=state["output_index"],
++                                delta=call.parameters,
++                            )
++                        )
++        except Exception:
++            logger.exception("Error while streaming /v1/responses")
++            failed = _sanitize_response_dict(
++                ResponsesResponse.from_request(
++                    request,
++                    sampling_params,
++                    model_name=model_name,
++                    created_time=created_time,
++                    output=[],
++                    status="failed",
++                    usage=None,
++                ).model_dump()
++            )
++            yield _send_event(
++                openai_responses_types.ResponseFailedEvent(
++                    type="response.failed",
++                    sequence_number=-1,
++                    response=failed,
++                )
++            )
++            return
++
++        for ev in _close_reasoning_item():
++            yield ev
++        for ev in _close_message_item():
++            yield ev
++        for tool_index in list(tool_call_states):
++            for ev in _close_tool_call_state(tool_index):
++                yield ev
++
++        final_output_items = list(emitted_items)
++
++        usage = UsageInfo(
++            prompt_tokens=prompt_tokens,
++            completion_tokens=completion_tokens,
++            total_tokens=total_tokens_meta or (prompt_tokens + completion_tokens),
++            reasoning_tokens=reasoning_tokens_meta,
++        )
++        if self.enable_prompt_tokens_details and cached_tokens:
++            usage.prompt_tokens_details = PromptTokenUsageInfo(
++                cached_tokens=cached_tokens
++            )
++        request_metadata.final_usage_info = usage
++
++        final_response = ResponsesResponse.from_request(
++            request,
++            sampling_params,
++            model_name=model_name,
++            created_time=created_time,
++            output=final_output_items,
++            status="completed",
++            usage=usage,
++        )
++        if request.store:
++            async with self.response_store_lock:
++                stored = self.response_store.get(final_response.id)
++                if stored is None or stored.status != "cancelled":
++                    self.response_store[final_response.id] = final_response
++
++        response_dict = _sanitize_response_dict(final_response.model_dump())
++        if response_dict.get("usage"):
++            usage_info = response_dict["usage"]
++            response_dict["usage"] = {
++                "input_tokens": usage_info.get("prompt_tokens", 0),
++                "input_tokens_details": {
++                    "cached_tokens": cached_tokens,
++                },
++                "output_tokens": usage_info.get("completion_tokens", 0),
++                "output_tokens_details": {
++                    "reasoning_tokens": reasoning_tokens_meta,
++                },
++                "total_tokens": usage_info.get("total_tokens", 0),
++            }
++
++        yield _send_event(
++            openai_responses_types.ResponseCompletedEvent(
++                type="response.completed",
++                sequence_number=-1,
++                response=response_dict,
++            )
++        )
++
+     async def _generate_with_builtin_tools(
+         self,
+         request_id: str,
+diff --git a/python/sglang/srt/environ.py b/python/sglang/srt/environ.py
+index e29aa6d129..c556668b91 100644
+--- a/python/sglang/srt/environ.py
++++ b/python/sglang/srt/environ.py
+@@ -486,6 +486,9 @@ class Envs:
+     # Tool-Call behavior
+     SGLANG_TOOL_STRICT_LEVEL = EnvInt(ToolStrictLevel.OFF)
+ 
++    # Think tokens budget: negative means unlimited, >= 0 caps thinking tokens
++    SGLANG_MAX_THINK_TOKENS = EnvInt(-1)
++
+     # Ngram
+     SGLANG_NGRAM_FORCE_GREEDY_VERIFY = EnvBool(False)
+ 
+diff --git a/python/sglang/srt/function_call/base_format_detector.py b/python/sglang/srt/function_call/base_format_detector.py
+index 3163867bcd..726288ea38 100644
+--- a/python/sglang/srt/function_call/base_format_detector.py
++++ b/python/sglang/srt/function_call/base_format_detector.py
+@@ -1,13 +1,19 @@
+ import json
+ import logging
+ from abc import ABC, abstractmethod
+-from typing import Any, Dict, List
++from typing import Any, Dict, List, Literal, Optional, Union
+ 
+ import orjson
+ from partial_json_parser.core.exceptions import MalformedJSON
+ from partial_json_parser.core.options import Allow
+ 
+-from sglang.srt.entrypoints.openai.protocol import Tool
++try:
++    from xgrammar import StructuralTag, get_model_structural_tag
++except ImportError:
++    StructuralTag = Any
++    get_model_structural_tag = None
++
++from sglang.srt.entrypoints.openai.protocol import Tool, ToolChoice
+ from sglang.srt.environ import envs
+ from sglang.srt.function_call.core_types import (
+     StreamingParseResult,
+@@ -270,7 +276,7 @@ class BaseFormatDetector(ABC):
+                 cur_arguments = current_tool_call.get("arguments")
+                 res = StreamingParseResult()
+ 
+-                if cur_arguments:
++                if cur_arguments is not None:
+                     # Calculate how much of the arguments we've already streamed
+                     sent = len(self.streamed_args_for_tool[self.current_tool_id])
+                     cur_args_json = json.dumps(cur_arguments, ensure_ascii=False)
+@@ -361,3 +367,45 @@ class BaseFormatDetector(ABC):
+             A function that takes a tool name (str) and returns StructureInfo
+         """
+         raise NotImplementedError()
++
++    def get_structural_tag_name(self) -> Optional[str]:
++        """Return the XGrammar model name for native structural tags, if supported."""
++        return None
++
++    def get_structural_tag(
++        self,
++        tools: Union[List[Tool], None] = None,
++        tool_choice: Union[ToolChoice, Literal["auto", "required"]] = "auto",
++        thinking_mode: bool = False,
++    ) -> Optional[StructuralTag]:
++        """
++        Return a model-native XGrammar structural tag when supported.
++
++        Args:
++            tools: List of available tools
++            tool_choice: The tool choice setting from the request
++            thinking_mode: Whether to include the model's reasoning prefix in
++                the returned structural tag. Pass False when SGLang's
++                ReasonerGrammarBackend will own the <think>...</think> prefix
++                (the typical case when --reasoning-parser is configured) so
++                only one layer constrains the reasoning section.
++
++        Returns:
++            StructuralTag if this detector supports model-native tags, otherwise None
++        """
++        structural_tag_name = self.get_structural_tag_name()
++        if not structural_tag_name or get_model_structural_tag is None:
++            return None
++
++        converted_tools = [tool.model_dump() for tool in tools or []]
++        converted_tool_choice = (
++            tool_choice.model_dump()
++            if isinstance(tool_choice, ToolChoice)
++            else tool_choice
++        )
++        return get_model_structural_tag(
++            model=structural_tag_name,
++            tools=converted_tools,
++            tool_choice=converted_tool_choice,
++            reasoning=thinking_mode,
++        )
+diff --git a/python/sglang/srt/function_call/deepseekv32_detector.py b/python/sglang/srt/function_call/deepseekv32_detector.py
+index d9228743b6..5bc3fdcb2b 100644
+--- a/python/sglang/srt/function_call/deepseekv32_detector.py
++++ b/python/sglang/srt/function_call/deepseekv32_detector.py
+@@ -351,3 +351,6 @@ class DeepSeekV32Detector(BaseFormatDetector):
+             end="</｜DSML｜invoke>",
+             trigger="<｜DSML｜invoke",
+         )
++
++    def get_structural_tag_name(self) -> str:
++        return "deepseek_v3_2"
+diff --git a/python/sglang/srt/function_call/deepseekv3_detector.py b/python/sglang/srt/function_call/deepseekv3_detector.py
+index 8dcc2da431..3e744bec9e 100644
+--- a/python/sglang/srt/function_call/deepseekv3_detector.py
++++ b/python/sglang/srt/function_call/deepseekv3_detector.py
+@@ -203,7 +203,9 @@ class DeepSeekV3Detector(BaseFormatDetector):
+ 
+     def structure_info(self) -> _GetInfoFunc:
+         return lambda name: StructureInfo(
+-            begin=">" + name + "\n```json\n",
+-            end="\n```<",
+-            trigger=">" + name + "\n```json\n",
++            begin="<｜tool▁calls▁begin｜><｜tool▁call▁begin｜>function<｜tool▁sep｜>"
++            + name
++            + "\n```json\n",
++            end="\n```<｜tool▁call▁end｜><｜tool▁calls▁end｜>",
++            trigger="<｜tool▁calls▁begin｜>",
+         )
+diff --git a/python/sglang/srt/function_call/deepseekv4_detector.py b/python/sglang/srt/function_call/deepseekv4_detector.py
+new file mode 100644
+index 0000000000..10d4d559f3
+--- /dev/null
++++ b/python/sglang/srt/function_call/deepseekv4_detector.py
+@@ -0,0 +1,67 @@
++import logging
++
++from sglang.srt.function_call.deepseekv32_detector import DeepSeekV32Detector
++
++logger = logging.getLogger(__name__)
++
++
++class DeepSeekV4Detector(DeepSeekV32Detector):
++    """
++    Detector for DeepSeek V4 model function call format.
++
++    The DeepSeek V4 format uses XML-like DSML tags to delimit function calls.
++    Supports two parameter formats:
++
++    Format 1 - XML Parameter Tags:
++    ```
++    <｜DSML｜tool_calls>
++        <｜DSML｜invoke name="function_name">
++        <｜DSML｜parameter name="param_name" string="true">value</｜DSML｜parameter>
++        ...
++    </｜DSML｜invoke>
++    </｜DSML｜tool_calls>
++    ```
++
++    Format 2 - Direct JSON:
++    ```
++    <｜DSML｜tool_calls>
++        <｜DSML｜invoke name="function_name">
++        {
++            "param_name": "value"
++        }
++    </｜DSML｜invoke>
++    </｜DSML｜tool_calls>
++    ```
++
++    Examples:
++    ```
++    <｜DSML｜tool_calls>
++        <｜DSML｜invoke name="get_favorite_tourist_spot">
++        <｜DSML｜parameter name="city" string="true">San Francisco</｜DSML｜parameter>
++    </｜DSML｜invoke>
++    </｜DSML｜tool_calls>
++
++    <｜DSML｜tool_calls>
++        <｜DSML｜invoke name="get_favorite_tourist_spot">
++        { "city": "San Francisco" }
++    </｜DSML｜invoke>
++    </｜DSML｜tool_calls>
++    ```
++
++    Key Components:
++    - Tool Calls Section: Wrapped between `<｜DSML｜tool_calls>` and `</｜DSML｜tool_calls>`
++    - Individual Tool Call: Wrapped between `<｜DSML｜invoke name="...">` and `</｜DSML｜invoke>`
++    - Parameters: Either XML tags or direct JSON format
++    - Supports multiple tool calls
++
++    Reference: DeepSeek V4 format specification
++    """
++
++    def __init__(self):
++        super().__init__()
++        self.bot_token = "<｜DSML｜tool_calls>"
++        self.eot_token = "</｜DSML｜tool_calls>"
++        self.function_calls_regex = r"<｜DSML｜tool_calls>(.*?)</｜DSML｜tool_calls>"
++
++    def get_structural_tag_name(self) -> str:
++        return "deepseek_v4"
+diff --git a/python/sglang/srt/function_call/function_call_parser.py b/python/sglang/srt/function_call/function_call_parser.py
+index 84196d8cb0..505cb043c3 100644
+--- a/python/sglang/srt/function_call/function_call_parser.py
++++ b/python/sglang/srt/function_call/function_call_parser.py
+@@ -3,6 +3,7 @@ from typing import Dict, List, Literal, Optional, Set, Tuple, Type, Union
+ 
+ from sglang.srt.entrypoints.openai.protocol import (
+     LegacyStructuralTagResponseFormat,
++    StructuralTagResponseFormat,
+     StructuresResponseFormat,
+     Tool,
+     ToolCallConstraint,
+@@ -32,7 +33,10 @@ from sglang.srt.function_call.qwen3_coder_detector import Qwen3CoderDetector
+ from sglang.srt.function_call.qwen25_detector import Qwen25Detector
+ from sglang.srt.function_call.step3_detector import Step3Detector
+ from sglang.srt.function_call.trinity_detector import TrinityDetector
+-from sglang.srt.function_call.utils import get_json_schema_constraint
++from sglang.srt.function_call.utils import (
++    _get_tool_schema_defs,
++    get_json_schema_constraint,
++)
+ 
+ logger = logging.getLogger(__name__)
+ 
+@@ -146,12 +150,24 @@ class FunctionCallParser:
+ 
+         return final_normal_text, final_calls
+ 
+-    def get_structure_tag(self) -> LegacyStructuralTagResponseFormat:
++    def get_legacy_structural_tag(
++        self, at_least_one: bool = False
++    ) -> StructuralTagResponseFormat:
+         """
+         Generate a structural tag response format for all available tools.
+ 
+         This creates the necessary structural tags that guide the model's output format.
++
++        Args:
++            at_least_one: If True, the grammar forces at least one tool call
++                (no free text allowed). Used for required/named tool_choice.
++
++        Raises:
++            ValueError: If tools have conflicting $defs schemas.
+         """
++        # Validate $defs consistency before building structural tags
++        _get_tool_schema_defs(self.tools)
++
+         tool_structures: List[StructuresResponseFormat] = list()
+         tool_trigger_set: Set[str] = set()
+ 
+@@ -183,12 +199,14 @@ class FunctionCallParser:
+             type="structural_tag",
+             structures=tool_structures,
+             triggers=list(tool_trigger_set),
++            at_least_one=at_least_one,
+         )
+ 
+     def get_structure_constraint(
+         self,
+         tool_choice: Union[ToolChoice, Literal["auto", "required"]],
+         parallel_tool_calls: bool = True,
++        thinking_mode: bool = False,
+     ) -> Optional[ToolCallConstraint]:
+         """
+         Returns the appropriate structure constraint for tool calls based on the tool_choice.
+@@ -201,20 +219,37 @@ class FunctionCallParser:
+             A tuple of (constraint_type, constraint_value) to be added to sampling parameters,
+             or None if no constraint applies.
+         """
+-        # NOTE: structural_tag only supports JSON-compatible content between the begin and end.
+-        # It cannot parse or validate function call Pythonic or XML-ish syntax.
+-        if (
+-            self.detector.supports_structural_tag()
+-            and tool_choice == "auto"
+-            and (
+-                any(tool.function.strict for tool in self.tools)
+-                or self.tool_strict_level >= ToolStrictLevel.FUNCTION
+-            )
+-        ):
+-            tag = self.get_structure_tag()
+-            return ("structural_tag", tag)
+-        elif tool_choice == "required" or isinstance(tool_choice, ToolChoice):
+-            json_schema = get_json_schema_constraint(
+-                self.tools, tool_choice, parallel_tool_calls=parallel_tool_calls
+-            )
+-            return ("json_schema", json_schema)
++        is_required = tool_choice == "required" or isinstance(tool_choice, ToolChoice)
++        should_constrain_auto = tool_choice == "auto" and (
++            any(tool.function.strict for tool in self.tools)
++            or self.tool_strict_level >= ToolStrictLevel.FUNCTION
++        )
++
++        # Highest priority: model-native structural_tag when available.
++        try:
++            if is_required or should_constrain_auto:
++                structural_tag = self.detector.get_structural_tag(
++                    tools=self.tools,
++                    thinking_mode=thinking_mode,
++                    tool_choice=tool_choice,
++                )
++                if structural_tag is not None:
++                    return ("structural_tag", structural_tag)
++
++                # Fallback to legacy structural tag if model-native tag is not supported.
++                if self.detector.supports_structural_tag():
++                    # For "required"/named: always use structural_tag to preserve the
++                    # model's native tool call format. Schema is only included when
++                    # strict=True, per OpenAI protocol semantics.
++                    # For "auto": only constrain when strict is enabled.
++                    tag = self.get_legacy_structural_tag(at_least_one=is_required)
++                    return ("structural_tag", tag)
++
++            if tool_choice == "required" or isinstance(tool_choice, ToolChoice):
++                json_schema = get_json_schema_constraint(
++                    self.tools, tool_choice, parallel_tool_calls=parallel_tool_calls
++                )
++                return ("json_schema", json_schema)
++        except Exception as e:
++            logger.error(f"Error getting structure constraint: {e}")
++            return None
+diff --git a/python/sglang/srt/function_call/gpt_oss_detector.py b/python/sglang/srt/function_call/gpt_oss_detector.py
+index b3fd5ac61e..b7234262f7 100644
+--- a/python/sglang/srt/function_call/gpt_oss_detector.py
++++ b/python/sglang/srt/function_call/gpt_oss_detector.py
+@@ -239,3 +239,6 @@ class GptOssDetector(BaseFormatDetector):
+ 
+     def structure_info(self) -> _GetInfoFunc:
+         raise NotImplementedError("structure_info not used with HarmonyParser")
++
++    def get_structural_tag_name(self) -> str:
++        return "harmony"
+diff --git a/python/sglang/srt/function_call/kimik2_detector.py b/python/sglang/srt/function_call/kimik2_detector.py
+index 21cf46cb01..113031c8e5 100644
+--- a/python/sglang/srt/function_call/kimik2_detector.py
++++ b/python/sglang/srt/function_call/kimik2_detector.py
+@@ -253,3 +253,13 @@ class KimiK2Detector(BaseFormatDetector):
+             )
+ 
+         return get_info
++
++    # Kimi stays on the SGLang legacy structural tag path. xgrammar 0.2.0's
++    # get_kimi_structural_tag(tool_choice="auto") emits a bare
++    # <|tool_call_begin|>...<|tool_call_end|> grammar without the
++    # <|tool_calls_section_begin|>/<|tool_calls_section_end|> wrapper Kimi's
++    # chat template uses, and KimiK2Detector.has_tool_call() keys off the
++    # section marker — bare tool calls would be silently dropped. Inheriting
++    # the base get_structural_tag_name (returns None) keeps FunctionCallParser
++    # on the legacy path, whose structure_info bakes the section markers in.
++    # TODO: re-enable the builtin once https://github.com/mlc-ai/xgrammar/issues/622 is fixed.
+diff --git a/python/sglang/srt/function_call/qwen3_coder_detector.py b/python/sglang/srt/function_call/qwen3_coder_detector.py
+index 9dd77903d4..025404572b 100644
+--- a/python/sglang/srt/function_call/qwen3_coder_detector.py
++++ b/python/sglang/srt/function_call/qwen3_coder_detector.py
+@@ -468,7 +468,10 @@ class Qwen3CoderDetector(BaseFormatDetector):
+         return StreamingParseResult(calls=calls, normal_text=normal_text)
+ 
+     def supports_structural_tag(self) -> bool:
+-        return False
++        return True
+ 
+     def structure_info(self) -> _GetInfoFunc:
+         raise NotImplementedError
++
++    def get_structural_tag_name(self) -> str:
++        return "qwen_3_coder"
+diff --git a/python/sglang/srt/function_call/utils.py b/python/sglang/srt/function_call/utils.py
+index 1ef93e0519..f36179a9fe 100644
+--- a/python/sglang/srt/function_call/utils.py
++++ b/python/sglang/srt/function_call/utils.py
+@@ -8,6 +8,168 @@ from partial_json_parser.core.options import Allow
+ 
+ from sglang.srt.entrypoints.openai.protocol import Tool, ToolChoice
+ 
++_STANDARD_JSON_SCHEMA_TYPES = {
++    "null",
++    "boolean",
++    "object",
++    "array",
++    "number",
++    "string",
++    "integer",
++}
++
++# Non-standard ``type`` values commonly emitted by DB/ORM-driven tool-schema
++# generators. Mapped to the closest JSON Schema 2020-12 primitive so that
++# ``Draft202012Validator.check_schema`` does not reject an otherwise-usable
++# tool definition.
++_JSON_SCHEMA_TYPE_ALIASES: Dict[str, str] = {
++    "str": "string",
++    "text": "string",
++    "varchar": "string",
++    "char": "string",
++    "enum": "string",
++    "uuid": "string",
++    "date": "string",
++    "datetime": "string",
++    "time": "string",
++    "timestamp": "string",
++    "binary": "string",
++    "blob": "string",
++    "bytea": "string",
++    "bytes": "string",
++    "varbinary": "string",
++    "bool": "boolean",
++    "bigint": "integer",
++    "smallint": "integer",
++    "tinyint": "integer",
++    "double": "number",
++    "decimal": "number",
++    "real": "number",
++    "numeric": "number",
++    "arr": "array",
++    "tuple": "array",
++    "set": "array",
++    "map": "object",
++}
++
++# Prefix-based matching so that parameterised names like ``int32`` /
++# ``float64`` / ``list[str]`` / ``dict[str, int]`` resolve. A prefix only
++# matches when it spans the entire token or is followed by a non-identifier
++# char, so "int" does not swallow "internal" and "list" does not swallow
++# "list_price".
++_PREFIX_BOUNDARY_CHARS = frozenset("0123456789[<( \t")
++_PREFIX_RULES: Tuple[Tuple[Tuple[str, ...], str], ...] = (
++    (("int", "uint", "long", "short", "unsigned"), "integer"),
++    (("num", "float"), "number"),
++    (("list",), "array"),
++    (("dict",), "object"),
++)
++
++
++def _matches_type_prefix(base: str, prefixes: Tuple[str, ...]) -> bool:
++    for p in prefixes:
++        if base == p:
++            return True
++        if (
++            len(base) > len(p)
++            and base.startswith(p)
++            and base[len(p)] in _PREFIX_BOUNDARY_CHARS
++        ):
++            return True
++    return False
++
++
++def _normalize_single_type(raw: Any) -> Any:
++    if not isinstance(raw, str):
++        return raw
++    if raw in _STANDARD_JSON_SCHEMA_TYPES:
++        return raw
++    # ``split("(", 1)[0]`` strips parenthesized params like ``varchar(255)``
++    # or ``decimal(10,2)`` without the overhead of a regex per call.
++    base = raw.split("(", 1)[0].strip().lower()
++    if base in _STANDARD_JSON_SCHEMA_TYPES:
++        return base
++    mapped = _JSON_SCHEMA_TYPE_ALIASES.get(base)
++    if mapped is not None:
++        return mapped
++    for prefixes, target in _PREFIX_RULES:
++        if _matches_type_prefix(base, prefixes):
++            return target
++    return raw
++
++
++def _normalize_type_list(raw_items: List[Any]) -> List[Any]:
++    normalized_items: List[Any] = []
++    for item in raw_items:
++        normalized_item = _normalize_single_type(item)
++        if normalized_item not in normalized_items:
++            normalized_items.append(normalized_item)
++    return normalized_items
++
++
++def normalize_json_schema_types(schema: Any) -> None:
++    """
++    Walk a JSON Schema in place and rewrite non-standard ``"type"`` values
++    (e.g. ``"varchar"``, ``"enum"``, ``"int"``) to their standard JSON Schema
++    equivalents.
++
++    Acts as a compatibility layer for tool ``parameters`` schemas exported
++    from database / ORM tooling, which often uses DB type names rather than
++    JSON Schema types. Unknown types are left untouched so that downstream
++    validation can still surface genuine errors.
++
++    Mutates the input dict in place; the rewritten schema is also what gets
++    rendered into the model prompt, so e.g. a user-supplied ``"varchar"``
++    reaches the model as ``"string"``. ``$ref`` values are not resolved;
++    callers pass tree-shaped schemas (HTTP JSON input is always a tree).
++    """
++    if isinstance(schema, list):
++        for item in schema:
++            normalize_json_schema_types(item)
++        return
++    if not isinstance(schema, dict):
++        return
++
++    if "type" in schema:
++        t = schema["type"]
++        if isinstance(t, str):
++            schema["type"] = _normalize_single_type(t)
++        elif isinstance(t, list):
++            schema["type"] = _normalize_type_list(t)
++
++    for key in (
++        "properties",
++        "patternProperties",
++        "$defs",
++        "definitions",
++        "dependentSchemas",
++    ):
++        nested = schema.get(key)
++        if isinstance(nested, dict):
++            for v in nested.values():
++                normalize_json_schema_types(v)
++
++    for key in ("anyOf", "oneOf", "allOf", "prefixItems"):
++        nested = schema.get(key)
++        if isinstance(nested, list):
++            for v in nested:
++                normalize_json_schema_types(v)
++
++    for key in (
++        "items",
++        "additionalProperties",
++        "not",
++        "if",
++        "then",
++        "else",
++        "contains",
++        "propertyNames",
++        "unevaluatedItems",
++        "unevaluatedProperties",
++    ):
++        if key in schema:
++            normalize_json_schema_types(schema[key])
++
+ 
+ def _find_common_prefix(s1: str, s2: str) -> str:
+     prefix = ""
+diff --git a/python/sglang/srt/layers/attention/linear/gdn_backend.py b/python/sglang/srt/layers/attention/linear/gdn_backend.py
+index 6fd0069a5f..956c627def 100644
+--- a/python/sglang/srt/layers/attention/linear/gdn_backend.py
++++ b/python/sglang/srt/layers/attention/linear/gdn_backend.py
+@@ -26,6 +26,11 @@ if not is_cpu():
+         CHUNK_SIZE as FLA_CHUNK_SIZE,
+     )
+ 
++if is_cuda():
++    from sglang.jit_kernel.triton.gdn_fused_proj import fused_qkv_split_gdn_prefill
++
++MAX_FUSED_QKV_SPLIT_DIM = 8192
++
+ if is_cuda():
+     from sglang.srt.layers.attention.mamba.causal_conv1d import (
+         causal_conv1d_fn as causal_conv1d_fn_cuda,
+@@ -350,16 +355,27 @@ class GDNAttnBackend(MambaAttnBackendBase):
+                 seq_lens_cpu=forward_batch.extend_seq_lens_cpu,
+             ).transpose(0, 1)[:seq_len]
+ 
+-        query, key, value = torch.split(
+-            mixed_qkv,
+-            [layer.q_dim, layer.k_dim, layer.v_dim],
+-            dim=-1,
+-        )
+-
+-        actual_seq_len = query.shape[0]
+-        query = query.view(1, actual_seq_len, layer.num_q_heads, layer.head_q_dim)
+-        key = key.view(1, actual_seq_len, layer.num_k_heads, layer.head_k_dim)
+-        value = value.view(1, actual_seq_len, layer.num_v_heads, layer.head_v_dim)
++        actual_seq_len = mixed_qkv.shape[0]
++        qkv_dim = layer.q_dim + layer.k_dim + layer.v_dim
++        if is_cuda() and qkv_dim <= MAX_FUSED_QKV_SPLIT_DIM:
++            query, key, value = fused_qkv_split_gdn_prefill(
++                mixed_qkv,
++                layer.num_q_heads,
++                layer.num_k_heads,
++                layer.num_v_heads,
++                layer.head_q_dim,
++                layer.head_k_dim,
++                layer.head_v_dim,
++            )
++        else:
++            query, key, value = torch.split(
++                mixed_qkv,
++                [layer.q_dim, layer.k_dim, layer.v_dim],
++                dim=-1,
++            )
++            query = query.view(1, actual_seq_len, layer.num_q_heads, layer.head_q_dim)
++            key = key.view(1, actual_seq_len, layer.num_k_heads, layer.head_k_dim)
++            value = value.view(1, actual_seq_len, layer.num_v_heads, layer.head_v_dim)
+ 
+         if is_target_verify:
+             core_attn_out = self.kernel_dispatcher.target_verify(
+diff --git a/python/sglang/srt/layers/attention/linear/lightning_backend.py b/python/sglang/srt/layers/attention/linear/lightning_backend.py
+index b34fefbfd2..d9e6ae2847 100644
+--- a/python/sglang/srt/layers/attention/linear/lightning_backend.py
++++ b/python/sglang/srt/layers/attention/linear/lightning_backend.py
+@@ -38,6 +38,17 @@ class LightningAttentionBackend(MambaAttnBackendBase):
+ 
+     def __init__(self, model_runner: ModelRunner):
+         super().__init__(model_runner)
++        # seg_la processes draft tokens as a chain -- it has no parent-indices
++        # plumbing for tree-shaped drafts, so spec v2 tree verify (topk > 1) would
++        # commit wrong mamba states silently. Fail fast instead of mis-decoding.
++        # (ported from upstream #27463; getattr: our base class sets topk only
++        # for spec runs, and conv_states_shape is omitted -- different pool API)
++        if getattr(self, "topk", 1) > 1:
++            raise NotImplementedError(
++                "Lightning (seg_la) linear-attention backend does not support "
++                "speculative decoding with topk > 1; seg_la verifies a draft "
++                "tree as a chain. Use --speculative-eagle-topk 1."
++            )
+ 
+         assert not (
+             model_runner.sliding_window_size is not None
+diff --git a/python/sglang/srt/layers/logits_processor.py b/python/sglang/srt/layers/logits_processor.py
+index 1980e55203..ea949f8179 100644
+--- a/python/sglang/srt/layers/logits_processor.py
++++ b/python/sglang/srt/layers/logits_processor.py
+@@ -530,12 +530,15 @@ class LogitsProcessor(nn.Module):
+                 pruned_states_before_norm = torch.cat(pruned_states_before_norm_list)
+             if aux_pruned_states_lists is not None:
+                 aux_pruned_states = [torch.cat(lst) for lst in aux_pruned_states_lists]
++
++            # Build the index tensors via pinned host memory + non-blocking H2D
++            # so the small copy doesn't drain the stream.
+             sample_indices = torch.tensor(
+-                sample_indices, device=pruned_states.device, dtype=torch.int64
+-            )
++                sample_indices, dtype=torch.int64, pin_memory=True
++            ).to(pruned_states.device, non_blocking=True)
+             input_logprob_indices = torch.tensor(
+-                input_logprob_indices, device=pruned_states.device, dtype=torch.int64
+-            )
++                input_logprob_indices, dtype=torch.int64, pin_memory=True
++            ).to(pruned_states.device, non_blocking=True)
+ 
+         return (
+             pruned_states,
+@@ -604,8 +607,9 @@ class LogitsProcessor(nn.Module):
+     ):
+         pruned_lens = torch.tensor(
+             logits_metadata.extend_logprob_pruned_lens_cpu,
+-            device=device,
+-        )
++            dtype=torch.int64,
++            pin_memory=True,
++        ).to(device, non_blocking=True)
+         if logits_metadata.temp_scaled_logprobs:
+             logits_metadata.temperature = torch.repeat_interleave(
+                 logits_metadata.temperature.view(-1),
+diff --git a/python/sglang/srt/managers/detokenizer_manager.py b/python/sglang/srt/managers/detokenizer_manager.py
+index 9749af0e09..f676cd5ded 100644
+--- a/python/sglang/srt/managers/detokenizer_manager.py
++++ b/python/sglang/srt/managers/detokenizer_manager.py
+@@ -42,6 +42,7 @@ from sglang.srt.utils import (
+ )
+ from sglang.srt.utils.hf_transformers_utils import get_tokenizer
+ from sglang.srt.utils.network import get_zmq_socket
++from sglang.srt.utils.patch_tokenizer import decode_without_hf_kwargs
+ from sglang.srt.utils.watchdog import Watchdog
+ from sglang.utils import (
+     TypeBasedDispatcher,
+@@ -68,6 +69,22 @@ class DecodeStatus:
+     read_offset: int
+     # Offset that's sent to tokenizer for incremental update.
+     sent_offset: int = 0
++    decoded_text_len: int = dataclasses.field(init=False)
++    decoded_text_chunks: List[str] = dataclasses.field(default_factory=list)
++
++    def __post_init__(self):
++        self.decoded_text_len = len(self.decoded_text)
++
++    def append_decoded_text(self, text: str):
++        if text:
++            self.decoded_text_chunks.append(text)
++            self.decoded_text_len += len(text)
++
++    def get_decoded_text(self) -> str:
++        if self.decoded_text_chunks:
++            self.decoded_text += "".join(self.decoded_text_chunks)
++            self.decoded_text_chunks.clear()
++        return self.decoded_text
+ 
+ 
+ class DetokenizerManager(MultiHttpWorkerDetokenizerMixin):
+@@ -147,7 +164,7 @@ class DetokenizerManager(MultiHttpWorkerDetokenizerMixin):
+     def trim_matched_stop(
+         self, output: Union[str, List[int]], finished_reason: Dict, no_stop_trim: bool
+     ):
+-        if no_stop_trim or not finished_reason:
++        if not finished_reason:
+             return output
+ 
+         matched = finished_reason.get("matched", None)
+@@ -159,10 +176,15 @@ class DetokenizerManager(MultiHttpWorkerDetokenizerMixin):
+         # Trim stop str.
+         if isinstance(matched, str) and isinstance(output, str):
+             pos = output.find(matched)
+-            return output[:pos] if pos != -1 else output
++            if pos == -1:
++                return output
++            end = pos + len(matched)
++            return output[:end] if no_stop_trim else output[:pos]
+ 
+         # Trim stop token.
+         if isinstance(matched, int) and isinstance(output, list):
++            if no_stop_trim:
++                return output
+             # 200012 <|call|> is the tool call token and one of eos tokens for gpt-oss model
+             if output[-1] == 200012 and self.is_tool_call_parser_gpt_oss:
+                 return output
+@@ -182,36 +204,61 @@ class DetokenizerManager(MultiHttpWorkerDetokenizerMixin):
+         space_list: List[bool],
+     ) -> List[str]:
+         """Batch decode with grouping by (skip_special_tokens, spaces_between_special_tokens)."""
+-
+-        # fast path
+-        first_skip, first_space = skip_list[0], space_list[0]
+-        if all(
+-            s == first_skip and sp == first_space
+-            for s, sp in zip(skip_list, space_list)
+-        ):
+-            return self.tokenizer.batch_decode(
+-                ids_list,
+-                skip_special_tokens=first_skip,
+-                spaces_between_special_tokens=first_space,
+-            )
+-
+-        # Group indices by (skip, space) tuple
+-        groups: Dict[Tuple[bool, bool], List[int]]
+-        groups = defaultdict(list)
+-        for idx, (skip, space) in enumerate(zip(skip_list, space_list)):
+-            groups[(skip, space)].append(idx)
+-
+-        # Decode each group and collect results
+-        results: List[str] = [""] * len(ids_list)
+-        for (skip, space), indices in groups.items():
+-            decoded = self.tokenizer.batch_decode(
+-                [ids_list[idx] for idx in indices],
+-                skip_special_tokens=skip,
+-                spaces_between_special_tokens=space,
+-            )
+-            for idx, text in zip(indices, decoded):
+-                results[idx] = text
+-
++        n = len(ids_list)
++        if n == 0:
++            return []
++
++        # Empty token spans decode to "" but tokenizer.batch_decode (and the
++        # slow per-row decode_without_hf_kwargs path) still pays per-row
++        # overhead; under high-concurrency streaming this adds up. Filter
++        # empties out, decode the rest, then scatter back.
++        keep_idx: Optional[List[int]] = None
++        if not all(ids_list):
++            keep_idx = [i for i, ids in enumerate(ids_list) if ids]
++            if not keep_idx:
++                return [""] * n
++            ids_list = [ids_list[i] for i in keep_idx]
++            skip_list = [skip_list[i] for i in keep_idx]
++            space_list = [space_list[i] for i in keep_idx]
++
++        if not getattr(self.tokenizer, "is_fast", False):
++            decoded = [
++                decode_without_hf_kwargs(self.tokenizer, ids, skip)
++                for ids, skip in zip(ids_list, skip_list)
++            ]
++        else:
++            # fast path: all rows share the same (skip, space) flags.
++            first_skip, first_space = skip_list[0], space_list[0]
++            if all(
++                s == first_skip and sp == first_space
++                for s, sp in zip(skip_list, space_list)
++            ):
++                decoded = self.tokenizer.batch_decode(
++                    ids_list,
++                    skip_special_tokens=first_skip,
++                    spaces_between_special_tokens=first_space,
++                )
++            else:
++                # Group indices by (skip, space) tuple and decode each group.
++                groups: Dict[Tuple[bool, bool], List[int]] = defaultdict(list)
++                for idx, (skip, space) in enumerate(zip(skip_list, space_list)):
++                    groups[(skip, space)].append(idx)
++
++                decoded = [""] * len(ids_list)
++                for (skip, space), indices in groups.items():
++                    group_decoded = self.tokenizer.batch_decode(
++                        [ids_list[idx] for idx in indices],
++                        skip_special_tokens=skip,
++                        spaces_between_special_tokens=space,
++                    )
++                    for idx, text in zip(indices, group_decoded):
++                        decoded[idx] = text
++
++        if keep_idx is None:
++            return decoded
++        results = [""] * n
++        for i, text in zip(keep_idx, decoded):
++            results[i] = text
+         return results
+ 
+     def _decode_batch_token_id_output(self, recv_obj: BatchTokenIDOutput):
+@@ -294,25 +341,36 @@ class DetokenizerManager(MultiHttpWorkerDetokenizerMixin):
+                 )
+             new_text = read_texts[i][len(surr_texts[i]) :]
+             if recv_obj.finished_reasons[i] is None:
+-                # Streaming chunk: update the decode status
++                # Streaming. Invariant: sent_offset >= decoded_text_len. The
++                # gap (`pending`) is "printable but uncommitted" text emitted
++                # in a prior "�" recovery step; we skip it from this step's
++                # emission so we don't double-send.
++                pending = s.sent_offset - s.decoded_text_len
+                 if new_text and not new_text.endswith("�"):
+-                    s.decoded_text += new_text
++                    # Clean text: commit to decoded_text and advance offsets.
++                    s.append_decoded_text(new_text)
+                     s.surr_offset = s.read_offset
+                     s.read_offset = len(s.decode_ids)
+-                    new_text = ""
++                    s.sent_offset = s.decoded_text_len
++                    output_strs.append(new_text[pending:] if pending else new_text)
+                 else:
+-                    new_text = find_printable_text(new_text)
+-            else:
+-                if rid in self.decode_status:
+-                    del self.decode_status[rid]
+-
++                    # Incomplete UTF-8: emit the printable prefix only; do not
++                    # commit (token offsets stay so the next iteration retries
++                    # with more tokens).
++                    printable = find_printable_text(new_text)
++                    s.sent_offset = s.decoded_text_len + len(printable)
++                    output_strs.append(printable[pending:] if pending else printable)
++                continue
++
++            if rid in self.decode_status:
++                del self.decode_status[rid]
++
++            # Finished: materialize once, trim the matched stop, emit the tail.
+             output_str = self.trim_matched_stop(
+-                s.decoded_text + new_text,
++                s.get_decoded_text() + new_text,
+                 recv_obj.finished_reasons[i],
+                 recv_obj.no_stop_trim[i],
+             )
+-
+-            # Incrementally send text.
+             incremental_output = output_str[s.sent_offset :]
+             s.sent_offset = len(output_str)
+             output_strs.append(incremental_output)
+diff --git a/python/sglang/srt/managers/schedule_batch.py b/python/sglang/srt/managers/schedule_batch.py
+index dabf8dc5dc..770f7e5b9a 100644
+--- a/python/sglang/srt/managers/schedule_batch.py
++++ b/python/sglang/srt/managers/schedule_batch.py
+@@ -1051,7 +1051,18 @@ class Req(ReqDllmMixin):
+ 
+         return self.surr_and_decode_ids, self.read_offset - self.surr_offset
+ 
+-    def tail_str(self) -> str:
++    def _stop_match_tail_len(self, new_accepted_len: int) -> int:
++        max_len_tail_str = max(
++            self.sampling_params.stop_str_max_len + 1,
++            self.sampling_params.stop_regex_max_len + 1,
++        )
++        # Cover all newly accepted tokens so an early stop string is not missed
++        # when speculative decoding accepts multiple tokens per step.
++        return min(
++            max_len_tail_str + max(new_accepted_len - 1, 0), len(self.output_ids)
++        )
++
++    def tail_str(self, new_accepted_len: int = 1) -> str:
+         # Check stop strings and stop regex patterns together
+         if (
+             len(self.sampling_params.stop_strs) == 0
+@@ -1059,12 +1070,7 @@ class Req(ReqDllmMixin):
+         ):
+             return ""
+ 
+-        max_len_tail_str = max(
+-            self.sampling_params.stop_str_max_len + 1,
+-            self.sampling_params.stop_regex_max_len + 1,
+-        )
+-
+-        tail_len = min(max_len_tail_str, len(self.output_ids))
++        tail_len = self._stop_match_tail_len(new_accepted_len)
+         return self.tokenizer.decode(self.output_ids[-tail_len:])
+ 
+     def check_match_stop_str_prefix(self) -> bool:
+@@ -1120,18 +1126,51 @@ class Req(ReqDllmMixin):
+ 
+         return False
+ 
+-    def _check_str_based_finish(self):
++    def _locate_str_stop_finished_len(
++        self,
++        new_accepted_len: int,
++        *,
++        stop_str: Optional[str] = None,
++        stop_regex: Optional[str] = None,
++    ) -> int:
++        """Map a matched stop string/regex to output_ids length (stop included)."""
++
++        def matched(text: str) -> bool:
++            if stop_str is not None:
++                return stop_str in text
++            return re.search(stop_regex, text) is not None
++
++        tail_len = self._stop_match_tail_len(new_accepted_len)
++        start = len(self.output_ids) - tail_len
++        token_window = self.output_ids[start:]
++
++        # Old prefixes were checked in the previous step.
++        for token_count in range(
++            max(1, len(token_window) - new_accepted_len + 1), len(token_window)
++        ):
++            if matched(self.tokenizer.decode(token_window[:token_count])):
++                return start + token_count
++
++        # The full tail window is already known to match by the caller.
++        return len(self.output_ids)
++
++    def _check_str_based_finish(self, new_accepted_len: int = 1):
+         if (
+             len(self.sampling_params.stop_strs) > 0
+             or len(self.sampling_params.stop_regex_strs) > 0
+         ):
+-            tail_str = self.tail_str()
++            tail_str = self.tail_str(new_accepted_len)
+ 
+             # Check stop strings
+             if len(self.sampling_params.stop_strs) > 0:
+                 for stop_str in self.sampling_params.stop_strs:
+-                    if stop_str in tail_str or stop_str in self.decoded_text:
++                    stop_str_in_tail = stop_str in tail_str
++                    if stop_str_in_tail or stop_str in self.decoded_text:
+                         self.finished_reason = FINISH_MATCHED_STR(matched=stop_str)
++                        if stop_str_in_tail:
++                            self.finished_len = self._locate_str_stop_finished_len(
++                                new_accepted_len, stop_str=stop_str
++                            )
+                         return True
+ 
+             # Check stop regex
+@@ -1141,6 +1180,9 @@ class Req(ReqDllmMixin):
+                         self.finished_reason = FINISHED_MATCHED_REGEX(
+                             matched=stop_regex_str
+                         )
++                        self.finished_len = self._locate_str_stop_finished_len(
++                            new_accepted_len, stop_regex=stop_regex_str
++                        )
+                         return True
+ 
+         return False
+@@ -1190,7 +1232,7 @@ class Req(ReqDllmMixin):
+         if self._check_vocab_boundary_finish(new_accepted_tokens):
+             return
+ 
+-        if self._check_str_based_finish():
++        if self._check_str_based_finish(new_accepted_len):
+             return
+ 
+     def reset_for_retract(self):
+@@ -1312,6 +1354,17 @@ class Req(ReqDllmMixin):
+         )
+ 
+ 
++def _compute_chunked_req_next_prompt_token(
++    chunked_req: Optional[Req],
++) -> Optional[int]:
++    if chunked_req is None:
++        return None
++    fill_len = len(chunked_req.fill_ids)
++    if fill_len >= len(chunked_req.origin_input_ids):
++        return None
++    return int(chunked_req.origin_input_ids[fill_len])
++
++
+ @dataclasses.dataclass
+ class ScheduleBatch(ScheduleBatchDisaggregationDecodeMixin):
+     """Store all information of a batch on the scheduler."""
+@@ -1334,6 +1387,9 @@ class ScheduleBatch(ScheduleBatchDisaggregationDecodeMixin):
+ 
+     # For chunked prefill in PP
+     chunked_req: Optional[Req] = None
++    # Next prompt token after the current prefill chunk (EAGLE draft chain
++    # correctness across chunk boundaries, upstream #26800)
++    chunked_req_next_prompt_token: Optional[int] = None
+ 
+     # Sampling info
+     sampling_info: SamplingBatchInfo = None
+@@ -1487,6 +1543,9 @@ class ScheduleBatch(ScheduleBatchDisaggregationDecodeMixin):
+             return_routed_experts=any(req.return_routed_experts for req in reqs),
+             is_prefill_only=all(req.is_prefill_only for req in reqs),
+             chunked_req=chunked_req,
++            chunked_req_next_prompt_token=_compute_chunked_req_next_prompt_token(
++                chunked_req
++            ),
+             dllm_config=dllm_config,
+         )
+ 
+@@ -2492,6 +2551,12 @@ class ScheduleBatch(ScheduleBatchDisaggregationDecodeMixin):
+             dllm_block_offsets=[req.dllm_block_offset for req in self.reqs],
+             dllm_config=self.dllm_config,
+             reqs=self.reqs,
++            chunked_req_next_prompt_token=self.chunked_req_next_prompt_token,
++            chunked_req_index=(
++                self.reqs.index(self.chunked_req)
++                if (self.chunked_req is not None and self.chunked_req in self.reqs)
++                else -1
++            ),
+             has_grammar=self.has_grammar,
+             mamba_track_indices=self.mamba_track_indices,
+             mamba_track_mask=self.mamba_track_mask,
+@@ -2693,6 +2758,10 @@ class ModelWorkerBatch:
+     # For constrained decoding
+     # FIXME(lsyin): remove this after fully overlap grammar
+     reqs: Optional[List[Req]] = None
++    # EAGLE chunked-prefill draft-chain (upstream #26800, adapted: our worker
++    # path receives ModelWorkerBatch, so the field rides along with an index)
++    chunked_req_next_prompt_token: Optional[int] = None
++    chunked_req_index: int = -1
+     has_grammar: bool = False
+ 
+     # For hidden states before normal
+diff --git a/python/sglang/srt/managers/scheduler.py b/python/sglang/srt/managers/scheduler.py
+index 2bb563122f..1f8490e632 100644
+--- a/python/sglang/srt/managers/scheduler.py
++++ b/python/sglang/srt/managers/scheduler.py
+@@ -2762,7 +2762,10 @@ class Scheduler(
+                     batch_result.copy_done = self.device_module.Event()
+                     if batch_result.delay_sample_func is None:
+                         self.future_map.store_to_map(future_indices, batch_result)
+-                        batch_result.copy_to_cpu(return_logprob=batch.return_logprob)
++                        batch_result.copy_to_cpu(
++                            return_logprob=batch.return_logprob,
++                            return_hidden_states=batch.return_hidden_states,
++                        )
+                     else:
+                         batch_result.future_indices = future_indices
+ 
+@@ -2869,7 +2872,10 @@ class Scheduler(
+             _batch_result = batch_result.delay_sample_func()
+             assert _batch_result is batch_result
+             self.future_map.store_to_map(batch_result.future_indices, batch_result)
+-            batch_result.copy_to_cpu(return_logprob=self.cur_batch.return_logprob)
++            batch_result.copy_to_cpu(
++                return_logprob=self.cur_batch.return_logprob,
++                return_hidden_states=self.cur_batch.return_hidden_states,
++            )
+ 
+         # Release the closure and large GPU tensors that are no longer needed.
+         # The delay_sample_func closure captures forward_batch (which holds
+diff --git a/python/sglang/srt/managers/utils.py b/python/sglang/srt/managers/utils.py
+index ba77733000..407e4c410d 100644
+--- a/python/sglang/srt/managers/utils.py
++++ b/python/sglang/srt/managers/utils.py
+@@ -49,7 +49,7 @@ class GenerationBatchResult:
+     # metrics
+     expert_distribution_metrics: Optional[ExpertDistributionMetrics] = None
+ 
+-    def copy_to_cpu(self, return_logprob: bool):
++    def copy_to_cpu(self, return_logprob: bool, return_hidden_states: bool = True):
+         """Copy tensors to CPU in overlap scheduling.
+         Only the tensors which are needed for processing results are copied,
+         e.g., next_token_ids, logits outputs
+@@ -78,7 +78,7 @@ class GenerationBatchResult:
+                     v.to("cpu", non_blocking=True) if torch.is_tensor(v) else v
+                     for v in self.logits_output.next_token_token_ids_logprobs_val
+                 ]
+-        if self.logits_output.hidden_states is not None:
++        if return_hidden_states and self.logits_output.hidden_states is not None:
+             self.logits_output.hidden_states = self.logits_output.hidden_states.to(
+                 "cpu", non_blocking=True
+             )
+diff --git a/python/sglang/srt/mem_cache/mamba_radix_cache.py b/python/sglang/srt/mem_cache/mamba_radix_cache.py
+index d07702cf1e..d282e31d1f 100644
+--- a/python/sglang/srt/mem_cache/mamba_radix_cache.py
++++ b/python/sglang/srt/mem_cache/mamba_radix_cache.py
+@@ -207,6 +207,9 @@ class LRUList:
+         setattr(
+             getattr(node, self.nxt), self.prv, getattr(node, self.prv)
+         )  # node.next.prev = node.prev
++        # Clear self pointers to break reference cycles among evicted nodes.
++        setattr(node, self.prv, None)
++        setattr(node, self.nxt, None)
+ 
+     def _get_lru(self) -> Optional[TreeNode]:
+         """
+diff --git a/python/sglang/srt/mem_cache/memory_pool.py b/python/sglang/srt/mem_cache/memory_pool.py
+index d59a18fcb9..f22320a22e 100644
+--- a/python/sglang/srt/mem_cache/memory_pool.py
++++ b/python/sglang/srt/mem_cache/memory_pool.py
+@@ -475,7 +475,7 @@ class HybridReqToTokenPool(ReqToTokenPool):
+         self.start_layer = start_layer if start_layer is not None else 0
+         self.layer_transfer_counter = None
+         self._init_mamba_pool(
+-            size=mamba_size,
++            mamba_size=mamba_size,
+             mamba_spec_state_size=mamba_spec_state_size,
+             cache_params=cache_params,
+             mamba_layer_ids=mamba_layer_ids,
+@@ -486,7 +486,7 @@ class HybridReqToTokenPool(ReqToTokenPool):
+ 
+     def _init_mamba_pool(
+         self,
+-        size: int,
++        mamba_size: int,
+         mamba_spec_state_size: int,
+         cache_params: BaseLinearStateParams,
+         mamba_layer_ids: List[int],
+@@ -495,7 +495,7 @@ class HybridReqToTokenPool(ReqToTokenPool):
+         speculative_num_draft_tokens: int = None,
+     ):
+         self.mamba_pool = MambaPool(
+-            size=size,
++            size=mamba_size,
+             spec_state_size=mamba_spec_state_size,
+             cache_params=cache_params,
+             mamba_layer_ids=mamba_layer_ids,
+@@ -506,13 +506,16 @@ class HybridReqToTokenPool(ReqToTokenPool):
+         self.mamba_map = {layer_id: i for i, layer_id in enumerate(mamba_layer_ids)}
+ 
+         self.device = device
++        # Indexed by req_pool_idx, so size from the req pool buffer
++        # (self.req_to_token.shape[0]), not from the mamba state pool size.
++        req_pool_size = self.req_to_token.shape[0]
+         self.req_index_to_mamba_index_mapping: torch.Tensor = torch.zeros(
+-            size, dtype=torch.int32, device=self.device
++            req_pool_size, dtype=torch.int32, device=self.device
+         )
+         if enable_mamba_extra_buffer:
+             self.req_index_to_mamba_ping_pong_track_buffer_mapping: torch.Tensor = (
+                 torch.zeros(
+-                    (size, self.mamba_ping_pong_track_buffer_size),
++                    (req_pool_size, self.mamba_ping_pong_track_buffer_size),
+                     dtype=torch.int32,
+                     device=self.device,
+                 )
+@@ -630,6 +633,12 @@ class HybridReqToTokenPool(ReqToTokenPool):
+                         mamba_ping_pong_track_buffer_to_free[0:0]
+                     )
+             self.mamba_pool.free(mamba_ping_pong_track_buffer_to_free)
++            # Match the req.mamba_pool_idx=None clear above so the next
++            # alloc() doesn't see a stale ping-pong reference on the req
++            # and skip allocation (which would silently reuse a freed
++            # tensor on the req side while the new pool slot leaks).
++            req.mamba_ping_pong_track_buffer = None
++            req.mamba_next_track_idx = None
+ 
+     def clear(self):
+         logger.info("Reset HybridReqToTokenPool")
+@@ -1284,6 +1293,7 @@ class HybridLinearKVPool(KVCache):
+         device: str,
+         mamba_pool: MambaPool,
+         enable_memory_saver: bool = False,
++        enable_kv_cache_copy: bool = False,
+         # TODO: refactor mla related args
+         use_mla: bool = False,
+         kv_lora_rank: int = None,
+@@ -1329,6 +1339,7 @@ class HybridLinearKVPool(KVCache):
+                 layer_num=self.full_layer_nums,
+                 device=device,
+                 enable_memory_saver=enable_memory_saver,
++                enable_kv_cache_copy=enable_kv_cache_copy,
+                 **quant_method_kwarg,
+             )
+         else:
+diff --git a/python/sglang/srt/mem_cache/swa_radix_cache.py b/python/sglang/srt/mem_cache/swa_radix_cache.py
+index 6e1b1c8473..ec19f34448 100644
+--- a/python/sglang/srt/mem_cache/swa_radix_cache.py
++++ b/python/sglang/srt/mem_cache/swa_radix_cache.py
+@@ -161,6 +161,9 @@ class LRUList:
+         setattr(
+             getattr(node, self.nxt), self.prv, getattr(node, self.prv)
+         )  # node.next.prev = node.prev
++        # Clear self pointers to break reference cycles among evicted nodes.
++        setattr(node, self.prv, None)
++        setattr(node, self.nxt, None)
+ 
+     def _get_lru(self) -> Optional[TreeNode]:
+         """
+diff --git a/python/sglang/srt/model_executor/model_runner_kv_cache_mixin.py b/python/sglang/srt/model_executor/model_runner_kv_cache_mixin.py
+index d90317220c..e200ec45ae 100644
+--- a/python/sglang/srt/model_executor/model_runner_kv_cache_mixin.py
++++ b/python/sglang/srt/model_executor/model_runner_kv_cache_mixin.py
+@@ -683,6 +683,9 @@ class ModelRunnerKVCacheMixin:
+                     device=self.device,
+                     mamba_pool=self.req_to_token_pool.mamba_pool,
+                     enable_memory_saver=self.server_args.enable_memory_saver,
++                    enable_kv_cache_copy=(
++                        self.server_args.speculative_algorithm is not None
++                    ),
+                     use_mla=self.use_mla_backend,
+                     quant_method=hybrid_quant_method,
+                     start_layer=self.start_layer,
+diff --git a/python/sglang/srt/parser/jinja_template_utils.py b/python/sglang/srt/parser/jinja_template_utils.py
+index 37434713de..4a760f0d5c 100644
+--- a/python/sglang/srt/parser/jinja_template_utils.py
++++ b/python/sglang/srt/parser/jinja_template_utils.py
+@@ -157,14 +157,16 @@ def process_content_for_template_format(
+             if isinstance(chunk, dict):
+                 chunk_type = chunk.get("type")
+ 
+-                if chunk_type == "image_url":
++                if chunk_type in ("image_url", "input_image"):
+                     image_obj = chunk.get("image_url") or {}
++                    if isinstance(image_obj, str):
++                        image_obj = {"url": image_obj, "detail": chunk.get("detail")}
+                     mdp = image_obj.get("max_dynamic_patch", None)
+                     # Also allow flat style: chunk["max_dynamic_patch"]
+                     image_data.append(
+                         ImageData(
+                             url=image_obj["url"],
+-                            detail=image_obj.get("detail", "auto"),
++                            detail=image_obj.get("detail") or "auto",
+                             max_dynamic_patch=mdp,
+                         )
+                     )
+@@ -194,13 +196,15 @@ def process_content_for_template_format(
+                     audio_data.append(chunk["audio_url"]["url"])
+                     # Normalize to simple 'audio' type
+                     processed_content_parts.append({"type": "audio"})
+-                elif chunk_type == "text":
++                elif chunk_type in ("text", "input_text"):
+                     # For v32 encoding, collect text parts separately
+                     if use_dpsk_v32_encoding:
+                         text_parts.append(chunk["text"])
+                     else:
+                         # Keep text content as-is for openai format
+-                        processed_content_parts.append(chunk)
++                        processed_content_parts.append(
++                            {"type": "text", "text": chunk["text"]}
++                        )
+ 
+         new_msg = {
+             k: v for k, v in msg_dict.items() if v is not None and k != "content"
+@@ -215,7 +219,7 @@ def process_content_for_template_format(
+         # String format: flatten to text only (for templates like DeepSeek)
+         text_parts = []
+         for chunk in msg_dict["content"]:
+-            if isinstance(chunk, dict) and chunk.get("type") == "text":
++            if isinstance(chunk, dict) and chunk.get("type") in ("text", "input_text"):
+                 text_parts.append(chunk["text"])
+             # Note: For string format, we ignore images/audio since the template
+             # doesn't expect structured content - multimodal placeholders would
+diff --git a/python/sglang/srt/parser/reasoning_parser.py b/python/sglang/srt/parser/reasoning_parser.py
+index 8811c90b2d..3c018427d1 100644
+--- a/python/sglang/srt/parser/reasoning_parser.py
++++ b/python/sglang/srt/parser/reasoning_parser.py
+@@ -1,4 +1,4 @@
+-from typing import Dict, Optional, Tuple, Type
++from typing import Dict, List, Optional, Tuple, Type
+ 
+ from sglang.srt.entrypoints.openai.protocol import ChatCompletionRequest
+ from sglang.srt.parser.harmony_parser import HarmonyParser
+@@ -23,6 +23,7 @@ class BaseReasoningFormatDetector:
+         self,
+         think_start_token: str,
+         think_end_token: str,
++        think_excluded_tokens: Optional[List[str]] = None,
+         force_reasoning: bool = False,
+         stream_reasoning: bool = True,
+         tool_start_token: Optional[str] = None,
+@@ -31,6 +32,7 @@ class BaseReasoningFormatDetector:
+     ):
+         self.think_start_token = think_start_token
+         self.think_end_token = think_end_token
++        self.think_excluded_tokens = think_excluded_tokens
+         self.tool_start_token = tool_start_token
+         self._in_reasoning = force_reasoning
+         self.stream_reasoning = stream_reasoning
+@@ -237,11 +239,21 @@ class Qwen3Detector(BaseReasoningFormatDetector):
+         continue_final_message: bool = False,
+         previous_content: str = "",
+     ):
++        think_excluded_tokens = [
++            "<tool_call>",
++            "</tool_call>",
++            "<|im_end|>",
++            "<|endoftext|>",
++        ]
+         super().__init__(
+             "<think>",
+             "</think>",
++            think_excluded_tokens=think_excluded_tokens,
+             force_reasoning=force_reasoning,
+             stream_reasoning=stream_reasoning,
++            # Qwen3.5 sometimes opens ``<tool_call>`` without closing
++            # ``</think>``; treat it as an implicit reasoning close.
++            tool_start_token="<tool_call>",
+             continue_final_message=continue_final_message,
+             previous_content=previous_content,
+         )
+@@ -290,9 +302,22 @@ class KimiK2Detector(BaseReasoningFormatDetector):
+         continue_final_message: bool = False,
+         previous_content: str = "",
+     ):
++        think_excluded_tokens = [
++            "<think>",
++            "<|tool_calls_section_begin|>",
++            "<|tool_call_begin|>",
++            "<|tool_call_argument_begin|>",
++            "<|tool_call_section_end|>",
++            "<|tool_call_end|>",
++            "[EOS]",
++            "<|im_end|>",
++            "<|end_header_id|>",
++            "[EOT]",
++        ]
+         super().__init__(
+             "<think>",
+             "</think>",
++            think_excluded_tokens=think_excluded_tokens,
+             force_reasoning=force_reasoning,
+             stream_reasoning=stream_reasoning,
+             tool_start_token="<|tool_calls_section_begin|>",
+@@ -315,9 +340,17 @@ class Glm45Detector(BaseReasoningFormatDetector):
+     """
+ 
+     def __init__(self, stream_reasoning: bool = True, force_reasoning: bool = False):
++        think_excluded_tokens = [
++            "<tool_call>",
++            "</tool_call>",
++            "<eop>",
++            "<|user|>",
++            "<|endoftext|>",
++        ]
+         super().__init__(
+             "<think>",
+             "</think>",
++            think_excluded_tokens=think_excluded_tokens,
+             force_reasoning=force_reasoning,
+             stream_reasoning=stream_reasoning,
+             tool_start_token="<tool_call>",
+diff --git a/python/sglang/srt/server_args.py b/python/sglang/srt/server_args.py
+index d80b4eb5ed..9abd0581e5 100644
+--- a/python/sglang/srt/server_args.py
++++ b/python/sglang/srt/server_args.py
+@@ -445,6 +445,9 @@ class ServerArgs:
+     file_storage_path: str = "sglang_storage"
+     enable_cache_report: bool = False
+     reasoning_parser: Optional[str] = None
++    # NOTE: upstream's strip_thinking_cache field omitted — its feature commit
++    # is not in this tree and a field without an argparse arg breaks from_cli_args
++    enable_strict_thinking: bool = False
+     tool_call_parser: Optional[str] = None
+     tool_server: Optional[str] = None
+     sampling_defaults: str = "model"
+@@ -4853,6 +4856,14 @@ class ServerArgs:
+             default=ServerArgs.reasoning_parser,
+             help=f"Specify the parser for reasoning models, supported parsers are: {list(ReasoningParser.DetectorMap.keys())}.",
+         )
++        parser.add_argument(
++            "--enable-strict-thinking",
++            action="store_true",
++            default=ServerArgs.enable_strict_thinking,
++            help="Enable strict token filtering during the thinking phase. "
++            "Blocks model-specific excluded tokens (e.g., tool call markers) "
++            "during reasoning. Requires a grammar backend that supports token filtering.",
++        )
+         tool_call_parser_choices = list(FunctionCallParser.ToolCallParserEnum.keys())
+         parser.add_argument(
+             "--tool-call-parser",
+diff --git a/python/sglang/srt/speculative/eagle_draft_extend_cuda_graph_runner.py b/python/sglang/srt/speculative/eagle_draft_extend_cuda_graph_runner.py
+index 4f813d140d..d062545026 100644
+--- a/python/sglang/srt/speculative/eagle_draft_extend_cuda_graph_runner.py
++++ b/python/sglang/srt/speculative/eagle_draft_extend_cuda_graph_runner.py
+@@ -28,12 +28,15 @@ from sglang.srt.model_executor.input_buffers import ForwardInputBuffers
+ from sglang.srt.speculative.eagle_info import EagleDraftInput
+ from sglang.srt.speculative.spec_utils import fast_topk
+ from sglang.srt.utils import (
++    is_hip,
+     require_attn_tp_gather,
+     require_gathered_buffer,
+     require_mlp_sync,
+     require_mlp_tp_gather,
+ )
+ 
++_is_hip = is_hip()
++
+ if TYPE_CHECKING:
+     from sglang.srt.speculative.eagle_worker import EAGLEWorker
+ 
+@@ -409,8 +412,17 @@ class EAGLEDraftExtendCudaGraphRunner:
+                 forward_batch.positions,
+                 forward_batch,
+             )
+-            probs = torch.softmax(ret.next_token_logits, dim=-1)
+-            ret.topk_p, ret.topk_index = fast_topk(probs, self.topk, dim=-1)
++            # ROCm's argmax tie-breaks differently from CUDA's softmax+max
++            # path on FP8 logits, which corrupts MTP draft selection on AMD.
++            # Keep the fastpath CUDA-only.
++            if self.topk == 1 and not _is_hip:
++                ret.topk_index = torch.argmax(
++                    ret.next_token_logits, dim=-1, keepdim=True
++                )
++                ret.topk_p = torch.ones_like(ret.topk_index, dtype=torch.float32)
++            else:
++                probs = torch.softmax(ret.next_token_logits, dim=-1)
++                ret.topk_p, ret.topk_index = fast_topk(probs, self.topk, dim=-1)
+ 
+             forward_batch.out_cache_loc = output_cache_loc_backup
+             forward_batch.spec_info.hidden_states = hidden_states_backup
+diff --git a/python/sglang/srt/speculative/eagle_info.py b/python/sglang/srt/speculative/eagle_info.py
+index c1eee12985..9c81b7fc9f 100644
+--- a/python/sglang/srt/speculative/eagle_info.py
++++ b/python/sglang/srt/speculative/eagle_info.py
+@@ -1,5 +1,5 @@
++import copy
+ import logging
+-from copy import copy
+ from dataclasses import dataclass
+ from typing import List, Optional, Tuple
+ 
+diff --git a/python/sglang/srt/speculative/eagle_utils.py b/python/sglang/srt/speculative/eagle_utils.py
+index f41a92523e..8742fb10e3 100644
+--- a/python/sglang/srt/speculative/eagle_utils.py
++++ b/python/sglang/srt/speculative/eagle_utils.py
+@@ -3,6 +3,13 @@ from enum import IntEnum
+ from typing import List, Optional
+ 
+ import torch
++from typing import TYPE_CHECKING
++
++# our tree keeps maybe_detect_oob in spec_utils (no utils.async_probe module)
++from sglang.srt.speculative.spec_utils import maybe_detect_oob
++
++if TYPE_CHECKING:
++    from sglang.srt.managers.schedule_batch import ScheduleBatch
+ 
+ from sglang.srt.utils import is_cuda, is_hip, is_npu
+ 
+@@ -16,6 +23,26 @@ if _is_cuda or _is_hip:
+     )
+ 
+ 
++def _eagle_prefill_tail_tokens(
++    batch: "ScheduleBatch", next_token_ids: torch.Tensor
++) -> torch.Tensor:
++    """Per-seq tail token for EAGLE prefill rotation; uses next prompt token for
++    non-final chunks (chunked-prefill chain consistency, see PR #26329)."""
++    tail_tokens = next_token_ids.to(batch.input_ids.dtype)
++    next_prompt_token = getattr(batch, "chunked_req_next_prompt_token", None)
++    if next_prompt_token is not None:
++        idx = getattr(batch, "chunked_req_index", -1)
++        if idx < 0 and getattr(batch, "chunked_req", None) is not None:
++            for i, r in enumerate(batch.reqs or []):
++                if r is batch.chunked_req:
++                    idx = i
++                    break
++        if 0 <= idx < tail_tokens.shape[0]:
++            tail_tokens = tail_tokens.clone()
++            tail_tokens[idx] = next_prompt_token
++    return tail_tokens
++
++
+ def organize_draft_results(
+     score_list: List[torch.Tensor],
+     token_list: List[torch.Tensor],
+@@ -27,13 +54,21 @@ def organize_draft_results(
+     top_scores = torch.topk(score_list, num_draft_token - 1, dim=-1)
+     top_scores_index = top_scores.indices
+     top_scores_index = torch.sort(top_scores_index).values
++    maybe_detect_oob(
++        top_scores_index,
++        0,
++        ss_token_list.shape[1],
++        "organize_draft_results: top_scores_index OOB for gather on ss_token_list",
++    )
+     draft_tokens = torch.gather(ss_token_list, index=top_scores_index, dim=1)
+ 
+     if len(parents_list) > 1:
+         parent_list = torch.cat(parents_list[:-1], dim=1)
+     else:
+         batch_size = parents_list[0].shape[0]
+-        parent_list = torch.empty(batch_size, 0, device=parents_list[0].device)
++        parent_list = torch.empty(
++            batch_size, 0, dtype=torch.long, device=parents_list[0].device
++        )
+ 
+     return parent_list, top_scores_index, draft_tokens
+ 
+diff --git a/python/sglang/srt/speculative/eagle_worker_v2.py b/python/sglang/srt/speculative/eagle_worker_v2.py
+index b151968040..bf97626ed9 100644
+--- a/python/sglang/srt/speculative/eagle_worker_v2.py
++++ b/python/sglang/srt/speculative/eagle_worker_v2.py
+@@ -42,7 +42,12 @@ from sglang.srt.speculative.eagle_info_v2 import (
+     fill_accepted_out_cache_loc,
+     fill_new_verified_id,
+ )
+-from sglang.srt.speculative.eagle_utils import TreeMaskMode, build_tree_kernel_efficient
++from sglang.srt.speculative.eagle_utils import (
++    TreeMaskMode,
++    _eagle_prefill_tail_tokens,
++    build_tree_kernel_efficient,
++    organize_draft_results,
++)
+ from sglang.srt.speculative.spec_info import SpeculativeAlgorithm
+ from sglang.srt.speculative.spec_utils import (
+     draft_tp_context,
+@@ -115,6 +120,11 @@ class EagleDraftWorker(BaseDraftWorker):
+             server_args.speculative_algorithm
+         )
+ 
++        # Pre-allocated constants for the topk=1 chain fast path in draft_forward.
++        self._topk1_parents_prealloc = None
++        self._topk1_score_indices_prealloc = None
++        self._rebuild_topk1_chain_buffers()
++
+         # Do not capture cuda graph in `TpModelWorker` init,
+         # will capture later with init_cuda_graphs()
+         backup_disable_cuda_graph = server_args.disable_cuda_graph
+@@ -179,6 +189,35 @@ class EagleDraftWorker(BaseDraftWorker):
+ 
+         self.plan_stream, self.plan_stream_ctx = _get_plan_stream(self.device)
+ 
++    def _rebuild_topk1_chain_buffers(self) -> None:
++        # For topk=1 the draft tree degenerates to a chain, so parent_list and
++        # top_scores_index are runtime-invariant. Must be rebuilt after any
++        # change to speculative_num_steps / speculative_num_draft_tokens.
++        if self.topk != 1:
++            return
++        # _override_worker_state can set both directly, bypassing the hook that
++        # pins this relation; the fast path is only valid when it holds.
++        assert self.speculative_num_draft_tokens == self.speculative_num_steps + 1, (
++            "topk=1 requires speculative_num_draft_tokens == speculative_num_steps + 1, "
++            f"got {self.speculative_num_draft_tokens} and {self.speculative_num_steps}"
++        )
++        num_steps = self.speculative_num_steps
++        sa = self.server_args
++        max_bs = max(
++            sa.cuda_graph_max_bs or 0,
++            sa.max_running_requests or 0,
++            1,
++        )
++        # A single-step chain has no parent entries (slow path drops the last
++        # step). repeat (not expand): the kernel reads these as contiguous.
++        parent_width = num_steps if num_steps > 1 else 0
++        self._topk1_parents_prealloc = torch.arange(
++            -1, parent_width - 1, dtype=torch.long, device=self.device
++        ).repeat(max_bs, 1)
++        self._topk1_score_indices_prealloc = torch.arange(
++            num_steps, dtype=torch.long, device=self.device
++        ).repeat(max_bs, 1)
++
+     def init_token_map(self):
+         # Load hot token ids
+         if self.speculative_algorithm.is_eagle3():
+@@ -448,8 +487,19 @@ class EagleDraftWorker(BaseDraftWorker):
+                 forward_batch, skip_attn_backend_init=True
+             ).logits_output
+             maybe_detect_nan(logits_output.next_token_logits, f"draft_forward step {i}")
+-            probs = torch.softmax(logits_output.next_token_logits, dim=-1)
+-            topk_p, topk_index = fast_topk(probs, self.topk, dim=-1)
++            if self.topk == 1 and not _is_hip:
++                # topk=1 → degenerate single-path tree; `topk_p` is unused
++                # downstream, so skip softmax and just argmax over logits.
++                # Gated to CUDA: on ROCm the argmax tie-break diverges from
++                # the softmax+max path on FP8 logits and corrupts MTP draft
++                # selection (DSV3.2 MTP GSM8K, see #26358).
++                topk_index = torch.argmax(
++                    logits_output.next_token_logits, dim=-1, keepdim=True
++                )
++                topk_p = torch.ones_like(topk_index, dtype=torch.float32)
++            else:
++                probs = torch.softmax(logits_output.next_token_logits, dim=-1)
++                topk_p, topk_index = fast_topk(probs, self.topk, dim=-1)
+             maybe_detect_oob(
+                 topk_index,
+                 0,
+@@ -461,32 +511,24 @@ class EagleDraftWorker(BaseDraftWorker):
+             hidden_states = logits_output.hidden_states
+ 
+         # Organize the results
+-        score_list = torch.cat(score_list, dim=1).flatten(
+-            1
+-        )  # b, n, topk; n= 1 + (num_steps-1) * self.topk
+-        ss_token_list = torch.cat(
+-            token_list, dim=1
+-        )  # b, (self.topk + (num_steps-1) * self.topk)
+-        top_scores = torch.topk(
+-            score_list, self.speculative_num_draft_tokens - 1, dim=-1
+-        )
+-        top_scores_index = top_scores.indices
+-        top_scores_index = torch.sort(top_scores_index).values
+-        maybe_detect_oob(
+-            top_scores_index,
+-            0,
+-            ss_token_list.shape[1],
+-            "draft_forward: top_scores_index OOB for gather on ss_token_list",
++        if (
++            self.topk == 1
++            and token_list[0].shape[0] <= self._topk1_parents_prealloc.shape[0]
++        ):
++            # Chain topology: draft_tokens = concat of per-step tokens; the
++            # full-length topk/sort/gather over score_list collapses to an
++            # identity. parent_list and top_scores_index are runtime-invariant
++            # constants pre-allocated on the worker. Oversized batches (rare,
++            # would silently truncate the slice) fall through to the slow path.
++            bs = token_list[0].shape[0]
++            draft_tokens = torch.cat(token_list, dim=1)
++            top_scores_index = self._topk1_score_indices_prealloc[:bs]
++            parent_list = self._topk1_parents_prealloc[:bs]
++            return parent_list, top_scores_index, draft_tokens
++
++        return organize_draft_results(
++            score_list, token_list, parents_list, self.speculative_num_draft_tokens
+         )
+-        draft_tokens = torch.gather(ss_token_list, index=top_scores_index, dim=1)
+-
+-        if len(parents_list) > 1:
+-            parent_list = torch.cat(parents_list[:-1], dim=1)
+-        else:
+-            batch_size = parents_list[0].shape[0]
+-            parent_list = torch.empty(batch_size, 0, device=parents_list[0].device)
+-
+-        return parent_list, top_scores_index, draft_tokens
+ 
+     def draft_extend(self):
+         pass
+@@ -508,11 +550,13 @@ class EagleDraftWorker(BaseDraftWorker):
+         """
+         # Construct input_ids
+         if not batch.forward_mode.is_idle():
++            # Chunked-prefill-aware tail tokens (see PR #26329).
++            tail_tokens = _eagle_prefill_tail_tokens(batch, next_token_ids)
+             pt = 0
+             for i, extend_len in enumerate(batch.extend_seq_lens):
+                 input_ids = batch.input_ids[pt : pt + extend_len]
+                 batch.input_ids[pt : pt + extend_len] = torch.cat(
+-                    (input_ids[1:], next_token_ids[i].reshape(1))
++                    (input_ids[1:], tail_tokens[i].reshape(1))
+                 )
+                 pt += extend_len
+ 
+@@ -604,8 +648,16 @@ class EagleDraftWorker(BaseDraftWorker):
+         draft_logits_output.hidden_states = draft_logits_output.hidden_states[
+             select_index
+         ]
+-        probs = torch.softmax(draft_logits_output.next_token_logits, dim=-1)
+-        ret_topk_p, ret_topk_index = fast_topk(probs, self.topk, dim=-1)
++        if self.topk == 1 and not _is_hip:
++            # Gated to CUDA: see #26358 — ROCm's argmax tie-break corrupts
++            # MTP draft selection on FP8 logits.
++            ret_topk_index = torch.argmax(
++                draft_logits_output.next_token_logits, dim=-1, keepdim=True
++            )
++            ret_topk_p = torch.ones_like(ret_topk_index, dtype=torch.float32)
++        else:
++            probs = torch.softmax(draft_logits_output.next_token_logits, dim=-1)
++            ret_topk_p, ret_topk_index = fast_topk(probs, self.topk, dim=-1)
+         ret_hidden_states = draft_logits_output.hidden_states
+ 
+         # Construct the return values
+@@ -831,9 +883,7 @@ class EAGLEWorkerV2(BaseSpecWorker):
+             self.target_worker.model_runner.hybrid_gdn_config is not None
+             or self.target_worker.model_runner.mamba2_config is not None
+         ):
+-            self._mamba_verify_update(
+-                batch, verify_input, accept_length, accept_index, bs
+-            )
++            self._mamba_verify_update(batch, accept_length, accept_index, bs)
+ 
+         verify_done = torch.get_device_module(self.device).Event()
+         verify_done.record()
+@@ -873,33 +923,38 @@ class EAGLEWorkerV2(BaseSpecWorker):
+     def _mamba_verify_update(
+         self,
+         batch: ModelWorkerBatch,
+-        verify_input: EagleVerifyInput,
+-        accept_length: torch.Tensor,
++        accept_lens: torch.Tensor,
+         accept_index: torch.Tensor,
+         bs: int,
+     ):
+-        """Update mamba state for hybrid GDN models after verification."""
+-        # Calculate accepted_steps for mamba state update
+-        # Include the bonus token (+1)
+-        accepted_length_with_bonus = accept_length
+-        if not batch.forward_mode.is_idle() and accept_index.numel() > 0:
+-            if verify_input.topk != 1:
+-                raise ValueError("Spec v2 currently only supports topk = 1.")
++        """Update mamba state for hybrid GDN models after verification.
+ 
++        `accept_lens` already includes the bonus token (drafts + 1 per req).
++        Ported from upstream #27463: tree-aware (topk > 1) last-step selection;
++        our backend keeps the pre-rename `accepted_steps` kwarg, which carries
++        the same meaning (intermediate-state slot to commit per request).
++        """
++        if not batch.forward_mode.is_idle() and accept_index.numel() > 0:
+             accepted_indices_offset = torch.arange(
+                 0,
+                 bs * self.speculative_num_draft_tokens,
+                 step=self.speculative_num_draft_tokens,
+-                dtype=accepted_length_with_bonus.dtype,
+-                device=accepted_length_with_bonus.device,
++                dtype=accept_lens.dtype,
++                device=accept_lens.device,
++            )
++            req_idx = torch.arange(bs, dtype=torch.int64, device=accept_lens.device)
++            # Per-req tree step of the last accepted node, i.e. the step whose
++            # mamba state to commit; reduces to accept_lens - 1 for topk == 1.
++            last_correct_step_indices = (
++                accept_index[req_idx, (accept_lens - 1).to(torch.int64)]
++                - accepted_indices_offset
+             )
+-            accepted_steps = accepted_length_with_bonus - 1
+ 
+             if batch.mamba_track_indices is not None:
+                 # If after verify, the request's seq_lens has crossed a mamba track interval,
+                 # we need to update the mamba state for the request at the crossing point.
+                 seq_lens_pre_verify = batch.seq_lens
+-                seq_lens_post_verify = batch.seq_lens + accepted_length_with_bonus
++                seq_lens_post_verify = batch.seq_lens + accept_lens
+                 mamba_track_interval = self.server_args.mamba_track_interval
+                 to_track_mask = (
+                     seq_lens_pre_verify // mamba_track_interval
+@@ -911,11 +966,6 @@ class EAGLEWorkerV2(BaseSpecWorker):
+                 to_track_ith = torch.clamp(
+                     tracking_point - seq_lens_pre_verify - 1, min=0
+                 ).to(torch.int64)
+-                req_idx = torch.arange(
+-                    bs,
+-                    dtype=torch.int64,
+-                    device=accepted_length_with_bonus.device,
+-                )
+                 candidate_track_steps = (
+                     accept_index[req_idx, to_track_ith] - accepted_indices_offset
+                 )
+@@ -928,7 +978,7 @@ class EAGLEWorkerV2(BaseSpecWorker):
+                 mamba_steps_to_track = None
+ 
+             self.target_worker.model_runner.attn_backend.update_mamba_state_after_mtp_verify(
+-                accepted_steps=accepted_steps,
++                accepted_steps=last_correct_step_indices,
+                 mamba_track_indices=batch.mamba_track_indices,
+                 mamba_steps_to_track=mamba_steps_to_track,
+                 model=self.target_worker.model_runner.model,
+diff --git a/python/sglang/srt/speculative/multi_layer_eagle_worker_v2.py b/python/sglang/srt/speculative/multi_layer_eagle_worker_v2.py
+index 34ce26ee4f..fef672b0ac 100644
+--- a/python/sglang/srt/speculative/multi_layer_eagle_worker_v2.py
++++ b/python/sglang/srt/speculative/multi_layer_eagle_worker_v2.py
+@@ -383,6 +383,7 @@ class MultiLayerEagleDraftWorker(BaseDraftWorker):
+         forward_batch.return_hidden_states_before_norm = True
+ 
+         # Construct input_ids
++        # TODO: same chunked-prefill chain divergence as PR #26329.
+         if not batch.forward_mode.is_idle():
+             rotate_input_ids_triton(
+                 forward_batch.input_ids,
+diff --git a/python/sglang/srt/speculative/spec_utils.py b/python/sglang/srt/speculative/spec_utils.py
+index 05421c202c..125fd34797 100644
+--- a/python/sglang/srt/speculative/spec_utils.py
++++ b/python/sglang/srt/speculative/spec_utils.py
+@@ -605,14 +605,14 @@ def traverse_tree(
+         if accepted:
+             if curr != 0:
+                 # Accept the current token
+-                grammar.accept_token(draft_tokens[curr])
++                grammar.accept_token(int(draft_tokens[curr]))
+             if not grammar.is_terminated():
+                 # Generate the bitmask for the current token
+                 grammar.fill_vocab_mask(allocate_token_bitmask, curr)
+                 if retrieve_next_token[curr] != -1:
+                     # Visit the child node
+                     dfs(
+-                        retrieve_next_token[curr],
++                        int(retrieve_next_token[curr]),
+                         retrieve_next_token,
+                         retrieve_next_sibling,
+                         curr,
+@@ -625,7 +625,7 @@ def traverse_tree(
+         if retrieve_next_sibling[curr] != -1:
+             # Visit the sibling node
+             dfs(
+-                retrieve_next_sibling[curr],
++                int(retrieve_next_sibling[curr]),
+                 retrieve_next_token,
+                 retrieve_next_sibling,
+                 parent_pos,
+diff --git a/python/sglang/srt/speculative/standalone_worker_v2.py b/python/sglang/srt/speculative/standalone_worker_v2.py
+index ecaab3cc0e..c805502306 100644
+--- a/python/sglang/srt/speculative/standalone_worker_v2.py
++++ b/python/sglang/srt/speculative/standalone_worker_v2.py
+@@ -67,6 +67,11 @@ class StandaloneDraftWorker(EagleDraftWorker):
+             server_args.speculative_algorithm
+         )
+ 
++        # Pre-allocated constants for the topk=1 chain fast path in draft_forward.
++        self._topk1_parents_prealloc = None
++        self._topk1_score_indices_prealloc = None
++        self._rebuild_topk1_chain_buffers()
++
+         # Set constant
+         from sglang.srt.speculative.eagle_info import EagleDraftInput
+ 
+diff --git a/python/sglang/srt/utils/patch_tokenizer.py b/python/sglang/srt/utils/patch_tokenizer.py
+index 7ad1114da8..1d083180f4 100644
+--- a/python/sglang/srt/utils/patch_tokenizer.py
++++ b/python/sglang/srt/utils/patch_tokenizer.py
+@@ -29,6 +29,15 @@ def _is_kimi_tiktoken_tokenizer(tokenizer):
+     return class_name == "TikTokenTokenizer" and "tokenization_kimi" in module_name
+ 
+ 
++def decode_without_hf_kwargs(tokenizer, token_ids, skip_special_tokens):
++    if skip_special_tokens:
++        special_ids = getattr(tokenizer, "all_special_ids_set", None)
++        if special_ids is None:
++            special_ids = set(tokenizer.all_special_ids)
++        token_ids = [tid for tid in token_ids if tid not in special_ids]
++    return tokenizer.decode(token_ids)
++
++
+ class _SpecialTokensCachePatcher:
+     _PATCHED_FLAG = "_sglang_special_tokens_patched"
+     _CACHED_TOKENS_ATTR = "_sglang_cached_special_tokens"
+diff --git a/sgl-kernel/benchmark/bench_moe_topk_softmax.py b/sgl-kernel/benchmark/bench_moe_topk_softmax.py
+index 4b22224051..c0cfc3ac2e 100644
+--- a/sgl-kernel/benchmark/bench_moe_topk_softmax.py
++++ b/sgl-kernel/benchmark/bench_moe_topk_softmax.py
+@@ -94,7 +94,7 @@ if IS_CI:
+ else:
+     num_tokens_range = [128, 512, 1024, 2048, 4096, 8192, 16384, 32768]
+     num_experts_range = [32, 64, 128, 256, 12, 512]
+-    topk_range = [1, 2, 4, 8]
++    topk_range = [1, 2, 4, 8, 10]
+ 
+ configs = list(itertools.product(num_tokens_range, num_experts_range, topk_range))
+ 
+diff --git a/sgl-kernel/csrc/moe/moe_topk_softmax_kernels.cu b/sgl-kernel/csrc/moe/moe_topk_softmax_kernels.cu
+index ba12f4dd86..c4d7bda5dc 100644
+--- a/sgl-kernel/csrc/moe/moe_topk_softmax_kernels.cu
++++ b/sgl-kernel/csrc/moe/moe_topk_softmax_kernels.cu
+@@ -694,6 +694,9 @@ void topkGatingSoftmaxKernelLauncher(
+     case 256:
+       LAUNCH_SOFTMAX(T, 256, WARPS_PER_TB);
+       break;
++    case 512:
++      LAUNCH_SOFTMAX(T, 512, WARPS_PER_TB);
++      break;
+     default: {
+       TORCH_CHECK(
+           softmax_workspace != nullptr,
+@@ -749,7 +752,7 @@ void topk_softmax(
+   const int topk = static_cast<int>(topk_weights.size(-1));
+ 
+   const bool is_pow_2 = (num_experts != 0) && ((num_experts & (num_experts - 1)) == 0);
+-  const bool needs_workspace = !is_pow_2 || num_experts > 256;
++  const bool needs_workspace = !is_pow_2 || num_experts > 512;
+   const int64_t workspace_size = needs_workspace ? num_tokens * num_experts : 0;
+ 
+   const at::cuda::OptionalCUDAGuard device_guard(device_of(gating_output));
+diff --git a/sgl-kernel/tests/test_moe_topk_softmax.py b/sgl-kernel/tests/test_moe_topk_softmax.py
+index 1a8bfb93ca..77ffe8a460 100644
+--- a/sgl-kernel/tests/test_moe_topk_softmax.py
++++ b/sgl-kernel/tests/test_moe_topk_softmax.py
+@@ -18,7 +18,7 @@ def compare_topk_values(gating_output, topk_indices_ref, topk_indices):
+         itertools.product(
+             [1, 16, 128, 512, 1024, 2048],  # num_tokens
+             [512],  # num_experts
+-            [1, 2, 3, 4, 5, 8],  # topk
++            [1, 2, 3, 4, 5, 8, 10],  # topk
+         )
+     ),
+ )
+diff --git a/test/registered/4-gpu-models/test_qwen3_next_models_mtp.py b/test/registered/4-gpu-models/test_qwen3_next_models_mtp.py
+index e7edfbee9e..d7b718fbc0 100644
+--- a/test/registered/4-gpu-models/test_qwen3_next_models_mtp.py
++++ b/test/registered/4-gpu-models/test_qwen3_next_models_mtp.py
+@@ -41,6 +41,9 @@ class TestQwen3NextMTP(GSM8KMixin, KLDivergenceMixin, DefaultServerBase):
+ class TestQwen3NextMTPTopk(
+     GSM8KMixin, KLDivergenceMixin, PrefixCacheBranchingMixin, DefaultServerBase
+ ):
++    # topk > 1 (tree) MTP on a hybrid-GDN model, on spec v2: the tree-aware mamba
++    # state update lives in the spec v2 verify path, so mamba + topk > 1 no longer
++    # falls back to spec v1.
+     model = QWEN3_NEXT_MODEL
+     cache_chunk_size = 64
+     gsm8k_accuracy_thres = 0.93
+diff --git a/test/registered/openai_server/basic/test_serving_chat.py b/test/registered/openai_server/basic/test_serving_chat.py
+index e1d765aa85..744910cf3f 100644
+--- a/test/registered/openai_server/basic/test_serving_chat.py
++++ b/test/registered/openai_server/basic/test_serving_chat.py
+@@ -822,5 +822,77 @@ class ServingChatTestCase(unittest.TestCase):
+         self.assertIn("must be an integer", context.exception.detail)
+ 
+ 
++class TestProcessToolCallsWithRequiredToolChoice(unittest.TestCase):
++    """Test _process_tool_calls with tool_choice='required' uses model-specific parser."""
++
++    def setUp(self):
++        tm = _MockTokenizerManager()
++        tm.server_args.tool_call_parser = "kimi_k2"
++        self.chat = OpenAIServingChat(tm, _MockTemplateManager())
++
++    def test_required_with_parser_uses_function_call_parser(self):
++        """tool_choice='required' should use FunctionCallParser when tool_call_parser is set."""
++        with patch(
++            "sglang.srt.entrypoints.openai.serving_chat.FunctionCallParser"
++        ) as ParserMock:
++            call_info = Mock()
++            call_info.name = "get_weather"
++            call_info.parameters = '{"location":"Tokyo"}'
++            call_info.tool_index = 0
++
++            parser_instance = ParserMock.return_value
++            parser_instance.has_tool_call.return_value = True
++            parser_instance.parse_non_stream.return_value = ("", [call_info])
++
++            finish_reason = {"type": "stop", "matched": None}
++            tools = [{"type": "function", "function": {"name": "get_weather"}}]
++
++            tool_calls, text, fr = self.chat._process_tool_calls(
++                text="<|tool_calls_section_begin|>...<|tool_calls_section_end|>",
++                tools=tools,
++                finish_reason=finish_reason,
++                tool_choice="required",
++            )
++
++            self.assertIsNotNone(tool_calls)
++            self.assertEqual(len(tool_calls), 1)
++            self.assertEqual(tool_calls[0].function.name, "get_weather")
++            self.assertEqual(fr["type"], "tool_calls")
++
++    def test_required_without_parser_falls_back_to_json(self):
++        """tool_choice='required' without parser should parse as JSON array."""
++        self.chat.tool_call_parser = None
++
++        finish_reason = {"type": "stop", "matched": None}
++        tools = [{"type": "function", "function": {"name": "get_weather"}}]
++
++        tool_calls, text, fr = self.chat._process_tool_calls(
++            text='[{"name":"get_weather","parameters":{"location":"Tokyo"}}]',
++            tools=tools,
++            finish_reason=finish_reason,
++            tool_choice="required",
++        )
++
++        self.assertIsNotNone(tool_calls)
++        self.assertEqual(len(tool_calls), 1)
++        self.assertEqual(tool_calls[0].function.name, "get_weather")
++
++    def test_required_without_parser_invalid_json_returns_none(self):
++        """tool_choice='required' without parser and invalid JSON returns tool_calls=None."""
++        self.chat.tool_call_parser = None
++
++        finish_reason = {"type": "stop", "matched": None}
++        tools = [{"type": "function", "function": {"name": "get_weather"}}]
++
++        tool_calls, text, fr = self.chat._process_tool_calls(
++            text="<|tool_calls_section_begin|>not json",
++            tools=tools,
++            finish_reason=finish_reason,
++            tool_choice="required",
++        )
++
++        self.assertIsNone(tool_calls)
++
++
+ if __name__ == "__main__":
+     unittest.main(verbosity=2)
+diff --git a/test/registered/openai_server/function_call/test_tool_choice.py b/test/registered/openai_server/function_call/test_tool_choice.py
+index a20cd4e56d..1c7e496174 100644
+--- a/test/registered/openai_server/function_call/test_tool_choice.py
++++ b/test/registered/openai_server/function_call/test_tool_choice.py
+@@ -348,8 +348,12 @@ class TestToolChoiceLlama32(CustomTestCase):
+         self.assertEqual(found_name, "get_weather")
+ 
+     def test_required_streaming_arguments_chunks_json(self):
+-        """In streaming required mode, complete tool call arguments should be valid JSON when all chunks are combined"""
++        """In streaming required mode, complete tool call arguments should be valid JSON when all chunks are combined.
++        Uses strict=True so the grammar enforces the parameter schema."""
+         tools = self.get_test_tools()
++        # Add strict=True so arguments are schema-constrained
++        for tool in tools:
++            tool["function"]["strict"] = True
+         messages = self.get_test_messages()
+ 
+         response = self.client.chat.completions.create(
+@@ -406,13 +410,15 @@ class TestToolChoiceLlama32(CustomTestCase):
+                 )
+ 
+     def test_complex_parameters_required_non_streaming(self):
+-        """Validate complex nested parameter schemas in non-streaming required mode"""
++        """Validate complex nested parameter schemas in non-streaming required mode.
++        Uses strict=True so the grammar enforces the parameter schema."""
+         complex_tools = [
+             {
+                 "type": "function",
+                 "function": {
+                     "name": "analyze_data",
+                     "description": "Analyze complex data structures",
++                    "strict": True,
+                     "parameters": {
+                         "type": "object",
+                         "properties": {
+diff --git a/test/registered/unit/constrained/test_base_grammar_backend.py b/test/registered/unit/constrained/test_base_grammar_backend.py
+index 1f3a7a4f93..191fb4b3a0 100644
+--- a/test/registered/unit/constrained/test_base_grammar_backend.py
++++ b/test/registered/unit/constrained/test_base_grammar_backend.py
+@@ -269,10 +269,13 @@ class TestCreateGrammarBackend(unittest.TestCase):
+         GRAMMAR_BACKEND_REGISTRY.clear()
+         GRAMMAR_BACKEND_REGISTRY.update(self._saved)
+ 
+-    def _make_server_args(self, backend="none", reasoning_parser=None):
++    def _make_server_args(
++        self, backend="none", reasoning_parser=None, enable_strict_thinking=False
++    ):
+         args = MagicMock()
+         args.grammar_backend = backend
+         args.reasoning_parser = reasoning_parser
++        args.enable_strict_thinking = enable_strict_thinking
+         args.constrained_json_whitespace_pattern = None
+         args.constrained_json_disable_any_whitespace = False
+         return args
+@@ -282,6 +285,11 @@ class TestCreateGrammarBackend(unittest.TestCase):
+         result = create_grammar_backend(args, None, 32000)
+         self.assertIsNone(result)
+ 
++    def test_none_backend_with_strict_thinking_raises(self):
++        args = self._make_server_args("none", enable_strict_thinking=True)
++        with self.assertRaisesRegex(ValueError, "enable-strict-thinking"):
++            create_grammar_backend(args, None, 32000)
++
+     def test_invalid_backend_raises(self):
+         args = self._make_server_args("nonexistent_backend")
+         with self.assertRaises(ValueError):
+@@ -316,7 +324,7 @@ class TestCreateGrammarBackend(unittest.TestCase):
+         mock_inner = MagicMock(spec=BaseGrammarBackend)
+         register_grammar_backend("inner_r", lambda *a: mock_inner)
+ 
+-        args = self._make_server_args("inner_r", reasoning_parser="deepseek")
++        args = self._make_server_args("inner_r", reasoning_parser="deepseek-r1")
+         tokenizer = MagicMock()
+ 
+         result = create_grammar_backend(args, tokenizer, 32000)
+@@ -382,13 +390,15 @@ class TestCreateGrammarBackend(unittest.TestCase):
+         )
+ 
+         mock_backend = MagicMock(spec=BaseGrammarBackend)
++        mock_backend.is_support_token_filter = False
+         mock_outlines_cls.return_value = mock_backend
+-        args = self._make_server_args("outlines", reasoning_parser="deepseek")
++        args = self._make_server_args("outlines", reasoning_parser="deepseek-r1")
+         tokenizer = MagicMock()
++        # encode must return a single-token list for think_start/end tokens
++        tokenizer.encode.return_value = [42]
+ 
+         result = create_grammar_backend(args, tokenizer, 32000, think_end_id=42)
+         self.assertIsInstance(result, ReasonerGrammarBackend)
+-        self.assertEqual(result.think_end_id, 42)
+         self.assertIs(result.grammar_backend, mock_backend)
+ 
+     @patch("sglang.srt.constrained.outlines_backend.OutlinesGrammarBackend")
+@@ -396,7 +406,7 @@ class TestCreateGrammarBackend(unittest.TestCase):
+         """Without think_end_id passed in, no reasoner wrapping."""
+         mock_backend = MagicMock(spec=BaseGrammarBackend)
+         mock_outlines_cls.return_value = mock_backend
+-        args = self._make_server_args("outlines", reasoning_parser="deepseek")
++        args = self._make_server_args("outlines", reasoning_parser="deepseek-r1")
+         tokenizer = MagicMock(spec=[])  # No think_end_id attribute
+ 
+         result = create_grammar_backend(args, tokenizer, 32000, think_end_id=None)
+diff --git a/test/registered/unit/constrained/test_e2e_constrained_reasoning.py b/test/registered/unit/constrained/test_e2e_constrained_reasoning.py
+new file mode 100644
+index 0000000000..48e69a4aca
+--- /dev/null
++++ b/test/registered/unit/constrained/test_e2e_constrained_reasoning.py
+@@ -0,0 +1,314 @@
++"""
++End-to-end tests for strict reasoning + constrained decoding.
++
++Tests that the full pipeline works:
++- AC-5.1: Strict reasoning + JSON schema constrained generation
++- AC-5.2: Strict reasoning + tool call parsing (basic validation only)
++
++These tests launch a real server with a small model and verify
++the constrained decoding pipeline produces valid output.
++"""
++
++import json
++import unittest
++
++import requests
++
++from sglang.srt.utils import kill_process_tree
++from sglang.test.ci.ci_register import register_cuda_ci
++from sglang.test.test_utils import (
++    DEFAULT_TIMEOUT_FOR_SERVER_LAUNCH,
++    CustomTestCase,
++    popen_launch_server,
++)
++
++register_cuda_ci(est_time=120, suite="stage-b-test-1-gpu-small")
++
++MODEL = "Qwen/Qwen3-0.6B"
++BASE_URL = "http://127.0.0.1:39877"
++API_KEY = "sk-test-1234"
++
++
++class TestConstrainedReasoningE2E(CustomTestCase):
++    @classmethod
++    def setUpClass(cls):
++        cls.model = MODEL
++        cls.base_url = BASE_URL
++        cls.api_key = API_KEY
++        cls.process = popen_launch_server(
++            cls.model,
++            cls.base_url,
++            timeout=DEFAULT_TIMEOUT_FOR_SERVER_LAUNCH,
++            api_key=cls.api_key,
++            other_args=[
++                "--reasoning-parser",
++                "qwen3",
++            ],
++        )
++
++    @classmethod
++    def tearDownClass(cls):
++        kill_process_tree(cls.process.pid)
++
++    def _chat(self, **kwargs):
++        default = {
++            "model": self.model,
++            "messages": [
++                {
++                    "role": "user",
++                    "content": "What is 2+2? Answer with just the number.",
++                }
++            ],
++            "temperature": 0,
++            "max_tokens": 256,
++        }
++        default.update(kwargs)
++        resp = requests.post(
++            f"{self.base_url}/v1/chat/completions",
++            headers={"Authorization": f"Bearer {self.api_key}"},
++            json=default,
++            timeout=60,
++        )
++        self.assertEqual(resp.status_code, 200, f"Request failed: {resp.text}")
++        return resp.json()
++
++    def test_reasoning_with_json_schema(self):
++        """AC-5.1: Reasoning + JSON schema produces valid JSON output."""
++        schema = {
++            "type": "object",
++            "properties": {
++                "answer": {"type": "integer"},
++            },
++            "required": ["answer"],
++        }
++        data = self._chat(
++            response_format={
++                "type": "json_schema",
++                "json_schema": {
++                    "name": "answer_schema",
++                    "schema": schema,
++                },
++            },
++            chat_template_kwargs={"enable_thinking": True},
++            separate_reasoning=True,
++        )
++
++        choice = data["choices"][0]
++        content = choice["message"]["content"] or ""
++
++        # Content should be valid JSON conforming to schema when non-empty.
++        # With small models + separate_reasoning, content may be empty if the
++        # model puts everything in reasoning_content. That's acceptable.
++        if content.strip():
++            try:
++                parsed = json.loads(content)
++                self.assertIn("answer", parsed)
++                self.assertIsInstance(parsed["answer"], int)
++            except (json.JSONDecodeError, TypeError):
++                # Small models may produce imperfect JSON
++                self.assertTrue(
++                    content.strip().startswith("{"),
++                    f"Expected JSON-like output, got: {content!r}",
++                )
++
++        # Content should NOT contain <think> tags (those go to reasoning_content)
++        self.assertNotIn("<think>", content)
++
++    def test_reasoning_disabled_with_json_schema(self):
++        """JSON schema still works when reasoning is explicitly disabled."""
++        schema = {
++            "type": "object",
++            "properties": {
++                "answer": {"type": "integer"},
++            },
++            "required": ["answer"],
++        }
++        data = self._chat(
++            response_format={
++                "type": "json_schema",
++                "json_schema": {
++                    "name": "answer_schema",
++                    "schema": schema,
++                },
++            },
++            chat_template_kwargs={"enable_thinking": False},
++        )
++
++        choice = data["choices"][0]
++        content = choice["message"]["content"]
++
++        # Should still produce valid JSON
++        parsed = json.loads(content)
++        self.assertIn("answer", parsed)
++
++    def test_reasoning_with_separate_output(self):
++        """Reasoning content is correctly separated from normal content."""
++        data = self._chat(
++            chat_template_kwargs={"enable_thinking": True},
++            separate_reasoning=True,
++        )
++
++        choice = data["choices"][0]
++        content = choice["message"]["content"]
++        reasoning = choice["message"].get("reasoning_content")
++
++        # Content should not contain think tags
++        self.assertNotIn("<think>", content)
++        self.assertNotIn("</think>", content)
++
++    def test_tool_call_after_reasoning(self):
++        """AC-5.2: Tool call parsing works with reasoning enabled."""
++        tools = [
++            {
++                "type": "function",
++                "function": {
++                    "name": "get_weather",
++                    "description": "Get the current weather",
++                    "parameters": {
++                        "type": "object",
++                        "properties": {
++                            "location": {"type": "string"},
++                        },
++                        "required": ["location"],
++                    },
++                },
++            }
++        ]
++        data = self._chat(
++            messages=[
++                {
++                    "role": "user",
++                    "content": "What's the weather in Paris?",
++                }
++            ],
++            tools=tools,
++            chat_template_kwargs={"enable_thinking": True},
++            separate_reasoning=True,
++        )
++
++        choice = data["choices"][0]
++        # The model may or may not produce tool calls (depends on model capability)
++        # but the response should be well-formed (no crashes)
++        self.assertIn("message", choice)
++        self.assertIn("finish_reason", choice)
++        # finish_reason should be either "stop" or "tool_calls"
++        self.assertIn(choice["finish_reason"], ["stop", "tool_calls", "length"])
++
++
++class TestStrictThinkingE2E(CustomTestCase):
++    """E2E tests with --enable-strict-thinking flag.
++
++    Validates that the strict thinking flag is correctly propagated through
++    the full pipeline: server_args -> grammar_backend -> ReasonerGrammarBackend
++    -> token filtering during thinking phase.
++    """
++
++    @classmethod
++    def setUpClass(cls):
++        cls.model = MODEL
++        cls.base_url = "http://127.0.0.1:39878"
++        cls.api_key = API_KEY
++        cls.process = popen_launch_server(
++            cls.model,
++            cls.base_url,
++            timeout=DEFAULT_TIMEOUT_FOR_SERVER_LAUNCH,
++            api_key=cls.api_key,
++            other_args=[
++                "--reasoning-parser",
++                "qwen3",
++                "--enable-strict-thinking",
++            ],
++        )
++
++    @classmethod
++    def tearDownClass(cls):
++        kill_process_tree(cls.process.pid)
++
++    def _chat(self, **kwargs):
++        default = {
++            "model": self.model,
++            "messages": [
++                {
++                    "role": "user",
++                    "content": "What is 2+2? Answer with just the number.",
++                }
++            ],
++            "temperature": 0,
++            "max_tokens": 256,
++        }
++        default.update(kwargs)
++        resp = requests.post(
++            f"{self.base_url}/v1/chat/completions",
++            headers={"Authorization": f"Bearer {self.api_key}"},
++            json=default,
++            timeout=60,
++        )
++        self.assertEqual(resp.status_code, 200, f"Request failed: {resp.text}")
++        return resp.json()
++
++    def test_strict_thinking_with_json_schema(self):
++        """Strict thinking + JSON schema: server starts and produces valid output."""
++        schema = {
++            "type": "object",
++            "properties": {
++                "answer": {"type": "integer"},
++            },
++            "required": ["answer"],
++        }
++        data = self._chat(
++            response_format={
++                "type": "json_schema",
++                "json_schema": {
++                    "name": "answer_schema",
++                    "schema": schema,
++                },
++            },
++            chat_template_kwargs={"enable_thinking": True},
++            separate_reasoning=True,
++        )
++
++        choice = data["choices"][0]
++        content = choice["message"]["content"] or ""
++
++        if content.strip():
++            try:
++                parsed = json.loads(content)
++                self.assertIn("answer", parsed)
++            except (json.JSONDecodeError, TypeError):
++                self.assertTrue(
++                    content.strip().startswith("{"),
++                    f"Expected JSON-like output, got: {content!r}",
++                )
++
++        # Think tags must not leak into content
++        self.assertNotIn("<think>", content)
++
++    def test_strict_thinking_disabled_per_request(self):
++        """When thinking is disabled per-request, strict server still works."""
++        data = self._chat(
++            chat_template_kwargs={"enable_thinking": False},
++        )
++
++        choice = data["choices"][0]
++        self.assertIn("message", choice)
++        self.assertIn("finish_reason", choice)
++        # Should complete normally without errors
++        self.assertIn(choice["finish_reason"], ["stop", "length"])
++
++    def test_strict_thinking_separate_reasoning(self):
++        """Strict thinking with separate_reasoning produces well-formed output."""
++        data = self._chat(
++            chat_template_kwargs={"enable_thinking": True},
++            separate_reasoning=True,
++        )
++
++        choice = data["choices"][0]
++        content = choice["message"]["content"] or ""
++
++        # Think tags must not leak into content
++        self.assertNotIn("<think>", content)
++        self.assertNotIn("</think>", content)
++
++
++if __name__ == "__main__":
++    unittest.main()
+diff --git a/test/registered/unit/constrained/test_grammar_manager.py b/test/registered/unit/constrained/test_grammar_manager.py
+index 649bf49f47..2d25a4bc4a 100644
+--- a/test/registered/unit/constrained/test_grammar_manager.py
++++ b/test/registered/unit/constrained/test_grammar_manager.py
+@@ -24,6 +24,7 @@ from sglang.srt.constrained.base_grammar_backend import (
+     InvalidGrammarObject,
+ )
+ from sglang.srt.constrained.grammar_manager import GrammarManager
++from sglang.srt.constrained.reasoner_grammar_backend import ReasonerGrammarObject
+ from sglang.test.ci.ci_register import register_cpu_ci
+ 
+ register_cpu_ci(2.0, "stage-a-test-cpu")
+@@ -48,7 +49,12 @@ def _make_scheduler(grammar_backend_name="none", skip_tokenizer=False):
+ 
+ 
+ def _make_req(
+-    json_schema=None, regex=None, ebnf=None, structural_tag=None, rid="req-1"
++    json_schema=None,
++    regex=None,
++    ebnf=None,
++    structural_tag=None,
++    rid="req-1",
++    custom_params=None,
+ ):
+     """Create a mock request with sampling params."""
+     req = MagicMock()
+@@ -57,6 +63,7 @@ def _make_req(
+     req.sampling_params.regex = regex
+     req.sampling_params.ebnf = ebnf
+     req.sampling_params.structural_tag = structural_tag
++    req.sampling_params.custom_params = custom_params
+     req.require_reasoning = False
+     req.grammar = None
+     req.grammar_key = None
+@@ -256,6 +263,39 @@ class TestProcessReqWithGrammar(unittest.TestCase):
+         self.assertTrue(mgr.has_waiting_grammars())
+         self.assertEqual(len(mgr), 1)
+ 
++    def test_cache_hit_applies_request_thinking_budget(self):
++        mgr = self._make_mgr()
++        grammar_obj = ReasonerGrammarObject(
++            grammar=None, think_end_id=0, max_think_tokens=99
++        )
++        mgr.grammar_backend.get_cached_or_future_value.return_value = (
++            grammar_obj,
++            True,
++        )
++
++        req = _make_req(
++            json_schema="schema",
++            custom_params={"thinking_budget": 7},
++        )
++        mgr.process_req_with_grammar(req)
++
++        self.assertEqual(req.grammar.max_think_tokens, 7)
++
++    def test_strict_reasoning_grammar_applies_request_thinking_budget(self):
++        mgr = self._make_mgr()
++        mgr._enable_strict_thinking = True
++        grammar_obj = ReasonerGrammarObject(
++            grammar=None, think_end_id=0, max_think_tokens=99
++        )
++        mgr.grammar_backend.init_strict_reasoning_grammar.return_value = grammar_obj
++
++        req = _make_req(custom_params={"thinking_budget": 3})
++        req.require_reasoning = True
++        mgr.process_req_with_grammar(req)
++
++        self.assertIs(req.grammar, grammar_obj)
++        self.assertEqual(req.grammar.max_think_tokens, 3)
++
+ 
+ class TestAbortRequests(unittest.TestCase):
+     """Test abort_requests handling."""
+@@ -494,8 +534,8 @@ class TestGetReadyGrammarRequests(unittest.TestCase):
+         req.set_finish_with_abort.assert_called_once()
+         self.assertIn("timed out", req.set_finish_with_abort.call_args[0][0])
+ 
+-    def test_future_exception_propagates(self):
+-        """A future that raised an exception should propagate on .result()."""
++    def test_future_exception_creates_invalid_grammar_object(self):
++        """A future that raised an exception should create InvalidGrammarObject, not crash."""
+         mgr = self._make_mgr()
+ 
+         future = Future()
+@@ -506,8 +546,32 @@ class TestGetReadyGrammarRequests(unittest.TestCase):
+         req.grammar_key = ("json", "crash")
+         mgr.grammar_queue.append(req)
+ 
+-        with self.assertRaises(RuntimeError):
+-            mgr.get_ready_grammar_requests()
++        result = mgr.get_ready_grammar_requests()
++        self.assertEqual(len(result), 1)
++        self.assertIsInstance(result[0].grammar, InvalidGrammarObject)
++        req.set_finish_with_abort.assert_called_once()
++
++    def test_ready_future_applies_request_budget_without_polluting_cache(self):
++        mgr = self._make_mgr()
++
++        grammar_obj = ReasonerGrammarObject(
++            grammar=None, think_end_id=0, max_think_tokens=99
++        )
++        future = Future()
++        future.set_result(grammar_obj)
++
++        req = _make_req(json_schema="schema", custom_params={"thinking_budget": 4})
++        req.grammar = future
++        req.grammar_key = ("json", "schema")
++        mgr.grammar_queue.append(req)
++
++        result = mgr.get_ready_grammar_requests()
++
++        self.assertEqual(len(result), 1)
++        self.assertEqual(req.grammar.max_think_tokens, 4)
++        cached_key, cached_value = mgr.grammar_backend.set_cache.call_args[0]
++        self.assertEqual(cached_key, ("json", "schema"))
++        self.assertEqual(cached_value.max_think_tokens, 99)
+ 
+     @patch("sglang.srt.constrained.grammar_manager.torch.distributed.all_gather_object")
+     def test_multi_rank_sync_intersects_ready_unions_failed(self, mock_all_gather):
+@@ -579,5 +643,100 @@ class TestGetReadyGrammarRequests(unittest.TestCase):
+         self.assertEqual(len(mgr.grammar_queue), 0)
+ 
+ 
++class TestStrictReasoningPaths(unittest.TestCase):
++    """Test _enable_strict_thinking code paths in GrammarManager."""
++
++    def _make_mgr(self):
++        scheduler = _make_scheduler()
++        scheduler.server_args.skip_tokenizer_init = True
++        mgr = GrammarManager(scheduler)
++        mgr.grammar_backend = MagicMock(spec=BaseGrammarBackend)
++        mgr._enable_strict_thinking = True
++        return mgr
++
++    def test_strict_unconstrained_request_gets_strict_grammar(self):
++        """Request without json_schema/regex/ebnf should get strict-only grammar."""
++        mgr = self._make_mgr()
++        grammar_obj = MagicMock()
++        mgr.grammar_backend.init_strict_reasoning_grammar.return_value = grammar_obj
++
++        req = _make_req()  # No constraint
++        req.require_reasoning = True
++        result = mgr.process_req_with_grammar(req)
++
++        self.assertFalse(result)  # Not added to grammar queue
++        self.assertIs(req.grammar, grammar_obj)
++        mgr.grammar_backend.init_strict_reasoning_grammar.assert_called_once_with(True)
++
++    def test_strict_unconstrained_no_reasoning_flag(self):
++        """Unconstrained request with require_reasoning=False still gets strict grammar."""
++        mgr = self._make_mgr()
++        grammar_obj = MagicMock()
++        mgr.grammar_backend.init_strict_reasoning_grammar.return_value = grammar_obj
++
++        req = _make_req()
++        req.require_reasoning = False
++        mgr.process_req_with_grammar(req)
++
++        self.assertIs(req.grammar, grammar_obj)
++        mgr.grammar_backend.init_strict_reasoning_grammar.assert_called_once_with(False)
++
++    def test_strict_unconstrained_none_grammar_is_fine(self):
++        """If init_strict_reasoning_grammar returns None, req.grammar stays None."""
++        mgr = self._make_mgr()
++        mgr.grammar_backend.init_strict_reasoning_grammar.return_value = None
++
++        req = _make_req()
++        req.require_reasoning = True
++        mgr.process_req_with_grammar(req)
++
++        self.assertIsNone(req.grammar)
++
++    def test_strict_constrained_request_uses_normal_dispatch(self):
++        """Request with json_schema should go through normal dispatch, not strict path."""
++        mgr = self._make_mgr()
++        future = MagicMock(spec=Future)
++        mgr.grammar_backend.get_cached_or_future_value.return_value = (future, False)
++
++        req = _make_req(json_schema='{"type": "object"}')
++        req.require_reasoning = True
++        result = mgr.process_req_with_grammar(req)
++
++        self.assertTrue(result)  # Added to grammar queue
++        mgr.grammar_backend.init_strict_reasoning_grammar.assert_not_called()
++
++    def test_strict_not_set_skips_strict_path(self):
++        """When _enable_strict_thinking=False, unconstrained requests get no grammar."""
++        mgr = self._make_mgr()
++        mgr._enable_strict_thinking = False
++
++        req = _make_req()
++        req.require_reasoning = True
++        mgr.process_req_with_grammar(req)
++
++        self.assertIsNone(req.grammar)
++        mgr.grammar_backend.init_strict_reasoning_grammar.assert_not_called()
++
++    def test_future_exception_creates_invalid_grammar(self):
++        """Future.result() raising should create InvalidGrammarObject, not crash."""
++        mgr = self._make_mgr()
++
++        future = Future()
++        future.set_exception(RuntimeError("compilation failed"))
++
++        req = _make_req(json_schema='{"type": "object"}')
++        req.require_reasoning = True
++        req.grammar = future
++        req.grammar_key = ("json", '{"type": "object"}')
++        mgr.grammar_queue.append(req)
++
++        mgr.SGLANG_GRAMMAR_POLL_INTERVAL = 0.001
++        result = mgr.get_ready_grammar_requests()
++
++        self.assertEqual(len(result), 1)
++        self.assertIsInstance(result[0].grammar, InvalidGrammarObject)
++        req.set_finish_with_abort.assert_called_once()
++
++
+ if __name__ == "__main__":
+     unittest.main()
+diff --git a/test/registered/unit/constrained/test_reasoner_grammar_backend.py b/test/registered/unit/constrained/test_reasoner_grammar_backend.py
+index 1f9afdb69f..365d42c3cf 100644
+--- a/test/registered/unit/constrained/test_reasoner_grammar_backend.py
++++ b/test/registered/unit/constrained/test_reasoner_grammar_backend.py
+@@ -1,413 +1,453 @@
+-"""
+-Unit tests for sglang.srt.constrained.reasoner_grammar_backend.
+-
+-Test Coverage:
+-- ReasonerGrammarObject: state transitions, accept_token during thinking
+-  vs post-thinking, rollback across think boundary, fill_vocab_mask gating,
+-  copy semantics, finished delegation, delegation of jump methods
+-- ReasonerGrammarBackend: dispatch wrapping, invalid grammar passthrough,
+-  None grammar passthrough, reasoning init on wrapped object
+-
+-Usage:
+-    python -m pytest test_reasoner_grammar_backend.py -v
+-"""
+-
++import os
+ import unittest
+-from unittest.mock import MagicMock, call
++from types import SimpleNamespace
++from unittest.mock import MagicMock
+ 
+-from sglang.srt.constrained.base_grammar_backend import (
+-    BaseGrammarBackend,
+-    BaseGrammarObject,
+-    InvalidGrammarObject,
+-)
++import torch
++
++from sglang.srt.constrained.base_grammar_backend import BaseGrammarBackend
+ from sglang.srt.constrained.reasoner_grammar_backend import (
+     ReasonerGrammarBackend,
+     ReasonerGrammarObject,
+ )
++from sglang.srt.constrained.torch_ops.token_filter_torch_ops import (
++    set_token_filter_torch,
++)
+ from sglang.test.ci.ci_register import register_cpu_ci
+ 
+ register_cpu_ci(2.0, "stage-a-test-cpu")
+ 
+-THINK_END_ID = 99
+-
+-
+-class TestReasonerGrammarObjectStateTransitions(unittest.TestCase):
+-    """Test thinking state machine in ReasonerGrammarObject."""
+-
+-    def _make(self):
+-        grammar = MagicMock(spec=BaseGrammarObject)
+-        return ReasonerGrammarObject(grammar, THINK_END_ID), grammar
+-
+-    def test_initial_state_thinking(self):
+-        obj, _ = self._make()
+-        self.assertEqual(obj.tokens_after_think_end, -1)
+-
+-    def test_transfer_state_during_thinking(self):
+-        """Regular tokens during thinking don't change state."""
+-        obj, _ = self._make()
+-        obj.transfer_state(10)
+-        self.assertEqual(obj.tokens_after_think_end, -1)
+-
+-    def test_transfer_state_think_end_token(self):
+-        """Think end token transitions from -1 to 0."""
+-        obj, _ = self._make()
+-        obj.transfer_state(THINK_END_ID)
+-        self.assertEqual(obj.tokens_after_think_end, 0)
+-
+-    def test_transfer_state_increments_after_thinking(self):
+-        """After thinking ends, each token increments counter."""
+-        obj, _ = self._make()
+-        obj.tokens_after_think_end = 0
+-        obj.transfer_state(10)
+-        self.assertEqual(obj.tokens_after_think_end, 1)
+-        obj.transfer_state(20)
+-        self.assertEqual(obj.tokens_after_think_end, 2)
+-
+-    def test_think_end_after_thinking_already_ended(self):
+-        """Second think_end_id after thinking ended just increments."""
+-        obj, _ = self._make()
+-        obj.tokens_after_think_end = 3
+-        obj.transfer_state(THINK_END_ID)
+-        self.assertEqual(obj.tokens_after_think_end, 4)
+-
+-    def test_rollback_state_from_post_thinking(self):
+-        obj, _ = self._make()
+-        obj.tokens_after_think_end = 3
+-        obj.rollback_state()
+-        self.assertEqual(obj.tokens_after_think_end, 2)
+-
+-    def test_rollback_state_at_boundary(self):
+-        """Rollback from 0 goes back to -1 (thinking)."""
+-        obj, _ = self._make()
+-        obj.tokens_after_think_end = 0
+-        obj.rollback_state()
+-        self.assertEqual(obj.tokens_after_think_end, -1)
+-
+-    def test_rollback_state_during_thinking(self):
+-        """Rollback during thinking stays at -1."""
+-        obj, _ = self._make()
+-        obj.rollback_state()
+-        self.assertEqual(obj.tokens_after_think_end, -1)
+-
+-
+-class TestReasonerGrammarObjectAcceptToken(unittest.TestCase):
+-    """Test accept_token behavior with thinking/post-thinking states."""
+-
+-    def _make(self):
+-        grammar = MagicMock(spec=BaseGrammarObject)
+-        return ReasonerGrammarObject(grammar, THINK_END_ID), grammar
+-
+-    def test_accept_during_thinking_skips_grammar(self):
+-        """During thinking phase, inner grammar should NOT receive tokens."""
+-        obj, grammar = self._make()
+-        obj.accept_token(10)
+-        grammar.accept_token.assert_not_called()
+-        # State should still be -1
+-        self.assertEqual(obj.tokens_after_think_end, -1)
+-
+-    def test_accept_think_end_token(self):
+-        """Think end token transitions state but doesn't call inner grammar (state was -1 before transfer)."""
+-        obj, grammar = self._make()
+-        # tokens_after_think_end is -1, so grammar.accept_token is not called
+-        # But wait: accept_token checks `>= 0` BEFORE transfer_state
+-        # At call time tokens_after_think_end == -1, so grammar.accept_token skipped
+-        obj.accept_token(THINK_END_ID)
+-        grammar.accept_token.assert_not_called()
+-        self.assertEqual(obj.tokens_after_think_end, 0)
+-
+-    def test_accept_after_thinking_calls_grammar(self):
+-        """After thinking ends, tokens go to inner grammar."""
+-        obj, grammar = self._make()
+-        obj.tokens_after_think_end = 0
+-        obj.accept_token(42)
+-        grammar.accept_token.assert_called_once_with(42)
+-        self.assertEqual(obj.tokens_after_think_end, 1)
+-
+-    def test_accept_sequence_through_thinking_and_generation(self):
+-        """Full sequence: think tokens -> think_end -> generation tokens."""
+-        obj, grammar = self._make()
+-
+-        # Thinking phase
+-        obj.accept_token(1)
+-        obj.accept_token(2)
+-        self.assertEqual(grammar.accept_token.call_count, 0)
+-
+-        # Think end
+-        obj.accept_token(THINK_END_ID)
+-        self.assertEqual(grammar.accept_token.call_count, 0)
+-
+-        # Generation phase
++
++class _DummyTokenizer:
++    def __init__(self, token_map):
++        self._token_map = token_map
++
++    def encode(self, text, add_special_tokens=False):
++        return list(self._token_map.get(text, []))
++
++
++class _DummyGrammarBackend(BaseGrammarBackend):
++    def __init__(self, support_token_filter=True):
++        super().__init__()
++        self._support_token_filter = support_token_filter
++        self._dispatch_result = None
++
++    @property
++    def is_support_token_filter(self):
++        return self._support_token_filter
++
++    @staticmethod
++    def allocate_vocab_mask(vocab_size, batch_size, device):
++        return torch.zeros((batch_size, (vocab_size + 31) // 32), dtype=torch.int32)
++
++    @staticmethod
++    def move_vocab_mask(vocab_mask, device):
++        return vocab_mask
++
++    @staticmethod
++    def apply_vocab_mask(logits, vocab_mask):
++        return None
++
++    @staticmethod
++    def set_token_filter(
++        vocab_mask, token_ids, batch_idx, is_allowed=True, reset_vocab_mask=True
++    ):
++        set_token_filter_torch(
++            vocab_mask, token_ids, batch_idx, is_allowed, reset_vocab_mask
++        )
++
++    def _init_value_dispatch(self, key, reasoning):
++        return self._dispatch_result
++
++
++def _allowed_token_ids(vocab_mask, token_ids):
++    allowed = []
++    for token_id in token_ids:
++        elem = token_id // 32
++        bit = token_id % 32
++        if int(vocab_mask[0, elem].item()) & (1 << bit):
++            allowed.append(token_id)
++    return allowed
++
++
++class TestReasonerGrammarObject(unittest.TestCase):
++    def _make_strict_object(self):
++        return ReasonerGrammarObject(
++            grammar=None,
++            think_end_id=7,
++            think_excluded_token_ids=[3, 5],
++            max_think_tokens=2,
++            enable_token_filter=True,
++            token_filter_fn=set_token_filter_torch,
++            allocate_vocab_mask_fn=lambda vocab_size, batch_size, device: torch.zeros(
++                (batch_size, (vocab_size + 31) // 32), dtype=torch.int32
++            ),
++            move_vocab_mask_fn=lambda vocab_mask, device: vocab_mask,
++            apply_vocab_mask_fn=lambda logits, vocab_mask: None,
++        )
++
++    def test_strict_thinking_phase_excludes_configured_tokens(self):
++        obj = self._make_strict_object()
++        obj.maybe_init_reasoning(True)
++        mask = obj.allocate_vocab_mask(64, 1, "cpu")
++
++        obj.fill_vocab_mask(mask, 0)
++
++        allowed = _allowed_token_ids(mask, [0, 1, 3, 5, 7, 8])
++        self.assertEqual(allowed, [0, 1, 7, 8])
++
++    def test_budget_exhaustion_allows_only_think_end(self):
++        obj = self._make_strict_object()
++        obj.maybe_init_reasoning(True)
+         obj.accept_token(10)
+-        obj.accept_token(20)
+-        self.assertEqual(grammar.accept_token.call_count, 2)
+-        grammar.accept_token.assert_has_calls([call(10), call(20)])
++        obj.accept_token(11)
++        mask = obj.allocate_vocab_mask(64, 1, "cpu")
++
++        obj.fill_vocab_mask(mask, 0)
++
++        allowed = _allowed_token_ids(mask, [0, 1, 3, 5, 7, 8, 10, 11])
++        self.assertEqual(allowed, [7])
++
++    def test_strict_only_wrapper_exposes_backend_mask_hooks(self):
++        obj = self._make_strict_object()
++        mask = obj.allocate_vocab_mask(64, 2, "cpu")
++
++        self.assertEqual(mask.shape, (2, 2))
++        self.assertIs(obj.move_vocab_mask(mask, "cpu"), mask)
++        self.assertIsNotNone(obj.apply_vocab_mask)
++
++
++class TestReasonerGrammarBackend(unittest.TestCase):
++    def setUp(self):
++        self._prev_budget = os.environ.get("SGLANG_MAX_THINK_TOKENS")
++
++    def tearDown(self):
++        if self._prev_budget is None:
++            os.environ.pop("SGLANG_MAX_THINK_TOKENS", None)
++        else:
++            os.environ["SGLANG_MAX_THINK_TOKENS"] = self._prev_budget
++
++    def _make_parser(self):
++        detector = SimpleNamespace(
++            think_start_token="<think>",
++            think_end_token="</think>",
++            think_excluded_tokens=["<tool_call>", "</tool_call>"],
++        )
++        return SimpleNamespace(detector=detector)
++
++    def _make_tokenizer(self, start_ids=None, end_ids=None):
++        return _DummyTokenizer(
++            {
++                "<think>": [1] if start_ids is None else start_ids,
++                "</think>": [2] if end_ids is None else end_ids,
++                "<tool_call>": [3],
++                "</tool_call>": [4],
++            }
++        )
++
++    def test_init_strict_reasoning_grammar_uses_token_filter_and_budget(self):
++        os.environ["SGLANG_MAX_THINK_TOKENS"] = "2"
++        backend = _DummyGrammarBackend(support_token_filter=True)
++        reasoner = ReasonerGrammarBackend(
++            backend,
++            self._make_parser(),
++            self._make_tokenizer(),
++            enable_strict_thinking=True,
++        )
++
++        obj = reasoner.init_strict_reasoning_grammar(reasoning=True)
++
++        self.assertIsInstance(obj, ReasonerGrammarObject)
++        self.assertTrue(obj.enable_token_filter)
++        self.assertEqual(obj.max_think_tokens, 2)
++        self.assertEqual(obj.think_excluded_token_ids, [3, 4])
++
++    def test_init_strict_reasoning_grammar_none_when_strict_disabled(self):
++        backend = _DummyGrammarBackend(support_token_filter=True)
++        reasoner = ReasonerGrammarBackend(
++            backend,
++            self._make_parser(),
++            self._make_tokenizer(),
++            enable_strict_thinking=False,
++        )
++
++        self.assertIsNone(reasoner.init_strict_reasoning_grammar(reasoning=True))
++
++    def test_wraps_inner_grammar_with_reasoning_state_machine(self):
++        os.environ["SGLANG_MAX_THINK_TOKENS"] = "1"
++        backend = _DummyGrammarBackend(support_token_filter=True)
++        inner_grammar = MagicMock()
++        backend._dispatch_result = inner_grammar
++        reasoner = ReasonerGrammarBackend(
++            backend,
++            self._make_parser(),
++            self._make_tokenizer(),
++            enable_strict_thinking=True,
++        )
++
++        wrapped = reasoner._init_value_dispatch(("json", "{}"), reasoning=True)
++        self.assertIsInstance(wrapped, ReasonerGrammarObject)
++        wrapped.accept_token(10)
++        inner_grammar.accept_token.assert_not_called()
++        wrapped.accept_token(2)
++        wrapped.accept_token(42)
++        inner_grammar.accept_token.assert_called_once_with(42)
++
++    def test_accepts_multi_token_think_start_marker(self):
++        """think_start_token can be multi-token (e.g., GPT-OSS) since it's not used."""
++        backend = _DummyGrammarBackend(support_token_filter=True)
++        reasoner = ReasonerGrammarBackend(
++            backend,
++            self._make_parser(),
++            self._make_tokenizer(start_ids=[1, 2]),
++            enable_strict_thinking=True,
++        )
++        self.assertIsNotNone(reasoner)
++
++    def test_rejects_multi_token_think_end_marker(self):
++        backend = _DummyGrammarBackend(support_token_filter=True)
++
++        with self.assertRaisesRegex(ValueError, "must encode to exactly one token"):
++            ReasonerGrammarBackend(
++                backend,
++                self._make_parser(),
++                self._make_tokenizer(end_ids=[2, 3]),
++                enable_strict_thinking=True,
++            )
++
++    def test_rejects_unencodable_excluded_token(self):
++        backend = _DummyGrammarBackend(support_token_filter=True)
++        parser = self._make_parser()
++        parser.detector.think_excluded_tokens = ["<unknown>"]
++        tokenizer = _DummyTokenizer(
++            {
++                "<think>": [1],
++                "</think>": [2],
++            }
++        )
++
++        with self.assertRaisesRegex(ValueError, "could not be encoded"):
++            ReasonerGrammarBackend(
++                backend,
++                parser,
++                tokenizer,
++                enable_strict_thinking=True,
++            )
++
++    def test_strict_mode_fails_when_backend_lacks_token_filter(self):
++        backend = _DummyGrammarBackend(support_token_filter=False)
++
++        with self.assertRaisesRegex(ValueError, "does not support token filtering"):
++            ReasonerGrammarBackend(
++                backend,
++                self._make_parser(),
++                self._make_tokenizer(),
++                enable_strict_thinking=True,
++            )
+ 
+ 
+ class TestReasonerGrammarObjectRollback(unittest.TestCase):
+-    """Test rollback across thinking boundary."""
+-
+-    def _make(self):
+-        grammar = MagicMock(spec=BaseGrammarObject)
+-        return ReasonerGrammarObject(grammar, THINK_END_ID), grammar
+-
+-    def test_rollback_within_generation(self):
+-        """Rollback entirely within generation phase."""
+-        obj, grammar = self._make()
+-        obj.tokens_after_think_end = 5
+-        obj.rollback(3)
+-        grammar.rollback.assert_called_once_with(3)
+-        self.assertEqual(obj.tokens_after_think_end, 2)
+-
+-    def test_rollback_across_boundary(self):
+-        """Rollback that crosses from generation back into thinking."""
+-        obj, grammar = self._make()
+-        obj.tokens_after_think_end = 2
+-        obj.rollback(4)
+-        # Only 2 tokens were post-thinking, so inner grammar rolls back 2
+-        grammar.rollback.assert_called_once_with(2)
+-        # After 4 rollback_state calls from 2: 2->1->0->-1->-1
+-        self.assertEqual(obj.tokens_after_think_end, -1)
+-
+-    def test_rollback_during_thinking(self):
+-        """Rollback during thinking phase doesn't touch inner grammar."""
+-        obj, grammar = self._make()
+-        obj.rollback(3)
+-        grammar.rollback.assert_not_called()
+-        self.assertEqual(obj.tokens_after_think_end, -1)
+-
+-    def test_rollback_zero(self):
+-        obj, grammar = self._make()
+-        obj.tokens_after_think_end = 2
+-        obj.rollback(0)
+-        grammar.rollback.assert_not_called()
+-        self.assertEqual(obj.tokens_after_think_end, 2)
+-
+-    def test_rollback_exactly_to_boundary(self):
+-        """Rollback exactly the number of post-thinking tokens."""
+-        obj, grammar = self._make()
+-        obj.tokens_after_think_end = 3
+-        obj.rollback(3)
+-        grammar.rollback.assert_called_once_with(3)
+-        self.assertEqual(obj.tokens_after_think_end, 0)
+-
+-    def test_rollback_far_beyond_all_tokens(self):
+-        """Rollback k much larger than tokens_after_think_end clamps grammar rollback."""
+-        obj, grammar = self._make()
+-        obj.tokens_after_think_end = 2
+-        obj.rollback(100)
+-        # Inner grammar only rolls back the 2 post-thinking tokens
+-        grammar.rollback.assert_called_once_with(2)
+-        # State bottoms out at -1
+-        self.assertEqual(obj.tokens_after_think_end, -1)
+-
+-    def test_accept_then_rollback_roundtrip(self):
+-        """Accept tokens then rollback should restore original state."""
+-        obj, grammar = self._make()
+-        obj.tokens_after_think_end = 0  # Just finished thinking
+-
+-        # Accept 3 generation tokens
++    """Tests for rollback correctness at the THINKING→GENERATION boundary."""
++
++    def _make_object_with_mock_grammar(self):
++        inner_grammar = MagicMock()
++        inner_grammar.is_terminated.return_value = False
++        obj = ReasonerGrammarObject(
++            grammar=inner_grammar,
++            think_end_id=7,
++            think_excluded_token_ids=[3, 5],
++            max_think_tokens=-1,
++            enable_token_filter=True,
++            token_filter_fn=set_token_filter_torch,
++            allocate_vocab_mask_fn=lambda vs, bs, d: torch.zeros(
++                (bs, (vs + 31) // 32), dtype=torch.int32
++            ),
++            move_vocab_mask_fn=lambda vm, d: vm,
++            apply_vocab_mask_fn=lambda l, vm: None,
++        )
++        return obj, inner_grammar
++
++    def test_rollback_at_generation_boundary_returns_to_thinking(self):
++        obj, inner_grammar = self._make_object_with_mock_grammar()
++        obj.maybe_init_reasoning(True)
++
++        # Accept 3 thinking tokens then think_end_id
+         obj.accept_token(10)
+-        obj.accept_token(20)
+-        obj.accept_token(30)
+-        self.assertEqual(obj.tokens_after_think_end, 3)
+-        self.assertEqual(grammar.accept_token.call_count, 3)
+-
+-        # Rollback all 3
+-        obj.rollback(3)
+-        self.assertEqual(obj.tokens_after_think_end, 0)
+-        grammar.rollback.assert_called_once_with(3)
+-
+-
+-class TestReasonerGrammarObjectVocabMask(unittest.TestCase):
+-    """Test vocab mask gating based on thinking state."""
+-
+-    def _make(self):
+-        grammar = MagicMock(spec=BaseGrammarObject)
+-        return ReasonerGrammarObject(grammar, THINK_END_ID), grammar
+-
+-    def test_fill_during_thinking_skips(self):
+-        obj, grammar = self._make()
+-        obj.fill_vocab_mask("mask", 0)
+-        grammar.fill_vocab_mask.assert_not_called()
+-
+-    def test_fill_after_thinking_delegates(self):
+-        obj, grammar = self._make()
+-        obj.tokens_after_think_end = 0
+-        obj.fill_vocab_mask("mask", 0)
+-        grammar.fill_vocab_mask.assert_called_once_with("mask", 0)
+-
+-    def test_fill_well_into_generation(self):
+-        obj, grammar = self._make()
+-        obj.tokens_after_think_end = 5
+-        obj.fill_vocab_mask("mask", 2)
+-        grammar.fill_vocab_mask.assert_called_once_with("mask", 2)
+-
+-    def test_fill_at_think_end_boundary(self):
+-        """After accepting think_end token, fill_vocab_mask should delegate."""
+-        obj, grammar = self._make()
+-        # Simulate: accept think_end, state goes from -1 to 0
+-        obj.accept_token(THINK_END_ID)
+-        self.assertEqual(obj.tokens_after_think_end, 0)
+-        obj.fill_vocab_mask("mask", 0)
+-        grammar.fill_vocab_mask.assert_called_once_with("mask", 0)
+-
+-    def test_allocate_delegates(self):
+-        obj, grammar = self._make()
+-        obj.allocate_vocab_mask(32000, 4, "cpu")
+-        grammar.allocate_vocab_mask.assert_called_once_with(32000, 4, "cpu")
+-
+-    def test_move_delegates(self):
+-        obj, grammar = self._make()
+-        obj.move_vocab_mask("mask", "cuda")
+-        grammar.move_vocab_mask.assert_called_once_with("mask", "cuda")
+-
+-
+-class TestReasonerGrammarObjectDelegation(unittest.TestCase):
+-    """Test that non-state methods delegate to inner grammar."""
+-
+-    def _make(self):
+-        grammar = MagicMock(spec=BaseGrammarObject)
+-        return ReasonerGrammarObject(grammar, THINK_END_ID), grammar
+-
+-    def test_is_terminated_delegates(self):
+-        obj, grammar = self._make()
+-        grammar.is_terminated.return_value = True
+-        self.assertTrue(obj.is_terminated())
+-
+-    def test_finished_getter_delegates(self):
+-        obj, grammar = self._make()
+-        grammar.finished = True
+-        self.assertTrue(obj.finished)
+-
+-    def test_finished_setter_delegates(self):
+-        obj, grammar = self._make()
+-        obj.finished = True
+-        self.assertTrue(grammar.finished)
+-
+-    def test_try_jump_forward_delegates(self):
+-        obj, grammar = self._make()
+-        grammar.try_jump_forward.return_value = ([1, 2], "ab")
+-        result = obj.try_jump_forward("tokenizer")
+-        grammar.try_jump_forward.assert_called_once_with("tokenizer")
+-        self.assertEqual(result, ([1, 2], "ab"))
+-
+-    def test_jump_forward_str_state_delegates(self):
+-        obj, grammar = self._make()
+-        grammar.jump_forward_str_state.return_value = ("str", 5)
+-        result = obj.jump_forward_str_state("helper")
+-        self.assertEqual(result, ("str", 5))
+-
+-    def test_jump_and_retokenize_delegates(self):
+-        obj, grammar = self._make()
+-        obj.jump_and_retokenize([1], [2], 3)
+-        grammar.jump_and_retokenize.assert_called_once_with([1], [2], 3)
+-
+-    def test_apply_vocab_mask_property(self):
+-        obj, grammar = self._make()
+-        grammar.apply_vocab_mask = "mask_fn"
+-        self.assertEqual(obj.apply_vocab_mask, "mask_fn")
+-
+-    def test_copy_creates_new_wrapper(self):
+-        obj, grammar = self._make()
+-        grammar_copy = MagicMock(spec=BaseGrammarObject)
+-        grammar.copy.return_value = grammar_copy
+-
+-        copied = obj.copy()
+-        self.assertIsInstance(copied, ReasonerGrammarObject)
+-        self.assertIsNot(copied, obj)
+-        self.assertIs(copied.grammar, grammar_copy)
+-        self.assertEqual(copied.think_end_id, THINK_END_ID)
+-
+-    def test_copy_does_not_share_state(self):
+-        """Modifying copy's state should not affect the original."""
+-        obj, grammar = self._make()
+-        grammar_copy = MagicMock(spec=BaseGrammarObject)
+-        grammar.copy.return_value = grammar_copy
+-
+-        copied = obj.copy()
+-        copied.tokens_after_think_end = 5
+-        self.assertEqual(obj.tokens_after_think_end, -1)
+-
+-
+-class TestReasonerGrammarObjectMaybeInitReasoning(unittest.TestCase):
+-    """Test maybe_init_reasoning state initialization."""
+-
+-    def test_reasoning_true_sets_thinking(self):
+-        grammar = MagicMock(spec=BaseGrammarObject)
+-        obj = ReasonerGrammarObject(grammar, THINK_END_ID)
++        obj.accept_token(11)
++        obj.accept_token(12)
++        obj.accept_token(7)  # think_end_id → tokens_after_end = 0
++
++        self.assertTrue(obj._is_generation())
++        self.assertEqual(obj.tokens_after_end, 0)
++
++        # Rollback 1 step: should return to THINKING
++        obj.rollback(1)
++        self.assertTrue(obj._is_thinking())
++        self.assertEqual(obj.tokens_in_think, 3)
++        self.assertEqual(obj.tokens_after_end, -1)
++        # Grammar should not have been rolled back (no generation tokens were accepted)
++        inner_grammar.rollback.assert_not_called()
++
++    def test_rollback_spanning_both_phases(self):
++        obj, inner_grammar = self._make_object_with_mock_grammar()
++        obj.maybe_init_reasoning(True)
++
++        # 2 thinking tokens + think_end + 3 generation tokens
++        obj.accept_token(10)  # think
++        obj.accept_token(11)  # think
++        obj.accept_token(7)  # think_end_id
++        obj.accept_token(20)  # gen 1
++        obj.accept_token(21)  # gen 2
++        obj.accept_token(22)  # gen 3
++
++        self.assertEqual(obj.tokens_after_end, 3)
++
++        # Rollback 5: should roll back 3 generation tokens + think_end + 1 thinking token
++        obj.rollback(5)
++        self.assertTrue(obj._is_thinking())
++        self.assertEqual(obj.tokens_in_think, 1)
++        # Grammar should be rolled back by 3 (only generation tokens)
++        inner_grammar.rollback.assert_called_once_with(3)
++
++    def test_rollback_generation_tokens_only(self):
++        obj, inner_grammar = self._make_object_with_mock_grammar()
+         obj.maybe_init_reasoning(True)
+-        self.assertEqual(obj.tokens_after_think_end, -1)
+ 
+-    def test_reasoning_false_skips_thinking(self):
+-        grammar = MagicMock(spec=BaseGrammarObject)
+-        obj = ReasonerGrammarObject(grammar, THINK_END_ID)
+-        obj.maybe_init_reasoning(False)
+-        self.assertEqual(obj.tokens_after_think_end, 0)
++        obj.accept_token(10)  # think
++        obj.accept_token(7)  # think_end_id
++        obj.accept_token(20)  # gen 1
++        obj.accept_token(21)  # gen 2
+ 
+-    def test_reasoning_toggle(self):
+-        """Toggling reasoning resets state regardless of current position."""
+-        grammar = MagicMock(spec=BaseGrammarObject)
+-        obj = ReasonerGrammarObject(grammar, THINK_END_ID)
+-        obj.tokens_after_think_end = 5  # Deep into generation
++        # Rollback 1: should only roll back 1 generation token
++        obj.rollback(1)
++        self.assertTrue(obj._is_generation())
++        self.assertEqual(obj.tokens_after_end, 1)
++        inner_grammar.rollback.assert_called_once_with(1)
+ 
++    def test_rollback_thinking_tokens_does_not_touch_grammar(self):
++        obj, inner_grammar = self._make_object_with_mock_grammar()
+         obj.maybe_init_reasoning(True)
+-        self.assertEqual(obj.tokens_after_think_end, -1)
+ 
+-        obj.maybe_init_reasoning(False)
+-        self.assertEqual(obj.tokens_after_think_end, 0)
++        obj.accept_token(10)
++        obj.accept_token(11)
++        obj.accept_token(12)
+ 
++        obj.rollback(2)
++        self.assertTrue(obj._is_thinking())
++        self.assertEqual(obj.tokens_in_think, 1)
++        inner_grammar.rollback.assert_not_called()
++        inner_grammar.accept_token.assert_not_called()
+ 
+-class TestReasonerGrammarBackend(unittest.TestCase):
+-    """Test ReasonerGrammarBackend dispatch wrapping."""
+-
+-    def _make(self):
+-        inner = MagicMock(spec=BaseGrammarBackend)
+-        backend = ReasonerGrammarBackend(inner, THINK_END_ID)
+-        return backend, inner
+-
+-    def test_wraps_valid_grammar(self):
+-        backend, inner = self._make()
+-        mock_grammar = MagicMock(spec=BaseGrammarObject)
+-        inner._init_value_dispatch.return_value = mock_grammar
+-
+-        result = backend._init_value_dispatch(("json", "schema"), True)
+-        self.assertIsInstance(result, ReasonerGrammarObject)
+-        self.assertIs(result.grammar, mock_grammar)
+-        self.assertEqual(result.think_end_id, THINK_END_ID)
+-
+-    def test_passes_through_invalid_grammar(self):
+-        backend, inner = self._make()
+-        invalid = InvalidGrammarObject("bad grammar")
+-        inner._init_value_dispatch.return_value = invalid
+-
+-        result = backend._init_value_dispatch(("json", "schema"), False)
+-        self.assertIs(result, invalid)
+-        self.assertIsInstance(result, InvalidGrammarObject)
+-
+-    def test_passes_through_none(self):
+-        backend, inner = self._make()
+-        inner._init_value_dispatch.return_value = None
+-
+-        result = backend._init_value_dispatch(("json", "schema"), False)
+-        self.assertIsNone(result)
+-
+-    def test_inits_reasoning_on_wrapped(self):
+-        backend, inner = self._make()
+-        mock_grammar = MagicMock(spec=BaseGrammarObject)
+-        inner._init_value_dispatch.return_value = mock_grammar
+-
+-        result = backend._init_value_dispatch(("json", "schema"), True)
+-        # reasoning=True → tokens_after_think_end should be -1
+-        self.assertEqual(result.tokens_after_think_end, -1)
+-
+-    def test_inits_no_reasoning_on_wrapped(self):
+-        backend, inner = self._make()
+-        mock_grammar = MagicMock(spec=BaseGrammarObject)
+-        inner._init_value_dispatch.return_value = mock_grammar
+-
+-        result = backend._init_value_dispatch(("json", "schema"), False)
+-        # reasoning=False → tokens_after_think_end should be 0
+-        self.assertEqual(result.tokens_after_think_end, 0)
++    def test_copy_preserves_state(self):
++        obj, inner_grammar = self._make_object_with_mock_grammar()
++        obj.maybe_init_reasoning(True)
++
++        obj.accept_token(10)
++        obj.accept_token(7)  # think_end_id → GENERATION
++        obj.accept_token(20)
++
++        self.assertEqual(obj.tokens_in_think, 1)
++        self.assertEqual(obj.tokens_after_end, 1)
++
++        copy = obj.copy()
++        # State counters must be preserved for speculative decoding
++        self.assertEqual(copy.tokens_in_think, 1)
++        self.assertEqual(copy.tokens_after_end, 1)
++        self.assertTrue(copy._is_generation())
++        self.assertIsNotNone(copy.grammar)
++        inner_grammar.copy.assert_called_once()
++
++    def test_copy_preserves_thinking_state(self):
++        obj, inner_grammar = self._make_object_with_mock_grammar()
++        obj.maybe_init_reasoning(True)
++
++        obj.accept_token(10)
++        obj.accept_token(11)
++
++        copy = obj.copy()
++        self.assertEqual(copy.tokens_in_think, 2)
++        self.assertEqual(copy.tokens_after_end, -1)
++        self.assertTrue(copy._is_thinking())
++
++
++class TestReasonerGrammarObjectFillVocabMask(unittest.TestCase):
++    """Tests for fill_vocab_mask behavior in different states."""
++
++    def test_thinking_phase_does_not_consult_inner_grammar(self):
++        inner_grammar = MagicMock()
++        # Must return a real tensor for allocate_vocab_mask since fill_vocab_mask
++        # delegates to allocate_vocab_mask via self.grammar when grammar is not None
++        inner_grammar.allocate_vocab_mask.side_effect = lambda vs, bs, d: torch.zeros(
++            (bs, (vs + 31) // 32), dtype=torch.int32
++        )
++        obj = ReasonerGrammarObject(
++            grammar=inner_grammar,
++            think_end_id=7,
++            think_excluded_token_ids=[3, 5],
++            max_think_tokens=-1,
++            enable_token_filter=True,
++            token_filter_fn=set_token_filter_torch,
++            allocate_vocab_mask_fn=lambda vs, bs, d: torch.zeros(
++                (bs, (vs + 31) // 32), dtype=torch.int32
++            ),
++            move_vocab_mask_fn=lambda vm, d: vm,
++            apply_vocab_mask_fn=lambda l, vm: None,
++        )
++        obj.maybe_init_reasoning(True)
++        mask = obj.allocate_vocab_mask(64, 1, "cpu")
++
++        obj.fill_vocab_mask(mask, 0)
++
++        inner_grammar.fill_vocab_mask.assert_not_called()
++        # Excluded tokens (3, 5) should be blocked
++        allowed = _allowed_token_ids(mask, [0, 1, 3, 5, 7, 8])
++        self.assertEqual(allowed, [0, 1, 7, 8])
++
++    def test_generation_phase_consults_inner_grammar(self):
++        inner_grammar = MagicMock()
++        inner_grammar.allocate_vocab_mask.side_effect = lambda vs, bs, d: torch.zeros(
++            (bs, (vs + 31) // 32), dtype=torch.int32
++        )
++        obj = ReasonerGrammarObject(
++            grammar=inner_grammar,
++            think_end_id=7,
++            think_excluded_token_ids=[3, 5],
++            max_think_tokens=-1,
++            enable_token_filter=True,
++            token_filter_fn=set_token_filter_torch,
++            allocate_vocab_mask_fn=lambda vs, bs, d: torch.zeros(
++                (bs, (vs + 31) // 32), dtype=torch.int32
++            ),
++            move_vocab_mask_fn=lambda vm, d: vm,
++            apply_vocab_mask_fn=lambda l, vm: None,
++        )
++        obj.maybe_init_reasoning(True)
++        obj.accept_token(10)
++        obj.accept_token(7)  # think_end_id → GENERATION
++
++        mask = obj.allocate_vocab_mask(64, 1, "cpu")
++        obj.fill_vocab_mask(mask, 0)
++
++        inner_grammar.fill_vocab_mask.assert_called_once_with(mask, 0)
++
++    def test_non_strict_thinking_is_noop(self):
++        inner_grammar = MagicMock()
++        obj = ReasonerGrammarObject(
++            grammar=inner_grammar,
++            think_end_id=7,
++            think_excluded_token_ids=None,
++            max_think_tokens=-1,
++            enable_token_filter=False,
++            token_filter_fn=None,
++        )
++        obj.maybe_init_reasoning(True)
++        mask = torch.zeros((1, 2), dtype=torch.int32)
++
++        obj.fill_vocab_mask(mask, 0)
++
++        inner_grammar.fill_vocab_mask.assert_not_called()
++        # Mask should remain all zeros (no filtering)
++        self.assertTrue(torch.all(mask == 0))
+ 
+ 
+ if __name__ == "__main__":
+diff --git a/test/registered/unit/constrained/test_token_filter_ops.py b/test/registered/unit/constrained/test_token_filter_ops.py
+new file mode 100644
+index 0000000000..08dba0b4b4
+--- /dev/null
++++ b/test/registered/unit/constrained/test_token_filter_ops.py
+@@ -0,0 +1,146 @@
++"""
++Unit tests for token filter operations (Triton and Torch paths).
++
++Verifies that both implementations produce identical bitmask output
++for the same inputs, ensuring parity across GPU and CPU paths.
++"""
++
++import unittest
++
++import torch
++
++from sglang.srt.constrained.torch_ops.token_filter_torch_ops import (
++    set_token_filter_torch,
++)
++from sglang.test.ci.ci_register import register_cpu_ci
++
++register_cpu_ci(2.0, "stage-a-test-cpu")
++
++# Conditionally import Triton path
++_has_cuda = torch.cuda.is_available()
++if _has_cuda:
++    from sglang.srt.constrained.triton_ops.token_filter_ops import (
++        set_token_filter_triton,
++    )
++
++
++def _get_allowed_tokens(vocab_mask, batch_idx, max_token_id):
++    """Extract allowed token IDs from a bitmask row."""
++    allowed = []
++    for token_id in range(max_token_id):
++        elem = token_id // 32
++        bit = token_id % 32
++        val = int(vocab_mask[batch_idx, elem].item())
++        if val & (1 << bit):
++            allowed.append(token_id)
++    return allowed
++
++
++class TestSetTokenFilterTorch(unittest.TestCase):
++    """Tests for the Torch token filter implementation."""
++
++    def test_allow_tokens_from_blank_mask(self):
++        vocab_mask = torch.zeros((1, 4), dtype=torch.int32)  # 128 tokens
++        set_token_filter_torch(vocab_mask, [0, 5, 31, 32, 63], 0, is_allowed=True)
++
++        allowed = _get_allowed_tokens(vocab_mask, 0, 64)
++        self.assertEqual(allowed, [0, 5, 31, 32, 63])
++
++    def test_block_tokens_from_full_mask(self):
++        vocab_mask = torch.full((1, 4), -1, dtype=torch.int32)  # all bits set
++        set_token_filter_torch(
++            vocab_mask, [3, 5], 0, is_allowed=False, reset_vocab_mask=False
++        )
++
++        allowed = _get_allowed_tokens(vocab_mask, 0, 64)
++        self.assertNotIn(3, allowed)
++        self.assertNotIn(5, allowed)
++        self.assertIn(0, allowed)
++        self.assertIn(1, allowed)
++
++    def test_reset_then_allow(self):
++        vocab_mask = torch.full((1, 2), -1, dtype=torch.int32)
++        set_token_filter_torch(
++            vocab_mask, [7], 0, is_allowed=True, reset_vocab_mask=True
++        )
++
++        allowed = _get_allowed_tokens(vocab_mask, 0, 64)
++        self.assertEqual(allowed, [7])
++
++    def test_reset_then_block(self):
++        vocab_mask = torch.zeros((1, 2), dtype=torch.int32)
++        set_token_filter_torch(
++            vocab_mask, [3, 5], 0, is_allowed=False, reset_vocab_mask=True
++        )
++
++        allowed = _get_allowed_tokens(vocab_mask, 0, 64)
++        self.assertNotIn(3, allowed)
++        self.assertNotIn(5, allowed)
++        # All other tokens should be allowed (reset to -1 for block mode)
++        self.assertIn(0, allowed)
++        self.assertIn(7, allowed)
++
++    def test_empty_token_list(self):
++        vocab_mask = torch.zeros((1, 2), dtype=torch.int32)
++        set_token_filter_torch(
++            vocab_mask, [], 0, is_allowed=True, reset_vocab_mask=True
++        )
++
++        allowed = _get_allowed_tokens(vocab_mask, 0, 64)
++        self.assertEqual(allowed, [])
++
++    def test_batch_indexing(self):
++        vocab_mask = torch.zeros((3, 2), dtype=torch.int32)
++        set_token_filter_torch(vocab_mask, [1], 0, is_allowed=True)
++        set_token_filter_torch(vocab_mask, [2], 1, is_allowed=True)
++        set_token_filter_torch(vocab_mask, [3], 2, is_allowed=True)
++
++        self.assertEqual(_get_allowed_tokens(vocab_mask, 0, 64), [1])
++        self.assertEqual(_get_allowed_tokens(vocab_mask, 1, 64), [2])
++        self.assertEqual(_get_allowed_tokens(vocab_mask, 2, 64), [3])
++
++
++@unittest.skipUnless(_has_cuda, "CUDA not available")
++class TestTritonTorchParity(unittest.TestCase):
++    """Tests that Triton and Torch produce identical output."""
++
++    def _compare_outputs(self, token_ids, is_allowed, reset):
++        vocab_size = 128
++        num_elements = (vocab_size + 31) // 32
++
++        torch_mask = torch.zeros((1, num_elements), dtype=torch.int32)
++        triton_mask = torch.zeros((1, num_elements), dtype=torch.int32, device="cuda")
++
++        set_token_filter_torch(
++            torch_mask,
++            token_ids,
++            0,
++            is_allowed=is_allowed,
++            reset_vocab_mask=reset,
++        )
++        set_token_filter_triton(
++            triton_mask,
++            token_ids,
++            0,
++            is_allowed=is_allowed,
++            reset_vocab_mask=reset,
++        )
++
++        triton_cpu = triton_mask.cpu()
++        self.assertTrue(
++            torch.equal(torch_mask, triton_cpu),
++            f"Mismatch: torch={torch_mask} triton={triton_cpu}",
++        )
++
++    def test_parity_allow_tokens(self):
++        self._compare_outputs([0, 5, 31, 32, 63, 100], is_allowed=True, reset=True)
++
++    def test_parity_block_tokens(self):
++        self._compare_outputs([3, 5, 10], is_allowed=False, reset=True)
++
++    def test_parity_empty_tokens(self):
++        self._compare_outputs([], is_allowed=True, reset=True)
++
++
++if __name__ == "__main__":
++    unittest.main()
+diff --git a/test/registered/unit/function_call/test_function_call_parser.py b/test/registered/unit/function_call/test_function_call_parser.py
+index f0974d45ef..3fb68066e7 100644
+--- a/test/registered/unit/function_call/test_function_call_parser.py
++++ b/test/registered/unit/function_call/test_function_call_parser.py
+@@ -1,10 +1,16 @@
+ import json
+ import unittest
+ 
+-from sglang.srt.entrypoints.openai.protocol import Function, Tool
++from sglang.srt.entrypoints.openai.protocol import (
++    Function,
++    Tool,
++    ToolChoice,
++    ToolChoiceFuncName,
++)
+ from sglang.srt.function_call.base_format_detector import BaseFormatDetector
+ from sglang.srt.function_call.core_types import StreamingParseResult
+ from sglang.srt.function_call.deepseekv3_detector import DeepSeekV3Detector
++from sglang.srt.function_call.deepseekv4_detector import DeepSeekV4Detector
+ from sglang.srt.function_call.deepseekv32_detector import DeepSeekV32Detector
+ from sglang.srt.function_call.gemma4_detector import (
+     Gemma4Detector,
+@@ -15,6 +21,7 @@ from sglang.srt.function_call.gemma4_detector import (
+ from sglang.srt.function_call.gigachat3_detector import GigaChat3Detector
+ from sglang.srt.function_call.glm4_moe_detector import Glm4MoeDetector
+ from sglang.srt.function_call.glm47_moe_detector import Glm47MoeDetector
++from sglang.srt.function_call.gpt_oss_detector import GptOssDetector
+ from sglang.srt.function_call.json_array_parser import JsonArrayParser
+ from sglang.srt.function_call.kimik2_detector import KimiK2Detector
+ from sglang.srt.function_call.lfm2_detector import Lfm2Detector
+@@ -1632,6 +1639,478 @@ class TestDeepSeekV32Detector(unittest.TestCase):
+         params = json.loads(tool_calls_by_index[0]["parameters"])
+         self.assertEqual(params, {})
+ 
++    def test_get_model_structural_tag(self):
++        import xgrammar as xgr
++
++        structural_tag = self.detector.get_structural_tag(
++            self.tools, thinking_mode=True
++        )
++        self.assertIsInstance(structural_tag, xgr.StructuralTag)
++        grammar = xgr.Grammar.from_structural_tag(structural_tag)
++        self.assertIsInstance(grammar, xgr.Grammar)
++
++        structural_tag = self.detector.get_structural_tag(
++            self.tools, thinking_mode=False
++        )
++        self.assertIsInstance(structural_tag, xgr.StructuralTag)
++        grammar = xgr.Grammar.from_structural_tag(structural_tag)
++        self.assertIsInstance(grammar, xgr.Grammar)
++
++        structural_tag = self.detector.get_structural_tag(
++            self.tools, thinking_mode=True, tool_choice="required"
++        )
++        self.assertIsInstance(structural_tag, xgr.StructuralTag)
++        grammar = xgr.Grammar.from_structural_tag(structural_tag)
++        self.assertIsInstance(grammar, xgr.Grammar)
++
++        structural_tag = self.detector.get_structural_tag(
++            self.tools, thinking_mode=False, tool_choice="required"
++        )
++        self.assertIsInstance(structural_tag, xgr.StructuralTag)
++        grammar = xgr.Grammar.from_structural_tag(structural_tag)
++        self.assertIsInstance(grammar, xgr.Grammar)
++
++        tool_choice_name = ToolChoiceFuncName(name="search")
++        tool_choice = ToolChoice(function=tool_choice_name)
++        structural_tag = self.detector.get_structural_tag(
++            self.tools, thinking_mode=True, tool_choice=tool_choice
++        )
++        self.assertIsInstance(structural_tag, xgr.StructuralTag)
++        grammar = xgr.Grammar.from_structural_tag(structural_tag)
++        self.assertIsInstance(grammar, xgr.Grammar)
++
++        structural_tag = self.detector.get_structural_tag(
++            self.tools, thinking_mode=False, tool_choice=tool_choice
++        )
++        self.assertIsInstance(structural_tag, xgr.StructuralTag)
++        grammar = xgr.Grammar.from_structural_tag(structural_tag)
++        self.assertIsInstance(grammar, xgr.Grammar)
++
++
++class TestDeepSeekV4Detector(unittest.TestCase):
++    def setUp(self):
++        """Set up test tools and detector for DeepSeekV4 format testing."""
++        self.tools = [
++            Tool(
++                type="function",
++                function=Function(
++                    name="search",
++                    description="Searches for information related to query and displays topn results.",
++                    parameters={
++                        "type": "object",
++                        "properties": {
++                            "query": {
++                                "type": "string",
++                                "description": "The search query string",
++                            },
++                            "topn": {
++                                "type": "integer",
++                                "description": "Number of top results to display",
++                                "default": 10,
++                            },
++                            "source": {
++                                "type": "string",
++                                "description": "Source to search within",
++                                "enum": ["web", "news"],
++                                "default": "web",
++                            },
++                        },
++                        "required": ["query"],
++                    },
++                ),
++            ),
++            Tool(
++                type="function",
++                function=Function(
++                    name="get_favorite_tourist_spot",
++                    description="Return the favorite tourist spot for a given city.",
++                    parameters={
++                        "type": "object",
++                        "properties": {"city": {"type": "string"}},
++                        "required": ["city"],
++                    },
++                ),
++            ),
++        ]
++        self.detector = DeepSeekV4Detector()
++        from sglang.srt.utils.hf_transformers_utils import get_tokenizer
++
++        self.tokenizer = get_tokenizer("deepseek-ai/DeepSeek-V3.2")
++        self.interval = 1
++
++    def test_detect_and_parse_xml_format(self):
++        """Test parsing standard XML format (DSML)"""
++        text = """I'll help you with information about San Francisco and get its favorite tourist spot for you.\n\n
++        <｜DSML｜tool_calls>\n
++            <｜DSML｜invoke name="get_favorite_tourist_spot">\n
++                <｜DSML｜parameter name="city" string="true">San Francisco</｜DSML｜parameter>\n
++            </｜DSML｜invoke>\n
++            <｜DSML｜invoke name="search">
++                <｜DSML｜parameter name="query" string="true">WebNav benchmark</｜DSML｜parameter>
++                <｜DSML｜parameter name="topn" string="false">10</｜DSML｜parameter>
++                <｜DSML｜parameter name="source" string="true">web</｜DSML｜parameter>
++            </｜DSML｜invoke>
++        </｜DSML｜tool_calls>
++        """
++        result = self.detector.detect_and_parse(text, self.tools)
++
++        self.assertIn("I'll help you with information", result.normal_text)
++        self.assertEqual(len(result.calls), 2)
++
++        # Check first call
++        call1 = result.calls[0]
++        self.assertEqual(call1.name, "get_favorite_tourist_spot")
++        params1 = json.loads(call1.parameters)
++        self.assertEqual(params1["city"], "San Francisco")
++
++        # Check second call
++        call2 = result.calls[1]
++        self.assertEqual(call2.name, "search")
++        params2 = json.loads(call2.parameters)
++        self.assertEqual(params2["query"], "WebNav benchmark")
++        self.assertEqual(params2["topn"], 10)
++        self.assertEqual(params2["source"], "web")
++
++    def test_detect_and_parse_json_format(self):
++        """Test parsing JSON format inside invoke tags"""
++        text = """I'll help you with information about San Francisco and get its favorite tourist spot for you.
++
++        <｜DSML｜tool_calls>
++            <｜DSML｜invoke name="get_favorite_tourist_spot">
++            {
++                "city": "San Francisco"
++            }
++        </｜DSML｜invoke>
++            <｜DSML｜invoke name="search">
++            {
++                "query": "WebNav benchmark",
++                "topn": 10,
++                "source": "web"
++            }
++        </｜DSML｜invoke>
++        </｜DSML｜tool_calls>
++        """
++        result = self.detector.detect_and_parse(text, self.tools)
++
++        self.assertIn("I'll help you with information", result.normal_text)
++        self.assertEqual(len(result.calls), 2)
++
++        # Check first call
++        call1 = result.calls[0]
++        self.assertEqual(call1.name, "get_favorite_tourist_spot")
++        params1 = json.loads(call1.parameters)
++        self.assertEqual(params1["city"], "San Francisco")
++
++        # Check second call
++        call2 = result.calls[1]
++        self.assertEqual(call2.name, "search")
++        params2 = json.loads(call2.parameters)
++        self.assertEqual(params2["query"], "WebNav benchmark")
++        self.assertEqual(params2["topn"], 10)
++        self.assertEqual(params2["source"], "web")
++
++    def test_streaming_xml_format(self):
++        """Test streaming parsing of XML format"""
++        text = """<｜DSML｜tool_calls>
++            <｜DSML｜invoke name="get_favorite_tourist_spot">
++                <｜DSML｜parameter name="city" string="true">San Francisco</｜DSML｜parameter>
++                <｜DSML｜parameter name="another_city" string="true">London</｜DSML｜parameter>
++                <｜DSML｜parameter name="topn" string="false">10</｜DSML｜parameter>
++                <｜DSML｜parameter name="obj" string="false">{"name": "John", "age": 30}</｜DSML｜parameter>
++            </｜DSML｜invoke>
++        </｜DSML｜tool_calls>"""
++
++        input_ids = self.tokenizer.encode(text, add_special_tokens=False)
++        chunk_ids = [
++            input_ids[i : i + self.interval]
++            for i in range(0, len(input_ids), self.interval)
++        ]
++        chunks = [self.tokenizer.decode(chunk_id) for chunk_id in chunk_ids]
++
++        tool_calls_by_index = {}
++
++        num_tool_call_chunks = 0
++        for chunk in chunks:
++            result = self.detector.parse_streaming_increment(chunk, self.tools)
++            for call in result.calls:
++                num_tool_call_chunks += 1
++                if call.tool_index is not None:
++                    if call.tool_index not in tool_calls_by_index:
++                        tool_calls_by_index[call.tool_index] = {
++                            "name": "",
++                            "parameters": "",
++                        }
++
++                    if call.name:
++                        tool_calls_by_index[call.tool_index]["name"] = call.name
++                    if call.parameters:
++                        tool_calls_by_index[call.tool_index][
++                            "parameters"
++                        ] += call.parameters
++
++        self.assertGreater(num_tool_call_chunks, 8)
++
++        self.assertEqual(len(tool_calls_by_index), 1)
++        self.assertEqual(tool_calls_by_index[0]["name"], "get_favorite_tourist_spot")
++        params = json.loads(tool_calls_by_index[0]["parameters"])
++        self.assertEqual(params["city"], "San Francisco")
++        self.assertEqual(params["another_city"], "London")
++        self.assertEqual(params["topn"], 10)
++        self.assertEqual(params["obj"]["name"], "John")
++        self.assertEqual(params["obj"]["age"], 30)
++
++    def test_streaming_json_format(self):
++        """Test streaming parsing of JSON format"""
++        text = """<｜DSML｜tool_calls>
++            <｜DSML｜invoke name="get_favorite_tourist_spot">
++            {
++                "city": "San Francisco",
++                "another_city": "London",
++                "topn": 10,
++                "obj": {
++                    "name": "John",
++                    "age": 30
++                }
++            }
++            </｜DSML｜invoke>
++        </｜DSML｜tool_calls>"""
++
++        input_ids = self.tokenizer.encode(text, add_special_tokens=False)
++        chunk_ids = [
++            input_ids[i : i + self.interval]
++            for i in range(0, len(input_ids), self.interval)
++        ]
++        chunks = [self.tokenizer.decode(chunk_id) for chunk_id in chunk_ids]
++
++        tool_calls_by_index = {}
++
++        num_tool_call_chunks = 0
++        for chunk in chunks:
++            result = self.detector.parse_streaming_increment(chunk, self.tools)
++            for call in result.calls:
++                num_tool_call_chunks += 1
++                if call.tool_index is not None:
++                    if call.tool_index not in tool_calls_by_index:
++                        tool_calls_by_index[call.tool_index] = {
++                            "name": "",
++                            "parameters": "",
++                        }
++
++                    if call.name:
++                        tool_calls_by_index[call.tool_index]["name"] = call.name
++                    if call.parameters:
++                        tool_calls_by_index[call.tool_index][
++                            "parameters"
++                        ] += call.parameters
++
++        self.assertGreater(num_tool_call_chunks, 8)
++        self.assertEqual(len(tool_calls_by_index), 1)
++        self.assertEqual(tool_calls_by_index[0]["name"], "get_favorite_tourist_spot")
++
++        # Clean up parameters string if needed (trim whitespace)
++        params_str = tool_calls_by_index[0]["parameters"].strip()
++        params = json.loads(params_str)
++        self.assertEqual(params["city"], "San Francisco")
++
++    def test_detect_and_parse_no_parameters(self):
++        """Test parsing function calls with no parameters (non-streaming)"""
++        # Add a no-parameter tool
++        tools_with_no_param = self.tools + [
++            Tool(
++                type="function",
++                function=Function(
++                    name="get_date",
++                    description="Get the current date.",
++                    parameters={"type": "object", "properties": {}},
++                ),
++            ),
++        ]
++
++        text = """Let me get the current date for you.
++
++<｜DSML｜tool_calls>
++<｜DSML｜invoke name="get_date">
++</｜DSML｜invoke>
++</｜DSML｜tool_calls>"""
++
++        result = self.detector.detect_and_parse(text, tools_with_no_param)
++
++        self.assertIn("Let me get the current date", result.normal_text)
++        self.assertEqual(len(result.calls), 1)
++
++        call = result.calls[0]
++        self.assertEqual(call.name, "get_date")
++        params = json.loads(call.parameters)
++        self.assertEqual(params, {})
++
++    def test_streaming_no_parameters(self):
++        """Test streaming parsing of function calls with no parameters.
++
++        This test verifies the fix for the bug where functions with no parameters
++        were being silently skipped in streaming mode.
++        """
++        # Add a no-parameter tool
++        tools_with_no_param = self.tools + [
++            Tool(
++                type="function",
++                function=Function(
++                    name="get_date",
++                    description="Get the current date.",
++                    parameters={"type": "object", "properties": {}},
++                ),
++            ),
++        ]
++
++        text = """<｜DSML｜tool_calls>
++<｜DSML｜invoke name="get_date">
++</｜DSML｜invoke>
++</｜DSML｜tool_calls>"""
++
++        # Reset detector state
++        self.detector = DeepSeekV4Detector()
++
++        # Simulate streaming by splitting into small chunks
++        input_ids = self.tokenizer.encode(text, add_special_tokens=False)
++        chunk_ids = [
++            input_ids[i : i + self.interval]
++            for i in range(0, len(input_ids), self.interval)
++        ]
++        chunks = [self.tokenizer.decode(chunk_id) for chunk_id in chunk_ids]
++
++        tool_calls_by_index = {}
++
++        for chunk in chunks:
++            result = self.detector.parse_streaming_increment(chunk, tools_with_no_param)
++            for call in result.calls:
++                if call.tool_index is not None:
++                    if call.tool_index not in tool_calls_by_index:
++                        tool_calls_by_index[call.tool_index] = {
++                            "name": "",
++                            "parameters": "",
++                        }
++
++                    if call.name:
++                        tool_calls_by_index[call.tool_index]["name"] = call.name
++                    if call.parameters:
++                        tool_calls_by_index[call.tool_index][
++                            "parameters"
++                        ] += call.parameters
++
++        # Verify that the no-parameter function was correctly parsed
++        self.assertEqual(
++            len(tool_calls_by_index), 1, "Should have exactly one tool call"
++        )
++        self.assertEqual(tool_calls_by_index[0]["name"], "get_date")
++
++        # Parameters should be empty JSON object
++        params_str = tool_calls_by_index[0]["parameters"].strip()
++        params = json.loads(params_str)
++        self.assertEqual(params, {})
++
++    def test_streaming_no_parameters_with_whitespace(self):
++        """Test streaming parsing when invoke content has only whitespace (newlines)."""
++        tools_with_no_param = self.tools + [
++            Tool(
++                type="function",
++                function=Function(
++                    name="get_date",
++                    description="Get the current date.",
++                    parameters={"type": "object", "properties": {}},
++                ),
++            ),
++        ]
++
++        # This format has newlines inside the invoke tag (common model output)
++        text = """<｜DSML｜tool_calls>
++<｜DSML｜invoke name="get_date">
++
++</｜DSML｜invoke>
++</｜DSML｜tool_calls>"""
++
++        # Reset detector state
++        self.detector = DeepSeekV4Detector()
++
++        input_ids = self.tokenizer.encode(text, add_special_tokens=False)
++        chunk_ids = [
++            input_ids[i : i + self.interval]
++            for i in range(0, len(input_ids), self.interval)
++        ]
++        chunks = [self.tokenizer.decode(chunk_id) for chunk_id in chunk_ids]
++
++        tool_calls_by_index = {}
++
++        for chunk in chunks:
++            result = self.detector.parse_streaming_increment(chunk, tools_with_no_param)
++            for call in result.calls:
++                if call.tool_index is not None:
++                    if call.tool_index not in tool_calls_by_index:
++                        tool_calls_by_index[call.tool_index] = {
++                            "name": "",
++                            "parameters": "",
++                        }
++
++                    if call.name:
++                        tool_calls_by_index[call.tool_index]["name"] = call.name
++                    if call.parameters:
++                        tool_calls_by_index[call.tool_index][
++                            "parameters"
++                        ] += call.parameters
++
++        # Should still parse correctly even with whitespace-only content
++        self.assertEqual(
++            len(tool_calls_by_index), 1, "Should have exactly one tool call"
++        )
++        self.assertEqual(tool_calls_by_index[0]["name"], "get_date")
++        params = json.loads(tool_calls_by_index[0]["parameters"])
++        self.assertEqual(params, {})
++
++    def test_get_model_structural_tag(self):
++        import xgrammar as xgr
++
++        structural_tag = self.detector.get_structural_tag(
++            self.tools, thinking_mode=True
++        )
++        self.assertIsInstance(structural_tag, xgr.StructuralTag)
++        grammar = xgr.Grammar.from_structural_tag(structural_tag)
++        self.assertIsInstance(grammar, xgr.Grammar)
++
++        structural_tag = self.detector.get_structural_tag(
++            self.tools, thinking_mode=False
++        )
++        self.assertIsInstance(structural_tag, xgr.StructuralTag)
++        grammar = xgr.Grammar.from_structural_tag(structural_tag)
++        self.assertIsInstance(grammar, xgr.Grammar)
++
++        structural_tag = self.detector.get_structural_tag(
++            self.tools, thinking_mode=True, tool_choice="required"
++        )
++        self.assertIsInstance(structural_tag, xgr.StructuralTag)
++        grammar = xgr.Grammar.from_structural_tag(structural_tag)
++        self.assertIsInstance(grammar, xgr.Grammar)
++
++        structural_tag = self.detector.get_structural_tag(
++            self.tools, thinking_mode=False, tool_choice="required"
++        )
++        self.assertIsInstance(structural_tag, xgr.StructuralTag)
++        grammar = xgr.Grammar.from_structural_tag(structural_tag)
++        self.assertIsInstance(grammar, xgr.Grammar)
++
++        tool_choice_name = ToolChoiceFuncName(name="search")
++        tool_choice = ToolChoice(function=tool_choice_name)
++        structural_tag = self.detector.get_structural_tag(
++            self.tools, thinking_mode=True, tool_choice=tool_choice
++        )
++        self.assertIsInstance(structural_tag, xgr.StructuralTag)
++        grammar = xgr.Grammar.from_structural_tag(structural_tag)
++        self.assertIsInstance(grammar, xgr.Grammar)
++
++        structural_tag = self.detector.get_structural_tag(
++            self.tools, thinking_mode=False, tool_choice=tool_choice
++        )
++        self.assertIsInstance(structural_tag, xgr.StructuralTag)
++        grammar = xgr.Grammar.from_structural_tag(structural_tag)
++        self.assertIsInstance(grammar, xgr.Grammar)
++
+ 
+ class TestQwen3CoderDetector(unittest.TestCase):
+     """Test suite for Qwen3CoderDetector."""
+@@ -1985,6 +2464,148 @@ class TestQwen3CoderDetector(unittest.TestCase):
+         self.assertFalse(self.detector.has_tool_call("plain text only"))
+         self.assertFalse(self.detector.has_tool_call(""))
+ 
++    # ==================== Structural tag (xgrammar builtin) ====================
++    # Qwen3 Coder uses the new builtin structural tag path. supports_structural_tag()
++    # is True so required/named tool_choice routes through FunctionCallParser
++    # instead of JsonArrayParser.
++
++    def test_supports_structural_tag(self):
++        self.assertTrue(self.detector.supports_structural_tag())
++
++    def test_get_model_structural_tag(self):
++        import xgrammar as xgr
++
++        structural_tag = self.detector.get_structural_tag(
++            self.tools, thinking_mode=True
++        )
++        self.assertIsInstance(structural_tag, xgr.StructuralTag)
++        grammar = xgr.Grammar.from_structural_tag(structural_tag)
++        self.assertIsInstance(grammar, xgr.Grammar)
++
++        structural_tag = self.detector.get_structural_tag(
++            self.tools, thinking_mode=False
++        )
++        self.assertIsInstance(structural_tag, xgr.StructuralTag)
++        grammar = xgr.Grammar.from_structural_tag(structural_tag)
++        self.assertIsInstance(grammar, xgr.Grammar)
++
++        structural_tag = self.detector.get_structural_tag(
++            self.tools, thinking_mode=True, tool_choice="required"
++        )
++        self.assertIsInstance(structural_tag, xgr.StructuralTag)
++        grammar = xgr.Grammar.from_structural_tag(structural_tag)
++        self.assertIsInstance(grammar, xgr.Grammar)
++
++        structural_tag = self.detector.get_structural_tag(
++            self.tools, thinking_mode=False, tool_choice="required"
++        )
++        self.assertIsInstance(structural_tag, xgr.StructuralTag)
++        grammar = xgr.Grammar.from_structural_tag(structural_tag)
++        self.assertIsInstance(grammar, xgr.Grammar)
++
++        tool_choice_name = ToolChoiceFuncName(name="get_current_weather")
++        tool_choice = ToolChoice(function=tool_choice_name)
++        structural_tag = self.detector.get_structural_tag(
++            self.tools, thinking_mode=True, tool_choice=tool_choice
++        )
++        self.assertIsInstance(structural_tag, xgr.StructuralTag)
++        grammar = xgr.Grammar.from_structural_tag(structural_tag)
++        self.assertIsInstance(grammar, xgr.Grammar)
++
++        structural_tag = self.detector.get_structural_tag(
++            self.tools, thinking_mode=False, tool_choice=tool_choice
++        )
++        self.assertIsInstance(structural_tag, xgr.StructuralTag)
++        grammar = xgr.Grammar.from_structural_tag(structural_tag)
++        self.assertIsInstance(grammar, xgr.Grammar)
++
++
++class TestGptOssDetector(unittest.TestCase):
++    def setUp(self):
++        self.tools = [
++            Tool(
++                type="function",
++                function=Function(
++                    name="search",
++                    description="Searches for information.",
++                    parameters={
++                        "type": "object",
++                        "properties": {
++                            "query": {"type": "string"},
++                            "topn": {"type": "integer"},
++                        },
++                        "required": ["query"],
++                    },
++                ),
++            ),
++            Tool(
++                type="function",
++                function=Function(
++                    name="get_weather",
++                    description="Get weather information for a city.",
++                    parameters={
++                        "type": "object",
++                        "properties": {
++                            "city": {"type": "string"},
++                            "unit": {
++                                "type": "string",
++                                "enum": ["celsius", "fahrenheit"],
++                            },
++                        },
++                        "required": ["city"],
++                    },
++                ),
++            ),
++        ]
++        self.detector = GptOssDetector()
++
++    def test_get_model_structural_tag(self):
++        import xgrammar as xgr
++
++        structural_tag = self.detector.get_structural_tag(
++            self.tools, thinking_mode=True
++        )
++        self.assertIsInstance(structural_tag, xgr.StructuralTag)
++        grammar = xgr.Grammar.from_structural_tag(structural_tag)
++        self.assertIsInstance(grammar, xgr.Grammar)
++
++        structural_tag = self.detector.get_structural_tag(
++            self.tools, thinking_mode=False
++        )
++        self.assertIsInstance(structural_tag, xgr.StructuralTag)
++        grammar = xgr.Grammar.from_structural_tag(structural_tag)
++        self.assertIsInstance(grammar, xgr.Grammar)
++
++        structural_tag = self.detector.get_structural_tag(
++            self.tools, thinking_mode=True, tool_choice="required"
++        )
++        self.assertIsInstance(structural_tag, xgr.StructuralTag)
++        grammar = xgr.Grammar.from_structural_tag(structural_tag)
++        self.assertIsInstance(grammar, xgr.Grammar)
++
++        structural_tag = self.detector.get_structural_tag(
++            self.tools, thinking_mode=False, tool_choice="required"
++        )
++        self.assertIsInstance(structural_tag, xgr.StructuralTag)
++        grammar = xgr.Grammar.from_structural_tag(structural_tag)
++        self.assertIsInstance(grammar, xgr.Grammar)
++
++        tool_choice_name = ToolChoiceFuncName(name="search")
++        tool_choice = ToolChoice(function=tool_choice_name)
++        structural_tag = self.detector.get_structural_tag(
++            self.tools, thinking_mode=True, tool_choice=tool_choice
++        )
++        self.assertIsInstance(structural_tag, xgr.StructuralTag)
++        grammar = xgr.Grammar.from_structural_tag(structural_tag)
++        self.assertIsInstance(grammar, xgr.Grammar)
++
++        structural_tag = self.detector.get_structural_tag(
++            self.tools, thinking_mode=False, tool_choice=tool_choice
++        )
++        self.assertIsInstance(structural_tag, xgr.StructuralTag)
++        grammar = xgr.Grammar.from_structural_tag(structural_tag)
++        self.assertIsInstance(grammar, xgr.Grammar)
++
+ 
+ class TestGlm4MoeDetector(unittest.TestCase):
+     def setUp(self):
+@@ -3925,6 +4546,146 @@ function call<|role_sep|>
+         self.assertEqual(params["city"], "Rome")
+ 
+ 
++class TestGetStructureConstraint(unittest.TestCase):
++    """Tests for FunctionCallParser.get_structure_constraint() logic.
++
++    Verifies that detectors supporting structural_tag use it for required/named
++    tool_choice, and that the generic json_schema fallback is used otherwise.
++    """
++
++    def _make_tools(self, strict=False):
++        return [
++            Tool(
++                type="function",
++                function=Function(
++                    name="get_weather",
++                    description="Get weather",
++                    parameters={
++                        "type": "object",
++                        "properties": {"city": {"type": "string"}},
++                        "required": ["city"],
++                    },
++                    strict=strict,
++                ),
++            ),
++        ]
++
++    def _make_parser(self, parser_name, strict=False):
++        from sglang.srt.function_call.function_call_parser import FunctionCallParser
++
++        return FunctionCallParser(self._make_tools(strict=strict), parser_name)
++
++    # --- structural_tag detectors (kimi_k2, deepseekv3, qwen25, etc.) ---
++
++    def test_kimi_required_strict_returns_structural_tag(self):
++        parser = self._make_parser("kimi_k2", strict=True)
++        result = parser.get_structure_constraint("required")
++        self.assertIsNotNone(result)
++        self.assertEqual(result[0], "structural_tag")
++        self.assertTrue(result[1].at_least_one)
++
++    def test_kimi_required_no_strict_returns_structural_tag(self):
++        """required should use structural_tag even without strict, to preserve native format."""
++        parser = self._make_parser("kimi_k2", strict=False)
++        result = parser.get_structure_constraint("required")
++        self.assertIsNotNone(result)
++        self.assertEqual(result[0], "structural_tag")
++        self.assertTrue(result[1].at_least_one)
++
++    def test_kimi_auto_strict_returns_structural_tag(self):
++        parser = self._make_parser("kimi_k2", strict=True)
++        result = parser.get_structure_constraint("auto")
++        self.assertIsNotNone(result)
++        self.assertEqual(result[0], "structural_tag")
++        self.assertFalse(result[1].at_least_one)
++
++    def test_kimi_routes_through_legacy_with_section_markers(self):
++        """xgrammar 0.2.0's get_kimi_structural_tag(tool_choice='auto') emits
++        a bare <|tool_call_begin|>...<|tool_call_end|> grammar without the
++        section wrapper Kimi's chat template uses, so the parser would drop
++        any generated tool calls. KimiK2Detector therefore stays on the
++        legacy path; pin that here so a future tweak doesn't silently
++        re-route Kimi through the broken builtin."""
++        from sglang.srt.entrypoints.openai.protocol import (
++            LegacyStructuralTagResponseFormat,
++        )
++
++        parser = self._make_parser("kimi_k2", strict=True)
++        result = parser.get_structure_constraint("auto")
++        self.assertIsInstance(result[1], LegacyStructuralTagResponseFormat)
++        self.assertIn("<|tool_calls_section_begin|>", result[1].structures[0].begin)
++        self.assertIn("<|tool_calls_section_end|>", result[1].structures[0].end)
++
++    def test_kimi_auto_no_strict_returns_none(self):
++        """auto without strict should not constrain."""
++        parser = self._make_parser("kimi_k2", strict=False)
++        result = parser.get_structure_constraint("auto")
++        self.assertIsNone(result)
++
++    def test_kimi_named_tool_choice_returns_structural_tag(self):
++        from sglang.srt.entrypoints.openai.protocol import (
++            ToolChoice,
++            ToolChoiceFuncName,
++        )
++
++        parser = self._make_parser("kimi_k2", strict=False)
++        tool_choice = ToolChoice(function=ToolChoiceFuncName(name="get_weather"))
++        result = parser.get_structure_constraint(tool_choice)
++        self.assertIsNotNone(result)
++        self.assertEqual(result[0], "structural_tag")
++
++    def test_deepseekv3_required_no_strict_returns_structural_tag(self):
++        parser = self._make_parser("deepseekv3", strict=False)
++        result = parser.get_structure_constraint("required")
++        self.assertIsNotNone(result)
++        self.assertEqual(result[0], "structural_tag")
++
++    def test_qwen25_required_no_strict_returns_structural_tag(self):
++        parser = self._make_parser("qwen25", strict=False)
++        result = parser.get_structure_constraint("required")
++        self.assertIsNotNone(result)
++        self.assertEqual(result[0], "structural_tag")
++
++    # --- structural_tag content verification ---
++
++    def test_kimi_structural_tag_has_kimi_tokens(self):
++        """Verify structural_tag contains kimi-specific special tokens."""
++        parser = self._make_parser("kimi_k2", strict=True)
++        result = parser.get_structure_constraint("required")
++        tag = result[1]
++        self.assertTrue(len(tag.structures) > 0)
++        self.assertIn("<|tool_calls_section_begin|>", tag.structures[0].begin)
++        self.assertIn("<|tool_call_end|>", tag.structures[0].end)
++
++    def test_kimi_required_no_strict_uses_empty_schema(self):
++        """Without strict, structural_tag should use empty schema per OpenAI
++        protocol: strict=False means no parameter schema enforcement."""
++        parser = self._make_parser("kimi_k2", strict=False)
++        result = parser.get_structure_constraint("required")
++        self.assertEqual(result[1].structures[0].schema_, {})
++
++    def test_kimi_required_strict_uses_tool_schema(self):
++        """With strict, structural_tag should include the tool's parameter schema."""
++        parser = self._make_parser("kimi_k2", strict=True)
++        result = parser.get_structure_constraint("required")
++        schema = result[1].structures[0].schema_
++        self.assertIn("properties", schema)
++        self.assertIn("city", schema["properties"])
++
++    # --- reasoning-prefix ownership ---
++
++    def test_default_thinking_mode_is_false(self):
++        """Default must be False so callers don't silently get a reasoning
++        prefix added to their grammar (only relevant for detectors routed
++        through the xgrammar builtin)."""
++        import inspect
++
++        from sglang.srt.function_call.function_call_parser import FunctionCallParser
++
++        sig = inspect.signature(FunctionCallParser.get_structure_constraint)
++        self.assertIs(sig.parameters["thinking_mode"].default, False)
++
++
+ class TestQwen25Detector(unittest.TestCase):
+     """Test Qwen25Detector streaming and non-streaming multi-tool-call parsing."""
+ 
+diff --git a/test/registered/unit/function_call/test_normalize_json_schema_types.py b/test/registered/unit/function_call/test_normalize_json_schema_types.py
+new file mode 100644
+index 0000000000..bbf64d69a8
+--- /dev/null
++++ b/test/registered/unit/function_call/test_normalize_json_schema_types.py
+@@ -0,0 +1,409 @@
++"""Unit tests for tool-parameter schema alias normalization."""
++
++import json
++import unittest
++
++from jsonschema import Draft202012Validator, SchemaError
++
++from sglang.srt.function_call.utils import normalize_json_schema_types
++from sglang.test.ci.ci_register import register_cpu_ci
++from sglang.test.test_utils import CustomTestCase
++
++register_cpu_ci(1.0, "base-a-test-cpu")
++
++
++class TestNormalizeJsonSchemaTypes(CustomTestCase):
++    def _assert_accepts(self, schema: dict) -> None:
++        Draft202012Validator.check_schema(schema)
++
++    def test_enum_alias_becomes_string(self):
++        schema = {
++            "type": "object",
++            "properties": {"color": {"type": "enum", "enum": ["red", "green", "blue"]}},
++        }
++        normalize_json_schema_types(schema)
++        self.assertEqual(schema["properties"]["color"]["type"], "string")
++        self.assertEqual(
++            schema["properties"]["color"]["enum"], ["red", "green", "blue"]
++        )
++        self._assert_accepts(schema)
++
++    def test_varchar_alias_becomes_string(self):
++        schema = {
++            "type": "object",
++            "properties": {
++                "name": {"type": "varchar"},
++                "short_name": {"type": "VARCHAR(255)"},
++            },
++        }
++        normalize_json_schema_types(schema)
++        self.assertEqual(schema["properties"]["name"]["type"], "string")
++        self.assertEqual(schema["properties"]["short_name"]["type"], "string")
++        self._assert_accepts(schema)
++
++    def test_numeric_aliases(self):
++        schema = {
++            "type": "object",
++            "properties": {
++                "age": {"type": "int"},
++                "big": {"type": "bigint"},
++                "price": {"type": "decimal(10,2)"},
++                "ratio": {"type": "float"},
++            },
++        }
++        normalize_json_schema_types(schema)
++        props = schema["properties"]
++        self.assertEqual(props["age"]["type"], "integer")
++        self.assertEqual(props["big"]["type"], "integer")
++        self.assertEqual(props["price"]["type"], "number")
++        self.assertEqual(props["ratio"]["type"], "number")
++        self._assert_accepts(schema)
++
++    def test_prefix_matched_numeric_types(self):
++        schema = {
++            "type": "object",
++            "properties": {
++                "a": {"type": "int32"},
++                "b": {"type": "int64"},
++                "c": {"type": "uint"},
++                "d": {"type": "unsigned"},
++                "e": {"type": "long"},
++                "f": {"type": "short"},
++                "g": {"type": "float32"},
++                "h": {"type": "float64"},
++                "i": {"type": "num"},
++                "j": {"type": "numeric"},
++            },
++        }
++        normalize_json_schema_types(schema)
++        p = schema["properties"]
++        for k in ("a", "b", "c", "d", "e", "f"):
++            self.assertEqual(p[k]["type"], "integer")
++        for k in ("g", "h", "i", "j"):
++            self.assertEqual(p[k]["type"], "number")
++        self._assert_accepts(schema)
++
++    def test_prefix_matched_compound_types(self):
++        schema = {
++            "type": "object",
++            "properties": {
++                "a": {"type": "list[str]"},
++                "b": {"type": "list<int>"},
++                "c": {"type": "dict"},
++                "d": {"type": "dict[str, int]"},
++                "e": {"type": "long long"},
++            },
++        }
++        normalize_json_schema_types(schema)
++        p = schema["properties"]
++        self.assertEqual(p["a"]["type"], "array")
++        self.assertEqual(p["b"]["type"], "array")
++        self.assertEqual(p["c"]["type"], "object")
++        self.assertEqual(p["d"]["type"], "object")
++        self.assertEqual(p["e"]["type"], "integer")
++        self._assert_accepts(schema)
++
++    def test_word_boundary_prevents_false_positives(self):
++        """Prefixes must end at a non-identifier char, so custom type names
++        that merely start with a known prefix are left alone."""
++        schema = {
++            "type": "object",
++            "properties": {
++                "a": {"type": "internal"},
++                "b": {"type": "list_price"},
++                "c": {"type": "integer_enum"},
++                "d": {"type": "dictionary_entry"},
++                "e": {"type": "floating"},
++            },
++        }
++        normalize_json_schema_types(schema)
++        p = schema["properties"]
++        for key, expected in [
++            ("a", "internal"),
++            ("b", "list_price"),
++            ("c", "integer_enum"),
++            ("d", "dictionary_entry"),
++            ("e", "floating"),
++        ]:
++            self.assertEqual(p[key]["type"], expected)
++
++    def test_recurses_into_draft_2020_12_keywords(self):
++        schema = {
++            "type": "object",
++            "properties": {
++                "row": {
++                    "dependentSchemas": {
++                        "kind": {
++                            "properties": {"sku": {"type": "varchar"}},
++                        },
++                    },
++                    "propertyNames": {"type": "str"},
++                    "unevaluatedProperties": {"type": "bigint"},
++                },
++                "rows": {
++                    "type": "arr",
++                    "unevaluatedItems": {"type": "int32"},
++                },
++            },
++        }
++        normalize_json_schema_types(schema)
++        row = schema["properties"]["row"]
++        rows = schema["properties"]["rows"]
++        self.assertEqual(
++            row["dependentSchemas"]["kind"]["properties"]["sku"]["type"], "string"
++        )
++        self.assertEqual(row["propertyNames"]["type"], "string")
++        self.assertEqual(row["unevaluatedProperties"]["type"], "integer")
++        self.assertEqual(rows["type"], "array")
++        self.assertEqual(rows["unevaluatedItems"]["type"], "integer")
++        self._assert_accepts(schema)
++
++    def test_bytes_and_arr_aliases(self):
++        schema = {
++            "type": "object",
++            "properties": {
++                "payload": {"type": "binary"},
++                "raw": {"type": "bytea"},
++                "items": {"type": "arr"},
++            },
++        }
++        normalize_json_schema_types(schema)
++        self.assertEqual(schema["properties"]["payload"]["type"], "string")
++        self.assertEqual(schema["properties"]["raw"]["type"], "string")
++        self.assertEqual(schema["properties"]["items"]["type"], "array")
++        self._assert_accepts(schema)
++
++    def test_bool_alias_becomes_boolean(self):
++        schema = {"type": "object", "properties": {"flag": {"type": "bool"}}}
++        normalize_json_schema_types(schema)
++        self.assertEqual(schema["properties"]["flag"]["type"], "boolean")
++        self._assert_accepts(schema)
++
++    def test_case_insensitive(self):
++        schema = {
++            "type": "object",
++            "properties": {
++                "a": {"type": "VARCHAR"},
++                "b": {"type": "INT"},
++                "c": {"type": "String"},
++            },
++        }
++        normalize_json_schema_types(schema)
++        p = schema["properties"]
++        self.assertEqual(p["a"]["type"], "string")
++        self.assertEqual(p["b"]["type"], "integer")
++        self.assertEqual(p["c"]["type"], "string")
++        self._assert_accepts(schema)
++
++    def test_array_and_object_aliases(self):
++        schema = {
++            "type": "object",
++            "properties": {
++                "tags": {"type": "list", "items": {"type": "str"}},
++                "meta": {"type": "dict"},
++            },
++        }
++        normalize_json_schema_types(schema)
++        self.assertEqual(schema["properties"]["tags"]["type"], "array")
++        self.assertEqual(schema["properties"]["tags"]["items"]["type"], "string")
++        self.assertEqual(schema["properties"]["meta"]["type"], "object")
++        self._assert_accepts(schema)
++
++    def test_nested_anyof_and_defs(self):
++        schema = {
++            "type": "object",
++            "properties": {
++                "value": {
++                    "anyOf": [
++                        {"type": "int"},
++                        {"type": "varchar"},
++                    ]
++                }
++            },
++            "$defs": {
++                "Row": {"type": "object", "properties": {"id": {"type": "bigint"}}}
++            },
++        }
++        normalize_json_schema_types(schema)
++        any_of = schema["properties"]["value"]["anyOf"]
++        self.assertEqual(any_of[0]["type"], "integer")
++        self.assertEqual(any_of[1]["type"], "string")
++        self.assertEqual(schema["$defs"]["Row"]["properties"]["id"]["type"], "integer")
++        self._assert_accepts(schema)
++
++    def test_type_list_member_normalized(self):
++        schema = {"type": ["varchar", "null"]}
++        normalize_json_schema_types(schema)
++        self.assertEqual(schema["type"], ["string", "null"])
++        self._assert_accepts(schema)
++
++    def test_type_list_deduplicates_after_normalization(self):
++        schema = {"type": ["varchar", "string", "null", "int", "integer"]}
++        normalize_json_schema_types(schema)
++        self.assertEqual(schema["type"], ["string", "null", "integer"])
++        self._assert_accepts(schema)
++
++    def test_standard_types_untouched(self):
++        schema = {
++            "type": "object",
++            "properties": {
++                "a": {"type": "string"},
++                "b": {"type": "integer"},
++                "c": {"type": "boolean"},
++            },
++        }
++        normalize_json_schema_types(schema)
++        self.assertEqual(schema["properties"]["a"]["type"], "string")
++        self.assertEqual(schema["properties"]["b"]["type"], "integer")
++        self.assertEqual(schema["properties"]["c"]["type"], "boolean")
++
++    def test_unknown_type_left_alone(self):
++        schema = {"type": "object", "properties": {"x": {"type": "geometry"}}}
++        normalize_json_schema_types(schema)
++        self.assertEqual(schema["properties"]["x"]["type"], "geometry")
++        with self.assertRaises(SchemaError):
++            self._assert_accepts(schema)
++
++    def test_common_db_orm_type_names_accepted(self):
++        """Common non-standard DB/ORM type names all survive validation."""
++        recognized = [
++            # string family
++            "string",
++            "str",
++            "text",
++            "varchar",
++            "char",
++            "enum",
++            # integer via prefix
++            "int",
++            "int32",
++            "int64",
++            "uint",
++            "uint8",
++            "long",
++            "long long",
++            "short",
++            "unsigned",
++            # number via prefix
++            "num",
++            "numeric",
++            "float",
++            "float32",
++            "float64",
++            # boolean
++            "boolean",
++            "bool",
++            "binary",
++            "bytea",
++            "bytes",
++            "blob",
++            "varbinary",
++            # compound
++            "object",
++            "array",
++            "arr",
++            "dict",
++            "dict[str, int]",
++            "list",
++            "list[str]",
++        ]
++        for t in recognized:
++            schema = {"type": "object", "properties": {"x": {"type": t}}}
++            normalize_json_schema_types(schema)
++            try:
++                self._assert_accepts(schema)
++            except SchemaError as e:
++                self.fail(f"type {t!r} -> {schema['properties']['x']['type']!r}: {e}")
++
++    def test_pre_existing_400_schema_now_accepted(self):
++        schema = {
++            "type": "object",
++            "properties": {
++                "sql": {"type": "varchar"},
++                "mode": {"type": "enum", "enum": ["read", "write"]},
++            },
++            "required": ["sql", "mode"],
++        }
++        normalize_json_schema_types(schema)
++        self._assert_accepts(schema)
++
++    def test_idempotent(self):
++        """Running normalize twice produces the same result as running it once."""
++        schema = {
++            "type": "object",
++            "properties": {
++                "a": {"type": "varchar"},
++                "b": {"type": "int32"},
++                "c": {"type": ["bigint", "null"]},
++                "d": {
++                    "anyOf": [{"type": "enum"}, {"type": "decimal(10,2)"}],
++                },
++            },
++        }
++        normalize_json_schema_types(schema)
++        once = json.loads(json.dumps(schema))
++        normalize_json_schema_types(schema)
++        self.assertEqual(schema, once)
++
++    def test_non_string_type_values_pass_through(self):
++        """``type`` that isn't str/list is left for the real validator to reject."""
++        for bad in (None, 42, {"$ref": "#/$defs/Foo"}, ["string", 1, None]):
++            schema = {"properties": {"x": {"type": bad}}}
++            normalize_json_schema_types(schema)
++            self.assertEqual(schema["properties"]["x"]["type"], bad)
++
++    def test_recurses_into_all_walked_keywords(self):
++        """Every keyword the walker recurses into must actually rewrite nested aliases."""
++        schema = {
++            "patternProperties": {"^x_": {"type": "varchar"}},
++            "definitions": {"Row": {"type": "bigint"}},
++            "prefixItems": [{"type": "int32"}, {"type": "float64"}],
++            "if": {"type": "bool"},
++            "then": {"type": "str"},
++            "else": {"type": "decimal"},
++            "not": {"type": "uuid"},
++            "contains": {"type": "enum"},
++            "additionalProperties": {"type": "bool"},
++        }
++        normalize_json_schema_types(schema)
++        self.assertEqual(schema["patternProperties"]["^x_"]["type"], "string")
++        self.assertEqual(schema["definitions"]["Row"]["type"], "integer")
++        self.assertEqual(schema["prefixItems"][0]["type"], "integer")
++        self.assertEqual(schema["prefixItems"][1]["type"], "number")
++        self.assertEqual(schema["if"]["type"], "boolean")
++        self.assertEqual(schema["then"]["type"], "string")
++        self.assertEqual(schema["else"]["type"], "number")
++        self.assertEqual(schema["not"]["type"], "string")
++        self.assertEqual(schema["contains"]["type"], "string")
++        self.assertEqual(schema["additionalProperties"]["type"], "boolean")
++
++    def test_cyclic_schema_raises_recursion_error(self):
++        """A pathological cyclic schema surfaces as RecursionError; caller
++        (``_validate_request``) converts it to a 400, not a 500."""
++        schema = {"type": "object"}
++        schema["items"] = schema
++        with self.assertRaises(RecursionError):
++            normalize_json_schema_types(schema)
++
++    def test_boolean_subschema_does_not_crash(self):
++        """``additionalProperties: True`` and ``items: false`` are valid 2020-12
++        forms; the walker must pass through without raising."""
++        schema = {
++            "type": "object",
++            "properties": {
++                "a": {"type": "varchar"},
++                "b": {"type": "array", "items": False},
++            },
++            "additionalProperties": True,
++            "unevaluatedProperties": False,
++        }
++        normalize_json_schema_types(schema)
++        self.assertEqual(schema["properties"]["a"]["type"], "string")
++        self.assertIs(schema["properties"]["b"]["items"], False)
++        self.assertIs(schema["additionalProperties"], True)
++        self.assertIs(schema["unevaluatedProperties"], False)
++        self._assert_accepts(schema)
++
++
++if __name__ == "__main__":
++    unittest.main()
+diff --git a/test/registered/unit/managers/test_stop_str_speculative.py b/test/registered/unit/managers/test_stop_str_speculative.py
+new file mode 100644
+index 0000000000..351d84cd18
+--- /dev/null
++++ b/test/registered/unit/managers/test_stop_str_speculative.py
+@@ -0,0 +1,130 @@
++"""Regression for stop-string / stop-regex finishing under speculative decoding
++(multi-token commits): a stop committed mid-chunk must (1) trigger the finish
++check and (2) set finished_len so the emitted output is trimmed at the stop, not
++leaking tokens accepted after it. Drives the real `Req.update_finish_state` with
++a fake tokenizer; pure CPU. Each test guards a distinct branch of
++`_locate_str_stop_finished_len` / `_check_str_based_finish`."""
++
++import unittest
++from array import array
++
++from sglang.srt.managers.schedule_batch import Req
++from sglang.srt.sampling.sampling_params import SamplingParams
++from sglang.test.ci.ci_register import register_cpu_ci
++
++register_cpu_ci(est_time=5, suite="base-a-test-cpu")
++
++# Token id -> decoded text; decode() concatenates. Distinct symbols so no
++# accidental cross-matches (10-39 are lowercase letters).
++STOP_ID = 1
++ID_TO_TEXT = {
++    STOP_ID: "STOP",
++    **{i: chr(ord("a") + i % 26) for i in range(10, 40)},
++    60: "a",
++    61: ".",
++    62: "b",
++    63: ".",
++    70: "X",
++    71: "Y",
++}
++
++# "STOP" (index 3) sits 6 tokens back: outside the old (stop_str_max_len + 1)
++# window, inside the one widened by new_accepted_len.
++MIDCHUNK = [10, 11, 12, STOP_ID, 20, 21, 22, 23, 24]
++
++
++class _FakeTokenizer:
++    eos_token_id = -1
++    additional_stop_token_ids = None
++
++    def decode(self, ids):
++        return "".join(ID_TO_TEXT[int(i)] for i in ids)
++
++
++def _make_req(output_ids, stop=None, stop_regex=None):
++    sp = SamplingParams(max_new_tokens=1000, stop=stop, stop_regex=stop_regex)
++    sp.normalize(tokenizer=None)  # char-based stop_str_max_len
++    req = Req(
++        rid="t",
++        origin_input_text="",
++        origin_input_ids=array("q", [0]),
++        sampling_params=sp,
++        eos_token_ids=set(),
++        vocab_size=10_000,
++    )
++    req.tokenizer = _FakeTokenizer()
++    req.output_ids = array("q", output_ids)
++    return req
++
++
++class TestStopStrSpeculative(unittest.TestCase):
++    def test_no_stop_does_not_finish(self):
++        req = _make_req([10, 11, 12, 20, 21, 22, 23, 24], stop=["STOP"])
++        req.update_finish_state(new_accepted_len=6)
++        self.assertFalse(req.finished())
++
++    # --- _locate_str_stop_finished_len: loop match / fallback / empty loop / span ---
++    def test_stop_str_midchunk(self):
++        # Loop match: "STOP" (index 3) finishes; finished_len lands just past it,
++        # so the 5 trailing tokens are dropped.
++        req = _make_req(MIDCHUNK, stop=["STOP"])
++        req.update_finish_state(new_accepted_len=6)
++        self.assertTrue(req.finished())
++        self.assertEqual(req.finished_reason.matched, "STOP")
++        self.assertEqual(req.finished_len, 4)
++
++    def test_stop_str_at_chunk_end_uses_full_len(self):
++        # Stop is the last token -> loop never matches before the full window ->
++        # fallback returns len(output_ids).
++        req = _make_req([10, 11, 12, 20, 21, STOP_ID], stop=["STOP"])
++        req.update_finish_state(new_accepted_len=6)
++        self.assertTrue(req.finished())
++        self.assertEqual(req.finished_len, 6)
++
++    def test_stop_str_non_spec_single_token(self):
++        # new_accepted_len == 1: locate's range is empty -> fallback (non-spec
++        # path preserved, no extra decode).
++        req = _make_req([10, 11, STOP_ID], stop=["STOP"])
++        req.update_finish_state(new_accepted_len=1)
++        self.assertTrue(req.finished())
++        self.assertEqual(req.finished_len, 3)
++
++    def test_stop_str_spanning_two_tokens(self):
++        # "XY" completes only once both tokens (70, 71) are decoded -> finished_len
++        # covers both; trailing tokens dropped.
++        req = _make_req([10, 11, 70, 71, 20, 21], stop=["XY"])
++        req.update_finish_state(new_accepted_len=6)
++        self.assertTrue(req.finished())
++        self.assertEqual(req.finished_len, 4)
++
++    # --- regex matched() branch ---
++    def test_stop_regex_midchunk(self):
++        req = _make_req([10, 11, 70, 71, 20, 21], stop_regex=[r"XY"])
++        req.update_finish_state(new_accepted_len=6)
++        self.assertTrue(req.finished())
++        self.assertEqual(req.finished_reason.matched, r"XY")
++        self.assertEqual(req.finished_len, 4)
++
++    def test_stop_regex_end_anchored_trims_at_first_match(self):
++        # Documents current behavior: text "a.b." matches `\.$` at the chunk end,
++        # but locate scans growing prefixes and stops at the FIRST period ("a."),
++        # so finished_len == 2 and "b." is dropped.
++        req = _make_req([60, 61, 62, 63], stop_regex=[r"\.$"])
++        req.update_finish_state(new_accepted_len=4)
++        self.assertTrue(req.finished())
++        self.assertEqual(req.finished_reason.matched, r"\.$")
++        self.assertEqual(req.finished_len, 2)
++
++    # --- decoded_text-only branch ---
++    def test_stop_str_only_in_decoded_text_sets_no_finished_len(self):
++        # Documents current behavior: when the stop is only in decoded_text (not
++        # the tail), the request finishes but finished_len is left unset.
++        req = _make_req([10, 11, 12], stop=["STOP"])  # no STOP in output tokens
++        req.decoded_text = "earlier STOP text"
++        req.update_finish_state(new_accepted_len=3)
++        self.assertTrue(req.finished())
++        self.assertIsNone(req.finished_len)
++
++
++if __name__ == "__main__":
++    unittest.main()
+diff --git a/test/registered/unit/managers/test_trim_matched_stop.py b/test/registered/unit/managers/test_trim_matched_stop.py
+new file mode 100644
+index 0000000000..3fd09e59c6
+--- /dev/null
++++ b/test/registered/unit/managers/test_trim_matched_stop.py
+@@ -0,0 +1,68 @@
++"""Unit test for DetokenizerManager.trim_matched_stop.
++
++Under speculative decoding the output handed to trim_matched_stop may carry
++content after the matched stop. With no_stop_trim the stop string must be kept
++but the trailing over-generation still dropped (`output[:end]`); without it the
++stop is removed (`output[:pos]`). Pure CPU: calls the method with a stub self,
++so no DetokenizerManager.__init__ / IPC / tokenizer."""
++
++import unittest
++from types import SimpleNamespace
++
++from sglang.srt.managers.detokenizer_manager import DetokenizerManager
++from sglang.test.ci.ci_register import register_cpu_ci
++
++register_cpu_ci(est_time=5, suite="base-a-test-cpu")
++
++GPT_OSS_CALL_TOKEN = 200012
++
++
++def _trim(output, matched, no_stop_trim, *, gpt_oss=False):
++    stub = SimpleNamespace(is_tool_call_parser_gpt_oss=gpt_oss)
++    finished_reason = None if matched is None else {"matched": matched}
++    return DetokenizerManager.trim_matched_stop(
++        stub, output, finished_reason, no_stop_trim
++    )
++
++
++class TestTrimMatchedStop(unittest.TestCase):
++    def test_no_finished_reason_returns_output(self):
++        self.assertEqual(_trim("abc", None, False), "abc")
++
++    def test_no_matched_returns_output(self):
++        stub = SimpleNamespace(is_tool_call_parser_gpt_oss=False)
++        self.assertEqual(
++            DetokenizerManager.trim_matched_stop(stub, "abc", {}, False), "abc"
++        )
++
++    # --- stop string ---
++    def test_str_trim_removes_stop(self):
++        # no_stop_trim=False: drop the stop string and anything after it.
++        self.assertEqual(_trim("ans\n\nQuestion: A", "Question", False), "ans\n\n")
++
++    def test_str_no_trim_keeps_stop_but_drops_trailing(self):
++        # no_stop_trim=True: keep through the stop, drop the over-generated tail.
++        self.assertEqual(
++            _trim("ans\n\nQuestion: A", "Question", True), "ans\n\nQuestion"
++        )
++
++    def test_str_not_found_returns_output(self):
++        self.assertEqual(_trim("no stop here", "Question", False), "no stop here")
++
++    # --- stop token ---
++    def test_token_trim_drops_last(self):
++        self.assertEqual(_trim([1, 2, 3], 3, False), [1, 2])
++
++    def test_token_no_trim_keeps_all(self):
++        self.assertEqual(_trim([1, 2, 3], 3, True), [1, 2, 3])
++
++    def test_token_gpt_oss_call_kept(self):
++        # gpt-oss tool-call token is also an eos; keep it even when trimming.
++        self.assertEqual(
++            _trim([1, 2, GPT_OSS_CALL_TOKEN], GPT_OSS_CALL_TOKEN, False, gpt_oss=True),
++            [1, 2, GPT_OSS_CALL_TOKEN],
++        )
++
++
++if __name__ == "__main__":
++    unittest.main()
+diff --git a/test/registered/unit/spec/test_eagle_worker_v2_topk1_fastpath.py b/test/registered/unit/spec/test_eagle_worker_v2_topk1_fastpath.py
+new file mode 100644
+index 0000000000..fe24a63f24
+--- /dev/null
++++ b/test/registered/unit/spec/test_eagle_worker_v2_topk1_fastpath.py
+@@ -0,0 +1,94 @@
++"""Equivalence tests for the EagleDraftWorker topk=1 chain fast path.
++
++For topk=1 the draft tree degenerates to a chain, so `draft_forward` skips the
++cat/topk/sort/gather of the slow path and returns pre-allocated constants. These
++tests check that the pre-allocated `parent_list` / `top_scores_index` match the
++slow path (`organize_draft_results`) for num_steps in {1, 2, 3, 4}.
++"""
++
++import unittest
++from types import SimpleNamespace
++
++import torch
++
++from sglang.srt.speculative.eagle_utils import organize_draft_results
++from sglang.srt.speculative.eagle_worker_v2 import EagleDraftWorker
++from sglang.srt.utils import get_device
++from sglang.test.ci.ci_register import register_cuda_ci
++from sglang.test.test_utils import CustomTestCase
++
++register_cuda_ci(est_time=20, suite="base-b-test-1-gpu-small")
++
++DEVICE = get_device()
++
++
++def _make_chain_lists(num_steps: int, bs: int):
++    """Build the (score, token, parents) lists a topk=1 chain produces.
++
++    Shapes/values mirror `select_top_k_tokens` for topk=1: each step yields one
++    token; the first step's parents are [-1, 0], later steps' parents are [i].
++    """
++    score_list, token_list, parents_list = [], [], []
++    for i in range(num_steps):
++        # Strictly decreasing scores, as a real chain produces (cumulative probs).
++        score_list.append(torch.full((bs, 1, 1), float(num_steps - i), device=DEVICE))
++        token_list.append(
++            torch.arange(i * bs, (i + 1) * bs, device=DEVICE).unsqueeze(1)
++        )
++        if i == 0:
++            parents_list.append(
++                torch.tensor([-1, 0], dtype=torch.long, device=DEVICE).repeat(bs, 1)
++            )
++        else:
++            parents_list.append(torch.full((bs, 1), i, dtype=torch.long, device=DEVICE))
++    return score_list, token_list, parents_list
++
++
++def _make_worker(num_steps: int, num_draft_tokens: int):
++    worker = object.__new__(EagleDraftWorker)
++    worker.topk = 1
++    worker.device = DEVICE
++    worker.speculative_num_steps = num_steps
++    worker.speculative_num_draft_tokens = num_draft_tokens
++    worker.server_args = SimpleNamespace(cuda_graph_max_bs=8, max_running_requests=8)
++    return worker
++
++
++class TestEagleWorkerV2Topk1FastPath(CustomTestCase):
++    def test_fast_path_matches_slow_path(self):
++        bs = 3
++        for num_steps in (1, 2, 3, 4):
++            with self.subTest(num_steps=num_steps):
++                num_draft_tokens = num_steps + 1
++                worker = _make_worker(num_steps, num_draft_tokens)
++                worker._rebuild_topk1_chain_buffers()
++
++                score_list, token_list, parents_list = _make_chain_lists(num_steps, bs)
++                ref_parent, ref_index, ref_tokens = organize_draft_results(
++                    score_list, token_list, parents_list, num_draft_tokens
++                )
++
++                fast_parent = worker._topk1_parents_prealloc[:bs]
++                fast_index = worker._topk1_score_indices_prealloc[:bs]
++                fast_tokens = torch.cat(token_list, dim=1)
++
++                self.assertEqual(fast_parent.shape, ref_parent.shape)
++                self.assertEqual(fast_parent.tolist(), ref_parent.long().tolist())
++                self.assertEqual(fast_index.tolist(), ref_index.long().tolist())
++                self.assertEqual(fast_tokens.tolist(), ref_tokens.tolist())
++
++                # The kernel reads these via data_ptr() as contiguous int64.
++                self.assertEqual(fast_parent.dtype, torch.long)
++                self.assertEqual(fast_index.dtype, torch.long)
++                self.assertTrue(fast_parent.is_contiguous())
++                self.assertTrue(fast_index.is_contiguous())
++
++    def test_assert_on_inconsistent_steps_and_draft_tokens(self):
++        # num_draft_tokens must equal num_steps + 1 for topk=1.
++        worker = _make_worker(num_steps=3, num_draft_tokens=3)
++        with self.assertRaises(AssertionError):
++            worker._rebuild_topk1_chain_buffers()
++
++
++if __name__ == "__main__":
++    unittest.main()
+diff --git a/test/registered/unit/spec/test_spec_utils_traverse_tree.py b/test/registered/unit/spec/test_spec_utils_traverse_tree.py
+new file mode 100644
+index 0000000000..d580e024c1
+--- /dev/null
++++ b/test/registered/unit/spec/test_spec_utils_traverse_tree.py
+@@ -0,0 +1,71 @@
++"""Regression test for spec_utils.traverse_tree calling xgrammar with tensors.
++
++xgrammar 0.2.0 tightened its FFI binding and rejects 0-d tensors where Python
++ints are expected. The dfs in traverse_tree recurses with `retrieve_next_token[curr]`
++and reads `draft_tokens[curr]`, both of which return 0-d tensors and must be
++explicitly cast before being handed to the grammar matcher.
++"""
++
++import unittest
++from unittest.mock import MagicMock
++
++import torch
++
++from sglang.srt.speculative.spec_utils import traverse_tree
++from sglang.test.ci.ci_register import register_cpu_ci
++
++register_cpu_ci(est_time=4, suite="stage-a-test-cpu")
++
++
++class TestTraverseTreePassesIntsToGrammar(unittest.TestCase):
++    def _record_grammar(self):
++        """A grammar mock that records every call argument and rejects torch tensors."""
++        grammar = MagicMock()
++        grammar.is_terminated.return_value = False
++        accept_calls = []
++        fill_calls = []
++
++        def record_accept(token):
++            if isinstance(token, torch.Tensor):
++                raise TypeError(f"accept_token got torch.Tensor: {token!r}")
++            accept_calls.append(token)
++
++        def record_fill(bitmask, idx):
++            if isinstance(idx, torch.Tensor):
++                raise TypeError(f"fill_vocab_mask got torch.Tensor idx: {idx!r}")
++            fill_calls.append(idx)
++
++        grammar.accept_token.side_effect = record_accept
++        grammar.fill_vocab_mask.side_effect = record_fill
++        grammar.rollback.return_value = None
++        return grammar, accept_calls, fill_calls
++
++    def test_branching_tree_passes_ints(self):
++        # Binary tree exercises both child recursion and sibling recursion:
++        #   0 ─┬─ 1
++        #      └─ 2 ─── 3
++        retrieve_next_token = torch.tensor([1, -1, 3, -1], dtype=torch.int32)
++        retrieve_next_sibling = torch.tensor([-1, 2, -1, -1], dtype=torch.int32)
++        draft_tokens = torch.tensor([100, 11, 22, 33], dtype=torch.int64)
++        # all bits set: every draft token passes the parent's bitmask check
++        bitmask = torch.full((4, 4), -1, dtype=torch.int32)
++
++        grammar, accept_calls, fill_calls = self._record_grammar()
++        traverse_tree(
++            retrieve_next_token,
++            retrieve_next_sibling,
++            draft_tokens,
++            grammar,
++            bitmask,
++        )
++
++        self.assertEqual(set(accept_calls), {11, 22, 33})
++        self.assertEqual(set(fill_calls), {0, 1, 2, 3})
++        for token in accept_calls:
++            self.assertIsInstance(token, int)
++        for idx in fill_calls:
++            self.assertIsInstance(idx, int)
++
++
++if __name__ == "__main__":
++    unittest.main()
+diff --git a/test/registered/unit/utils/test_patch_tokenizer.py b/test/registered/unit/utils/test_patch_tokenizer.py
+index ea0ba75335..ac27829a60 100644
+--- a/test/registered/unit/utils/test_patch_tokenizer.py
++++ b/test/registered/unit/utils/test_patch_tokenizer.py
+@@ -6,6 +6,7 @@ from transformers import AutoTokenizer
+ 
+ from sglang.srt.utils.patch_tokenizer import (
+     _SpecialTokensCachePatcher,
++    decode_without_hf_kwargs,
+     unpatch_tokenizer,
+ )
+ from sglang.test.ci.ci_register import register_cpu_ci
+@@ -150,6 +151,19 @@ class TestPatchTokenizerUnitTest(unittest.TestCase):
+ 
+         unpatch_tokenizer(tokenizer)
+ 
++    def test_decode_without_hf_kwargs_uses_native_decode(self):
++        tokenizer = _FakeDecodeTokenizer()
++
++        self.assertEqual(
++            decode_without_hf_kwargs(tokenizer, [1, 99, 2], True),
++            "ab",
++        )
++        self.assertEqual(
++            decode_without_hf_kwargs(tokenizer, [1, 99, 2], False),
++            "a<special>b",
++        )
++        self.assertEqual(tokenizer.decode_calls, [[1, 2], [1, 99, 2]])
++
+ 
+ def _get_class_attr_ids(cls):
+     return {
+@@ -174,5 +188,18 @@ def _patched_tokenizer():
+         unpatch_tokenizer(tokenizer)
+ 
+ 
++class _FakeDecodeTokenizer:
++    all_special_ids_set = {99}
++
++    def __init__(self):
++        self.decode_calls = []
++
++    def decode(self, token_ids):
++        token_ids = list(token_ids)
++        self.decode_calls.append(token_ids)
++        token_text = {1: "a", 2: "b", 99: "<special>"}
++        return "".join(token_text[token_id] for token_id in token_ids)
++
++
+ if __name__ == "__main__":
+     unittest.main()

--- a/patches/fix-pcie-oneshot-nccl-group.py
+++ b/patches/fix-pcie-oneshot-nccl-group.py
@@ -1,0 +1,165 @@
+#!/usr/bin/env python3
+"""Pass the NCCL device group to the b12x PCIe oneshot IPC exchange.
+
+b12x >= 0.16 pcie_oneshot does its IPC handle exchange via
+dist.broadcast_object_list(device=cuda) and asserts the exchange group is
+NCCL-backed. sglang's GroupCoordinator constructs CustomAllreduce with the
+gloo cpu_group (vLLM heritage), so setup fails with:
+    "PCIe oneshot IPC exchange requires an NCCL process group, got gloo"
+and the whole custom allreduce silently falls back to NCCL.
+
+Fix: thread the coordinator's device_group (NCCL) into CustomAllreduce and
+use it as the b12x exchange_group. The gloo group keeps serving everything
+else (vLLM-style IPC buffer setup for the non-b12x path).
+"""
+import sys
+from pathlib import Path
+
+SRT = Path("/opt/sglang/python/sglang/srt")
+
+# --- 1. custom_all_reduce.py: accept + use device_group ----------------------
+ca = SRT / "distributed/device_communicators/custom_all_reduce.py"
+src = ca.read_text()
+
+if "device_group" in src:
+    print(f"Already patched: {ca}")
+else:
+    old_init = """    def __init__(
+        self,
+        group: ProcessGroup,
+        device: Union[int, str, torch.device],
+        max_size=_MAX_CAR_SIZE,
+    ) -> None:"""
+    new_init = """    def __init__(
+        self,
+        group: ProcessGroup,
+        device: Union[int, str, torch.device],
+        max_size=_MAX_CAR_SIZE,
+        device_group: ProcessGroup = None,
+    ) -> None:"""
+    if old_init not in src:
+        print(f"ERROR: __init__ anchor not found in {ca}", file=sys.stderr)
+        sys.exit(1)
+    src = src.replace(old_init, new_init, 1)
+
+    old_store = """        self.device = device
+        self.group = group"""
+    new_store = """        self.device = device
+        self.group = group
+        # NCCL-backed group for b12x pcie_oneshot IPC exchange (b12x >= 0.16
+        # rejects gloo); falls back to `group` when not provided.
+        self.device_group = device_group"""
+    if old_store not in src:
+        print(f"ERROR: attribute-store anchor not found in {ca}", file=sys.stderr)
+        sys.exit(1)
+    src = src.replace(old_store, new_store, 1)
+
+    old_call = """            self._pcie_runtime = runtime_cls.from_exchange_group(
+                exchange_group=group,"""
+    new_call = """            self._pcie_runtime = runtime_cls.from_exchange_group(
+                exchange_group=(
+                    self.device_group if self.device_group is not None else group
+                ),"""
+    if old_call not in src:
+        print(f"ERROR: from_exchange_group anchor not found in {ca}", file=sys.stderr)
+        sys.exit(1)
+    src = src.replace(old_call, new_call, 1)
+    ca.write_text(src)
+    print(f"OK: patched {ca}")
+
+# --- 1b. custom_all_reduce.py: disable b12x stream-affinity enforcement ------
+# b12x >= 0.16 binds each channel to one CUDA stream and raises during sglang's
+# graph capture (capture stream != default stream). The single-channel usage
+# here matches b12x's own PCIeOneshotAllReducePool(single_channel=True), which
+# sets _stream_affine=False — pass the constructor's explicit opt-out.
+src = ca.read_text()
+if "stream_affine=False" in src:
+    print(f"Already patched (stream_affine): {ca}")
+else:
+    old_args = """                eager_buffer_bytes=self.max_size,
+                max_size=self.max_size,
+            )"""
+    new_args = """                eager_buffer_bytes=self.max_size,
+                max_size=self.max_size,
+                stream_affine=False,
+            )"""
+    if old_args not in src:
+        print(f"ERROR: from_exchange_group args anchor not found in {ca}", file=sys.stderr)
+        sys.exit(1)
+    src = src.replace(old_args, new_args, 1)
+    ca.write_text(src)
+    print(f"OK: patched stream_affine in {ca}")
+
+# --- 2. parallel_state.py: pass device_group at the call site ----------------
+ps = SRT / "distributed/parallel_state.py"
+src = ps.read_text()
+
+if "device_group=self.device_group," in src:
+    print(f"Already patched: {ps}")
+else:
+    old = """                CAClass = dispatch_custom_allreduce()
+                self.ca_comm = CAClass(
+                    group=self.cpu_group,
+                    device=self.device,
+                )"""
+    new = """                CAClass = dispatch_custom_allreduce()
+                try:
+                    self.ca_comm = CAClass(
+                        group=self.cpu_group,
+                        device=self.device,
+                        device_group=self.device_group,
+                    )
+                except TypeError:
+                    # CA variants (HIP quick/mscclpp) without device_group param
+                    self.ca_comm = CAClass(
+                        group=self.cpu_group,
+                        device=self.device,
+                    )"""
+    if old not in src:
+        print(f"ERROR: call-site anchor not found in {ps}", file=sys.stderr)
+        sys.exit(1)
+    src = src.replace(old, new, 1)
+    ps.write_text(src)
+    print(f"OK: patched {ps}")
+
+# --- 3. parallel_state.py: re-wire the crossover autotune ---------------------
+# The Apr-13 fork rebuild lost the block (present at f7a239ac) that calls
+# ca_comm.find_crossover_size() after construction when max-size='auto'.
+# Without it the b12x runtime keeps max_size=1MB, including the 128KB-1MB
+# range where NCCL beats the oneshot kernel on this PCIe topology.
+src = ps.read_text()
+if "find_crossover_size" in src:
+    print(f"Already patched (crossover): {ps}")
+else:
+    anchor = """                except TypeError:
+                    # CA variants (HIP quick/mscclpp) without device_group param
+                    self.ca_comm = CAClass(
+                        group=self.cpu_group,
+                        device=self.device,
+                    )
+            except Exception as e:
+                logger.warning(
+                    f"Setup Custom allreduce failed with {e}. To silence this "
+                    "warning, specify --disable-custom-all-reduce explicitly."
+                )
+"""
+    addition = anchor + """
+            if (
+                self.ca_comm is not None
+                and not self.ca_comm.disabled
+                and getattr(self.ca_comm, "_needs_crossover_bench", False)
+            ):
+                self.ca_comm.find_crossover_size(self.device_group)
+"""
+    if anchor not in src:
+        print(f"ERROR: crossover anchor not found in {ps}", file=sys.stderr)
+        sys.exit(1)
+    src = src.replace(anchor, addition, 1)
+    ps.write_text(src)
+    print(f"OK: re-wired crossover autotune in {ps}")
+
+# --- syntax check -------------------------------------------------------------
+import ast
+for f in (ca, ps):
+    ast.parse(f.read_text(), str(f))
+print("OK: syntax verified")

--- a/smoke_test_cu132.py
+++ b/smoke_test_cu132.py
@@ -1,0 +1,26 @@
+import importlib.util
+import torch, flashinfer, transformers, sglang, b12x
+print(f'PyTorch:      {torch.__version__}')
+print(f'CUDA:         {torch.version.cuda}')
+print(f'torch NCCL:   {torch.cuda.nccl.version()}')
+print(f'FlashInfer:   {flashinfer.__version__}')
+print(f'Transformers: {transformers.__version__}')
+print(f'SGLang:       {getattr(sglang, "__version__", "editable-install")}')
+print(f'b12x:         {getattr(b12x, "__version__", "?")}')
+assert torch.__version__.startswith('2.12.0+cu132'), torch.__version__
+# Verify the patched NCCL via ctypes on the actual .so files (deterministic;
+# torch.cuda.nccl.version() can report the compiled-against version instead)
+import ctypes, glob
+nccl_libs = glob.glob('/opt/venv/lib/python3.12/site-packages/**/libnccl.so.2', recursive=True)
+assert nccl_libs, 'no libnccl.so.2 in venv'
+for _p in nccl_libs:
+    _lib = ctypes.CDLL(_p)
+    _v = ctypes.c_int()
+    _lib.ncclGetVersion(ctypes.byref(_v))
+    print(f'NCCL at {_p}: {_v.value}')
+    # NCCL encodes 2.30.4 as 2*10000 + 30*100 + 4 = 23004
+    assert _v.value >= 23004, f'patched NCCL not active at {_p}: {_v.value}'
+assert importlib.util.find_spec('sglang.srt.layers.attention.b12x_backend'), 'b12x backend missing'
+import sgl_kernel
+from sglang.srt.server_args import ServerArgs
+print('OK: smoke test passed')

--- a/smoke_test_cu132.py
+++ b/smoke_test_cu132.py
@@ -34,8 +34,12 @@ from sglang.srt.server_args import ServerArgs
 
 _parser = argparse.ArgumentParser()
 ServerArgs.add_cli_args(_parser)
-_args = _parser.parse_args(['--model-path', 'smoke-test-dummy',
-                            '--enable-strict-thinking'])
+# --enable-strict-thinking exists only once the cherry-pick layer is applied;
+# this script also gates the base image build, so probe before passing it.
+_argv = ['--model-path', 'smoke-test-dummy']
+if '--enable-strict-thinking' in _parser._option_string_actions:
+    _argv.append('--enable-strict-thinking')
+_args = _parser.parse_args(_argv)
 try:
     ServerArgs.from_cli_args(_args)
 except AttributeError as e:

--- a/smoke_test_cu132.py
+++ b/smoke_test_cu132.py
@@ -24,3 +24,25 @@ assert importlib.util.find_spec('sglang.srt.layers.attention.b12x_backend'), 'b1
 import sgl_kernel
 from sglang.srt.server_args import ServerArgs
 print('OK: smoke test passed')
+
+# --- ServerArgs.from_cli_args gate (CodeRabbit: moved out of inline Dockerfile
+# python). An orphaned dataclass field (added without its CLI arg) raises
+# AttributeError here — the exact failure mode that once crashed a deploy at
+# server start. Network/config errors in __post_init__ are expected offline.
+import argparse
+from sglang.srt.server_args import ServerArgs
+
+_parser = argparse.ArgumentParser()
+ServerArgs.add_cli_args(_parser)
+_args = _parser.parse_args(['--model-path', 'smoke-test-dummy',
+                            '--enable-strict-thinking'])
+try:
+    ServerArgs.from_cli_args(_args)
+except AttributeError as e:
+    print(f'FATAL orphaned dataclass field: {e}')
+    sys.exit(1)
+except Exception as e:
+    print(f'OK: field mapping passed (post-init stopped at expected '
+          f'{type(e).__name__})')
+else:
+    print('OK: from_cli_args full round-trip')


### PR DESCRIPTION
# PR draft: local-inference-lab/blackwell-llm-docker

> Status: **draft, not pushed**. Written 2026-06-11 from the cu132 refresh on
> host aibeast (4× RTX PRO 6000 Blackwell **Workstation** Edition, sm_120,
> driver 595.71.05, 251 GB RAM). All files referenced below exist in the local
> clone at `/home/mbelleau/sglang_qwen35/blackwell-llm-docker/`.

---

## Title

**SGLang cu132 refresh: wheel-based CUDA 13.2.1 stack, b12x 0.20 integration fixes, memory-guarded builds; remove the broken `Dockerfile.sglang-cu132`**

## Summary

This PR replaces the stale, no-longer-buildable `Dockerfile.sglang-cu132` with
a refreshed cu132 stack that was built, smoke-tested, and benchmarked in
production on 2026-06-11. It also adds a runtime patch fixing three b12x
0.20-era integration bugs in the April fork tree, a memory-guarded build
wrapper (after an unguarded sgl-kernel build OOM-killed a production host),
Workstation Edition MoE configs, and documentation of two podman/buildah
pitfalls that silently corrupted earlier builds of these Dockerfiles.

## Files added

| File | Purpose |
|---|---|
| `Dockerfile.sglang-cu132` *(replaced in place)* | Full multi-stage build of the new `voipmonitor/sglang:cu132` image |
| `patches/fix-pcie-oneshot-nccl-group.py` | Fixes three b12x ≥0.16 integration bugs (details below) |
| `smoke_test_cu132.py` | Build-time smoke test (plain `COPY`, not a heredoc — see podman notes) |
| `Dockerfile.sglang-cu132-picks` | Cherry-pick layer over the cu132 image (validated upstream backports; see commit message for the pick list). Also includes ports of two still-open upstream fixes validated in production: [#27983](https://github.com/sgl-project/sglang/pull/27983) (rope overrides reach `text_config` — fixes the `--json-model-override-args` silent no-op/crash on VLM-format models, issue [#27974](https://github.com/sgl-project/sglang/issues/27974)) and the [#27324](https://github.com/sgl-project/sglang/pull/27324) guard (None `mamba_next_track_idx` scheduler crash in spec-v2 verify with `extra_buffer`, issue [#27325](https://github.com/sgl-project/sglang/issues/27325) — hit 5× in production before the guard) |
| `patches/cherry-picks-20260611.diff` | The pick set applied by the picks layer (and by the main Dockerfile before the sgl-kernel build) |
| `configs/E=512,N=256,device_name=NVIDIA_RTX_PRO_6000_Blackwell_Workstation_Edition.json` | Tuned Triton MoE config for **Workstation** Edition cards (repo previously shipped Server Edition only) |

## Replaced in place

| File | Why |
|---|---|
| `Dockerfile.sglang-cu132` (previous content) | **Was broken, could not build.** (1) It is `FROM voipmonitor/torch:cu132`, the source-built torch base — superseded by official `torch 2.12.0+cu132` wheels. (2) It clones upstream `sgl-project/sglang` **unpinned** (`git clone --recursive`, no commit checkout), so the 14 cherry-picked PR SHAs no longer apply against current main. (3) Its b12x integration step fetches `https://github.com/lukealonso/sglang.git` commit `c70c22a1` — **that repository has been deleted**, so the build fails unconditionally at that `RUN`. (4) Its default `MAX_JOBS=128` is exactly the failure mode the new build wrapper exists to prevent. |

(The `voipmonitor/torch:cu132` base image row and the `Dockerfile.torch-cu132`
build step in the README go away with it; the refresh needs no torch base.)

## The new stack (`Dockerfile.sglang-cu132`)

| Component | Version / source |
|---|---|
| CUDA | 13.2.1 (`nvidia/cuda:13.2.1-cudnn-devel-ubuntu24.04`) |
| cuBLAS / cuDNN | 13.4.1.2-1 / 9.22.0.52-1 apt overlays, with toolkit-dir symlink redirection so the toolkit libs don't shadow them |
| PyTorch | 2.12.0+cu132 / torchvision 0.27.0+cu132 (**official wheels**, no source build) |
| NCCL | patched 2.30.4 from `local-inference-lab/nccl-canonical` branch `canonical/cu132-nccl2304-amd-noxml` @ `dfab7c1ace32da250ba97757879429c341b7bcf9` — replaces the pip wheel's `libnccl.so.2` in-place, verified at build time via ctypes `ncclGetVersion() >= 23004`; `SGLANG_NCCL_SO_PATH` also points at the patched lib for sglang's pynccl |
| CUTLASS DSL | 4.5.2 (`nvidia-cutlass-dsl[cu13]`; `-libs-cu13` force-reinstalled last so CUDA-13 NVVM/ptxas wins; the 4.4.2-era `blockscaled_layout.py` git-overlay hack is no longer needed) |
| b12x | 0.20.0 (PyPI, `--no-deps`) |
| FlashInfer | flashinfer-python 0.6.12 (JIT mode + cubin package; no more source build of PR #2913 — it merged) |
| transformers | `>=5.3.0,<5.4` (5.4+ breaks the Qwen3.5 composite config) |
| SGLang | fork `voipmonitor/sglang` @ `260194aafb4f90b948140acce4a83b925fe78df3` (the 2026-04-13 rebuild: upstream main 2026-04-08 + the PATCHES.txt cherry-picks + lukealonso b12x integration incl. the MoE-via-`apply` modelopt fix) |
| sgl-kernel | built in-image, `TORCH_CUDA_ARCH_LIST=12.0a`, `MAX_JOBS=12` (ARG `KERNEL_MAX_JOBS`) |

**Why pin the fork at the April tree instead of rebasing on current upstream:**
the June 2026 upstream refactor of the CUDA-graph / attention-replay
architecture (#23906, #27192, #27193) means the b12x attention backend needs a
real port, not a rebase. PR audit (2026-06-11): #20479, #21599, #20114,
#20460, #21314 have merged upstream since April (#20439 superseded), but the
260194aa tree predates those merges, so the corresponding runtime patches in
this repo are still required here.

## `patches/fix-pcie-oneshot-nccl-group.py` — three b12x 0.20-era bugs

The April fork integrated b12x ≤0.10 semantics. b12x ≥0.16 changed three
things that break the PCIe oneshot allreduce path on this tree:

1. **IPC exchange group must be NCCL, not gloo.** b12x ≥0.16 `pcie_oneshot`
   does its IPC handle exchange via `dist.broadcast_object_list` on CUDA and
   asserts an NCCL-backed group. sglang's `GroupCoordinator` constructs
   `CustomAllreduce` with the gloo `cpu_group` (vLLM heritage), so startup
   logs:

   ```
   Setup Custom allreduce failed with PCIe oneshot IPC exchange requires an NCCL process group, got gloo
   ```

   and the custom allreduce is **silently disabled** — the server runs, ~all
   of the PCIe oneshot benefit is lost, and nothing else flags it. Fix:
   thread the coordinator's `device_group` (NCCL) into
   `CustomAllreduce.__init__` and use it as the b12x `exchange_group` (with a
   `TypeError` fallback for CA variants — HIP quick / mscclpp — that lack the
   parameter). The gloo group keeps serving the non-b12x vLLM-style IPC
   buffer setup.

2. **Stream-affinity enforcement crashes draft-model CUDA-graph capture.**
   b12x ≥0.16 binds each channel to one CUDA stream and raises when sglang's
   EAGLE draft capture runs on a non-default stream. The single-channel usage
   here matches b12x's own `PCIeOneshotAllReducePool(single_channel=True)`,
   which sets `_stream_affine=False` — the patch passes the constructor's
   explicit opt-out: `from_exchange_group(..., stream_affine=False)`.

3. **The crossover autotune was never wired in the Apr-13 rebuild.** The
   block present at `f7a239ac` that calls `ca_comm.find_crossover_size()`
   after construction when `--pcie-oneshot-allreduce-max-size auto` was lost
   in the rebuild, so the b12x runtime kept `max_size=1MB` — including the
   128KB–1MB range where plain NCCL beats the oneshot kernel on this PCIe
   topology. The patch restores it in `parallel_state.py`. With the patched
   NCCL 2.30.4, the auto crossover settles at **80KB** (it was a fixed 120KB
   with stock NCCL under the old fusion-pass flag).

The patch is idempotent, fails loudly if any anchor is missing, and
`ast.parse`-verifies both files afterward. The cherry-pick layer
applies it to an existing image and asserts the `device_group` parameter
landed.

## Flag change (breaking for launch scripts)

At fork commit 260194aa, **`--enable-pcie-oneshot-allreduce-fusion` no longer
exists** (the Apr-12 rework removed the fixed-crossover + fusion pass). The
replacement is:

```
--enable-pcie-oneshot-allreduce --pcie-oneshot-allreduce-max-size auto
```

Launch scripts moving between cu130 ↔ cu132 images must swap this flag in
both directions (the cu130 tree does not know `--pcie-oneshot-allreduce-max-size`).

## Triton MoE configs: version-keyed dir + Workstation Edition

Two distinct gotchas, both addressed:

- **The config directory is triton-version-keyed.** sglang resolves tuned
  MoE configs under `fused_moe_triton/configs/triton_<ver>/`. torch 2.12
  ships **triton 3.7.0**, so configs hardcoded into `triton_3_6_0/` (as the
  removed Dockerfile did) are silently invisible on the new stack. The
  refresh Dockerfile computes the directory at build time from the installed
  triton (`triton.__version__`), so it stays correct across torch bumps.
- **Configs are keyed on the exact GPU name.** The repo only shipped
  `device_name=NVIDIA_RTX_PRO_6000_Blackwell_Server_Edition` configs;
  **Workstation** Edition cards report a different name and fall back to
  untuned defaults. This PR adds the
  `E=512,N=256,device_name=NVIDIA_RTX_PRO_6000_Blackwell_Workstation_Edition.json`
  tuned config (the Dockerfile's copy loop auto-generates the `_down` and
  dtype-stripped variants).

## Build safety note

Compiling sgl-kernel with high parallelism is memory-hungry: 48 parallel
nvcc jobs on the CUTLASS-heavy units transiently exceeded a 251 GB host
and the kernel OOM-killer's victims included a co-located production
inference service. `Dockerfile.sglang-cu132` therefore defaults to
`KERNEL_MAX_JOBS=12`; keep it conservative and avoid building while a
co-located service is loading model weights (~200 GB transient mmap).
## Podman/buildah pitfalls (why earlier cu132 builds were silently wrong)

These Dockerfiles were originally written for Docker BuildKit. Building them
with rootless podman/buildah 1.33 (OCI format) revealed two silent failure
modes, now documented and worked around throughout:

1. **Heredoc `COPY`/`RUN <<EOF` is unsupported** in buildah 1.33 — hence
   `smoke_test_cu132.py` is a real file with a plain `COPY` (see the comment
   at the COPY site in the refresh Dockerfile).
2. **The `SHELL` directive is ignored in OCI format**, so every `RUN` is
   `/bin/sh -c`. Bashisms — `[[ ]]`, brace ranges like `{1..5}` — do not
   error; they **silently no-op or misparse**. Concretely: an earlier
   iteration's cuBLAS overlay symlinking and pip-wheel NCCL replacement were
   silently skipped, producing an image that "built fine" with the wrong
   BLAS and stock NCCL. All `RUN` steps are now POSIX sh
   (`for attempt in 1 2 3 4 5`, `[ ]`), and the risky steps carry hard
   verification that fails the build: `test -f` on the resolved cuBLAS libs,
   an explicit error if no `libnccl.so.2*` was found to replace, and a
   ctypes `ncclGetVersion` assert (`>= 23004`) on the replaced libraries.
   The build-time smoke test re-asserts torch `2.12.0+cu132`, the patched
   NCCL on every `.so`, the b12x backend module, and `sgl_kernel` import.

## Verification done (2026-06-11, aibeast)

- Image built with `KERNEL_MAX_JOBS=12`, smoke test green (torch 2.12.0+cu132,
  NCCL 23004 via ctypes, flashinfer 0.6.12, b12x 0.20.0, sgl-kernel import).
- Production serve: `QuantTrio/Qwen3.5-397B-A17B-AWQ`, TP=4, EAGLE MTP,
  4× RTX PRO 6000 Workstation. Custom allreduce active (no gloo fallback
  warning), crossover autotune settled at 80KB, draft CUDA-graph capture OK.
- Vision verified working via image probe; needle retrieval 3/3 at 518K
  tokens; 10/10 short-context battery.
- Benchmarks (same host, same launch flags, 30 s/test, `logs/bench-*.json`):

  | tok/s (ctx=0) | c=1 | c=4 | c=16 |
  |---|---|---|---|
  | cu130 baseline | 244.3 | 617.3 | 1206.1 |
  | cu132 refresh | 233.2 | 636.3 | 1226.3 |
  | delta | −4.5% | +3.1% | +1.7% |

  The c=1 regression is the dropped fusion pass (replaced by the auto
  max-size rework); with the final production config (YaRN-524K patched
  checkpoint + `--schedule-policy lpm`, steps=4/draft=5) c=1 measured 240.1
  (−1.7% vs cu130). Concurrency wins are b12x 0.10→0.20 + the crossover fix.

## Related (not in this PR)

The Qwen3.5 rope-override silent no-op (`--json-model-override-args
rope_scaling` never reaches `text_config`) is an **upstream sglang** bug, not
an image bug — issue draft at
`/home/mbelleau/sglang_qwen35/upstream-issue-rope-override-text-config.md`
(unfiled as of 2026-06-11; closest prior art is sglang Discussion #26440).
The companion rtx6kpro doc update
(`upstream-contrib/rtx6kpro-doc-update.md`) carries the operator-facing
workaround.

---

## Proposed README diff

```diff
 ## Images

 | Image | Dockerfile | Stack |
 |-------|-----------|-------|
 | `voipmonitor/sglang:cu130` | `Dockerfile.sglang-cu130` | CUDA 13.0, torch 2.11 stable cu130, FlashInfer source (PR #2913), SGLang + b12x + PCIe allreduce |
-| `voipmonitor/sglang:cu132` | `Dockerfile.sglang-cu132` | CUDA 13.2, torch 2.12 from source, FlashInfer source (PR #2913), SGLang + b12x |
+| `voipmonitor/sglang:cu132` | `Dockerfile.sglang-cu132` | CUDA 13.2.1, torch 2.12.0+cu132 wheels, patched NCCL 2.30.4 (local-inference-lab/nccl-canonical @ dfab7c1), cuBLAS 13.4.1.2 / cuDNN 9.22 overlays, flashinfer-python 0.6.12, b12x 0.20.0, SGLang fork @ 260194aa |
 | `voipmonitor/vllm:cu130` | `Dockerfile.vllm-cu130` | CUDA 13.0, torch 2.11 stable cu130, FlashInfer source (PR #2913), vLLM + cherry-picks |
 | `voipmonitor/vllm:vllm-b12x-cu132` | `Dockerfile.vllm-b12x-cu132` | Clean CUDA 13.2.1, PyTorch 2.12 cu132 wheels, patched NCCL 2.30.4, FlashInfer, DeepGEMM, B12X, vLLM |
 | `voipmonitor/vllm:lucifer` | `Dockerfile.vllm-b12x-cu132` | Lucifer DS4 Flash/CUTLASS vLLM branch on the same CUDA 13.2.1 base, FlashInfer, DeepGEMM, and Triton kernels source hook |

-Base image for cu132 (torch + FlashInfer compiled from source):
-
-| Image | Dockerfile | Stack |
-|-------|-----------|-------|
-| `voipmonitor/torch:cu132` | `Dockerfile.torch-cu132` | CUDA 13.2, torch 2.12 from source (no pip nvidia-*), FlashInfer from source |
+> **SGLang cu132 flag change:** the fork commit in the cu132 image removed
+> `--enable-pcie-oneshot-allreduce-fusion`. Use
+> `--pcie-oneshot-allreduce-max-size auto` instead (runtime-benchmarked
+> NCCL/oneshot crossover; settles at ~80KB with the patched NCCL 2.30.4).
+> Swap the flag both ways when moving launch scripts between cu130 and cu132.
```

```diff
 ## Build

 ```bash
 # SGLang cu130
 docker build --build-arg CACHEBUST=$(date +%s) -f Dockerfile.sglang-cu130 -t voipmonitor/sglang:cu130 .

-# SGLang cu132 (requires torch base first)
-docker build -f Dockerfile.torch-cu132 -t voipmonitor/torch:cu132 .
-docker build --build-arg CACHEBUST=$(date +%s) -f Dockerfile.sglang-cu132 -t voipmonitor/sglang:cu132 .
+# SGLang cu132 (official cu132 wheels — no torch base image needed).
+# Always build through the memory-guarded wrapper (see Build safety):
+  -f Dockerfile.sglang-cu132-refresh -t voipmonitor/sglang:cu132 .
 ```
```

```diff
+### Build safety
+
+sgl-kernel compiles CUTLASS-heavy translation units that peak at multiple GB
+of RAM each. An unguarded build at MAX_JOBS=48 has OOM-killed a 251 GB host
+(taking a production inference service down with it). A conservative `KERNEL_MAX_JOBS`
+wraps `podman build` with a watchdog that kills the build — never anything
+else — when `MemAvailable` drops below `FLOOR_GB` (default 40). Keep
+`KERNEL_MAX_JOBS` at 12 unless the host is idle, never run two kernel
+compiles concurrently, and never build while a service is loading weights.
+
+### Podman/buildah notes
+
+These Dockerfiles must stay compatible with rootless podman/buildah (OCI
+format), which differs from Docker BuildKit in two silent ways:
+
+- **No heredocs**: `COPY <<EOF` / `RUN <<EOF` are unsupported (buildah 1.33).
+  Ship scripts as real files and `COPY` them (see `smoke_test_cu132.py`).
+- **`SHELL` is ignored in OCI format**: every `RUN` executes under
+  `/bin/sh -c`. Bashisms (`[[ ]]`, `{1..5}`) do not error — they silently
+  no-op, which has previously skipped the cuBLAS overlay symlinks and the
+  NCCL wheel replacement without failing the build. Keep all `RUN` steps
+  POSIX sh and pair any critical mutation with an assertion that fails the
+  build (the refresh Dockerfile asserts the replaced NCCL version via
+  ctypes, and errors if no wheel lib was found to replace).
```

```diff
 ## Key features

 - **FlashInfer from source** with PR #2913 (GDC for SM120) — no prebuilt cubin/jit-cache that would override patched kernels
 - **b12x backend** (lukealonso) — TP-only NVFP4 MoE/GEMM for SM120
-- **PCIe allreduce** — custom allreduce for PCIe topologies (cu130 only)
+- **PCIe oneshot allreduce** — custom allreduce for PCIe topologies.
+  cu130: `--enable-pcie-oneshot-allreduce-fusion` (fixed 120KB crossover +
+  fusion pass). cu132: that flag is gone — use
+  `--pcie-oneshot-allreduce-max-size auto` (runtime-benchmarked crossover).
 - **nvidia-cublas pinned to 13.1** (cu130) — 13.3 causes illegal memory access on CUDA 13.0 toolkit
 - **Model profiles** — preconfigured launch configs via `MODEL_PROFILE` env var
 - **Adaptive speculative decoding** (PR #21599) — dynamically adjusts num_steps
-- Pre-tuned Triton MoE configs for RTX PRO 6000 Blackwell
+- Pre-tuned Triton MoE configs for RTX PRO 6000 Blackwell — **Server and
+  Workstation** Edition (configs are keyed on the exact GPU name), installed
+  under the `triton_<version>/` dir matching the image's triton (3.7.0 for
+  torch 2.12)
```
