### PR TITLE
fix(glm52): preflight PCIe calibration and contain probe failures

### DIFF
--- a/launchers/glm52-pcie-calibration.py
+++ b/launchers/glm52-pcie-calibration.py
@@ -1,5 +1,16 @@
 #!/usr/bin/env python3
-"""Cache a lossless SparkInfer PCIe calibration before vLLM starts."""
+"""Cache a lossless SparkInfer PCIe calibration before vLLM starts.
+
+r10 changes (from the venice.kpchosting field failure, 2026-07-29):
+- Preflight: every selected GPU must have MIN_FREE_MIB free before the
+  probe launches; otherwise exit 3 with one clean status line naming the
+  busy GPUs and the processes holding them. No traceback, no torchrun.
+- Operational failures never print a Python traceback or an elastic
+  error wall. The complete untruncated probe output is written to
+  `<cache-dir>/<digest>.failure.log` and a single summary line points
+  at it. Exit codes: 0 measured/cache-hit, 2 usage error, 3 skipped by
+  preflight, 4 probe failed (details in file).
+"""
 
 from __future__ import annotations
 
@@ -21,12 +32,28 @@ from typing import Any, Sequence
 
 
 SCHEMA_VERSION = 1
+MIN_FREE_MIB = 4096
+EXIT_SKIPPED_PREFLIGHT = 3
+EXIT_PROBE_FAILED = 4
 COLLECTIVE_ENV_PREFIXES = (
     "NCCL_",
     "SPARKINFER_PCIE_",
     "B12X_PCIE_",
     "VLLM_PCIE_",
 )
+
+
+class CalibrationSkip(Exception):
+    """Calibration cannot run right now; this is a clean, expected skip."""
+
+
+class CalibrationFailure(Exception):
+    """The probe ran and failed; `detail` holds its complete output."""
+
+    def __init__(self, reason: str, detail: str) -> None:
+        super().__init__(reason)
+        self.reason = reason
+        self.detail = detail
 
 
 def _comma_ints(value: str) -> tuple[int, ...]:
@@ -65,7 +92,12 @@ def _file_identity(path: str | None) -> dict[str, Any]:
 
 
 def _probe_source_digest() -> str:
-    spec = importlib.util.find_spec("sparkinfer.comm.pcie.overlap_probe")
+    try:
+        spec = importlib.util.find_spec("sparkinfer.comm.pcie.overlap_probe")
+    except ImportError:
+        # find_spec raises (rather than returning None) when the parent
+        # package itself is absent; treat both cases as unavailable.
+        spec = None
     if spec is None or spec.origin is None:
         return "unavailable"
     try:
@@ -114,22 +146,36 @@ def _collective_environment() -> dict[str, str]:
     }
 
 
+def _run_nvidia_smi(arguments: list[str]) -> str:
+    command = ["nvidia-smi"] + arguments
+    try:
+        completed = subprocess.run(
+            command,
+            check=True,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+            text=True,
+            timeout=30.0,
+        )
+    except FileNotFoundError as exc:
+        raise CalibrationSkip("nvidia-smi is not available") from exc
+    except subprocess.TimeoutExpired as exc:
+        raise CalibrationSkip("nvidia-smi timed out") from exc
+    except subprocess.CalledProcessError as exc:
+        raise CalibrationSkip(
+            f"nvidia-smi failed with exit {exc.returncode}"
+        ) from exc
+    return completed.stdout
+
+
 def _gpu_inventory(selected: Sequence[int]) -> list[dict[str, Any]]:
-    command = [
-        "nvidia-smi",
+    stdout = _run_nvidia_smi([
         "--query-gpu=index,uuid,pci.bus_id,pcie.link.gen.current,"
         "pcie.link.width.current,driver_version",
         "--format=csv,noheader,nounits",
-    ]
-    completed = subprocess.run(
-        command,
-        check=True,
-        stdout=subprocess.PIPE,
-        stderr=subprocess.PIPE,
-        text=True,
-    )
+    ])
     inventory: dict[int, dict[str, Any]] = {}
-    for line in completed.stdout.splitlines():
+    for line in stdout.splitlines():
         fields = [field.strip() for field in line.split(",")]
         if len(fields) != 6:
             continue
@@ -144,8 +190,53 @@ def _gpu_inventory(selected: Sequence[int]) -> list[dict[str, Any]]:
         }
     missing = [index for index in selected if index not in inventory]
     if missing:
-        raise RuntimeError(f"selected GPUs missing from nvidia-smi: {missing}")
+        raise CalibrationSkip(f"selected GPUs missing from nvidia-smi: {missing}")
     return [inventory[index] for index in selected]
+
+
+def _preflight_free_memory(selected: Sequence[int]) -> None:
+    """Refuse to launch the probe when GPUs lack free memory.
+
+    The probe needs roughly 3 GiB per GPU. Launching it against occupied
+    GPUs (a still-running previous server instance, another tenant)
+    produces an eight-rank CUDA OOM cascade; this check turns that into
+    one clean skip line instead."""
+    stdout = _run_nvidia_smi([
+        "--query-gpu=index,memory.free", "--format=csv,noheader,nounits",
+    ])
+    free_by_index: dict[int, int] = {}
+    for line in stdout.splitlines():
+        fields = [field.strip() for field in line.split(",")]
+        if len(fields) != 2:
+            continue
+        try:
+            free_by_index[int(fields[0])] = int(fields[1])
+        except ValueError:
+            continue
+    busy = [
+        (index, free_by_index[index])
+        for index in selected
+        if index in free_by_index and free_by_index[index] < MIN_FREE_MIB
+    ]
+    if not busy:
+        return
+    busy_text = ", ".join(f"GPU{index}:{free}MiB" for index, free in busy)
+    holders = "unavailable"
+    try:
+        holders_output = _run_nvidia_smi([
+            "--query-compute-apps=pid,process_name,used_memory",
+            "--format=csv,noheader",
+        ]).strip()
+        if holders_output:
+            holders = "; ".join(
+                line.strip() for line in holders_output.splitlines()[:4]
+            )
+    except CalibrationSkip:
+        pass
+    raise CalibrationSkip(
+        f"gpu-memory-busy: {busy_text} free, need {MIN_FREE_MIB}MiB "
+        f"(holders: {holders})"
+    )
 
 
 def build_fingerprint_payload(args: argparse.Namespace) -> dict[str, Any]:
@@ -302,7 +393,7 @@ def _run_probe(args: argparse.Namespace, output: Path) -> dict[str, Any]:
             start_new_session=True,
         )
     except OSError as exc:
-        raise RuntimeError(f"failed to launch PCIe calibration: {exc}") from exc
+        raise CalibrationFailure(f"failed to launch torchrun: {exc}", "") from exc
     try:
         stdout, _ = process.communicate(timeout=args.timeout)
     except subprocess.TimeoutExpired as exc:
@@ -310,30 +401,44 @@ def _run_probe(args: argparse.Namespace, output: Path) -> dict[str, Any]:
         terminated_output = _terminate_process_group(process)
         if terminated_output:
             captured = terminated_output
-        tail = "\n".join(captured.splitlines()[-40:]) or "<no probe output>"
-        raise RuntimeError(
-            f"PCIe calibration timed out after {args.timeout:g}s:\n{tail}"
-        ) from exc
+        raise CalibrationFailure(
+            f"probe timed out after {args.timeout:g}s", captured) from exc
     except BaseException:
         _terminate_process_group(process)
         raise
     stdout = _output_text(stdout)
     if process.returncode != 0:
-        tail = "\n".join(stdout.splitlines()[-40:])
-        raise RuntimeError(
-            f"PCIe calibration exited with {process.returncode}:\n{tail}"
-        )
+        raise CalibrationFailure(
+            f"probe exited with {process.returncode}", stdout)
     print(stdout, file=sys.stderr, end="")
     try:
         result = json.loads(output.read_text(encoding="utf-8"))
     except (OSError, json.JSONDecodeError) as exc:
-        tail = "\n".join(stdout.splitlines()[-40:]) or "<no probe output>"
-        raise RuntimeError(
-            f"PCIe calibration produced no valid result at {output}: {exc}\n"
-            f"Probe output:\n{tail}"
+        raise CalibrationFailure(
+            f"probe produced no valid result at {output}: {exc}", stdout
         ) from exc
-    validate_probe_result(result)
+    try:
+        validate_probe_result(result)
+    except ValueError as exc:
+        raise CalibrationFailure(f"probe result rejected: {exc}", stdout) from exc
     return result
+
+
+def _write_failure_log(cache_dir: Path, digest: str, reason: str,
+                       detail: str) -> Path:
+    failure_path = cache_dir / f"{digest}.failure.log"
+    try:
+        body = (
+            f"# PCIe calibration failure\n"
+            f"# time: {time.strftime('%Y-%m-%d %H:%M:%S %z')}\n"
+            f"# reason: {reason}\n"
+            f"# complete probe output follows (nothing truncated)\n\n"
+        )
+        failure_path.write_text(body + (detail or "(no output)\n"),
+                                encoding="utf-8")
+    except OSError:
+        return Path("(failure log could not be written)")
+    return failure_path
 
 
 def calibrate(args: argparse.Namespace) -> tuple[str, dict[str, Any], Path]:
@@ -350,13 +455,24 @@ def calibrate(args: argparse.Namespace) -> tuple[str, dict[str, Any], Path]:
             if cached is not None:
                 return "cache-hit", cached, cache_path
 
+        # Only a real measurement needs free GPUs; the cache hit above
+        # is served regardless of current GPU occupancy.
+        _preflight_free_memory(args.gpus[: args.tp_size])
+
         fd, temporary_name = tempfile.mkstemp(
             prefix=f"{digest}.", suffix=".probe.json", dir=args.cache_dir
         )
         os.close(fd)
         temporary = Path(temporary_name)
         try:
-            probe_result = _run_probe(args, temporary)
+            try:
+                probe_result = _run_probe(args, temporary)
+            except CalibrationFailure as exc:
+                failure_path = _write_failure_log(
+                    args.cache_dir, digest, exc.reason, exc.detail)
+                raise CalibrationFailure(
+                    f"{exc.reason}; complete output: {failure_path}", ""
+                ) from exc
             record = {
                 "schema": SCHEMA_VERSION,
                 "fingerprint": digest,
@@ -414,7 +530,14 @@ def main(argv: Sequence[str] | None = None) -> int:
     if args.timeout <= 0:
         raise SystemExit("timeout must be positive")
 
-    status, record, cache_path = calibrate(args)
+    try:
+        status, record, cache_path = calibrate(args)
+    except CalibrationSkip as exc:
+        print(f"PCIe calibration preflight: skipped ({exc})", file=sys.stderr)
+        return EXIT_SKIPPED_PREFLIGHT
+    except CalibrationFailure as exc:
+        print(f"PCIe calibration: {exc.reason}", file=sys.stderr)
+        return EXIT_PROBE_FAILED
     values = validate_probe_result(record["probe"])
     print(
         "\t".join(

--- a/launchers/glm52-pcie-calibration.py
+++ b/launchers/glm52-pcie-calibration.py
@@ -147,7 +147,7 @@ def _collective_environment() -> dict[str, str]:
 
 
 def _run_nvidia_smi(arguments: list[str]) -> str:
-    command = ["nvidia-smi"] + arguments
+    command = ["nvidia-smi", *arguments]
     try:
         completed = subprocess.run(
             command,
@@ -162,18 +162,18 @@ def _run_nvidia_smi(arguments: list[str]) -> str:
     except subprocess.TimeoutExpired as exc:
         raise CalibrationSkip("nvidia-smi timed out") from exc
     except subprocess.CalledProcessError as exc:
-        raise CalibrationSkip(
-            f"nvidia-smi failed with exit {exc.returncode}"
-        ) from exc
+        raise CalibrationSkip(f"nvidia-smi failed with exit {exc.returncode}") from exc
     return completed.stdout
 
 
 def _gpu_inventory(selected: Sequence[int]) -> list[dict[str, Any]]:
-    stdout = _run_nvidia_smi([
-        "--query-gpu=index,uuid,pci.bus_id,pcie.link.gen.current,"
-        "pcie.link.width.current,driver_version",
-        "--format=csv,noheader,nounits",
-    ])
+    stdout = _run_nvidia_smi(
+        [
+            "--query-gpu=index,uuid,pci.bus_id,pcie.link.gen.current,"
+            "pcie.link.width.current,driver_version",
+            "--format=csv,noheader,nounits",
+        ]
+    )
     inventory: dict[int, dict[str, Any]] = {}
     for line in stdout.splitlines():
         fields = [field.strip() for field in line.split(",")]
@@ -201,9 +201,12 @@ def _preflight_free_memory(selected: Sequence[int]) -> None:
     GPUs (a still-running previous server instance, another tenant)
     produces an eight-rank CUDA OOM cascade; this check turns that into
     one clean skip line instead."""
-    stdout = _run_nvidia_smi([
-        "--query-gpu=index,memory.free", "--format=csv,noheader,nounits",
-    ])
+    stdout = _run_nvidia_smi(
+        [
+            "--query-gpu=index,memory.free",
+            "--format=csv,noheader,nounits",
+        ]
+    )
     free_by_index: dict[int, int] = {}
     for line in stdout.splitlines():
         fields = [field.strip() for field in line.split(",")]
@@ -223,10 +226,12 @@ def _preflight_free_memory(selected: Sequence[int]) -> None:
     busy_text = ", ".join(f"GPU{index}:{free}MiB" for index, free in busy)
     holders = "unavailable"
     try:
-        holders_output = _run_nvidia_smi([
-            "--query-compute-apps=pid,process_name,used_memory",
-            "--format=csv,noheader",
-        ]).strip()
+        holders_output = _run_nvidia_smi(
+            [
+                "--query-compute-apps=pid,process_name,used_memory",
+                "--format=csv,noheader",
+            ]
+        ).strip()
         if holders_output:
             holders = "; ".join(
                 line.strip() for line in holders_output.splitlines()[:4]
@@ -402,14 +407,14 @@ def _run_probe(args: argparse.Namespace, output: Path) -> dict[str, Any]:
         if terminated_output:
             captured = terminated_output
         raise CalibrationFailure(
-            f"probe timed out after {args.timeout:g}s", captured) from exc
+            f"probe timed out after {args.timeout:g}s", captured
+        ) from exc
     except BaseException:
         _terminate_process_group(process)
         raise
     stdout = _output_text(stdout)
     if process.returncode != 0:
-        raise CalibrationFailure(
-            f"probe exited with {process.returncode}", stdout)
+        raise CalibrationFailure(f"probe exited with {process.returncode}", stdout)
     print(stdout, file=sys.stderr, end="")
     try:
         result = json.loads(output.read_text(encoding="utf-8"))
@@ -424,8 +429,7 @@ def _run_probe(args: argparse.Namespace, output: Path) -> dict[str, Any]:
     return result
 
 
-def _write_failure_log(cache_dir: Path, digest: str, reason: str,
-                       detail: str) -> Path:
+def _write_failure_log(cache_dir: Path, digest: str, reason: str, detail: str) -> Path:
     failure_path = cache_dir / f"{digest}.failure.log"
     try:
         body = (
@@ -434,8 +438,7 @@ def _write_failure_log(cache_dir: Path, digest: str, reason: str,
             f"# reason: {reason}\n"
             f"# complete probe output follows (nothing truncated)\n\n"
         )
-        failure_path.write_text(body + (detail or "(no output)\n"),
-                                encoding="utf-8")
+        failure_path.write_text(body + (detail or "(no output)\n"), encoding="utf-8")
     except OSError:
         return Path("(failure log could not be written)")
     return failure_path
@@ -469,7 +472,8 @@ def calibrate(args: argparse.Namespace) -> tuple[str, dict[str, Any], Path]:
                 probe_result = _run_probe(args, temporary)
             except CalibrationFailure as exc:
                 failure_path = _write_failure_log(
-                    args.cache_dir, digest, exc.reason, exc.detail)
+                    args.cache_dir, digest, exc.reason, exc.detail
+                )
                 raise CalibrationFailure(
                     f"{exc.reason}; complete output: {failure_path}", ""
                 ) from exc
@@ -518,17 +522,21 @@ def _build_parser() -> argparse.ArgumentParser:
 def main(argv: Sequence[str] | None = None) -> int:
     args = _build_parser().parse_args(argv)
     if args.tp_size < 2 or args.dcp_size < 1 or args.tp_size % args.dcp_size:
-        raise SystemExit(
-            "tp-size must be at least 2 and divisible by positive dcp-size"
+        print(
+            "tp-size must be at least 2 and divisible by positive dcp-size",
+            file=sys.stderr,
         )
+        raise SystemExit(2)
     if (
         args.indexer_shards < 1
         or args.dcp_size % args.indexer_shards
         or args.tp_size % args.indexer_shards
     ):
-        raise SystemExit("indexer-shards must divide TP and DCP")
+        print("indexer-shards must divide TP and DCP", file=sys.stderr)
+        raise SystemExit(2)
     if args.timeout <= 0:
-        raise SystemExit("timeout must be positive")
+        print("timeout must be positive", file=sys.stderr)
+        raise SystemExit(2)
 
     try:
         status, record, cache_path = calibrate(args)

--- a/launchers/serve-glm52-v19.sh
+++ b/launchers/serve-glm52-v19.sh
@@ -151,8 +151,14 @@ else
   force_arg=()
   [[ "${PCIE_CALIBRATION}" == "force" ]] && force_arg=(--force)
 
+  # Calibrator exit contract: 0 measured/cache-hit; 3 clean preflight skip
+  # (busy GPUs, nvidia-smi unavailable); 4 probe failure with the complete
+  # untruncated output parked in <cache-dir>/<digest>.failure.log. For 3
+  # and 4 the calibrator prints exactly one stderr line; no traceback or
+  # torchrun error wall ever reaches the boot log.
   calibration_line=""
-  if calibration_line="$(
+  calibration_exit=0
+  calibration_line="$(
     "${PCIE_CALIBRATOR}" \
       --tp-size "${TP}" \
       --dcp-size "${DCP}" \
@@ -161,7 +167,8 @@ else
       --cache-dir "${PCIE_CALIBRATION_CACHE_DIR}" \
       --timeout "${PCIE_CALIBRATION_TIMEOUT}" \
       "${force_arg[@]}"
-  )"; then
+  )" || calibration_exit=$?
+  if [[ "${calibration_exit}" -eq 0 ]]; then
     calibration_line="$(awk 'NF { line=$0 } END { print line }' \
       <<<"${calibration_line}")"
     IFS=$'\t' read -r \
@@ -200,9 +207,15 @@ else
     if [[ "${PCIE_DMA_MIN_BYTES}" == "auto" ]]; then
       PCIE_DMA_MIN_BYTES="${calibration_dma_min_bytes}"
     fi
+  elif [[ "${calibration_exit}" -eq 3 ]]; then
+    # Expected condition (for example GPUs still hold memory from a
+    # previous instance); the calibrator already printed its one-line
+    # reason. The conservative topology policy applies.
+    calibration_status="skipped:preflight"
   else
     calibration_status="failed:fallback-to-topology"
-    printf 'WARNING: PCIe calibration failed; using conservative topology policy.\n' >&2
+    printf 'NOTICE: PCIe calibration unavailable (calibrator exit %s); using conservative topology policy.\n' \
+      "${calibration_exit}" >&2
   fi
 fi
 

--- a/tests/test-glm52-pcie-calibration.py
+++ b/tests/test-glm52-pcie-calibration.py
@@ -112,9 +112,7 @@ def test_run_probe_reports_timeout_with_captured_output(
         def communicate(self, timeout: float | None = None) -> tuple[str, None]:
             self.communicate_calls += 1
             if self.communicate_calls == 1:
-                raise subprocess.TimeoutExpired(
-                    "probe", 5.0, output="probe stalled"
-                )
+                raise subprocess.TimeoutExpired("probe", 5.0, output="probe stalled")
             return "probe stalled\nworkers stopped\n", None
 
     process = TimeoutProcess()
@@ -130,8 +128,10 @@ def test_run_probe_reports_timeout_with_captured_output(
         calibration.os, "killpg", lambda pid, sig: signals.append((pid, sig))
     )
 
-    with pytest.raises(RuntimeError, match=r"(?s)timed out.*probe stalled"):
+    with pytest.raises(calibration.CalibrationFailure) as failure:
         calibration._run_probe(_probe_args(tmp_path), tmp_path / "result.json")
+    assert failure.value.reason == "probe timed out after 5s"
+    assert failure.value.detail == "probe stalled\nworkers stopped\n"
     assert signals == [(process.pid, signal.SIGTERM)]
     assert process.communicate_calls == 2
     assert popen_kwargs["start_new_session"] is True
@@ -155,8 +155,48 @@ def test_run_probe_reports_invalid_result_with_probe_output(
     output = tmp_path / "result.json"
     output.write_text("not JSON", encoding="utf-8")
 
-    with pytest.raises(RuntimeError, match=r"(?s)no valid result.*probe complete"):
+    with pytest.raises(calibration.CalibrationFailure) as failure:
         calibration._run_probe(_probe_args(tmp_path), output)
+    assert failure.value.reason.startswith("probe produced no valid result")
+    assert failure.value.detail == "probe complete\n"
+
+
+@pytest.mark.parametrize(
+    ("arguments", "message"),
+    [
+        (
+            ["--tp-size", "1", "--dcp-size", "1", "--indexer-shards", "1"],
+            "tp-size must be at least 2 and divisible by positive dcp-size",
+        ),
+        (
+            ["--tp-size", "8", "--dcp-size", "4", "--indexer-shards", "3"],
+            "indexer-shards must divide TP and DCP",
+        ),
+        (
+            [
+                "--tp-size",
+                "8",
+                "--dcp-size",
+                "4",
+                "--indexer-shards",
+                "2",
+                "--timeout",
+                "0",
+            ],
+            "timeout must be positive",
+        ),
+    ],
+)
+def test_manual_validation_uses_usage_exit_contract(
+    arguments: list[str], message: str, capsys: pytest.CaptureFixture[str]
+) -> None:
+    with pytest.raises(SystemExit) as exit_info:
+        calibration.main([*arguments, "--gpus", "0,1,2,3,4,5,6,7"])
+
+    assert exit_info.value.code == 2
+    captured = capsys.readouterr()
+    assert captured.out == ""
+    assert captured.err == f"{message}\n"
 
 
 def test_fingerprint_is_order_sensitive() -> None:


### PR DESCRIPTION
## Problem

A stock `v20-r9` boot with `PCIE_CALIBRATION=auto` on an 8-GPU host printed a full torchrun elastic error wall (eight per-rank failure blocks) before falling back, making a routine recoverable condition look like a crash. Field incident: GPU memory was still occupied by a previous server instance when calibration ran, so all eight probe ranks hit CUDA OOM. Worse, the wrapper's 40-line failure tail was consumed entirely by the elastic summary, so the actual `torch.OutOfMemoryError` traceback never reached the operator — diagnosing it required manually re-running the probe.

`auto` should never look like it broke and crashed out.

## Changes

**`launchers/glm52-pcie-calibration.py`**
- **Preflight** (after the cache-hit check, so cached calibrations still serve regardless of GPU occupancy): every selected GPU must have ≥ 4096 MiB free, or the calibrator exits **3** with one status line naming the busy GPUs and the processes holding them, e.g.
  `PCIe calibration preflight: skipped (gpu-memory-busy: GPU0:424MiB free, need 4096MiB (holders: 909, vllm::EngineCore, 92040 MiB))`
  Missing/failing `nvidia-smi` is also a clean exit-3 skip.
- **Probe failure/timeout** writes the **complete untruncated** torchrun output to `<cache-dir>/<digest>.failure.log` and exits **4** with a single line pointing at it. This also retires the tail-40 truncation: full output always lands in the file.
- Harden `_probe_source_digest` against `ModuleNotFoundError` (`find_spec` raises rather than returning `None` when the parent package is absent).
- Exit-code contract: `0` measured/cache-hit, `2` usage error, `3` preflight skip, `4` probe failed.

**`launchers/serve-glm52-v19.sh`**
- Maps exit 3 to `calibration_status=skipped:preflight` with no warning (the calibrator's one line is the whole story), other nonzero exits to one `NOTICE` line plus the existing `failed:fallback-to-topology` conservative policy. Exit-0 parsing unchanged.

Boot log for the incident scenario is now two calm lines:
```
PCIe calibration preflight: skipped (gpu-memory-busy: GPU0:424MiB … (holders: 909, vllm::EngineCore, 92040 MiB))
GLM-5.2 PCIe calibration: skipped:preflight cache=none DMA-min=6MB
```

## Testing

- Wrapper: busy-GPU skip, missing-nvidia-smi skip, and probe-failure paths exercised with a fake `nvidia-smi` (exit codes 3/3/4, exactly one stderr line each; failure log written with complete output; `py_compile` clean).
- Serve script: all three calibrator-exit branches exercised under Linux bash 5 with stub calibrators — measured values parsed and applied unchanged; skip and failure produce the single-line output above; `bash -n` clean.
- Not run on GPU hardware; behavior on the success path is unchanged by construction (same invocation, same tab-separated stdout contract).

https://claude.ai/code/session_01JiB9P4gxmeH1EpXpmvL3hW

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added GPU memory preflight checks before PCIe calibration attempts, with dedicated skip status when preflight indicates the run should not proceed.
  * Added standardized exit codes and clearer calibration outcomes for probe failures.
  * Added complete diagnostic failure logs for failed probe attempts.

* **Bug Fixes**
  * Improved robustness when GPU discovery/inventory is missing, times out, or returns unusable data.
  * Ensured invalid/unparseable probe results are reported consistently with actionable details.
  * Calibration cache results can still be used without performing preflight again.

* **Operational Improvements**
  * Service runner now distinguishes expected preflight skips from other calibration failures, emitting a clear notice when falling back.

* **Tests**
  * Updated calibration probe and validation tests to match the new failure/exit behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->