### PR TITLE
build(v20): publish reviewed r13 release

### DIFF
--- a/build-gilded-gnosis-v20-final-cu132.sh
+++ b/build-gilded-gnosis-v20-final-cu132.sh
@@ -101,8 +101,18 @@ if [[ "${composition_mode}" == "clean" ]]; then
     --output-dir "${lmcache_composition_dir}" >/dev/null
   configure_lmcache_composition "${lmcache_composition_dir}" 1
 
-  export IMAGE="${IMAGE:-voipmonitor/vllm:gilded-gnosis-v20-vllm${VLLM_INTEGRATION_TREE:0:7}-si${SPARKINFER_INTEGRATION_TREE:0:7}-fi801d57a-cu132-${release_date}-r12}"
-  export VLLM_BUILD_VERSION="${VLLM_BUILD_VERSION:-0.11.2.dev280+gilded.gnosis.v20.vllm${VLLM_INTEGRATION_TREE:0:7}.si${SPARKINFER_INTEGRATION_TREE:0:7}.fi801d57a.cu132.${release_date}.r12}"
+  export IMAGE="${IMAGE:-voipmonitor/vllm:gilded-gnosis-v20-vllm${VLLM_INTEGRATION_TREE:0:7}-si${SPARKINFER_INTEGRATION_TREE:0:7}-fi801d57a-cu132-${release_date}-r13}"
+  export VLLM_BUILD_VERSION="${VLLM_BUILD_VERSION:-0.11.2.dev280+gilded.gnosis.v20.vllm${VLLM_INTEGRATION_TREE:0:7}.si${SPARKINFER_INTEGRATION_TREE:0:7}.fi801d57a.cu132.${release_date}.r13}"
+elif [[ "${composition_mode}" == "reproduce-r13" ]]; then
+  configure_vllm_composition \
+    "patches/releases/gilded-gnosis-v20-r13/vllm" 0
+  configure_sparkinfer_composition \
+    "patches/releases/gilded-gnosis-v20-r13/sparkinfer" 0
+  configure_lmcache_composition \
+    "patches/releases/gilded-gnosis-v20-r13/lmcache" 0
+
+  export IMAGE="${IMAGE:-voipmonitor/vllm:gilded-gnosis-v20-vllm69ba80b-sia2ea608-fi801d57a-cu132-20260730-r13}"
+  export VLLM_BUILD_VERSION="${VLLM_BUILD_VERSION:-0.11.2.dev280+gilded.gnosis.v20.vllm69ba80b.sia2ea608.fi801d57a.cu132.20260730.r13}"
 elif [[ "${composition_mode}" == "reproduce-r12" ]]; then
   configure_vllm_composition \
     "patches/releases/gilded-gnosis-v20-r12/vllm" 0
@@ -237,7 +247,7 @@ export TRITON_KERNELS_REF=
 export TRITON_KERNELS_COMMIT=
 
 export XGRAMMAR_REPO="${XGRAMMAR_REPO:-https://github.com/mlc-ai/xgrammar.git}"
-if [[ "${composition_mode}" == "clean" || "${composition_mode}" == "reproduce-r8" || "${composition_mode}" == "reproduce-r9" || "${composition_mode}" == "reproduce-r11" || "${composition_mode}" == "reproduce-r12" ]]; then
+if [[ "${composition_mode}" == "clean" || "${composition_mode}" == "reproduce-r8" || "${composition_mode}" == "reproduce-r9" || "${composition_mode}" == "reproduce-r11" || "${composition_mode}" == "reproduce-r12" || "${composition_mode}" == "reproduce-r13" ]]; then
   export XGRAMMAR_REF="${XGRAMMAR_REF:-v0.2.5}"
   export XGRAMMAR_COMMIT="${XGRAMMAR_COMMIT:-2ea71da4ccb997a06928c9fb69b99f330da56697}"
   export XGRAMMAR_VERSION="${XGRAMMAR_VERSION:-0.2.5}"
@@ -254,7 +264,7 @@ fi
 export INSTANTTENSOR_REPO="${INSTANTTENSOR_REPO:-https://github.com/scitix/InstantTensor.git}"
 export INSTANTTENSOR_REF="${INSTANTTENSOR_REF:-85e7c5f5539d9c006ee0c26bc1b5233c65251b6b}"
 export INSTANTTENSOR_COMMIT="${INSTANTTENSOR_COMMIT:-85e7c5f5539d9c006ee0c26bc1b5233c65251b6b}"
-if [[ "${composition_mode}" == "clean" || "${composition_mode}" == "reproduce-r11" || "${composition_mode}" == "reproduce-r12" ]]; then
+if [[ "${composition_mode}" == "clean" || "${composition_mode}" == "reproduce-r11" || "${composition_mode}" == "reproduce-r12" || "${composition_mode}" == "reproduce-r13" ]]; then
   export LMCACHE_BUILD_VERSION="${LMCACHE_BUILD_VERSION:-0.5.2+glm52dcp.4}"
 elif [[ "${composition_mode}" == "reproduce-r6" ]]; then
   export LMCACHE_REPO="${LMCACHE_REPO:-https://github.com/LMCache/LMCache.git}"
@@ -273,9 +283,10 @@ else
 fi
 
 if [[ "${PRINT_RELEASE_CONFIG:-0}" == 1 ]]; then
-  printf 'composition=%s\nimage=%s\nversion=%s\nvllm_tree=%s\nsparkinfer_tree=%s\nlmcache_tree=%s\nlmcache_repo=%s\nlmcache_ref=%s\nlmcache_commit=%s\nlmcache_patch=%s\nlmcache_version=%s\nxgrammar_repo=%s\nxgrammar_ref=%s\nxgrammar_commit=%s\nxgrammar_version=%s\nxgrammar_transformers5_compat=%s\n' \
+  printf 'composition=%s\nimage=%s\nversion=%s\nvllm_tree=%s\nsparkinfer_tree=%s\nlauncher_repo=%s\nlauncher_ref=%s\nlauncher_commit=%s\nlmcache_tree=%s\nlmcache_repo=%s\nlmcache_ref=%s\nlmcache_commit=%s\nlmcache_patch=%s\nlmcache_version=%s\nxgrammar_repo=%s\nxgrammar_ref=%s\nxgrammar_commit=%s\nxgrammar_version=%s\nxgrammar_transformers5_compat=%s\n' \
     "${composition_mode}" "${IMAGE}" "${VLLM_BUILD_VERSION}" \
     "${VLLM_INTEGRATION_TREE:-}" "${SPARKINFER_INTEGRATION_TREE:-}" \
+    "${LAUNCHER_REPO}" "${LAUNCHER_REF}" "${LAUNCHER_COMMIT}" \
     "${LMCACHE_INTEGRATION_TREE:-}" \
     "${LMCACHE_REPO}" "${LMCACHE_REF}" "${LMCACHE_COMMIT}" \
     "${LMCACHE_PATCH_FILE}" "${LMCACHE_BUILD_VERSION}" \
@@ -327,7 +338,7 @@ jq -e --arg value "${EXLLAMAV3_COMMIT}" '."local-inference.exllamav3.commit" == 
 jq -e --arg value "${LMCACHE_COMMIT}" '."local-inference.lmcache.commit" == $value' <<<"${labels}" >/dev/null
 jq -e --arg value "${LMCACHE_PATCH_SHA256}" '."local-inference.lmcache.patch_sha256" == $value' <<<"${labels}" >/dev/null
 jq -e --arg value "${LMCACHE_BUILD_VERSION}" '."local-inference.lmcache.version" == $value' <<<"${labels}" >/dev/null
-if [[ "${composition_mode}" == "clean" || "${composition_mode}" == "reproduce-r11" || "${composition_mode}" == "reproduce-r12" ]]; then
+if [[ "${composition_mode}" == "clean" || "${composition_mode}" == "reproduce-r11" || "${composition_mode}" == "reproduce-r12" || "${composition_mode}" == "reproduce-r13" ]]; then
   jq -e --arg value "${LMCACHE_INTEGRATION_TREE}" '."local-inference.lmcache.integration.tree" == $value' <<<"${labels}" >/dev/null
   jq -e --arg value "${LMCACHE_INTEGRATION_PRS}" '."local-inference.lmcache.integration.prs" == $value' <<<"${labels}" >/dev/null
   jq -e --arg value "${LMCACHE_INTEGRATION_LOCK_SHA256}" '."local-inference.lmcache.integration.lock_sha256" == $value' <<<"${labels}" >/dev/null

--- a/build-gilded-gnosis-v20-final-cu132.sh
+++ b/build-gilded-gnosis-v20-final-cu132.sh
@@ -101,8 +101,18 @@ if [[ "${composition_mode}" == "clean" ]]; then
     --output-dir "${lmcache_composition_dir}" >/dev/null
   configure_lmcache_composition "${lmcache_composition_dir}" 1
 
-  export IMAGE="${IMAGE:-voipmonitor/vllm:gilded-gnosis-v20-vllm${VLLM_INTEGRATION_TREE:0:7}-si${SPARKINFER_INTEGRATION_TREE:0:7}-fi801d57a-cu132-${release_date}-r11}"
-  export VLLM_BUILD_VERSION="${VLLM_BUILD_VERSION:-0.11.2.dev280+gilded.gnosis.v20.vllm${VLLM_INTEGRATION_TREE:0:7}.si${SPARKINFER_INTEGRATION_TREE:0:7}.fi801d57a.cu132.${release_date}.r11}"
+  export IMAGE="${IMAGE:-voipmonitor/vllm:gilded-gnosis-v20-vllm${VLLM_INTEGRATION_TREE:0:7}-si${SPARKINFER_INTEGRATION_TREE:0:7}-fi801d57a-cu132-${release_date}-r12}"
+  export VLLM_BUILD_VERSION="${VLLM_BUILD_VERSION:-0.11.2.dev280+gilded.gnosis.v20.vllm${VLLM_INTEGRATION_TREE:0:7}.si${SPARKINFER_INTEGRATION_TREE:0:7}.fi801d57a.cu132.${release_date}.r12}"
+elif [[ "${composition_mode}" == "reproduce-r12" ]]; then
+  configure_vllm_composition \
+    "patches/releases/gilded-gnosis-v20-r12/vllm" 0
+  configure_sparkinfer_composition \
+    "patches/releases/gilded-gnosis-v20-r12/sparkinfer" 0
+  configure_lmcache_composition \
+    "patches/releases/gilded-gnosis-v20-r12/lmcache" 0
+
+  export IMAGE="${IMAGE:-voipmonitor/vllm:gilded-gnosis-v20-vllmb46c3aa-si35aebc6-fi801d57a-cu132-20260730-r12}"
+  export VLLM_BUILD_VERSION="${VLLM_BUILD_VERSION:-0.11.2.dev280+gilded.gnosis.v20.vllmb46c3aa.si35aebc6.fi801d57a.cu132.20260730.r12}"
 elif [[ "${composition_mode}" == "reproduce-r11" ]]; then
   configure_vllm_composition \
     "patches/releases/gilded-gnosis-v20-r11/vllm" 0
@@ -213,8 +223,8 @@ export VLLM_PATCH_URL=
 export SPARKINFER_VERSION="${SPARKINFER_VERSION:-1.0.1}"
 
 export LAUNCHER_REPO="${LAUNCHER_REPO:-https://github.com/local-inference-lab/blackwell-llm-docker.git}"
-export LAUNCHER_REF="${LAUNCHER_REF:-62c94d42b36601007ecb8931bbf103fd502668fb}"
-export LAUNCHER_COMMIT="${LAUNCHER_COMMIT:-62c94d42b36601007ecb8931bbf103fd502668fb}"
+export LAUNCHER_REF="${LAUNCHER_REF:-513bd84a1d8f4b834ca343abb4189e82acb1df52}"
+export LAUNCHER_COMMIT="${LAUNCHER_COMMIT:-513bd84a1d8f4b834ca343abb4189e82acb1df52}"
 export VLLM_REQUIRED_LAUNCHERS="serve-gilded-gnosis.sh serve-fathomless-firmament.sh serve-glm52-v16.sh serve-glm52-v18.sh serve-glm52-v19.sh serve-glm52-hybrid-v17.sh serve-glm52-hybrid-v18.sh serve-glm52-hybrid-v19.sh glm52-dcp-prefill-policy.sh glm52-pcie-runtime-env.sh glm52-pcie-calibration.py glm52-lmcache-wrapper.sh"
 
 export CUTLASS_REF="${CUTLASS_REF:-e6233cbac5d7c7a865c19c91cd684ceece19513c}"
@@ -227,7 +237,7 @@ export TRITON_KERNELS_REF=
 export TRITON_KERNELS_COMMIT=
 
 export XGRAMMAR_REPO="${XGRAMMAR_REPO:-https://github.com/mlc-ai/xgrammar.git}"
-if [[ "${composition_mode}" == "clean" || "${composition_mode}" == "reproduce-r8" || "${composition_mode}" == "reproduce-r9" || "${composition_mode}" == "reproduce-r11" ]]; then
+if [[ "${composition_mode}" == "clean" || "${composition_mode}" == "reproduce-r8" || "${composition_mode}" == "reproduce-r9" || "${composition_mode}" == "reproduce-r11" || "${composition_mode}" == "reproduce-r12" ]]; then
   export XGRAMMAR_REF="${XGRAMMAR_REF:-v0.2.5}"
   export XGRAMMAR_COMMIT="${XGRAMMAR_COMMIT:-2ea71da4ccb997a06928c9fb69b99f330da56697}"
   export XGRAMMAR_VERSION="${XGRAMMAR_VERSION:-0.2.5}"
@@ -244,7 +254,7 @@ fi
 export INSTANTTENSOR_REPO="${INSTANTTENSOR_REPO:-https://github.com/scitix/InstantTensor.git}"
 export INSTANTTENSOR_REF="${INSTANTTENSOR_REF:-85e7c5f5539d9c006ee0c26bc1b5233c65251b6b}"
 export INSTANTTENSOR_COMMIT="${INSTANTTENSOR_COMMIT:-85e7c5f5539d9c006ee0c26bc1b5233c65251b6b}"
-if [[ "${composition_mode}" == "clean" || "${composition_mode}" == "reproduce-r11" ]]; then
+if [[ "${composition_mode}" == "clean" || "${composition_mode}" == "reproduce-r11" || "${composition_mode}" == "reproduce-r12" ]]; then
   export LMCACHE_BUILD_VERSION="${LMCACHE_BUILD_VERSION:-0.5.2+glm52dcp.4}"
 elif [[ "${composition_mode}" == "reproduce-r6" ]]; then
   export LMCACHE_REPO="${LMCACHE_REPO:-https://github.com/LMCache/LMCache.git}"
@@ -317,7 +327,7 @@ jq -e --arg value "${EXLLAMAV3_COMMIT}" '."local-inference.exllamav3.commit" == 
 jq -e --arg value "${LMCACHE_COMMIT}" '."local-inference.lmcache.commit" == $value' <<<"${labels}" >/dev/null
 jq -e --arg value "${LMCACHE_PATCH_SHA256}" '."local-inference.lmcache.patch_sha256" == $value' <<<"${labels}" >/dev/null
 jq -e --arg value "${LMCACHE_BUILD_VERSION}" '."local-inference.lmcache.version" == $value' <<<"${labels}" >/dev/null
-if [[ "${composition_mode}" == "clean" || "${composition_mode}" == "reproduce-r11" ]]; then
+if [[ "${composition_mode}" == "clean" || "${composition_mode}" == "reproduce-r11" || "${composition_mode}" == "reproduce-r12" ]]; then
   jq -e --arg value "${LMCACHE_INTEGRATION_TREE}" '."local-inference.lmcache.integration.tree" == $value' <<<"${labels}" >/dev/null
   jq -e --arg value "${LMCACHE_INTEGRATION_PRS}" '."local-inference.lmcache.integration.prs" == $value' <<<"${labels}" >/dev/null
   jq -e --arg value "${LMCACHE_INTEGRATION_LOCK_SHA256}" '."local-inference.lmcache.integration.lock_sha256" == $value' <<<"${labels}" >/dev/null
@@ -385,6 +395,7 @@ from sparkinfer.comm.pcie.pcie_dma import (
     _normalize_fp8_mode,
 )
 from sparkinfer.gemm import bmm, can_implement_bmm, prewarm_bmm
+from sparkinfer.moe import fused_moe
 from sparkinfer.moe.fused_moe import _impl as fused_moe_impl
 from sparkinfer.moe._shared.kernels.w4a16 import kernel as w4a16_kernel
 from vllm import envs as vllm_envs
@@ -421,9 +432,15 @@ for exl3_export in (
     "exl3_moe_max_concurrency",
 ):
     assert hasattr(exl3_ext, exl3_export), exl3_export
-from sparkinfer.moe import trellis_moe
-for trellis_export in ("Caps", "plan", "prepare_weights", "bind", "run"):
-    assert hasattr(trellis_moe, trellis_export), trellis_export
+for fused_moe_export in (
+    "Caps",
+    "plan",
+    "plan_weights",
+    "prepare_weights",
+    "bind",
+    "run",
+):
+    assert hasattr(fused_moe, fused_moe_export), fused_moe_export
 assert fused_moe_impl._dynamic_kernel_intermediate_size(352, "w4a8_mx") == 384
 assert tiled_topk._COARSE_RADIX_BITS == 10
 assert tiled_topk._SMEM_CANDS == 8192

--- a/manifests/sparkinfer/gilded-gnosis-v20.json
+++ b/manifests/sparkinfer/gilded-gnosis-v20.json
@@ -5,24 +5,9 @@
   "base_ref": "refs/heads/master",
   "pull_requests": [
     {
-      "number": 81,
-      "head": "f049ccdfeafd80b1424e09983bfb75ce629246f1",
-      "title": "Add lossless PCIe serving calibration probe"
-    },
-    {
-      "number": 49,
-      "head": "669a12ddc7cf3021e91a25f398b1a883b703fd12",
-      "title": "Add planned EXL3 Trellis path for fused Blackwell MoE"
-    },
-    {
-      "number": 86,
-      "head": "0ddd13b4fdbb6a287581aec55fcf9dbbb7e52fd3",
-      "title": "Add inline per-token outer scales to 368-byte NVFP4 records"
-    },
-    {
-      "number": 87,
-      "head": "c24a01441f87c0eccd1390aee2a170c535340894",
-      "title": "Bound two-level fold workspace"
+      "number": 92,
+      "head": "de04125508c75e748016493f851e6bd4513b515b",
+      "title": "Stabilize Trellis arena memory profiling"
     }
   ]
 }

--- a/manifests/sparkinfer/gilded-gnosis-v20.json
+++ b/manifests/sparkinfer/gilded-gnosis-v20.json
@@ -6,7 +6,7 @@
   "pull_requests": [
     {
       "number": 92,
-      "head": "de04125508c75e748016493f851e6bd4513b515b",
+      "head": "06032ce74afba49a683d01339ed2c971568cec3f",
       "title": "Stabilize Trellis arena memory profiling"
     }
   ]

--- a/manifests/vllm/gilded-gnosis-v20.json
+++ b/manifests/vllm/gilded-gnosis-v20.json
@@ -16,7 +16,7 @@
     },
     {
       "number": 190,
-      "head": "214ccf58e472cb2135f26edfc240db2dd55ebda5",
+      "head": "e55627045ac68aa2ab87273e26a0cc190b6e2b78",
       "title": "Add EXL3 Trellis backend for rank-sliced MoE checkpoints"
     },
     {

--- a/manifests/vllm/gilded-gnosis-v20.json
+++ b/manifests/vllm/gilded-gnosis-v20.json
@@ -10,54 +10,19 @@
       "title": "GLM-5.2 calibrated NVFP4 MLA KV outer scales"
     },
     {
-      "number": 172,
-      "head": "0c05ab9ec43c2446bfa4197fe1bbc1c1ec7e6cbe",
-      "title": "MRV2 high-utilization startup memory profiling"
-    },
-    {
       "number": 175,
       "head": "2c14a58a21c724f08d01d988b9972d10c77ed4c0",
       "title": "Shard sparse prefill queries and halve result traffic"
     },
     {
-      "number": 179,
-      "head": "ef60ee72e95084cfbdc054b54941094516b102df",
-      "title": "Partial replicated sparse-indexer topology"
-    },
-    {
-      "number": 184,
-      "head": "c4022e80099e9bffa6091691663970591f8f05ec",
-      "title": "Calibrate lossless PCIe DMA dispatch crossover"
-    },
-    {
-      "number": 185,
-      "head": "961f545b98dacbc160ffe595c7b8d6242fd81a7a",
-      "title": "Gate DCP query split by measured context crossover"
-    },
-    {
       "number": 190,
-      "head": "d35dd8ffd6d7e48e54e6917aa559b89465b61387",
+      "head": "214ccf58e472cb2135f26edfc240db2dd55ebda5",
       "title": "Add EXL3 Trellis backend for rank-sliced MoE checkpoints"
     },
     {
-      "number": 194,
-      "head": "854735ac77896eca1447faa9468db0acf8d7da05",
-      "title": "Preload CUDA-clean worker modules with forkserver"
-    },
-    {
-      "number": 189,
-      "head": "b57062274c3f53bec69b431bfae7230977f5f10c",
-      "title": "Wire dynamic per-token NVFP4 scaling and cache ABI"
-    },
-    {
-      "number": 195,
-      "head": "e06891f20ae276d41600d318d9f22d31bbc46a77",
-      "title": "Preserve required tool choice with an empty tools list"
-    },
-    {
-      "number": 196,
-      "head": "bc5dbf497dfaa14f820921c5db87fa84eee7a16f",
-      "title": "Resolve late GLM KV transfer configuration"
+      "number": 198,
+      "head": "703af3ffd6ae60e4b99abbd5fa8a5a03d629c7e7",
+      "title": "Measure repeatable activation peak after kernel warmup"
     }
   ]
 }

--- a/patches/releases/gilded-gnosis-v20-r12/lmcache/integration.lock.json
+++ b/patches/releases/gilded-gnosis-v20-r12/lmcache/integration.lock.json
@@ -1,0 +1,96 @@
+{
+  "base": {
+    "commit": "9cebd405d0caf4bebe01d694b5a8bf4e3e354314",
+    "ref": "refs/heads/release/v0.5.2-glm52-dcp-base",
+    "repository": "https://github.com/local-inference-lab/LMCache.git"
+  },
+  "manifest": {
+    "sha256": "3cf644fec4a00188f7689d245156841fad0b86acd2a14ed9a7a2f31476a032c1"
+  },
+  "name": "gilded-gnosis-v20-lmcache",
+  "pull_requests": [
+    {
+      "disposition": "merged",
+      "head": "7b7583aef55e98ba05a6c199e71601d78552e794",
+      "number": 7,
+      "ref": "refs/pull/7/head",
+      "title": "Return bounded LMCache MP RPC handler errors"
+    },
+    {
+      "disposition": "merged",
+      "head": "31c4175d2134518e5b43fe8f4a7d072df6043a13",
+      "number": 8,
+      "ref": "refs/pull/8/head",
+      "title": "Recover failed MP retrieves by recomputing invalid blocks"
+    },
+    {
+      "disposition": "merged",
+      "head": "c3b73de74d855f6263deea8b6c6c4dde87e6e5b9",
+      "number": 9,
+      "ref": "refs/pull/9/head",
+      "title": "Restore the largest exact L1 prefix after allocation failure"
+    },
+    {
+      "disposition": "merged",
+      "head": "59186798bb5859b7add7bcac81dff9f2fd4037ab",
+      "number": 10,
+      "ref": "refs/pull/10/head",
+      "title": "Protect native lookup keys from concurrent deletion"
+    },
+    {
+      "disposition": "merged",
+      "head": "2cee5a2c1ef7e80028e94b1bc4bfbfc02e2c2a8d",
+      "number": 11,
+      "ref": "refs/pull/11/head",
+      "title": "Log bounded prefetch failure key samples"
+    },
+    {
+      "disposition": "merged",
+      "head": "baf1345106ebe568a116a35fdcee36bfec73da57",
+      "number": 12,
+      "ref": "refs/pull/12/head",
+      "title": "Return native per-key store results"
+    },
+    {
+      "disposition": "merged",
+      "head": "d4dce69bf90362953cf9ac9a86cccc186b3219dc",
+      "number": 13,
+      "ref": "refs/pull/13/head",
+      "title": "Enforce native filesystem O_DIRECT alignment"
+    },
+    {
+      "disposition": "merged",
+      "head": "502b3c60f2e61625d6e32a31d0d725eedc620792",
+      "number": 14,
+      "ref": "refs/pull/14/head",
+      "title": "Support current and legacy native filesystem object-group keys"
+    },
+    {
+      "disposition": "merged",
+      "head": "7892d42a6996df855fe743edb271fa154503bef8",
+      "number": 15,
+      "ref": "refs/pull/15/head",
+      "title": "Make native stores durable before reporting completion"
+    },
+    {
+      "disposition": "merged",
+      "head": "e6c2708fe8ae8a96d3c66e83bf4b548c734fbb13",
+      "number": 16,
+      "ref": "refs/pull/16/head",
+      "title": "Restore native filesystem capacity accounting after restart"
+    },
+    {
+      "disposition": "merged",
+      "head": "01743addbc3afd818a24390e1c40346d3378d77a",
+      "number": 17,
+      "ref": "refs/pull/17/head",
+      "title": "Add bounded L1 writeback to durable storage"
+    }
+  ],
+  "result": {
+    "patch": "integration.patch",
+    "patch_sha256": "fa5bfa65c6d66a7e94444fca1f4a928cc5c2de026eb5ca69b544dae479ea00e7",
+    "tree": "175e59294436a02861e9e3ebedf7358edea4ed36"
+  },
+  "schema_version": 1
+}

--- a/patches/releases/gilded-gnosis-v20-r12/lmcache/integration.patch
+++ b/patches/releases/gilded-gnosis-v20-r12/lmcache/integration.patch
@@ -1,0 +1,3939 @@
+diff --git a/csrc/storage_backends/connector_base.h b/csrc/storage_backends/connector_base.h
+index c2cd35a174a1225c467d1479ea347b0d6e5ebd0e..0df7677cef0d0172a7cb60f7c9f3599cb189b555 100644
+--- a/csrc/storage_backends/connector_base.h
++++ b/csrc/storage_backends/connector_base.h
+@@ -111,6 +111,9 @@ class ConnectorBase : public IStorageConnector {
+     auto [batch_future_id, batch_state, num_tiles, tile_size] =
+         prepare_batch_operation(num_items, Op::BATCH_TILE_SET);
+ 
++    // pre-allocate per-key results so partial store failures are visible
++    batch_state->per_key_results.assign(num_items, 0);
++
+     // fan out work to threads
+     for (size_t tile_idx = 0; tile_idx < num_tiles; ++tile_idx) {
+       auto tile_req = create_tile_request(
+@@ -326,10 +329,30 @@ class ConnectorBase : public IStorageConnector {
+       }
+     }
+   }
++  // Records a per-key result for every key in the tile (continuing past
++  // failures instead of aborting the tile), then rethrows so batch-level
++  // ok=false semantics are preserved for consumers that ignore per-key
++  // results.
+   virtual void do_batch_set(ConnectionType& conn, const Request& req) {
++    bool any_failed = false;
++    std::string first_error;
+     for (size_t i = 0; i < req.keys.size(); ++i) {
+-      do_single_set(conn, req.keys[i], req.buf_ptrs[i], req.buf_lens[i],
+-                    req.batch_chunk_num_bytes);
++      try {
++        do_single_set(conn, req.keys[i], req.buf_ptrs[i], req.buf_lens[i],
++                      req.batch_chunk_num_bytes);
++        req.batch->per_key_results[req.start_idx + i] = 1;
++      } catch (const std::exception& e) {
++        req.batch->per_key_results[req.start_idx + i] = 0;
++        if (!any_failed) {
++          any_failed = true;
++          first_error = e.what();
++        }
++        fprintf(stderr, "[LMCache SET] key %s failed: %s\n",
++                req.keys[i].c_str(), e.what());
++      }
++    }
++    if (any_failed) {
++      throw std::runtime_error("batch set partially failed: " + first_error);
+     }
+   }
+   virtual void do_batch_exists(ConnectionType& conn, const Request& req) {
+@@ -612,9 +635,10 @@ class ConnectorBase : public IStorageConnector {
+         std::lock_guard<std::mutex> lk(req.batch->err_mu);
+         batch_comp.error = req.batch->first_error;
+       }
+-      // for batch exists and batch get, move per-key results
++      // move per-key results for every op that records them
+       if (req.batch->batch_op == Op::BATCH_TILE_EXISTS ||
+           req.batch->batch_op == Op::BATCH_TILE_GET ||
++          req.batch->batch_op == Op::BATCH_TILE_SET ||
+           req.batch->batch_op == Op::BATCH_TILE_DELETE) {
+         batch_comp.result_bytes = std::move(req.batch->per_key_results);
+       }
+diff --git a/csrc/storage_backends/fs/connector.cpp b/csrc/storage_backends/fs/connector.cpp
+index e54d98f54f5428afad363cf1c5f5f380cdd8fffb..727ed016f10ae0b0c6e863c4234439dbaac0e7f8 100644
+--- a/csrc/storage_backends/fs/connector.cpp
++++ b/csrc/storage_backends/fs/connector.cpp
+@@ -2,10 +2,22 @@
+ 
+ #include "connector.h"
+ #include <cerrno>
++#include <cstdint>
+ #include <cstdio>
+ #include <stdexcept>
+ #include <string>
+ 
++namespace {
++// O_DIRECT requires the buffer ADDRESS to be block-aligned as well as the
++// length; a misaligned address fails the read/write with EINVAL. Buffers
++// come from Python and carry no alignment guarantee, so fall back to
++// buffered I/O whenever either constraint is unmet.
++bool odirect_eligible(const void* buf, size_t len, size_t disk_block_size) {
++  return disk_block_size > 0 && len % disk_block_size == 0 &&
++         reinterpret_cast<uintptr_t>(buf) % disk_block_size == 0;
++}
++}  // namespace
++
+ namespace lmcache {
+ namespace connector {
+ 
+@@ -27,22 +39,23 @@ std::string FSConnector::replace_all(const std::string& str,
+ 
+ std::string FSConnector::key_to_filename(const std::string& key) {
+   // Input key format (from _object_key_to_string):
+-  //   Unsalted: <model_name>@<kv_rank_hex>@<chunk_hash_hex>
+-  //   Salted  : <model_name>@<kv_rank_hex>@<chunk_hash_hex>@<cache_salt>
++  //   Legacy unsalted: <model_name>@<kv_rank_hex>@<chunk_hash_hex>
++  //   Legacy salted  : <model_name>@<kv_rank_hex>@<chunk_hash_hex>@<cache_salt>
++  //   Current unsalted:
++  //     <model_name>@<kv_rank_hex>@<object_group_id_hex>@<chunk_hash_hex>
++  //   Current salted appends @<cache_salt> to the current unsalted shape.
+   //
+   // Output filename (matching fs_l2_adapter.py._object_key_to_filename):
+   //   Unsalted: <model_name_safe>@0x<kv_rank_hex>@<chunk_hash_hex>.data
+   //   Salted  :
+   //   <model_name_safe>@0x<kv_rank_hex>@<chunk_hash_hex>@<cache_salt>.data
+   //
+-  // The unsalted 3-field shape is bit-identical to the pre-cache_salt
+-  // format, so existing cache directories remain valid.
+-  //
+-  // NOTE: both model_name and cache_salt are forbidden from containing
+-  // '@' (invariant enforced on the Python side), so splitting on '@'
+-  // is unambiguous — no marker, no rsplit.
++  // Four fields are intentionally not interpreted: that shape can mean a
++  // legacy salted key or a current unsalted key, and both map correctly by
++  // preserving every field after kv_rank verbatim.
+ 
+-  // Split on '@' — must yield 3 (unsalted) or 4 (salted) fields.
++  // Split on '@'. Current ObjectKey serialization has four or five fields;
++  // three-field legacy keys remain readable for cache compatibility.
+   std::vector<std::string> parts;
+   size_t start = 0;
+   for (size_t pos = 0; pos <= key.size(); ++pos) {
+@@ -51,34 +64,28 @@ std::string FSConnector::key_to_filename(const std::string& key) {
+       start = pos + 1;
+     }
+   }
+-  if (parts.size() != 3 && parts.size() != 4) {
++  if (parts.size() < 3 || parts.size() > 5) {
+     throw std::runtime_error(
+-        "FSConnector: malformed key (expected 3 or 4 '@'-separated fields): " +
++        "FSConnector: malformed key (expected 3 to 5 '@'-separated fields): " +
+         key);
+   }
+ 
+   const std::string& model_name = parts[0];
+   const std::string& kv_rank_hex = parts[1];
+-  const std::string& chunk_hash = parts[2];
+-  const std::string cache_salt = parts.size() == 4 ? parts[3] : std::string();
+ 
+   // Replace '/' with '-SEP-' for filesystem safety
+   std::string safe_model = replace_all(model_name, "/", PATH_SLASH_REPLACEMENT);
+ 
+-  // Emit filename. Salt is appended at the tail so the unsalted shape
+-  // matches what older builds wrote to disk.
++  // Emit the model and normalized rank, preserving all remaining fields.
+   std::string result;
+-  result.reserve(safe_model.size() + kv_rank_hex.size() + chunk_hash.size() +
+-                 cache_salt.size() + 32);
++  result.reserve(key.size() + 16);
+   result += safe_model;
+   result += KEY_SEP;
+   result += "0x";
+   result += kv_rank_hex;
+-  result += KEY_SEP;
+-  result += chunk_hash;
+-  if (!cache_salt.empty()) {
++  for (size_t i = 2; i < parts.size(); ++i) {
+     result += KEY_SEP;
+-    result += cache_salt;
++    result += parts[i];
+   }
+   result += FILE_EXT;
+   return result;
+@@ -174,8 +181,11 @@ void FSConnector::do_single_get(WorkerFSConn& conn, const std::string& key,
+   int flags = O_RDONLY;
+   bool do_odirect = conn.use_odirect;
+   if (do_odirect) {
+-    bool aligned = conn.disk_block_size > 0 && len % conn.disk_block_size == 0;
+-    if (aligned) {
++    const bool split_aligned = conn.disk_block_size > 0 &&
++                               (conn.read_ahead_size == 0 ||
++                                len <= conn.read_ahead_size ||
++                                conn.read_ahead_size % conn.disk_block_size == 0);
++    if (odirect_eligible(buf, len, conn.disk_block_size) && split_aligned) {
+ #ifdef O_DIRECT
+       flags |= O_DIRECT;
+ #endif
+@@ -243,8 +253,7 @@ void FSConnector::do_single_set(WorkerFSConn& conn, const std::string& key,
+   int flags = O_CREAT | O_WRONLY | O_TRUNC;
+   bool do_odirect = conn.use_odirect;
+   if (do_odirect) {
+-    bool aligned = conn.disk_block_size > 0 && len % conn.disk_block_size == 0;
+-    if (aligned) {
++    if (odirect_eligible(buf, len, conn.disk_block_size)) {
+ #ifdef O_DIRECT
+       flags |= O_DIRECT;
+ #endif
+diff --git a/csrc/storage_backends/fs/connector.h b/csrc/storage_backends/fs/connector.h
+index 03b7b9cc5e0a2cac7ab9e39404d80c760b4e9018..7b9010947c18de36684317ed7c2628c3d2be0161 100644
+--- a/csrc/storage_backends/fs/connector.h
++++ b/csrc/storage_backends/fs/connector.h
+@@ -21,7 +21,9 @@ static constexpr const char* FILE_EXT = ".data";
+ static constexpr const char* TMP_EXT = ".tmp";
+ 
+ // Per-worker connection state for the FS connector.
+-// Each worker maintains its own I/O buffer for O_DIRECT.
++// O_DIRECT engages per request only when both the transfer length and the
++// caller's buffer address are multiples of the disk block size; anything
++// else falls back to buffered I/O.
+ struct WorkerFSConn {
+   std::filesystem::path base_path;
+   std::filesystem::path tmp_dir;  // empty if not configured
+@@ -52,17 +54,20 @@ class FSConnector : public ConnectorBase<WorkerFSConn> {
+   // Build the filesystem-safe filename from a serialized key string.
+   //
+   // Input key (from NativeConnectorL2Adapter._object_key_to_string):
+-  //   Unsalted: "{model}@{kv_rank:08x}@{hash.hex()}"
+-  //   Salted  : "{model}@{kv_rank:08x}@{hash.hex()}@{cache_salt}"
++  //   Current unsalted:
++  //     "{model}@{kv_rank:08x}@{object_group:x}@{hash.hex()}"
++  //   Current salted appends "@{cache_salt}". Legacy three/four-field keys
++  //   without object_group_id remain supported.
+   //
+   // Output filename (matching fs_l2_adapter.py._object_key_to_filename):
+-  //   Unsalted: "{safe_model}@{kv_rank:#010x}@{hash.hex()}.data"
+-  //   Salted  : "{safe_model}@{kv_rank:#010x}@{hash.hex()}@{cache_salt}.data"
++  //   Current unsalted:
++  //     "{safe_model}@{kv_rank:#010x}@{object_group:x}@{hash.hex()}.data"
++  //   Current salted appends "@{cache_salt}" before ".data".
+   //
+   // Differences from the input: '/' in model becomes '-SEP-', kv_rank
+-  // gains a '0x' prefix, and '.data' is appended. Both model_name and
+-  // cache_salt are forbidden from containing '@' (enforced on the
+-  // Python side), so the parse is unambiguous.
++  // gains a '0x' prefix, and '.data' is appended. All fields after kv_rank
++  // are preserved because four fields can represent either a legacy salted
++  // key or a current unsalted key.
+   static std::string key_to_filename(const std::string& key);
+ 
+   static std::string replace_all(const std::string& str,
+diff --git a/csrc/storage_backends/mooncake/connector.cpp b/csrc/storage_backends/mooncake/connector.cpp
+index 685fa4165b188b517a5c0de50753e5ae2e596d6f..0d5109e0dbb5595476806071d62c6dedd6f2bf98 100644
+--- a/csrc/storage_backends/mooncake/connector.cpp
++++ b/csrc/storage_backends/mooncake/connector.cpp
+@@ -173,12 +173,23 @@ void MooncakeConnector::do_batch_set(WorkerMooncakeConn& conn,
+       conn.client->batch_put_from(req.keys, req.buf_ptrs, req.buf_lens);
+   ensure_batch_result_size(results, req.keys.size(), "batch_put_from");
+ 
++  // Record per-key results before failing the tile so partial store
++  // failures stay visible to consumers that honor them.
++  size_t first_failed = results.size();
+   for (size_t i = 0; i < results.size(); ++i) {
+-    if (results[i] != 0) {
+-      throw std::runtime_error("Mooncake batch_put_from failed for key: " +
+-                               req.keys[i]);
++    if (results[i] == 0) {
++      req.batch->per_key_results[req.start_idx + i] = 1;
++    } else {
++      req.batch->per_key_results[req.start_idx + i] = 0;
++      if (first_failed == results.size()) {
++        first_failed = i;
++      }
+     }
+   }
++  if (first_failed != results.size()) {
++    throw std::runtime_error("Mooncake batch_put_from failed for key: " +
++                             req.keys[first_failed]);
++  }
+ }
+ 
+ void MooncakeConnector::do_batch_exists(WorkerMooncakeConn& conn,
+diff --git a/lmcache/integration/vllm/lmcache_mp_connector.py b/lmcache/integration/vllm/lmcache_mp_connector.py
+index d268070c3c0daa534a616c88312f8da7b5c665de..21af3747ede9f78c608841a692acc9c25e0bbc29 100644
+--- a/lmcache/integration/vllm/lmcache_mp_connector.py
++++ b/lmcache/integration/vllm/lmcache_mp_connector.py
+@@ -464,6 +464,42 @@ class LMCacheMPRequestMetadata:
+             "number of LMCache hit tokens. "
+         )
+         if end_token_idx > start_token_idx:
++            # allocated_block_ids must cover [start_token_idx, end_token_idx)
++            # in every engine group. slice_block_ids_per_group() validates
++            # chunk alignment only; its plain Python slice truncates
++            # silently, so a tracker primed with LMCache hit counts on a
++            # scheduling pass whose allocation never materialised would emit
++            # a retrieve op with too few block ids. The MP server fails
++            # closed on the short list, wasting a doomed round-trip and
++            # relying on the failure being surfaced at all. Suppress the op
++            # instead so the request recomputes cleanly. Never clamp
++            # end_token_idx: a clamped retrieve completes a load vLLM does
++            # not expect and re-creates the desync downstream.
++            # One allocated id of group g covers group_tokens_per_block[g]
++            # global token positions (KV-spec block_size, DCP-scaled), the
++            # same arithmetic GetStoreMetadata uses to bound its
++            # allocated_tokens.
++            for group_idx, tokens_per_block in enumerate(group_tokens_per_block):
++                allocated = len(tracker.allocated_block_ids.get(group_idx, []))
++                if allocated * tokens_per_block < end_token_idx:
++                    logger.warning(
++                        "LMCache retrieve suppressed for request_id=%s: "
++                        "engine group %d has %d allocated block(s) x %d "
++                        "tokens/block = %d tokens < end_token_idx=%d "
++                        "(start_token_idx=%d, vllm_hit_tokens=%d, "
++                        "lmcache_hit_tokens=%d) -- tracker/allocation "
++                        "desync; falling back to recompute.",
++                        tracker.request_id,
++                        group_idx,
++                        allocated,
++                        tokens_per_block,
++                        allocated * tokens_per_block,
++                        end_token_idx,
++                        start_token_idx,
++                        tracker.num_vllm_hit_tokens,
++                        tracker.num_lmcache_hit_tokens,
++                    )
++                    return None
+             block_ids = slice_block_ids_per_group(
+                 tracker.allocated_block_ids,
+                 group_tokens_per_block,
+diff --git a/lmcache/integration/vllm/vllm_multi_process_adapter.py b/lmcache/integration/vllm/vllm_multi_process_adapter.py
+index d74fe3af02cbefc7755c8446434a36034c681ef3..dd5aa0e6033292eaad06dd8f0b7961d58cf6b2f1 100644
+--- a/lmcache/integration/vllm/vllm_multi_process_adapter.py
++++ b/lmcache/integration/vllm/vllm_multi_process_adapter.py
+@@ -1173,8 +1173,11 @@ class LMCacheMPWorkerAdapter:
+         self.store_events: dict[str, list[_IpcEvent]] = {}
+         self.retrieve_events: dict[str, _IpcEvent] = {}
+ 
+-        # Block IDs that failed due to retrieve timeout
++        # Block IDs of failed retrieves (timeout, server-reported failure,
++        # or raising future), consumed by get_block_ids_with_load_errors().
+         self.error_block_ids: set[int] = set()
++        # Total failed retrieves on this worker, for log-based diagnostics.
++        self.retrieve_failure_count: int = 0
+ 
+         # Retrieve request ids dropped by the unhealthy early-return of
+         # submit_retrieve_request. get_finished must still report each id
+@@ -1657,6 +1660,9 @@ class LMCacheMPWorkerAdapter:
+             - The second set contains the finished retrieve request ids,
+                 including retrieves dropped at submit time while unhealthy
+                 (reported exactly once; blocks already in error_block_ids).
++                A failed retrieve (server result False or a raising future)
++                is reported finished with its block ids recorded in
++                error_block_ids so the scheduler recomputes them.
+ 
+         Notes:
+             When enabling async scheduling in vLLM, the same request ID may appear
+@@ -1701,19 +1707,45 @@ class LMCacheMPWorkerAdapter:
+ 
+         finished_stores = self._poll_store_futures()
+         finished_retrieves = set()
+-        for request_id, (r_future, _) in self.retrieve_futures.items():
++        for request_id, (r_future, r_block_ids) in self.retrieve_futures.items():
+             if not r_future.query():
+                 continue
+ 
+-            r_result = r_future.result()
++            try:
++                r_result = r_future.result()
++            except Exception as exc:
++                # A raising future must not propagate out of get_finished
++                # (that would kill the engine step); contain it as a failed
++                # retrieve on the standard failure path.
++                logger.error(
++                    "LMCache retrieve future raised for request_id=%s: %r "
++                    "-- treating as failed retrieve.",
++                    request_id,
++                    exc,
++                )
++                r_result = False
+             finished_retrieves.add(request_id)
+ 
+             if not r_result:
++                # Surface the failure to the scheduler. Reporting the
++                # request finished without recording the failed span would
++                # ACK the load as successful: the request then decodes over
++                # never-written GPU blocks and the phantom blocks enter the
++                # shared prefix cache. error_block_ids feeds
++                # get_block_ids_with_load_errors() ->
++                # kv_connector_output.invalid_block_ids -> scheduler
++                # recompute. The MP server collapses per-key results into
++                # one bool, so marking the op's whole span is
++                # conservative-correct for partial failures too.
++                self.error_block_ids.update(r_block_ids)
++                self.retrieve_failure_count += 1
+                 logger.error(
+-                    "Something went wrong when processing the "
+-                    "retrieve request for request_id=%s, result=%s",
++                    "LMCache retrieve failed for request_id=%s: %d block(s) "
++                    "marked invalid for scheduler recompute "
++                    "(total retrieve failures this worker: %d)",
+                     request_id,
+-                    r_result,
++                    len(r_block_ids),
++                    self.retrieve_failure_count,
+                 )
+ 
+         # Store futures and events are removed together by _poll_store_futures.
+@@ -1758,8 +1790,8 @@ class LMCacheMPWorkerAdapter:
+ 
+     def get_block_ids_with_load_errors(self) -> set[int]:
+         """
+-        Returns the block IDs that failed due to retrieve timeout,
+-        then clears the internal set.
++        Returns the block IDs of failed retrieves (timeout, server-reported
++        failure, or raising future), then clears the internal set.
+         """
+         errors = self.error_block_ids.copy()
+         self.error_block_ids.clear()
+diff --git a/lmcache/v1/distributed/config.py b/lmcache/v1/distributed/config.py
+index de36535a57df7ceb8ca8bbb97276c4733e568270..ac11158668fdbfd00f36512cc08a90b7f42860b4 100644
+--- a/lmcache/v1/distributed/config.py
++++ b/lmcache/v1/distributed/config.py
+@@ -226,6 +226,21 @@ class EvictionConfig:
+     extra_logging_interval: float = field(default=10.0)
+     """ Seconds between L1 memory usage log lines when extra logging is enabled. """
+ 
++    write_back_on_evict: bool = field(default=False)
++    """ Flush evicted L1 objects to L2 synchronously and delete them from L1
++    only once every key in the batch is durable; without this, eviction
++    discards the objects. Requires an L2 adapter with store_objects_sync(). """
++
++    periodic_flush_interval: float = field(default=0.0)
++    """ Seconds between periodic L1-to-L2 backup flush scans while below the
++    eviction watermark (0 disables). Backup keeps the L1 copy; only L2 gains
++    a copy, so a restart or session expiry no longer costs a cold prefill. """
++
++    emergency_evict_for_prefetch: bool = field(default=False)
++    """ Allow the prefetch controller to synchronously evict LRU L1 keys to
++    make room for large L2-to-L1 restores. Effective only together with
++    write_back_on_evict, so victims are persisted before deletion. """
++
+ 
+ @dataclass
+ class StorageManagerConfig:
+@@ -296,6 +311,12 @@ def validate_storage_manager_config(config: StorageManagerConfig) -> None:
+         ValueError: If mutually exclusive L1 tiers are both configured, or
+             hybrid L1 is paired with incompatible L2 adapters.
+     """
++    eviction = config.eviction_config
++    if eviction.periodic_flush_interval < 0:
++        raise ValueError("periodic_flush_interval must be >= 0")
++    if eviction.emergency_evict_for_prefetch and not eviction.write_back_on_evict:
++        raise ValueError("emergency_evict_for_prefetch requires write_back_on_evict")
++
+     if (
+         config.l1_manager_config.gds_l1_config is not None
+         and config.l1_manager_config.memory_config.devdax_path
+@@ -471,6 +492,28 @@ def add_storage_manager_args(
+         help="The fraction of memory to evict when triggered (0.0 to 1.0). "
+         "Default is 0.2.",
+     )
++    eviction_group.add_argument(
++        "--write-back-on-evict",
++        action="store_true",
++        help="Flush evicted L1 objects to L2 synchronously and delete them "
++        "from L1 only once every key in the batch is durable. Requires an "
++        "L2 adapter with a synchronous store path.",
++    )
++    eviction_group.add_argument(
++        "--periodic-flush-interval",
++        type=float,
++        default=0.0,
++        help="Seconds between periodic L1-to-L2 backup flush scans while "
++        "below the eviction watermark (0 disables). The backup keeps the "
++        "L1 copy; only L2 gains a copy.",
++    )
++    eviction_group.add_argument(
++        "--emergency-evict-for-prefetch",
++        action="store_true",
++        help="Allow the prefetch controller to synchronously evict LRU L1 "
++        "keys to make room for large L2-to-L1 restores. Effective only "
++        "together with --write-back-on-evict.",
++    )
+ 
+     # L2 Policies
+     # Import here to break circular dependency:
+@@ -596,6 +639,11 @@ def parse_args_to_config(
+         eviction_ratio=args.eviction_ratio,
+         extra_logging_enabled=getattr(args, "enable_extra_logging", False),
+         extra_logging_interval=getattr(args, "extra_logging_interval", 10.0),
++        write_back_on_evict=getattr(args, "write_back_on_evict", False),
++        periodic_flush_interval=getattr(args, "periodic_flush_interval", 0.0),
++        emergency_evict_for_prefetch=getattr(
++            args, "emergency_evict_for_prefetch", False
++        ),
+     )
+ 
+     l2_adapter_config = parse_args_to_l2_adapters_config(args)
+diff --git a/lmcache/v1/distributed/l1_manager.py b/lmcache/v1/distributed/l1_manager.py
+index 44cf55f615f2bf491bdf72784ac152a7ee422457..4a2be000b86a576759cb3d5579acbc45181b14e7 100644
+--- a/lmcache/v1/distributed/l1_manager.py
++++ b/lmcache/v1/distributed/l1_manager.py
+@@ -5,6 +5,7 @@ Managing objects and memory for L1 cache
+ 
+ # Standard
+ from dataclasses import dataclass
++from itertools import chain, islice
+ from typing import Literal
+ import threading
+ 
+@@ -462,6 +463,11 @@ class L1Manager:
+         Errors:
+             KEY_NOT_WRITABLE: The key exists but is not writable.
+             OUT_OF_MEMORY: Not enough memory to allocate for the object.
++
++        Note:
++            When the full batch does not fit, the longest prefix of the
++            to-be-allocated keys that fits is allocated and the remaining
++            keys report OUT_OF_MEMORY.
+         """
+         need_to_allocate: list[tuple[ObjectKey, bool]] = []
+         ret: dict[ObjectKey, L1OperationResult] = {}
+@@ -499,6 +505,26 @@ class L1Manager:
+             layout_desc, len(need_to_allocate)
+         )
+ 
++        # A full-batch allocation failure would fail every key even when
++        # most of the batch fits, collapsing large L2->L1 restores to zero
++        # prefix hits and forcing full re-prefills upstream. Fall back to
++        # allocating the longest prefix that fits; callers already handle
++        # per-key OOM (prefetch trims to the contiguous prefix, the store
++        # path skips failed keys).
++        if err != L1Error.SUCCESS and len(need_to_allocate) > 1:
++            if allocated_objs:
++                self._memory_manager.free(allocated_objs)
++                allocated_objs = []
++            err, allocated_objs = self._allocate_largest_prefix(
++                layout_desc, len(need_to_allocate)
++            )
++            if err == L1Error.SUCCESS:
++                logger.warning(
++                    "Partial L1 allocation: %d/%d objects (prefix) allocated",
++                    len(allocated_objs),
++                    len(need_to_allocate),
++                )
++
+         if err != L1Error.SUCCESS:
+             for key, _ in need_to_allocate:
+                 ret[key] = (L1Error.OUT_OF_MEMORY, None)
+@@ -508,6 +534,10 @@ class L1Manager:
+                 self._memory_manager.free(allocated_objs)
+ 
+         else:
++            # Mark any unallocated tail as OOM so every requested key keeps
++            # an explicit per-key result.
++            for key, _ in need_to_allocate[len(allocated_objs) :]:
++                ret[key] = (L1Error.OUT_OF_MEMORY, None)
+             for (key, is_temp), mem_obj in zip(
+                 need_to_allocate, allocated_objs, strict=False
+             ):
+@@ -531,6 +561,41 @@ class L1Manager:
+         )
+         return ret
+ 
++    def _allocate_largest_prefix(
++        self, layout_desc: MemoryLayoutDesc, want: int
++    ) -> tuple[L1Error, list[MemoryObj]]:
++        """Allocate the largest prefix below an already-failed full batch.
++
++        L1 allocators have an all-or-nothing batch contract. While holding the
++        L1 manager lock, allocation feasibility is therefore monotonic: if a
++        batch of size ``n`` fits, every smaller batch also fits. Binary search
++        finds the maximum without relying on byte estimates that can be wrong
++        for alignment or fragmented free lists. Successful probes are freed
++        before the final allocation.
++
++        This recovery path runs only after the ``want`` allocation failed, so
++        normal reservations still perform exactly one allocation.
++        """
++        low = 1
++        high = want - 1
++        largest = 0
++
++        while low <= high:
++            candidate = (low + high) // 2
++            err, objects = self._memory_manager.allocate(layout_desc, candidate)
++            if err == L1Error.SUCCESS:
++                largest = candidate
++                self._memory_manager.free(objects)
++                low = candidate + 1
++            else:
++                if objects:
++                    self._memory_manager.free(objects)
++                high = candidate - 1
++
++        if largest == 0:
++            return L1Error.OUT_OF_MEMORY, []
++        return self._memory_manager.allocate(layout_desc, largest)
++
+     @l1_mgr_synchronized
+     def finish_write(
+         self,
+@@ -793,6 +858,59 @@ class L1Manager:
+             locked_count,
+         )
+ 
++    @l1_mgr_synchronized
++    def get_evictable_keys(
++        self,
++        limit: int,
++        cursor: int = 0,
++        scan_limit: int | None = None,
++    ) -> tuple[list[ObjectKey], int]:
++        """Return a bounded, rotating batch of evictable keys.
++
++        ``cursor`` is an insertion-order offset returned by the previous call.
++        The scan wraps once and inspects at most ``scan_limit`` entries, so a
++        periodic backup cannot materialize the complete L1 keyspace while the
++        manager lock is held. Concurrent insertions or removals may shift the
++        offset, but every returned key is revalidated by ``reserve_read``.
++
++        Args:
++            limit: Maximum number of keys to return.
++            cursor: Insertion-order offset at which to resume scanning.
++            scan_limit: Maximum entries to inspect. Defaults to four batches.
++
++        Returns:
++            A pair of the eligible keys and the cursor for the next call.
++        """
++        if limit <= 0 or not self._objects:
++            return [], 0
++
++        object_count = len(self._objects)
++        start = cursor % object_count
++        max_scan = min(
++            object_count,
++            max(limit, scan_limit if scan_limit is not None else limit * 4),
++        )
++        ordered_keys = chain(
++            islice(self._objects, start, None),
++            islice(self._objects, 0, start),
++        )
++        keys: list[ObjectKey] = []
++        scanned = 0
++        for key in ordered_keys:
++            scanned += 1
++            if self.is_key_evictable(key):
++                keys.append(key)
++                if len(keys) >= limit:
++                    break
++            if scanned >= max_scan:
++                break
++        return keys, (start + scanned) % object_count
++
++    @l1_mgr_synchronized
++    def num_objects(self) -> int:
++        """Return the number of objects currently tracked in L1."""
++        return len(self._objects)
++
+     def is_key_evictable(self, key: ObjectKey) -> bool:
+         """Check if a key is eligible for eviction (not locked).
+ 
+diff --git a/lmcache/v1/distributed/l2_adapters/base.py b/lmcache/v1/distributed/l2_adapters/base.py
+index 1838553e285ce0f2c7a0b3d9a3180b6ad57ed499..910cec00199586224936da8b0323a02659cc74c1 100644
+--- a/lmcache/v1/distributed/l2_adapters/base.py
++++ b/lmcache/v1/distributed/l2_adapters/base.py
+@@ -354,13 +354,8 @@ class L2AdapterInterface(ABC):
+         """Register a listener to receive L2 adapter events."""
+         self._listeners.append(listener)
+ 
+-    def _notify_keys_stored(self, keys: list[ObjectKey], sizes: list[int]) -> None:
+-        """Update byte accounting and notify listeners that ``keys`` were
+-        stored. ``sizes[i]`` is the byte size of ``keys[i]``.
+-
+-        Accounting is held under ``_usage_lock``; listener callbacks fire
+-        outside the lock so a slow listener cannot stall further notifies.
+-        """
++    def _account_keys_stored(self, keys: list[ObjectKey], sizes: list[int]) -> None:
++        """Apply stored-key byte accounting without invoking listeners."""
+         # Aggregate per-salt deltas before touching
+         # ``_bytes_by_cache_salt`` — one dict read/write per unique
+         # salt instead of one per key. This matters when the registry is
+@@ -377,9 +372,26 @@ class L2AdapterInterface(ABC):
+                 self._bytes_by_cache_salt[salt] = (
+                     self._bytes_by_cache_salt.get(salt, 0) + d
+                 )
++
++    def _notify_keys_stored_listeners(
++        self,
++        keys: list[ObjectKey],
++        sizes: list[int],
++    ) -> None:
++        """Notify stored-key observers after accounting is committed."""
+         for listener in self._listeners:
+             listener.on_l2_keys_stored(keys, sizes)
+ 
++    def _notify_keys_stored(self, keys: list[ObjectKey], sizes: list[int]) -> None:
++        """Update byte accounting and notify listeners that ``keys`` were
++        stored. ``sizes[i]`` is the byte size of ``keys[i]``.
++
++        Accounting is held under ``_usage_lock``; listener callbacks fire
++        outside the lock so a slow listener cannot stall further notifies.
++        """
++        self._account_keys_stored(keys, sizes)
++        self._notify_keys_stored_listeners(keys, sizes)
++
+     def _notify_keys_accessed(self, keys: list[ObjectKey]) -> None:
+         # ``_notify_keys_accessed`` carries no byte impact — only LRU
+         # bookkeeping cares about it, so no accounting is needed here.
+diff --git a/lmcache/v1/distributed/l2_adapters/fs_native_l2_adapter.py b/lmcache/v1/distributed/l2_adapters/fs_native_l2_adapter.py
+index 2d703499d20c5aa1c0ecc8e1f0667f2bf857c6a2..dacdead73b3eb1a34bec530fe14c535759607b2a 100644
+--- a/lmcache/v1/distributed/l2_adapters/fs_native_l2_adapter.py
++++ b/lmcache/v1/distributed/l2_adapters/fs_native_l2_adapter.py
+@@ -10,9 +10,11 @@ Backed by the native C++ filesystem connector wrapped with
+ from __future__ import annotations
+ 
+ # Standard
++from pathlib import Path
+ from typing import TYPE_CHECKING, Optional
+ 
+ if TYPE_CHECKING:
++    from lmcache.v1.distributed.api import ObjectKey
+     from lmcache.v1.distributed.internal_api import (
+         L1MemoryDesc,
+     )
+@@ -158,7 +160,7 @@ def _create_fs_native_l2_adapter(
+         config.use_odirect,
+         config.read_ahead_size,
+     )
+-    return NativeConnectorL2Adapter(
++    adapter = NativeConnectorL2Adapter(
+         native_client,
+         max_capacity_gb=config.max_capacity_gb,
+         type_name="FSNativeL2Adapter",
+@@ -169,6 +171,53 @@ def _create_fs_native_l2_adapter(
+             "read_ahead_size": config.read_ahead_size,
+         },
+     )
++    try:
++        keys, sizes = _scan_existing_fs_native_files(config.base_path)
++        adapter.prime_existing_keys(keys, sizes)
++    except Exception:
++        adapter.close()
++        raise
++    return adapter
++
++
++def _scan_existing_fs_native_files(
++    base_path: str,
++) -> tuple[list["ObjectKey"], list[int]]:
++    """Recover durable keys and sizes, ordered from oldest to newest."""
++    # First Party
++    from lmcache.v1.distributed.l2_adapters.fs_l2_adapter import (
++        _filename_to_object_key,
++    )
++
++    root = Path(base_path)
++    if not root.is_dir():
++        return [], []
++
++    entries: list[tuple[int, str, ObjectKey, int]] = []
++    for path in root.glob("*.data"):
++        try:
++            if not path.is_file():
++                continue
++            key = _filename_to_object_key(path.name)
++            if key is None:
++                logger.warning("Ignoring unrecognized cache file: %s", path)
++                continue
++            stat = path.stat()
++            if stat.st_size <= 0:
++                logger.warning("Ignoring empty cache file: %s", path)
++                continue
++            entries.append((stat.st_mtime_ns, path.name, key, stat.st_size))
++        except OSError as exc:
++            # Silently omitting a durable object would under-report usage and
++            # seed an incomplete eviction index. Fail adapter construction so
++            # the operator can repair the directory or retry the startup scan.
++            raise RuntimeError(f"Could not inspect cache file {path}: {exc}") from exc
++
++    entries.sort(key=lambda entry: (entry[0], entry[1]))
++    return (
++        [entry[2] for entry in entries],
++        [entry[3] for entry in entries],
++    )
+ 
+ 
+ register_l2_adapter_type("fs_native", FSNativeL2AdapterConfig)
+diff --git a/lmcache/v1/distributed/l2_adapters/native_connector_l2_adapter.py b/lmcache/v1/distributed/l2_adapters/native_connector_l2_adapter.py
+index c10d3802dfbdba50b6a49e4d764ebf10a567a0df..e3a73e35d5f5316f9d9dd0dcbc5d57b949661be6 100644
+--- a/lmcache/v1/distributed/l2_adapters/native_connector_l2_adapter.py
++++ b/lmcache/v1/distributed/l2_adapters/native_connector_l2_adapter.py
+@@ -30,7 +30,7 @@ import threading
+ from lmcache.logging import init_logger
+ from lmcache.native_storage_ops import Bitmap
+ from lmcache.v1.distributed.api import MemoryLayoutDesc, ObjectKey
+-from lmcache.v1.distributed.internal_api import L2StoreResult
++from lmcache.v1.distributed.internal_api import L2AdapterListener, L2StoreResult
+ from lmcache.v1.distributed.l2_adapters.base import (
+     L2AdapterInterface,
+     L2TaskId,
+@@ -98,6 +98,7 @@ class NativeConnectorL2Adapter(L2AdapterInterface):
+ 
+     # Operation type tags for the pending-ops map
+     _OP_STORE = "store"
++    _OP_SYNC_STORE = "sync_store"
+     _OP_LOOKUP = "lookup"
+     _OP_LOAD = "load"
+     _OP_DELETE = "delete"
+@@ -144,6 +145,12 @@ class NativeConnectorL2Adapter(L2AdapterInterface):
+         # Pending delete events for synchronous delete() calls
+         self._pending_delete_events: dict[L2TaskId, threading.Event] = {}
+ 
++        # Synchronous stores use private completions so StoreController cannot
++        # consume another thread's result from _completed_stores.
++        self._pending_sync_store_events: dict[
++            L2TaskId, tuple[threading.Event, dict[str, Any]]
++        ] = {}
++
+         # Per-key size tracking. ``_key_sizes`` lets us look up byte sizes
+         # at delete time (the native completion only carries booleans, not
+         # sizes) so we can pass them to ``_notify_keys_deleted``. Aggregate
+@@ -154,6 +161,12 @@ class NativeConnectorL2Adapter(L2AdapterInterface):
+         # demux thread can fire ``_notify_keys_stored(keys, sizes)``.
+         self._pending_store_sizes: dict[int, tuple[list[ObjectKey], list[int]]] = {}
+ 
++        # A filesystem factory may prime durable objects before the eviction
++        # listener exists. Keep one temporary startup snapshot for that first
++        # listener; _key_sizes remains the sole long-lived key index.
++        self._startup_primed = False
++        self._startup_replay: tuple[list[ObjectKey], list[int]] | None = None
++
+         # Task ID counter
+         self._next_task_id: L2TaskId = 0
+ 
+@@ -219,6 +232,71 @@ class NativeConnectorL2Adapter(L2AdapterInterface):
+             self._completed_stores = {}
+         return completed
+ 
++    def store_objects_sync(
++        self,
++        keys: list[ObjectKey],
++        objects: list[MemoryObj],
++        timeout: float | None = None,
++    ) -> tuple[bool, int, int]:
++        """Persist objects and wait for their native backend completion.
++
++        Returns ``(success, persisted_count, bytes_written)``. ``success`` is
++        true only when every key persisted, while the other fields account
++        for successful keys in a partially failed batch.
++        """
++        if len(keys) != len(objects):
++            raise ValueError("keys and objects length mismatch")
++        if not keys:
++            return True, 0, 0
++        if timeout is not None and timeout <= 0:
++            raise ValueError("timeout must be positive")
++
++        key_strings = [_object_key_to_string(key) for key in keys]
++        memviews = [_obj_to_memoryview(obj) for obj in objects]
++        per_key_sizes = [obj.get_size() for obj in objects]
++        done_event = threading.Event()
++        result: dict[str, Any] = {
++            "ok": False,
++            "persisted_count": 0,
++            "bytes_written": 0,
++        }
++
++        with self._lock:
++            task_id = self._get_next_task_id()
++            future_id = int(self._client.submit_batch_set(key_strings, memviews))
++            self._pending_ops[future_id] = (
++                self._OP_SYNC_STORE,
++                task_id,
++                len(keys),
++                None,
++            )
++            self._pending_store_sizes[future_id] = (list(keys), per_key_sizes)
++            self._pending_sync_store_events[task_id] = (done_event, result)
++
++        wait_timeout = (
++            timeout if timeout is not None else max(30.0, min(300.0, len(keys) * 5.0))
++        )
++        if not done_event.wait(timeout=wait_timeout):
++            with self._lock:
++                self._pending_sync_store_events.pop(task_id, None)
++                for fid, entry in list(self._pending_ops.items()):
++                    if entry[1] == task_id:
++                        self._pending_ops.pop(fid, None)
++                        self._pending_store_sizes.pop(fid, None)
++                        break
++            logger.warning(
++                "store_objects_sync() timed out after %.1fs for %d keys",
++                wait_timeout,
++                len(keys),
++            )
++            return False, 0, 0
++
++        return (
++            bool(result["ok"]),
++            int(result["persisted_count"]),
++            int(result["bytes_written"]),
++        )
++
+     # ---------------------------------------------------------------
+     # Lookup and Lock Interface
+     # ---------------------------------------------------------------
+@@ -297,22 +375,46 @@ class NativeConnectorL2Adapter(L2AdapterInterface):
+         tracking stays in sync.
+ 
+         No-op if the connector does not expose ``submit_batch_delete``
+-        or if the key list is empty.
++        or if the key list is empty. Keys currently lookup-locked by an
++        in-flight prefetch are skipped: the load task would race the
++        unlink and fail with a phantom not_found.
+         """
+         if not keys or not self._has_delete:
+             return
+ 
+-        key_strings = [_object_key_to_string(k) for k in keys]
+         done_event = threading.Event()
+ 
+         with self._lock:
++            # A key becomes lookup-locked only when the native EXISTS
++            # completion is demultiplexed. Protect pending lookup keys as
++            # well, otherwise eviction can delete a key between lookup
++            # submission and lock acquisition. Filtering and delete submit
++            # stay in one critical section so a new lookup cannot enter that
++            # same gap.
++            protected_keys = set(self._locked_keys)
++            for op_type, _task_id, _num_keys, op_keys in self._pending_ops.values():
++                if op_type == self._OP_LOOKUP and op_keys is not None:
++                    protected_keys.update(op_keys)
++
++            delete_keys = [key for key in keys if key not in protected_keys]
++            skipped_count = len(keys) - len(delete_keys)
++            if skipped_count:
++                logger.info(
++                    "delete(): skipping %d lookup-pending or locked keys; %d remain",
++                    skipped_count,
++                    len(delete_keys),
++                )
++            if not delete_keys:
++                return
++
++            key_strings = [_object_key_to_string(k) for k in delete_keys]
+             task_id = self._get_next_task_id()
+             future_id = int(self._client.submit_batch_delete(key_strings))
+             self._pending_ops[future_id] = (
+                 self._OP_DELETE,
+                 task_id,
+-                len(keys),
+-                list(keys),
++                len(delete_keys),
++                delete_keys,
+             )
+             self._pending_delete_events[task_id] = done_event
+ 
+@@ -328,7 +430,7 @@ class NativeConnectorL2Adapter(L2AdapterInterface):
+                         break
+             logger.warning(
+                 "delete() timed out after 30s for %d keys",
+-                len(keys),
++                len(delete_keys),
+             )
+             return
+ 
+@@ -345,6 +447,52 @@ class NativeConnectorL2Adapter(L2AdapterInterface):
+     # Status Interface
+     # ---------------------------------------------------------------
+ 
++    def prime_existing_keys(
++        self,
++        keys: list[ObjectKey],
++        sizes: list[int],
++    ) -> None:
++        """Account durable objects discovered before adapter registration."""
++        if len(keys) != len(sizes):
++            raise ValueError("keys and sizes length mismatch")
++
++        unique: dict[ObjectKey, int] = {}
++        for key, size in zip(keys, sizes, strict=True):
++            if size <= 0:
++                raise ValueError("existing object sizes must be positive")
++            unique.setdefault(key, int(size))
++
++        primed_keys = list(unique)
++        primed_sizes = list(unique.values())
++        with self._lock:
++            if self._startup_primed:
++                raise RuntimeError("existing keys were already primed")
++            if self._listeners:
++                raise RuntimeError("existing keys must be primed before listeners")
++            self._startup_primed = True
++            self._key_sizes.update(unique)
++            self._startup_replay = (primed_keys, primed_sizes)
++
++        # No listener is registered during factory construction. This uses
++        # the common accounting implementation without retaining a second
++        # byte-accounting path in this adapter.
++        if primed_keys:
++            self._notify_keys_stored(primed_keys, primed_sizes)
++            logger.info(
++                "Startup scan primed %.2f GB in %d existing objects",
++                sum(primed_sizes) / 1e9,
++                len(primed_keys),
++            )
++
++    def register_listener(self, listener: L2AdapterListener) -> None:
++        """Register a listener and replay the one-time startup snapshot."""
++        with self._lock:
++            replay = self._startup_replay
++            self._startup_replay = None
++        if replay is not None and replay[0]:
++            listener.on_l2_keys_stored(*replay)
++        super().register_listener(listener)
++
+     def report_status(self) -> dict[str, Any]:
+         """Return a status dict for this native-connector L2 adapter.
+ 
+@@ -372,6 +520,14 @@ class NativeConnectorL2Adapter(L2AdapterInterface):
+         self._stop.set()
+         self._demux_thread.join(timeout=5)
+ 
++        with self._lock:
++            sync_events = [
++                event for event, _result in self._pending_sync_store_events.values()
++            ]
++            self._pending_sync_store_events.clear()
++        for event in sync_events:
++            event.set()
++
+         self._client.close()
+ 
+         self._store_efd.close()
+@@ -425,6 +581,7 @@ class NativeConnectorL2Adapter(L2AdapterInterface):
+             # the caller unblocks and calls ``get_usage()``, the base
+             # class's byte counters already reflect the deletion.
+             delete_done_events: list[threading.Event] = []
++            sync_store_done_events: list[threading.Event] = []
+ 
+             with self._lock:
+                 for (
+@@ -449,12 +606,30 @@ class NativeConnectorL2Adapter(L2AdapterInterface):
+                         lookup_keys,
+                     ) = entry
+ 
+-                    if op_type == self._OP_STORE:
++                    if op_type in (self._OP_STORE, self._OP_SYNC_STORE):
+                         store_info = self._pending_store_sizes.pop(fid, None)
+                         task_bytes = 0
+-                        if ok and store_info is not None:
++                        persisted_count = 0
++                        completion_ok = False
++                        if store_info is not None:
+                             store_keys, sizes = store_info
+-                            for key, size in zip(store_keys, sizes, strict=True):
++                            if result_bools is None:
++                                stored_flags = [bool(ok)] * len(store_keys)
++                            else:
++                                stored_flags = [bool(value) for value in result_bools]
++                                if len(stored_flags) < len(store_keys):
++                                    stored_flags.extend(
++                                        [False] * (len(store_keys) - len(stored_flags))
++                                    )
++                                elif len(stored_flags) > len(store_keys):
++                                    stored_flags = stored_flags[: len(store_keys)]
++                            completion_ok = bool(ok) and all(stored_flags)
++                            for key, size, stored in zip(
++                                store_keys, sizes, stored_flags, strict=True
++                            ):
++                                if not stored:
++                                    continue
++                                persisted_count += 1
+                                 # First-store wins for byte accounting:
+                                 # a re-store of an existing key adds 0
+                                 # bytes (the backend already holds it).
+@@ -470,8 +645,21 @@ class NativeConnectorL2Adapter(L2AdapterInterface):
+                                 else:
+                                     keys_stored.append(key)
+                                     sizes_stored.append(0)
+-                        self._completed_stores[task_id] = L2StoreResult(ok, task_bytes)
+-                        self._store_efd.notify()
++                        if op_type == self._OP_STORE:
++                            self._completed_stores[task_id] = L2StoreResult(
++                                completion_ok, task_bytes
++                            )
++                            self._store_efd.notify()
++                        else:
++                            sync_entry = self._pending_sync_store_events.pop(
++                                task_id, None
++                            )
++                            if sync_entry is not None:
++                                sync_event, sync_result = sync_entry
++                                sync_result["ok"] = completion_ok
++                                sync_result["persisted_count"] = persisted_count
++                                sync_result["bytes_written"] = task_bytes
++                                sync_store_done_events.append(sync_event)
+ 
+                     elif op_type == self._OP_LOOKUP:
+                         bitmap = Bitmap(num_keys)
+@@ -519,10 +707,17 @@ class NativeConnectorL2Adapter(L2AdapterInterface):
+                         if evt is not None:
+                             delete_done_events.append(evt)
+ 
+-            # Fire listener notifications outside the lock so a slow
+-            # listener cannot stall further demux iterations.
++            # Commit byte accounting before releasing synchronous callers.
++            if keys_stored:
++                self._account_keys_stored(keys_stored, sizes_stored)
++            for evt in sync_store_done_events:
++                evt.set()
++
++            # Observer callbacks remain outside the lock and after synchronous
++            # durability completion. A slow observer must not defeat a caller's
++            # store timeout after persistence and accounting have committed.
+             if keys_stored:
+-                self._notify_keys_stored(keys_stored, sizes_stored)
++                self._notify_keys_stored_listeners(keys_stored, sizes_stored)
+             if keys_accessed:
+                 self._notify_keys_accessed(keys_accessed)
+             if keys_deleted:
+diff --git a/lmcache/v1/distributed/storage_controllers/eviction_controller.py b/lmcache/v1/distributed/storage_controllers/eviction_controller.py
+index 8624207de385ab334a102852b6d1b7c19d3182b0..b777b2fa7ab8c1dc9caca4c5c849ad51eff9a17d 100644
+--- a/lmcache/v1/distributed/storage_controllers/eviction_controller.py
++++ b/lmcache/v1/distributed/storage_controllers/eviction_controller.py
+@@ -7,6 +7,8 @@ from __future__ import annotations
+ from abc import abstractmethod
+ from collections import Counter
+ from typing import TYPE_CHECKING
++import inspect
++import math
+ import threading
+ import time
+ 
+@@ -16,6 +18,7 @@ from lmcache.v1.distributed.api import ObjectKey
+ from lmcache.v1.distributed.config import EvictionConfig
+ from lmcache.v1.distributed.eviction import L1EvictionPolicy, L2EvictionPolicy
+ from lmcache.v1.distributed.eviction_policy import CreateEvictionPolicy
++from lmcache.v1.distributed.error import L1Error
+ from lmcache.v1.distributed.internal_api import (
+     EvictionAction,
+     EvictionDestination,
+@@ -92,12 +95,31 @@ class L1EvictionController(EvictionController):
+     Uses an L1EvictionPolicy bridge to keep the eviction policy up-to-date
+     with L1 manager events, and periodically triggers eviction based on
+     L1 memory usage.
++
++    With ``EvictionConfig.write_back_on_evict`` enabled and L2 adapters
++    injected via ``set_l2_adapters``, eviction actions target
++    ``EvictionDestination.L2_CACHE``: readable objects are synchronously
++    persisted to L2 in bounded batches and deleted from L1 only once every
++    key in the batch is durable. Repeated flush failures open a circuit
++    breaker that pauses write-back instead of retrying every second.
++
++    ``EvictionConfig.periodic_flush_interval`` additionally enables a
++    below-watermark backup flush that copies evictable L1 keys to L2
++    without deleting them from L1.
+     """
+ 
++    # Bounded batches keep each blocking sync-store call short.
++    _SYNC_FLUSH_BATCH_SIZE = 128
++    # Keys per periodic backup flush cycle.
++    _BACKUP_FLUSH_BATCH_SIZE = 128
++    # A prefetch request must not stall the controller indefinitely on L2.
++    _EMERGENCY_FLUSH_TIMEOUT_SECONDS = 1.0
++
+     def __init__(
+         self,
+         l1_manager: L1Manager,
+         eviction_config: EvictionConfig,
++        l2_adapters: dict[int, L2AdapterInterface] | None = None,
+     ):
+         super().__init__()
+         self._eviction_config = eviction_config
+@@ -108,13 +130,78 @@ class L1EvictionController(EvictionController):
+         self._event_bus = get_event_bus()
+         self._last_extra_log = time.monotonic()
+ 
++        self._write_back_enabled = bool(eviction_config.write_back_on_evict)
++        self._l2_adapters: dict[int, L2AdapterInterface] = {}
++        self._l2_adapters_lock = threading.Lock()
++        # Serializes all synchronous L2 flushes and adapter-set replacement.
++        # StorageManager can therefore remove an adapter only after any L1
++        # writeback currently using it has finished.
++        self._flush_lock = threading.Lock()
++        # Sync-flush circuit breaker: a dead L2 must not cause a
++        # multi-thousand-key synchronous retry and warning storm every
++        # second.
++        self._sync_flush_failures: int = 0
++        self._sync_flush_backoff_until: float = 0.0
++        self._last_backup_flush = time.monotonic()
++        self._backup_flush_cursor: int = 0
++        # Serializes emergency evictions from concurrent callers.
++        self._emergency_evict_lock = threading.Lock()
++        if self._write_back_enabled:
++            # Writeback must fail closed. Register the L2 destination even
++            # before a compatible adapter exists so policy never falls back
++            # to DISCARD when persistence is unavailable.
++            self._eviction_policy.register_eviction_destination(
++                EvictionDestination.L2_CACHE
++            )
++        if l2_adapters:
++            self.set_l2_adapters(l2_adapters)
++
++    def set_l2_adapters(self, l2_adapters: dict[int, L2AdapterInterface]) -> None:
++        """Late-inject L2 adapters after StorageManager creates them.
++
++        Only adapters with an explicit synchronous durability contract are
++        eligible. The L2 eviction destination itself is registered at
++        construction so enabled writeback always fails closed.
++        """
++        compatible = {
++            adapter_id: adapter
++            for adapter_id, adapter in l2_adapters.items()
++            if callable(getattr(adapter, "store_objects_sync", None))
++        }
++        ignored = sorted(set(l2_adapters) - set(compatible))
++        if ignored:
++            logger.warning(
++                "L1 writeback ignored adapters without store_objects_sync: %s",
++                ignored,
++            )
++        with self._flush_lock:
++            with self._l2_adapters_lock:
++                self._l2_adapters = compatible
++
++    def has_l2_flush_adapter(self) -> bool:
++        """Return whether a synchronous durability backend is available."""
++        return bool(self._snapshot_l2_adapters())
++
++    def _snapshot_l2_adapters(self) -> list[tuple[int, L2AdapterInterface]]:
++        with self._l2_adapters_lock:
++            return list(self._l2_adapters.items())
++
+     def report_status(self) -> dict:
++        adapters = self._snapshot_l2_adapters()
+         return {
+             "is_healthy": self._thread.is_alive(),
+             "thread_alive": self._thread.is_alive(),
+             "eviction_policy": self._eviction_config.eviction_policy,
+             "trigger_watermark": self._eviction_config.trigger_watermark,
+             "eviction_ratio": self._eviction_config.eviction_ratio,
++            "write_back_enabled": self._write_back_enabled,
++            "l2_flush_enabled": bool(adapters),
++            "l2_flush_adapter_ids": [adapter_id for adapter_id, _ in adapters],
++            "periodic_flush_interval": (self._eviction_config.periodic_flush_interval),
++            "sync_flush_failures": self._sync_flush_failures,
++            "sync_flush_backoff_seconds": max(
++                0.0, self._sync_flush_backoff_until - time.monotonic()
++            ),
+         }
+ 
+     def _publish_skipped(self, usage: float, watermark: float) -> None:
+@@ -160,6 +247,7 @@ class L1EvictionController(EvictionController):
+     def eviction_loop(self):
+         watermark = self._eviction_config.trigger_watermark
+         eviction_ratio = self._eviction_config.eviction_ratio
++        backup_interval = self._eviction_config.periodic_flush_interval
+ 
+         while not self._stop_flag.is_set():
+             time.sleep(1)
+@@ -168,6 +256,13 @@ class L1EvictionController(EvictionController):
+                 self._maybe_log_memory_usage(used_bytes, total_bytes)
+             usage = 0 if total_bytes == 0 else used_bytes / total_bytes
+             if usage < watermark:
++                if (
++                    backup_interval > 0
++                    and self._snapshot_l2_adapters()
++                    and time.monotonic() - self._last_backup_flush >= backup_interval
++                ):
++                    self._last_backup_flush = time.monotonic()
++                    self._backup_to_l2_no_delete(self._BACKUP_FLUSH_BATCH_SIZE)
+                 logger.debug(
+                     "L1 memory usage %.2f below watermark %.2f; skipping eviction.",
+                     usage,
+@@ -176,6 +271,13 @@ class L1EvictionController(EvictionController):
+                 self._publish_skipped(usage, watermark)
+                 continue
+ 
++            if (
++                self._write_back_enabled
++                and time.monotonic() < self._sync_flush_backoff_until
++            ):
++                self._publish_skipped(usage, watermark)
++                continue
++
+             logger.info(
+                 "L1 memory usage %.2f above watermark %.2f; triggering eviction.",
+                 usage,
+@@ -190,13 +292,309 @@ class L1EvictionController(EvictionController):
+             self._publish_triggered(usage, watermark)
+ 
+     def execute_eviction_action(self, action: EvictionAction):
+-        if action.destination == EvictionDestination.DISCARD:
++        if action.destination == EvictionDestination.L2_CACHE:
++            self._flush_to_l2_then_delete(action.keys)
++        elif action.destination == EvictionDestination.DISCARD:
+             self._l1_manager.delete(action.keys)
+         else:
+             logger.error("Unsupported eviction destination: %s", action.destination)
+             logger.error("Treating it as DISCARD.")
+             self._l1_manager.delete(action.keys)
+ 
++    def emergency_evict_bytes(self, target_free_bytes: int, requester: str = "") -> int:
++        """Synchronously evict LRU L1 keys until at least
++        ``target_free_bytes`` bytes are free.
++
++        Victims take the normal eviction path, so with write-back enabled
++        they are flushed to L2 before deletion. Intended for the prefetch
++        controller when a large L2-to-L1 restore cannot reserve L1 buffers.
++
++        Args:
++            target_free_bytes: The free-space goal in bytes.
++            requester: Optional label for logging.
++
++        Returns:
++            The free byte count after eviction.
++        """
++        deadline = time.monotonic() + self._EMERGENCY_FLUSH_TIMEOUT_SECONDS
++        if not self._emergency_evict_lock.acquire(
++            timeout=self._EMERGENCY_FLUSH_TIMEOUT_SECONDS
++        ):
++            used, total = self._l1_manager.get_memory_usage()
++            return max(0, total - used)
++        try:
++            used, total = self._l1_manager.get_memory_usage()
++            free = max(0, total - used)
++            if free >= target_free_bytes:
++                return free
++            deficit = target_free_bytes - free
++            num_objects = self._l1_manager.num_objects()
++            if num_objects <= 0:
++                return free
++            if self._write_back_enabled and (
++                time.monotonic() < self._sync_flush_backoff_until
++                or not self.has_l2_flush_adapter()
++            ):
++                return free
++            per_key = max(1, used // num_objects)
++            need_keys = math.ceil(deficit / per_key)
++            need_keys += max(1, math.ceil(need_keys / 8))
++            tracked = num_objects
++            get_tracked = getattr(self._eviction_policy, "get_num_tracked_keys", None)
++            if callable(get_tracked):
++                tracked = max(1, int(get_tracked()))
++            ratio = min(1.0, need_keys / max(tracked, 1))
++            start = time.monotonic()
++            actions = self._eviction_policy.get_eviction_actions(
++                ratio,
++                key_eligible_filter=self._l1_manager.is_key_evictable,
++            )
++            evicted_keys = 0
++            for action in actions:
++                evicted_keys += len(action.keys)
++                if action.destination == EvictionDestination.L2_CACHE:
++                    self._flush_to_l2_then_delete(action.keys, deadline=deadline)
++                else:
++                    self.execute_eviction_action(action)
++                if time.monotonic() >= deadline:
++                    break
++            used_after, total_after = self._l1_manager.get_memory_usage()
++            free_after = max(0, total_after - used_after)
++            logger.info(
++                "Emergency L1 eviction%s: wanted %.0f MB free, evicted %d "
++                "keys in %.0f ms; free %.0f MB -> %.0f MB",
++                (" for " + requester) if requester else "",
++                target_free_bytes / 1e6,
++                evicted_keys,
++                (time.monotonic() - start) * 1000.0,
++                free / 1e6,
++                free_after / 1e6,
++            )
++            return free_after
++        finally:
++            self._emergency_evict_lock.release()
++
++    def _flush_to_l2_then_delete(
++        self,
++        keys: list[ObjectKey],
++        deadline: float | None = None,
++    ) -> None:
++        """Persist bounded batches to L2 and delete only fully durable
++        batches from L1.
++
++        The native adapter reports a store successful only when every key
++        persisted, so this method conservatively retains the whole readable
++        batch on any partial failure. Repeated failures open the circuit
++        breaker with exponential backoff.
++        """
++        if deadline is None:
++            self._flush_lock.acquire()
++        else:
++            remaining = deadline - time.monotonic()
++            if remaining <= 0 or not self._flush_lock.acquire(timeout=remaining):
++                return
++        try:
++            if not keys:
++                return
++            if time.monotonic() < self._sync_flush_backoff_until:
++                return
++
++            all_ok = True
++            for start in range(0, len(keys), self._SYNC_FLUSH_BATCH_SIZE):
++                if deadline is not None and time.monotonic() >= deadline:
++                    all_ok = False
++                    break
++                batch = keys[start : start + self._SYNC_FLUSH_BATCH_SIZE]
++                if not self._flush_one_l2_batch_then_delete(batch, deadline=deadline):
++                    all_ok = False
++                    break
++
++            if all_ok:
++                self._sync_flush_failures = 0
++                self._sync_flush_backoff_until = 0.0
++            else:
++                self._sync_flush_failures += 1
++                delay = min(60.0, float(2 ** min(self._sync_flush_failures, 6)))
++                self._sync_flush_backoff_until = time.monotonic() + delay
++                logger.warning(
++                    "L1-to-L2 flush circuit breaker: failure=%d, retry in %.0fs; "
++                    "remaining L1 keys preserved",
++                    self._sync_flush_failures,
++                    delay,
++                )
++        finally:
++            self._flush_lock.release()
++
++    def _flush_one_l2_batch_then_delete(
++        self,
++        keys: list[ObjectKey],
++        deadline: float | None = None,
++    ) -> bool:
++        """Flush one batch to L2; delete from L1 only when fully durable.
++
++        Returns:
++            True when every readable key in the batch was persisted (or the
++            batch had no readable keys), False otherwise.
++        """
++        if not keys:
++            return True
++
++        read_result = self._l1_manager.reserve_read(keys)
++        readable_keys: list[ObjectKey] = []
++        readable_objs = []
++        for key in keys:
++            entry = read_result.get(key)
++            if (
++                entry is not None
++                and entry[0] == L1Error.SUCCESS
++                and entry[1] is not None
++            ):
++                readable_keys.append(key)
++                readable_objs.append(entry[1])
++
++        flushed = not readable_keys
++        if readable_keys:
++            try:
++                for idx, adapter in self._snapshot_l2_adapters():
++                    sync_store = adapter.store_objects_sync
++                    try:
++                        if deadline is None:
++                            result = sync_store(readable_keys, readable_objs)
++                        else:
++                            remaining = deadline - time.monotonic()
++                            if remaining <= 0:
++                                break
++                            try:
++                                supports_timeout = (
++                                    "timeout"
++                                    in inspect.signature(sync_store).parameters
++                                )
++                            except (TypeError, ValueError):
++                                supports_timeout = False
++                            if not supports_timeout:
++                                logger.warning(
++                                    "Emergency L1 writeback skipped adapter %d: "
++                                    "store_objects_sync has no timeout contract",
++                                    idx,
++                                )
++                                continue
++                            result = sync_store(
++                                readable_keys,
++                                readable_objs,
++                                timeout=remaining,
++                            )
++                        ok, persisted_count, bytes_written = result
++                    except Exception:
++                        logger.exception(
++                            "L1-to-L2 flush: sync store failed on adapter %d", idx
++                        )
++                        continue
++                    # Never delete unless every readable key is durable.
++                    if ok and persisted_count == len(readable_keys):
++                        flushed = True
++                        logger.info(
++                            "L1-to-L2 flush: sync persisted %d/%d keys "
++                            "(%d bytes) via adapter %d",
++                            persisted_count,
++                            len(readable_keys),
++                            bytes_written,
++                            idx,
++                        )
++                        break
++                    logger.warning(
++                        "L1-to-L2 flush: adapter %d partial/failed persist "
++                        "(%d/%d keys, %d bytes)",
++                        idx,
++                        persisted_count,
++                        len(readable_keys),
++                        bytes_written,
++                    )
++            finally:
++                self._l1_manager.finish_read(readable_keys)
++
++        # Only keys we read and then fully persisted may be deleted. A key
++        # that failed reserve_read can have become locked after candidate
++        # selection and must never be treated as absent.
++        keys_to_delete = list(readable_keys) if flushed else []
++        if not flushed and readable_keys:
++            logger.warning(
++                "L1-to-L2 flush: preserving %d readable keys after failed persist",
++                len(readable_keys),
++            )
++
++        if keys_to_delete:
++            result = self._l1_manager.delete(keys_to_delete)
++            not_deleted = [k for k, err in result.items() if err != L1Error.SUCCESS]
++            if not_deleted:
++                logger.debug(
++                    "L1-to-L2 flush: %d keys not deleted, likely still locked",
++                    len(not_deleted),
++                )
++        return flushed
++
++    def _backup_to_l2_no_delete(self, batch_limit: int) -> None:
++        """Flush evictable L1 keys to L2 without deleting them from L1.
++
++        A backup, not an eviction: keys remain in L1 for fast access while
++        L2 gains a copy, so losing L1 (session expiry, restart) no longer
++        costs a cold prefill. A rotating cursor spreads repeated scans over
++        the whole L1 keyspace instead of hammering the first ``batch_limit``
++        insertion-ordered keys forever. Adapters skip keys they already
++        hold, so the flush is idempotent.
++        """
++        with self._flush_lock:
++            self._backup_to_l2_no_delete_locked(batch_limit)
++
++    def _backup_to_l2_no_delete_locked(self, batch_limit: int) -> None:
++        """Implementation of periodic backup under ``_flush_lock``."""
++        batch, self._backup_flush_cursor = self._l1_manager.get_evictable_keys(
++            limit=batch_limit,
++            cursor=self._backup_flush_cursor,
++        )
++        if not batch:
++            return
++
++        read_result = self._l1_manager.reserve_read(batch)
++        readable_keys: list[ObjectKey] = []
++        readable_objs = []
++        for key in batch:
++            entry = read_result.get(key)
++            if (
++                entry is not None
++                and entry[0] == L1Error.SUCCESS
++                and entry[1] is not None
++            ):
++                readable_keys.append(key)
++                readable_objs.append(entry[1])
++
++        if not readable_keys:
++            return
++
++        persisted_keys = 0
++        persisted_bytes = 0
++        try:
++            for idx, adapter in self._snapshot_l2_adapters():
++                sync_store = adapter.store_objects_sync
++                try:
++                    ok, persisted, written = sync_store(readable_keys, readable_objs)
++                    if ok and persisted == len(readable_keys):
++                        persisted_keys = persisted
++                        persisted_bytes = written
++                        break
++                except Exception:
++                    logger.exception("Periodic L2 backup: sync store failed on %d", idx)
++        finally:
++            self._l1_manager.finish_read(readable_keys)
++
++        if persisted_bytes > 0:
++            logger.info(
++                "Periodic L2 backup: persisted %d keys (%d new bytes, "
++                "%d evictable in L1, none deleted)",
++                persisted_keys,
++                persisted_bytes,
++                len(batch),
++            )
++
+ 
+ class L2AdapterEvictionState:
+     """Per-adapter eviction state: its own policy, listener, and config."""
+diff --git a/lmcache/v1/distributed/storage_controllers/prefetch_controller.py b/lmcache/v1/distributed/storage_controllers/prefetch_controller.py
+index 2138a33aa01ce95d7926bd4f6bcda79ae7d1955a..46239e518abaee70412223ec76eaa89f934a4bbe 100644
+--- a/lmcache/v1/distributed/storage_controllers/prefetch_controller.py
++++ b/lmcache/v1/distributed/storage_controllers/prefetch_controller.py
+@@ -55,6 +55,9 @@ from lmcache.v1.platform import (
+ 
+ if TYPE_CHECKING:
+     # First Party
++    from lmcache.v1.distributed.storage_controllers.eviction_controller import (
++        L1EvictionController,
++    )
+     from lmcache.v1.memory_management import MemoryObj
+ 
+ logger = init_logger(__name__)
+@@ -121,6 +124,17 @@ def trim_load_plan_with_mask(
+     return trimmed_plan
+ 
+ 
++def _layout_nbytes(layout_desc: MemoryLayoutDesc) -> int:
++    """Return the byte size of one object with the given layout."""
++    total = 0
++    for shape, dtype in zip(layout_desc.shapes, layout_desc.dtypes, strict=True):
++        numel = 1
++        for dim in shape:
++            numel *= int(dim)
++        total += numel * dtype.itemsize
++    return total
++
++
+ # Poll timeout in milliseconds for the prefetch loop
+ PREFETCH_LOOP_POLL_TIMEOUT_MS = 500
+ 
+@@ -227,6 +241,11 @@ class PrefetchController(StorageControllerInterface):
+         self._policy = policy
+         self._max_in_flight = max_in_flight
+ 
++        # Optional L1 eviction controller for emergency make-room before
++        # large restores; injected by StorageManager when
++        # EvictionConfig.emergency_evict_for_prefetch is enabled.
++        self._l1_eviction_controller: "L1EvictionController | None" = None
++
+         # Adapters that are being drained and will be removed after all
+         # the in-flight operations are done.
+         self._draining: dict[int, threading.Event] = {}
+@@ -847,6 +866,25 @@ class PrefetchController(StorageControllerInterface):
+     # =========================================================================
+     # Load phase
+     # =========================================================================
++    def _select_l1_retentions(
++        self,
++        request_id: int,
++        keys: list[ObjectKey],
++    ) -> list[bool]:
++        """Return one retention decision per key, degrading safely on a
++        malformed policy result."""
++        retentions = self._policy.select_l1_retentions(keys)
++        if len(retentions) != len(keys):
++            logger.error(
++                "Prefetch request %d: policy returned %d retentions for "
++                "%d keys; defaulting to temporary entries",
++                request_id,
++                len(retentions),
++                len(keys),
++            )
++            return [False] * len(keys)
++        return retentions
++
+     def _transition_to_load_phase(self, request: InFlightPrefetchRequest) -> None:
+         """Compute load plan, reserve L1 buffers, and submit load tasks."""
+         request.phase = PrefetchPhase.PLAN_AND_LOAD
+@@ -899,15 +937,23 @@ class PrefetchController(StorageControllerInterface):
+         if request.mode is PrefetchMode.WARM:
+             retentions = [True] * len(keys_to_reserve)
+         else:
+-            retentions = self._policy.select_l1_retentions(
++            retentions = self._select_l1_retentions(
++                request.request_id,
+                 keys_to_reserve,
+             )
++            # Non-WARM only: a WARM warm-up must never trigger emergency
++            # eviction of other sessions' chunks.
++            self._make_room_for_restore(request, keys_to_reserve)
+         write_results = l1_mgr.reserve_write(
+             keys=keys_to_reserve,
+             is_temporary=[not r for r in retentions],
+             layout_desc=request.layout_desc,
+             mode="new",
+         )
++        if request.mode is not PrefetchMode.WARM:
++            write_results = self._retry_oom_reservations(
++                request, keys_to_reserve, retentions, write_results
++            )
+ 
+         # Step 4: filter to successfully reserved keys
+         reserved_key_set: set[ObjectKey] = set()
+@@ -1038,6 +1084,123 @@ class PrefetchController(StorageControllerInterface):
+             len(reserved_key_set),
+         )
+ 
++    def set_l1_eviction_controller(
++        self,
++        controller: "L1EvictionController | None",
++    ) -> None:
++        """Enable emergency L1 eviction for large restores.
++
++        With a controller injected, a non-WARM restore that would not fit
++        in free L1 space synchronously evicts LRU keys (write-back first)
++        before reserving, and retries OOM reservations once. Pass ``None``
++        after the last synchronous L2 adapter is removed to disable this path.
++        """
++        self._l1_eviction_controller = controller
++
++    # Never let a single restore claim more than this fraction of L1: a
++    # huge context must not wipe every hot chunk of the running sessions.
++    _EMERGENCY_EVICT_MAX_L1_FRACTION = 0.6
++    # Headroom per object for alignment and allocator bookkeeping.
++    _PER_OBJECT_HEADROOM_BYTES = 8192
++
++    def _make_room_for_restore(
++        self,
++        request: InFlightPrefetchRequest,
++        keys_to_reserve: list[ObjectKey],
++    ) -> None:
++        """Pre-evict LRU L1 chunks so the upcoming reserve_write for this
++        restore can succeed. No-op unless an eviction controller was
++        injected via ``set_l1_eviction_controller``."""
++        evictor = self._l1_eviction_controller
++        if evictor is None or not keys_to_reserve:
++            return
++        per_obj = _layout_nbytes(request.layout_desc)
++        if per_obj <= 0:
++            return
++        used, total = self._l1_manager.get_memory_usage()
++        need = (per_obj + self._PER_OBJECT_HEADROOM_BYTES) * len(keys_to_reserve)
++        need = min(need, int(total * self._EMERGENCY_EVICT_MAX_L1_FRACTION))
++        free = max(0, total - used)
++        if free >= need:
++            return
++        try:
++            evictor.emergency_evict_bytes(
++                need, requester=f"prefetch_request={request.request_id}"
++            )
++        except Exception:
++            logger.exception(
++                "Emergency eviction failed for prefetch request %d",
++                request.request_id,
++            )
++
++    def _retry_oom_reservations(
++        self,
++        request: InFlightPrefetchRequest,
++        keys_to_reserve: list[ObjectKey],
++        retentions: list[bool],
++        write_results: dict[ObjectKey, tuple[L1Error, "MemoryObj | None"]],
++    ) -> dict[ObjectKey, tuple[L1Error, "MemoryObj | None"]]:
++        """One retry round for keys whose reservation failed with
++        OUT_OF_MEMORY: evict the missing amount, reserve just those keys
++        again, and merge the results. No-op unless an eviction controller
++        was injected."""
++        evictor = self._l1_eviction_controller
++        if evictor is None:
++            return write_results
++        oom_keys: list[ObjectKey] = []
++        retention_by_key = dict(zip(keys_to_reserve, retentions, strict=True))
++        for key in keys_to_reserve:
++            entry = write_results.get(key)
++            if entry is None:
++                oom_keys.append(key)
++                continue
++            err, mem_obj = entry
++            if err == L1Error.OUT_OF_MEMORY or (
++                err == L1Error.SUCCESS and mem_obj is None
++            ):
++                oom_keys.append(key)
++        if not oom_keys:
++            return write_results
++        per_obj = _layout_nbytes(request.layout_desc)
++        if per_obj <= 0:
++            return write_results
++        _, total = self._l1_manager.get_memory_usage()
++        need = (per_obj + self._PER_OBJECT_HEADROOM_BYTES) * len(oom_keys)
++        need = min(need, int(total * self._EMERGENCY_EVICT_MAX_L1_FRACTION))
++        try:
++            evictor.emergency_evict_bytes(
++                need, requester=f"prefetch_request={request.request_id}/retry"
++            )
++        except Exception:
++            logger.exception(
++                "Emergency eviction retry failed for prefetch request %d",
++                request.request_id,
++            )
++            return write_results
++        retry_results = self._l1_manager.reserve_write(
++            keys=oom_keys,
++            is_temporary=[not retention_by_key[k] for k in oom_keys],
++            layout_desc=request.layout_desc,
++            mode="new",
++        )
++        recovered = sum(
++            1
++            for k in oom_keys
++            if retry_results.get(k)
++            and retry_results[k][0] == L1Error.SUCCESS
++            and retry_results[k][1] is not None
++        )
++        if recovered:
++            logger.info(
++                "Retry recovered %d/%d OOM reservations for prefetch request %d",
++                recovered,
++                len(oom_keys),
++                request.request_id,
++            )
++        merged = dict(write_results)
++        merged.update(retry_results)
++        return merged
++
+     def _update_lookup_results(
+         self, request_id: PrefetchRequestId, prefix_hit_count: int
+     ) -> None:
+@@ -1181,6 +1344,17 @@ class PrefetchController(StorageControllerInterface):
+         # added once the serde PR lands and adapters can distinguish
+         # deserialization errors from missing objects.
+         if failed_keys:
++            # These keys were reported present by the L2 lookup but the load
++            # returned no data. Sample a few so the on-disk state can be
++            # inspected post hoc.
++            logger.warning(
++                "Prefetch request %d: %d/%d plan keys failed to load from "
++                "L2 (lookup hit, load empty); sample: %s",
++                request.request_id,
++                len(failed_keys),
++                len(request.write_reserved_keys),
++                [str(k)[:160] for k in failed_keys[:3]],
++            )
+             self._event_bus.publish(
+                 Event(
+                     event_type=EventType.L2_PREFETCH_FAILED,
+diff --git a/lmcache/v1/distributed/storage_manager.py b/lmcache/v1/distributed/storage_manager.py
+index 3054e2441c5c7d98d817ca7a1f9ac30b4a7e92d7..a7da312a475264ddd1c829ad73937fc103cbf1a8 100644
+--- a/lmcache/v1/distributed/storage_manager.py
++++ b/lmcache/v1/distributed/storage_manager.py
+@@ -66,6 +66,7 @@ logger = init_logger(__name__)
+ 
+ class StorageManager:
+     def __init__(self, config: StorageManagerConfig):
++        self._eviction_config = config.eviction_config
+         self._l1_manager = L1Manager(config.l1_manager_config)
+         self._event_bus = get_event_bus()
+ 
+@@ -154,6 +155,31 @@ class StorageManager:
+         )
+         self._prefetch_controller.start()
+ 
++        # Opt-in L1 write-back tier: wire L2 adapters into the L1 eviction
++        # controller so evicted or periodically backed-up chunks are flushed
++        # to L2, and optionally let the prefetch controller trigger
++        # emergency eviction to make room for large restores.
++        eviction_config = config.eviction_config
++        wants_l1_write_back = (
++            eviction_config.write_back_on_evict
++            or eviction_config.periodic_flush_interval > 0
++        )
++        if wants_l1_write_back:
++            self._sync_l1_writeback_adapters()
++            if not self._eviction_controller.has_l2_flush_adapter():
++                logger.warning(
++                    "write_back_on_evict / periodic_flush_interval is set but "
++                    "no L2 adapter exposes store_objects_sync"
++                )
++        if (
++            eviction_config.emergency_evict_for_prefetch
++            and not self._eviction_controller.has_l2_flush_adapter()
++        ):
++            logger.warning(
++                "emergency_evict_for_prefetch has no synchronous L2 "
++                "adapter; inactive until one is added"
++            )
++
+         # L2 usage gauge — one observation per adapter, tagged by
+         # ``l2_name``.  Parallel to L1Manager's ``l1_memory_usage_bytes``.
+         register_gauge(
+@@ -904,6 +930,7 @@ class StorageManager:
+             with self._adapters_lock:
+                 self._l2_adapters[adapter_id] = adapter
+                 self._adapter_descriptors[adapter_id] = descriptor
++            self._sync_l1_writeback_adapters()
+             self._store_controller.add_adapter(adapter_id, adapter, descriptor)
+             self._prefetch_controller.add_adapter(adapter_id, adapter, descriptor)
+             if self._should_enable_l2_eviction(adapter, config.eviction_config):
+@@ -956,6 +983,9 @@ class StorageManager:
+             with self._adapters_lock:
+                 adapter = self._l2_adapters.pop(adapter_id)
+                 self._adapter_descriptors.pop(adapter_id, None)
++            # Waits for any synchronous L1 flush using the removed adapter
++            # before adapter.close() releases its native resources.
++            self._sync_l1_writeback_adapters()
+             adapter.close()
+             logger.info("Deleted L2 adapter %d", adapter_id)
+ 
+@@ -1121,6 +1151,21 @@ class StorageManager:
+             return False
+         return True
+ 
++    def _sync_l1_writeback_adapters(self) -> None:
++        """Publish the current adapter set to the optional L1 writeback tier."""
++        config = self._eviction_config
++        if not (config.write_back_on_evict or config.periodic_flush_interval > 0):
++            return
++        with self._adapters_lock:
++            adapters = dict(self._l2_adapters)
++        self._eviction_controller.set_l2_adapters(adapters)
++        if config.emergency_evict_for_prefetch:
++            self._prefetch_controller.set_l1_eviction_controller(
++                self._eviction_controller
++                if self._eviction_controller.has_l2_flush_adapter()
++                else None
++            )
++
+     def _unwrap_reconfigurable_l2_adapter(
+         self,
+         adapter: L2AdapterInterface,
+diff --git a/lmcache/v1/multiprocess/futures.py b/lmcache/v1/multiprocess/futures.py
+index beadae5505e4062d95b3e5f083d8e72b6bdf06d1..ab5195eec56aa3fcd9b52550aac52dc6133680b4 100644
+--- a/lmcache/v1/multiprocess/futures.py
++++ b/lmcache/v1/multiprocess/futures.py
+@@ -14,6 +14,7 @@ class MessagingFuture(Generic[T]):
+     def __init__(self):
+         self.is_done_ = threading.Event()
+         self.result_ = None
++        self.exception_: BaseException | None = None
+ 
+     def query(self) -> bool:
+         """
+@@ -54,6 +55,8 @@ class MessagingFuture(Generic[T]):
+         flag = self.wait(timeout)
+         if not flag:
+             raise LMCacheTimeoutError("Future result not available within timeout")
++        if self.exception_ is not None:
++            raise self.exception_
+         return self.result_
+ 
+     def set_result(self, result: T) -> None:
+@@ -68,6 +71,13 @@ class MessagingFuture(Generic[T]):
+         self.result_ = result
+         self.is_done_.set()
+ 
++    def set_exception(self, exception: BaseException) -> None:
++        """Complete the future with an exception from the messaging system."""
++        if not isinstance(exception, BaseException):
++            raise TypeError("exception must derive from BaseException")
++        self.exception_ = exception
++        self.is_done_.set()
++
+     def to_cuda_future(
+         self,
+         device: Any | None = None,
+diff --git a/lmcache/v1/multiprocess/mq.py b/lmcache/v1/multiprocess/mq.py
+index 271ff93b2a933f6c0f70f95a95d6f2249e7636c1..a5d0d0cf7322a523a9a8b89a0c5af2e2466109b1 100644
+--- a/lmcache/v1/multiprocess/mq.py
++++ b/lmcache/v1/multiprocess/mq.py
+@@ -40,6 +40,26 @@ T = TypeVar("T")
+ # Internal type used for the client-server communication
+ RequestUID = int
+ 
++_ERROR_RESPONSE_MARKER = b"LMCACHE_RPC_ERROR_V1"
++_MAX_REMOTE_ERROR_MESSAGE_BYTES = 4096
++
++
++class RemoteHandlerError(RuntimeError):
++    """A request handler failed in the remote LMCache process."""
++
++    def __init__(
++        self, request_type: RequestType, error_type: str, message: str
++    ) -> None:
++        self.request_type = request_type
++        self.error_type = error_type
++        self.remote_message = message
++        super().__init__(f"{request_type.name} handler failed: {error_type}: {message}")
++
++
++class _RemoteErrorPayload(msgspec.Struct, frozen=True):
++    error_type: str
++    message: str
++
+ 
+ # Helper functions
+ def encode_request_uid(uid: RequestUID) -> bytes:
+@@ -346,7 +366,28 @@ class MessageQueueClient:
+ 
+         if request_uid in self.pending_futures:
+             future = self.pending_futures.pop(request_uid)
+-            if b_response:
++            if b_response and b_response[0] == _ERROR_RESPONSE_MARKER:
++                if len(b_response) != 2:
++                    future.set_exception(
++                        RuntimeError("Malformed LMCache RPC error response")
++                    )
++                    return
++                try:
++                    error = msgspec_decode(b_response[1], cls=_RemoteErrorPayload)
++                except Exception:
++                    future.set_exception(
++                        RuntimeError("Failed to decode LMCache RPC error response")
++                    )
++                    logger.exception("Failed to decode RPC error response")
++                    return
++                future.set_exception(
++                    RemoteHandlerError(
++                        request_type=request_type,
++                        error_type=error.error_type,
++                        message=error.message,
++                    )
++                )
++            elif b_response:
+                 response = msgspec_decode(b_response[0], cls=response_cls)
+                 future.set_result(response)
+             else:
+@@ -516,6 +557,24 @@ class MessageQueueServer:
+         # Thread pools assigned via add_normal_thread_pool / add_affinity_thread_pool
+         self.extra_pools: list[ThreadPoolExecutor | AffinityThreadPool] = []
+ 
++    def _queue_error_response(
++        self, prefix_frames: list[bytes], exception: BaseException
++    ) -> None:
++        """Return a bounded error response without touching ZMQ off-thread."""
++        message = str(exception).encode("utf-8")[:_MAX_REMOTE_ERROR_MESSAGE_BYTES]
++        payload = _RemoteErrorPayload(
++            error_type=type(exception).__name__,
++            message=message.decode("utf-8", errors="replace"),
++        )
++        self.output_queue.put(
++            prefix_frames
++            + [
++                _ERROR_RESPONSE_MARKER,
++                msgspec_encode(payload, cls=_RemoteErrorPayload),
++            ]
++        )
++        self._output_efd.notify()
++
+     def _call_sync_handler(
+         self,
+         handler_entry: SyncRequestHandler[Any],
+@@ -571,8 +630,9 @@ class MessageQueueServer:
+                 self.output_queue.put(frames_to_send)
+                 self._output_efd.notify()
+ 
+-            except Exception:
++            except Exception as exc:
+                 logger.exception("Error in blocking handler")
++                self._queue_error_response(prefix_frames, exc)
+ 
+         future.add_done_callback(_notify_response)
+ 
+@@ -619,13 +679,23 @@ class MessageQueueServer:
+                             payloads=payloads,
+                             prefix_frames=[identity, b_request_uid, b_request_type],
+                         )
+-                    except Exception:
++                    except Exception as exc:
+                         logger.exception("Error handling request %s", request_type)
++                        self._queue_error_response(
++                            [identity, b_request_uid, b_request_type], exc
++                        )
+                 else:
+                     logger.error(
+                         "No handler registered for request type %s", request_type
+                     )
+                     logger.error("Available handlers: %s", list(self.handlers.keys()))
++                    self._queue_error_response(
++                        [identity, b_request_uid, b_request_type],
++                        RuntimeError(
++                            "No handler registered for request type "
++                            f"{request_type.name}"
++                        ),
++                    )
+ 
+             # Send the responses
+             if outbound_state and outbound_state & zmq.POLLIN:
+diff --git a/tests/v1/distributed/test_fs_native_startup_scan.py b/tests/v1/distributed/test_fs_native_startup_scan.py
+new file mode 100644
+index 0000000000000000000000000000000000000000..796c27e183c9ff0bc923b4d5fbe7e7dfdb6957bc
+--- /dev/null
++++ b/tests/v1/distributed/test_fs_native_startup_scan.py
+@@ -0,0 +1,78 @@
++# SPDX-License-Identifier: Apache-2.0
++"""Restart accounting for the native filesystem L2 adapter."""
++
++# Standard
++import os
++
++# Third Party
++import pytest
++
++# First Party
++from lmcache.v1.distributed.api import ObjectKey
++from lmcache.v1.distributed.l2_adapters.fs_l2_adapter import (
++    _object_key_to_filename,
++)
++from lmcache.v1.distributed.l2_adapters.fs_native_l2_adapter import (
++    _scan_existing_fs_native_files,
++)
++
++
++def _key(chunk_id: int) -> ObjectKey:
++    return ObjectKey(
++        chunk_hash=ObjectKey.IntHash2Bytes(chunk_id),
++        model_name="test-model",
++        kv_rank=0,
++    )
++
++
++def _write(root, key: ObjectKey, size: int, mtime_ns: int) -> None:
++    path = root / _object_key_to_filename(key)
++    path.write_bytes(b"x" * size)
++    os.utime(path, ns=(mtime_ns, mtime_ns))
++
++
++def test_scan_returns_oldest_to_newest_keys_and_sizes(tmp_path):
++    newer = _key(2)
++    older = _key(1)
++    _write(tmp_path, newer, 200, 2_000_000_000)
++    _write(tmp_path, older, 100, 1_000_000_000)
++
++    keys, sizes = _scan_existing_fs_native_files(str(tmp_path))
++
++    assert keys == [older, newer]
++    assert sizes == [100, 200]
++
++
++def test_scan_skips_foreign_empty_and_temporary_files(tmp_path):
++    valid = _key(1)
++    _write(tmp_path, valid, 100, 1_000_000_000)
++    (tmp_path / "not-a-cache-file.data").write_bytes(b"x")
++    (tmp_path / _object_key_to_filename(_key(2))).write_bytes(b"")
++    (tmp_path / "pending.tmp").write_bytes(b"x")
++
++    keys, sizes = _scan_existing_fs_native_files(str(tmp_path))
++
++    assert keys == [valid]
++    assert sizes == [100]
++
++
++def test_scan_missing_directory_returns_empty(tmp_path):
++    assert _scan_existing_fs_native_files(str(tmp_path / "missing")) == ([], [])
++
++
++def test_scan_fails_closed_when_existing_file_cannot_be_inspected(
++    tmp_path, monkeypatch
++):
++    path = tmp_path / "broken.data"
++    path.write_bytes(b"x")
++    original_stat = type(path).stat
++
++    def fail_data_stat(self, *args, **kwargs):
++        if self == path:
++            raise OSError("injected stat failure")
++        return original_stat(self, *args, **kwargs)
++
++    monkeypatch.setattr(type(path), "stat", fail_data_stat)
++
++    with pytest.raises(RuntimeError, match="Could not inspect cache file"):
++        _scan_existing_fs_native_files(str(tmp_path))
+diff --git a/tests/v1/distributed/test_l1_manager.py b/tests/v1/distributed/test_l1_manager.py
+index fea845f903879a84856058ac107589a4b21e0fc7..5b0fb89bc77f4b274f8a27bc48c876aa3c7b54bb 100644
+--- a/tests/v1/distributed/test_l1_manager.py
++++ b/tests/v1/distributed/test_l1_manager.py
+@@ -132,18 +132,6 @@ def basic_layout():
+     )
+ 
+ 
+-@pytest.fixture
+-def large_layout():
+-    """Create a large MemoryLayoutDesc that will exhaust small memory.
+-
+-    Each allocation is 8MB (2M elements * 4 bytes).
+-    """
+-    return MemoryLayoutDesc(
+-        shapes=[torch.Size([2048, 1024])],  # 2M elements * 4 bytes = 8MB
+-        dtypes=[torch.float32],
+-    )
+-
+-
+ def make_object_key(chunk_hash: int, model_name: str = "test_model", kv_rank: int = 0):
+     """Helper to create ObjectKey instances."""
+     hash_bytes = ObjectKey.IntHash2Bytes(chunk_hash)
+@@ -879,14 +867,23 @@ class TestReserveWrite:
+ 
+         manager.close()
+ 
+-    def test_reserve_write_out_of_memory(self, small_l1_config, large_layout):
+-        """Test that reserve_write returns OUT_OF_MEMORY when allocation fails."""
++    def test_reserve_write_out_of_memory(self, small_l1_config):
++        """Test that reserve_write returns OUT_OF_MEMORY when allocation fails.
++
++        Uses an object larger than the whole pool; a batch that partially
++        fits allocates the longest prefix instead (see
++        tests/v1/distributed/test_l1_manager_partial_alloc.py).
++        """
+         manager = L1Manager(small_l1_config)
+         keys = [make_object_key(i) for i in range(10)]
+         is_temporary = [False] * 10
+ 
+-        # Request more memory than available (8MB * 10 = 80MB > 64MB)
+-        result = manager.reserve_write(keys, is_temporary, large_layout)
++        # A single object (128MB) exceeds the 64MB pool.
++        oversized_layout = MemoryLayoutDesc(
++            shapes=[torch.Size([2048 * 16, 1024])],
++            dtypes=[torch.float32],
++        )
++        result = manager.reserve_write(keys, is_temporary, oversized_layout)
+ 
+         # All keys should return OUT_OF_MEMORY
+         for key in keys:
+diff --git a/tests/v1/distributed/test_l1_manager_partial_alloc.py b/tests/v1/distributed/test_l1_manager_partial_alloc.py
+new file mode 100644
+index 0000000000000000000000000000000000000000..30ddc3fba0ce10c957ad6375874fac7df9cc8585
+--- /dev/null
++++ b/tests/v1/distributed/test_l1_manager_partial_alloc.py
+@@ -0,0 +1,151 @@
++# SPDX-License-Identifier: Apache-2.0
++"""Partial-prefix allocation behavior of ``L1Manager.reserve_write``.
++
++A batch whose full allocation does not fit must not fail every key
++(all-or-nothing would collapse large L2->L1 restores to zero prefix hits):
++the longest prefix that fits is allocated and only the tail reports
++OUT_OF_MEMORY. Uses the CPU shared-memory allocator, no GPU required.
++"""
++
++# Standard
++from collections.abc import Iterator
++from types import SimpleNamespace
++
++# Third Party
++import pytest
++import torch
++
++# First Party
++from lmcache.v1.distributed.api import MemoryLayoutDesc, ObjectKey
++from lmcache.v1.distributed.config import (
++    L1ManagerConfig,
++    L1MemoryManagerConfig,
++)
++from lmcache.v1.distributed.error import L1Error
++from lmcache.v1.distributed.l1_manager import L1Manager
++
++POOL_BYTES = 64 * 1024 * 1024
++
++# 8MB per object: ten of them cannot fit in the 64MB pool, most can.
++OBJECT_LAYOUT = MemoryLayoutDesc(
++    shapes=[torch.Size([2048, 1024])],
++    dtypes=[torch.float32],
++)
++
++# A single 128MB object exceeds the whole pool.
++OVERSIZED_LAYOUT = MemoryLayoutDesc(
++    shapes=[torch.Size([2048 * 16, 1024])],
++    dtypes=[torch.float32],
++)
++
++
++@pytest.fixture
++def manager() -> Iterator[L1Manager]:
++    config = L1ManagerConfig(
++        memory_config=L1MemoryManagerConfig(
++            size_in_bytes=POOL_BYTES,
++            use_lazy=False,
++            init_size_in_bytes=POOL_BYTES,
++            align_bytes=0x1000,
++        ),
++        write_ttl_seconds=600,
++        read_ttl_seconds=300,
++    )
++    manager = L1Manager(config)
++    yield manager
++    manager.close()
++
++
++def _make_keys(count: int) -> list[ObjectKey]:
++    return [
++        ObjectKey(
++            chunk_hash=ObjectKey.IntHash2Bytes(i),
++            model_name="test_model",
++            kv_rank=0,
++        )
++        for i in range(count)
++    ]
++
++
++def test_reserve_write_allocates_longest_prefix_on_oom(manager: L1Manager) -> None:
++    """When the full batch does not fit, a non-empty prefix succeeds and
++    only the tail reports OUT_OF_MEMORY; every requested key keeps an
++    explicit per-key result."""
++    keys = _make_keys(10)
++    result = manager.reserve_write(keys, [False] * 10, OBJECT_LAYOUT)
++
++    assert set(result) == set(keys)
++    statuses = [result[key][0] for key in keys]
++    num_success = statuses.count(L1Error.SUCCESS)
++    assert 0 < num_success < 10
++
++    # The successful keys form a prefix in request order.
++    assert statuses == [L1Error.SUCCESS] * num_success + [L1Error.OUT_OF_MEMORY] * (
++        10 - num_success
++    )
++    for key in keys[:num_success]:
++        assert result[key][1] is not None
++    for key in keys[num_success:]:
++        assert result[key][1] is None
++
++
++def test_partial_prefix_is_committable(manager: L1Manager) -> None:
++    """The allocated prefix stays usable: finish_write succeeds for it."""
++    keys = _make_keys(10)
++    result = manager.reserve_write(keys, [False] * 10, OBJECT_LAYOUT)
++    successful = [key for key in keys if result[key][0] == L1Error.SUCCESS]
++    assert successful
++
++    finish_result = manager.finish_write(successful)
++    for key in successful:
++        assert finish_result[key] == L1Error.SUCCESS
++
++
++def test_reserve_write_all_oom_when_nothing_fits(manager: L1Manager) -> None:
++    """An object larger than the pool still fails every key."""
++    keys = _make_keys(3)
++    result = manager.reserve_write(keys, [False] * 3, OVERSIZED_LAYOUT)
++
++    for key in keys:
++        assert result[key][0] == L1Error.OUT_OF_MEMORY
++        assert result[key][1] is None
++
++
++def test_single_key_batch_keeps_all_or_nothing(manager: L1Manager) -> None:
++    """A one-key batch has no prefix to fall back to; it simply fails."""
++    keys = _make_keys(1)
++    result = manager.reserve_write(keys, [False], OVERSIZED_LAYOUT)
++
++    assert result[keys[0]] == (L1Error.OUT_OF_MEMORY, None)
++
++
++def test_largest_prefix_search_does_not_stop_at_a_smaller_fit() -> None:
++    """The OOM fallback finds the maximum, rather than accepting a midpoint."""
++
++    class BoundedMemoryManager:
++        def __init__(self, capacity: int) -> None:
++            self.capacity = capacity
++            self.allocate_counts: list[int] = []
++
++        def allocate(self, _layout: MemoryLayoutDesc, count: int):
++            self.allocate_counts.append(count)
++            if count > self.capacity:
++                return L1Error.OUT_OF_MEMORY, []
++            return L1Error.SUCCESS, [object() for _ in range(count)]
++
++        def free(self, _objects: list[object]) -> L1Error:
++            return L1Error.SUCCESS
++
++    memory_manager = BoundedMemoryManager(capacity=7)
++    manager = SimpleNamespace(_memory_manager=memory_manager)
++
++    err, objects = L1Manager._allocate_largest_prefix(
++        manager,
++        OBJECT_LAYOUT,
++        10,  # type: ignore[arg-type]
++    )
++
++    assert err == L1Error.SUCCESS
++    assert len(objects) == 7
++    assert memory_manager.allocate_counts[-1] == 7
++    assert 8 in memory_manager.allocate_counts
+diff --git a/tests/v1/distributed/test_l1_write_back_eviction.py b/tests/v1/distributed/test_l1_write_back_eviction.py
+new file mode 100644
+index 0000000000000000000000000000000000000000..cafe22398bfa296195527cf244adc483c24cf63c
+--- /dev/null
++++ b/tests/v1/distributed/test_l1_write_back_eviction.py
+@@ -0,0 +1,591 @@
++# SPDX-License-Identifier: Apache-2.0
++"""Opt-in L1 write-back tier.
++
++With ``EvictionConfig.write_back_on_evict`` enabled, L1 eviction flushes
++readable objects to L2 synchronously and deletes them from L1 only once
++every key in the batch is durable. ``periodic_flush_interval`` adds a
++below-watermark backup flush that keeps the L1 copy.
++``emergency_evict_for_prefetch`` lets the prefetch controller make room
++for large restores through the same write-back path.
++
++Uses the CPU shared-memory allocator; no GPU required.
++"""
++
++# Standard
++from collections.abc import Iterator
++import argparse
++import threading
++import time
++
++# Third Party
++import pytest
++import torch
++
++# First Party
++from lmcache.v1.distributed.api import MemoryLayoutDesc, ObjectKey
++from lmcache.v1.distributed.config import (
++    EvictionConfig,
++    L1ManagerConfig,
++    L1MemoryManagerConfig,
++    StorageManagerConfig,
++    add_storage_manager_args,
++    parse_args_to_config,
++)
++from lmcache.v1.distributed.error import L1Error
++from lmcache.v1.distributed.internal_api import (
++    EvictionAction,
++    EvictionDestination,
++)
++from lmcache.v1.distributed.l1_manager import L1Manager
++from lmcache.v1.distributed.storage_controllers.eviction_controller import (
++    L1EvictionController,
++)
++from lmcache.v1.distributed.storage_controllers.prefetch_controller import (
++    InFlightPrefetchRequest,
++    PrefetchController,
++    PrefetchPhase,
++)
++from lmcache.v1.distributed.storage_controllers.prefetch_policy import (
++    DefaultPrefetchPolicy,
++)
++from lmcache.v1.mp_observability.config import add_observability_args
++
++POOL_BYTES = 8 * 1024 * 1024
++
++# 1MB per object so a handful of objects create real memory pressure.
++OBJECT_LAYOUT = MemoryLayoutDesc(
++    shapes=[torch.Size([256, 1024])],
++    dtypes=[torch.float32],
++)
++
++
++class FakeSyncStoreAdapter:
++    """L2 adapter double exposing only the synchronous store path.
++
++    ``result`` overrides the returned tuple; by default every key is
++    reported durable.
++    """
++
++    def __init__(self) -> None:
++        self.stored_batches: list[list[ObjectKey]] = []
++        self.result: tuple[bool, int, int] | None = None
++
++    def store_objects_sync(
++        self,
++        keys: list[ObjectKey],
++        objects: list,
++        timeout: float | None = None,
++    ) -> tuple[bool, int, int]:
++        self.stored_batches.append(list(keys))
++        if self.result is not None:
++            return self.result
++        return True, len(keys), sum(obj.get_size() for obj in objects)
++
++
++class BlockingSyncStoreAdapter(FakeSyncStoreAdapter):
++    def __init__(self) -> None:
++        super().__init__()
++        self.entered = threading.Event()
++        self.release = threading.Event()
++
++    def store_objects_sync(self, keys, objects, timeout=None):
++        self.entered.set()
++        if not self.release.wait(timeout=timeout or 5.0):
++            return False, 0, 0
++        return super().store_objects_sync(keys, objects, timeout=timeout)
++
++
++@pytest.fixture
++def l1_manager() -> Iterator[L1Manager]:
++    config = L1ManagerConfig(
++        memory_config=L1MemoryManagerConfig(
++            size_in_bytes=POOL_BYTES,
++            use_lazy=False,
++            init_size_in_bytes=POOL_BYTES,
++            align_bytes=0x1000,
++        ),
++        write_ttl_seconds=600,
++        read_ttl_seconds=300,
++    )
++    manager = L1Manager(config)
++    yield manager
++    manager.close()
++
++
++def _make_controller(
++    l1_manager: L1Manager,
++    adapter: FakeSyncStoreAdapter,
++    **config_kwargs,
++) -> L1EvictionController:
++    config = EvictionConfig(eviction_policy="LRU", **config_kwargs)
++    return L1EvictionController(
++        l1_manager=l1_manager,
++        eviction_config=config,
++        l2_adapters={0: adapter},
++    )
++
++
++def _make_keys(count: int) -> list[ObjectKey]:
++    return [
++        ObjectKey(
++            chunk_hash=ObjectKey.IntHash2Bytes(i),
++            model_name="test_model",
++            kv_rank=0,
++        )
++        for i in range(count)
++    ]
++
++
++def _store_keys(l1_manager: L1Manager, keys: list[ObjectKey]) -> None:
++    result = l1_manager.reserve_write(keys, [False] * len(keys), OBJECT_LAYOUT)
++    for key in keys:
++        assert result[key][0] == L1Error.SUCCESS
++    l1_manager.finish_write(keys)
++
++
++def _readable_keys(l1_manager: L1Manager, keys: list[ObjectKey]) -> list[ObjectKey]:
++    result = l1_manager.reserve_read(keys)
++    readable = [
++        key
++        for key in keys
++        if result.get(key) is not None and result[key][0] == L1Error.SUCCESS
++    ]
++    if readable:
++        l1_manager.finish_read(readable)
++    return readable
++
++
++class TestWriteBackOnEvict:
++    def test_flush_then_delete(self, l1_manager):
++        """A durable flush deletes the batch from L1."""
++        adapter = FakeSyncStoreAdapter()
++        controller = _make_controller(l1_manager, adapter, write_back_on_evict=True)
++        keys = _make_keys(3)
++        _store_keys(l1_manager, keys)
++
++        controller.execute_eviction_action(
++            EvictionAction(keys=keys, destination=EvictionDestination.L2_CACHE)
++        )
++
++        assert adapter.stored_batches == [keys]
++        assert _readable_keys(l1_manager, keys) == []
++
++    def test_failed_flush_preserves_l1(self, l1_manager):
++        """A failed flush keeps every readable key in L1 and opens the
++        circuit breaker."""
++        adapter = FakeSyncStoreAdapter()
++        adapter.result = (False, 0, 0)
++        controller = _make_controller(l1_manager, adapter, write_back_on_evict=True)
++        keys = _make_keys(3)
++        _store_keys(l1_manager, keys)
++
++        controller.execute_eviction_action(
++            EvictionAction(keys=keys, destination=EvictionDestination.L2_CACHE)
++        )
++
++        assert _readable_keys(l1_manager, keys) == keys
++        status = controller.report_status()
++        assert status["sync_flush_failures"] == 1
++        assert status["sync_flush_backoff_seconds"] > 0.0
++
++    def test_partial_flush_preserves_l1(self, l1_manager):
++        """A partial persist is not durable; the batch stays in L1."""
++        adapter = FakeSyncStoreAdapter()
++        adapter.result = (False, 2, 1024)
++        controller = _make_controller(l1_manager, adapter, write_back_on_evict=True)
++        keys = _make_keys(3)
++        _store_keys(l1_manager, keys)
++
++        controller.execute_eviction_action(
++            EvictionAction(keys=keys, destination=EvictionDestination.L2_CACHE)
++        )
++
++        assert _readable_keys(l1_manager, keys) == keys
++
++    def test_missing_sync_adapter_fails_closed(self, l1_manager):
++        config = EvictionConfig(eviction_policy="LRU", write_back_on_evict=True)
++        controller = L1EvictionController(
++            l1_manager=l1_manager,
++            eviction_config=config,
++            l2_adapters={0: object()},
++        )
++        keys = _make_keys(2)
++        _store_keys(l1_manager, keys)
++
++        controller.execute_eviction_action(
++            EvictionAction(keys=keys, destination=EvictionDestination.L2_CACHE)
++        )
++
++        assert controller.has_l2_flush_adapter() is False
++        assert _readable_keys(l1_manager, keys) == keys
++
++    def test_reserve_read_failure_is_not_deleted(self, l1_manager, monkeypatch):
++        adapter = FakeSyncStoreAdapter()
++        controller = _make_controller(l1_manager, adapter, write_back_on_evict=True)
++        keys = _make_keys(1)
++        _store_keys(l1_manager, keys)
++        monkeypatch.setattr(
++            l1_manager,
++            "reserve_read",
++            lambda _keys: {keys[0]: (L1Error.KEY_IS_LOCKED, None)},
++        )
++
++        controller.execute_eviction_action(
++            EvictionAction(keys=keys, destination=EvictionDestination.L2_CACHE)
++        )
++
++        monkeypatch.undo()
++        assert adapter.stored_batches == []
++        assert _readable_keys(l1_manager, keys) == keys
++
++    def test_adapter_replacement_waits_for_active_flush(self, l1_manager):
++        adapter = BlockingSyncStoreAdapter()
++        controller = _make_controller(l1_manager, adapter, write_back_on_evict=True)
++        keys = _make_keys(1)
++        _store_keys(l1_manager, keys)
++        flush = threading.Thread(
++            target=lambda: controller.execute_eviction_action(
++                EvictionAction(keys=keys, destination=EvictionDestination.L2_CACHE)
++            )
++        )
++        replaced = threading.Event()
++        replace = threading.Thread(
++            target=lambda: (
++                controller.set_l2_adapters({}),
++                replaced.set(),
++            )
++        )
++
++        flush.start()
++        assert adapter.entered.wait(timeout=5.0)
++        replace.start()
++        time.sleep(0.05)
++        assert not replaced.is_set()
++
++        adapter.release.set()
++        flush.join(timeout=5.0)
++        replace.join(timeout=5.0)
++
++        assert replaced.is_set()
++        assert not flush.is_alive()
++        assert not replace.is_alive()
++
++
++class TestEmergencyEvict:
++    def test_emergency_evict_frees_bytes_via_write_back(self, l1_manager):
++        """emergency_evict_bytes flushes LRU victims to L2 and frees L1."""
++        adapter = FakeSyncStoreAdapter()
++        controller = _make_controller(l1_manager, adapter, write_back_on_evict=True)
++        keys = _make_keys(6)
++        _store_keys(l1_manager, keys)
++
++        used_before, total = l1_manager.get_memory_usage()
++        free_before = total - used_before
++
++        free_after = controller.emergency_evict_bytes(
++            free_before + 2 * 1024 * 1024, requester="test"
++        )
++
++        assert free_after > free_before
++        assert adapter.stored_batches
++        evicted = [k for batch in adapter.stored_batches for k in batch]
++        assert set(evicted) <= set(keys)
++        assert len(evicted) < len(keys)
++        # Evicted keys are gone from L1.
++        assert not set(evicted) & set(_readable_keys(l1_manager, keys))
++
++    def test_emergency_evict_noop_when_enough_free(self, l1_manager):
++        adapter = FakeSyncStoreAdapter()
++        controller = _make_controller(l1_manager, adapter, write_back_on_evict=True)
++        keys = _make_keys(2)
++        _store_keys(l1_manager, keys)
++
++        controller.emergency_evict_bytes(1024, requester="test")
++
++        assert adapter.stored_batches == []
++        assert _readable_keys(l1_manager, keys) == keys
++
++    def test_emergency_evict_skips_scan_during_backoff(self, l1_manager, monkeypatch):
++        adapter = FakeSyncStoreAdapter()
++        controller = _make_controller(l1_manager, adapter, write_back_on_evict=True)
++        keys = _make_keys(6)
++        _store_keys(l1_manager, keys)
++        controller._sync_flush_backoff_until = time.monotonic() + 60
++        monkeypatch.setattr(
++            controller._eviction_policy,
++            "get_eviction_actions",
++            lambda *args, **kwargs: pytest.fail("eviction scan should be skipped"),
++        )
++
++        used, total = l1_manager.get_memory_usage()
++        free = total - used
++        assert controller.emergency_evict_bytes(free + 1024) == free
++
++    def test_emergency_evict_has_bounded_store_wait(self, l1_manager):
++        adapter = BlockingSyncStoreAdapter()
++        controller = _make_controller(l1_manager, adapter, write_back_on_evict=True)
++        controller._EMERGENCY_FLUSH_TIMEOUT_SECONDS = 0.05
++        keys = _make_keys(6)
++        _store_keys(l1_manager, keys)
++        used, total = l1_manager.get_memory_usage()
++
++        start = time.monotonic()
++        free_after = controller.emergency_evict_bytes(total - used + 1024)
++        elapsed = time.monotonic() - start
++
++        assert adapter.entered.is_set()
++        assert elapsed < 0.5
++        assert free_after == total - used
++        assert _readable_keys(l1_manager, keys) == keys
++
++
++class TestPeriodicBackupFlush:
++    def test_backup_flush_keeps_l1_copy(self, l1_manager):
++        """The periodic backup flush copies keys to L2 without deleting
++        them from L1."""
++        adapter = FakeSyncStoreAdapter()
++        controller = _make_controller(l1_manager, adapter, periodic_flush_interval=0.1)
++        keys = _make_keys(3)
++        _store_keys(l1_manager, keys)
++
++        controller.start()
++        try:
++            deadline = time.monotonic() + 5.0
++            while not adapter.stored_batches and time.monotonic() < deadline:
++                time.sleep(0.1)
++        finally:
++            controller.stop()
++
++        assert adapter.stored_batches
++        flushed = {k for batch in adapter.stored_batches for k in batch}
++        assert flushed <= set(keys)
++        assert _readable_keys(l1_manager, keys) == keys
++
++    def test_backup_batches_rotate_without_full_snapshot(self, l1_manager):
++        adapter = FakeSyncStoreAdapter()
++        controller = _make_controller(l1_manager, adapter)
++        keys = _make_keys(6)
++        _store_keys(l1_manager, keys)
++
++        for _ in range(3):
++            controller._backup_to_l2_no_delete(batch_limit=2)
++
++        assert [len(batch) for batch in adapter.stored_batches] == [2, 2, 2]
++        assert {key for batch in adapter.stored_batches for key in batch} == set(keys)
++
++    def test_evictable_batch_scan_wraps_and_is_bounded(self, l1_manager):
++        keys = _make_keys(5)
++        _store_keys(l1_manager, keys)
++        assert l1_manager.reserve_read([keys[0]])[keys[0]][0] == L1Error.SUCCESS
++        try:
++            first, cursor = l1_manager.get_evictable_keys(
++                limit=2,
++                cursor=0,
++                scan_limit=2,
++            )
++            second, cursor = l1_manager.get_evictable_keys(
++                limit=2,
++                cursor=cursor,
++                scan_limit=2,
++            )
++            third, _ = l1_manager.get_evictable_keys(
++                limit=2,
++                cursor=cursor,
++                scan_limit=2,
++            )
++        finally:
++            l1_manager.finish_read([keys[0]])
++
++        assert first == [keys[1]]
++        assert second == keys[2:4]
++        assert third == [keys[4]]
++
++
++class _RecordingEvictor:
++    """Eviction-controller double recording emergency_evict_bytes calls."""
++
++    def __init__(self) -> None:
++        self.calls: list[tuple[int, str]] = []
++
++    def emergency_evict_bytes(self, target_free_bytes: int, requester: str = "") -> int:
++        self.calls.append((target_free_bytes, requester))
++        return target_free_bytes
++
++
++@pytest.fixture
++def prefetch_controller(l1_manager: L1Manager) -> Iterator[PrefetchController]:
++    controller = PrefetchController(
++        l1_manager=l1_manager,
++        l2_adapters=[],
++        adapter_descriptors=[],
++        policy=DefaultPrefetchPolicy(),
++    )
++    yield controller
++    # The loop thread was never started, so stop() cannot join it.
++    controller._submission_efd.close()
++    controller._adapter_ctrl_efd.close()
++
++
++def _make_request(keys: list[ObjectKey]) -> InFlightPrefetchRequest:
++    return InFlightPrefetchRequest(
++        request_id=7,
++        keys=keys,
++        layout_desc=OBJECT_LAYOUT,
++        phase=PrefetchPhase.PLAN_AND_LOAD,
++    )
++
++
++class TestPrefetchMakeRoom:
++    def test_make_room_asks_evictor_when_short(self, l1_manager, prefetch_controller):
++        """A restore that does not fit in free L1 asks for eviction."""
++        controller = prefetch_controller
++        evictor = _RecordingEvictor()
++        controller.set_l1_eviction_controller(evictor)
++        resident = _make_keys(6)
++        _store_keys(l1_manager, resident)
++
++        restore_keys = [
++            ObjectKey(
++                chunk_hash=ObjectKey.IntHash2Bytes(100 + i),
++                model_name="test_model",
++                kv_rank=0,
++            )
++            for i in range(4)
++        ]
++        controller._make_room_for_restore(_make_request(restore_keys), restore_keys)
++
++        assert len(evictor.calls) == 1
++        target, requester = evictor.calls[0]
++        assert target > 0
++        assert "prefetch_request=7" in requester
++
++    def test_make_room_noop_when_space_available(self, l1_manager, prefetch_controller):
++        controller = prefetch_controller
++        evictor = _RecordingEvictor()
++        controller.set_l1_eviction_controller(evictor)
++
++        keys = _make_keys(2)
++        controller._make_room_for_restore(_make_request(keys), keys)
++
++        assert evictor.calls == []
++
++    def test_make_room_noop_without_evictor(self, l1_manager, prefetch_controller):
++        controller = prefetch_controller
++        keys = _make_keys(2)
++
++        controller._make_room_for_restore(_make_request(keys), keys)
++
++    def test_eviction_controller_can_be_disconnected(self, prefetch_controller):
++        evictor = _RecordingEvictor()
++        prefetch_controller.set_l1_eviction_controller(evictor)
++        prefetch_controller.set_l1_eviction_controller(None)
++
++        assert prefetch_controller._l1_eviction_controller is None
++
++    def test_short_retention_policy_degrades_to_temporary(
++        self, prefetch_controller, monkeypatch
++    ):
++        keys = _make_keys(3)
++        monkeypatch.setattr(
++            prefetch_controller._policy,
++            "select_l1_retentions",
++            lambda _keys: [True],
++        )
++
++        assert prefetch_controller._select_l1_retentions(7, keys) == [
++            False,
++            False,
++            False,
++        ]
++
++    def test_retry_recovers_oom_reservations(self, l1_manager, prefetch_controller):
++        """OOM reservations are retried once after emergency eviction."""
++        controller = prefetch_controller
++        evictor = _RecordingEvictor()
++        controller.set_l1_eviction_controller(evictor)
++        keys = _make_keys(2)
++        write_results = {key: (L1Error.OUT_OF_MEMORY, None) for key in keys}
++
++        merged = controller._retry_oom_reservations(
++            _make_request(keys), keys, [True, True], write_results
++        )
++
++        assert len(evictor.calls) == 1
++        for key in keys:
++            err, mem_obj = merged[key]
++            assert err == L1Error.SUCCESS
++            assert mem_obj is not None
++        l1_manager.finish_write(keys)
++
++    def test_retry_noop_when_all_reserved(self, l1_manager, prefetch_controller):
++        controller = prefetch_controller
++        evictor = _RecordingEvictor()
++        controller.set_l1_eviction_controller(evictor)
++        keys = _make_keys(2)
++        result = l1_manager.reserve_write(keys, [False, False], OBJECT_LAYOUT)
++
++        merged = controller._retry_oom_reservations(
++            _make_request(keys), keys, [True, True], result
++        )
++
++        assert evictor.calls == []
++        assert merged is result
++        l1_manager.finish_write(keys)
++
++
++class TestConfigPlumbing:
++    def test_parser_populates_write_back_fields(self):
++        parser = argparse.ArgumentParser()
++        add_storage_manager_args(parser)
++        add_observability_args(parser)
++        args = parser.parse_args(
++            [
++                "--l1-size-gb",
++                "1",
++                "--eviction-policy",
++                "LRU",
++                "--write-back-on-evict",
++                "--periodic-flush-interval",
++                "30.0",
++                "--emergency-evict-for-prefetch",
++            ]
++        )
++        config = parse_args_to_config(args)
++        assert config.eviction_config.write_back_on_evict is True
++        assert config.eviction_config.periodic_flush_interval == 30.0
++        assert config.eviction_config.emergency_evict_for_prefetch is True
++
++    def test_defaults_are_disabled(self):
++        parser = argparse.ArgumentParser()
++        add_storage_manager_args(parser)
++        add_observability_args(parser)
++        args = parser.parse_args(["--l1-size-gb", "1", "--eviction-policy", "LRU"])
++        config = parse_args_to_config(args)
++        assert config.eviction_config.write_back_on_evict is False
++        assert config.eviction_config.periodic_flush_interval == 0.0
++        assert config.eviction_config.emergency_evict_for_prefetch is False
++
++    @pytest.mark.parametrize(
++        "eviction_config",
++        [
++            EvictionConfig(
++                eviction_policy="LRU",
++                periodic_flush_interval=-1.0,
++            ),
++            EvictionConfig(
++                eviction_policy="LRU",
++                emergency_evict_for_prefetch=True,
++            ),
++        ],
++    )
++    def test_invalid_writeback_config_is_rejected(self, eviction_config):
++        with pytest.raises(ValueError):
++            StorageManagerConfig(
++                l1_manager_config=L1ManagerConfig(
++                    memory_config=L1MemoryManagerConfig(
++                        size_in_bytes=POOL_BYTES,
++                        use_lazy=False,
++                    )
++                ),
++                eviction_config=eviction_config,
++            )
+diff --git a/tests/v1/distributed/test_native_connector_l2_adapter.py b/tests/v1/distributed/test_native_connector_l2_adapter.py
+index dc16cdd1ae0161bf2306759cd2b72614a93c83fc..ff992bee7592a1814c760dea510728e8c96a850b 100644
+--- a/tests/v1/distributed/test_native_connector_l2_adapter.py
++++ b/tests/v1/distributed/test_native_connector_l2_adapter.py
+@@ -10,6 +10,7 @@ C++ IStorageConnector interface, so no Redis or C++ build is needed.
+ import ctypes
+ import select
+ import threading
++import time
+ 
+ # Third Party
+ import pytest
+@@ -56,6 +57,9 @@ class MockNativeConnector:
+         self._completions: list[tuple[int, bool, str, list[bool] | None]] = []
+         self._lock = threading.Lock()
+         self._closed = False
++        self.report_set_per_key_results = True
++        self.fail_set_keys: set[str] = set()
++        self.suppress_set_completion = False
+ 
+     def event_fd(self) -> int:
+         return self._efd.fileno()
+@@ -66,9 +70,21 @@ class MockNativeConnector:
+             self._next_id += 1
+ 
+         try:
++            results = []
+             for key, mv in zip(keys, memoryviews, strict=False):
++                if key in self.fail_set_keys:
++                    results.append(False)
++                    continue
+                 self._store[key] = bytes(mv)
+-            self._push_completion(fid, True, "", None)
++                results.append(True)
++            ok = all(results)
++            if not self.suppress_set_completion:
++                self._push_completion(
++                    fid,
++                    ok,
++                    "" if ok else "injected set failure",
++                    results if self.report_set_per_key_results else None,
++                )
+         except Exception as e:
+             self._push_completion(fid, False, str(e), None)
+ 
+@@ -155,6 +171,27 @@ class MockNativeConnector:
+             pass
+ 
+ 
++class DeferredExistsConnector(MockNativeConnector):
++    """Hold EXISTS completion to expose the submit-to-lock race window."""
++
++    def __init__(self):
++        super().__init__()
++        self.pending_exists: tuple[int, list[str]] | None = None
++
++    def submit_batch_exists(self, keys: list[str]) -> int:
++        with self._lock:
++            fid = self._next_id
++            self._next_id += 1
++        self.pending_exists = (fid, list(keys))
++        return fid
++
++    def complete_exists(self) -> None:
++        assert self.pending_exists is not None
++        fid, keys = self.pending_exists
++        self.pending_exists = None
++        self._push_completion(fid, True, "", [key in self._store for key in keys])
++
++
+ # =============================================================================
+ # Test Fixtures
+ # =============================================================================
+@@ -203,6 +240,14 @@ def adapter():
+     adp.close()
+ 
+ 
++@pytest.fixture
++def adapter_and_mock():
++    mock_client = MockNativeConnector()
++    adp = NativeConnectorL2Adapter(mock_client)
++    yield adp, mock_client
++    adp.close()
++
++
+ # =============================================================================
+ # ObjectKey Serialization Tests
+ # =============================================================================
+@@ -1182,6 +1227,91 @@ class TestDeleteInterface:
+     def test_delete_empty_keys(self, adapter):
+         adapter.delete([])  # should not raise
+ 
++    def test_delete_skips_lookup_locked_keys(self, adapter):
++        """Keys lookup-locked by an in-flight prefetch survive delete();
++        unlocked keys in the same batch are still deleted, and the locked
++        key becomes deletable again after unlock."""
++        keys = [create_object_key(i) for i in range(2)]
++        objs = [create_memory_obj(fill_value=float(i)) for i in range(2)]
++        store_fd = adapter.get_store_event_fd()
++        lookup_fd = adapter.get_lookup_and_lock_event_fd()
++
++        adapter.submit_store_task(keys, objs)
++        wait_for_event_fd(store_fd, timeout=5.0)
++        adapter.pop_completed_store_tasks()
++
++        # An in-flight prefetch holds a lookup lock on keys[0].
++        task_id = adapter.submit_lookup_and_lock_task([keys[0]], _EMPTY_LAYOUT)
++        wait_for_event_fd(lookup_fd, timeout=5.0)
++        bitmap = adapter.query_lookup_and_lock_result(task_id)
++        assert bitmap.test(0) is True
++
++        adapter.delete(keys)
++
++        # keys[0] survived, keys[1] is gone. This lookup takes another
++        # lock on keys[0].
++        task_id = adapter.submit_lookup_and_lock_task(keys, _EMPTY_LAYOUT)
++        wait_for_event_fd(lookup_fd, timeout=5.0)
++        bitmap = adapter.query_lookup_and_lock_result(task_id)
++        assert bitmap.test(0) is True
++        assert bitmap.test(1) is False
++
++        # Release both locks; the key is deletable again.
++        adapter.submit_unlock([keys[0]])
++        adapter.submit_unlock([keys[0]])
++        adapter.delete([keys[0]])
++
++        task_id = adapter.submit_lookup_and_lock_task([keys[0]], _EMPTY_LAYOUT)
++        wait_for_event_fd(lookup_fd, timeout=5.0)
++        bitmap = adapter.query_lookup_and_lock_result(task_id)
++        assert bitmap.test(0) is False
++
++    def test_delete_all_keys_locked_is_noop(self, adapter):
++        """delete() returns without submitting when every key is locked."""
++        key = create_object_key(1)
++        obj = create_memory_obj()
++        store_fd = adapter.get_store_event_fd()
++        lookup_fd = adapter.get_lookup_and_lock_event_fd()
++
++        adapter.submit_store_task([key], [obj])
++        wait_for_event_fd(store_fd, timeout=5.0)
++        adapter.pop_completed_store_tasks()
++
++        task_id = adapter.submit_lookup_and_lock_task([key], _EMPTY_LAYOUT)
++        wait_for_event_fd(lookup_fd, timeout=5.0)
++        assert adapter.query_lookup_and_lock_result(task_id).test(0) is True
++
++        adapter.delete([key])
++
++        task_id = adapter.submit_lookup_and_lock_task([key], _EMPTY_LAYOUT)
++        wait_for_event_fd(lookup_fd, timeout=5.0)
++        assert adapter.query_lookup_and_lock_result(task_id).test(0) is True
++        adapter.submit_unlock([key])
++        adapter.submit_unlock([key])
++
++    def test_delete_skips_lookup_that_has_not_completed(self):
++        """Eviction cannot enter between lookup submission and lock acquire."""
++        client = DeferredExistsConnector()
++        adapter = NativeConnectorL2Adapter(client)
++        key = create_object_key(1)
++        obj = create_memory_obj()
++
++        try:
++            adapter.submit_store_task([key], [obj])
++            wait_for_event_fd(adapter.get_store_event_fd(), timeout=5.0)
++            adapter.pop_completed_store_tasks()
++
++            task_id = adapter.submit_lookup_and_lock_task([key], _EMPTY_LAYOUT)
++            adapter.delete([key])
++            assert _object_key_to_string(key) in client._store
++
++            client.complete_exists()
++            wait_for_event_fd(adapter.get_lookup_and_lock_event_fd(), timeout=5.0)
++            assert adapter.query_lookup_and_lock_result(task_id).test(0) is True
++            adapter.submit_unlock([key])
++        finally:
++            adapter.close()
++
+     def test_delete_batch(self, adapter):
+         keys = [create_object_key(i) for i in range(5)]
+         objs = [create_memory_obj(fill_value=float(i)) for i in range(5)]
+@@ -1294,7 +1424,6 @@ class TestUsageTracking:
+         # 400 bytes / 2000 bytes = 0.2
+         assert usage.usage_fraction == pytest.approx(0.2)
+         assert usage.total_bytes_used == 400
+-
+     def test_get_usage_after_delete(self, adapter_with_capacity):
+         adp = adapter_with_capacity
+         store_fd = adp.get_store_event_fd()
+@@ -1358,3 +1487,136 @@ class TestUsageTracking:
+         usage = adp.get_usage()
+         assert usage.usage_fraction == pytest.approx(0.2)
+         assert usage.total_bytes_used == 400
++
++
++# =============================================================================
++# Durable Store Tests
++# =============================================================================
++
++
++class _BlockingStoreListener:
++    def __init__(self):
++        self.entered = threading.Event()
++        self.release = threading.Event()
++
++    def on_l2_keys_stored(self, keys, sizes) -> None:
++        self.entered.set()
++        assert self.release.wait(timeout=5.0)
++
++
++class TestStoreObjectsSync:
++    def test_success_uses_private_completion(self, adapter):
++        keys = [create_object_key(i) for i in range(2)]
++        objs = [create_memory_obj(fill_value=float(i)) for i in range(2)]
++
++        ok, persisted, bytes_written = adapter.store_objects_sync(keys, objs)
++
++        assert ok is True
++        assert persisted == 2
++        assert bytes_written == sum(obj.get_size() for obj in objs)
++        assert adapter.get_usage().total_bytes_used == bytes_written
++        assert adapter.pop_completed_store_tasks() == {}
++
++    def test_partial_failure_accounts_only_persisted_keys(self, adapter_and_mock):
++        adapter, mock_client = adapter_and_mock
++        keys = [create_object_key(i) for i in range(2)]
++        objs = [create_memory_obj(fill_value=float(i)) for i in range(2)]
++        mock_client.fail_set_keys = {_object_key_to_string(keys[1])}
++
++        ok, persisted, bytes_written = adapter.store_objects_sync(keys, objs)
++
++        assert ok is False
++        assert persisted == 1
++        assert bytes_written == objs[0].get_size()
++        assert adapter.get_usage().total_bytes_used == objs[0].get_size()
++
++    def test_async_partial_failure_uses_per_key_results(self, adapter_and_mock):
++        adapter, mock_client = adapter_and_mock
++        keys = [create_object_key(i) for i in range(2)]
++        objs = [create_memory_obj(fill_value=float(i)) for i in range(2)]
++        mock_client.fail_set_keys = {_object_key_to_string(keys[1])}
++
++        task_id = adapter.submit_store_task(keys, objs)
++        assert wait_for_event_fd(adapter.get_store_event_fd(), timeout=5.0)
++
++        result = adapter.pop_completed_store_tasks()[task_id]
++        assert result.is_successful() is False
++        assert adapter.get_usage().total_bytes_used == objs[0].get_size()
++
++    def test_batch_fallback_without_per_key_results(self, adapter_and_mock):
++        adapter, mock_client = adapter_and_mock
++        mock_client.report_set_per_key_results = False
++        keys = [create_object_key(i) for i in range(2)]
++        objs = [create_memory_obj(fill_value=float(i)) for i in range(2)]
++
++        ok, persisted, bytes_written = adapter.store_objects_sync(keys, objs)
++
++        assert ok is True
++        assert persisted == 2
++        assert bytes_written == sum(obj.get_size() for obj in objs)
++
++    def test_validates_inputs(self, adapter):
++        with pytest.raises(ValueError, match="length mismatch"):
++            adapter.store_objects_sync([create_object_key(1)], [])
++        with pytest.raises(ValueError, match="timeout must be positive"):
++            adapter.store_objects_sync(
++                [create_object_key(1)], [create_memory_obj()], timeout=0
++            )
++        assert adapter.store_objects_sync([], []) == (True, 0, 0)
++
++    def test_real_timeout_cleans_pending_operation(self, adapter_and_mock):
++        adapter, mock_client = adapter_and_mock
++        mock_client.suppress_set_completion = True
++
++        result = adapter.store_objects_sync(
++            [create_object_key(1)], [create_memory_obj()], timeout=0.05
++        )
++
++        assert result == (False, 0, 0)
++        assert adapter._pending_sync_store_events == {}
++        assert adapter._pending_ops == {}
++
++    def test_completion_at_timeout_does_not_wait_for_observer(self, adapter):
++        listener = _BlockingStoreListener()
++        adapter.register_listener(listener)
++        result = []
++        worker = threading.Thread(
++            target=lambda: result.append(
++                adapter.store_objects_sync(
++                    [create_object_key(1)],
++                    [create_memory_obj()],
++                    timeout=0.05,
++                )
++            )
++        )
++        worker.start()
++        assert listener.entered.wait(timeout=5.0)
++        time.sleep(0.1)
++        assert not worker.is_alive()
++        assert result[0][0] is True
++        assert adapter.get_usage().total_bytes_used == result[0][2]
++
++        listener.release.set()
++        worker.join(timeout=5.0)
++
++        assert not worker.is_alive()
++
++    def test_close_unblocks_waiter(self, adapter_and_mock):
++        adapter, mock_client = adapter_and_mock
++        mock_client.suppress_set_completion = True
++        result = []
++        worker = threading.Thread(
++            target=lambda: result.append(
++                adapter.store_objects_sync(
++                    [create_object_key(1)], [create_memory_obj()], timeout=10.0
++                )
++            )
++        )
++        worker.start()
++        time.sleep(0.05)
++
++        adapter.close()
++        worker.join(timeout=5.0)
++
++        assert not worker.is_alive()
++        assert result == [(False, 0, 0)]
+diff --git a/tests/v1/distributed/test_native_connector_restart_accounting.py b/tests/v1/distributed/test_native_connector_restart_accounting.py
+new file mode 100644
+index 0000000000000000000000000000000000000000..dc5d6c68c3fcb236bafd2bfdf9a2b8c9582e00d8
+--- /dev/null
++++ b/tests/v1/distributed/test_native_connector_restart_accounting.py
+@@ -0,0 +1,66 @@
++# SPDX-License-Identifier: Apache-2.0
++"""Restart accounting behavior shared by native L2 connectors."""
++
++# Third Party
++import pytest
++
++# First Party
++from tests.v1.distributed.test_native_connector_l2_adapter import (
++    adapter,
++    create_object_key,
++)
++
++
++class _RecordingL2Listener:
++    def __init__(self):
++        self.stored = []
++
++    def on_l2_keys_stored(self, keys, sizes) -> None:
++        self.stored.append((list(keys), list(sizes)))
++
++
++class TestPrimeExistingKeys:
++    def test_priming_accounts_deduplicated_usage(self, adapter):
++        key = create_object_key(1)
++
++        adapter.prime_existing_keys([key, key], [100, 999])
++
++        assert adapter.get_usage().total_bytes_used == 100
++        assert adapter._key_sizes == {key: 100}
++
++    def test_first_listener_receives_startup_snapshot_once(self, adapter):
++        keys = [create_object_key(1), create_object_key(2)]
++        adapter.prime_existing_keys(keys, [100, 200])
++        first = _RecordingL2Listener()
++        second = _RecordingL2Listener()
++
++        adapter.register_listener(first)
++        adapter.register_listener(second)
++
++        assert first.stored == [(keys, [100, 200])]
++        assert second.stored == []
++        assert adapter.get_usage().total_bytes_used == 300
++
++    def test_empty_snapshot_is_consumed_without_callback(self, adapter):
++        adapter.prime_existing_keys([], [])
++        listener = _RecordingL2Listener()
++
++        adapter.register_listener(listener)
++
++        assert listener.stored == []
++
++    def test_rejects_invalid_or_repeated_priming(self, adapter):
++        with pytest.raises(ValueError, match="length mismatch"):
++            adapter.prime_existing_keys([create_object_key(1)], [1, 2])
++        with pytest.raises(ValueError, match="must be positive"):
++            adapter.prime_existing_keys([create_object_key(1)], [0])
++
++        adapter.prime_existing_keys([], [])
++        with pytest.raises(RuntimeError, match="already primed"):
++            adapter.prime_existing_keys([], [])
++
++    def test_rejects_priming_after_listener_registration(self, adapter):
++        adapter.register_listener(_RecordingL2Listener())
++
++        with pytest.raises(RuntimeError, match="before listeners"):
++            adapter.prime_existing_keys([], [])
+diff --git a/tests/v1/distributed/test_native_fs_connector_results.py b/tests/v1/distributed/test_native_fs_connector_results.py
+new file mode 100644
+index 0000000000000000000000000000000000000000..458fcf0edfcf8a04ab13a4431248640e557cb8c3
+--- /dev/null
++++ b/tests/v1/distributed/test_native_fs_connector_results.py
+@@ -0,0 +1,54 @@
++# SPDX-License-Identifier: Apache-2.0
++"""Native FS connector completion semantics.
++
++These tests exercise the compiled extension. They are skipped when the
++optional native FS module is not part of the test environment.
++"""
++
++# Standard
++import select
++import time
++
++# Third Party
++import pytest
++
++lmcache_fs = pytest.importorskip("lmcache.lmcache_fs")
++
++
++def _wait_for_completion(client, timeout: float = 5.0):
++    poller = select.poll()
++    poller.register(client.event_fd(), select.POLLIN)
++    deadline = time.monotonic() + timeout
++    while time.monotonic() < deadline:
++        if poller.poll(50):
++            completions = client.drain_completions()
++            if completions:
++                return completions
++    raise AssertionError("native connector completion timed out")
++
++
++def test_batch_set_reports_partial_results_and_continues(tmp_path):
++    client = lmcache_fs.LMCacheFSClient(str(tmp_path), 1)
++    try:
++        buffers = [bytearray(b"first"), bytearray(b"bad"), bytearray(b"last")]
++        keys = [
++            "model@00000000@01",
++            "malformed-key",
++            "model@00000000@03",
++        ]
++
++        future_id = client.submit_batch_set(
++            keys,
++            [memoryview(buffer) for buffer in buffers],
++        )
++        completions = _wait_for_completion(client)
++
++        assert len(completions) == 1
++        completed_id, ok, error, results = completions[0]
++        assert completed_id == future_id
++        assert ok is False
++        assert "partially failed" in error
++        assert results == [True, False, True]
++        assert len(list(tmp_path.glob("*.data"))) == 2
++    finally:
++        client.close()
+diff --git a/tests/v1/distributed/test_native_fs_key_compatibility.py b/tests/v1/distributed/test_native_fs_key_compatibility.py
+new file mode 100644
+index 0000000000000000000000000000000000000000..d18fba4e8f8c662a3826f1a8182ac681ca9a0584
+--- /dev/null
++++ b/tests/v1/distributed/test_native_fs_key_compatibility.py
+@@ -0,0 +1,55 @@
++# SPDX-License-Identifier: Apache-2.0
++"""ObjectKey compatibility of the compiled native FS connector."""
++
++# Standard
++import select
++import time
++
++# Third Party
++import pytest
++
++lmcache_fs = pytest.importorskip("lmcache.lmcache_fs")
++
++
++def _wait_for_completion(client, timeout: float = 5.0):
++    poller = select.poll()
++    poller.register(client.event_fd(), select.POLLIN)
++    deadline = time.monotonic() + timeout
++    while time.monotonic() < deadline:
++        if poller.poll(50):
++            completions = client.drain_completions()
++            if completions:
++                return completions[0]
++    raise AssertionError("native connector completion timed out")
++
++
++@pytest.mark.parametrize(
++    ("wire_key", "filename"),
++    [
++        ("model@00000000@aabb", "model@0x00000000@aabb.data"),
++        (
++            "model@00000000@aabb@salt",
++            "model@0x00000000@aabb@salt.data",
++        ),
++        (
++            "model@00000000@2@aabb",
++            "model@0x00000000@2@aabb.data",
++        ),
++        (
++            "model@00000000@2@aabb@salt",
++            "model@0x00000000@2@aabb@salt.data",
++        ),
++    ],
++)
++def test_legacy_and_current_key_shapes(wire_key, filename, tmp_path):
++    client = lmcache_fs.LMCacheFSClient(str(tmp_path), 1)
++    try:
++        payload = bytearray(b"payload")
++        future_id = client.submit_batch_set([wire_key], [memoryview(payload)])
++        completed_id, ok, error, _results = _wait_for_completion(client)
++
++        assert completed_id == future_id
++        assert ok, error
++        assert (tmp_path / filename).read_bytes() == payload
++    finally:
++        client.close()
+diff --git a/tests/v1/distributed/test_native_fs_odirect.py b/tests/v1/distributed/test_native_fs_odirect.py
+new file mode 100644
+index 0000000000000000000000000000000000000000..1d5118eca102011208e580b447f3d034cb8afd13
+--- /dev/null
++++ b/tests/v1/distributed/test_native_fs_odirect.py
+@@ -0,0 +1,80 @@
++# SPDX-License-Identifier: Apache-2.0
++"""O_DIRECT behavior of the compiled native FS connector."""
++
++# Standard
++import ctypes
++import select
++import time
++
++# Third Party
++import pytest
++
++lmcache_fs = pytest.importorskip("lmcache.lmcache_fs")
++
++
++def _aligned_view(size: int, alignment: int = 4096):
++    storage = bytearray(size + alignment)
++    address = ctypes.addressof(ctypes.c_char.from_buffer(storage))
++    offset = (-address) % alignment
++    return storage, memoryview(storage)[offset : offset + size]
++
++
++def _wait_for_completion(client, timeout: float = 5.0):
++    poller = select.poll()
++    poller.register(client.event_fd(), select.POLLIN)
++    deadline = time.monotonic() + timeout
++    while time.monotonic() < deadline:
++        if poller.poll(50):
++            completions = client.drain_completions()
++            if completions:
++                return completions[0]
++    raise AssertionError("native connector completion timed out")
++
++
++def test_odirect_falls_back_for_misaligned_buffer_address(tmp_path):
++    client = lmcache_fs.LMCacheFSClient(str(tmp_path), 1, "", True)
++    try:
++        payload_storage = bytearray(4097)
++        payload = memoryview(payload_storage)[1:]
++        payload[:] = b"x" * len(payload)
++        key = "model@00000000@01"
++
++        store_id = client.submit_batch_set([key], [payload])
++        completed_id, ok, error, _results = _wait_for_completion(client)
++        assert completed_id == store_id
++        assert ok, error
++
++        loaded_storage = bytearray(4097)
++        loaded = memoryview(loaded_storage)[1:]
++        load_id = client.submit_batch_get([key], [loaded])
++        completed_id, ok, error, results = _wait_for_completion(client)
++        assert completed_id == load_id
++        assert ok, error
++        assert results == [True]
++        assert loaded == payload
++    finally:
++        client.close()
++
++
++def test_odirect_falls_back_for_misaligned_readahead_split(tmp_path):
++    client = lmcache_fs.LMCacheFSClient(str(tmp_path), 1, "", True, 4095)
++    try:
++        payload_storage, payload = _aligned_view(8192)
++        payload[:] = b"x" * len(payload)
++        key = "model@00000000@02"
++
++        store_id = client.submit_batch_set([key], [payload])
++        completed_id, ok, error, _results = _wait_for_completion(client)
++        assert completed_id == store_id
++        assert ok, error
++
++        loaded_storage, loaded = _aligned_view(8192)
++        load_id = client.submit_batch_get([key], [loaded])
++        completed_id, ok, error, results = _wait_for_completion(client)
++        assert completed_id == load_id
++        assert ok, error
++        assert results == [True]
++        assert loaded == payload
++        del payload_storage, loaded_storage
++    finally:
++        client.close()
+diff --git a/tests/v1/distributed/test_prefetch_controller.py b/tests/v1/distributed/test_prefetch_controller.py
+index 09c06c5819646d20d65485ee446793a1a9a7f9d0..e86ac177a07f19f54bb6417858dea1d4ff116cfd 100644
+--- a/tests/v1/distributed/test_prefetch_controller.py
++++ b/tests/v1/distributed/test_prefetch_controller.py
+@@ -35,6 +35,9 @@ from lmcache.v1.distributed.l2_adapters.mock_l2_adapter import (
+     MockL2Adapter,
+     MockL2AdapterConfig,
+ )
++from lmcache.v1.distributed.storage_controllers import (
++    prefetch_controller as prefetch_controller_module,
++)
+ from lmcache.v1.distributed.storage_controllers.prefetch_controller import (
+     PrefetchController,
+     build_trim_mask,
+@@ -363,7 +366,7 @@ class TestSingleAdapterPrefetch:
+         ctrl.stop()
+         adapter.close()
+ 
+-    def test_fault_inject_load_gap_segmented_vs_prefix(self, l1_manager):
++    def test_fault_inject_load_gap_segmented_vs_prefix(self, l1_manager, monkeypatch):
+         """fault_inject (load fails at index 2) drives the segmented path.
+ 
+         Lookup reports all 5 keys present; the *load* of index 2 fails (the L2
+@@ -371,6 +374,14 @@ class TestSingleAdapterPrefetch:
+         post-gap keys {0,1,3,4}; PREFIX truncates at the hole to {0,1}. Distinct
+         key ranges per policy keep the shared L1 from serving the second pass.
+         """
++        warning_messages: list[str] = []
++
++        def capture_warning(message, *args, **_kwargs):
++            warning_messages.append(message % args)
++
++        monkeypatch.setattr(
++            prefetch_controller_module.logger, "warning", capture_warning
++        )
+         layout = make_layout()
+         for base, trim, expected in (
+             (0, TrimPolicy.SEGMENTED_PREFIX, [0, 1, 3, 4]),
+@@ -402,6 +413,11 @@ class TestSingleAdapterPrefetch:
+             ctrl.stop()
+             fault.close()
+ 
++        assert any(
++            "1/5 plan keys failed to load from L2" in message and "sample:" in message
++            for message in warning_messages
++        )
++
+     def test_key0_missing(self, l1_manager):
+         """L2 has keys {1,2,3} but not 0 → prefix = 0, nothing loaded."""
+         adapter = make_adapter()
+diff --git a/tests/v1/multiprocess/test_futures.py b/tests/v1/multiprocess/test_futures.py
+index 53cf694bc5c29ee852c5511d2753b6a8a676511a..c9086609ec879d9ed6fcceab478da9c5c7117d49 100644
+--- a/tests/v1/multiprocess/test_futures.py
++++ b/tests/v1/multiprocess/test_futures.py
+@@ -173,6 +173,27 @@ def test_messaging_future_complex_type():
+     thread.join()
+ 
+ 
++def test_messaging_future_exception_is_re_raised():
++    """A remote messaging failure completes the future instead of hanging it."""
++    future = MessagingFuture[int]()
++    error = RuntimeError("remote operation failed")
++
++    future.set_exception(error)
++
++    assert future.query()
++    assert future.wait(timeout=0.1)
++    with pytest.raises(RuntimeError, match="remote operation failed") as exc_info:
++        future.result(timeout=0.1)
++    assert exc_info.value is error
++
++
++def test_messaging_future_rejects_non_exception():
++    future = MessagingFuture[int]()
++
++    with pytest.raises(TypeError, match="must derive from BaseException"):
++        future.set_exception("not an exception")  # type: ignore[arg-type]
++
++
+ # ==============================================================================
+ # CUDAMessagingFuture Tests
+ # ==============================================================================
+diff --git a/tests/v1/multiprocess/test_mq.py b/tests/v1/multiprocess/test_mq.py
+index 75ff9cd7a0630391f0515622e36e1f38fe243764..93ef515bfc0c3a66feda76720178b2dd140a7211 100644
+--- a/tests/v1/multiprocess/test_mq.py
++++ b/tests/v1/multiprocess/test_mq.py
+@@ -21,6 +21,7 @@ from lmcache.v1.multiprocess.mq import (
+     BlockingRequestHandler,
+     MessageQueueClient,
+     MessageQueueServer,
++    RemoteHandlerError,
+ )
+ from lmcache.v1.multiprocess.protocol import (
+     RequestType,
+@@ -683,6 +684,58 @@ def test_shared_loop_dispatch():
+         server.close()
+ 
+ 
++def test_sync_handler_failure_completes_future_and_loop_recovers():
++    context = zmq.Context.instance()
++    server = MessageQueueServer("tcp://127.0.0.1:16021", context)
++    add_handler_helper(
++        server, RequestType.NOOP, test_mq_handler_helpers.failing_noop_handler
++    )
++    server.start()
++    client = MessageQueueClient("tcp://127.0.0.1:16021", context)
++
++    try:
++        failed = client.submit_request(RequestType.NOOP, [])
++        with pytest.raises(
++            RemoteHandlerError, match="intentional sync handler failure"
++        ) as exc_info:
++            failed.result(timeout=2)
++        assert exc_info.value.request_type is RequestType.NOOP
++        assert exc_info.value.error_type == "ValueError"
++
++        server.add_sync_handler(
++            RequestType.NOOP, [], test_mq_handler_helpers.noop_handler
++        )
++        assert (
++            client.submit_request(RequestType.NOOP, []).result(timeout=2) == "NOOP_OK"
++        )
++    finally:
++        client.close()
++        server.close()
++
++
++def test_blocking_handler_failure_completes_future():
++    context = zmq.Context.instance()
++    server = MessageQueueServer("tcp://127.0.0.1:16022", context)
++    add_handler_helper(
++        server, RequestType.LOOKUP, test_mq_handler_helpers.failing_lookup_handler
++    )
++    server.add_normal_thread_pool([RequestType.LOOKUP], max_workers=1)
++    server.start()
++    client = MessageQueueClient("tcp://127.0.0.1:16022", context)
++
++    try:
++        future = client.submit_request(RequestType.LOOKUP, [create_cache_key(1), 1])
++        with pytest.raises(
++            RemoteHandlerError, match="intentional blocking handler failure"
++        ) as exc_info:
++            future.result(timeout=2)
++        assert exc_info.value.request_type is RequestType.LOOKUP
++        assert exc_info.value.error_type == "OSError"
++    finally:
++        client.close()
++        server.close()
++
++
+ def test_shared_loop_recreate():
+     """
+     Test that closing all clients and creating new ones starts a fresh loop.
+diff --git a/tests/v1/multiprocess/test_mq_handler_helpers.py b/tests/v1/multiprocess/test_mq_handler_helpers.py
+index b1d65251d3fd0a615bc256fb483cf78a4a8ef16e..9837df531ef7414473af86834bc63afcb7f842c0 100644
+--- a/tests/v1/multiprocess/test_mq_handler_helpers.py
++++ b/tests/v1/multiprocess/test_mq_handler_helpers.py
+@@ -29,6 +29,11 @@ def noop_handler() -> str:
+     return "NOOP_OK"
+ 
+ 
++def failing_noop_handler() -> str:
++    """Raise a deterministic error for RPC error propagation tests."""
++    raise ValueError("intentional sync handler failure")
++
++
+ # ==============================================================================
+ # REGISTER_KV_CACHE Request Handlers
+ # ==============================================================================
+@@ -203,6 +208,12 @@ def lookup_handler(key: KeyType, tp_size: int) -> None:
+     assert isinstance(tp_size, int), f"Expected tp_size to be int, got {type(tp_size)}"
+ 
+ 
++def failing_lookup_handler(key: KeyType, tp_size: int) -> None:
++    """Raise a deterministic error from a blocking request handler."""
++    del key, tp_size
++    raise OSError("intentional blocking handler failure")
++
++
+ # ==============================================================================
+ # FREE_LOOKUP_LOCKS Request Handlers
+ # ==============================================================================
+diff --git a/tests/v1/test_vllm_mp_adapter.py b/tests/v1/test_vllm_mp_adapter.py
+index d64ca9ec7061a0714cba7c9c488e3fb0cef9179a..ddf180a64dd9e6b9d8f4af4114324bc927fbf12f 100644
+--- a/tests/v1/test_vllm_mp_adapter.py
++++ b/tests/v1/test_vllm_mp_adapter.py
+@@ -782,3 +782,65 @@ def test_recover_callback_rebuilds_transfer_ctx_without_closing_previous(
+     assert len(contexts) == 3
+     assert adapter.transfer_ctx is contexts[2]
+     contexts[1].close.assert_not_called()
++
++
++def _finished_retrieve_future(result: object) -> MagicMock:
++    """Build a completed retrieve future; an Exception *result* makes
++    ``result()`` raise it."""
++    future = MagicMock(name="retrieve_future")
++    future.query.return_value = True
++    if isinstance(result, Exception):
++        future.result.side_effect = result
++    else:
++        future.result.return_value = result
++    return future
++
++
++def test_failed_retrieve_marks_blocks_invalid(fake_adapter) -> None:
++    """A retrieve the healthy server answers with ``result=False`` is
++    reported finished AND its block ids are surfaced through
++    ``get_block_ids_with_load_errors`` so the scheduler recomputes them
++    instead of decoding over never-written blocks."""
++    adapter, _send_mock, _ = fake_adapter
++    adapter.retrieve_futures["req-1"] = (
++        _finished_retrieve_future(False),
++        [3, 4, 5],
++    )
++
++    ret_stores, finished_retrieves = adapter.get_finished(set())
++
++    assert ret_stores == set()
++    assert finished_retrieves == {"req-1"}
++    assert adapter.get_block_ids_with_load_errors() == {3, 4, 5}
++    # The error set is consumed on read.
++    assert adapter.get_block_ids_with_load_errors() == set()
++    assert adapter.retrieve_failure_count == 1
++
++
++def test_raising_retrieve_future_contained_as_failure(fake_adapter) -> None:
++    """A retrieve future whose ``result()`` raises must not propagate out
++    of ``get_finished`` (that would kill the engine step); it lands on the
++    same failure path as ``result=False``."""
++    adapter, _send_mock, _ = fake_adapter
++    adapter.retrieve_futures["req-1"] = (
++        _finished_retrieve_future(RuntimeError("ipc receive failed")),
++        [7, 8],
++    )
++
++    _ret_stores, finished_retrieves = adapter.get_finished(set())
++
++    assert finished_retrieves == {"req-1"}
++    assert adapter.get_block_ids_with_load_errors() == {7, 8}
++    assert adapter.retrieve_failure_count == 1
++
++
++def test_successful_retrieve_marks_no_blocks_invalid(fake_adapter) -> None:
++    """A successful retrieve reports no load errors."""
++    adapter, _send_mock, _ = fake_adapter
++    adapter.retrieve_futures["req-1"] = (_finished_retrieve_future(True), [1, 2])
++
++    _ret_stores, finished_retrieves = adapter.get_finished(set())
++
++    assert finished_retrieves == {"req-1"}
++    assert adapter.get_block_ids_with_load_errors() == set()
++    assert adapter.retrieve_failure_count == 0
+diff --git a/tests/v1/test_vllm_mp_connector_metadata.py b/tests/v1/test_vllm_mp_connector_metadata.py
+new file mode 100644
+index 0000000000000000000000000000000000000000..45d427bd561aed4dcc953eda04259e2854008e15
+--- /dev/null
++++ b/tests/v1/test_vllm_mp_connector_metadata.py
+@@ -0,0 +1,133 @@
++# SPDX-License-Identifier: Apache-2.0
++"""Unit tests for ``LMCacheMPRequestMetadata.GetRetrieveMetadata``.
++
++The retrieve op must only be emitted when the tracker's allocated block ids
++actually cover the retrieve token range in every engine group:
++``slice_block_ids_per_group`` validates chunk alignment only, and its plain
++Python slice truncates silently, so an uncovered range would otherwise emit
++an op with too few block ids.
++"""
++
++# Standard
++from types import SimpleNamespace
++
++# Third Party
++import pytest
++
++# First Party
++from lmcache.integration.vllm.lmcache_mp_connector import (
++    LMCacheMPRequestMetadata,
++    LMCacheMPRequestState,
++    LMCacheMPRequestTracker,
++)
++
++CHUNK_TOKENS = 64
++
++
++def _tracker(
++    num_tokens: int,
++    lmcache_hit_tokens: int,
++    vllm_hit_tokens: int,
++    allocated_block_ids: dict[int, list[int]],
++) -> LMCacheMPRequestTracker:
++    """Build a tracker that is ready for retrieving over *num_tokens*."""
++    request = SimpleNamespace(
++        request_id="req-1",
++        cache_salt="",
++        all_token_ids=list(range(num_tokens)),
++    )
++    tracker = LMCacheMPRequestTracker(request)
++    tracker.num_lmcache_hit_tokens = lmcache_hit_tokens
++    tracker.num_vllm_hit_tokens = vllm_hit_tokens
++    tracker.allocated_block_ids = allocated_block_ids
++    tracker.state = LMCacheMPRequestState.WAITING_FOR_LOAD
++    return tracker
++
++
++@pytest.mark.parametrize(
++    ("group_tokens_per_block", "allocated_block_ids", "expected_block_ids"),
++    [
++        # Single group, plain geometry: 64 tokens / 16 tokens per block.
++        ([16], {0: [0, 1, 2, 3]}, [[0, 1, 2, 3]]),
++        # Single group, DCP-scaled: one manager block id covers 64 tokens.
++        ([64], {0: [5]}, [[5]]),
++        # Hybrid geometries: each group sliced by its own tokens-per-block.
++        ([16, 32], {0: [0, 1, 2, 3], 1: [10, 11]}, [[0, 1, 2, 3], [10, 11]]),
++        # Extra allocated blocks beyond the range are fine (and not emitted).
++        ([16], {0: [0, 1, 2, 3, 4, 5]}, [[0, 1, 2, 3]]),
++    ],
++)
++def test_retrieve_metadata_emitted_when_allocation_covers_range(
++    group_tokens_per_block: list[int],
++    allocated_block_ids: dict[int, list[int]],
++    expected_block_ids: list[list[int]],
++) -> None:
++    tracker = _tracker(
++        num_tokens=CHUNK_TOKENS,
++        lmcache_hit_tokens=CHUNK_TOKENS,
++        vllm_hit_tokens=0,
++        allocated_block_ids=allocated_block_ids,
++    )
++
++    metadata = LMCacheMPRequestMetadata.GetRetrieveMetadata(
++        tracker, CHUNK_TOKENS, group_tokens_per_block
++    )
++
++    assert metadata is not None
++    assert metadata.direction == "RETRIEVE"
++    assert metadata.op.start == 0
++    assert metadata.op.end == CHUNK_TOKENS
++    assert metadata.op.block_ids == expected_block_ids
++
++
++@pytest.mark.parametrize(
++    ("group_tokens_per_block", "allocated_block_ids"),
++    [
++        # One block short in the only group.
++        ([16], {0: [0, 1, 2]}),
++        # DCP-scaled group with no allocation at all.
++        ([64], {0: []}),
++        # Group 0 covered, group 1 one block short.
++        ([16, 32], {0: [0, 1, 2, 3], 1: [10]}),
++        # Group key missing entirely (counts as zero blocks).
++        ([16, 16], {0: [0, 1, 2, 3]}),
++    ],
++)
++def test_retrieve_metadata_suppressed_when_allocation_short(
++    group_tokens_per_block: list[int],
++    allocated_block_ids: dict[int, list[int]],
++) -> None:
++    """Any engine group whose allocation does not cover the retrieve range
++    suppresses the op entirely: the request falls back to recompute instead
++    of retrieving over silently truncated block-id lists."""
++    tracker = _tracker(
++        num_tokens=CHUNK_TOKENS,
++        lmcache_hit_tokens=CHUNK_TOKENS,
++        vllm_hit_tokens=0,
++        allocated_block_ids=allocated_block_ids,
++    )
++
++    metadata = LMCacheMPRequestMetadata.GetRetrieveMetadata(
++        tracker, CHUNK_TOKENS, group_tokens_per_block
++    )
++
++    assert metadata is None
++
++
++def test_retrieve_metadata_skip_tokens_preserved_on_emitted_op() -> None:
++    """vLLM-hit tokens inside the first chunk round the start down and are
++    carried as skip_first_n_tokens; coverage is still checked against the
++    chunk-aligned end."""
++    tracker = _tracker(
++        num_tokens=CHUNK_TOKENS,
++        lmcache_hit_tokens=CHUNK_TOKENS,
++        vllm_hit_tokens=16,
++        allocated_block_ids={0: [0, 1, 2, 3]},
++    )
++
++    metadata = LMCacheMPRequestMetadata.GetRetrieveMetadata(tracker, CHUNK_TOKENS, [16])
++
++    assert metadata is not None
++    assert metadata.op.start == 0
++    assert metadata.op.end == CHUNK_TOKENS
++    assert metadata.op.skip_first_n_tokens == 16

--- a/patches/releases/gilded-gnosis-v20-r12/sparkinfer/integration.lock.json
+++ b/patches/releases/gilded-gnosis-v20-r12/sparkinfer/integration.lock.json
@@ -1,0 +1,26 @@
+{
+  "base": {
+    "commit": "36cade0bd8d87a26b7eb2fc8cc46188496465a06",
+    "ref": "refs/heads/master",
+    "repository": "https://github.com/local-inference-lab/sparkinfer.git"
+  },
+  "manifest": {
+    "sha256": "50feaf1e9fd2eeb14864285afce13907e1ec2f21374118bb9a0aec7d7a9b56fb"
+  },
+  "name": "gilded-gnosis-v20-sparkinfer",
+  "pull_requests": [
+    {
+      "disposition": "merged",
+      "head": "de04125508c75e748016493f851e6bd4513b515b",
+      "number": 92,
+      "ref": "refs/pull/92/head",
+      "title": "Stabilize Trellis arena memory profiling"
+    }
+  ],
+  "result": {
+    "patch": "integration.patch",
+    "patch_sha256": "eb1ade5a8bb021e6d9e362bb0ec584784192a2599282e6d116ffb315591d1945",
+    "tree": "35aebc6d46a0d3d4f7275b81251211864f410269"
+  },
+  "schema_version": 1
+}

--- a/patches/releases/gilded-gnosis-v20-r12/sparkinfer/integration.patch
+++ b/patches/releases/gilded-gnosis-v20-r12/sparkinfer/integration.patch
@@ -1,0 +1,484 @@
+diff --git a/sparkinfer/moe/fused_moe/_impl.py b/sparkinfer/moe/fused_moe/_impl.py
+index 2a340db1bcffd61d368922d681ac795715496cee..185419719a9c7ae7bd9e59358c5b7f3dd172c976 100644
+--- a/sparkinfer/moe/fused_moe/_impl.py
++++ b/sparkinfer/moe/fused_moe/_impl.py
+@@ -858,6 +858,14 @@ class TPMoEScratchPlan:
+     launch_plan: TPMoEPlan
+     _core_workspace_plan: _TPCoreWorkspacePlan
+     _scratch_specs: tuple[ScratchBufferSpec, ...]
++    _prewarmed_fused_launches: tuple[tuple[int, object], ...] = field(
++        default=(), repr=False
++    )
++    _prewarmed_topk_sum_launches: tuple[
++        tuple[torch.dtype, bool, object], ...
++    ] = field(
++        default=(), repr=False
++    )
+ 
+     @property
+     def full_rotation(self) -> bool:
+@@ -946,6 +954,8 @@ class TPMoEScratchPlan:
+             layer_idx=layer_idx,
+             route_expert_map=route_expert_map,
+             output_expert_map=output_expert_map,
++            fused_launch=None,
++            topk_sum_launch=None,
+         )
+ 
+ 
+@@ -1882,11 +1892,12 @@ def _arena_core_token_counts(
+     num_topk: int,
+     core_token_counts: tuple[int, ...] | None,
+     quant_mode: str,
++    bucket_w4a16_tokens: bool = True,
+ ) -> tuple[int, ...]:
+     max_tokens = max(int(max_tokens), 1)
+     num_topk = max(int(num_topk), 1)
+     quant_mode = _normalize_quant_mode(quant_mode)
+-    if quant_mode == "w4a16":
++    if quant_mode == "w4a16" and bucket_w4a16_tokens:
+         from sparkinfer.moe._shared.kernels.w4a16.host import (
+             route_pack_token_capacity,
+         )
+@@ -1898,7 +1909,7 @@ def _arena_core_token_counts(
+         normalized = tuple(
+             max(int(token_count), 1) for token_count in core_token_counts
+         )
+-        if quant_mode == "w4a16":
++        if quant_mode == "w4a16" and bucket_w4a16_tokens:
+             normalized = tuple(
+                 route_pack_token_capacity(token_count, num_topk)
+                 for token_count in normalized
+@@ -1910,7 +1921,7 @@ def _arena_core_token_counts(
+     max_micro_tokens = micro_cutover_pairs // num_topk
+     if max_micro_tokens >= 1:
+         micro_boundary_tokens = min(max_tokens, max_micro_tokens)
+-        if quant_mode == "w4a16":
++        if quant_mode == "w4a16" and bucket_w4a16_tokens:
+             micro_boundary_tokens = route_pack_token_capacity(
+                 micro_boundary_tokens,
+                 num_topk,
+@@ -2194,6 +2205,8 @@ def _build_tp_moe_fp4_binding_from_views(
+     layer_idx: int | None = None,
+     route_expert_map: torch.Tensor | None = None,
+     output_expert_map: torch.Tensor | None = None,
++    fused_launch: object | None = None,
++    topk_sum_launch: object | None = None,
+ ) -> TPMoEFP4Binding:
+     if not isinstance(experts, SPARKINFERFP4ExpertWeights):
+         raise TypeError("experts must come from prepare_sparkinfer_fp4_moe_weights")
+@@ -2385,6 +2398,8 @@ def _build_tp_moe_fp4_binding_from_views(
+             route_block_size_m=plan.route_block_size_m,
+             route_expert_map=route_expert_map,
+             output_expert_map=output_expert_map,
++            fused_launch=fused_launch,
++            topk_sum_launch=topk_sum_launch,
+         )
+ 
+     if plan.implementation == "micro":
+@@ -6070,6 +6085,12 @@ def plan_tp_moe_arena_layout(
+         num_topk=num_topk,
+         core_token_counts=core_token_counts,
+         quant_mode=quant_mode,
++        # Trellis plans one fixed caller-owned capacity and its route-pack
++        # wrapper already falls back to that exact capacity when the supplied
++        # buffers are smaller than the generic compile bucket. Rounding a
++        # 3072-token EXL3 plan to 4096 therefore reserves roughly 320 MiB of
++        # unreachable activation scratch without reducing launch variants.
++        bucket_w4a16_tokens=source_format != "exl3_trellis_mcg",
+     )
+     route_num_experts = int(
+         route_num_experts if route_num_experts is not None else weight_E
+@@ -6137,6 +6158,213 @@ def plan_tp_moe_arena_layout(
+     )
+ 
+ 
++def _plan_full_rotation_w4a16_launches(
++    *,
++    caps: TPMoEScratchCaps,
++    core_plan: _TPCoreWorkspacePlan,
++    capacity_tokens: int,
++) -> tuple[
++    tuple[tuple[int, object], ...],
++    tuple[tuple[torch.dtype, bool, object], ...],
++]:
++    """Compile the fixed Trellis launches before serving memory profiling.
++
++    The caller-owned scratch path cannot use the mutable workspace prewarm
++    dictionaries.  Keeping the launch objects on the immutable scratch plan
++    preserves the old Trellis API contract and prevents first-use compilation
++    from being charged as peak activation memory by vLLM.
++    """
++    if not core_plan.full_rotation:
++        return (), ()
++    if caps.quant_mode != "w4a16":
++        raise RuntimeError("full-rotation TP MoE requires W4A16 execution")
++    if core_plan.device.type != "cuda":
++        return (), ()
++    if not torch.cuda.is_available():
++        raise RuntimeError("CUDA must be available before planning Trellis MoE")
++    if torch.cuda.is_current_stream_capturing():
++        raise RuntimeError("Trellis launch planning cannot run during capture")
++
++    from sparkinfer.moe._shared.kernels.w4a16.host import (
++        max_packed_route_slots,
++    )
++    from sparkinfer.moe._shared.kernels.w4a16.kernel import (
++        _DEFAULT_MAX_SHARED_MEM,
++        compile_w4a16_fused_moe,
++        compile_w4a16_topk_sum,
++        pack_topk_routes_by_expert,
++    )
++
++    capacity_tokens = max(int(capacity_tokens), 1)
++    if not core_plan.route_block_size_m:
++        raise RuntimeError(
++            "Trellis launch planning requires the arena's route_block_size_m"
++        )
++    block_size_m = int(core_plan.route_block_size_m)
++    weight_layout = _normalize_w4a16_weight_layout(
++        caps.w4a16_weight_layout
++        or _w4a16_weight_layout_for_source(caps.source_format)
++    )
++    scale_format = _normalize_w4a16_scale_format(
++        caps.w4a16_scale_format
++        or _w4a16_scale_format_for_source(caps.source_format)
++    )
++    if weight_layout != "trellis3_t256" or scale_format != "e4m3_k32":
++        raise RuntimeError(
++            "full-rotation Trellis launch planning requires "
++            "weight_layout='trellis3_t256' and scale_format='e4m3_k32'; "
++            f"got weight_layout={weight_layout!r}, scale_format={scale_format!r}"
++        )
++    w13_layout = "trellis3_t256_proj"
++    capacity_route_slots = max_packed_route_slots(
++        capacity_tokens * core_plan.num_topk,
++        block_size_m,
++        core_plan.route_E,
++    )
++    capacity_m_blocks = (
++        capacity_route_slots + block_size_m - 1
++    ) // block_size_m
++    rotation_input_dtype = _w4a16_element_dtype(core_plan.dtype)
++
++    with torch.cuda.device(core_plan.device):
++        props = torch.cuda.get_device_properties(core_plan.device)
++        sms = int(props.multi_processor_count)
++        max_shared_mem = int(
++            getattr(
++                props,
++                "shared_memory_per_block_optin",
++                _DEFAULT_MAX_SHARED_MEM,
++            )
++        )
++        # Decode plans are deliberately exact-M: the unified API's measured
++        # speedup over the retired Trellis wrapper comes from specializing the
++        # small live shapes instead of always launching its M=32 capacity
++        # kernel.  Large prefill plans retain one capacity launch.
++        fused_token_counts = (
++            tuple(range(1, capacity_tokens + 1))
++            if capacity_tokens <= 32
++            else (capacity_tokens,)
++        )
++
++        def compile_fused(token_count: int) -> object:
++            return compile_w4a16_fused_moe(
++                size_m=token_count,
++                hidden_size=core_plan.k,
++                intermediate_size=core_plan.n,
++                num_experts=core_plan.weight_E,
++                top_k=core_plan.num_topk,
++                activation=core_plan.activation,
++                apply_router_weight_on_input=caps.apply_router_weight_on_input,
++                zero_fc2_output=False,
++                moe_block_size=block_size_m,
++                # Match the lazy unified path: specialize the live M while
++                # retaining the caller-owned route arena's full grid capacity.
++                max_m_blocks=capacity_m_blocks,
++                element_dtype="fp16",
++                fast_math=caps.w4a16_fast_math,
++                sms=sms,
++                max_shared_mem=max_shared_mem,
++                swiglu_limit=core_plan.swiglu_limit,
++                swiglu_alpha=core_plan.swiglu_alpha,
++                swiglu_beta=core_plan.swiglu_beta,
++                weight_layout=weight_layout,
++                scale_format=scale_format,
++                w13_layout=w13_layout,
++                trellis_bits=core_plan.trellis_bits,
++                force_tile_config=core_plan.trellis_tile_config,
++                intermediate_rotation=True,
++                full_rotation=True,
++                rotation_input_dtype=rotation_input_dtype,
++            )
++
++        fused_launches = tuple(
++            (token_count, compile_fused(token_count))
++            for token_count in fused_token_counts
++        )
++        topk_sum_launches = tuple(
++            (
++                ids_dtype,
++                mapped,
++                compile_w4a16_topk_sum(
++                    m=capacity_tokens,
++                    topk=core_plan.num_topk,
++                    hidden_size=core_plan.k,
++                    element_dtype="fp16",
++                    full_rotation=True,
++                    num_experts=core_plan.weight_E,
++                    route_num_experts=(core_plan.route_E if mapped else 0),
++                    route_ids_dtype=ids_dtype,
++                    use_expert_map=mapped,
++                ),
++            )
++            for ids_dtype in (torch.int32, torch.int64)
++            for mapped in (False, True)
++        )
++        for mapped in (False, True):
++            route_pack_key = (
++                core_plan.device.type,
++                int(torch.cuda.current_device()),
++                capacity_tokens * core_plan.num_topk,
++                int(block_size_m),
++                int(core_plan.route_E),
++                mapped,
++            )
++            if route_pack_key in _W4A16_ROUTE_PACK_PREWARMED:
++                continue
++            dummy_topk_ids = torch.zeros(
++                capacity_tokens,
++                core_plan.num_topk,
++                dtype=torch.int32,
++                device=core_plan.device,
++            )
++            packed_route_indices = torch.empty(
++                capacity_route_slots,
++                dtype=torch.int32,
++                device=core_plan.device,
++            )
++            block_expert_ids = torch.empty(
++                capacity_m_blocks,
++                dtype=torch.int32,
++                device=core_plan.device,
++            )
++            packed_route_count = torch.empty(
++                1,
++                dtype=torch.int32,
++                device=core_plan.device,
++            )
++            expert_offsets = torch.empty(
++                core_plan.route_E + 1,
++                dtype=torch.int32,
++                device=core_plan.device,
++            )
++            expert_counts = torch.empty(
++                core_plan.route_E,
++                dtype=torch.int32,
++                device=core_plan.device,
++            )
++            expert_map = None
++            if mapped:
++                expert_map = torch.arange(
++                    core_plan.route_E,
++                    dtype=torch.int32,
++                    device=core_plan.device,
++                )
++            pack_topk_routes_by_expert(
++                dummy_topk_ids,
++                block_size_m,
++                core_plan.route_E,
++                expert_map=expert_map,
++                packed_route_indices=packed_route_indices,
++                block_expert_ids=block_expert_ids,
++                packed_route_count=packed_route_count,
++                expert_offsets=expert_offsets,
++                expert_counts=expert_counts,
++            )
++            torch.cuda.current_stream(core_plan.device).synchronize()
++            _W4A16_ROUTE_PACK_PREWARMED.add(route_pack_key)
++    return fused_launches, topk_sum_launches
++
++
+ def plan_tp_moe_scratch(caps: TPMoEScratchCaps) -> TPMoEScratchPlan:
+     deterministic_output = caps.deterministic_output
+     if deterministic_output is None:
+@@ -6203,6 +6431,11 @@ def plan_tp_moe_scratch(caps: TPMoEScratchCaps) -> TPMoEScratchPlan:
+         swiglu_alpha=launch_plan.swiglu_alpha,
+         swiglu_beta=launch_plan.swiglu_beta,
+     )
++    fused_launches, topk_sum_launches = _plan_full_rotation_w4a16_launches(
++        caps=caps,
++        core_plan=core_workspace_plan,
++        capacity_tokens=capacity_tokens,
++    )
+     return TPMoEScratchPlan(
+         caps=caps,
+         layout=layout,
+@@ -6215,6 +6448,12 @@ def plan_tp_moe_scratch(caps: TPMoEScratchCaps) -> TPMoEScratchPlan:
+                 device=torch.device(caps.device),
+             ),
+         ),
++        # Keep strong references to the launches primed in the module caches,
++        # but leave the runtime binding unresolved.  ``run_w4a16_moe`` uses a
++        # None launch as a dispatch signal and then gets these exact objects
++        # from its compile cache without doing first-use JIT work.
++        _prewarmed_fused_launches=fused_launches,
++        _prewarmed_topk_sum_launches=topk_sum_launches,
+     )
+ 
+ 
+diff --git a/tests/moe/test_tp_moe_scratch_bindings.py b/tests/moe/test_tp_moe_scratch_bindings.py
+index c885570b92d9d92aaf5e46055f4f5b6128ef8c1c..75d327b6b1d530994301c8b85d0ac2e03a5008bb 100644
+--- a/tests/moe/test_tp_moe_scratch_bindings.py
++++ b/tests/moe/test_tp_moe_scratch_bindings.py
+@@ -525,6 +525,149 @@ def test_w4a16_scratch_plan_uses_route_pack_capacity_buckets(
+     assert plan_4080.shapes_and_dtypes() == plan_4096.shapes_and_dtypes()
+ 
+ 
++def test_trellis_scratch_plan_preserves_exact_fixed_capacity(
++    monkeypatch: pytest.MonkeyPatch,
++) -> None:
++    """Trellis must not pay the generic W4A16 compile-bucket memory cost."""
++    monkeypatch.setattr(tp_moe_impl, "get_num_sm", lambda _device: 188)
++    weight_plan = plan_sparkinfer_fp4_moe_weights(
++        quant_modes="w4a16",
++        source_format="exl3_trellis_mcg",
++        activation="silu",
++        params_dtype=torch.bfloat16,
++        num_experts=256,
++        hidden_size=6144,
++        intermediate_size=512,
++        trellis_bits=3,
++        trellis_tile_config=(64, 256, 64, 256),
++    )
++    plan = plan_tp_moe_scratch(
++        TPMoEScratchCaps(
++            max_tokens=3072,
++            core_token_counts=(3072,),
++            num_topk=8,
++            route_num_experts=0,
++            device="cpu",
++            weight_plan=weight_plan,
++            quant_mode="w4a16",
++            w4a16_block_size_m=64,
++        )
++    )
++
++    assert plan.layout.core_token_counts[0] == 3072
++    assert 4096 not in plan.layout.core_token_counts
++    assert plan.layout.route_workspace_nbytes == 0
++    assert 1000 * (1 << 20) < plan.layout.core_workspace_nbytes < 1060 * (1 << 20)
++    assert plan.layout.total_nbytes == plan.layout.core_workspace_nbytes
++
++
++@pytest.mark.skipif(not torch.cuda.is_available(), reason="requires CUDA")
++def test_trellis_launch_planner_compiles_fixed_launch_matrix() -> None:
++    """The real planner must cover every fixed decode and route-pack variant."""
++    weight_plan = plan_sparkinfer_fp4_moe_weights(
++        quant_modes="w4a16",
++        source_format="exl3_trellis_mcg",
++        activation="silu",
++        params_dtype=torch.bfloat16,
++        num_experts=8,
++        hidden_size=128,
++        intermediate_size=128,
++        trellis_bits=3,
++        trellis_tile_config=(64, 128, 64, 128),
++    )
++    plan = plan_tp_moe_scratch(
++        TPMoEScratchCaps(
++            max_tokens=4,
++            core_token_counts=(4,),
++            num_topk=2,
++            route_num_experts=8,
++            device="cuda",
++            weight_plan=weight_plan,
++            quant_mode="w4a16",
++            w4a16_block_size_m=8,
++        )
++    )
++
++    assert tuple(tokens for tokens, _launch in plan._prewarmed_fused_launches) == (
++        1,
++        2,
++        3,
++        4,
++    )
++    assert {
++        (ids_dtype, mapped)
++        for ids_dtype, mapped, _launch in plan._prewarmed_topk_sum_launches
++    } == {
++        (torch.int32, False),
++        (torch.int32, True),
++        (torch.int64, False),
++        (torch.int64, True),
++    }
++
++
++def test_trellis_scratch_plan_prewarms_without_forcing_runtime_dispatch(
++    monkeypatch: pytest.MonkeyPatch,
++) -> None:
++    fused_launches = tuple((tokens, object()) for tokens in range(1, 5))
++    sums = tuple(
++        (ids_dtype, mapped, object())
++        for ids_dtype in (torch.int32, torch.int64)
++        for mapped in (False, True)
++    )
++    monkeypatch.setattr(tp_moe_impl, "get_num_sm", lambda _device: 188)
++    monkeypatch.setattr(
++        tp_moe_impl,
++        "_plan_full_rotation_w4a16_launches",
++        lambda **_kwargs: (fused_launches, sums),
++    )
++    weight_plan = plan_sparkinfer_fp4_moe_weights(
++        quant_modes="w4a16",
++        source_format="exl3_trellis_mcg",
++        activation="silu",
++        params_dtype=torch.bfloat16,
++        num_experts=8,
++        hidden_size=128,
++        intermediate_size=128,
++        trellis_bits=3,
++        trellis_tile_config=(64, 128, 64, 128),
++    )
++    plan = plan_tp_moe_scratch(
++        TPMoEScratchCaps(
++            max_tokens=4,
++            core_token_counts=(4,),
++            num_topk=2,
++            route_num_experts=0,
++            device="cpu",
++            weight_plan=weight_plan,
++            quant_mode="w4a16",
++            w4a16_block_size_m=8,
++        )
++    )
++    tensors = _runtime_tensors(n=128)
++    captured = {}
++
++    def _capture_binding(**kwargs):
++        captured.update(kwargs)
++        return SimpleNamespace()
++
++    monkeypatch.setattr(
++        tp_moe_impl,
++        "_build_tp_moe_fp4_binding_from_views",
++        _capture_binding,
++    )
++    output_expert_map = torch.arange(8, dtype=torch.int32)
++    plan.bind(
++        scratch=_scratch_for_plan(plan),
++        **_binding_args(tensors, _experts(tensors, weight_plan)),
++        output_expert_map=output_expert_map,
++    )
++
++    assert plan._prewarmed_fused_launches == fused_launches
++    assert plan._prewarmed_topk_sum_launches == sums
++    assert captured["fused_launch"] is None
++    assert captured["topk_sum_launch"] is None
++
++
+ def test_w4a16_topk6_bucket_binds_with_planned_scratch(
+     monkeypatch: pytest.MonkeyPatch,
+ ) -> None:

--- a/patches/releases/gilded-gnosis-v20-r12/vllm/integration.lock.json
+++ b/patches/releases/gilded-gnosis-v20-r12/vllm/integration.lock.json
@@ -1,0 +1,47 @@
+{
+  "base": {
+    "commit": "f978d009fab996617f9a3cadef36ce727bcd83cd",
+    "ref": "refs/heads/dev/gilded-gnosis",
+    "repository": "https://github.com/local-inference-lab/vllm.git"
+  },
+  "manifest": {
+    "sha256": "bdf0d8abedaeedc3ab81e0b6800252af0823ce532f67752a5b1fbfb127d325a2"
+  },
+  "name": "gilded-gnosis-v20",
+  "pull_requests": [
+    {
+      "disposition": "merged",
+      "head": "99bf3f13f13012b72d6d67e49572d686b45b2833",
+      "number": 145,
+      "ref": "refs/pull/145/head",
+      "title": "GLM-5.2 calibrated NVFP4 MLA KV outer scales"
+    },
+    {
+      "disposition": "merged",
+      "head": "2c14a58a21c724f08d01d988b9972d10c77ed4c0",
+      "number": 175,
+      "ref": "refs/pull/175/head",
+      "title": "Shard sparse prefill queries and halve result traffic"
+    },
+    {
+      "disposition": "merged",
+      "head": "214ccf58e472cb2135f26edfc240db2dd55ebda5",
+      "number": 190,
+      "ref": "refs/pull/190/head",
+      "title": "Add EXL3 Trellis backend for rank-sliced MoE checkpoints"
+    },
+    {
+      "disposition": "merged",
+      "head": "703af3ffd6ae60e4b99abbd5fa8a5a03d629c7e7",
+      "number": 198,
+      "ref": "refs/pull/198/head",
+      "title": "Measure repeatable activation peak after kernel warmup"
+    }
+  ],
+  "result": {
+    "patch": "integration.patch",
+    "patch_sha256": "88d536c843f9161a818dc8ca340e69cd8ee591b1393953bbcfbf73adc1fb655e",
+    "tree": "b46c3aac9421ec6c03b9dfcb5aacc8c1eb11f09b"
+  },
+  "schema_version": 1
+}

--- a/patches/releases/gilded-gnosis-v20-r12/vllm/integration.patch
+++ b/patches/releases/gilded-gnosis-v20-r12/vllm/integration.patch
@@ -1,0 +1,4032 @@
+diff --git a/kv-scales/README.md b/kv-scales/README.md
+new file mode 100644
+index 0000000000000000000000000000000000000000..36b37d5aa188027675ec9eaa447e9597b3921e4c
+--- /dev/null
++++ b/kv-scales/README.md
+@@ -0,0 +1,49 @@
++# GLM-5.2 NVFP4 MLA KV outer scales
++
++Per-layer calibration for the `nvfp4_ds_mla` KV cache writer
++(`VLLM_NVFP4_MLA_SCALES_FILE`, format `nvfp4_ds_mla_outer_scale_v1`).
++
++GLM-5.2's post-RMSNorm 512-dim `kv_c` latent spans a ~240x amplitude range
++across layers. With the default outer scale of 1.0, shallow layers quantize
++with E4M3 block scales at or below the subnormal floor, and shallow-layer KV
++error is strongly amplified downstream. `s_l = max_abs(kv_c_normed) / (6*448)`
++re-centers every layer so its largest block scale lands at the top of the
++E4M3 range.
++
++## Files
++
++- `glm52-nvfp4-nf3-hybrid_mla_outer_scales_v1.json` — calibrated on
++  `madeby561/GLM-5.2-MXFP8-NVFP4-NF3-Hybrid` (K64R16), Salesforce/wikitext
++  (wikitext-2-raw-v1, test), 2048-token context, TP4; per-layer envelope with
++  an independent community capture of the same base model for shallow-layer
++  headroom. `max_abs` per layer is included for auditability.
++
++## Usage
++
++```bash
++VLLM_NVFP4_MLA_SCALES_FILE=/path/to/glm52-nvfp4-nf3-hybrid_mla_outer_scales_v1.json \
++  ./serve-glm52.sh   # nvfp4_ds_mla + B12X_MLA_SPARSE only; inert otherwise
++```
++
++## Results (teacher-forced prefill KLD vs BF16 reference, 5 fresh boots each)
++
++| KV config | mean +/- sd | max ctx (4x96GB) |
++|---|---|---|
++| fp8_ds_mla | 0.1263 +/- 0.0030 | 373k |
++| nvfp4_ds_mla + scales, bf16 rope | 0.1345 +/- 0.0035 | 550k |
++| nvfp4_ds_mla + scales, fp8 rope (`KV_FP8_ROPE=1`) | 0.1356 +/- 0.0054 | 600k+ |
++| nvfp4_ds_mla, no scales, bf16 rope | 0.158 | 550k |
++| nvfp4_ds_mla, no scales, fp8 rope | 0.168 | 600k+ |
++
++Protocol: local-inference-lab/rtx6kpro `benchmarks/glm52-kld-evaluation.md`
++(festr2 2026-07-08 reference logits, one fixed 2048-token window, 2047
++positions, full 154,880 vocab, `KL(ref || candidate)`).
++
++## Cache invalidation (required)
++
++CuTeDSL folds the outer-scale multiply out of the kernel when `latent_scale`
++traces at exactly 1.0. b12x builds without the identity/dynamic compile-spec
++fact (see lukealonso/b12x PR "mla: split latent_scale identity/dynamic
++compile-cache entries") replay stale identity cubins from persistent compile
++caches, silently dropping the restore. Clear mounted b12x compile caches once
++when enabling scales on such builds.
+diff --git a/kv-scales/glm52-nvfp4-nf3-hybrid_mla_outer_scales_v1.json b/kv-scales/glm52-nvfp4-nf3-hybrid_mla_outer_scales_v1.json
+new file mode 100644
+index 0000000000000000000000000000000000000000..7ae9d9351c4e8de79f6387b5f64a5fa9618bf155
+--- /dev/null
++++ b/kv-scales/glm52-nvfp4-nf3-hybrid_mla_outer_scales_v1.json
+@@ -0,0 +1,178 @@
++{
++ "format": "nvfp4_ds_mla_outer_scale_v1",
++ "num_layers": 78,
++ "latent_dim": 512,
++ "denominator": 2688.0,
++ "formula": "s_l = max_abs(kv_c_normed) / (6 * 448)",
++ "model": "madeby561/GLM-5.2-MXFP8-NVFP4-NF3-Hybrid (local K64R16 build; own capture)",
++ "dataset": {
++  "name": "Salesforce/wikitext",
++  "config": "wikitext-2-raw-v1",
++  "split": "test",
++  "context_length": 2048,
++  "windows": 1,
++  "note": "the canonical festr2-0708 census window"
++ },
++ "created_utc": "2026-07-20T16:40:43.312260+00:00",
++ "hook": "mla.py kv_a_layernorm output (bind-mount capture patch), per-TP-rank agreement checked",
++ "max_abs": [
++  0.04833984375,
++  0.021728515625,
++  0.03662109375,
++  0.1005859375,
++  0.023681640625,
++  0.03515625,
++  0.046875,
++  0.033203125,
++  0.259765625,
++  0.1474609375,
++  0.7734375,
++  1.0,
++  1.1171875,
++  0.150390625,
++  0.76171875,
++  0.392578125,
++  0.25390625,
++  0.455078125,
++  0.80859375,
++  0.80078125,
++  0.96875,
++  0.78515625,
++  0.58203125,
++  0.330078125,
++  0.89453125,
++  0.73046875,
++  1.0390625,
++  1.578125,
++  1.0078125,
++  0.92578125,
++  1.25,
++  1.5859375,
++  1.234375,
++  1.9140625,
++  1.9453125,
++  1.7578125,
++  1.7890625,
++  2.546875,
++  2.296875,
++  2.4375,
++  1.921875,
++  2.171875,
++  2.875,
++  2.546875,
++  2.765625,
++  3.234375,
++  2.5625,
++  3.390625,
++  2.40625,
++  2.546875,
++  3.09375,
++  2.90625,
++  3.671875,
++  2.46875,
++  2.609375,
++  2.359375,
++  3.078125,
++  3.171875,
++  2.578125,
++  2.359375,
++  3.890625,
++  2.953125,
++  4.09375,
++  4.09375,
++  5.0625,
++  5.1875,
++  2.984375,
++  2.875,
++  2.984375,
++  3.296875,
++  3.828125,
++  2.859375,
++  3.59375,
++  3.734375,
++  4.25,
++  4.1875,
++  4.84375,
++  3.75
++ ],
++ "scales": [
++  1.7983572823660715e-05,
++  8.083525158110119e-06,
++  1.3623918805803572e-05,
++  3.742036365327381e-05,
++  8.810134161086309e-06,
++  1.3078962053571428e-05,
++  1.743861607142857e-05,
++  1.2352353050595238e-05,
++  9.663899739583333e-05,
++  5.485897972470238e-05,
++  0.00028773716517857144,
++  0.0003720238095238095,
++  0.00041562034970238094,
++  5.5948893229166664e-05,
++  0.0002833775111607143,
++  0.00014604840959821428,
++  9.445917038690477e-05,
++  0.00016929989769345238,
++  0.00030081612723214287,
++  0.0002979096912202381,
++  0.0003603980654761905,
++  0.00029209681919642856,
++  0.00021652948288690475,
++  0.0001227969215029762,
++  0.00033278692336309525,
++  0.00027175176711309525,
++  0.0003865559895833333,
++  0.0005871000744047619,
++  0.0003749302455357143,
++  0.0003444126674107143,
++  0.0004650297619047619,
++  0.0005900065104166666,
++  0.0004592168898809524,
++  0.0007120768229166666,
++  0.0007237025669642857,
++  0.0006539481026785714,
++  0.0006655738467261905,
++  0.0009474981398809524,
++  0.0008544921875,
++  0.0009068080357142857,
++  0.0007149832589285714,
++  0.0008079892113095238,
++  0.0010695684523809525,
++  0.0009474981398809524,
++  0.0010288783482142857,
++  0.0012032645089285715,
++  0.0009533110119047619,
++  0.0012613932291666667,
++  0.0008951822916666666,
++  0.0009474981398809524,
++  0.0011509486607142857,
++  0.0010811941964285715,
++  0.001366024925595238,
++  0.0009184337797619048,
++  0.0009707496279761905,
++  0.0008777436755952381,
++  0.0011451357886904762,
++  0.0011800130208333333,
++  0.0009591238839285714,
++  0.0008777436755952381,
++  0.0014474051339285715,
++  0.0010986328125,
++  0.0015229724702380952,
++  0.0015229724702380952,
++  0.0018833705357142857,
++  0.001929873511904762,
++  0.001110258556547619,
++  0.0010695684523809525,
++  0.001110258556547619,
++  0.0012265159970238095,
++  0.0014241536458333333,
++  0.0010637555803571428,
++  0.0013369605654761905,
++  0.0013892764136904762,
++  0.0015811011904761905,
++  0.0015578497023809525,
++  0.0018019903273809525,
++  0.0013950892857142857
++ ]
++}
+\ No newline at end of file
+diff --git a/serve-glm52.sh b/serve-glm52.sh
+index 68f7501b3d618dea5c4ae93047b281cd56efd85d..8933ad62d752aabbc9f2e6a80bc3b17945afef41 100755
+--- a/serve-glm52.sh
++++ b/serve-glm52.sh
+@@ -107,6 +107,8 @@ MOE_BACKEND="${MOE_BACKEND:-b12x}"
+ MOE_SPEC_BACKEND="${MOE_SPEC_BACKEND:-b12x}"
+ ATTENTION_BACKEND="${ATTENTION_BACKEND:-B12X_MLA_SPARSE}"
+ KV_CACHE_DTYPE="${KV_CACHE_DTYPE:-fp8}"
++# Calibrated per-layer outer scales for nvfp4_ds_mla KV (empty = disabled).
++export VLLM_NVFP4_MLA_SCALES_FILE="${VLLM_NVFP4_MLA_SCALES_FILE:-}"
+ GLM51_PROFILE="${GLM51_PROFILE:-0}"
+ GLM52_CAUSAL_CASCADE="${GLM52_CAUSAL_CASCADE:-0}"
+ GLM52_DSPARK="${GLM52_DSPARK:-0}"
+diff --git a/tests/distributed/test_query_split_groups.py b/tests/distributed/test_query_split_groups.py
+new file mode 100644
+index 0000000000000000000000000000000000000000..d0dd36e26c8665a1d777aa23a925cddf7fc004cd
+--- /dev/null
++++ b/tests/distributed/test_query_split_groups.py
+@@ -0,0 +1,60 @@
++# SPDX-License-Identifier: Apache-2.0
++# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
++
++import pytest
++
++from vllm.distributed.parallel_state import _get_query_split_group_ranks
++
++
++@pytest.mark.parametrize(
++    ("tp_groups", "dcp_size", "expected"),
++    [
++        (
++            [list(range(8))],
++            4,
++            [[0, 4], [1, 5], [2, 6], [3, 7]],
++        ),
++        (
++            [list(range(8))],
++            2,
++            [[0, 2, 4, 6], [1, 3, 5, 7]],
++        ),
++        (
++            [list(range(8)), list(range(8, 16))],
++            4,
++            [
++                [0, 4],
++                [1, 5],
++                [2, 6],
++                [3, 7],
++                [8, 12],
++                [9, 13],
++                [10, 14],
++                [11, 15],
++            ],
++        ),
++        (
++            [list(range(8))],
++            8,
++            [[0], [1], [2], [3], [4], [5], [6], [7]],
++        ),
++        (
++            [list(range(8))],
++            1,
++            [list(range(8))],
++        ),
++    ],
++)
++def test_get_query_split_group_ranks(tp_groups, dcp_size, expected):
++    assert _get_query_split_group_ranks(tp_groups, dcp_size) == expected
++
++
++@pytest.mark.parametrize("dcp_size", [0, -1])
++def test_get_query_split_group_ranks_rejects_nonpositive_dcp(dcp_size):
++    with pytest.raises(ValueError, match="must be positive"):
++        _get_query_split_group_ranks([[0, 1]], dcp_size)
++
++
++def test_get_query_split_group_ranks_rejects_partial_dcp_group():
++    with pytest.raises(ValueError, match="must be divisible"):
++        _get_query_split_group_ranks([[0, 1, 2]], 2)
+diff --git a/tests/model_executor/layers/test_mla_cache_format.py b/tests/model_executor/layers/test_mla_cache_format.py
+index 9a128a5fc7e900d5fa9904e1f5815efbc82e8ac0..5c50e3e6ae877a91cb0479d4912aaa52f8525940 100644
+--- a/tests/model_executor/layers/test_mla_cache_format.py
++++ b/tests/model_executor/layers/test_mla_cache_format.py
+@@ -14,10 +14,17 @@ from vllm.model_executor.layers.mla_cache_format import (
+ )
+ 
+ 
+-def test_cache_format_envs_are_registered():
++def test_cache_format_envs_are_registered(monkeypatch):
+     assert NVFP4_MLA_DYNAMIC_SCALE_ENV in envs.environment_variables
+     assert NVFP4_MLA_SCALES_ENV in envs.environment_variables
+ 
++    scales_file = envs.environment_variables[NVFP4_MLA_SCALES_ENV]
++    monkeypatch.delenv(NVFP4_MLA_SCALES_ENV, raising=False)
++    assert scales_file() == ""
++
++    monkeypatch.setenv(NVFP4_MLA_SCALES_ENV, "  /tmp/static-scales.json  ")
++    assert scales_file() == "/tmp/static-scales.json"
++
+ 
+ def test_from_env_captures_one_server_static_mode(monkeypatch):
+     monkeypatch.setenv(NVFP4_MLA_DYNAMIC_SCALE_ENV, "1")
+diff --git a/tests/model_executor/layers/test_sparse_attn_indexer_b12x.py b/tests/model_executor/layers/test_sparse_attn_indexer_b12x.py
+index dda32a85ded7044b9c1011efae7a1ba5816d36a0..a7c46870760307887e06666d1f7b662380a20833 100644
+--- a/tests/model_executor/layers/test_sparse_attn_indexer_b12x.py
++++ b/tests/model_executor/layers/test_sparse_attn_indexer_b12x.py
+@@ -288,6 +288,88 @@ def _install_fake_b12x_dcp_merge(monkeypatch, run_row_topk, *, world_size: int):
+     )
+ 
+ 
++def test_query_split_gathers_indices_in_place_without_scores():
++    calls: list[tuple[int, int]] = []
++
++    class FakePyNccl:
++        disabled = False
++
++        def all_gather(self, output, input_):
++            calls.append((output.data_ptr(), input_.data_ptr()))
++            rows = input_.shape[0]
++            output[:rows].fill_(10)
++            output[rows:].fill_(20)
++
++    group = types.SimpleNamespace(
++        world_size=2,
++        rank_in_group=1,
++        device_communicator=types.SimpleNamespace(pynccl_comm=FakePyNccl()),
++    )
++    gathered_indices = torch.full((4, 3), -1, dtype=torch.int32)
++    local_indices = gathered_indices[2:]
++    local_indices.fill_(20)
++    scores = torch.arange(12, dtype=torch.float32).reshape(4, 3)
++    scores_before = scores.clone()
++
++    indexer_mod._query_split_all_gather_indices(group, local_indices, gathered_indices)
++
++    assert calls == [(gathered_indices.data_ptr(), local_indices.data_ptr())]
++    assert gathered_indices.tolist() == [[10] * 3, [10] * 3, [20] * 3, [20] * 3]
++    assert torch.equal(scores, scores_before)
++
++
++def test_query_split_copies_aliased_input_for_torch_distributed_fallback(
++    monkeypatch,
++):
++    calls: list[tuple[int, int]] = []
++
++    def fake_all_gather_into_tensor(output, input_, *, group):
++        assert group == "device-group"
++        calls.append((output.data_ptr(), input_.data_ptr()))
++        rows = input_.shape[0]
++        output[:rows].fill_(10)
++        output[rows:].copy_(input_)
++
++    monkeypatch.setattr(
++        torch.distributed,
++        "all_gather_into_tensor",
++        fake_all_gather_into_tensor,
++    )
++    group = types.SimpleNamespace(
++        world_size=2,
++        rank_in_group=1,
++        device_communicator=types.SimpleNamespace(
++            pynccl_comm=types.SimpleNamespace(disabled=True),
++            device_group="device-group",
++        ),
++    )
++    gathered_indices = torch.full((4, 3), -1, dtype=torch.int32)
++    local_indices = gathered_indices[2:]
++    local_indices.fill_(20)
++    local_ptr = local_indices.data_ptr()
++
++    indexer_mod._query_split_all_gather_indices(
++        group,
++        local_indices,
++        gathered_indices,
++    )
++
++    assert calls[0][0] == gathered_indices.data_ptr()
++    assert calls[0][1] != local_ptr
++    assert gathered_indices.tolist() == [[10] * 3, [10] * 3, [20] * 3, [20] * 3]
++
++
++def test_query_split_rejects_non_aliasing_local_indices():
++    group = types.SimpleNamespace(world_size=2, rank_in_group=0)
++    gathered_indices = torch.empty((4, 3), dtype=torch.int32)
++    local_indices = torch.empty((2, 3), dtype=torch.int32)
++
++    with pytest.raises(RuntimeError, match="must alias"):
++        indexer_mod._query_split_all_gather_indices(
++            group, local_indices, gathered_indices
++        )
++
++
+ @pytest.mark.parametrize(
+     "page_stride0",
+     [
+@@ -1434,9 +1516,12 @@ def test_b12x_schedule_metadata_uses_canonical_indexer_import(monkeypatch):
+     monkeypatch.setattr(
+         mla_indexer_mod.envs,
+         "VLLM_USE_B12X_SPARSE_INDEXER",
+-        True,
++        False,
+     )
+     builder = object.__new__(mla_indexer_mod.DeepseekV32IndexerMetadataBuilder)
++    # Backend selection is resolved once in __init__. The metadata path must
++    # use that result even when the legacy environment flag is unset.
++    builder.use_b12x_sparse_indexer = True
+     builder.scheduler_metadata_buffer = torch.zeros((5, 2), dtype=torch.int32)
+     builder.kv_cache_spec = types.SimpleNamespace(storage_block_size=64)
+     builder.num_sms = 4
+@@ -1459,6 +1544,27 @@ def test_b12x_schedule_metadata_uses_canonical_indexer_import(monkeypatch):
+     ]
+ 
+ 
++def test_b12x_schedule_metadata_respects_cached_backend_choice(monkeypatch):
++    from vllm.v1.attention.backends.mla import indexer as mla_indexer_mod
++
++    monkeypatch.setattr(
++        mla_indexer_mod.envs,
++        "VLLM_USE_B12X_SPARSE_INDEXER",
++        True,
++    )
++    builder = object.__new__(mla_indexer_mod.DeepseekV32IndexerMetadataBuilder)
++    builder.use_b12x_sparse_indexer = False
++
++    result = builder._maybe_build_b12x_schedule_metadata(
++        seq_lens=torch.tensor([64], dtype=torch.int32),
++        block_table=torch.zeros((1, 1), dtype=torch.int32),
++        num_decode_tokens=1,
++        requires_padding=False,
++    )
++
++    assert result is None
++
++
+ def test_mtp_variable_decode_preserves_block_table_alignment_padding():
+     from vllm.v1.attention.backends.mla import indexer as mla_indexer_mod
+ 
+diff --git a/tests/model_executor/test_eagle_quantization.py b/tests/model_executor/test_eagle_quantization.py
+index 72c189d8331324baba6da5de56f1d6d5917189bb..423273182cfef26ae58e2784ab1a65e1eae393bf 100644
+--- a/tests/model_executor/test_eagle_quantization.py
++++ b/tests/model_executor/test_eagle_quantization.py
+@@ -1,6 +1,7 @@
+ # SPDX-License-Identifier: Apache-2.0
+ # SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+ 
++from types import SimpleNamespace
+ from unittest.mock import Mock, patch
+ 
+ import pytest
+@@ -54,6 +55,49 @@ def test_get_draft_quant_config_without_draft_model():
+     assert result is None
+ 
+ 
++def test_dense_exl3_draft_skips_rank_sliced_hydration():
++    quant_config = Mock()
++    quant_config.get_name.return_value = "exl3"
++    draft_model_config = SimpleNamespace(
++        model="dense-exl3-draft",
++        hf_config=SimpleNamespace(),
++    )
++    vllm_config = SimpleNamespace(
++        speculative_config=SimpleNamespace(draft_model_config=draft_model_config),
++        load_config=object(),
++        model_config=SimpleNamespace(hf_config=SimpleNamespace()),
++    )
++
++    with patch.object(VllmConfig, "get_quantization_config", return_value=quant_config):
++        result = get_draft_quant_config(vllm_config)
++
++    assert result is quant_config
++    quant_config.maybe_update_config.assert_not_called()
++
++
++def test_rank_sliced_exl3_draft_hydrates_from_target_metadata():
++    quant_config = Mock()
++    quant_config.get_name.return_value = "exl3"
++    target_hf = SimpleNamespace(hybrid_tr3_tail={"tp": 4})
++    draft_model_config = SimpleNamespace(
++        model="rank-sliced-draft",
++        hf_config=SimpleNamespace(),
++    )
++    vllm_config = SimpleNamespace(
++        speculative_config=SimpleNamespace(draft_model_config=draft_model_config),
++        load_config=object(),
++        model_config=SimpleNamespace(hf_config=target_hf),
++    )
++
++    with patch.object(VllmConfig, "get_quantization_config", return_value=quant_config):
++        result = get_draft_quant_config(vllm_config)
++
++    assert result is quant_config
++    quant_config.maybe_update_config.assert_called_once_with(
++        "rank-sliced-draft", hf_config=target_hf
++    )
++
++
+ @torch.inference_mode()
+ @pytest.mark.parametrize("device", DEVICES)
+ def test_fc_layer_quant_config_usage(default_vllm_config, dist_init, device) -> None:
+diff --git a/tests/quantization/test_exl3.py b/tests/quantization/test_exl3.py
+new file mode 100644
+index 0000000000000000000000000000000000000000..e9c8055bf6db4c9ba01c5922f08da281da91d4e1
+--- /dev/null
++++ b/tests/quantization/test_exl3.py
+@@ -0,0 +1,374 @@
++# SPDX-License-Identifier: Apache-2.0
++# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
++
++from types import SimpleNamespace
++
++import pytest
++import torch
++
++import vllm.model_executor.layers.quantization.exl3 as exl3_module
++import vllm.model_executor.parameter as parameter_module
++from vllm.config import CompilationMode
++from vllm.model_executor.layers.fused_moe import MoEActivation
++from vllm.model_executor.layers.quantization import get_quantization_config
++from vllm.model_executor.layers.quantization.exl3 import (
++    Exl3Config,
++    Exl3MoEMethod,
++    Exl3MoEParameter,
++)
++from vllm.model_executor.models import glm4_moe
++
++
++def _rank_sliced_metadata(**overrides):
++    metadata = {
++        "format": "exl3-trellis",
++        "bits": 3.0,
++        "codebook": "mcg",
++        "experts_per_layer": 256,
++        "moe_layers": [3, 77],
++        "tensor_schema": (
++            "model.layers.{L}.mlp.experts.{E}.{proj}.rank{r}.{trellis|suh|svh|mcg}"
++        ),
++        "tp": 4,
++    }
++    metadata.update(overrides)
++    return metadata
++
++
++def test_rank_sliced_checkpoint_selects_exl3_override():
++    hf_config = SimpleNamespace(hybrid_tr3_tail=_rank_sliced_metadata())
++
++    assert get_quantization_config("exl3") is Exl3Config
++    assert (
++        Exl3Config.override_quantization_method(
++            {"quant_method": "modelopt"}, None, hf_config
++        )
++        == "exl3"
++    )
++    assert (
++        Exl3Config.override_quantization_method(
++            {"quant_method": "modelopt"}, "fp8", hf_config
++        )
++        is None
++    )
++
++
++def test_glm_model_retains_quant_config_for_weight_loading(monkeypatch):
++    pp_group = SimpleNamespace(is_first_rank=False, is_last_rank=False)
++    monkeypatch.setattr(glm4_moe, "get_pp_group", lambda: pp_group)
++    monkeypatch.setattr(
++        glm4_moe,
++        "make_layers",
++        lambda *args, **kwargs: (0, 0, torch.nn.ModuleList()),
++    )
++    monkeypatch.setattr(
++        glm4_moe,
++        "make_empty_intermediate_tensors_factory",
++        lambda *args, **kwargs: object(),
++    )
++    quant_config = object()
++    vllm_config = SimpleNamespace(
++        model_config=SimpleNamespace(
++            hf_config=SimpleNamespace(
++                vocab_size=1,
++                hidden_size=8,
++                num_hidden_layers=0,
++            )
++        ),
++        cache_config=object(),
++        quant_config=quant_config,
++        parallel_config=SimpleNamespace(enable_eplb=False),
++        compilation_config=SimpleNamespace(mode=CompilationMode.NONE),
++    )
++
++    model = glm4_moe.Glm4MoeModel(vllm_config=vllm_config)
++
++    assert model.quant_config is quant_config
++
++
++@pytest.mark.parametrize(
++    ("overrides", "message"),
++    [
++        ({"codebook": "mul1"}, "MCG codebook"),
++        ({"moe_layers": [77, 3]}, "moe_layers"),
++        ({"tensor_schema": "unsupported"}, "tensor schema"),
++    ],
++)
++def test_rank_sliced_metadata_fails_closed(overrides, message):
++    config = Exl3Config()
++    hf_config = SimpleNamespace(hybrid_tr3_tail=_rank_sliced_metadata(**overrides))
++
++    with pytest.raises(ValueError, match=message):
++        config.maybe_update_config("unused", hf_config)
++
++
++def test_rank_sliced_metadata_admits_only_declared_moe_layers():
++    config = Exl3Config()
++    config.maybe_update_config(
++        "unused",
++        SimpleNamespace(hybrid_tr3_tail=_rank_sliced_metadata()),
++    )
++
++    assert config._moe_prefix_is_exl3("model.layers.3.mlp.experts")
++    assert config._moe_prefix_is_exl3("model.layers.77.mlp.experts")
++    assert not config._moe_prefix_is_exl3("model.layers.2.mlp.experts")
++    assert not config._moe_prefix_is_exl3("model.layers.78.mlp.experts")
++    assert (
++        config.codebook_for_prefix("model.layers.10.mlp.experts.0.gate_proj") == "mcg"
++    )
++
++
++def test_rank_sliced_weight_name_keeps_only_local_tp_rank(monkeypatch):
++    config = Exl3Config()
++    config.maybe_update_config(
++        "unused",
++        SimpleNamespace(hybrid_tr3_tail=_rank_sliced_metadata()),
++    )
++    monkeypatch.setattr(exl3_module, "get_tensor_model_parallel_rank", lambda: 2)
++    prefix = "model.layers.3.mlp.experts.17.gate_proj"
++
++    assert (
++        config.normalize_rank_sliced_weight_name(f"{prefix}.rank2.trellis")
++        == f"{prefix}.trellis"
++    )
++    assert config.normalize_rank_sliced_weight_name(f"{prefix}.rank1.trellis") is None
++    assert (
++        config.normalize_rank_sliced_weight_name("model.embed_tokens.weight")
++        == "model.embed_tokens.weight"
++    )
++
++
++def test_rank_sliced_parameter_preallocates_projection_major_slab(monkeypatch):
++    monkeypatch.setattr(parameter_module, "get_tensor_model_parallel_rank", lambda: 0)
++    monkeypatch.setattr(
++        parameter_module, "get_tensor_model_parallel_world_size", lambda: 1
++    )
++    param = Exl3MoEParameter(
++        weight_loader=lambda *args, **kwargs: None,
++        num_experts=3,
++        shard_ids=("w1", "w3"),
++        preallocate=True,
++    )
++    w1 = torch.arange(8, dtype=torch.int16).reshape(2, 2, 2)
++    w3 = w1 + 20
++
++    param.load_exl3_weight(w1, expert_id=1, shard_id="w1")
++    param.load_exl3_weight(w3, expert_id=2, shard_id="w3")
++
++    assert param.exl3_backing is not None
++    assert tuple(param.exl3_backing.shape) == (2, 3, 2, 2, 2)
++    assert (
++        param.exl3_tensors[(1, "w1")].data_ptr() == param.exl3_backing[0, 1].data_ptr()
++    )
++    assert (
++        param.exl3_tensors[(2, "w3")].data_ptr() == param.exl3_backing[1, 2].data_ptr()
++    )
++    torch.testing.assert_close(param.exl3_tensors[(1, "w1")], w1)
++    torch.testing.assert_close(param.exl3_tensors[(2, "w3")], w3)
++
++
++def test_rank_sliced_weights_use_unified_fused_moe_contract(monkeypatch):
++    experts = 2
++    hidden = intermediate = 128
++    bits = 3
++    slabs = {
++        "w13_trellis": torch.zeros(
++            (2, experts, hidden // 16, intermediate // 16, 16 * bits),
++            dtype=torch.int16,
++        ),
++        "w2_trellis": torch.zeros(
++            (experts, intermediate // 16, hidden // 16, 16 * bits),
++            dtype=torch.int16,
++        ),
++        "w13_suh": torch.ones((2, experts, hidden), dtype=torch.float16),
++        "w13_svh": torch.ones((2, experts, intermediate), dtype=torch.float16),
++        "w2_suh": torch.ones((experts, intermediate), dtype=torch.float16),
++        "w2_svh": torch.ones((experts, hidden), dtype=torch.float16),
++    }
++
++    class FakeFusedMoe:
++        def __init__(self):
++            self.plan_kwargs = None
++            self.prepare_kwargs = None
++
++        def plan_weights(self, **kwargs):
++            self.plan_kwargs = kwargs
++            return SimpleNamespace(source_format=kwargs["source_format"])
++
++        def prepare_weights(self, **kwargs):
++            self.prepare_kwargs = kwargs
++            return SimpleNamespace(plan=kwargs["plan"])
++
++    api = FakeFusedMoe()
++    monkeypatch.setattr(exl3_module, "_load_sparkinfer_fused_moe", lambda: api)
++    method = object.__new__(Exl3MoEMethod)
++    method.quant_config = SimpleNamespace(bits=float(bits))
++    method._rank_sliced_backing = lambda _layer, name: slabs[name]
++    marker = torch.tensor(0xCBAC1FED - (1 << 32), dtype=torch.int32)
++    layer = SimpleNamespace(
++        local_num_experts=experts,
++        exl3_hidden_size=hidden,
++        exl3_intermediate_size_per_partition=intermediate,
++        exl3_params_dtype=torch.float16,
++        activation=MoEActivation.SILU,
++        w13_mcg=SimpleNamespace(exl3_tensors={(0, "w1"): marker}),
++    )
++
++    method._prepare_rank_sliced_weights(layer)
++
++    assert api.plan_kwargs == {
++        "quant_modes": "w4a16",
++        "source_format": "exl3_trellis_mcg",
++        "activation": "silu",
++        "params_dtype": torch.float16,
++        "num_experts": experts,
++        "hidden_size": hidden,
++        "intermediate_size": intermediate,
++        "w13_layout": "w13",
++        "trellis_bits": bits,
++        "trellis_tile_config": (64, 128, 64, 128),
++    }
++    assert api.prepare_kwargs["plan"] is layer.exl3_trellis_weights.plan
++    assert api.prepare_kwargs["params_dtype"] == torch.float16
++    assert api.prepare_kwargs["w1_fp4"] is slabs["w13_trellis"]
++    assert api.prepare_kwargs["w2_fp4"] is slabs["w2_trellis"]
++    assert api.prepare_kwargs["trellis_mcg"] is marker
++
++
++def test_rank_sliced_runtime_scope_is_per_owning_model():
++    """Target and rank-sliced MTP draft layers must not share a cached runtime.
++
++    The rank-sliced runtime cache stores mutable Trellis/prefill scratch and
++    parity staging buffers. A target MoE layer and an MTP draft layer of the same
++    model have identical shapes, topk and planner settings, so a shape-only key
++    would hand the draft the target's scratch and break the target/draft
++    isolation their independently captured CUDA graphs depend on.
++    """
++    target_config = SimpleNamespace()
++    draft_config = SimpleNamespace()
++
++    target_scope = exl3_module._runtime_scope_id(target_config)
++    draft_scope = exl3_module._runtime_scope_id(draft_config)
++
++    # Distinct owning configs must never collide...
++    assert target_scope != draft_scope
++    # ...and the scope must be stable, so every layer of one model keeps sharing
++    # a single runtime (the prefill arena is ~1 GiB; per-layer runtimes would not
++    # fit on a 75+ layer model).
++    assert exl3_module._runtime_scope_id(target_config) == target_scope
++    assert exl3_module._runtime_scope_id(draft_config) == draft_scope
++
++
++def test_rank_sliced_runtime_key_differs_across_models_with_same_shape():
++    """Two same-shape layers owned by different models get different cache keys."""
++
++    def _key(quant_config):
++        # Mirrors the scope-prefixed key built in Exl3MoEMethod._rank_sliced_runtime
++        # for two layers whose shape/planner components are byte-for-byte equal.
++        return (
++            exl3_module._runtime_scope_id(quant_config),
++            0,  # device index
++            torch.bfloat16,
++            5120,  # hidden size
++            768,  # intermediate size per partition
++            64,  # local experts
++            8,  # topk
++            3072,  # max batched tokens
++        )
++
++    target_config = SimpleNamespace()
++    draft_config = SimpleNamespace()
++
++    target_key = _key(target_config)
++    draft_key = _key(draft_config)
++
++    assert target_key != draft_key
++    # Everything except the leading scope is identical, proving the scope is the
++    # only thing preventing the collision.
++    assert target_key[1:] == draft_key[1:]
++    # Same owner -> same key, so target layers still share one runtime.
++    assert _key(target_config) == target_key
++
++
++def test_rank_sliced_window_defaults_to_min_capturable_m(monkeypatch) -> None:
++    """Every rank-sliced layer must cover small rows without an env workaround.
++
++    Regression test for the boot failure reported in vLLM #183: with the Trellis
++    window left at its historical default of 4, CUDA-graph capture of an EXL3
++    rank-sliced MTP draft reaches the eager parity path at m=1,2,3 and the engine
++    cannot start:
++
++        RuntimeError: EXL3 eager parity path entered during CUDA graph capture
++        (m=3); capture sizes must lie inside the Trellis window [4, 32]
++
++    It was invariant to num_speculative_tokens and to cudagraph_capture_sizes,
++    because m here is the draft's row count per step, not a target batch size.
++    Target profiling can also produce m=3, so role-dependent defaults merely
++    move the same failure from the draft to MTP0. The backend declares one
++    capability floor and uses it for both roles.
++    """
++    from types import SimpleNamespace
++
++    from vllm.model_executor.layers.quantization import exl3 as exl3_mod
++
++    monkeypatch.delenv("VLLM_EXL3_TRELLIS_MIN_M", raising=False)
++
++    # The GLM-5.2 MTP head is named exactly like a target layer, so the role
++    # comes from the exl3_is_draft stamp applied by load_eagle_model -- name
++    # inspection alone cannot classify it.
++    draft = SimpleNamespace(
++        layer_name="model.layers.78.mlp.experts", exl3_is_draft=True
++    )
++    target = SimpleNamespace(layer_name="model.layers.30.mlp.experts")
++
++    assert exl3_mod._is_draft_layer(draft)
++    assert not exl3_mod._is_draft_layer(target)
++    # Unstamped draft with a distinctive prefix still classifies via fallback.
++    assert exl3_mod._is_draft_layer(
++        SimpleNamespace(layer_name="model.layers.0.mtp.mlp.experts")
++    )
++    # A stamp always wins over the name, in both directions.
++    assert not exl3_mod._is_draft_layer(
++        SimpleNamespace(layer_name="model.layers.0.mtp.experts", exl3_is_draft=False)
++    )
++
++    def resolved():
++        return exl3_mod._positive_env_int(
++            "VLLM_EXL3_TRELLIS_MIN_M", exl3_mod._DEFAULT_TRELLIS_MIN_M
++        )
++
++    assert resolved() == exl3_mod._DEFAULT_TRELLIS_MIN_M
++    assert resolved() == exl3_mod.MIN_CAPTURABLE_TRELLIS_M == 1
++
++    # An explicit value remains authoritative as a diagnostic kill switch.
++    monkeypatch.setenv("VLLM_EXL3_TRELLIS_MIN_M", "4")
++    assert resolved() == 4
++
++
++def test_draft_role_stamp_wins_over_name() -> None:
++    """The exl3_is_draft stamp set in create_weights is authoritative.
++
++    Forward/plan/capture time has no current vllm config, so the role cannot be
++    inferred there; create_weights stamps it from runner_type while the
++    construction context is live. Stamped values must win over any name
++    heuristic in both directions.
++    """
++    from types import SimpleNamespace
++
++    from vllm.model_executor.layers.quantization import exl3 as exl3_mod
++
++    # GLM-5.2 MTP head: named like a target, stamped draft.
++    assert exl3_mod._is_draft_layer(
++        SimpleNamespace(layer_name="model.layers.78.mlp.experts", exl3_is_draft=True)
++    )
++    # Target stamped False keeps its role even with a suspicious name.
++    assert not exl3_mod._is_draft_layer(
++        SimpleNamespace(layer_name="model.layers.0.mtp.experts", exl3_is_draft=False)
++    )
++    # Unstamped layers fall back to the name heuristic.
++    assert exl3_mod._is_draft_layer(
++        SimpleNamespace(layer_name="model.layers.0.mtp.mlp.experts")
++    )
++    assert not exl3_mod._is_draft_layer(
++        SimpleNamespace(layer_name="model.layers.30.mlp.experts")
++    )
+diff --git a/tests/quantization/test_exl3_prefill_plan.py b/tests/quantization/test_exl3_prefill_plan.py
+new file mode 100644
+index 0000000000000000000000000000000000000000..fb09e3bf533faab2963e11990fff831abd964f38
+--- /dev/null
++++ b/tests/quantization/test_exl3_prefill_plan.py
+@@ -0,0 +1,293 @@
++# SPDX-License-Identifier: Apache-2.0
++# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
++
++"""Dispatch-contract tests for the dual-plan rank-sliced EXL3 MoE runtime.
++
++The planned Trellis API and the ExLlamaV3 extension are mocked; these tests
++prove backend policy only:
++
++* decode window m in [min, max] binds the decode plan;
++* max < m <= capacity binds the prefill plan (block_size_m=64 by default);
++* m < min stays on the parity path with chunk-capped staging buffers;
++* VLLM_EXL3_PREFILL_TRELLIS=0 restores the single-plan parity behavior
++  with full-capacity staging;
++* m above planned capacity raises.
++
++CPU-only; no CUDA, sparkinfer, or exllamav3_ext required.
++"""
++
++import os
++from types import SimpleNamespace
++
++import pytest
++import torch
++
++import vllm.model_executor.layers.quantization.exl3 as exl3_module
++from vllm.model_executor.layers.quantization.exl3 import Exl3MoEMethod
++
++HIDDEN = 128
++INTERMEDIATE = 128
++EXPERTS = 8
++TOPK = 4
++MAX_BATCHED = 256
++
++
++class _FakePlan:
++    def __init__(self, caps):
++        self.caps = caps
++
++    def scratch_specs(self):
++        return (
++            SimpleNamespace(
++                shape=(64,),
++                dtype=torch.uint8,
++                device=self.caps["device"],
++            ),
++        )
++
++
++class _FakeFusedMoeApi:
++    def __init__(self):
++        self.planned = []
++        self.bound = []
++
++    def Caps(self, **kwargs):
++        return kwargs
++
++    def plan(self, caps):
++        plan = _FakePlan(caps)
++        self.planned.append(caps)
++        return plan
++
++    def bind(self, plan, *, scratch, a, experts, topk_weights, topk_ids):
++        del scratch, experts, topk_weights, topk_ids
++        self.bound.append((plan, int(a.shape[0])))
++        return SimpleNamespace(plan=plan, m=int(a.shape[0]))
++
++    def run(self, *, binding):
++        return torch.zeros((binding.m, HIDDEN), dtype=torch.float32)
++
++
++class _FakeExt:
++    """Parity extension without exl3_moe_fused: chunk loop only."""
++
++    def __init__(self):
++        self.moe_calls = []
++
++    def exl3_moe_max_concurrency(self, device):
++        del device
++        return 2
++
++    def exl3_moe(self, xh, out32, *args):
++        del args
++        self.moe_calls.append((int(xh.shape[0]), int(out32.shape[0])))
++
++
++def _make_layer():
++    return SimpleNamespace(
++        exl3_max_num_batched_tokens=MAX_BATCHED,
++        exl3_hidden_size=HIDDEN,
++        exl3_intermediate_size_per_partition=INTERMEDIATE,
++        local_num_experts=EXPERTS,
++        exl3_trellis_tile_config=(64, 128, 64, 128),
++        exl3_trellis_weights=SimpleNamespace(plan=object()),
++        exl3_pointer_tables=(),
++        exl3_expert_map=torch.arange(EXPERTS, dtype=torch.int64),
++    )
++
++
++def _make_method():
++    method = object.__new__(Exl3MoEMethod)
++    method.quant_config = SimpleNamespace(
++        bits=3.0,
++        rank_sliced_metadata={"tp": 4},
++    )
++    return method
++
++
++class _Harness:
++    def __init__(self, env=None):
++        self._env = dict(env or {})
++        self._saved_env = {}
++        self._saved_capturing = None
++        self.api = _FakeFusedMoeApi()
++        self.ext = _FakeExt()
++
++    def __enter__(self):
++        for name, value in self._env.items():
++            self._saved_env[name] = os.environ.get(name)
++            if value is None:
++                os.environ.pop(name, None)
++            else:
++                os.environ[name] = value
++        self._saved_loaders = (
++            exl3_module._load_sparkinfer_fused_moe,
++            exl3_module._load_exl3_ext,
++        )
++        exl3_module._load_sparkinfer_fused_moe = lambda: self.api
++        exl3_module._load_exl3_ext = lambda: self.ext
++        self._saved_capturing = torch.cuda.is_current_stream_capturing
++        torch.cuda.is_current_stream_capturing = lambda: False
++        self._saved_current_device = torch.cuda.current_device
++        torch.cuda.current_device = lambda: 0
++        exl3_module._RANK_SLICED_RUNTIMES.clear()
++        return self
++
++    def __exit__(self, *exc):
++        (
++            exl3_module._load_sparkinfer_fused_moe,
++            exl3_module._load_exl3_ext,
++        ) = self._saved_loaders
++        torch.cuda.is_current_stream_capturing = self._saved_capturing
++        torch.cuda.current_device = self._saved_current_device
++        for name, value in self._saved_env.items():
++            if value is None:
++                os.environ.pop(name, None)
++            else:
++                os.environ[name] = value
++        exl3_module._RANK_SLICED_RUNTIMES.clear()
++        return False
++
++
++def _apply(method, layer, m):
++    x = torch.zeros((m, HIDDEN), dtype=torch.bfloat16)
++    weights = torch.zeros((m, TOPK), dtype=torch.float32)
++    ids = torch.zeros((m, TOPK), dtype=torch.int64)
++    return method._apply_rank_sliced(layer, x, weights, ids)
++
++
++def test_dual_plan_construction_and_dispatch():
++    with _Harness() as h:
++        method = _make_method()
++        layer = _make_layer()
++
++        out = _apply(method, layer, 16)
++        assert out.dtype == torch.bfloat16 and out.shape == (16, HIDDEN)
++        # Two plans: decode (32, block 8) then prefill (capacity, block 64).
++        assert [
++            (caps["max_tokens"], caps["w4a16_block_size_m"])
++            for caps in h.planned_caps()
++        ] == [(32, 8), (MAX_BATCHED, 64)]
++        assert all(caps["route_num_experts"] == 0 for caps in h.planned_caps())
++        assert h.api.bound[-1][0].caps["max_tokens"] == 32
++
++        _apply(method, layer, 200)
++        assert h.api.bound[-1][0].caps["max_tokens"] == MAX_BATCHED
++        assert h.api.bound[-1][1] == 200
++        assert not h.ext.moe_calls
++
++        _apply(method, layer, 2)
++        assert h.api.bound[-1][0].caps["max_tokens"] == 32
++        assert h.api.bound[-1][1] == 2
++        assert not h.ext.moe_calls
++
++        runtime = next(iter(exl3_module._RANK_SLICED_RUNTIMES.values()))
++        assert runtime["parity_rows"] == 128
++        assert runtime["xh"].shape[0] == 128
++        assert runtime["token_sorted"].numel() == 128 * TOPK
++
++        # Batches above the scheduler contract must fail before allocating a
++        # replacement runtime or a larger Trellis arena during serving.
++        runtime_keys = tuple(exl3_module._RANK_SLICED_RUNTIMES)
++        runtime_count = len(exl3_module._RANK_SLICED_RUNTIMES)
++        plan_count = len(h.planned_caps())
++        with pytest.raises(
++            ValueError,
++            match=rf"m={MAX_BATCHED + 1}, capacity={MAX_BATCHED}",
++        ):
++            _apply(method, layer, MAX_BATCHED + 1)
++        assert tuple(exl3_module._RANK_SLICED_RUNTIMES) == runtime_keys
++        assert len(exl3_module._RANK_SLICED_RUNTIMES) == runtime_count
++        assert len(h.planned_caps()) == plan_count
++
++
++def test_prefill_trellis_disabled_restores_parity():
++    with _Harness(env={"VLLM_EXL3_PREFILL_TRELLIS": "0"}) as h:
++        method = _make_method()
++        layer = _make_layer()
++
++        _apply(method, layer, 200)
++        # Single decode plan only; large m runs the parity chunk loop.
++        assert [
++            (caps["max_tokens"], caps["w4a16_block_size_m"])
++            for caps in h.planned_caps()
++        ] == [(32, 8)]
++        assert not h.api.bound
++        assert h.ext.moe_calls == [(128, 128), (72, 72)]
++
++        runtime = next(iter(exl3_module._RANK_SLICED_RUNTIMES.values()))
++        assert runtime["prefill_plan"] is None
++        assert runtime["parity_rows"] == MAX_BATCHED
++        assert runtime["xh"].shape[0] == MAX_BATCHED
++
++
++def test_prefill_block_m_env_override():
++    with _Harness(env={"VLLM_EXL3_PREFILL_BLOCK_M": "48"}) as h:
++        method = _make_method()
++        layer = _make_layer()
++        _apply(method, layer, 40)
++        assert h.planned_caps()[-1]["w4a16_block_size_m"] == 48
++        assert h.api.bound[-1][0].caps["max_tokens"] == MAX_BATCHED
++
++
++def test_parity_window_capacity_is_validated_before_planning():
++    env = {
++        "VLLM_EXL3_TRELLIS_MIN_M": "160",
++        "VLLM_EXL3_TRELLIS_MAX_M": "192",
++        "VLLM_EXL3_PREFILL_CHUNK": "128",
++    }
++    with _Harness(env=env) as h:
++        with pytest.raises(ValueError, match="cannot cover the EXL3 parity window"):
++            _apply(_make_method(), _make_layer(), 16)
++        assert not h.planned_caps()
++
++
++def test_disabled_prefill_plan_keeps_full_parity_capacity():
++    env = {
++        "VLLM_EXL3_TRELLIS_MIN_M": "160",
++        "VLLM_EXL3_TRELLIS_MAX_M": "192",
++        "VLLM_EXL3_PREFILL_CHUNK": "128",
++        "VLLM_EXL3_PREFILL_TRELLIS": "0",
++    }
++    with _Harness(env=env):
++        _apply(_make_method(), _make_layer(), 159)
++        runtime = next(iter(exl3_module._RANK_SLICED_RUNTIMES.values()))
++        assert runtime["parity_rows"] == MAX_BATCHED
++
++
++def test_explicit_parity_path_guarded_against_capture():
++    with _Harness(env={"VLLM_EXL3_TRELLIS_MIN_M": "4"}) as h:
++        method = _make_method()
++        layer = _make_layer()
++        # Plan eagerly, then flip into "capturing" state.
++        _apply(method, layer, 16)
++        torch.cuda.is_current_stream_capturing = lambda: True
++        # Both trellis plans stay capture-safe.
++        _apply(method, layer, 16)
++        _apply(method, layer, 200)
++        assert h.api.bound[-1][1] == 200
++        # The eager parity path must refuse to be recorded.
++        try:
++            _apply(method, layer, 2)
++        except RuntimeError as err:
++            assert "capture" in str(err)
++        else:
++            raise AssertionError("parity path must raise during capture")
++
++
++def _install_planned_caps_helper():
++    def planned_caps(self):
++        return self.api.planned
++
++    _Harness.planned_caps = planned_caps
++
++
++_install_planned_caps_helper()
++
++
++if __name__ == "__main__":
++    test_dual_plan_construction_and_dispatch()
++    test_prefill_trellis_disabled_restores_parity()
++    test_prefill_block_m_env_override()
++    test_parity_path_guarded_against_capture()
++    print("EXL3_PREFILL_PLAN_TESTS_OK")
+diff --git a/tests/v1/structured_output/test_reasoning_structured_output.py b/tests/v1/structured_output/test_reasoning_structured_output.py
+index 861e919c102a698d905f1da9ad6c5da09c576e6f..5e0713519aedabd9af535068fab7409f6ff51a6d 100644
+--- a/tests/v1/structured_output/test_reasoning_structured_output.py
++++ b/tests/v1/structured_output/test_reasoning_structured_output.py
+@@ -241,6 +241,116 @@ class TestReasoningStructuredOutput:
+         assert structured_req.reasoning_ended is True
+         assert result is True
+ 
++    def test_should_advance_reasoning_just_ended_with_spec_decode_json(
++        self,
++        manager_with_reasoner,
++        mock_request_with_structured_output,
++    ):
++        """When reasoning ends this step under speculative decoding, advance
++        immediately for every structured type, not just structural tags: the
++        step may already contain accepted post-marker content, and deferring
++        leaves the grammar one token behind the sampled stream (#48228)."""
++        structured_req = mock_request_with_structured_output.structured_output_request
++        structured_req.reasoning_ended = False
++        structured_req.structured_output_key = (
++            StructuredOutputOptions.JSON,
++            '{"type": "object"}',
++        )
++        reasoner = MockReasoner(tokenizer=Mock())
++        reasoner.is_reasoning_end_streaming.return_value = True
++        structured_req.reasoner = reasoner
++
++        manager_with_reasoner.vllm_config.speculative_config = Mock()
++
++        result = manager_with_reasoner.should_advance(
++            mock_request_with_structured_output
++        )
++
++        assert structured_req.reasoning_ended is True
++        assert result is True
++        assert isinstance(structured_req.reasoning_end_token_index, int)
++
++    def test_should_advance_detects_end_from_new_token_ids(
++        self,
++        manager_with_reasoner,
++        mock_request_with_structured_output,
++    ):
++        """new_token_ids is the authoritative step delta: with speculative
++        decoding, num_computed_tokens is pre-incremented past accepted draft
++        tokens, so the counter-derived window misses the end marker (#34650)."""
++        end_token_id, content_token_id = 42, 99
++        request = mock_request_with_structured_output
++        structured_req = request.structured_output_request
++        structured_req.reasoning_ended = False
++        reasoner = MockReasoner(tokenizer=Mock())
++        reasoner.is_reasoning_end_streaming.side_effect = (
++            lambda input_ids, delta_ids: end_token_id in list(delta_ids)
++        )
++        structured_req.reasoner = reasoner
++
++        request.all_token_ids = request.prompt_token_ids + [
++            7,
++            end_token_id,
++            content_token_id,
++        ]
++        # Spec decode pre-incremented past the accepted tokens: the
++        # counter-derived window all_token_ids[num_computed_tokens:] is empty.
++        request.num_computed_tokens = len(request.all_token_ids)
++        request.num_output_placeholders = 0
++
++        # The counter fallback misses the marker...
++        assert manager_with_reasoner.should_advance(request) is False
++        assert structured_req.reasoning_ended is False
++
++        # ...the explicit step delta does not (no spec config here, so the
++        # advance itself is still deferred to the next step).
++        result = manager_with_reasoner.should_advance(
++            request, [end_token_id, content_token_id]
++        )
++        assert structured_req.reasoning_ended is True
++        assert result is False
++
++    def test_should_advance_straddle_step_trims_and_advances_same_step(
++        self,
++        manager_with_reasoner,
++        mock_request_with_structured_output,
++    ):
++        """A speculative step accepting [</think>, "{"] must advance the
++        grammar with exactly the post-marker content in the same step;
++        otherwise the next bitmask is computed from the un-advanced grammar
++        and re-forces the content token, doubling it in the output (#48228)."""
++        end_token_id, content_token_id = 42, 99
++        request = mock_request_with_structured_output
++        structured_req = request.structured_output_request
++        structured_req.reasoning_ended = False
++        structured_req.structured_output_key = (
++            StructuredOutputOptions.JSON,
++            '{"type": "object"}',
++        )
++        reasoner = MockReasoner(tokenizer=Mock())
++        reasoner.is_reasoning_end_streaming.side_effect = (
++            lambda input_ids, delta_ids: end_token_id in list(delta_ids)
++        )
++        structured_req.reasoner = reasoner
++        manager_with_reasoner.vllm_config.speculative_config = Mock()
++
++        new_token_ids = [end_token_id, content_token_id]
++        request.all_token_ids = request.prompt_token_ids + [
++            7,
++            end_token_id,
++            content_token_id,
++        ]
++        request.num_computed_tokens = len(request.all_token_ids)
++        request.num_output_placeholders = 0
++
++        assert manager_with_reasoner.should_advance(request, new_token_ids) is True
++        assert structured_req.reasoning_end_token_index == (
++            len(request.all_token_ids) - 2
++        )
++        assert manager_with_reasoner.trim_reasoning_for_advance(
++            request, new_token_ids
++        ) == [content_token_id]
++
+     def test_should_advance_reasoning_already_ended(
+         self,
+         manager_with_reasoner,
+diff --git a/tests/v1/worker/test_gpu_worker.py b/tests/v1/worker/test_gpu_worker.py
+index 088bdc2614d5351fbc0eb6e7998ab1e3f5827052..ca7d18a9d07dc6477e72745b2dd00d2549b15f55 100644
+--- a/tests/v1/worker/test_gpu_worker.py
++++ b/tests/v1/worker/test_gpu_worker.py
+@@ -111,6 +111,7 @@ def test_memory_profile_replays_model_after_kernel_warmup(
+ ):
+     worker = object.__new__(Worker)
+     calls = []
++    worker.device = "cuda:0"
+     worker.model_runner = SimpleNamespace(
+         profile_run=lambda: calls.append("profile"),
+     )
+@@ -127,10 +128,21 @@ def test_memory_profile_replays_model_after_kernel_warmup(
+         "_warmup_kernels_once",
+         lambda: calls.append("kernel_warmup"),
+     )
++    monkeypatch.setattr(
++        gpu_worker_module.torch.accelerator,
++        "reset_peak_memory_stats",
++        lambda device: calls.append(("reset_peak", device)),
++    )
+ 
+     worker._profile_model_with_kernel_warmup()
+ 
+-    assert calls == ["profile", "compressor", "kernel_warmup", "profile"]
++    assert calls == [
++        "profile",
++        "compressor",
++        "kernel_warmup",
++        ("reset_peak", "cuda:0"),
++        "profile",
++    ]
+ 
+ 
+ @pytest.mark.parametrize("video_backend", [None, "opencv"])
+diff --git a/vllm/config/model.py b/vllm/config/model.py
+index 159083f58859a35d5341fde0fa0b556f0d2e4d64..d573fac4142d822be9cc0859ad688771ae3f5bda 100644
+--- a/vllm/config/model.py
++++ b/vllm/config/model.py
+@@ -1052,6 +1052,10 @@ class ModelConfig:
+                 "awq_marlin",
+                 "inc",
+                 "moe_wna16",
++                # Rank-sliced EXL3 checkpoints retain a ModelOpt dispatch tag
++                # for backward compatibility, so EXL3 must inspect metadata
++                # before the ModelOpt overrides claim them.
++                "exl3",
+                 # Must precede modelopt_fp4: hybrid checkpoints are
+                 # modelopt-tagged NVFP4 plus a hybrid_bit_map.
+                 "nvfp4_nf3_hybrid",
+diff --git a/vllm/distributed/parallel_state.py b/vllm/distributed/parallel_state.py
+index 0f2ef8564b652448109d58d3423c766214fd177d..54da6ac47a4653681b9849115e6d2e84aa852af6 100644
+--- a/vllm/distributed/parallel_state.py
++++ b/vllm/distributed/parallel_state.py
+@@ -1950,6 +1950,41 @@ def init_distributed_environment(
+             _INNER_DP_WORLD = _WORLD
+ 
+ 
++def _get_query_split_group_ranks(
++    tp_group_ranks: list[list[int]], dcp_size: int
++) -> list[list[int]]:
++    """Transpose DCP groups within each independent TP cohort.
++
++    Args:
++        tp_group_ranks: Independent TP cohorts expressed as global ranks.
++        dcp_size: Number of consecutive ranks in each DCP group.
++
++    Returns:
++        Groups joining the same DCP-rank position across each TP cohort.
++
++    Raises:
++        ValueError: If ``dcp_size`` is nonpositive or does not divide a TP
++            cohort.
++    """
++    if dcp_size <= 0:
++        raise ValueError(f"dcp_size must be positive, got {dcp_size}")
++
++    query_split_ranks: list[list[int]] = []
++    for tp_ranks in tp_group_ranks:
++        if len(tp_ranks) % dcp_size != 0:
++            raise ValueError(
++                f"TP group size {len(tp_ranks)} must be divisible by "
++                f"dcp_size {dcp_size}"
++            )
++        dcp_groups = [
++            tp_ranks[start : start + dcp_size]
++            for start in range(0, len(tp_ranks), dcp_size)
++        ]
++        for dcp_rank in range(dcp_size):
++            query_split_ranks.append([group[dcp_rank] for group in dcp_groups])
++    return query_split_ranks
++
++
+ def initialize_model_parallel(
+     tensor_model_parallel_size: int = 1,
+     pipeline_model_parallel_size: int = 1,
+@@ -2073,17 +2108,16 @@ def initialize_model_parallel(
+         group_name="dcp",
+     )
+ 
+-    # Build the query-split groups for the indexer query split (Fix A).
+-    # Ranks sharing the same dcp_rank (position within their DCP group)
+-    # form a query-split group.  At TP=8/DCP=2 the DCP groups are
+-    # {0,1},{2,3},{4,5},{6,7} and the query-split groups are
+-    # {0,2,4,6} (dcp_rank=0) and {1,3,5,7} (dcp_rank=1).
++    # Build query-split groups for the sparse indexer. Ranks sharing the same
++    # dcp_rank form one group. This also applies to DCP=1: all TP ranks hold
++    # the same indexer inputs, so they can divide query rows and all-gather
++    # only the exact int32 top-k result.
+     global _QUERY_SPLIT
+     assert _QUERY_SPLIT is None, "query split group is already initialized"
+-    if decode_context_model_parallel_size > 1 and envs.VLLM_DCP_QUERY_SPLIT:
+-        query_split_ranks: list[list[int]] = []
+-        for dcp_rank_idx in range(decode_context_model_parallel_size):
+-            query_split_ranks.append([grp[dcp_rank_idx] for grp in group_ranks])
++    if envs.VLLM_DCP_QUERY_SPLIT:
++        query_split_ranks = _get_query_split_group_ranks(
++            tp_group_ranks, decode_context_model_parallel_size
++        )
+         _QUERY_SPLIT = init_model_parallel_group(
+             query_split_ranks,
+             get_world_group().local_rank,
+diff --git a/vllm/envs.py b/vllm/envs.py
+index a62f1b3d41b5aeeb009e04680c97d4048a4a43ad..3167a840af0635f4222e3a7467397c1502ccf084 100755
+--- a/vllm/envs.py
++++ b/vllm/envs.py
+@@ -2278,6 +2278,21 @@ environment_variables: dict[str, Callable[[], Any]] = {
+     # Each entry is VAR_NAME or VAR_NAME:<suffix> (suffix appended to
+     # RDMA device name). Must be set together with VLLM_GPU_NIC_PCIE_MAPPING.
+     "VLLM_NIC_SELECTION_VARS": lambda: os.getenv("VLLM_NIC_SELECTION_VARS", ""),
++    # --- EXL3 Trellis MoE runtime knobs (read directly by
++    # model_executor/layers/quantization/exl3.py; registered here so startup
++    # does not flag them as unknown). All are passthrough: consuming code
++    # applies its own defaults (the Trellis window minimum is 1 for both target
++    # and draft layers; an explicit value is a diagnostic override).
++    "VLLM_EXL3_TRELLIS_MIN_M": lambda: os.getenv("VLLM_EXL3_TRELLIS_MIN_M"),
++    "VLLM_EXL3_TRELLIS_MAX_M": lambda: os.getenv("VLLM_EXL3_TRELLIS_MAX_M"),
++    "VLLM_EXL3_TRELLIS_BLOCK_M": lambda: os.getenv("VLLM_EXL3_TRELLIS_BLOCK_M"),
++    "VLLM_EXL3_PREFILL_CHUNK": lambda: os.getenv("VLLM_EXL3_PREFILL_CHUNK"),
++    "VLLM_EXL3_PREFILL_TRELLIS": lambda: os.getenv("VLLM_EXL3_PREFILL_TRELLIS"),
++    "VLLM_EXL3_PREFILL_BLOCK_M": lambda: os.getenv("VLLM_EXL3_PREFILL_BLOCK_M"),
++    # Prebuilt exllamav3 extension location and torch-ABI compatibility shim.
++    "VLLM_EXL3_EXT_PATH": lambda: os.getenv("VLLM_EXL3_EXT_PATH"),
++    "VLLM_EXL3_ABI_SHIM": lambda: os.getenv("VLLM_EXL3_ABI_SHIM"),
++
+ }
+ 
+ 
+diff --git a/vllm/model_executor/layers/fused_moe/routed_experts.py b/vllm/model_executor/layers/fused_moe/routed_experts.py
+index 3585f5c553a30483f0ab6f9285e89be731b31c61..9cd850d31a48c1361b530b110710b9ac22f6e146 100644
+--- a/vllm/model_executor/layers/fused_moe/routed_experts.py
++++ b/vllm/model_executor/layers/fused_moe/routed_experts.py
+@@ -1,6 +1,7 @@
+ # SPDX-License-Identifier: Apache-2.0
+ # SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+ 
++import re
+ from collections.abc import Callable, Iterable
+ from enum import Enum
+ from typing import TYPE_CHECKING, Any, Literal, cast, overload
+@@ -37,6 +38,10 @@ if TYPE_CHECKING:
+ 
+ logger = init_logger(__name__)
+ 
++# Per-expert checkpoint names carry an explicit expert index ("experts.{i}.");
++# fused pre-fused-checkpoint entries never do (see build_expert_params_mapping).
++_PER_EXPERT_IDX_RE = re.compile(r"experts\.\d+\.")
++
+ 
+ class FusedMoeWeightScaleSupported(Enum):
+     TENSOR = "tensor"
+@@ -943,14 +948,24 @@ class RoutedExperts(PluggableLayer):
+         unpadded_hidden = self.moe_config.hidden_dim_unpadded
+         for expert_name, loaded_weight in weights:
+             qual_name = f"{self.layer_name}.{expert_name}"
+-            # Fused expert weights can be identified by their 3D tensors
+-            is_fused = loaded_weight.dim() == 3
++            # Fused expert weights are 3D tensors matched against a *fused*
++            # mapping entry. Rank alone is not decisive: per-expert tensors of
++            # some quantized formats (e.g. EXL3 trellis [K/16, N/16, 16*bpw])
++            # are also rank-3 and must not be routed down the fused
++            # transpose/chunk path. Fused entries are exactly those whose
++            # weight_name carries no per-expert index.
++            is_fused_rank = loaded_weight.dim() == 3
++            is_fused = False
+             matched = False
+             for param_name, weight_name, expert_id, shard_id in expert_mapping:
+                 if weight_name not in qual_name:
+                     if matched and is_fused:
+                         break
+                     continue
++                is_fused = (
++                    is_fused_rank
++                    and _PER_EXPERT_IDX_RE.search(weight_name) is None
++                )
+                 matched = True
+                 weight_name = qual_name.replace(weight_name, param_name)
+                 param_name = weight_name.removeprefix(f"{self.layer_name}.")
+diff --git a/vllm/model_executor/layers/quantization/__init__.py b/vllm/model_executor/layers/quantization/__init__.py
+index 6793b957c79236ba45a5aadacf4981aefb42e32c..9cefb4f3672821b5875abdd64b9a2dad83dac8c1 100644
+--- a/vllm/model_executor/layers/quantization/__init__.py
++++ b/vllm/model_executor/layers/quantization/__init__.py
+@@ -14,6 +14,7 @@ QuantizationMethods = Literal[
+     "auto_awq",
+     "fp8",
+     "fbgemm_fp8",
++    "exl3",
+     "fp_quant",
+     "modelopt",
+     "modelopt_fp4",
+@@ -123,6 +124,7 @@ def get_quantization_config(quantization: str) -> type[QuantizationConfig]:
+         CompressedTensorsConfig,
+     )
+     from .experts_int8 import ExpertsInt8Config
++    from .exl3 import Exl3Config
+     from .fbgemm_fp8 import FBGEMMFp8Config
+     from .fp8 import Fp8Config
+     from .fp_quant import FPQuantConfig
+@@ -146,6 +148,7 @@ def get_quantization_config(quantization: str) -> type[QuantizationConfig]:
+         "auto_awq": AutoAWQConfig,
+         "fp8": Fp8Config,
+         "fbgemm_fp8": FBGEMMFp8Config,
++        "exl3": Exl3Config,
+         "fp_quant": FPQuantConfig,
+         "modelopt": ModelOptFp8Config,
+         "modelopt_fp4": ModelOptNvFp4Config,
+diff --git a/vllm/model_executor/layers/quantization/exl3.py b/vllm/model_executor/layers/quantization/exl3.py
+new file mode 100644
+index 0000000000000000000000000000000000000000..8deb036c8fea981c2497cfe39540c67f99fff8a0
+--- /dev/null
++++ b/vllm/model_executor/layers/quantization/exl3.py
+@@ -0,0 +1,1971 @@
++# SPDX-License-Identifier: Apache-2.0
++# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
++
++"""EXL3 (ExLlamaV3 trellis) quantization support.
++
++Rank-sliced routed-expert checkpoints use Sparkinfer's unified planned
++``fused_moe`` API for the Trellis decode/prefill windows and the ExLlamaV3
++extension for the small eager parity window. Generic dense and non-rank-sliced
++MoE checkpoints use the
++bit-faithful ``exllamav3_ext.exl3_gemm`` parity path. Every logical checkpoint
++matrix is dispatched independently: vLLM's packed QKV and gate/up modules are
++not treated as one EXL3 matrix because each source matrix owns its Hadamard
++vectors and codebook marker.
++
++Both dependencies are imported lazily. Importing this module, parsing
++checkpoint metadata, or compiling it with ``py_compile`` does not load either
++one or initialize CUDA.
++"""
++
++from __future__ import annotations
++
++import ctypes
++import importlib
++import os
++import re
++import sys
++from typing import TYPE_CHECKING, Any
++
++import torch
++from transformers import PretrainedConfig
++
++from vllm.config import get_current_vllm_config_or_none
++from vllm.distributed import (
++    get_tensor_model_parallel_rank,
++    get_tensor_model_parallel_world_size,
++)
++from vllm.logger import init_logger
++from vllm.model_executor.layers.fused_moe import (
++    FusedMoEMethodBase,
++    FusedMoEQuantConfig,
++    MoEActivation,
++    RoutedExperts,
++)
++from vllm.model_executor.layers.linear import (
++    LinearBase,
++    LinearMethodBase,
++    QKVParallelLinear,
++    ReplicatedLinear,
++    UnquantizedLinearMethod,
++)
++from vllm.model_executor.layers.quantization.base_config import (
++    QuantizationConfig,
++    QuantizeMethodBase,
++)
++from vllm.model_executor.parameter import BasevLLMParameter
++from vllm.transformers_utils.repo_utils import get_hf_file_to_dict
++
++if TYPE_CHECKING:
++    from vllm.model_executor.layers.fused_moe.runner.shared_experts import (
++        SharedExperts,
++    )
++    from vllm.model_executor.models.utils import WeightsMapper
++
++logger = init_logger(__name__)
++
++_MCG_SENTINEL = 0xCBAC1FED
++_MUL1_SENTINEL = 0x83DCD12D
++_HADAMARD_BLOCK = 128
++_EXL3_EXT: Any | None = None
++_SPARKINFER_FUSED_MOE_API: Any | None = None
++_RANK_SLICED_RUNTIMES: dict[tuple[Any, ...], dict[str, Any]] = {}
++_NEXT_RUNTIME_SCOPE_ID = 0
++
++
++# Smallest m the Trellis kernel path can service, and therefore the smallest
++# row count an EXL3 rank-sliced MoE layer can be CUDA-graph captured at. A
++# capture-size selector may read this to align its sizes with the backend
++# instead of failing at capture time.
++MIN_CAPTURABLE_TRELLIS_M = 1
++
++# Target execution also reaches m=1..3 during profiling and small-batch decode.
++# Keep every supported row count on the native path by default; operators may
++# still raise the threshold explicitly as a diagnostic kill switch.
++_DEFAULT_TRELLIS_MIN_M = MIN_CAPTURABLE_TRELLIS_M
++
++
++def _is_draft_layer(layer: Any) -> bool:
++    """True for a rank-sliced MTP/nextn/eagle draft MoE layer.
++
++    The role is stamped (``exl3_is_draft = True``) on every draft-owned module
++    by ``load_eagle_model`` at draft construction, which is the single funnel
++    every speculator draft passes through. It is NOT inferable here: a
++    GLM-5.2-style MTP head is an extra decoder layer named exactly like a
++    target layer (``model.layers.78.*`` with ``num_hidden_layers = 78``), and
++    this function runs at plan/capture/forward time, when
++    ``set_current_vllm_config`` has already exited and
++    ``get_current_vllm_config_or_none()`` returns None -- so both name and
++    layer-index inference silently fail. The substring fallback below covers
++    drafts built outside ``load_eagle_model``.
++    """
++    stamped = getattr(layer, "exl3_is_draft", None)
++    if stamped is not None:
++        return bool(stamped)
++    name = str(getattr(layer, "layer_name", "") or getattr(layer, "prefix", ""))
++    return any(
++        token in name
++        for token in (".mtp", "mtp.", "nextn", "eagle", "draft", "speculator")
++    )
++
++
++def _runtime_owner_token(quant_config: Any, layer: Any) -> tuple[int, bool]:
++    """Runtime-cache owner identity: (config scope, is_draft).
++
++    Adding the role makes target/draft isolation independent of whether the model
++    file happened to mint a separate quant config.
++    """
++    return (_runtime_scope_id(quant_config), _is_draft_layer(layer))
++
++
++def _runtime_scope_id(quant_config: Any) -> int:
++    """Stable identity for the model that owns a rank-sliced runtime.
++
++    A cached runtime owns mutable Trellis/prefill scratch plus parity staging and
++    sort buffers, so an entry must never be shared across models. A target MoE
++    layer and a rank-sliced MTP draft layer have identical shapes, topk and
++    planner settings -- both read ``max_num_batched_tokens`` from the same
++    scheduler config -- so a shape-only key makes the draft reuse the target's
++    scratch. That defeats the target/draft resource isolation their
++    independently captured CUDA graphs rely on.
++
++    Scoping by the owning quant config is deliberately coarser than per-layer:
++    the draft is built with its own ``Exl3Config`` while every layer of one model
++    shares a single config, so each model gets exactly one runtime. The prefill
++    arena alone is ~1 GiB, so per-layer runtimes would cost tens of GiB per rank
++    on a 75+ layer model and are not affordable.
++    """
++    global _NEXT_RUNTIME_SCOPE_ID
++    scope = getattr(quant_config, "_exl3_runtime_scope_id", None)
++    if scope is not None:
++        return scope
++    scope = _NEXT_RUNTIME_SCOPE_ID
++    _NEXT_RUNTIME_SCOPE_ID += 1
++    try:
++        quant_config._exl3_runtime_scope_id = scope  # noqa: SLF001
++    except AttributeError:
++        # Frozen/slotted config: fall back to object identity. Configs live for
++        # the process lifetime, so reuse-after-GC aliasing is not a concern here.
++        return id(quant_config)
++    return scope
++
++
++_RANK_SLICED_FORMAT = "exl3-trellis"
++_RANK_SLICED_WEIGHT_RE = re.compile(
++    r"^(?P<prefix>.+)\.rank(?P<rank>\d+)\."
++    r"(?P<field>trellis|suh|svh|mcg|mul1)$"
++)
++
++ShardId = str | int | tuple[int, ...] | None
++
++
++def _load_exl3_ext() -> Any:
++    """Load the existing ExLlamaV3 extension only from an actual CUDA call."""
++
++    global _EXL3_EXT
++    if _EXL3_EXT is not None:
++        return _EXL3_EXT
++
++    shim = os.environ.get("VLLM_EXL3_ABI_SHIM")
++    if shim:
++        ctypes.CDLL(shim, mode=ctypes.RTLD_GLOBAL)
++
++    ext_path = os.environ.get("VLLM_EXL3_EXT_PATH")
++    if ext_path:
++        search_dir = ext_path if os.path.isdir(ext_path) else os.path.dirname(ext_path)
++        if search_dir and search_dir not in sys.path:
++            sys.path.insert(0, search_dir)
++
++    try:
++        ext = importlib.import_module("exllamav3_ext")
++    except Exception as exc:
++        hint = (
++            "Set VLLM_EXL3_EXT_PATH to the directory containing "
++            "exllamav3_ext*.so (and VLLM_EXL3_ABI_SHIM when the local "
++            "PyTorch ABI shim is required)."
++        )
++        raise RuntimeError(f"Unable to import exllamav3_ext. {hint}") from exc
++
++    if not hasattr(ext, "exl3_gemm"):
++        raise RuntimeError(
++            "The imported exllamav3_ext does not export exl3_gemm; rebuild the "
++            "track_a_retile extension used by this overlay."
++        )
++    _EXL3_EXT = ext
++    return ext
++
++
++def _load_sparkinfer_fused_moe() -> Any:
++    """Resolve the public unified MoE API lazily."""
++
++    global _SPARKINFER_FUSED_MOE_API
++    if _SPARKINFER_FUSED_MOE_API is not None:
++        return _SPARKINFER_FUSED_MOE_API
++    try:
++        from sparkinfer.moe import fused_moe
++    except Exception as exc:
++        raise RuntimeError(
++            "Rank-sliced EXL3 requires the exl3_trellis_mcg source in "
++            "sparkinfer.moe.fused_moe. Install a matching Sparkinfer build."
++        ) from exc
++    _SPARKINFER_FUSED_MOE_API = fused_moe
++    return fused_moe
++
++
++def _positive_env_int(name: str, default: int) -> int:
++    # An env var that is present but blank means "unset". Compose and Kubernetes
++    # both render an unset variable as the empty string, so int("") would abort
++    # engine startup with a bare
++    #   ValueError: invalid literal for int() with base 10: ''
++    # that names neither the variable nor the fix.
++    raw = os.environ.get(name)
++    if raw is None or not raw.strip():
++        return default
++    try:
++        value = int(raw.strip())
++    except ValueError:
++        raise ValueError(
++            f"{name} must be a positive integer or unset, got {raw!r}"
++        ) from None
++    if value <= 0:
++        raise ValueError(f"{name} must be positive, got {value}")
++    return value
++
++
++@torch.library.custom_op(
++    "vllm::exl3_gemm",
++    mutates_args=(),
++    device_types="cuda",
++)
++def _exl3_gemm(
++    x: torch.Tensor,
++    trellis: torch.Tensor,
++    suh: torch.Tensor,
++    svh: torch.Tensor,
++    mcg: bool,
++    mul1: bool,
++) -> torch.Tensor:
++    """Opaque torch op around the bit-faithful ExLlamaV3 dense call."""
++
++    ext = _load_exl3_ext()
++    output = torch.empty(
++        (x.shape[0], trellis.shape[1] * 16),
++        dtype=torch.float16,
++        device=x.device,
++    )
++    x_had = torch.empty_like(x)
++    ext.exl3_gemm(
++        x,
++        trellis,
++        output,
++        suh,
++        x_had,
++        svh,
++        -1,
++        mcg,
++        mul1,
++        0,
++    )
++    return output
++
++
++@_exl3_gemm.register_fake
++def _exl3_gemm_fake(
++    x: torch.Tensor,
++    trellis: torch.Tensor,
++    suh: torch.Tensor,
++    svh: torch.Tensor,
++    mcg: bool,
++    mul1: bool,
++) -> torch.Tensor:
++    del suh, svh, mcg, mul1
++    return torch.empty(
++        (x.shape[0], trellis.shape[1] * 16),
++        dtype=torch.float16,
++        device=x.device,
++    )
++
++
++class Exl3Config(QuantizationConfig):
++    """Configuration for modern and legacy EXL3 trellis checkpoints."""
++
++    def __init__(
++        self,
++        bits: float | None = None,
++        head_bits: float | None = None,
++        codebook: str | None = None,
++        version: str | None = None,
++        tensor_storage: dict[str, Any] | None = None,
++    ) -> None:
++        super().__init__()
++        self.bits = bits
++        self.head_bits = head_bits
++        self.codebook = codebook
++        self.version = version
++        self.tensor_storage = tensor_storage or {}
++        self._eager_checked = False
++        self.rank_sliced_metadata: dict[str, Any] | None = None
++
++    def get_name(self) -> str:
++        return "exl3"
++
++    def get_supported_act_dtypes(self) -> list[torch.dtype]:
++        # The kernel boundary is always fp16.  BF16 model activations are cast
++        # in apply() and converted back after the fp16 bias addition.
++        return [torch.float16, torch.bfloat16]
++
++    @classmethod
++    def get_min_capability(cls) -> int:
++        return 80
++
++    @staticmethod
++    def get_config_filenames() -> list[str]:
++        return ["quantization_config.json"]
++
++    @classmethod
++    def from_config(cls, config: dict[str, Any]) -> Exl3Config:
++        return cls(
++            bits=config.get("bits"),
++            head_bits=config.get("head_bits"),
++            codebook=config.get("codebook"),
++            version=config.get("version"),
++            tensor_storage=config.get("tensor_storage"),
++        )
++
++    @classmethod
++    def override_quantization_method(
++        cls,
++        hf_quant_cfg: dict[str, Any],
++        user_quant: str | None,
++        hf_config: PretrainedConfig | None = None,
++    ) -> str | None:
++        del hf_quant_cfg
++        if user_quant is not None and user_quant != "exl3":
++            return None
++        metadata = getattr(hf_config, "hybrid_tr3_tail", None)
++        if isinstance(metadata, dict) and metadata.get("format") == _RANK_SLICED_FORMAT:
++            return "exl3"
++        return None
++
++    def maybe_update_config(
++        self,
++        model_name: str,
++        hf_config: PretrainedConfig | None = None,
++        revision: str | None = None,
++    ) -> None:
++        rank_sliced = getattr(hf_config, "hybrid_tr3_tail", None)
++        if (
++            isinstance(rank_sliced, dict)
++            and rank_sliced.get("format") == _RANK_SLICED_FORMAT
++        ):
++            self._configure_rank_sliced(rank_sliced)
++            return
++
++        # vLLM returns the summary embedded in config.json without consulting
++        # get_config_filenames().  Hydrate the per-module records explicitly.
++        if not self.tensor_storage:
++            resolved_revision = revision
++            if resolved_revision is None and hf_config is not None:
++                resolved_revision = getattr(hf_config, "_commit_hash", None)
++            config = get_hf_file_to_dict(
++                "quantization_config.json",
++                model_name,
++                revision=resolved_revision,
++            )
++            if not config or not config.get("tensor_storage"):
++                raise ValueError(
++                    "EXL3 requires quantization_config.json with a non-empty "
++                    "tensor_storage map. For branch-indexed Hugging Face repos, "
++                    "download/serve an actual bpw revision rather than main."
++                )
++            self.bits = config.get("bits", self.bits)
++            self.head_bits = config.get("head_bits", self.head_bits)
++            self.codebook = config.get("codebook", self.codebook)
++            self.version = config.get("version", self.version)
++            self.tensor_storage = config["tensor_storage"]
++
++        self._validate_storage_metadata()
++        self._force_independent_lm_head(hf_config)
++
++    def _configure_rank_sliced(self, metadata: dict[str, Any]) -> None:
++        required = {
++            "bits",
++            "codebook",
++            "experts_per_layer",
++            "moe_layers",
++            "tensor_schema",
++            "tp",
++        }
++        missing = sorted(required.difference(metadata))
++        if missing:
++            raise ValueError(
++                "rank-sliced EXL3 metadata is missing: " + ", ".join(missing)
++            )
++        if metadata["codebook"] != "mcg":
++            raise ValueError(
++                "rank-sliced EXL3 currently requires the MCG codebook, got "
++                f"{metadata['codebook']!r}"
++            )
++        layers = metadata["moe_layers"]
++        if (
++            not isinstance(layers, list)
++            or len(layers) != 2
++            or int(layers[0]) < 0
++            or int(layers[1]) < int(layers[0])
++        ):
++            raise ValueError("rank-sliced EXL3 moe_layers must be [first, last]")
++        expected_schema = (
++            "model.layers.{L}.mlp.experts.{E}.{proj}.rank{r}.{trellis|suh|svh|mcg}"
++        )
++        if metadata["tensor_schema"] != expected_schema:
++            raise ValueError(
++                "unsupported rank-sliced EXL3 tensor schema: "
++                f"{metadata['tensor_schema']!r}"
++            )
++        self.rank_sliced_metadata = dict(metadata)
++        self.bits = float(metadata["bits"])
++        self.codebook = str(metadata["codebook"])
++        self.version = str(metadata.get("exllamav3_version", "rank-sliced"))
++
++    def apply_vllm_mapper(self, hf_to_vllm_mapper: WeightsMapper) -> None:
++        # Keep both spellings: loader prefixes use vLLM names, while packed
++        # source-matrix discovery intentionally refers to the unstacked HF name.
++        mapped = hf_to_vllm_mapper.apply_dict(self.tensor_storage)
++        self.tensor_storage = {**self.tensor_storage, **mapped}
++
++    def _validate_storage_metadata(self) -> None:
++        bad: list[str] = []
++        exl3_count = 0
++        for prefix, entry in self.tensor_storage.items():
++            if entry.get("quant_format") != "exl3":
++                continue
++            exl3_count += 1
++            stored = entry.get("stored_tensors", {})
++            suffixes = {name.rsplit(".", 1)[-1] for name in stored}
++            required = {"trellis"}
++            if not ({"suh", "su"} & suffixes):
++                required.add("suh|su")
++            if not ({"svh", "sv"} & suffixes):
++                required.add("svh|sv")
++            missing = [name for name in required if name not in suffixes]
++            if missing:
++                bad.append(f"{prefix}: missing {','.join(sorted(missing))}")
++            if {"mcg", "mul1"} <= suffixes:
++                bad.append(f"{prefix}: both mcg and mul1 are present")
++        if not exl3_count:
++            raise ValueError("quantization_config.json has no EXL3 tensor records")
++        if bad:
++            raise ValueError("Invalid EXL3 tensor metadata: " + "; ".join(bad[:16]))
++
++    def _force_independent_lm_head(self, hf_config: PretrainedConfig | None) -> None:
++        if hf_config is None or not self.has_quantized_lm_head():
++            return
++        configs: list[Any] = [hf_config]
++        try:
++            text_config = hf_config.get_text_config()
++        except (AttributeError, TypeError):
++            text_config = None
++        if text_config is not None and text_config is not hf_config:
++            configs.append(text_config)
++        changed = False
++        for config in configs:
++            if getattr(config, "tie_word_embeddings", False):
++                config.tie_word_embeddings = False
++                changed = True
++        if changed:
++            logger.warning_once(
++                "EXL3 metadata contains an independently quantized lm_head; "
++                "overriding tie_word_embeddings so vLLM instantiates it."
++            )
++
++    def _require_enforce_eager(self) -> None:
++        if self.rank_sliced_metadata is not None:
++            # The routed-expert fast path is eagerly planned before graph
++            # capture. Only its large-M parity fallback remains eager.
++            return
++        # exllamav3_ext's exl3_gemm autotunes with timing launches on the first
++        # call per (m-bucket, k, n, K) shape hash; under CUDA-graph capture
++        # those launches fault, and m-bucketing means a warmup pass cannot
++        # reliably cover every bucket. Fail fast at build time instead of
++        # faulting mid-capture.
++        if self._eager_checked:
++            return
++        self._eager_checked = True
++        vllm_config = get_current_vllm_config_or_none()
++        if vllm_config is None:
++            return
++        if not vllm_config.model_config.enforce_eager:
++            raise ValueError(
++                "The EXL3 quantization backend requires eager execution: "
++                "pass --enforce-eager (enforce_eager=True). exl3_gemm "
++                "autotunes with timing launches on first use per shape "
++                "bucket, which is incompatible with CUDA-graph capture."
++            )
++
++    def get_quant_method(
++        self, layer: torch.nn.Module, prefix: str
++    ) -> QuantizeMethodBase | None:
++        self._require_enforce_eager()
++        is_lm_head = layer.__class__.__name__ == "ParallelLMHead"
++        if is_lm_head and not prefix:
++            prefix = "lm_head"
++        if isinstance(layer, LinearBase) or is_lm_head:
++            if not self._linear_prefix_is_exl3(prefix):
++                return UnquantizedLinearMethod()
++            return Exl3LinearMethod(self)
++        if isinstance(layer, RoutedExperts):
++            if not self._moe_prefix_is_exl3(prefix, layer):
++                return None
++            return Exl3MoEMethod(self, layer.moe_config)
++        return None
++
++    def _storage_entry(self, prefix: str) -> dict[str, Any] | None:
++        candidates = [prefix]
++        if prefix.startswith("model."):
++            candidates.append(prefix.removeprefix("model."))
++        else:
++            candidates.append(f"model.{prefix}")
++
++        # Multimodal wrappers often add an extra `model` or `language_model`
++        # segment relative to vLLM's text-only module — interior
++        # (`model.language_model.layers...`) or leading
++        # (`language_model.lm_head`), so leading segments collapse too.
++        parts = prefix.split(".")
++        for removable in ("model", "language_model"):
++            for idx in range(0, len(parts) - 1):
++                if parts[idx] != removable:
++                    continue
++                collapsed = ".".join(parts[:idx] + parts[idx + 1 :])
++                candidates.extend((collapsed, f"model.{collapsed}"))
++                if collapsed.startswith("model."):
++                    candidates.append(collapsed.removeprefix("model."))
++
++        for candidate in dict.fromkeys(candidates):
++            entry = self.tensor_storage.get(candidate)
++            if entry is not None:
++                return entry
++        return None
++
++    def _is_exl3_prefix(self, prefix: str) -> bool:
++        entry = self._storage_entry(prefix)
++        return entry is not None and entry.get("quant_format") == "exl3"
++
++    def _linear_prefix_is_exl3(self, prefix: str) -> bool:
++        if self._is_exl3_prefix(prefix):
++            return True
++        leaf = prefix.rsplit(".", 1)[-1]
++        source_leaves = self.packed_modules_mapping.get(leaf)
++        if not source_leaves:
++            return False
++        base = prefix.rsplit(".", 1)[0] if "." in prefix else ""
++        return all(
++            self._is_exl3_prefix(f"{base}.{source}" if base else source)
++            for source in source_leaves
++        )
++
++    def _moe_prefix_is_exl3(
++        self, prefix: str, layer: torch.nn.Module | None = None
++    ) -> bool:
++        if self.rank_sliced_metadata is not None:
++            match = re.search(r"layers\.(\d+)\b", prefix)
++            if match is None:
++                return False
++            first, last = (int(v) for v in self.rank_sliced_metadata["moe_layers"])
++            return first <= int(match.group(1)) <= last
++        # Use the layer's checkpoint projection names (the same fields
++        # _validate_codebooks keys off) so remapped-projection MoE
++        # checkpoints are still detected; fall back to the defaults when the
++        # layer variant does not carry them.
++        projections = tuple(
++            getattr(layer, attr, default)
++            for attr, default in (
++                ("ckpt_gate_proj_name", "gate_proj"),
++                ("ckpt_up_proj_name", "up_proj"),
++                ("ckpt_down_proj_name", "down_proj"),
++            )
++        )
++        expert_prefixes = (f"{prefix}.0", f"{prefix}.experts.0")
++        return any(
++            all(
++                self._is_exl3_prefix(f"{expert}.{projection}")
++                for projection in projections
++            )
++            for expert in expert_prefixes
++        )
++
++    def codebook_for_prefix(self, prefix: str) -> str | None:
++        if self.rank_sliced_metadata is not None:
++            match = re.search(r"layers\.(\d+)\b", prefix)
++            if match is None:
++                return None
++            first, last = (int(v) for v in self.rank_sliced_metadata["moe_layers"])
++            return "mcg" if first <= int(match.group(1)) <= last else None
++        entry = self._storage_entry(prefix)
++        if entry is None:
++            return None
++        suffixes = {name.rsplit(".", 1)[-1] for name in entry.get("stored_tensors", {})}
++        if "mcg" in suffixes:
++            return "mcg"
++        if "mul1" in suffixes:
++            return "mul1"
++        return None
++
++    def has_quantized_lm_head(self) -> bool:
++        return self._is_exl3_prefix("lm_head")
++
++    def normalize_rank_sliced_weight_name(self, name: str) -> str | None:
++        """Drop non-local TP payloads and remove the serialized rank segment."""
++        if self.rank_sliced_metadata is None:
++            return name
++        match = _RANK_SLICED_WEIGHT_RE.match(name)
++        if match is None:
++            return name
++        if int(match.group("rank")) != get_tensor_model_parallel_rank():
++            return None
++        return f"{match.group('prefix')}.{match.group('field')}"
++
++
++class Exl3Parameter(BasevLLMParameter):
++    """Zero-sized parameter holding independently shaped EXL3 components."""
++
++    def __new__(cls, *, weight_loader):
++        data = torch.empty(0, dtype=torch.uint8)
++        return super().__new__(cls, data=data, weight_loader=weight_loader)
++
++    def __init__(self, *, weight_loader):
++        self.exl3_tensors: dict[ShardId, torch.Tensor] = {}
++        super().__init__(data=self.data, weight_loader=weight_loader)
++
++    def load_exl3_weight(
++        self,
++        loaded_weight: torch.Tensor,
++        shard_id: ShardId = None,
++    ) -> None:
++        self.exl3_tensors[shard_id] = loaded_weight.contiguous()
++
++
++def _exl3_weight_loader(
++    param: Exl3Parameter,
++    loaded_weight: torch.Tensor,
++    loaded_shard_id: ShardId = None,
++) -> None:
++    param.load_exl3_weight(loaded_weight, loaded_shard_id)
++
++
++class Exl3LinearMethod(LinearMethodBase):
++    def __init__(self, quant_config: Exl3Config) -> None:
++        self.quant_config = quant_config
++
++    def create_weights(
++        self,
++        layer: torch.nn.Module,
++        input_size_per_partition: int,
++        output_partition_sizes: list[int],
++        input_size: int,
++        output_size: int,
++        params_dtype: torch.dtype,
++        **extra_weight_attrs,
++    ) -> None:
++        del params_dtype, extra_weight_attrs
++        if layer.__class__.__name__ == "ParallelLMHead":
++            org = getattr(layer, "org_vocab_size", None)
++            total = getattr(layer, "num_embeddings", None)
++            if org is not None and total is not None and org != total:
++                raise NotImplementedError(
++                    "EXL3 lm_head with added vocabulary is unsupported: the "
++                    f"trellis tensor covers the original {org} rows but the "
++                    f"layer allocates {total}; TP slicing would silently "
++                    "misalign. Strip --lora-extra-vocab-size / added tokens "
++                    "or leave lm_head unquantized."
++                )
++        # Respect the layer's effective topology. disable_tp linears set their
++        # own tp_size=1, while ReplicatedLinear carries full weights even when
++        # the process-wide tensor group is larger than one.
++        if isinstance(layer, ReplicatedLinear):
++            layer.exl3_tp_rank = 0
++            layer.exl3_tp_size = 1
++        else:
++            layer.exl3_tp_rank = getattr(
++                layer, "tp_rank", get_tensor_model_parallel_rank()
++            )
++            layer.exl3_tp_size = getattr(
++                layer, "tp_size", get_tensor_model_parallel_world_size()
++            )
++        layer.exl3_input_size = input_size
++        layer.exl3_input_size_per_partition = input_size_per_partition
++        layer.exl3_output_size = output_size
++        layer.exl3_output_partition_sizes = output_partition_sizes
++        layer.exl3_shard_ids = self._shard_ids_for_layer(layer, output_partition_sizes)
++        layer.exl3_parallel_mode = (
++            "row" if input_size_per_partition != input_size else "column"
++        )
++        source_prefixes = self._source_prefixes_for_layer(layer, layer.exl3_shard_ids)
++        layer.exl3_expected_codebooks = {
++            shard_id: self.quant_config.codebook_for_prefix(source_prefix)
++            for shard_id, source_prefix in zip(
++                layer.exl3_shard_ids, source_prefixes, strict=True
++            )
++        }
++
++        # su/sv are legacy packed sign bitfields.  Modern checkpoints load
++        # suh/svh directly.
++        for name in ("suh", "svh", "su", "sv", "trellis", "mcg", "mul1"):
++            layer.register_parameter(
++                name,
++                Exl3Parameter(weight_loader=_exl3_weight_loader),
++            )
++
++    def process_weights_after_loading(self, layer: torch.nn.Module) -> None:
++        self._materialize_legacy_hadamard(layer)
++        missing: list[str] = []
++        for attr in ("suh", "svh", "trellis"):
++            param = getattr(layer, attr)
++            for shard_id in layer.exl3_shard_ids:
++                if shard_id not in param.exl3_tensors:
++                    missing.append(f"{attr}[{shard_id!r}]")
++        for shard_id in layer.exl3_shard_ids:
++            expected = layer.exl3_expected_codebooks[shard_id]
++            has_mcg = shard_id in layer.mcg.exl3_tensors
++            has_mul1 = shard_id in layer.mul1.exl3_tensors
++            if has_mcg and has_mul1:
++                missing.append(f"codebook[{shard_id!r}]=both mcg and mul1")
++            elif expected == "mcg" and not has_mcg:
++                missing.append(f"mcg[{shard_id!r}]")
++            elif expected == "mul1" and not has_mul1:
++                missing.append(f"mul1[{shard_id!r}]")
++            elif expected is None and (has_mcg or has_mul1):
++                missing.append(f"unexpected codebook[{shard_id!r}]")
++        if missing:
++            prefix = getattr(layer, "prefix", layer.__class__.__name__)
++            raise ValueError(
++                f"Missing or inconsistent EXL3 tensors for {prefix}: "
++                + ", ".join(missing)
++            )
++
++        self._validate_loaded_tensors(layer)
++        self._shard_tensors_for_tensor_parallel(layer)
++        self._validate_loaded_tensors(layer)
++
++        # device_loading_context has moved the zero-sized registered parameter
++        # to the model target device.  Its device is the safest destination for
++        # the tensors kept in the side dictionaries.
++        device = layer.trellis.device
++        for attr in ("suh", "svh", "trellis", "mcg", "mul1"):
++            param = getattr(layer, attr)
++            for shard_id, tensor in list(param.exl3_tensors.items()):
++                param.exl3_tensors[shard_id] = tensor.to(
++                    device=device, non_blocking=True
++                ).contiguous()
++
++    def apply(
++        self,
++        layer: torch.nn.Module,
++        x: torch.Tensor,
++        bias: torch.Tensor | None = None,
++    ) -> torch.Tensor:
++        original_shape = x.shape[:-1]
++        original_dtype = x.dtype
++        x_2d = x.reshape(-1, x.shape[-1]).to(torch.float16).contiguous()
++        outputs = [
++            self._apply_one(layer, x_2d, shard_id) for shard_id in layer.exl3_shard_ids
++        ]
++        output = outputs[0] if len(outputs) == 1 else torch.cat(outputs, dim=-1)
++        if bias is not None:
++            output = output + bias.to(dtype=output.dtype)
++        output = output.reshape(*original_shape, output.shape[-1])
++        return output if output.dtype == original_dtype else output.to(original_dtype)
++
++    @staticmethod
++    def _unpack_signs(bitfield: torch.Tensor) -> torch.Tensor:
++        words = bitfield.contiguous().view(torch.uint16).to(torch.int32)
++        masks = 1 << torch.arange(16, device=words.device, dtype=torch.int32)
++        negative = (words.unsqueeze(-1) & masks) != 0
++        return (
++            torch.where(
++                negative,
++                torch.tensor(-1.0, device=words.device, dtype=torch.float16),
++                torch.tensor(1.0, device=words.device, dtype=torch.float16),
++            )
++            .flatten()
++            .contiguous()
++        )
++
++    @classmethod
++    def _materialize_legacy_hadamard(cls, layer: torch.nn.Module) -> None:
++        for packed_name, half_name in (("su", "suh"), ("sv", "svh")):
++            packed = getattr(layer, packed_name).exl3_tensors
++            half = getattr(layer, half_name).exl3_tensors
++            for shard_id in layer.exl3_shard_ids:
++                if shard_id not in half and shard_id in packed:
++                    half[shard_id] = cls._unpack_signs(packed[shard_id])
++
++    @staticmethod
++    def _validate_marker(tensor: torch.Tensor, expected: int, name: str) -> None:
++        if tensor.dtype != torch.int32 or tensor.numel() != 1:
++            raise ValueError(f"EXL3 {name} must be a scalar int32 sentinel")
++        value = int(tensor.reshape(()).item()) & 0xFFFFFFFF
++        if value != expected:
++            raise ValueError(
++                f"Invalid EXL3 {name} sentinel 0x{value:08x}; expected 0x{expected:08x}"
++            )
++
++    @classmethod
++    def _validate_loaded_tensors(cls, layer: torch.nn.Module) -> None:
++        for shard_id in layer.exl3_shard_ids:
++            trellis = layer.trellis.exl3_tensors[shard_id]
++            suh = layer.suh.exl3_tensors[shard_id]
++            svh = layer.svh.exl3_tensors[shard_id]
++            if trellis.dtype != torch.int16 or trellis.ndim != 3:
++                raise ValueError("EXL3 trellis must be rank-3 int16")
++            if trellis.shape[2] % 16 or not 1 <= trellis.shape[2] // 16 <= 8:
++                raise ValueError(
++                    f"Invalid EXL3 trellis bit width {trellis.shape[2]} / 16"
++                )
++            if suh.dtype != torch.float16 or suh.ndim != 1:
++                raise ValueError("EXL3 suh must be rank-1 float16")
++            if svh.dtype != torch.float16 or svh.ndim != 1:
++                raise ValueError("EXL3 svh must be rank-1 float16")
++            k = trellis.shape[0] * 16
++            n = trellis.shape[1] * 16
++            if suh.numel() != k or svh.numel() != n:
++                raise ValueError(
++                    "EXL3 dimensions disagree: "
++                    f"trellis={tuple(trellis.shape)}, suh={suh.numel()}, "
++                    f"svh={svh.numel()}"
++                )
++            if k % _HADAMARD_BLOCK or n % _HADAMARD_BLOCK:
++                raise ValueError(
++                    f"EXL3 kernel dimensions must be {_HADAMARD_BLOCK}-aligned, "
++                    f"got K={k}, N={n}"
++                )
++            if shard_id in layer.mcg.exl3_tensors:
++                cls._validate_marker(
++                    layer.mcg.exl3_tensors[shard_id], _MCG_SENTINEL, "mcg"
++                )
++            if shard_id in layer.mul1.exl3_tensors:
++                cls._validate_marker(
++                    layer.mul1.exl3_tensors[shard_id], _MUL1_SENTINEL, "mul1"
++                )
++
++    @staticmethod
++    def _slice_exl3_tensor(
++        tensor: torch.Tensor,
++        *,
++        dim: int,
++        start: int,
++        size: int,
++    ) -> torch.Tensor:
++        if start % _HADAMARD_BLOCK or size % _HADAMARD_BLOCK:
++            axis = "output" if dim == 1 else "input"
++            raise ValueError(
++                f"EXL3 TP {axis} slice must be {_HADAMARD_BLOCK}-aligned, "
++                f"got start={start}, size={size}"
++            )
++        return tensor.narrow(dim, start // 16, size // 16).contiguous()
++
++    @staticmethod
++    def _output_shard_size(layer: torch.nn.Module, shard_id: ShardId) -> int:
++        if shard_id is None:
++            return layer.exl3_output_partition_sizes[0]
++        if isinstance(shard_id, str) and shard_id in ("q", "k", "v"):
++            return layer.exl3_output_partition_sizes[{"q": 0, "k": 1, "v": 2}[shard_id]]
++        if isinstance(shard_id, tuple):
++            return sum(layer.exl3_output_partition_sizes[idx] for idx in shard_id)
++        if isinstance(shard_id, int):
++            return layer.exl3_output_partition_sizes[shard_id]
++        return layer.exl3_output_partition_sizes[layer.exl3_shard_ids.index(shard_id)]
++
++    @staticmethod
++    def _qkv_output_start(
++        layer: torch.nn.Module, shard_id: ShardId, shard_size: int
++    ) -> int:
++        if shard_id in ("k", "v"):
++            shard_rank = layer.exl3_tp_rank // layer.num_kv_head_replicas
++        else:
++            shard_rank = layer.exl3_tp_rank
++        return shard_rank * shard_size
++
++    @classmethod
++    def _shard_tensors_for_tensor_parallel(cls, layer: torch.nn.Module) -> None:
++        if layer.exl3_tp_size == 1:
++            return
++        if layer.exl3_parallel_mode == "row":
++            start = layer.exl3_tp_rank * layer.exl3_input_size_per_partition
++            size = layer.exl3_input_size_per_partition
++            for shard_id in layer.exl3_shard_ids:
++                layer.suh.exl3_tensors[shard_id] = (
++                    layer.suh.exl3_tensors[shard_id].narrow(0, start, size).contiguous()
++                )
++                layer.trellis.exl3_tensors[shard_id] = cls._slice_exl3_tensor(
++                    layer.trellis.exl3_tensors[shard_id],
++                    dim=0,
++                    start=start,
++                    size=size,
++                )
++            return
++
++        already_sharded = cls._expand_tuple_output_shards(layer)
++        for shard_id in layer.exl3_shard_ids:
++            if shard_id in already_sharded:
++                continue
++            size = cls._output_shard_size(layer, shard_id)
++            start = cls._qkv_output_start(layer, shard_id, size)
++            layer.svh.exl3_tensors[shard_id] = (
++                layer.svh.exl3_tensors[shard_id].narrow(0, start, size).contiguous()
++            )
++            layer.trellis.exl3_tensors[shard_id] = cls._slice_exl3_tensor(
++                layer.trellis.exl3_tensors[shard_id],
++                dim=1,
++                start=start,
++                size=size,
++            )
++
++    @classmethod
++    def _expand_tuple_output_shards(cls, layer: torch.nn.Module) -> set[int]:
++        tuples = [sid for sid in layer.exl3_shard_ids if isinstance(sid, tuple)]
++        if not tuples:
++            return set()
++
++        expanded_ids: list[ShardId] = []
++        component_ids: set[int] = set()
++        for shard_id in layer.exl3_shard_ids:
++            if isinstance(shard_id, tuple):
++                expanded_ids.extend(shard_id)
++                component_ids.update(shard_id)
++            else:
++                expanded_ids.append(shard_id)
++
++        for tuple_id in tuples:
++            full_offsets: dict[int, int] = {}
++            offset = 0
++            for idx in tuple_id:
++                full_offsets[idx] = offset
++                offset += layer.exl3_output_partition_sizes[idx] * layer.exl3_tp_size
++            for idx in tuple_id:
++                size = layer.exl3_output_partition_sizes[idx]
++                start = full_offsets[idx] + layer.exl3_tp_rank * size
++                layer.suh.exl3_tensors[idx] = layer.suh.exl3_tensors[tuple_id]
++                layer.svh.exl3_tensors[idx] = (
++                    layer.svh.exl3_tensors[tuple_id].narrow(0, start, size).contiguous()
++                )
++                layer.trellis.exl3_tensors[idx] = cls._slice_exl3_tensor(
++                    layer.trellis.exl3_tensors[tuple_id],
++                    dim=1,
++                    start=start,
++                    size=size,
++                )
++                layer.exl3_expected_codebooks[idx] = layer.exl3_expected_codebooks[
++                    tuple_id
++                ]
++                for marker in ("mcg", "mul1"):
++                    tensors = getattr(layer, marker).exl3_tensors
++                    if tuple_id in tensors:
++                        tensors[idx] = tensors[tuple_id]
++            for attr in ("suh", "svh", "trellis", "mcg", "mul1"):
++                getattr(layer, attr).exl3_tensors.pop(tuple_id, None)
++            layer.exl3_expected_codebooks.pop(tuple_id, None)
++
++        layer.exl3_shard_ids = expanded_ids
++        return component_ids
++
++    @staticmethod
++    def _shard_ids_for_layer(
++        layer: torch.nn.Module,
++        output_partition_sizes: list[int],
++    ) -> list[ShardId]:
++        if len(output_partition_sizes) == 1:
++            return [None]
++        prefix = getattr(layer, "prefix", "")
++        if isinstance(layer, QKVParallelLinear) and len(output_partition_sizes) == 3:
++            return ["q", "k", "v"]
++        if prefix.endswith("in_proj_qkvz"):
++            return [(0, 1, 2), 3]
++        return list(range(len(output_partition_sizes)))
++
++    def _source_prefixes_for_layer(
++        self, layer: torch.nn.Module, shard_ids: list[ShardId]
++    ) -> list[str]:
++        prefix = getattr(layer, "prefix", "")
++        if len(shard_ids) == 1:
++            return [prefix or "lm_head"]
++        leaf = prefix.rsplit(".", 1)[-1]
++        base = prefix.rsplit(".", 1)[0] if "." in prefix else ""
++        sources = self.quant_config.packed_modules_mapping.get(leaf)
++        if sources and len(sources) == len(shard_ids):
++            return [f"{base}.{source}" if base else source for source in sources]
++        raise ValueError(
++            f"EXL3 does not know the source matrices for packed layer {prefix}; "
++            "add it to the model's packed_modules_mapping."
++        )
++
++    @staticmethod
++    def _apply_one(
++        layer: torch.nn.Module, x: torch.Tensor, shard_id: ShardId
++    ) -> torch.Tensor:
++        trellis = layer.trellis.exl3_tensors[shard_id]
++        packed_k = trellis.shape[0] * 16
++        if x.shape[-1] > packed_k:
++            raise ValueError(
++                f"EXL3 input width {x.shape[-1]} exceeds packed K={packed_k}"
++            )
++        if x.shape[-1] < packed_k:
++            x = torch.nn.functional.pad(x, (0, packed_k - x.shape[-1]))
++        output = _exl3_gemm(
++            x,
++            trellis,
++            layer.suh.exl3_tensors[shard_id],
++            layer.svh.exl3_tensors[shard_id],
++            shard_id in layer.mcg.exl3_tensors,
++            shard_id in layer.mul1.exl3_tensors,
++        )
++        logical_n = Exl3LinearMethod._output_shard_size(layer, shard_id)
++        if output.shape[-1] < logical_n:
++            raise ValueError(
++                f"EXL3 packed N={output.shape[-1]} is below logical N={logical_n}"
++            )
++        return output[..., :logical_n]
++
++
++class Exl3MoEParameter(BasevLLMParameter):
++    """EXL3 tensors keyed by expert/projection, optionally in one GPU slab."""
++
++    def __new__(
++        cls,
++        *,
++        weight_loader,
++        num_experts: int = 0,
++        shard_ids: tuple[str, ...] = (),
++        preallocate: bool = False,
++    ):
++        del num_experts, shard_ids, preallocate
++        data = torch.empty(0, dtype=torch.uint8)
++        return super().__new__(cls, data=data, weight_loader=weight_loader)
++
++    def __init__(
++        self,
++        *,
++        weight_loader,
++        num_experts: int = 0,
++        shard_ids: tuple[str, ...] = (),
++        preallocate: bool = False,
++    ):
++        self.exl3_tensors: dict[tuple[int, str], torch.Tensor] = {}
++        self.exl3_backing: torch.Tensor | None = None
++        self.exl3_num_experts = int(num_experts)
++        self.exl3_shard_ids = tuple(shard_ids)
++        self.exl3_preallocate = bool(preallocate)
++        super().__init__(data=self.data, weight_loader=weight_loader)
++
++    def load_exl3_weight(
++        self,
++        loaded_weight: torch.Tensor,
++        *,
++        expert_id: int,
++        shard_id: str,
++    ) -> None:
++        key = (int(expert_id), str(shard_id))
++        if not self.exl3_preallocate:
++            self.exl3_tensors[key] = loaded_weight.contiguous()
++            return
++        if self.exl3_num_experts <= 0 or shard_id not in self.exl3_shard_ids:
++            raise ValueError(
++                f"invalid EXL3 slab key expert={expert_id}, shard={shard_id!r}"
++            )
++        if not 0 <= int(expert_id) < self.exl3_num_experts:
++            raise ValueError(
++                f"EXL3 expert {expert_id} is outside [0, {self.exl3_num_experts})"
++            )
++        if self.device.type == "meta":
++            raise RuntimeError("rank-sliced EXL3 slabs cannot be allocated on meta")
++        if self.exl3_backing is None:
++            prefix = (
++                (len(self.exl3_shard_ids), self.exl3_num_experts)
++                if len(self.exl3_shard_ids) > 1
++                else (self.exl3_num_experts,)
++            )
++            self.exl3_backing = torch.empty(
++                prefix + tuple(loaded_weight.shape),
++                dtype=loaded_weight.dtype,
++                device=self.device,
++            )
++        shard_index = self.exl3_shard_ids.index(shard_id)
++        target = (
++            self.exl3_backing[shard_index, expert_id]
++            if len(self.exl3_shard_ids) > 1
++            else self.exl3_backing[expert_id]
++        )
++        if tuple(target.shape) != tuple(loaded_weight.shape):
++            raise ValueError(
++                "rank-sliced EXL3 tensor shape changed within one slab: "
++                f"expected={tuple(target.shape)}, got={tuple(loaded_weight.shape)}"
++            )
++        target.copy_(loaded_weight, non_blocking=True)
++        self.exl3_tensors[key] = target
++
++
++def _exl3_moe_weight_loader(
++    param: Exl3MoEParameter,
++    loaded_weight: torch.Tensor,
++    weight_name: str,
++    shard_id: str,
++    expert_id: int,
++    return_success: bool = False,
++) -> bool | None:
++    del weight_name
++    param.load_exl3_weight(
++        loaded_weight,
++        expert_id=expert_id,
++        shard_id=shard_id,
++    )
++    return True if return_success else None
++
++
++# Model loaders (e.g. llama4-style paths) check this attribute before routing
++# expert tensors through a param's weight_loader with MoE kwargs.
++_exl3_moe_weight_loader.supports_moe_loading = True  # type: ignore[attr-defined]
++
++
++class Exl3MoEMethod(FusedMoEMethodBase):
++    """Correctness MoE path: route, then use three dense EXL3 GEMMs/expert."""
++
++    def __init__(self, quant_config: Exl3Config, moe) -> None:
++        super().__init__(moe)
++        self.quant_config = quant_config
++
++    def create_weights(
++        self,
++        layer: RoutedExperts,
++        num_experts: int,
++        hidden_size: int,
++        intermediate_size_per_partition: int,
++        params_dtype: torch.dtype,
++        **extra_weight_attrs,
++    ) -> None:
++        del extra_weight_attrs
++        if params_dtype not in (torch.bfloat16, torch.float16):
++            raise ValueError(
++                f"EXL3 MoE requires BF16 or FP16 activations, got {params_dtype}"
++            )
++        if self.moe.moe_parallel_config.use_ep:
++            raise NotImplementedError(
++                "EXL3 correctness MoE currently supports TP but not expert parallelism"
++            )
++        if self.moe.has_bias:
++            raise NotImplementedError(
++                "EXL3 correctness MoE does not yet support expert biases"
++            )
++        layer.exl3_tp_rank = self.moe.moe_parallel_config.tp_rank
++        layer.exl3_tp_size = self.moe.moe_parallel_config.tp_size
++        layer.exl3_hidden_size = hidden_size
++        layer.exl3_intermediate_size_per_partition = intermediate_size_per_partition
++        layer.exl3_params_dtype = params_dtype
++        rank_sliced = self.quant_config.rank_sliced_metadata is not None
++        if rank_sliced:
++            checkpoint_tp = int(self.quant_config.rank_sliced_metadata["tp"])
++            if checkpoint_tp != layer.exl3_tp_size:
++                raise ValueError(
++                    "rank-sliced EXL3 checkpoint TP does not match runtime: "
++                    f"checkpoint={checkpoint_tp}, runtime={layer.exl3_tp_size}"
++                )
++            expected_experts = int(
++                self.quant_config.rank_sliced_metadata["experts_per_layer"]
++            )
++            if expected_experts != num_experts:
++                raise ValueError(
++                    "rank-sliced EXL3 expert count does not match the model: "
++                    f"checkpoint={expected_experts}, model={num_experts}"
++                )
++            vllm_config = get_current_vllm_config_or_none()
++            scheduler_config = (
++                vllm_config.scheduler_config if vllm_config is not None else None
++            )
++            # No silent fallback: a wrong capacity here puts the target and the
++            # rank-sliced MTP draft on different plans with no error, which is
++            # exactly the class of mismatch that corrupts only at scale.
++            if (
++                scheduler_config is None
++                or getattr(scheduler_config, "max_num_batched_tokens", None) is None
++            ):
++                raise ValueError(
++                    "EXL3 rank-sliced MoE requires scheduler_config."
++                    "max_num_batched_tokens to plan its Trellis arena; refusing to "
++                    "guess a capacity."
++                )
++            layer.exl3_max_num_batched_tokens = int(
++                scheduler_config.max_num_batched_tokens
++            )
++            # Stamp the layer role while the model-construction config context
++            # is still active. Forward time (the profile pass and CUDA graph
++            # capture) runs with no current vllm config, so neither name- nor
++            # index-based detection can resolve the role there -- a GLM-5.2
++            # style MTP head is named exactly like a target layer
++            # (model.layers.<num_hidden_layers>.*). runner_type is minted as
++            # "draft" for every model-backed speculator draft
++            # (SpeculativeConfig.__post_init__ -> ModelConfig(runner="draft")),
++            # which also covers speculators that bypass load_eagle_model.
++            layer.exl3_is_draft = (
++                getattr(vllm_config.model_config, "runner_type", None) == "draft"
++            )
++        for prefix, shard_ids in (("w13", ("w1", "w3")), ("w2", ("w2",))):
++            for suffix in ("suh", "svh", "trellis", "mcg", "mul1"):
++                layer.register_parameter(
++                    f"{prefix}_{suffix}",
++                    Exl3MoEParameter(
++                        weight_loader=_exl3_moe_weight_loader,
++                        num_experts=num_experts,
++                        shard_ids=shard_ids,
++                        preallocate=rank_sliced and suffix in {"suh", "svh", "trellis"},
++                    ),
++                )
++
++    def process_weights_after_loading(self, layer: RoutedExperts) -> None:
++        required = {"w13": ("w1", "w3"), "w2": ("w2",)}
++        missing: list[str] = []
++        for prefix, shard_ids in required.items():
++            for attr in ("suh", "svh", "trellis"):
++                tensors = getattr(layer, f"{prefix}_{attr}").exl3_tensors
++                for expert_id in range(layer.local_num_experts):
++                    for shard_id in shard_ids:
++                        if (expert_id, shard_id) not in tensors:
++                            missing.append(f"{prefix}_{attr}[{expert_id},{shard_id}]")
++        if missing:
++            raise ValueError(
++                f"Missing EXL3 MoE tensors for {layer.layer_name}: "
++                + ", ".join(missing[:32])
++                + (" ..." if len(missing) > 32 else "")
++            )
++        self._validate_codebooks(layer)
++        if self.quant_config.rank_sliced_metadata is None:
++            self._shard_tensors_for_tensor_parallel(layer)
++        device = layer.w13_trellis.device
++        for prefix in ("w13", "w2"):
++            for attr in ("suh", "svh", "trellis", "mcg", "mul1"):
++                param = getattr(layer, f"{prefix}_{attr}")
++                for key, tensor in list(param.exl3_tensors.items()):
++                    param.exl3_tensors[key] = tensor.to(
++                        device=device, non_blocking=True
++                    ).contiguous()
++        self._validate_moe_shapes(layer)
++
++        if self.quant_config.rank_sliced_metadata is not None:
++            self._prepare_rank_sliced_weights(layer)
++            return
++
++    def _validate_codebooks(self, layer: RoutedExperts) -> None:
++        projections = {
++            "w1": layer.ckpt_gate_proj_name,
++            "w2": layer.ckpt_down_proj_name,
++            "w3": layer.ckpt_up_proj_name,
++        }
++        for expert_id in range(layer.local_num_experts):
++            for shard_id, projection in projections.items():
++                prefix = f"{layer.layer_name}.{expert_id}.{projection}"
++                expected = self.quant_config.codebook_for_prefix(prefix)
++                group = "w2" if shard_id == "w2" else "w13"
++                key = (expert_id, shard_id)
++                has_mcg = key in getattr(layer, f"{group}_mcg").exl3_tensors
++                has_mul1 = key in getattr(layer, f"{group}_mul1").exl3_tensors
++                if has_mcg and has_mul1:
++                    raise ValueError(f"EXL3 MoE {prefix} has both codebooks")
++                if expected == "mcg" and not has_mcg:
++                    raise ValueError(f"EXL3 MoE {prefix} is missing mcg")
++                if expected == "mul1" and not has_mul1:
++                    raise ValueError(f"EXL3 MoE {prefix} is missing mul1")
++                if expected is None and (has_mcg or has_mul1):
++                    raise ValueError(
++                        f"EXL3 MoE {prefix} has an unexpected codebook marker"
++                    )
++                if has_mcg:
++                    Exl3LinearMethod._validate_marker(
++                        getattr(layer, f"{group}_mcg").exl3_tensors[key],
++                        _MCG_SENTINEL,
++                        "mcg",
++                    )
++                if has_mul1:
++                    Exl3LinearMethod._validate_marker(
++                        getattr(layer, f"{group}_mul1").exl3_tensors[key],
++                        _MUL1_SENTINEL,
++                        "mul1",
++                    )
++
++    @classmethod
++    def _shard_tensors_for_tensor_parallel(cls, layer: RoutedExperts) -> None:
++        if layer.exl3_tp_size == 1:
++            return
++        start = layer.exl3_tp_rank * layer.exl3_intermediate_size_per_partition
++        size = layer.exl3_intermediate_size_per_partition
++        for expert_id in range(layer.local_num_experts):
++            for shard_id in ("w1", "w3"):
++                key = (expert_id, shard_id)
++                layer.w13_svh.exl3_tensors[key] = (
++                    layer.w13_svh.exl3_tensors[key].narrow(0, start, size).contiguous()
++                )
++                layer.w13_trellis.exl3_tensors[key] = (
++                    Exl3LinearMethod._slice_exl3_tensor(
++                        layer.w13_trellis.exl3_tensors[key],
++                        dim=1,
++                        start=start,
++                        size=size,
++                    )
++                )
++            key = (expert_id, "w2")
++            layer.w2_suh.exl3_tensors[key] = (
++                layer.w2_suh.exl3_tensors[key].narrow(0, start, size).contiguous()
++            )
++            layer.w2_trellis.exl3_tensors[key] = Exl3LinearMethod._slice_exl3_tensor(
++                layer.w2_trellis.exl3_tensors[key],
++                dim=0,
++                start=start,
++                size=size,
++            )
++
++    @staticmethod
++    def _validate_moe_shapes(layer: RoutedExperts) -> None:
++        for expert_id in range(layer.local_num_experts):
++            for group, shard_ids in (("w13", ("w1", "w3")), ("w2", ("w2",))):
++                for shard_id in shard_ids:
++                    key = (expert_id, shard_id)
++                    trellis = getattr(layer, f"{group}_trellis").exl3_tensors[key]
++                    suh = getattr(layer, f"{group}_suh").exl3_tensors[key]
++                    svh = getattr(layer, f"{group}_svh").exl3_tensors[key]
++                    if (
++                        trellis.dtype != torch.int16
++                        or trellis.ndim != 3
++                        or trellis.shape[2] % 16
++                        or not 1 <= trellis.shape[2] // 16 <= 8
++                        or suh.dtype != torch.float16
++                        or suh.ndim != 1
++                        or svh.dtype != torch.float16
++                        or svh.ndim != 1
++                        or suh.numel() != trellis.shape[0] * 16
++                        or svh.numel() != trellis.shape[1] * 16
++                        or (trellis.shape[0] * 16) % _HADAMARD_BLOCK
++                        or (trellis.shape[1] * 16) % _HADAMARD_BLOCK
++                    ):
++                        raise ValueError(
++                            f"Invalid EXL3 MoE tensors for expert={expert_id}, "
++                            f"projection={shard_id}"
++                        )
++
++    @staticmethod
++    def _rank_sliced_backing(
++        layer: RoutedExperts,
++        param_name: str,
++    ) -> torch.Tensor:
++        param = getattr(layer, param_name)
++        backing = param.exl3_backing
++        if backing is None or not backing.is_contiguous():
++            raise RuntimeError(
++                f"rank-sliced EXL3 parameter {param_name} has no contiguous slab"
++            )
++        for (expert_id, shard_id), tensor in param.exl3_tensors.items():
++            shard_index = param.exl3_shard_ids.index(shard_id)
++            expected = (
++                backing[shard_index, expert_id]
++                if len(param.exl3_shard_ids) > 1
++                else backing[expert_id]
++            )
++            if tensor.data_ptr() != expected.data_ptr():
++                raise RuntimeError(
++                    "rank-sliced EXL3 expert payload lost its slab alias: "
++                    f"{param_name}[{expert_id},{shard_id}]"
++                )
++        return backing
++
++    @staticmethod
++    def _pointer_table(slab: torch.Tensor) -> torch.Tensor:
++        if slab.ndim < 2 or not slab[0].is_contiguous():
++            raise RuntimeError("EXL3 pointer-table rows must be contiguous")
++        step = slab.stride(0) * slab.element_size()
++        base = slab.data_ptr()
++        return torch.tensor(
++            [base + expert_id * step for expert_id in range(slab.shape[0])],
++            dtype=torch.int64,
++            device=slab.device,
++        )
++
++    @staticmethod
++    def _trellis_tile_config(hidden_size: int, intermediate_size: int):
++        if hidden_size % 128 or intermediate_size % 128:
++            raise ValueError(
++                "rank-sliced EXL3 full rotations require hidden and "
++                "intermediate dimensions divisible by 128"
++            )
++        if hidden_size % 256 == 0 and intermediate_size % 256 == 0:
++            return (64, 256, 64, 256)
++        return (64, 128, 64, 128)
++
++    def _prepare_rank_sliced_weights(self, layer: RoutedExperts) -> None:
++        api = _load_sparkinfer_fused_moe()
++        num_experts = int(layer.local_num_experts)
++        hidden_size = int(layer.exl3_hidden_size)
++        intermediate_size = int(layer.exl3_intermediate_size_per_partition)
++        bits = int(self.quant_config.bits or 0)
++        if float(bits) != self.quant_config.bits or bits not in (3, 4, 5, 6):
++            raise ValueError(
++                "rank-sliced EXL3 requires an integral 3/4/5/6 bitrate, got "
++                f"{self.quant_config.bits!r}"
++            )
++
++        w13 = self._rank_sliced_backing(layer, "w13_trellis")
++        w2 = self._rank_sliced_backing(layer, "w2_trellis")
++        gate_suh, up_suh = self._rank_sliced_backing(layer, "w13_suh")
++        gate_svh, up_svh = self._rank_sliced_backing(layer, "w13_svh")
++        down_suh = self._rank_sliced_backing(layer, "w2_suh")
++        down_svh = self._rank_sliced_backing(layer, "w2_svh")
++        expected_w13 = (
++            2,
++            num_experts,
++            hidden_size // 16,
++            intermediate_size // 16,
++            16 * bits,
++        )
++        expected_w2 = (
++            num_experts,
++            intermediate_size // 16,
++            hidden_size // 16,
++            16 * bits,
++        )
++        if tuple(w13.shape) != expected_w13 or tuple(w2.shape) != expected_w2:
++            raise ValueError(
++                "rank-sliced EXL3 slab geometry mismatch: "
++                f"w13={tuple(w13.shape)}, w2={tuple(w2.shape)}, "
++                f"expected={expected_w13}/{expected_w2}"
++            )
++
++        intermediate_rotations = torch.empty(
++            (num_experts, 3 * intermediate_size),
++            dtype=torch.float16,
++            device=w13.device,
++        )
++        intermediate_rotations[:, :intermediate_size].copy_(gate_svh)
++        intermediate_rotations[:, intermediate_size : 2 * intermediate_size].copy_(
++            up_svh
++        )
++        intermediate_rotations[:, 2 * intermediate_size :].copy_(down_suh)
++        tile_config = self._trellis_tile_config(hidden_size, intermediate_size)
++        marker = layer.w13_mcg.exl3_tensors[(0, "w1")]
++        weight_plan = api.plan_weights(
++            quant_modes="w4a16",
++            source_format="exl3_trellis_mcg",
++            activation=layer.activation.value,
++            params_dtype=layer.exl3_params_dtype,
++            num_experts=num_experts,
++            hidden_size=hidden_size,
++            intermediate_size=intermediate_size,
++            w13_layout="w13",
++            trellis_bits=bits,
++            trellis_tile_config=tile_config,
++        )
++        layer.exl3_trellis_weights = api.prepare_weights(
++            plan=weight_plan,
++            params_dtype=layer.exl3_params_dtype,
++            w1_fp4=w13,
++            w2_fp4=w2,
++            gate_suh=gate_suh,
++            up_suh=up_suh,
++            intermediate_rotations=intermediate_rotations,
++            down_svh=down_svh,
++            trellis_mcg=marker,
++        )
++
++        slabs = (
++            w13[0],
++            gate_suh,
++            gate_svh,
++            w13[1],
++            up_suh,
++            up_svh,
++            w2,
++            down_suh,
++            down_svh,
++        )
++        layer.exl3_pointer_tables = tuple(self._pointer_table(slab) for slab in slabs)
++        layer.exl3_expert_map = torch.arange(
++            num_experts,
++            dtype=torch.int64,
++            device=w13.device,
++        )
++        layer.exl3_trellis_tile_config = tile_config
++
++    def get_fused_moe_quant_config(
++        self, layer: RoutedExperts
++    ) -> FusedMoEQuantConfig | None:
++        del layer
++        return None
++
++    @property
++    def topk_indices_dtype(self) -> torch.dtype | None:
++        return torch.long
++
++    def _rank_sliced_runtime(
++        self,
++        layer: RoutedExperts,
++        x: torch.Tensor,
++        topk_ids: torch.Tensor,
++    ) -> dict[str, Any]:
++        # Rank-sliced target and draft layers both reach small row counts
++        # (typically m=1..3) during profiling, decode, or CUDA-graph capture. If
++        # m falls outside the Trellis window the eager parity path is reached;
++        # under capture that is illegal and during eager execution it adds an
++        # avoidable external-extension ABI dependency:
++        #
++        #   RuntimeError: EXL3 eager parity path entered during CUDA graph
++        #   capture (m=3); capture sizes must lie inside the Trellis window
++        #   [4, 32]
++        #
++        # The backend therefore owns one capability-based default for both
++        # roles. An explicit env value remains authoritative for diagnostics.
++        min_trellis_m = _positive_env_int(
++            "VLLM_EXL3_TRELLIS_MIN_M", _DEFAULT_TRELLIS_MIN_M
++        )
++        max_trellis_m = _positive_env_int("VLLM_EXL3_TRELLIS_MAX_M", 32)
++        block_m = _positive_env_int("VLLM_EXL3_TRELLIS_BLOCK_M", 8)
++        chunk = _positive_env_int("VLLM_EXL3_PREFILL_CHUNK", 128)
++        prefill_trellis = os.environ.get("VLLM_EXL3_PREFILL_TRELLIS", "1") == "1"
++        prefill_block_m = _positive_env_int("VLLM_EXL3_PREFILL_BLOCK_M", 64)
++        if min_trellis_m > max_trellis_m:
++            raise ValueError(
++                "VLLM_EXL3_TRELLIS_MIN_M cannot exceed VLLM_EXL3_TRELLIS_MAX_M"
++            )
++        # Batch-INVARIANT capacity. Including x.shape[0] here made the runtime
++        # cache key depend on the live batch, so any m above the planned capacity
++        # produced a cache MISS -- silently planning a fresh ~1 GiB arena mid-serve
++        # and making the capacity guard in _apply_rank_sliced unreachable. The
++        # planned capacity is a property of the layer, not of one forward pass.
++        max_batched_tokens = int(layer.exl3_max_num_batched_tokens)
++        prefill_plan_enabled = prefill_trellis and max_batched_tokens > max_trellis_m
++        parity_rows = (
++            min(chunk, max_batched_tokens)
++            if prefill_plan_enabled
++            else max_batched_tokens
++        )
++        max_parity_batch = min(max_batched_tokens, min_trellis_m - 1)
++        if max_parity_batch > parity_rows:
++            raise ValueError(
++                "VLLM_EXL3_PREFILL_CHUNK cannot cover the EXL3 parity window: "
++                f"chunk={chunk}, required_rows={max_parity_batch}. Increase "
++                "VLLM_EXL3_PREFILL_CHUNK or lower VLLM_EXL3_TRELLIS_MIN_M."
++            )
++        topk = int(topk_ids.shape[1])
++        device_index = x.device.index
++        key = (
++            # Owning model scope first: the cached runtime holds mutable scratch,
++            # so a target layer and a same-shape rank-sliced MTP draft layer must
++            # not share an entry (see _runtime_scope_id).
++            _runtime_owner_token(self.quant_config, layer),
++            device_index,
++            x.dtype,
++            int(layer.exl3_hidden_size),
++            int(layer.exl3_intermediate_size_per_partition),
++            int(layer.local_num_experts),
++            topk,
++            max_batched_tokens,
++            min_trellis_m,
++            max_trellis_m,
++            block_m,
++            chunk,
++            prefill_trellis,
++            prefill_block_m,
++            layer.exl3_trellis_tile_config,
++        )
++        runtime = _RANK_SLICED_RUNTIMES.get(key)
++        if runtime is not None:
++            return runtime
++        if torch.cuda.is_current_stream_capturing():
++            raise RuntimeError(
++                "Rank-sliced EXL3 runtime must be planned during the eager "
++                "profile pass before CUDA graph capture"
++            )
++
++        api = _load_sparkinfer_fused_moe()
++
++        def _plan_with_scratch(plan_max_tokens: int, plan_block_m: int):
++            caps = api.Caps(
++                max_tokens=plan_max_tokens,
++                num_topk=topk,
++                # vLLM supplies final top-k IDs/weights to bind(); the fused-MoE
++                # router workspace is unused. A zero route-workspace request
++                # still lets the W4A16 core derive route_E from weight_E.
++                route_num_experts=0,
++                device=x.device,
++                weight_plan=layer.exl3_trellis_weights.plan,
++                quant_mode="w4a16",
++                w4a16_block_size_m=plan_block_m,
++            )
++            plan = api.plan(caps)
++            scratch_spec = plan.scratch_specs()[0]
++            scratch = torch.empty(
++                scratch_spec.shape,
++                dtype=scratch_spec.dtype,
++                device=scratch_spec.device,
++            )
++            return plan, scratch
++
++        trellis_plan, trellis_scratch = _plan_with_scratch(max_trellis_m, block_m)
++        # Prefill batches (m > max_trellis_m) run through a second planned
++        # Trellis capacity instead of the eager ExLlamaV3 parity path. The
++        # large block keeps expert tiles streamed once per block of routed
++        # rows rather than once per 8-row block.
++        prefill_plan = None
++        prefill_scratch = None
++        if prefill_plan_enabled:
++            prefill_plan, prefill_scratch = _plan_with_scratch(
++                max_batched_tokens, prefill_block_m
++            )
++
++        ext = _load_exl3_ext()
++        required_ext = {
++            "exl3_moe",
++            "exl3_moe_max_concurrency",
++        }
++        missing_ext = sorted(name for name in required_ext if not hasattr(ext, name))
++        if missing_ext:
++            raise RuntimeError(
++                "The EXL3 extension lacks routed-expert entry points: "
++                + ", ".join(missing_ext)
++            )
++        concurrency = int(ext.exl3_moe_max_concurrency(torch.cuda.current_device()))
++        hidden_size = int(layer.exl3_hidden_size)
++        intermediate_size = int(layer.exl3_intermediate_size_per_partition)
++        num_experts = int(layer.local_num_experts)
++        device = x.device
++        # With the prefill plan live, the parity path only ever serves
++        # m < min_trellis_m, so its persistent staging shrinks to one chunk.
++        runtime = {
++            "api": api,
++            "trellis_plan": trellis_plan,
++            "trellis_scratch": trellis_scratch,
++            "prefill_plan": prefill_plan,
++            "prefill_scratch": prefill_scratch,
++            "ext": ext,
++            "min_trellis_m": min_trellis_m,
++            "max_trellis_m": max_trellis_m,
++            "max_batched_tokens": max_batched_tokens,
++            "parity_rows": parity_rows,
++            "topk": topk,
++            "chunk": chunk,
++            "xh": torch.empty(
++                (parity_rows, hidden_size),
++                dtype=torch.float16,
++                device=device,
++            ),
++            "out32": torch.empty(
++                (parity_rows, hidden_size),
++                dtype=torch.float32,
++                device=device,
++            ),
++            "tg": torch.empty(
++                (concurrency, chunk, hidden_size),
++                dtype=torch.float16,
++                device=device,
++            ),
++            "tu": torch.empty(
++                (concurrency, chunk, hidden_size),
++                dtype=torch.float16,
++                device=device,
++            ),
++            "ig": torch.empty(
++                (concurrency, chunk, intermediate_size),
++                dtype=torch.float16,
++                device=device,
++            ),
++            "iu": torch.empty(
++                (concurrency, chunk, intermediate_size),
++                dtype=torch.float16,
++                device=device,
++            ),
++            "expert_count": torch.empty(
++                num_experts + 1,
++                dtype=torch.int64,
++                device=device,
++            ),
++            "expert_offsets": torch.empty(
++                num_experts + 1,
++                dtype=torch.int64,
++                device=device,
++            ),
++            "token_sorted": torch.empty(
++                parity_rows * topk,
++                dtype=torch.int64,
++                device=device,
++            ),
++            "weight_sorted": torch.empty(
++                parity_rows * topk,
++                dtype=torch.float16,
++                device=device,
++            ),
++            "flat_token": torch.arange(
++                chunk,
++                dtype=torch.int64,
++                device=device,
++            ).repeat_interleave(topk),
++            "ones": torch.ones(
++                chunk * topk,
++                dtype=torch.int64,
++                device=device,
++            ),
++        }
++        _RANK_SLICED_RUNTIMES[key] = runtime
++        prefill_arena_mib = (
++            0.0
++            if prefill_scratch is None
++            else prefill_scratch.numel() * prefill_scratch.element_size() / (1 << 20)
++        )
++        logger.info_once(
++            "EXL3 rank-sliced runtime planned: Trellis m=%d..%d block_m=%d, "
++            "prefill %s capacity=%d chunk=%d topk=%d",
++            min_trellis_m,
++            max_trellis_m,
++            block_m,
++            (
++                f"trellis block_m={prefill_block_m} arena={prefill_arena_mib:.1f}MiB"
++                if prefill_plan is not None
++                else "parity"
++            ),
++            max_batched_tokens,
++            chunk,
++            topk,
++        )
++        return runtime
++
++    def _apply_rank_sliced(
++        self,
++        layer: RoutedExperts,
++        x: torch.Tensor,
++        topk_weights: torch.Tensor,
++        topk_ids: torch.Tensor,
++    ) -> torch.Tensor:
++        runtime = self._rank_sliced_runtime(layer, x, topk_ids)
++        m = int(x.shape[0])
++        if runtime["min_trellis_m"] <= m <= runtime["max_trellis_m"]:
++            binding = runtime["api"].bind(
++                runtime["trellis_plan"],
++                scratch=runtime["trellis_scratch"],
++                a=x,
++                experts=layer.exl3_trellis_weights,
++                topk_weights=topk_weights,
++                topk_ids=topk_ids,
++            )
++            output = runtime["api"].run(binding=binding)
++            return output.to(x.dtype)
++
++        if runtime["prefill_plan"] is not None and m > runtime["max_trellis_m"]:
++            if m > runtime["max_batched_tokens"]:
++                raise ValueError(
++                    "EXL3 batch exceeds its planned capacity: "
++                    f"m={m}, capacity={runtime['max_batched_tokens']}"
++                )
++            binding = runtime["api"].bind(
++                runtime["prefill_plan"],
++                scratch=runtime["prefill_scratch"],
++                a=x,
++                experts=layer.exl3_trellis_weights,
++                topk_weights=topk_weights,
++                topk_ids=topk_ids,
++            )
++            output = runtime["api"].run(binding=binding)
++            return output.to(x.dtype)
++
++        if torch.cuda.is_current_stream_capturing():
++            raise RuntimeError(
++                "EXL3 eager parity path entered during CUDA graph capture "
++                f"(m={m}); capture sizes must lie inside the Trellis window "
++                f"[{runtime['min_trellis_m']}, {runtime['max_trellis_m']}]. "
++                f"Layer {getattr(layer, 'layer_name', '<unknown>')!r} was "
++                f"classified as {'draft' if _is_draft_layer(layer) else 'target'}. "
++                "A rank-sliced draft layer should have had its window widened to "
++                f"MIN_CAPTURABLE_TRELLIS_M={MIN_CAPTURABLE_TRELLIS_M} "
++                "automatically; if VLLM_EXL3_TRELLIS_MIN_M is set explicitly, "
++                f"lower it to {MIN_CAPTURABLE_TRELLIS_M} or unset it."
++            )
++        if m > runtime["parity_rows"]:
++            raise ValueError(
++                "EXL3 batch exceeds its planned parity capacity: "
++                f"m={m}, capacity={runtime['parity_rows']}"
++            )
++        ext = runtime["ext"]
++        xh = runtime["xh"][:m]
++        xh.copy_(x)
++        out32 = runtime["out32"][:m]
++        out32.zero_()
++        chunk = int(runtime["chunk"])
++        pointer_args = layer.exl3_pointer_tables
++        if m > chunk and hasattr(ext, "exl3_moe_fused"):
++            ext.exl3_moe_fused(
++                xh,
++                out32,
++                topk_ids,
++                topk_weights,
++                layer.exl3_expert_map,
++                runtime["expert_count"],
++                runtime["expert_offsets"],
++                runtime["token_sorted"],
++                runtime["weight_sorted"],
++                runtime["tg"],
++                runtime["tu"],
++                runtime["ig"],
++                runtime["iu"],
++                0,
++                3,
++                3,
++                3,
++                *pointer_args,
++                True,
++                False,
++                True,
++                False,
++                True,
++                False,
++                0.0,
++                0,
++            )
++            return out32.to(x.dtype)
++
++        local_ids = layer.exl3_expert_map[topk_ids.long()]
++        half_weights = topk_weights.to(torch.float16)
++        topk = int(runtime["topk"])
++        for start in range(0, m, chunk):
++            current_m = min(chunk, m - start)
++            flat = local_ids[start : start + current_m].reshape(-1)
++            order = torch.argsort(flat)
++            route_count = current_m * topk
++            token_ids = runtime["flat_token"][:route_count].index_select(0, order)
++            route_weights = (
++                half_weights[start : start + current_m]
++                .reshape(-1)
++                .index_select(0, order)
++            )
++            counts = runtime["expert_count"]
++            counts.zero_()
++            counts.scatter_add_(0, flat, runtime["ones"][:route_count])
++            ext.exl3_moe(
++                xh[start : start + current_m],
++                out32[start : start + current_m],
++                counts,
++                token_ids,
++                route_weights,
++                runtime["tg"],
++                runtime["tu"],
++                runtime["ig"],
++                runtime["iu"],
++                0,
++                3,
++                3,
++                3,
++                *pointer_args,
++                True,
++                False,
++                True,
++                False,
++                True,
++                False,
++                0.0,
++            )
++        return out32.to(x.dtype)
++
++    def apply(
++        self,
++        layer: RoutedExperts,
++        x: torch.Tensor,
++        topk_weights: torch.Tensor,
++        topk_ids: torch.Tensor,
++        shared_experts: SharedExperts | None,
++        shared_experts_input: torch.Tensor | None,
++    ) -> torch.Tensor:
++        del shared_experts, shared_experts_input
++        if layer.activation != MoEActivation.SILU:
++            raise NotImplementedError(
++                f"EXL3 correctness MoE supports SiLU only, got {layer.activation}"
++            )
++        if layer.expert_map is not None:
++            raise NotImplementedError("EXL3 MoE expert maps/EPLB are not supported")
++        if layer.apply_router_weight_on_input:
++            raise NotImplementedError(
++                "EXL3 MoE does not support router weights applied on input"
++            )
++
++        original_shape = x.shape[:-1]
++        original_dtype = x.dtype
++        x_2d = x.reshape(-1, x.shape[-1]).contiguous()
++        ids = topk_ids.reshape(x_2d.shape[0], -1).contiguous()
++        weights = topk_weights.reshape_as(ids).to(torch.float32).contiguous()
++        if self.quant_config.rank_sliced_metadata is not None:
++            output = self._apply_rank_sliced(layer, x_2d, weights, ids)
++            return output.reshape(*original_shape, output.shape[-1])
++
++        x_2d = x_2d.to(torch.float16)
++        ids = ids.to(torch.long)
++        weights = weights.to(torch.float16)
++        output = torch.zeros(
++            (x_2d.shape[0], layer.hidden_size),
++            dtype=torch.float32,
++            device=x.device,
++        )
++        for expert_id in range(layer.local_num_experts):
++            positions = (ids == expert_id).nonzero(as_tuple=False)
++            if positions.shape[0] == 0:
++                continue
++            token_ids = positions[:, 0]
++            route_ids = positions[:, 1]
++            expert_input = x_2d.index_select(0, token_ids)
++            gate = self._apply_expert(layer, "w13", expert_input, expert_id, "w1")
++            up = self._apply_expert(layer, "w13", expert_input, expert_id, "w3")
++            hidden = torch.nn.functional.silu(gate) * up
++            expert_output = self._apply_expert(layer, "w2", hidden, expert_id, "w2")
++            route_weight = weights[token_ids, route_ids].unsqueeze(-1)
++            output.index_add_(
++                0,
++                token_ids,
++                (expert_output * route_weight).to(torch.float32),
++            )
++        output = output.reshape(*original_shape, output.shape[-1])
++        return output if output.dtype == original_dtype else output.to(original_dtype)
++
++    def apply_monolithic(
++        self,
++        layer: RoutedExperts,
++        x: torch.Tensor,
++        router_logits: torch.Tensor,
++        input_ids: torch.Tensor | None = None,
++    ) -> torch.Tensor:
++        del layer, x, router_logits, input_ids
++        raise NotImplementedError("EXL3 MoE uses vLLM's external router")
++
++    @staticmethod
++    def _apply_expert(
++        layer: RoutedExperts,
++        group: str,
++        x: torch.Tensor,
++        expert_id: int,
++        shard_id: str,
++    ) -> torch.Tensor:
++        key = (expert_id, shard_id)
++        trellis = getattr(layer, f"{group}_trellis").exl3_tensors[key]
++        packed_k = trellis.shape[0] * 16
++        if x.shape[-1] > packed_k:
++            raise ValueError(
++                f"EXL3 MoE input width {x.shape[-1]} exceeds packed K={packed_k}"
++            )
++        if x.shape[-1] < packed_k:
++            x = torch.nn.functional.pad(x, (0, packed_k - x.shape[-1]))
++        output = _exl3_gemm(
++            x,
++            trellis,
++            getattr(layer, f"{group}_suh").exl3_tensors[key],
++            getattr(layer, f"{group}_svh").exl3_tensors[key],
++            key in getattr(layer, f"{group}_mcg").exl3_tensors,
++            key in getattr(layer, f"{group}_mul1").exl3_tensors,
++        )
++        logical_n = (
++            layer.hidden_size
++            if shard_id == "w2"
++            else layer.exl3_intermediate_size_per_partition
++        )
++        if output.shape[-1] < logical_n:
++            raise ValueError(
++                f"EXL3 MoE packed N={output.shape[-1]} is below logical N={logical_n}"
++            )
++        return output[..., :logical_n]
++
++
++__all__ = ["Exl3Config", "Exl3LinearMethod", "Exl3MoEMethod"]
+diff --git a/vllm/model_executor/layers/sparse_attn_indexer.py b/vllm/model_executor/layers/sparse_attn_indexer.py
+index 3c1c1cd0e70f801fb94ac65fb5a99afed01f8dea..9ad66a9e7c964dafcec62b4ede8c71c1aea7ee2a 100644
+--- a/vllm/model_executor/layers/sparse_attn_indexer.py
++++ b/vllm/model_executor/layers/sparse_attn_indexer.py
+@@ -411,13 +411,63 @@ def _dcp_all_gather_first_dim_into(
+     if device_group is not None:
+         import torch.distributed as dist
+ 
+-        dist.all_gather_into_tensor(output_tensor, input_tensor, group=device_group)
++        gather_input = input_tensor
++        input_start = input_tensor.data_ptr()
++        input_end = input_start + input_tensor.numel() * input_tensor.element_size()
++        output_start = output_tensor.data_ptr()
++        output_end = output_start + output_tensor.numel() * output_tensor.element_size()
++        if input_start < output_end and output_start < input_end:
++            # PyTorch does not document NCCL's in-place alias contract. Keep
++            # its fallback portable; the deployed PyNCCL path above remains
++            # zero-copy.
++            gather_input = input_tensor.clone()
++        dist.all_gather_into_tensor(output_tensor, gather_input, group=device_group)
+         return
+ 
+     gathered = group.all_gather(input_tensor, dim=0)
+     output_tensor.copy_(gathered)
+ 
+ 
++def _query_split_all_gather_indices(
++    group,
++    local_indices: torch.Tensor,
++    gathered_indices: torch.Tensor,
++) -> None:
++    """Restore query-split rows directly into their shared index buffer.
++
++    Args:
++        group: Query-split process group and rank metadata.
++        local_indices: Contiguous rank-local rows aliasing their output slot.
++        gathered_indices: Contiguous output containing every rank's rows.
++
++    Raises:
++        RuntimeError: If the buffers are noncontiguous, have incompatible
++            shapes, or do not satisfy the rank-local alias contract.
++    """
++    if group.world_size <= 1:
++        return
++    if not local_indices.is_contiguous() or not gathered_indices.is_contiguous():
++        raise RuntimeError("query-split top-k buffers must be contiguous")
++    if gathered_indices.shape[0] != local_indices.shape[0] * group.world_size:
++        raise RuntimeError("query-split output has an invalid row count")
++    if gathered_indices.shape[1:] != local_indices.shape[1:]:
++        raise RuntimeError("query-split output has an invalid trailing shape")
++
++    rank = int(group.rank_in_group)
++    expected_local = gathered_indices.narrow(
++        0, rank * local_indices.shape[0], local_indices.shape[0]
++    )
++    if expected_local.data_ptr() != local_indices.data_ptr():
++        raise RuntimeError(
++            "query-split local indices must alias their rank slot in the output"
++        )
++
++    # NCCL supports in-place all-gather when the send buffer aliases the
++    # rank-local slice of the receive buffer. The generic fallback in
++    # _dcp_all_gather_first_dim_into remains correct when PyNCCL is unavailable.
++    _dcp_all_gather_first_dim_into(group, local_indices, gathered_indices)
++
++
+ def _unpack_b12x_dcp_gathered_candidates(
+     gathered_candidates: torch.Tensor,
+     candidate_indices: torch.Tensor,
+@@ -1994,19 +2044,17 @@ def sparse_attn_indexer(
+                 if used_owner_merge:
+                     continue
+                 if qs_active:
+-                    gathered_indices = qs_group.all_gather(
+-                        topk_indices.contiguous(), dim=0
+-                    )
+-                    topk_indices_buffer[
++                    gathered_indices = topk_indices_buffer[
+                         chunk.token_start : chunk.token_end, :topk_tokens
+-                    ].copy_(gathered_indices)
+-                    if topk_scores is not None:
+-                        gathered_scores = qs_group.all_gather(
+-                            topk_scores.contiguous(), dim=0
+-                        )
+-                        topk_scores_buffer[
+-                            chunk.token_start : chunk.token_end, :topk_tokens
+-                        ].copy_(gathered_scores)
++                    ]
++                    _query_split_all_gather_indices(
++                        qs_group,
++                        topk_indices,
++                        gathered_indices,
++                    )
++                    # Scores are only needed for the DCP-local candidate merge
++                    # above. Sparse attention consumes the restored indices, so
++                    # gathering scores here would double query-split traffic.
+                 continue
+ 
+             cu_seqlen_ks = chunk.cu_seqlen_ks
+diff --git a/vllm/model_executor/models/deepseek_mtp.py b/vllm/model_executor/models/deepseek_mtp.py
+index e37303a1d36f82f5baa07c84f0a90f3876c53161..85f727ce91ca2516afb5b64fc62974241f536c66 100644
+--- a/vllm/model_executor/models/deepseek_mtp.py
++++ b/vllm/model_executor/models/deepseek_mtp.py
+@@ -741,7 +741,22 @@ class DeepSeekMTP(nn.Module, DeepseekV2MixtureOfExperts):
+         loaded_params: set[str] = set()
+         _pending_wk_fp8: dict = {}  # FP8 indexer wk dequant buffer
+         _pending_fp8_linear: dict = {}
++        # Rank-sliced EXL3 checkpoints ship one tensor per TP rank
++        # (`....rank{r}.{trellis|suh|svh|mcg}`), while Exl3MoEMethod registers a
++        # single fused param per projection group (`w13_mcg`, `w2_trellis`, ...).
++        # Strip the `.rank{r}` segment before expert mapping, exactly as the
++        # target model (deepseek_v2.load_weights) does; otherwise the MTP loader
++        # looks up `...routed_experts.w2_rank0.mcg` and KeyErrors.
++        rank_sliced_name = getattr(
++            self.quant_config,
++            "normalize_rank_sliced_weight_name",
++            None,
++        )
+         for name, loaded_weight in weights:
++            if rank_sliced_name is not None:
++                name = rank_sliced_name(name)
++                if name is None:
++                    continue
+             if "rotary_emb.inv_freq" in name:
+                 continue
+             spec_layer = get_spec_layer_idx_from_weight_name(self.config, name)
+diff --git a/vllm/model_executor/models/deepseek_v2.py b/vllm/model_executor/models/deepseek_v2.py
+index 21b43a3365105ad771f81a6305903fb08a92a221..d62bf2d89a8ff206d7301438159f3a6f5099b766 100644
+--- a/vllm/model_executor/models/deepseek_v2.py
++++ b/vllm/model_executor/models/deepseek_v2.py
+@@ -1578,6 +1578,7 @@ class DeepseekV2Model(nn.Module):
+         config = vllm_config.model_config.hf_config
+         quant_config = vllm_config.quant_config
+         self.config = config
++        self.quant_config = quant_config
+         self.device = current_platform.device_type
+         self.hidden_size = config.hidden_size
+         self.vocab_size = config.vocab_size
+@@ -1796,12 +1797,21 @@ class DeepseekV2Model(nn.Module):
+         pp_missing_layer_names = get_pp_missing_layer_names(self)
+         params_dict = dict(self.named_parameters())
+         loaded_params: set[str] = set()
++        rank_sliced_name = getattr(
++            self.quant_config,
++            "normalize_rank_sliced_weight_name",
++            None,
++        )
+         # With index_topk_freq>1 only some layers build an indexer, yet the
+         # checkpoint ships indexer weights for all of them; track the built ones.
+         indexer_present_prefixes = {
+             n.rsplit(".indexer.", 1)[0] for n in params_dict if ".indexer." in n
+         }
+         for name, loaded_weight in weights:
++            if rank_sliced_name is not None:
++                name = rank_sliced_name(name)
++                if name is None:
++                    continue
+             if "rotary_emb.inv_freq" in name:
+                 continue
+ 
+diff --git a/vllm/model_executor/models/glm4_moe.py b/vllm/model_executor/models/glm4_moe.py
+index 1c64ccaba45a965cb07faf120ca82b2642d932a8..e87a48209cbc87419a6e3228819eafe47c598360 100644
+--- a/vllm/model_executor/models/glm4_moe.py
++++ b/vllm/model_executor/models/glm4_moe.py
+@@ -418,6 +418,7 @@ class Glm4MoeModel(nn.Module):
+         quant_config = vllm_config.quant_config
+         enable_eplb = vllm_config.parallel_config.enable_eplb
+         self.config = config
++        self.quant_config = quant_config
+ 
+         self.vocab_size = config.vocab_size
+ 
+@@ -522,7 +523,16 @@ class Glm4MoeModel(nn.Module):
+         params_dict = dict(self.named_parameters())
+         loaded_params: set[str] = set()
+         expert_params_mapping = self.get_expert_mapping()
++        rank_sliced_name = getattr(
++            self.quant_config,
++            "normalize_rank_sliced_weight_name",
++            None,
++        )
+         for name, loaded_weight in weights:
++            if rank_sliced_name is not None:
++                name = rank_sliced_name(name)
++                if name is None:
++                    continue
+             spec_layer = get_spec_layer_idx_from_weight_name(self.config, name)
+             if spec_layer is not None:
+                 continue
+diff --git a/vllm/model_executor/models/utils.py b/vllm/model_executor/models/utils.py
+index 86dc72de76c2b12ba5de71dbf2dfd9934cc72535..be0c6fba8bc5895dad07099dda7a26de2b8a82aa 100644
+--- a/vllm/model_executor/models/utils.py
++++ b/vllm/model_executor/models/utils.py
+@@ -796,12 +796,39 @@ def get_draft_quant_config(vllm_config: VllmConfig) -> "QuantizationConfig | Non
+     draft_model_config = vllm_config.speculative_config.draft_model_config
+     draft_load_config = vllm_config.load_config
+ 
+-    return (
+-        VllmConfig.get_quantization_config(draft_model_config, draft_load_config)
+-        if draft_model_config
+-        else None
++    if not draft_model_config:
++        return None
++
++    quant_config = VllmConfig.get_quantization_config(
++        draft_model_config, draft_load_config
+     )
+ 
++    # EXL3 rank-sliced (hybrid_tr3_tail) metadata is hydrated by VllmConfig via
++    # Exl3Config.maybe_update_config() for the *target* model only. The draft/MTP
++    # quant config is built separately here, so without this call its
++    # rank_sliced_metadata stays None and a rank-sliced MTP MoE layer silently
++    # falls back to the stock (non-tr3) expert path, KeyError-ing on
++    # `...experts.routed_experts.wN_rankR.mcg`. Mirror the target-model call so
++    # the MTP layer's experts load through the tr3 path.
++    if (
++        quant_config is not None
++        and getattr(quant_config, "get_name", lambda: None)() == "exl3"
++    ):
++        draft_hf = getattr(draft_model_config, "hf_config", None)
++        target_hf = getattr(
++            getattr(vllm_config, "model_config", None), "hf_config", None
++        )
++        hf_config = draft_hf
++        if getattr(draft_hf, "hybrid_tr3_tail", None) is None:
++            hf_config = target_hf
++        if getattr(hf_config, "hybrid_tr3_tail", None) is not None:
++            quant_config.maybe_update_config(
++                draft_model_config.model,
++                hf_config=hf_config,
++            )
++
++    return quant_config
++
+ 
+ def extract_layer_index(layer_name: str, num_attn_module: int = 1) -> int:
+     """
+diff --git a/vllm/models/deepseek_v32/nvidia/attention.py b/vllm/models/deepseek_v32/nvidia/attention.py
+index dcf955ad59baa698258cdc1125340b70e0b38205..320d7251fc3200afcb5bd4018430119f0e0f4b72 100644
+--- a/vllm/models/deepseek_v32/nvidia/attention.py
++++ b/vllm/models/deepseek_v32/nvidia/attention.py
+@@ -398,7 +398,10 @@ class DeepseekV32Attention(MLAAttention):
+         assert isinstance(slot_mapping, dict)
+         mla_slot = slot_mapping.get(self.layer_name)
+ 
+-        if self.indexer is not None:
++        # index_k is None when skip_topk (MTP draft steps 1+ under
++        # index_share_for_mtp_iteration): treat this forward as a shared
++        # layer so the step-0 top-k is reused instead of cleared/recomputed.
++        if self.indexer is not None and index_k is not None:
+             has_indexer = True
+             indexer_k_norm_w = self.indexer.k_norm.weight
+             indexer_k_norm_bias = self.indexer.k_norm.bias
+@@ -456,7 +459,7 @@ class DeepseekV32Attention(MLAAttention):
+         q_nope = q_nope.transpose(0, 1)
+         ql_nope = torch.bmm(q_nope, self.W_UK_T).transpose(0, 1)
+ 
+-        if self.indexer is not None:
++        if self.indexer is not None and has_indexer:
+             index_q = self.indexer.wq_b(q_c)[0]
+             index_q = index_q.view(-1, self.indexer.n_head, self.indexer.head_dim)
+         else:
+@@ -478,7 +481,7 @@ class DeepseekV32Attention(MLAAttention):
+             quantize_mqa=self._fp8_query,
+         )
+ 
+-        if self.indexer is not None:
++        if self.indexer is not None and has_indexer:
+             sparse_attn_indexer(
+                 q_c,
+                 self.indexer.k_cache.prefix,
+diff --git a/vllm/v1/attention/backends/mla/indexer.py b/vllm/v1/attention/backends/mla/indexer.py
+index fa4fbcafd24a7a4668928974c5a445afdcfe76d4..e22a12097931357840b927a96df85a208e1cd044 100644
+--- a/vllm/v1/attention/backends/mla/indexer.py
++++ b/vllm/v1/attention/backends/mla/indexer.py
+@@ -297,12 +297,16 @@ def get_indexer_max_num_blocks_per_req(
+     return cdiv(max_model_len, block_size * effective_cp_world_size)
+ 
+ 
+-def _supports_varlen_paged_mqa_logits() -> bool:
+-    if (
+-        envs.VLLM_USE_B12X_SPARSE_INDEXER
+-        and current_platform.is_cuda()
+-        and current_platform.is_device_capability_family(120)
+-    ):
++def _supports_varlen_paged_mqa_logits(
++    use_b12x_sparse_indexer: bool | None = None,
++) -> bool:
++    if use_b12x_sparse_indexer is None and current_platform.is_cuda():
++        from vllm.model_executor.layers.sparse_attn_indexer import (
++            use_b12x_sparse_indexer as resolve_b12x_sparse_indexer,
++        )
++
++        use_b12x_sparse_indexer = resolve_b12x_sparse_indexer()
++    if use_b12x_sparse_indexer:
+         # B12X consumes the already-flattened rank-1 seq_lens and repeated
+         # block-table rows directly, so it does not need DeepGEMM's indices.
+         return True
+@@ -430,16 +434,30 @@ class DeepseekV32IndexerMetadataBuilder(AttentionMetadataBuilder):
+         # caches). Outside the SM100 family the FP8
+         # paged MQA logits kernel only supports next_n in (1, 2)
+         # (deepgemm smxx_fp8_fp4_paged_mqa_logits.hpp:233), so flatten there.
+-        self.use_flattening = not current_platform.is_device_capability_family(
+-            100
+-        ) and next_n not in (1, 2)
++        # The B12X / sparkinfer sparse indexer handles native next_n>2 on SM120
++        # directly (see sparse_attn_indexer warmup q_rows 1, 2, 4), so it must
++        # NOT be forced onto the DeepGEMM next_n<=2 flatten fallback. Flattening
++        # MTP-2/MTP-3 verification into rank-1 rows produced subtly wrong accepted
++        # tokens (code-gen syntax errors); the native (B, next_n) path keeps MTP
++        # correct. Use the canonical backend-aware predicate so this also holds
++        # when B12X is selected via --attention-backend B12X_MLA_SPARSE with the
++        # VLLM_USE_B12X_SPARSE_INDEXER env var unset (it also asserts SM120).
++        from vllm.model_executor.layers.sparse_attn_indexer import (
++            use_b12x_sparse_indexer,
++        )
++
++        self.use_b12x_sparse_indexer = use_b12x_sparse_indexer()
++        self.use_flattening = (
++            not current_platform.is_device_capability_family(100)
++            and next_n not in (1, 2)
++            and not self.use_b12x_sparse_indexer
++        )
+         # SM100 supports the varlen paged MQA logits kernel (indices-selected,
+         # next_n == 1 rows). Only compact spec-decode verification batches opt
+         # into it; uniform DFlash draft proposal should keep the native path.
+-        self.use_varlen = (
+-            _supports_varlen_paged_mqa_logits()
+-            and _uses_varlen_dspark_capacity(self.vllm_config)
+-        )
++        self.use_varlen = _supports_varlen_paged_mqa_logits(
++            self.use_b12x_sparse_indexer
++        ) and _uses_varlen_dspark_capacity(self.vllm_config)
+         logger.info_once(
+             "DSA indexer decode path: use_flattening=%s use_varlen=%s "
+             "(next_n=%d, use_fp4_indexer_cache=%s)",
+@@ -683,7 +701,7 @@ class DeepseekV32IndexerMetadataBuilder(AttentionMetadataBuilder):
+                 # their slot mappings stay padded and their outputs are ignored.
+                 padding_seq_len = (
+                     self.compress_ratio
+-                    if force_flatten and envs.VLLM_USE_B12X_SPARSE_INDEXER
++                    if force_flatten and self.use_b12x_sparse_indexer
+                     else 0
+                 )
+                 self.decode_seq_lens_buffer[actual_expanded:num_decode_tokens] = (
+@@ -818,7 +836,7 @@ class DeepseekV32IndexerMetadataBuilder(AttentionMetadataBuilder):
+         num_decode_tokens: int,
+         requires_padding: bool,
+     ) -> torch.Tensor | None:
+-        if not envs.VLLM_USE_B12X_SPARSE_INDEXER or requires_padding:
++        if not self.use_b12x_sparse_indexer or requires_padding:
+             return None
+ 
+         schedule_seq_lens = seq_lens
+@@ -981,7 +999,7 @@ class DeepseekV32IndexerMetadataBuilder(AttentionMetadataBuilder):
+             # slice below).
+             assert common_attn_metadata.seq_lens_cpu_upper_bound is not None
+             seq_lens_cpu = common_attn_metadata.seq_lens_cpu_upper_bound
+-            if envs.VLLM_USE_B12X_SPARSE_INDEXER:
++            if self.use_b12x_sparse_indexer:
+                 # The b12x paged prefill streams one supertile at a time and
+                 # row-shares the page table, which requires single-request
+                 # chunks. Budget each request by the supertile K window.
+@@ -1160,7 +1178,7 @@ class DeepseekV32IndexerMetadataBuilder(AttentionMetadataBuilder):
+ 
+             active_width: torch.Tensor | None = None
+             decode_topk_max_seq_len: int | None = None
+-            if envs.VLLM_USE_B12X_SPARSE_INDEXER:
++            if self.use_b12x_sparse_indexer:
+                 # Live scorer window in cache tokens. ceil(max_seq_len /
+                 # compress_ratio) is an upper bound on the max compressed
+                 # context across the batch, so windowing to it is
+diff --git a/vllm/v1/core/sched/scheduler.py b/vllm/v1/core/sched/scheduler.py
+index b30a08d98d2e6e8ef443363f6df78b6fd88402b2..187bd59678d75e7c11852eab344d3758de05b5a3 100644
+--- a/vllm/v1/core/sched/scheduler.py
++++ b/vllm/v1/core/sched/scheduler.py
+@@ -1756,7 +1756,9 @@ class Scheduler(SchedulerInterface):
+                 request.status = RequestStatus.FINISHED_STOPPED
+                 stopped = True
+ 
+-            if new_token_ids and self.structured_output_manager.should_advance(request):
++            if new_token_ids and self.structured_output_manager.should_advance(
++                request, new_token_ids
++            ):
+                 struct_output_request = request.structured_output_request
+                 assert struct_output_request is not None
+                 grammar = struct_output_request.grammar
+diff --git a/vllm/v1/structured_output/__init__.py b/vllm/v1/structured_output/__init__.py
+index 4dfe362da8ce162dbd2f85a63eb53e31885b28d2..9b038bb0e14bb7a072ecd8b15a94d13ab995e187 100644
+--- a/vllm/v1/structured_output/__init__.py
++++ b/vllm/v1/structured_output/__init__.py
+@@ -15,7 +15,6 @@ from vllm.v1.structured_output.backend_guidance import GuidanceBackend
+ from vllm.v1.structured_output.backend_types import (
+     StructuredOutputBackend,
+     StructuredOutputGrammar,
+-    StructuredOutputOptions,
+ )
+ from vllm.v1.structured_output.backend_xgrammar import XgrammarBackend
+ 
+@@ -370,7 +369,9 @@ class StructuredOutputManager:
+             return request.structured_output_request.reasoning_ended
+         return True
+ 
+-    def should_advance(self, request: "Request") -> bool:
++    def should_advance(
++        self, request: "Request", new_token_ids: Sequence[int] | None = None
++    ) -> bool:
+         if not request.use_structured_output:
+             return False
+ 
+@@ -393,33 +394,38 @@ class StructuredOutputManager:
+         if structured_req.reasoning_ended:
+             return True
+ 
+-        # Check if reasoning ends in *this* step
+-        delta_from = request.num_computed_tokens - request.num_output_placeholders
++        # Check if reasoning ends in *this* step. Prefer the caller's actual
++        # new_token_ids over reconstructing the step window from scheduler
++        # counters: with speculative decoding, num_computed_tokens is already
++        # advanced past the accepted draft tokens when this runs, so the
++        # counter-derived window can miss the reasoning-end marker.
+         all_token_ids = request.all_token_ids
+-        start = (
+-            delta_from if delta_from >= 0 else max(len(all_token_ids) + delta_from, 0)
+-        )
+-        if reasoner.is_reasoning_end_streaming(
+-            all_token_ids, itertools.islice(all_token_ids, start, None)
+-        ):
++        if new_token_ids is not None:
++            start = max(len(all_token_ids) - len(new_token_ids), 0)
++            delta: Iterable[int] = new_token_ids
++        else:
++            delta_from = request.num_computed_tokens - request.num_output_placeholders
++            start = (
++                delta_from
++                if delta_from >= 0
++                else max(len(all_token_ids) + delta_from, 0)
++            )
++            delta = itertools.islice(all_token_ids, start, None)
++        if reasoner.is_reasoning_end_streaming(all_token_ids, delta):
+             structured_req.reasoning_ended = True
+ 
+-            # Reasoning just ended this step. Defer FSM advance until the next
+-            # pass (see reasoning_ended check above) for JSON/regex/choice/grammar:
+-            # advancing on the closing boundary token can accept tokens that still
+-            # belong to the reasoning stream. Structural tags are the only safe
+-            # same-step exception: they model phased output (e.g. thinking tag ->
+-            # answer tag), and speculative decoding must run grammar.validate_tokens
+-            # on draft tokens produced immediately after that transition.
+-            if (
+-                self.vllm_config.speculative_config is not None
+-                and structured_req.structured_output_key[0]
+-                == StructuredOutputOptions.STRUCTURAL_TAG
+-            ):
+-                # The scheduler will advance the grammar with this step's
+-                # tokens right away, but the step still contains reasoning
+-                # content up to and including the end marker. Record where
+-                # it ends so trim_reasoning_for_advance() can drop it.
++            # Reasoning just ended this step. Without speculative decoding the
++            # boundary step ends at the marker, so deferring the FSM advance to
++            # the next pass (see reasoning_ended check above) is safe. With
++            # speculative decoding the same step can already contain accepted
++            # post-marker content (e.g. a drafted "{" verified right after the
++            # end marker); deferring would leave the grammar permanently one
++            # token behind the sampled stream, and the next bitmask would then
++            # force a duplicate of a token the model already emitted. Advance
++            # same-step for every structured type: trim_reasoning_for_advance()
++            # drops everything up to and including the marker, so the grammar
++            # never sees reasoning content.
++            if self.vllm_config.speculative_config is not None:
+                 structured_req.reasoning_end_token_index = (
+                     self._find_reasoning_end_index(reasoner, all_token_ids, start)
+                 )
+diff --git a/vllm/v1/worker/gpu_worker.py b/vllm/v1/worker/gpu_worker.py
+index 7c6900b3da8b455e8a7bb57fe0b0ae35d9362f85..194e5fe0c15d1d2b1a7db17a34e4f10f40f20a60 100644
+--- a/vllm/v1/worker/gpu_worker.py
++++ b/vllm/v1/worker/gpu_worker.py
+@@ -486,6 +486,12 @@ class Worker(WorkerBase):
+         )
+         self._warmup_kernels_once()
+ 
++        # The first pass may include one-time compiler or loader temporaries.
++        # Keep every persistent allocation initialized above, but exclude that
++        # startup-only high-water mark from the activation measurement. The
++        # second pass below establishes the repeatable serving peak.
++        torch.accelerator.reset_peak_memory_stats(self.device)
++
+         # Kernel warmup can create persistent modules and communication pools.
+         # A second pass is required so the measured peak contains both those
+         # allocations and the model's transient activation workspace.

--- a/patches/releases/gilded-gnosis-v20-r13/lmcache/integration.lock.json
+++ b/patches/releases/gilded-gnosis-v20-r13/lmcache/integration.lock.json
@@ -1,63 +1,96 @@
 {
-  "schema_version": 1,
+  "base": {
+    "commit": "9cebd405d0caf4bebe01d694b5a8bf4e3e354314",
+    "ref": "refs/heads/release/v0.5.2-glm52-dcp-base",
+    "repository": "https://github.com/local-inference-lab/LMCache.git"
+  },
+  "manifest": {
+    "sha256": "89df49b01c9b077898a7141ac86581887a3b1e2bada744e8c891213e7d0caa03"
+  },
   "name": "gilded-gnosis-v20-lmcache",
-  "repository": "https://github.com/local-inference-lab/LMCache.git",
-  "base_ref": "refs/heads/release/v0.5.2-glm52-dcp-base",
   "pull_requests": [
     {
-      "number": 7,
+      "disposition": "merged",
       "head": "7b7583aef55e98ba05a6c199e71601d78552e794",
+      "number": 7,
+      "ref": "refs/pull/7/head",
       "title": "Return bounded LMCache MP RPC handler errors"
     },
     {
-      "number": 8,
+      "disposition": "merged",
       "head": "31c4175d2134518e5b43fe8f4a7d072df6043a13",
+      "number": 8,
+      "ref": "refs/pull/8/head",
       "title": "Recover failed MP retrieves by recomputing invalid blocks"
     },
     {
-      "number": 9,
+      "disposition": "merged",
       "head": "c3b73de74d855f6263deea8b6c6c4dde87e6e5b9",
+      "number": 9,
+      "ref": "refs/pull/9/head",
       "title": "Restore the largest exact L1 prefix after allocation failure"
     },
     {
-      "number": 10,
+      "disposition": "merged",
       "head": "59186798bb5859b7add7bcac81dff9f2fd4037ab",
+      "number": 10,
+      "ref": "refs/pull/10/head",
       "title": "Protect native lookup keys from concurrent deletion"
     },
     {
-      "number": 11,
+      "disposition": "merged",
       "head": "2cee5a2c1ef7e80028e94b1bc4bfbfc02e2c2a8d",
+      "number": 11,
+      "ref": "refs/pull/11/head",
       "title": "Log bounded prefetch failure key samples"
     },
     {
-      "number": 12,
+      "disposition": "merged",
       "head": "baf1345106ebe568a116a35fdcee36bfec73da57",
+      "number": 12,
+      "ref": "refs/pull/12/head",
       "title": "Return native per-key store results"
     },
     {
-      "number": 13,
+      "disposition": "merged",
       "head": "d4dce69bf90362953cf9ac9a86cccc186b3219dc",
+      "number": 13,
+      "ref": "refs/pull/13/head",
       "title": "Enforce native filesystem O_DIRECT alignment"
     },
     {
-      "number": 14,
+      "disposition": "merged",
       "head": "502b3c60f2e61625d6e32a31d0d725eedc620792",
+      "number": 14,
+      "ref": "refs/pull/14/head",
       "title": "Support current and legacy native filesystem object-group keys"
     },
     {
-      "number": 15,
+      "disposition": "merged",
       "head": "7892d42a6996df855fe743edb271fa154503bef8",
+      "number": 15,
+      "ref": "refs/pull/15/head",
       "title": "Make native stores durable before reporting completion"
     },
     {
-      "number": 16,
+      "disposition": "merged",
       "head": "e6c2708fe8ae8a96d3c66e83bf4b548c734fbb13",
+      "number": 16,
+      "ref": "refs/pull/16/head",
       "title": "Restore native filesystem capacity accounting after restart"
     },
     {
-      "number": 17,
+      "disposition": "merged",
       "head": "f9639e2094f70955a1145bfd7219b6fdd39ee143",
+      "number": 17,
+      "ref": "refs/pull/17/head",
       "title": "Add bounded L1 writeback to durable storage"
     }
-  ]
+  ],
+  "result": {
+    "patch": "integration.patch",
+    "patch_sha256": "34a0b73b2603ce2fb8c6d9383551871e23981ff2c0b837c000961c38afe73337",
+    "tree": "a5aa59cc8edca462a3f4c198d17fd2b9c1a7ffaa"
+  },
+  "schema_version": 1
 }

--- a/patches/releases/gilded-gnosis-v20-r13/lmcache/integration.patch
+++ b/patches/releases/gilded-gnosis-v20-r13/lmcache/integration.patch
@@ -1,0 +1,4028 @@
+diff --git a/csrc/storage_backends/connector_base.h b/csrc/storage_backends/connector_base.h
+index c2cd35a174a1225c467d1479ea347b0d6e5ebd0e..0df7677cef0d0172a7cb60f7c9f3599cb189b555 100644
+--- a/csrc/storage_backends/connector_base.h
++++ b/csrc/storage_backends/connector_base.h
+@@ -111,6 +111,9 @@ class ConnectorBase : public IStorageConnector {
+     auto [batch_future_id, batch_state, num_tiles, tile_size] =
+         prepare_batch_operation(num_items, Op::BATCH_TILE_SET);
+ 
++    // pre-allocate per-key results so partial store failures are visible
++    batch_state->per_key_results.assign(num_items, 0);
++
+     // fan out work to threads
+     for (size_t tile_idx = 0; tile_idx < num_tiles; ++tile_idx) {
+       auto tile_req = create_tile_request(
+@@ -326,10 +329,30 @@ class ConnectorBase : public IStorageConnector {
+       }
+     }
+   }
++  // Records a per-key result for every key in the tile (continuing past
++  // failures instead of aborting the tile), then rethrows so batch-level
++  // ok=false semantics are preserved for consumers that ignore per-key
++  // results.
+   virtual void do_batch_set(ConnectionType& conn, const Request& req) {
++    bool any_failed = false;
++    std::string first_error;
+     for (size_t i = 0; i < req.keys.size(); ++i) {
+-      do_single_set(conn, req.keys[i], req.buf_ptrs[i], req.buf_lens[i],
+-                    req.batch_chunk_num_bytes);
++      try {
++        do_single_set(conn, req.keys[i], req.buf_ptrs[i], req.buf_lens[i],
++                      req.batch_chunk_num_bytes);
++        req.batch->per_key_results[req.start_idx + i] = 1;
++      } catch (const std::exception& e) {
++        req.batch->per_key_results[req.start_idx + i] = 0;
++        if (!any_failed) {
++          any_failed = true;
++          first_error = e.what();
++        }
++        fprintf(stderr, "[LMCache SET] key %s failed: %s\n",
++                req.keys[i].c_str(), e.what());
++      }
++    }
++    if (any_failed) {
++      throw std::runtime_error("batch set partially failed: " + first_error);
+     }
+   }
+   virtual void do_batch_exists(ConnectionType& conn, const Request& req) {
+@@ -612,9 +635,10 @@ class ConnectorBase : public IStorageConnector {
+         std::lock_guard<std::mutex> lk(req.batch->err_mu);
+         batch_comp.error = req.batch->first_error;
+       }
+-      // for batch exists and batch get, move per-key results
++      // move per-key results for every op that records them
+       if (req.batch->batch_op == Op::BATCH_TILE_EXISTS ||
+           req.batch->batch_op == Op::BATCH_TILE_GET ||
++          req.batch->batch_op == Op::BATCH_TILE_SET ||
+           req.batch->batch_op == Op::BATCH_TILE_DELETE) {
+         batch_comp.result_bytes = std::move(req.batch->per_key_results);
+       }
+diff --git a/csrc/storage_backends/fs/connector.cpp b/csrc/storage_backends/fs/connector.cpp
+index e54d98f54f5428afad363cf1c5f5f380cdd8fffb..727ed016f10ae0b0c6e863c4234439dbaac0e7f8 100644
+--- a/csrc/storage_backends/fs/connector.cpp
++++ b/csrc/storage_backends/fs/connector.cpp
+@@ -2,10 +2,22 @@
+ 
+ #include "connector.h"
+ #include <cerrno>
++#include <cstdint>
+ #include <cstdio>
+ #include <stdexcept>
+ #include <string>
+ 
++namespace {
++// O_DIRECT requires the buffer ADDRESS to be block-aligned as well as the
++// length; a misaligned address fails the read/write with EINVAL. Buffers
++// come from Python and carry no alignment guarantee, so fall back to
++// buffered I/O whenever either constraint is unmet.
++bool odirect_eligible(const void* buf, size_t len, size_t disk_block_size) {
++  return disk_block_size > 0 && len % disk_block_size == 0 &&
++         reinterpret_cast<uintptr_t>(buf) % disk_block_size == 0;
++}
++}  // namespace
++
+ namespace lmcache {
+ namespace connector {
+ 
+@@ -27,22 +39,23 @@ std::string FSConnector::replace_all(const std::string& str,
+ 
+ std::string FSConnector::key_to_filename(const std::string& key) {
+   // Input key format (from _object_key_to_string):
+-  //   Unsalted: <model_name>@<kv_rank_hex>@<chunk_hash_hex>
+-  //   Salted  : <model_name>@<kv_rank_hex>@<chunk_hash_hex>@<cache_salt>
++  //   Legacy unsalted: <model_name>@<kv_rank_hex>@<chunk_hash_hex>
++  //   Legacy salted  : <model_name>@<kv_rank_hex>@<chunk_hash_hex>@<cache_salt>
++  //   Current unsalted:
++  //     <model_name>@<kv_rank_hex>@<object_group_id_hex>@<chunk_hash_hex>
++  //   Current salted appends @<cache_salt> to the current unsalted shape.
+   //
+   // Output filename (matching fs_l2_adapter.py._object_key_to_filename):
+   //   Unsalted: <model_name_safe>@0x<kv_rank_hex>@<chunk_hash_hex>.data
+   //   Salted  :
+   //   <model_name_safe>@0x<kv_rank_hex>@<chunk_hash_hex>@<cache_salt>.data
+   //
+-  // The unsalted 3-field shape is bit-identical to the pre-cache_salt
+-  // format, so existing cache directories remain valid.
+-  //
+-  // NOTE: both model_name and cache_salt are forbidden from containing
+-  // '@' (invariant enforced on the Python side), so splitting on '@'
+-  // is unambiguous — no marker, no rsplit.
++  // Four fields are intentionally not interpreted: that shape can mean a
++  // legacy salted key or a current unsalted key, and both map correctly by
++  // preserving every field after kv_rank verbatim.
+ 
+-  // Split on '@' — must yield 3 (unsalted) or 4 (salted) fields.
++  // Split on '@'. Current ObjectKey serialization has four or five fields;
++  // three-field legacy keys remain readable for cache compatibility.
+   std::vector<std::string> parts;
+   size_t start = 0;
+   for (size_t pos = 0; pos <= key.size(); ++pos) {
+@@ -51,34 +64,28 @@ std::string FSConnector::key_to_filename(const std::string& key) {
+       start = pos + 1;
+     }
+   }
+-  if (parts.size() != 3 && parts.size() != 4) {
++  if (parts.size() < 3 || parts.size() > 5) {
+     throw std::runtime_error(
+-        "FSConnector: malformed key (expected 3 or 4 '@'-separated fields): " +
++        "FSConnector: malformed key (expected 3 to 5 '@'-separated fields): " +
+         key);
+   }
+ 
+   const std::string& model_name = parts[0];
+   const std::string& kv_rank_hex = parts[1];
+-  const std::string& chunk_hash = parts[2];
+-  const std::string cache_salt = parts.size() == 4 ? parts[3] : std::string();
+ 
+   // Replace '/' with '-SEP-' for filesystem safety
+   std::string safe_model = replace_all(model_name, "/", PATH_SLASH_REPLACEMENT);
+ 
+-  // Emit filename. Salt is appended at the tail so the unsalted shape
+-  // matches what older builds wrote to disk.
++  // Emit the model and normalized rank, preserving all remaining fields.
+   std::string result;
+-  result.reserve(safe_model.size() + kv_rank_hex.size() + chunk_hash.size() +
+-                 cache_salt.size() + 32);
++  result.reserve(key.size() + 16);
+   result += safe_model;
+   result += KEY_SEP;
+   result += "0x";
+   result += kv_rank_hex;
+-  result += KEY_SEP;
+-  result += chunk_hash;
+-  if (!cache_salt.empty()) {
++  for (size_t i = 2; i < parts.size(); ++i) {
+     result += KEY_SEP;
+-    result += cache_salt;
++    result += parts[i];
+   }
+   result += FILE_EXT;
+   return result;
+@@ -174,8 +181,11 @@ void FSConnector::do_single_get(WorkerFSConn& conn, const std::string& key,
+   int flags = O_RDONLY;
+   bool do_odirect = conn.use_odirect;
+   if (do_odirect) {
+-    bool aligned = conn.disk_block_size > 0 && len % conn.disk_block_size == 0;
+-    if (aligned) {
++    const bool split_aligned = conn.disk_block_size > 0 &&
++                               (conn.read_ahead_size == 0 ||
++                                len <= conn.read_ahead_size ||
++                                conn.read_ahead_size % conn.disk_block_size == 0);
++    if (odirect_eligible(buf, len, conn.disk_block_size) && split_aligned) {
+ #ifdef O_DIRECT
+       flags |= O_DIRECT;
+ #endif
+@@ -243,8 +253,7 @@ void FSConnector::do_single_set(WorkerFSConn& conn, const std::string& key,
+   int flags = O_CREAT | O_WRONLY | O_TRUNC;
+   bool do_odirect = conn.use_odirect;
+   if (do_odirect) {
+-    bool aligned = conn.disk_block_size > 0 && len % conn.disk_block_size == 0;
+-    if (aligned) {
++    if (odirect_eligible(buf, len, conn.disk_block_size)) {
+ #ifdef O_DIRECT
+       flags |= O_DIRECT;
+ #endif
+diff --git a/csrc/storage_backends/fs/connector.h b/csrc/storage_backends/fs/connector.h
+index 03b7b9cc5e0a2cac7ab9e39404d80c760b4e9018..7b9010947c18de36684317ed7c2628c3d2be0161 100644
+--- a/csrc/storage_backends/fs/connector.h
++++ b/csrc/storage_backends/fs/connector.h
+@@ -21,7 +21,9 @@ static constexpr const char* FILE_EXT = ".data";
+ static constexpr const char* TMP_EXT = ".tmp";
+ 
+ // Per-worker connection state for the FS connector.
+-// Each worker maintains its own I/O buffer for O_DIRECT.
++// O_DIRECT engages per request only when both the transfer length and the
++// caller's buffer address are multiples of the disk block size; anything
++// else falls back to buffered I/O.
+ struct WorkerFSConn {
+   std::filesystem::path base_path;
+   std::filesystem::path tmp_dir;  // empty if not configured
+@@ -52,17 +54,20 @@ class FSConnector : public ConnectorBase<WorkerFSConn> {
+   // Build the filesystem-safe filename from a serialized key string.
+   //
+   // Input key (from NativeConnectorL2Adapter._object_key_to_string):
+-  //   Unsalted: "{model}@{kv_rank:08x}@{hash.hex()}"
+-  //   Salted  : "{model}@{kv_rank:08x}@{hash.hex()}@{cache_salt}"
++  //   Current unsalted:
++  //     "{model}@{kv_rank:08x}@{object_group:x}@{hash.hex()}"
++  //   Current salted appends "@{cache_salt}". Legacy three/four-field keys
++  //   without object_group_id remain supported.
+   //
+   // Output filename (matching fs_l2_adapter.py._object_key_to_filename):
+-  //   Unsalted: "{safe_model}@{kv_rank:#010x}@{hash.hex()}.data"
+-  //   Salted  : "{safe_model}@{kv_rank:#010x}@{hash.hex()}@{cache_salt}.data"
++  //   Current unsalted:
++  //     "{safe_model}@{kv_rank:#010x}@{object_group:x}@{hash.hex()}.data"
++  //   Current salted appends "@{cache_salt}" before ".data".
+   //
+   // Differences from the input: '/' in model becomes '-SEP-', kv_rank
+-  // gains a '0x' prefix, and '.data' is appended. Both model_name and
+-  // cache_salt are forbidden from containing '@' (enforced on the
+-  // Python side), so the parse is unambiguous.
++  // gains a '0x' prefix, and '.data' is appended. All fields after kv_rank
++  // are preserved because four fields can represent either a legacy salted
++  // key or a current unsalted key.
+   static std::string key_to_filename(const std::string& key);
+ 
+   static std::string replace_all(const std::string& str,
+diff --git a/csrc/storage_backends/mooncake/connector.cpp b/csrc/storage_backends/mooncake/connector.cpp
+index 685fa4165b188b517a5c0de50753e5ae2e596d6f..0d5109e0dbb5595476806071d62c6dedd6f2bf98 100644
+--- a/csrc/storage_backends/mooncake/connector.cpp
++++ b/csrc/storage_backends/mooncake/connector.cpp
+@@ -173,12 +173,23 @@ void MooncakeConnector::do_batch_set(WorkerMooncakeConn& conn,
+       conn.client->batch_put_from(req.keys, req.buf_ptrs, req.buf_lens);
+   ensure_batch_result_size(results, req.keys.size(), "batch_put_from");
+ 
++  // Record per-key results before failing the tile so partial store
++  // failures stay visible to consumers that honor them.
++  size_t first_failed = results.size();
+   for (size_t i = 0; i < results.size(); ++i) {
+-    if (results[i] != 0) {
+-      throw std::runtime_error("Mooncake batch_put_from failed for key: " +
+-                               req.keys[i]);
++    if (results[i] == 0) {
++      req.batch->per_key_results[req.start_idx + i] = 1;
++    } else {
++      req.batch->per_key_results[req.start_idx + i] = 0;
++      if (first_failed == results.size()) {
++        first_failed = i;
++      }
+     }
+   }
++  if (first_failed != results.size()) {
++    throw std::runtime_error("Mooncake batch_put_from failed for key: " +
++                             req.keys[first_failed]);
++  }
+ }
+ 
+ void MooncakeConnector::do_batch_exists(WorkerMooncakeConn& conn,
+diff --git a/lmcache/integration/vllm/lmcache_mp_connector.py b/lmcache/integration/vllm/lmcache_mp_connector.py
+index d268070c3c0daa534a616c88312f8da7b5c665de..21af3747ede9f78c608841a692acc9c25e0bbc29 100644
+--- a/lmcache/integration/vllm/lmcache_mp_connector.py
++++ b/lmcache/integration/vllm/lmcache_mp_connector.py
+@@ -464,6 +464,42 @@ class LMCacheMPRequestMetadata:
+             "number of LMCache hit tokens. "
+         )
+         if end_token_idx > start_token_idx:
++            # allocated_block_ids must cover [start_token_idx, end_token_idx)
++            # in every engine group. slice_block_ids_per_group() validates
++            # chunk alignment only; its plain Python slice truncates
++            # silently, so a tracker primed with LMCache hit counts on a
++            # scheduling pass whose allocation never materialised would emit
++            # a retrieve op with too few block ids. The MP server fails
++            # closed on the short list, wasting a doomed round-trip and
++            # relying on the failure being surfaced at all. Suppress the op
++            # instead so the request recomputes cleanly. Never clamp
++            # end_token_idx: a clamped retrieve completes a load vLLM does
++            # not expect and re-creates the desync downstream.
++            # One allocated id of group g covers group_tokens_per_block[g]
++            # global token positions (KV-spec block_size, DCP-scaled), the
++            # same arithmetic GetStoreMetadata uses to bound its
++            # allocated_tokens.
++            for group_idx, tokens_per_block in enumerate(group_tokens_per_block):
++                allocated = len(tracker.allocated_block_ids.get(group_idx, []))
++                if allocated * tokens_per_block < end_token_idx:
++                    logger.warning(
++                        "LMCache retrieve suppressed for request_id=%s: "
++                        "engine group %d has %d allocated block(s) x %d "
++                        "tokens/block = %d tokens < end_token_idx=%d "
++                        "(start_token_idx=%d, vllm_hit_tokens=%d, "
++                        "lmcache_hit_tokens=%d) -- tracker/allocation "
++                        "desync; falling back to recompute.",
++                        tracker.request_id,
++                        group_idx,
++                        allocated,
++                        tokens_per_block,
++                        allocated * tokens_per_block,
++                        end_token_idx,
++                        start_token_idx,
++                        tracker.num_vllm_hit_tokens,
++                        tracker.num_lmcache_hit_tokens,
++                    )
++                    return None
+             block_ids = slice_block_ids_per_group(
+                 tracker.allocated_block_ids,
+                 group_tokens_per_block,
+diff --git a/lmcache/integration/vllm/vllm_multi_process_adapter.py b/lmcache/integration/vllm/vllm_multi_process_adapter.py
+index d74fe3af02cbefc7755c8446434a36034c681ef3..dd5aa0e6033292eaad06dd8f0b7961d58cf6b2f1 100644
+--- a/lmcache/integration/vllm/vllm_multi_process_adapter.py
++++ b/lmcache/integration/vllm/vllm_multi_process_adapter.py
+@@ -1173,8 +1173,11 @@ class LMCacheMPWorkerAdapter:
+         self.store_events: dict[str, list[_IpcEvent]] = {}
+         self.retrieve_events: dict[str, _IpcEvent] = {}
+ 
+-        # Block IDs that failed due to retrieve timeout
++        # Block IDs of failed retrieves (timeout, server-reported failure,
++        # or raising future), consumed by get_block_ids_with_load_errors().
+         self.error_block_ids: set[int] = set()
++        # Total failed retrieves on this worker, for log-based diagnostics.
++        self.retrieve_failure_count: int = 0
+ 
+         # Retrieve request ids dropped by the unhealthy early-return of
+         # submit_retrieve_request. get_finished must still report each id
+@@ -1657,6 +1660,9 @@ class LMCacheMPWorkerAdapter:
+             - The second set contains the finished retrieve request ids,
+                 including retrieves dropped at submit time while unhealthy
+                 (reported exactly once; blocks already in error_block_ids).
++                A failed retrieve (server result False or a raising future)
++                is reported finished with its block ids recorded in
++                error_block_ids so the scheduler recomputes them.
+ 
+         Notes:
+             When enabling async scheduling in vLLM, the same request ID may appear
+@@ -1701,19 +1707,45 @@ class LMCacheMPWorkerAdapter:
+ 
+         finished_stores = self._poll_store_futures()
+         finished_retrieves = set()
+-        for request_id, (r_future, _) in self.retrieve_futures.items():
++        for request_id, (r_future, r_block_ids) in self.retrieve_futures.items():
+             if not r_future.query():
+                 continue
+ 
+-            r_result = r_future.result()
++            try:
++                r_result = r_future.result()
++            except Exception as exc:
++                # A raising future must not propagate out of get_finished
++                # (that would kill the engine step); contain it as a failed
++                # retrieve on the standard failure path.
++                logger.error(
++                    "LMCache retrieve future raised for request_id=%s: %r "
++                    "-- treating as failed retrieve.",
++                    request_id,
++                    exc,
++                )
++                r_result = False
+             finished_retrieves.add(request_id)
+ 
+             if not r_result:
++                # Surface the failure to the scheduler. Reporting the
++                # request finished without recording the failed span would
++                # ACK the load as successful: the request then decodes over
++                # never-written GPU blocks and the phantom blocks enter the
++                # shared prefix cache. error_block_ids feeds
++                # get_block_ids_with_load_errors() ->
++                # kv_connector_output.invalid_block_ids -> scheduler
++                # recompute. The MP server collapses per-key results into
++                # one bool, so marking the op's whole span is
++                # conservative-correct for partial failures too.
++                self.error_block_ids.update(r_block_ids)
++                self.retrieve_failure_count += 1
+                 logger.error(
+-                    "Something went wrong when processing the "
+-                    "retrieve request for request_id=%s, result=%s",
++                    "LMCache retrieve failed for request_id=%s: %d block(s) "
++                    "marked invalid for scheduler recompute "
++                    "(total retrieve failures this worker: %d)",
+                     request_id,
+-                    r_result,
++                    len(r_block_ids),
++                    self.retrieve_failure_count,
+                 )
+ 
+         # Store futures and events are removed together by _poll_store_futures.
+@@ -1758,8 +1790,8 @@ class LMCacheMPWorkerAdapter:
+ 
+     def get_block_ids_with_load_errors(self) -> set[int]:
+         """
+-        Returns the block IDs that failed due to retrieve timeout,
+-        then clears the internal set.
++        Returns the block IDs of failed retrieves (timeout, server-reported
++        failure, or raising future), then clears the internal set.
+         """
+         errors = self.error_block_ids.copy()
+         self.error_block_ids.clear()
+diff --git a/lmcache/v1/distributed/config.py b/lmcache/v1/distributed/config.py
+index de36535a57df7ceb8ca8bbb97276c4733e568270..ac11158668fdbfd00f36512cc08a90b7f42860b4 100644
+--- a/lmcache/v1/distributed/config.py
++++ b/lmcache/v1/distributed/config.py
+@@ -226,6 +226,21 @@ class EvictionConfig:
+     extra_logging_interval: float = field(default=10.0)
+     """ Seconds between L1 memory usage log lines when extra logging is enabled. """
+ 
++    write_back_on_evict: bool = field(default=False)
++    """ Flush evicted L1 objects to L2 synchronously and delete them from L1
++    only once every key in the batch is durable; without this, eviction
++    discards the objects. Requires an L2 adapter with store_objects_sync(). """
++
++    periodic_flush_interval: float = field(default=0.0)
++    """ Seconds between periodic L1-to-L2 backup flush scans while below the
++    eviction watermark (0 disables). Backup keeps the L1 copy; only L2 gains
++    a copy, so a restart or session expiry no longer costs a cold prefill. """
++
++    emergency_evict_for_prefetch: bool = field(default=False)
++    """ Allow the prefetch controller to synchronously evict LRU L1 keys to
++    make room for large L2-to-L1 restores. Effective only together with
++    write_back_on_evict, so victims are persisted before deletion. """
++
+ 
+ @dataclass
+ class StorageManagerConfig:
+@@ -296,6 +311,12 @@ def validate_storage_manager_config(config: StorageManagerConfig) -> None:
+         ValueError: If mutually exclusive L1 tiers are both configured, or
+             hybrid L1 is paired with incompatible L2 adapters.
+     """
++    eviction = config.eviction_config
++    if eviction.periodic_flush_interval < 0:
++        raise ValueError("periodic_flush_interval must be >= 0")
++    if eviction.emergency_evict_for_prefetch and not eviction.write_back_on_evict:
++        raise ValueError("emergency_evict_for_prefetch requires write_back_on_evict")
++
+     if (
+         config.l1_manager_config.gds_l1_config is not None
+         and config.l1_manager_config.memory_config.devdax_path
+@@ -471,6 +492,28 @@ def add_storage_manager_args(
+         help="The fraction of memory to evict when triggered (0.0 to 1.0). "
+         "Default is 0.2.",
+     )
++    eviction_group.add_argument(
++        "--write-back-on-evict",
++        action="store_true",
++        help="Flush evicted L1 objects to L2 synchronously and delete them "
++        "from L1 only once every key in the batch is durable. Requires an "
++        "L2 adapter with a synchronous store path.",
++    )
++    eviction_group.add_argument(
++        "--periodic-flush-interval",
++        type=float,
++        default=0.0,
++        help="Seconds between periodic L1-to-L2 backup flush scans while "
++        "below the eviction watermark (0 disables). The backup keeps the "
++        "L1 copy; only L2 gains a copy.",
++    )
++    eviction_group.add_argument(
++        "--emergency-evict-for-prefetch",
++        action="store_true",
++        help="Allow the prefetch controller to synchronously evict LRU L1 "
++        "keys to make room for large L2-to-L1 restores. Effective only "
++        "together with --write-back-on-evict.",
++    )
+ 
+     # L2 Policies
+     # Import here to break circular dependency:
+@@ -596,6 +639,11 @@ def parse_args_to_config(
+         eviction_ratio=args.eviction_ratio,
+         extra_logging_enabled=getattr(args, "enable_extra_logging", False),
+         extra_logging_interval=getattr(args, "extra_logging_interval", 10.0),
++        write_back_on_evict=getattr(args, "write_back_on_evict", False),
++        periodic_flush_interval=getattr(args, "periodic_flush_interval", 0.0),
++        emergency_evict_for_prefetch=getattr(
++            args, "emergency_evict_for_prefetch", False
++        ),
+     )
+ 
+     l2_adapter_config = parse_args_to_l2_adapters_config(args)
+diff --git a/lmcache/v1/distributed/l1_manager.py b/lmcache/v1/distributed/l1_manager.py
+index 44cf55f615f2bf491bdf72784ac152a7ee422457..4a2be000b86a576759cb3d5579acbc45181b14e7 100644
+--- a/lmcache/v1/distributed/l1_manager.py
++++ b/lmcache/v1/distributed/l1_manager.py
+@@ -5,6 +5,7 @@ Managing objects and memory for L1 cache
+ 
+ # Standard
+ from dataclasses import dataclass
++from itertools import chain, islice
+ from typing import Literal
+ import threading
+ 
+@@ -462,6 +463,11 @@ class L1Manager:
+         Errors:
+             KEY_NOT_WRITABLE: The key exists but is not writable.
+             OUT_OF_MEMORY: Not enough memory to allocate for the object.
++
++        Note:
++            When the full batch does not fit, the longest prefix of the
++            to-be-allocated keys that fits is allocated and the remaining
++            keys report OUT_OF_MEMORY.
+         """
+         need_to_allocate: list[tuple[ObjectKey, bool]] = []
+         ret: dict[ObjectKey, L1OperationResult] = {}
+@@ -499,6 +505,26 @@ class L1Manager:
+             layout_desc, len(need_to_allocate)
+         )
+ 
++        # A full-batch allocation failure would fail every key even when
++        # most of the batch fits, collapsing large L2->L1 restores to zero
++        # prefix hits and forcing full re-prefills upstream. Fall back to
++        # allocating the longest prefix that fits; callers already handle
++        # per-key OOM (prefetch trims to the contiguous prefix, the store
++        # path skips failed keys).
++        if err != L1Error.SUCCESS and len(need_to_allocate) > 1:
++            if allocated_objs:
++                self._memory_manager.free(allocated_objs)
++                allocated_objs = []
++            err, allocated_objs = self._allocate_largest_prefix(
++                layout_desc, len(need_to_allocate)
++            )
++            if err == L1Error.SUCCESS:
++                logger.warning(
++                    "Partial L1 allocation: %d/%d objects (prefix) allocated",
++                    len(allocated_objs),
++                    len(need_to_allocate),
++                )
++
+         if err != L1Error.SUCCESS:
+             for key, _ in need_to_allocate:
+                 ret[key] = (L1Error.OUT_OF_MEMORY, None)
+@@ -508,6 +534,10 @@ class L1Manager:
+                 self._memory_manager.free(allocated_objs)
+ 
+         else:
++            # Mark any unallocated tail as OOM so every requested key keeps
++            # an explicit per-key result.
++            for key, _ in need_to_allocate[len(allocated_objs) :]:
++                ret[key] = (L1Error.OUT_OF_MEMORY, None)
+             for (key, is_temp), mem_obj in zip(
+                 need_to_allocate, allocated_objs, strict=False
+             ):
+@@ -531,6 +561,41 @@ class L1Manager:
+         )
+         return ret
+ 
++    def _allocate_largest_prefix(
++        self, layout_desc: MemoryLayoutDesc, want: int
++    ) -> tuple[L1Error, list[MemoryObj]]:
++        """Allocate the largest prefix below an already-failed full batch.
++
++        L1 allocators have an all-or-nothing batch contract. While holding the
++        L1 manager lock, allocation feasibility is therefore monotonic: if a
++        batch of size ``n`` fits, every smaller batch also fits. Binary search
++        finds the maximum without relying on byte estimates that can be wrong
++        for alignment or fragmented free lists. Successful probes are freed
++        before the final allocation.
++
++        This recovery path runs only after the ``want`` allocation failed, so
++        normal reservations still perform exactly one allocation.
++        """
++        low = 1
++        high = want - 1
++        largest = 0
++
++        while low <= high:
++            candidate = (low + high) // 2
++            err, objects = self._memory_manager.allocate(layout_desc, candidate)
++            if err == L1Error.SUCCESS:
++                largest = candidate
++                self._memory_manager.free(objects)
++                low = candidate + 1
++            else:
++                if objects:
++                    self._memory_manager.free(objects)
++                high = candidate - 1
++
++        if largest == 0:
++            return L1Error.OUT_OF_MEMORY, []
++        return self._memory_manager.allocate(layout_desc, largest)
++
+     @l1_mgr_synchronized
+     def finish_write(
+         self,
+@@ -793,6 +858,59 @@ class L1Manager:
+             locked_count,
+         )
+ 
++    @l1_mgr_synchronized
++    def get_evictable_keys(
++        self,
++        limit: int,
++        cursor: int = 0,
++        scan_limit: int | None = None,
++    ) -> tuple[list[ObjectKey], int]:
++        """Return a bounded, rotating batch of evictable keys.
++
++        ``cursor`` is an insertion-order offset returned by the previous call.
++        The scan wraps once and inspects at most ``scan_limit`` entries, so a
++        periodic backup cannot materialize the complete L1 keyspace while the
++        manager lock is held. Concurrent insertions or removals may shift the
++        offset, but every returned key is revalidated by ``reserve_read``.
++
++        Args:
++            limit: Maximum number of keys to return.
++            cursor: Insertion-order offset at which to resume scanning.
++            scan_limit: Maximum entries to inspect. Defaults to four batches.
++
++        Returns:
++            A pair of the eligible keys and the cursor for the next call.
++        """
++        if limit <= 0 or not self._objects:
++            return [], 0
++
++        object_count = len(self._objects)
++        start = cursor % object_count
++        max_scan = min(
++            object_count,
++            max(limit, scan_limit if scan_limit is not None else limit * 4),
++        )
++        ordered_keys = chain(
++            islice(self._objects, start, None),
++            islice(self._objects, 0, start),
++        )
++        keys: list[ObjectKey] = []
++        scanned = 0
++        for key in ordered_keys:
++            scanned += 1
++            if self.is_key_evictable(key):
++                keys.append(key)
++                if len(keys) >= limit:
++                    break
++            if scanned >= max_scan:
++                break
++        return keys, (start + scanned) % object_count
++
++    @l1_mgr_synchronized
++    def num_objects(self) -> int:
++        """Return the number of objects currently tracked in L1."""
++        return len(self._objects)
++
+     def is_key_evictable(self, key: ObjectKey) -> bool:
+         """Check if a key is eligible for eviction (not locked).
+ 
+diff --git a/lmcache/v1/distributed/l2_adapters/base.py b/lmcache/v1/distributed/l2_adapters/base.py
+index 1838553e285ce0f2c7a0b3d9a3180b6ad57ed499..910cec00199586224936da8b0323a02659cc74c1 100644
+--- a/lmcache/v1/distributed/l2_adapters/base.py
++++ b/lmcache/v1/distributed/l2_adapters/base.py
+@@ -354,13 +354,8 @@ class L2AdapterInterface(ABC):
+         """Register a listener to receive L2 adapter events."""
+         self._listeners.append(listener)
+ 
+-    def _notify_keys_stored(self, keys: list[ObjectKey], sizes: list[int]) -> None:
+-        """Update byte accounting and notify listeners that ``keys`` were
+-        stored. ``sizes[i]`` is the byte size of ``keys[i]``.
+-
+-        Accounting is held under ``_usage_lock``; listener callbacks fire
+-        outside the lock so a slow listener cannot stall further notifies.
+-        """
++    def _account_keys_stored(self, keys: list[ObjectKey], sizes: list[int]) -> None:
++        """Apply stored-key byte accounting without invoking listeners."""
+         # Aggregate per-salt deltas before touching
+         # ``_bytes_by_cache_salt`` — one dict read/write per unique
+         # salt instead of one per key. This matters when the registry is
+@@ -377,9 +372,26 @@ class L2AdapterInterface(ABC):
+                 self._bytes_by_cache_salt[salt] = (
+                     self._bytes_by_cache_salt.get(salt, 0) + d
+                 )
++
++    def _notify_keys_stored_listeners(
++        self,
++        keys: list[ObjectKey],
++        sizes: list[int],
++    ) -> None:
++        """Notify stored-key observers after accounting is committed."""
+         for listener in self._listeners:
+             listener.on_l2_keys_stored(keys, sizes)
+ 
++    def _notify_keys_stored(self, keys: list[ObjectKey], sizes: list[int]) -> None:
++        """Update byte accounting and notify listeners that ``keys`` were
++        stored. ``sizes[i]`` is the byte size of ``keys[i]``.
++
++        Accounting is held under ``_usage_lock``; listener callbacks fire
++        outside the lock so a slow listener cannot stall further notifies.
++        """
++        self._account_keys_stored(keys, sizes)
++        self._notify_keys_stored_listeners(keys, sizes)
++
+     def _notify_keys_accessed(self, keys: list[ObjectKey]) -> None:
+         # ``_notify_keys_accessed`` carries no byte impact — only LRU
+         # bookkeeping cares about it, so no accounting is needed here.
+diff --git a/lmcache/v1/distributed/l2_adapters/fs_native_l2_adapter.py b/lmcache/v1/distributed/l2_adapters/fs_native_l2_adapter.py
+index 2d703499d20c5aa1c0ecc8e1f0667f2bf857c6a2..dacdead73b3eb1a34bec530fe14c535759607b2a 100644
+--- a/lmcache/v1/distributed/l2_adapters/fs_native_l2_adapter.py
++++ b/lmcache/v1/distributed/l2_adapters/fs_native_l2_adapter.py
+@@ -10,9 +10,11 @@ Backed by the native C++ filesystem connector wrapped with
+ from __future__ import annotations
+ 
+ # Standard
++from pathlib import Path
+ from typing import TYPE_CHECKING, Optional
+ 
+ if TYPE_CHECKING:
++    from lmcache.v1.distributed.api import ObjectKey
+     from lmcache.v1.distributed.internal_api import (
+         L1MemoryDesc,
+     )
+@@ -158,7 +160,7 @@ def _create_fs_native_l2_adapter(
+         config.use_odirect,
+         config.read_ahead_size,
+     )
+-    return NativeConnectorL2Adapter(
++    adapter = NativeConnectorL2Adapter(
+         native_client,
+         max_capacity_gb=config.max_capacity_gb,
+         type_name="FSNativeL2Adapter",
+@@ -169,6 +171,53 @@ def _create_fs_native_l2_adapter(
+             "read_ahead_size": config.read_ahead_size,
+         },
+     )
++    try:
++        keys, sizes = _scan_existing_fs_native_files(config.base_path)
++        adapter.prime_existing_keys(keys, sizes)
++    except Exception:
++        adapter.close()
++        raise
++    return adapter
++
++
++def _scan_existing_fs_native_files(
++    base_path: str,
++) -> tuple[list["ObjectKey"], list[int]]:
++    """Recover durable keys and sizes, ordered from oldest to newest."""
++    # First Party
++    from lmcache.v1.distributed.l2_adapters.fs_l2_adapter import (
++        _filename_to_object_key,
++    )
++
++    root = Path(base_path)
++    if not root.is_dir():
++        return [], []
++
++    entries: list[tuple[int, str, ObjectKey, int]] = []
++    for path in root.glob("*.data"):
++        try:
++            if not path.is_file():
++                continue
++            key = _filename_to_object_key(path.name)
++            if key is None:
++                logger.warning("Ignoring unrecognized cache file: %s", path)
++                continue
++            stat = path.stat()
++            if stat.st_size <= 0:
++                logger.warning("Ignoring empty cache file: %s", path)
++                continue
++            entries.append((stat.st_mtime_ns, path.name, key, stat.st_size))
++        except OSError as exc:
++            # Silently omitting a durable object would under-report usage and
++            # seed an incomplete eviction index. Fail adapter construction so
++            # the operator can repair the directory or retry the startup scan.
++            raise RuntimeError(f"Could not inspect cache file {path}: {exc}") from exc
++
++    entries.sort(key=lambda entry: (entry[0], entry[1]))
++    return (
++        [entry[2] for entry in entries],
++        [entry[3] for entry in entries],
++    )
+ 
+ 
+ register_l2_adapter_type("fs_native", FSNativeL2AdapterConfig)
+diff --git a/lmcache/v1/distributed/l2_adapters/native_connector_l2_adapter.py b/lmcache/v1/distributed/l2_adapters/native_connector_l2_adapter.py
+index c10d3802dfbdba50b6a49e4d764ebf10a567a0df..e3a73e35d5f5316f9d9dd0dcbc5d57b949661be6 100644
+--- a/lmcache/v1/distributed/l2_adapters/native_connector_l2_adapter.py
++++ b/lmcache/v1/distributed/l2_adapters/native_connector_l2_adapter.py
+@@ -30,7 +30,7 @@ import threading
+ from lmcache.logging import init_logger
+ from lmcache.native_storage_ops import Bitmap
+ from lmcache.v1.distributed.api import MemoryLayoutDesc, ObjectKey
+-from lmcache.v1.distributed.internal_api import L2StoreResult
++from lmcache.v1.distributed.internal_api import L2AdapterListener, L2StoreResult
+ from lmcache.v1.distributed.l2_adapters.base import (
+     L2AdapterInterface,
+     L2TaskId,
+@@ -98,6 +98,7 @@ class NativeConnectorL2Adapter(L2AdapterInterface):
+ 
+     # Operation type tags for the pending-ops map
+     _OP_STORE = "store"
++    _OP_SYNC_STORE = "sync_store"
+     _OP_LOOKUP = "lookup"
+     _OP_LOAD = "load"
+     _OP_DELETE = "delete"
+@@ -144,6 +145,12 @@ class NativeConnectorL2Adapter(L2AdapterInterface):
+         # Pending delete events for synchronous delete() calls
+         self._pending_delete_events: dict[L2TaskId, threading.Event] = {}
+ 
++        # Synchronous stores use private completions so StoreController cannot
++        # consume another thread's result from _completed_stores.
++        self._pending_sync_store_events: dict[
++            L2TaskId, tuple[threading.Event, dict[str, Any]]
++        ] = {}
++
+         # Per-key size tracking. ``_key_sizes`` lets us look up byte sizes
+         # at delete time (the native completion only carries booleans, not
+         # sizes) so we can pass them to ``_notify_keys_deleted``. Aggregate
+@@ -154,6 +161,12 @@ class NativeConnectorL2Adapter(L2AdapterInterface):
+         # demux thread can fire ``_notify_keys_stored(keys, sizes)``.
+         self._pending_store_sizes: dict[int, tuple[list[ObjectKey], list[int]]] = {}
+ 
++        # A filesystem factory may prime durable objects before the eviction
++        # listener exists. Keep one temporary startup snapshot for that first
++        # listener; _key_sizes remains the sole long-lived key index.
++        self._startup_primed = False
++        self._startup_replay: tuple[list[ObjectKey], list[int]] | None = None
++
+         # Task ID counter
+         self._next_task_id: L2TaskId = 0
+ 
+@@ -219,6 +232,71 @@ class NativeConnectorL2Adapter(L2AdapterInterface):
+             self._completed_stores = {}
+         return completed
+ 
++    def store_objects_sync(
++        self,
++        keys: list[ObjectKey],
++        objects: list[MemoryObj],
++        timeout: float | None = None,
++    ) -> tuple[bool, int, int]:
++        """Persist objects and wait for their native backend completion.
++
++        Returns ``(success, persisted_count, bytes_written)``. ``success`` is
++        true only when every key persisted, while the other fields account
++        for successful keys in a partially failed batch.
++        """
++        if len(keys) != len(objects):
++            raise ValueError("keys and objects length mismatch")
++        if not keys:
++            return True, 0, 0
++        if timeout is not None and timeout <= 0:
++            raise ValueError("timeout must be positive")
++
++        key_strings = [_object_key_to_string(key) for key in keys]
++        memviews = [_obj_to_memoryview(obj) for obj in objects]
++        per_key_sizes = [obj.get_size() for obj in objects]
++        done_event = threading.Event()
++        result: dict[str, Any] = {
++            "ok": False,
++            "persisted_count": 0,
++            "bytes_written": 0,
++        }
++
++        with self._lock:
++            task_id = self._get_next_task_id()
++            future_id = int(self._client.submit_batch_set(key_strings, memviews))
++            self._pending_ops[future_id] = (
++                self._OP_SYNC_STORE,
++                task_id,
++                len(keys),
++                None,
++            )
++            self._pending_store_sizes[future_id] = (list(keys), per_key_sizes)
++            self._pending_sync_store_events[task_id] = (done_event, result)
++
++        wait_timeout = (
++            timeout if timeout is not None else max(30.0, min(300.0, len(keys) * 5.0))
++        )
++        if not done_event.wait(timeout=wait_timeout):
++            with self._lock:
++                self._pending_sync_store_events.pop(task_id, None)
++                for fid, entry in list(self._pending_ops.items()):
++                    if entry[1] == task_id:
++                        self._pending_ops.pop(fid, None)
++                        self._pending_store_sizes.pop(fid, None)
++                        break
++            logger.warning(
++                "store_objects_sync() timed out after %.1fs for %d keys",
++                wait_timeout,
++                len(keys),
++            )
++            return False, 0, 0
++
++        return (
++            bool(result["ok"]),
++            int(result["persisted_count"]),
++            int(result["bytes_written"]),
++        )
++
+     # ---------------------------------------------------------------
+     # Lookup and Lock Interface
+     # ---------------------------------------------------------------
+@@ -297,22 +375,46 @@ class NativeConnectorL2Adapter(L2AdapterInterface):
+         tracking stays in sync.
+ 
+         No-op if the connector does not expose ``submit_batch_delete``
+-        or if the key list is empty.
++        or if the key list is empty. Keys currently lookup-locked by an
++        in-flight prefetch are skipped: the load task would race the
++        unlink and fail with a phantom not_found.
+         """
+         if not keys or not self._has_delete:
+             return
+ 
+-        key_strings = [_object_key_to_string(k) for k in keys]
+         done_event = threading.Event()
+ 
+         with self._lock:
++            # A key becomes lookup-locked only when the native EXISTS
++            # completion is demultiplexed. Protect pending lookup keys as
++            # well, otherwise eviction can delete a key between lookup
++            # submission and lock acquisition. Filtering and delete submit
++            # stay in one critical section so a new lookup cannot enter that
++            # same gap.
++            protected_keys = set(self._locked_keys)
++            for op_type, _task_id, _num_keys, op_keys in self._pending_ops.values():
++                if op_type == self._OP_LOOKUP and op_keys is not None:
++                    protected_keys.update(op_keys)
++
++            delete_keys = [key for key in keys if key not in protected_keys]
++            skipped_count = len(keys) - len(delete_keys)
++            if skipped_count:
++                logger.info(
++                    "delete(): skipping %d lookup-pending or locked keys; %d remain",
++                    skipped_count,
++                    len(delete_keys),
++                )
++            if not delete_keys:
++                return
++
++            key_strings = [_object_key_to_string(k) for k in delete_keys]
+             task_id = self._get_next_task_id()
+             future_id = int(self._client.submit_batch_delete(key_strings))
+             self._pending_ops[future_id] = (
+                 self._OP_DELETE,
+                 task_id,
+-                len(keys),
+-                list(keys),
++                len(delete_keys),
++                delete_keys,
+             )
+             self._pending_delete_events[task_id] = done_event
+ 
+@@ -328,7 +430,7 @@ class NativeConnectorL2Adapter(L2AdapterInterface):
+                         break
+             logger.warning(
+                 "delete() timed out after 30s for %d keys",
+-                len(keys),
++                len(delete_keys),
+             )
+             return
+ 
+@@ -345,6 +447,52 @@ class NativeConnectorL2Adapter(L2AdapterInterface):
+     # Status Interface
+     # ---------------------------------------------------------------
+ 
++    def prime_existing_keys(
++        self,
++        keys: list[ObjectKey],
++        sizes: list[int],
++    ) -> None:
++        """Account durable objects discovered before adapter registration."""
++        if len(keys) != len(sizes):
++            raise ValueError("keys and sizes length mismatch")
++
++        unique: dict[ObjectKey, int] = {}
++        for key, size in zip(keys, sizes, strict=True):
++            if size <= 0:
++                raise ValueError("existing object sizes must be positive")
++            unique.setdefault(key, int(size))
++
++        primed_keys = list(unique)
++        primed_sizes = list(unique.values())
++        with self._lock:
++            if self._startup_primed:
++                raise RuntimeError("existing keys were already primed")
++            if self._listeners:
++                raise RuntimeError("existing keys must be primed before listeners")
++            self._startup_primed = True
++            self._key_sizes.update(unique)
++            self._startup_replay = (primed_keys, primed_sizes)
++
++        # No listener is registered during factory construction. This uses
++        # the common accounting implementation without retaining a second
++        # byte-accounting path in this adapter.
++        if primed_keys:
++            self._notify_keys_stored(primed_keys, primed_sizes)
++            logger.info(
++                "Startup scan primed %.2f GB in %d existing objects",
++                sum(primed_sizes) / 1e9,
++                len(primed_keys),
++            )
++
++    def register_listener(self, listener: L2AdapterListener) -> None:
++        """Register a listener and replay the one-time startup snapshot."""
++        with self._lock:
++            replay = self._startup_replay
++            self._startup_replay = None
++        if replay is not None and replay[0]:
++            listener.on_l2_keys_stored(*replay)
++        super().register_listener(listener)
++
+     def report_status(self) -> dict[str, Any]:
+         """Return a status dict for this native-connector L2 adapter.
+ 
+@@ -372,6 +520,14 @@ class NativeConnectorL2Adapter(L2AdapterInterface):
+         self._stop.set()
+         self._demux_thread.join(timeout=5)
+ 
++        with self._lock:
++            sync_events = [
++                event for event, _result in self._pending_sync_store_events.values()
++            ]
++            self._pending_sync_store_events.clear()
++        for event in sync_events:
++            event.set()
++
+         self._client.close()
+ 
+         self._store_efd.close()
+@@ -425,6 +581,7 @@ class NativeConnectorL2Adapter(L2AdapterInterface):
+             # the caller unblocks and calls ``get_usage()``, the base
+             # class's byte counters already reflect the deletion.
+             delete_done_events: list[threading.Event] = []
++            sync_store_done_events: list[threading.Event] = []
+ 
+             with self._lock:
+                 for (
+@@ -449,12 +606,30 @@ class NativeConnectorL2Adapter(L2AdapterInterface):
+                         lookup_keys,
+                     ) = entry
+ 
+-                    if op_type == self._OP_STORE:
++                    if op_type in (self._OP_STORE, self._OP_SYNC_STORE):
+                         store_info = self._pending_store_sizes.pop(fid, None)
+                         task_bytes = 0
+-                        if ok and store_info is not None:
++                        persisted_count = 0
++                        completion_ok = False
++                        if store_info is not None:
+                             store_keys, sizes = store_info
+-                            for key, size in zip(store_keys, sizes, strict=True):
++                            if result_bools is None:
++                                stored_flags = [bool(ok)] * len(store_keys)
++                            else:
++                                stored_flags = [bool(value) for value in result_bools]
++                                if len(stored_flags) < len(store_keys):
++                                    stored_flags.extend(
++                                        [False] * (len(store_keys) - len(stored_flags))
++                                    )
++                                elif len(stored_flags) > len(store_keys):
++                                    stored_flags = stored_flags[: len(store_keys)]
++                            completion_ok = bool(ok) and all(stored_flags)
++                            for key, size, stored in zip(
++                                store_keys, sizes, stored_flags, strict=True
++                            ):
++                                if not stored:
++                                    continue
++                                persisted_count += 1
+                                 # First-store wins for byte accounting:
+                                 # a re-store of an existing key adds 0
+                                 # bytes (the backend already holds it).
+@@ -470,8 +645,21 @@ class NativeConnectorL2Adapter(L2AdapterInterface):
+                                 else:
+                                     keys_stored.append(key)
+                                     sizes_stored.append(0)
+-                        self._completed_stores[task_id] = L2StoreResult(ok, task_bytes)
+-                        self._store_efd.notify()
++                        if op_type == self._OP_STORE:
++                            self._completed_stores[task_id] = L2StoreResult(
++                                completion_ok, task_bytes
++                            )
++                            self._store_efd.notify()
++                        else:
++                            sync_entry = self._pending_sync_store_events.pop(
++                                task_id, None
++                            )
++                            if sync_entry is not None:
++                                sync_event, sync_result = sync_entry
++                                sync_result["ok"] = completion_ok
++                                sync_result["persisted_count"] = persisted_count
++                                sync_result["bytes_written"] = task_bytes
++                                sync_store_done_events.append(sync_event)
+ 
+                     elif op_type == self._OP_LOOKUP:
+                         bitmap = Bitmap(num_keys)
+@@ -519,10 +707,17 @@ class NativeConnectorL2Adapter(L2AdapterInterface):
+                         if evt is not None:
+                             delete_done_events.append(evt)
+ 
+-            # Fire listener notifications outside the lock so a slow
+-            # listener cannot stall further demux iterations.
++            # Commit byte accounting before releasing synchronous callers.
++            if keys_stored:
++                self._account_keys_stored(keys_stored, sizes_stored)
++            for evt in sync_store_done_events:
++                evt.set()
++
++            # Observer callbacks remain outside the lock and after synchronous
++            # durability completion. A slow observer must not defeat a caller's
++            # store timeout after persistence and accounting have committed.
+             if keys_stored:
+-                self._notify_keys_stored(keys_stored, sizes_stored)
++                self._notify_keys_stored_listeners(keys_stored, sizes_stored)
+             if keys_accessed:
+                 self._notify_keys_accessed(keys_accessed)
+             if keys_deleted:
+diff --git a/lmcache/v1/distributed/storage_controllers/eviction_controller.py b/lmcache/v1/distributed/storage_controllers/eviction_controller.py
+index 8624207de385ab334a102852b6d1b7c19d3182b0..899d8bf2166c2451fde6605dc839fa912e0e22f5 100644
+--- a/lmcache/v1/distributed/storage_controllers/eviction_controller.py
++++ b/lmcache/v1/distributed/storage_controllers/eviction_controller.py
+@@ -6,7 +6,10 @@ from __future__ import annotations
+ # Standard
+ from abc import abstractmethod
+ from collections import Counter
++from enum import Enum, auto
+ from typing import TYPE_CHECKING
++import inspect
++import math
+ import threading
+ import time
+ 
+@@ -16,6 +19,7 @@ from lmcache.v1.distributed.api import ObjectKey
+ from lmcache.v1.distributed.config import EvictionConfig
+ from lmcache.v1.distributed.eviction import L1EvictionPolicy, L2EvictionPolicy
+ from lmcache.v1.distributed.eviction_policy import CreateEvictionPolicy
++from lmcache.v1.distributed.error import L1Error
+ from lmcache.v1.distributed.internal_api import (
+     EvictionAction,
+     EvictionDestination,
+@@ -33,6 +37,12 @@ if TYPE_CHECKING:
+ logger = init_logger(__name__)
+ 
+ 
++class _SyncFlushResult(Enum):
++    SUCCESS = auto()
++    FAILURE = auto()
++    DEADLINE_EXHAUSTED = auto()
++
++
+ class EvictionController(StorageControllerInterface):
+     """
+     Abstract base class for eviction controllers.
+@@ -92,12 +102,33 @@ class L1EvictionController(EvictionController):
+     Uses an L1EvictionPolicy bridge to keep the eviction policy up-to-date
+     with L1 manager events, and periodically triggers eviction based on
+     L1 memory usage.
++
++    With ``EvictionConfig.write_back_on_evict`` enabled and L2 adapters
++    injected via ``set_l2_adapters``, eviction actions target
++    ``EvictionDestination.L2_CACHE``: readable objects are synchronously
++    persisted to L2 in bounded batches and deleted from L1 only once every
++    key in the batch is durable. Repeated flush failures open a circuit
++    breaker that pauses write-back instead of retrying every second.
++
++    ``EvictionConfig.periodic_flush_interval`` additionally enables a
++    below-watermark backup flush that copies evictable L1 keys to L2
++    without deleting them from L1.
+     """
+ 
++    # Bounded batches keep each blocking sync-store call short.
++    _SYNC_FLUSH_BATCH_SIZE = 128
++    # Keys per periodic backup flush cycle.
++    _BACKUP_FLUSH_BATCH_SIZE = 128
++    # A prefetch request must not stall the controller indefinitely on L2.
++    _EMERGENCY_FLUSH_TIMEOUT_SECONDS = 1.0
++    # Periodic backup runs under the flush lock and must remain stoppable.
++    _PERIODIC_FLUSH_TIMEOUT_SECONDS = 5.0
++
+     def __init__(
+         self,
+         l1_manager: L1Manager,
+         eviction_config: EvictionConfig,
++        l2_adapters: dict[int, L2AdapterInterface] | None = None,
+     ):
+         super().__init__()
+         self._eviction_config = eviction_config
+@@ -108,13 +139,101 @@ class L1EvictionController(EvictionController):
+         self._event_bus = get_event_bus()
+         self._last_extra_log = time.monotonic()
+ 
++        self._write_back_enabled = bool(eviction_config.write_back_on_evict)
++        self._l2_adapters: dict[int, L2AdapterInterface] = {}
++        self._l2_adapter_supports_timeout: dict[int, bool] = {}
++        self._l2_adapters_lock = threading.Lock()
++        # Serializes all synchronous L2 flushes and adapter-set replacement.
++        # StorageManager can therefore remove an adapter only after any L1
++        # writeback currently using it has finished.
++        self._flush_lock = threading.Lock()
++        # Sync-flush circuit breaker: a dead L2 must not cause a
++        # multi-thousand-key synchronous retry and warning storm every
++        # second.
++        self._sync_flush_failures: int = 0
++        self._sync_flush_backoff_until: float = 0.0
++        self._last_backup_flush = time.monotonic()
++        self._backup_flush_cursor: int = 0
++        # Serializes emergency evictions from concurrent callers.
++        self._emergency_evict_lock = threading.Lock()
++        if self._write_back_enabled:
++            # Writeback must fail closed. Register the L2 destination even
++            # before a compatible adapter exists so policy never falls back
++            # to DISCARD when persistence is unavailable.
++            self._eviction_policy.register_eviction_destination(
++                EvictionDestination.L2_CACHE
++            )
++        if l2_adapters:
++            self.set_l2_adapters(l2_adapters)
++
++    def set_l2_adapters(self, l2_adapters: dict[int, L2AdapterInterface]) -> None:
++        """Late-inject L2 adapters after StorageManager creates them.
++
++        Only adapters with an explicit synchronous durability contract are
++        eligible. The L2 eviction destination itself is registered at
++        construction so enabled writeback always fails closed.
++        """
++        compatible: dict[int, L2AdapterInterface] = {}
++        supports_timeout: dict[int, bool] = {}
++        for adapter_id, adapter in l2_adapters.items():
++            sync_store = getattr(adapter, "store_objects_sync", None)
++            if not callable(sync_store):
++                continue
++            compatible[adapter_id] = adapter
++            try:
++                supports_timeout[adapter_id] = (
++                    "timeout" in inspect.signature(sync_store).parameters
++                )
++            except (TypeError, ValueError):
++                supports_timeout[adapter_id] = False
++        ignored = sorted(set(l2_adapters) - set(compatible))
++        if ignored:
++            logger.warning(
++                "L1 writeback ignored adapters without store_objects_sync: %s",
++                ignored,
++            )
++        with self._flush_lock:
++            with self._l2_adapters_lock:
++                self._l2_adapters = compatible
++                self._l2_adapter_supports_timeout = supports_timeout
++
++    def has_l2_flush_adapter(self) -> bool:
++        """Return whether a synchronous durability backend is available."""
++        return bool(self._snapshot_l2_adapters())
++
++    def _snapshot_l2_adapters(self) -> list[tuple[int, L2AdapterInterface]]:
++        with self._l2_adapters_lock:
++            return list(self._l2_adapters.items())
++
++    def _snapshot_l2_flush_adapters(
++        self,
++    ) -> list[tuple[int, L2AdapterInterface, bool]]:
++        with self._l2_adapters_lock:
++            return [
++                (
++                    adapter_id,
++                    adapter,
++                    self._l2_adapter_supports_timeout.get(adapter_id, False),
++                )
++                for adapter_id, adapter in self._l2_adapters.items()
++            ]
++
+     def report_status(self) -> dict:
++        adapters = self._snapshot_l2_adapters()
+         return {
+             "is_healthy": self._thread.is_alive(),
+             "thread_alive": self._thread.is_alive(),
+             "eviction_policy": self._eviction_config.eviction_policy,
+             "trigger_watermark": self._eviction_config.trigger_watermark,
+             "eviction_ratio": self._eviction_config.eviction_ratio,
++            "write_back_enabled": self._write_back_enabled,
++            "l2_flush_enabled": bool(adapters),
++            "l2_flush_adapter_ids": [adapter_id for adapter_id, _ in adapters],
++            "periodic_flush_interval": (self._eviction_config.periodic_flush_interval),
++            "sync_flush_failures": self._sync_flush_failures,
++            "sync_flush_backoff_seconds": max(
++                0.0, self._sync_flush_backoff_until - time.monotonic()
++            ),
+         }
+ 
+     def _publish_skipped(self, usage: float, watermark: float) -> None:
+@@ -160,6 +279,7 @@ class L1EvictionController(EvictionController):
+     def eviction_loop(self):
+         watermark = self._eviction_config.trigger_watermark
+         eviction_ratio = self._eviction_config.eviction_ratio
++        backup_interval = self._eviction_config.periodic_flush_interval
+ 
+         while not self._stop_flag.is_set():
+             time.sleep(1)
+@@ -168,6 +288,13 @@ class L1EvictionController(EvictionController):
+                 self._maybe_log_memory_usage(used_bytes, total_bytes)
+             usage = 0 if total_bytes == 0 else used_bytes / total_bytes
+             if usage < watermark:
++                if (
++                    backup_interval > 0
++                    and self._snapshot_l2_adapters()
++                    and time.monotonic() - self._last_backup_flush >= backup_interval
++                ):
++                    self._last_backup_flush = time.monotonic()
++                    self._backup_to_l2_no_delete(self._BACKUP_FLUSH_BATCH_SIZE)
+                 logger.debug(
+                     "L1 memory usage %.2f below watermark %.2f; skipping eviction.",
+                     usage,
+@@ -176,6 +303,13 @@ class L1EvictionController(EvictionController):
+                 self._publish_skipped(usage, watermark)
+                 continue
+ 
++            if (
++                self._write_back_enabled
++                and time.monotonic() < self._sync_flush_backoff_until
++            ):
++                self._publish_skipped(usage, watermark)
++                continue
++
+             logger.info(
+                 "L1 memory usage %.2f above watermark %.2f; triggering eviction.",
+                 usage,
+@@ -190,13 +324,340 @@ class L1EvictionController(EvictionController):
+             self._publish_triggered(usage, watermark)
+ 
+     def execute_eviction_action(self, action: EvictionAction):
+-        if action.destination == EvictionDestination.DISCARD:
++        if action.destination == EvictionDestination.L2_CACHE:
++            self._flush_to_l2_then_delete(action.keys)
++        elif action.destination == EvictionDestination.DISCARD:
+             self._l1_manager.delete(action.keys)
+         else:
+             logger.error("Unsupported eviction destination: %s", action.destination)
+             logger.error("Treating it as DISCARD.")
+             self._l1_manager.delete(action.keys)
+ 
++    def emergency_evict_bytes(self, target_free_bytes: int, requester: str = "") -> int:
++        """Synchronously evict LRU L1 keys until at least
++        ``target_free_bytes`` bytes are free.
++
++        Victims take the normal eviction path, so with write-back enabled
++        they are flushed to L2 before deletion. Intended for the prefetch
++        controller when a large L2-to-L1 restore cannot reserve L1 buffers.
++
++        Args:
++            target_free_bytes: The free-space goal in bytes.
++            requester: Optional label for logging.
++
++        Returns:
++            The free byte count after eviction.
++        """
++        deadline = time.monotonic() + self._EMERGENCY_FLUSH_TIMEOUT_SECONDS
++        if not self._emergency_evict_lock.acquire(
++            timeout=self._EMERGENCY_FLUSH_TIMEOUT_SECONDS
++        ):
++            used, total = self._l1_manager.get_memory_usage()
++            return max(0, total - used)
++        try:
++            used, total = self._l1_manager.get_memory_usage()
++            free = max(0, total - used)
++            if free >= target_free_bytes:
++                return free
++            deficit = target_free_bytes - free
++            num_objects = self._l1_manager.num_objects()
++            if num_objects <= 0:
++                return free
++            if self._write_back_enabled and (
++                time.monotonic() < self._sync_flush_backoff_until
++                or not self.has_l2_flush_adapter()
++            ):
++                return free
++            per_key = max(1, used // num_objects)
++            need_keys = math.ceil(deficit / per_key)
++            need_keys += max(1, math.ceil(need_keys / 8))
++            tracked = num_objects
++            get_tracked = getattr(self._eviction_policy, "get_num_tracked_keys", None)
++            if callable(get_tracked):
++                tracked = max(1, int(get_tracked()))
++            ratio = min(1.0, need_keys / max(tracked, 1))
++            start = time.monotonic()
++            actions = self._eviction_policy.get_eviction_actions(
++                ratio,
++                key_eligible_filter=self._l1_manager.is_key_evictable,
++            )
++            evicted_keys = 0
++            for action in actions:
++                evicted_keys += len(action.keys)
++                if action.destination == EvictionDestination.L2_CACHE:
++                    self._flush_to_l2_then_delete(action.keys, deadline=deadline)
++                else:
++                    self.execute_eviction_action(action)
++                if time.monotonic() >= deadline:
++                    break
++            used_after, total_after = self._l1_manager.get_memory_usage()
++            free_after = max(0, total_after - used_after)
++            logger.info(
++                "Emergency L1 eviction%s: wanted %.0f MB free, evicted %d "
++                "keys in %.0f ms; free %.0f MB -> %.0f MB",
++                (" for " + requester) if requester else "",
++                target_free_bytes / 1e6,
++                evicted_keys,
++                (time.monotonic() - start) * 1000.0,
++                free / 1e6,
++                free_after / 1e6,
++            )
++            return free_after
++        finally:
++            self._emergency_evict_lock.release()
++
++    def _flush_to_l2_then_delete(
++        self,
++        keys: list[ObjectKey],
++        deadline: float | None = None,
++    ) -> None:
++        """Persist bounded batches to L2 and delete only fully durable
++        batches from L1.
++
++        The native adapter reports a store successful only when every key
++        persisted, so this method conservatively retains the whole readable
++        batch on any partial failure. Repeated failures open the circuit
++        breaker with exponential backoff.
++        """
++        if deadline is None:
++            self._flush_lock.acquire()
++        else:
++            remaining = deadline - time.monotonic()
++            if remaining <= 0 or not self._flush_lock.acquire(timeout=remaining):
++                return
++        try:
++            if not keys:
++                return
++            if time.monotonic() < self._sync_flush_backoff_until:
++                return
++
++            all_ok = True
++            deadline_exhausted = False
++            for start in range(0, len(keys), self._SYNC_FLUSH_BATCH_SIZE):
++                if deadline is not None and time.monotonic() >= deadline:
++                    deadline_exhausted = True
++                    break
++                batch = keys[start : start + self._SYNC_FLUSH_BATCH_SIZE]
++                result = self._flush_one_l2_batch_then_delete(batch, deadline=deadline)
++                if result == _SyncFlushResult.DEADLINE_EXHAUSTED:
++                    deadline_exhausted = True
++                    break
++                if result == _SyncFlushResult.FAILURE:
++                    all_ok = False
++                    break
++
++            if deadline_exhausted:
++                logger.debug(
++                    "L1-to-L2 emergency flush exhausted its time budget; "
++                    "remaining L1 keys preserved"
++                )
++            elif all_ok:
++                self._sync_flush_failures = 0
++                self._sync_flush_backoff_until = 0.0
++            else:
++                self._sync_flush_failures += 1
++                delay = min(60.0, float(2 ** min(self._sync_flush_failures, 6)))
++                self._sync_flush_backoff_until = time.monotonic() + delay
++                logger.warning(
++                    "L1-to-L2 flush circuit breaker: failure=%d, retry in %.0fs; "
++                    "remaining L1 keys preserved",
++                    self._sync_flush_failures,
++                    delay,
++                )
++        finally:
++            self._flush_lock.release()
++
++    def _flush_one_l2_batch_then_delete(
++        self,
++        keys: list[ObjectKey],
++        deadline: float | None = None,
++    ) -> _SyncFlushResult:
++        """Flush one batch to L2; delete from L1 only when fully durable.
++
++        Returns:
++            SUCCESS when every readable key was persisted (or none were
++            readable), FAILURE for an actual persistence failure, and
++            DEADLINE_EXHAUSTED when an emergency flush consumed its budget.
++        """
++        if not keys:
++            return _SyncFlushResult.SUCCESS
++
++        read_result = self._l1_manager.reserve_read(keys)
++        readable_keys: list[ObjectKey] = []
++        readable_objs = []
++        for key in keys:
++            entry = read_result.get(key)
++            if (
++                entry is not None
++                and entry[0] == L1Error.SUCCESS
++                and entry[1] is not None
++            ):
++                readable_keys.append(key)
++                readable_objs.append(entry[1])
++
++        flushed = not readable_keys
++        deadline_exhausted = False
++        if readable_keys:
++            try:
++                for (
++                    idx,
++                    adapter,
++                    supports_timeout,
++                ) in self._snapshot_l2_flush_adapters():
++                    sync_store = adapter.store_objects_sync
++                    try:
++                        if deadline is None:
++                            result = sync_store(readable_keys, readable_objs)
++                        else:
++                            remaining = deadline - time.monotonic()
++                            if remaining <= 0:
++                                deadline_exhausted = True
++                                break
++                            if not supports_timeout:
++                                logger.warning(
++                                    "Emergency L1 writeback skipped adapter %d: "
++                                    "store_objects_sync has no timeout contract",
++                                    idx,
++                                )
++                                continue
++                            result = sync_store(
++                                readable_keys,
++                                readable_objs,
++                                timeout=remaining,
++                            )
++                        ok, persisted_count, bytes_written = result
++                    except Exception:
++                        if deadline is not None and time.monotonic() >= deadline:
++                            deadline_exhausted = True
++                            break
++                        logger.exception(
++                            "L1-to-L2 flush: sync store failed on adapter %d", idx
++                        )
++                        continue
++                    if not ok and deadline is not None and time.monotonic() >= deadline:
++                        deadline_exhausted = True
++                        break
++                    # Never delete unless every readable key is durable.
++                    if ok and persisted_count == len(readable_keys):
++                        flushed = True
++                        logger.info(
++                            "L1-to-L2 flush: sync persisted %d/%d keys "
++                            "(%d bytes) via adapter %d",
++                            persisted_count,
++                            len(readable_keys),
++                            bytes_written,
++                            idx,
++                        )
++                        break
++                    logger.warning(
++                        "L1-to-L2 flush: adapter %d partial/failed persist "
++                        "(%d/%d keys, %d bytes)",
++                        idx,
++                        persisted_count,
++                        len(readable_keys),
++                        bytes_written,
++                    )
++            finally:
++                self._l1_manager.finish_read(readable_keys)
++
++        # Only keys we read and then fully persisted may be deleted. A key
++        # that failed reserve_read can have become locked after candidate
++        # selection and must never be treated as absent.
++        keys_to_delete = list(readable_keys) if flushed else []
++        if not flushed and readable_keys:
++            logger.warning(
++                "L1-to-L2 flush: preserving %d readable keys after failed persist",
++                len(readable_keys),
++            )
++
++        if keys_to_delete:
++            result = self._l1_manager.delete(keys_to_delete)
++            not_deleted = [k for k, err in result.items() if err != L1Error.SUCCESS]
++            if not_deleted:
++                logger.debug(
++                    "L1-to-L2 flush: %d keys not deleted, likely still locked",
++                    len(not_deleted),
++                )
++        if deadline_exhausted:
++            return _SyncFlushResult.DEADLINE_EXHAUSTED
++        if flushed:
++            return _SyncFlushResult.SUCCESS
++        return _SyncFlushResult.FAILURE
++
++    def _backup_to_l2_no_delete(self, batch_limit: int) -> None:
++        """Flush evictable L1 keys to L2 without deleting them from L1.
++
++        A backup, not an eviction: keys remain in L1 for fast access while
++        L2 gains a copy, so losing L1 (session expiry, restart) no longer
++        costs a cold prefill. A rotating cursor spreads repeated scans over
++        the whole L1 keyspace instead of hammering the first ``batch_limit``
++        insertion-ordered keys forever. Adapters skip keys they already
++        hold, so the flush is idempotent.
++        """
++        with self._flush_lock:
++            self._backup_to_l2_no_delete_locked(batch_limit)
++
++    def _backup_to_l2_no_delete_locked(self, batch_limit: int) -> None:
++        """Implementation of periodic backup under ``_flush_lock``."""
++        batch, self._backup_flush_cursor = self._l1_manager.get_evictable_keys(
++            limit=batch_limit,
++            cursor=self._backup_flush_cursor,
++        )
++        if not batch:
++            return
++
++        read_result = self._l1_manager.reserve_read(batch)
++        readable_keys: list[ObjectKey] = []
++        readable_objs = []
++        for key in batch:
++            entry = read_result.get(key)
++            if (
++                entry is not None
++                and entry[0] == L1Error.SUCCESS
++                and entry[1] is not None
++            ):
++                readable_keys.append(key)
++                readable_objs.append(entry[1])
++
++        if not readable_keys:
++            return
++
++        persisted_keys = 0
++        persisted_bytes = 0
++        try:
++            for idx, adapter, supports_timeout in self._snapshot_l2_flush_adapters():
++                if not supports_timeout:
++                    logger.warning(
++                        "Periodic L2 backup skipped adapter %d: "
++                        "store_objects_sync has no timeout contract",
++                        idx,
++                    )
++                    continue
++                sync_store = adapter.store_objects_sync
++                try:
++                    ok, persisted, written = sync_store(
++                        readable_keys,
++                        readable_objs,
++                        timeout=self._PERIODIC_FLUSH_TIMEOUT_SECONDS,
++                    )
++                    if ok and persisted == len(readable_keys):
++                        persisted_keys = persisted
++                        persisted_bytes = written
++                        break
++                except Exception:
++                    logger.exception("Periodic L2 backup: sync store failed on %d", idx)
++        finally:
++            self._l1_manager.finish_read(readable_keys)
++
++        if persisted_bytes > 0:
++            logger.info(
++                "Periodic L2 backup: persisted %d keys (%d new bytes, "
++                "%d evictable in L1, none deleted)",
++                persisted_keys,
++                persisted_bytes,
++                len(batch),
++            )
++
+ 
+ class L2AdapterEvictionState:
+     """Per-adapter eviction state: its own policy, listener, and config."""
+diff --git a/lmcache/v1/distributed/storage_controllers/prefetch_controller.py b/lmcache/v1/distributed/storage_controllers/prefetch_controller.py
+index 2138a33aa01ce95d7926bd4f6bcda79ae7d1955a..46239e518abaee70412223ec76eaa89f934a4bbe 100644
+--- a/lmcache/v1/distributed/storage_controllers/prefetch_controller.py
++++ b/lmcache/v1/distributed/storage_controllers/prefetch_controller.py
+@@ -55,6 +55,9 @@ from lmcache.v1.platform import (
+ 
+ if TYPE_CHECKING:
+     # First Party
++    from lmcache.v1.distributed.storage_controllers.eviction_controller import (
++        L1EvictionController,
++    )
+     from lmcache.v1.memory_management import MemoryObj
+ 
+ logger = init_logger(__name__)
+@@ -121,6 +124,17 @@ def trim_load_plan_with_mask(
+     return trimmed_plan
+ 
+ 
++def _layout_nbytes(layout_desc: MemoryLayoutDesc) -> int:
++    """Return the byte size of one object with the given layout."""
++    total = 0
++    for shape, dtype in zip(layout_desc.shapes, layout_desc.dtypes, strict=True):
++        numel = 1
++        for dim in shape:
++            numel *= int(dim)
++        total += numel * dtype.itemsize
++    return total
++
++
+ # Poll timeout in milliseconds for the prefetch loop
+ PREFETCH_LOOP_POLL_TIMEOUT_MS = 500
+ 
+@@ -227,6 +241,11 @@ class PrefetchController(StorageControllerInterface):
+         self._policy = policy
+         self._max_in_flight = max_in_flight
+ 
++        # Optional L1 eviction controller for emergency make-room before
++        # large restores; injected by StorageManager when
++        # EvictionConfig.emergency_evict_for_prefetch is enabled.
++        self._l1_eviction_controller: "L1EvictionController | None" = None
++
+         # Adapters that are being drained and will be removed after all
+         # the in-flight operations are done.
+         self._draining: dict[int, threading.Event] = {}
+@@ -847,6 +866,25 @@ class PrefetchController(StorageControllerInterface):
+     # =========================================================================
+     # Load phase
+     # =========================================================================
++    def _select_l1_retentions(
++        self,
++        request_id: int,
++        keys: list[ObjectKey],
++    ) -> list[bool]:
++        """Return one retention decision per key, degrading safely on a
++        malformed policy result."""
++        retentions = self._policy.select_l1_retentions(keys)
++        if len(retentions) != len(keys):
++            logger.error(
++                "Prefetch request %d: policy returned %d retentions for "
++                "%d keys; defaulting to temporary entries",
++                request_id,
++                len(retentions),
++                len(keys),
++            )
++            return [False] * len(keys)
++        return retentions
++
+     def _transition_to_load_phase(self, request: InFlightPrefetchRequest) -> None:
+         """Compute load plan, reserve L1 buffers, and submit load tasks."""
+         request.phase = PrefetchPhase.PLAN_AND_LOAD
+@@ -899,15 +937,23 @@ class PrefetchController(StorageControllerInterface):
+         if request.mode is PrefetchMode.WARM:
+             retentions = [True] * len(keys_to_reserve)
+         else:
+-            retentions = self._policy.select_l1_retentions(
++            retentions = self._select_l1_retentions(
++                request.request_id,
+                 keys_to_reserve,
+             )
++            # Non-WARM only: a WARM warm-up must never trigger emergency
++            # eviction of other sessions' chunks.
++            self._make_room_for_restore(request, keys_to_reserve)
+         write_results = l1_mgr.reserve_write(
+             keys=keys_to_reserve,
+             is_temporary=[not r for r in retentions],
+             layout_desc=request.layout_desc,
+             mode="new",
+         )
++        if request.mode is not PrefetchMode.WARM:
++            write_results = self._retry_oom_reservations(
++                request, keys_to_reserve, retentions, write_results
++            )
+ 
+         # Step 4: filter to successfully reserved keys
+         reserved_key_set: set[ObjectKey] = set()
+@@ -1038,6 +1084,123 @@ class PrefetchController(StorageControllerInterface):
+             len(reserved_key_set),
+         )
+ 
++    def set_l1_eviction_controller(
++        self,
++        controller: "L1EvictionController | None",
++    ) -> None:
++        """Enable emergency L1 eviction for large restores.
++
++        With a controller injected, a non-WARM restore that would not fit
++        in free L1 space synchronously evicts LRU keys (write-back first)
++        before reserving, and retries OOM reservations once. Pass ``None``
++        after the last synchronous L2 adapter is removed to disable this path.
++        """
++        self._l1_eviction_controller = controller
++
++    # Never let a single restore claim more than this fraction of L1: a
++    # huge context must not wipe every hot chunk of the running sessions.
++    _EMERGENCY_EVICT_MAX_L1_FRACTION = 0.6
++    # Headroom per object for alignment and allocator bookkeeping.
++    _PER_OBJECT_HEADROOM_BYTES = 8192
++
++    def _make_room_for_restore(
++        self,
++        request: InFlightPrefetchRequest,
++        keys_to_reserve: list[ObjectKey],
++    ) -> None:
++        """Pre-evict LRU L1 chunks so the upcoming reserve_write for this
++        restore can succeed. No-op unless an eviction controller was
++        injected via ``set_l1_eviction_controller``."""
++        evictor = self._l1_eviction_controller
++        if evictor is None or not keys_to_reserve:
++            return
++        per_obj = _layout_nbytes(request.layout_desc)
++        if per_obj <= 0:
++            return
++        used, total = self._l1_manager.get_memory_usage()
++        need = (per_obj + self._PER_OBJECT_HEADROOM_BYTES) * len(keys_to_reserve)
++        need = min(need, int(total * self._EMERGENCY_EVICT_MAX_L1_FRACTION))
++        free = max(0, total - used)
++        if free >= need:
++            return
++        try:
++            evictor.emergency_evict_bytes(
++                need, requester=f"prefetch_request={request.request_id}"
++            )
++        except Exception:
++            logger.exception(
++                "Emergency eviction failed for prefetch request %d",
++                request.request_id,
++            )
++
++    def _retry_oom_reservations(
++        self,
++        request: InFlightPrefetchRequest,
++        keys_to_reserve: list[ObjectKey],
++        retentions: list[bool],
++        write_results: dict[ObjectKey, tuple[L1Error, "MemoryObj | None"]],
++    ) -> dict[ObjectKey, tuple[L1Error, "MemoryObj | None"]]:
++        """One retry round for keys whose reservation failed with
++        OUT_OF_MEMORY: evict the missing amount, reserve just those keys
++        again, and merge the results. No-op unless an eviction controller
++        was injected."""
++        evictor = self._l1_eviction_controller
++        if evictor is None:
++            return write_results
++        oom_keys: list[ObjectKey] = []
++        retention_by_key = dict(zip(keys_to_reserve, retentions, strict=True))
++        for key in keys_to_reserve:
++            entry = write_results.get(key)
++            if entry is None:
++                oom_keys.append(key)
++                continue
++            err, mem_obj = entry
++            if err == L1Error.OUT_OF_MEMORY or (
++                err == L1Error.SUCCESS and mem_obj is None
++            ):
++                oom_keys.append(key)
++        if not oom_keys:
++            return write_results
++        per_obj = _layout_nbytes(request.layout_desc)
++        if per_obj <= 0:
++            return write_results
++        _, total = self._l1_manager.get_memory_usage()
++        need = (per_obj + self._PER_OBJECT_HEADROOM_BYTES) * len(oom_keys)
++        need = min(need, int(total * self._EMERGENCY_EVICT_MAX_L1_FRACTION))
++        try:
++            evictor.emergency_evict_bytes(
++                need, requester=f"prefetch_request={request.request_id}/retry"
++            )
++        except Exception:
++            logger.exception(
++                "Emergency eviction retry failed for prefetch request %d",
++                request.request_id,
++            )
++            return write_results
++        retry_results = self._l1_manager.reserve_write(
++            keys=oom_keys,
++            is_temporary=[not retention_by_key[k] for k in oom_keys],
++            layout_desc=request.layout_desc,
++            mode="new",
++        )
++        recovered = sum(
++            1
++            for k in oom_keys
++            if retry_results.get(k)
++            and retry_results[k][0] == L1Error.SUCCESS
++            and retry_results[k][1] is not None
++        )
++        if recovered:
++            logger.info(
++                "Retry recovered %d/%d OOM reservations for prefetch request %d",
++                recovered,
++                len(oom_keys),
++                request.request_id,
++            )
++        merged = dict(write_results)
++        merged.update(retry_results)
++        return merged
++
+     def _update_lookup_results(
+         self, request_id: PrefetchRequestId, prefix_hit_count: int
+     ) -> None:
+@@ -1181,6 +1344,17 @@ class PrefetchController(StorageControllerInterface):
+         # added once the serde PR lands and adapters can distinguish
+         # deserialization errors from missing objects.
+         if failed_keys:
++            # These keys were reported present by the L2 lookup but the load
++            # returned no data. Sample a few so the on-disk state can be
++            # inspected post hoc.
++            logger.warning(
++                "Prefetch request %d: %d/%d plan keys failed to load from "
++                "L2 (lookup hit, load empty); sample: %s",
++                request.request_id,
++                len(failed_keys),
++                len(request.write_reserved_keys),
++                [str(k)[:160] for k in failed_keys[:3]],
++            )
+             self._event_bus.publish(
+                 Event(
+                     event_type=EventType.L2_PREFETCH_FAILED,
+diff --git a/lmcache/v1/distributed/storage_manager.py b/lmcache/v1/distributed/storage_manager.py
+index 3054e2441c5c7d98d817ca7a1f9ac30b4a7e92d7..a7da312a475264ddd1c829ad73937fc103cbf1a8 100644
+--- a/lmcache/v1/distributed/storage_manager.py
++++ b/lmcache/v1/distributed/storage_manager.py
+@@ -66,6 +66,7 @@ logger = init_logger(__name__)
+ 
+ class StorageManager:
+     def __init__(self, config: StorageManagerConfig):
++        self._eviction_config = config.eviction_config
+         self._l1_manager = L1Manager(config.l1_manager_config)
+         self._event_bus = get_event_bus()
+ 
+@@ -154,6 +155,31 @@ class StorageManager:
+         )
+         self._prefetch_controller.start()
+ 
++        # Opt-in L1 write-back tier: wire L2 adapters into the L1 eviction
++        # controller so evicted or periodically backed-up chunks are flushed
++        # to L2, and optionally let the prefetch controller trigger
++        # emergency eviction to make room for large restores.
++        eviction_config = config.eviction_config
++        wants_l1_write_back = (
++            eviction_config.write_back_on_evict
++            or eviction_config.periodic_flush_interval > 0
++        )
++        if wants_l1_write_back:
++            self._sync_l1_writeback_adapters()
++            if not self._eviction_controller.has_l2_flush_adapter():
++                logger.warning(
++                    "write_back_on_evict / periodic_flush_interval is set but "
++                    "no L2 adapter exposes store_objects_sync"
++                )
++        if (
++            eviction_config.emergency_evict_for_prefetch
++            and not self._eviction_controller.has_l2_flush_adapter()
++        ):
++            logger.warning(
++                "emergency_evict_for_prefetch has no synchronous L2 "
++                "adapter; inactive until one is added"
++            )
++
+         # L2 usage gauge — one observation per adapter, tagged by
+         # ``l2_name``.  Parallel to L1Manager's ``l1_memory_usage_bytes``.
+         register_gauge(
+@@ -904,6 +930,7 @@ class StorageManager:
+             with self._adapters_lock:
+                 self._l2_adapters[adapter_id] = adapter
+                 self._adapter_descriptors[adapter_id] = descriptor
++            self._sync_l1_writeback_adapters()
+             self._store_controller.add_adapter(adapter_id, adapter, descriptor)
+             self._prefetch_controller.add_adapter(adapter_id, adapter, descriptor)
+             if self._should_enable_l2_eviction(adapter, config.eviction_config):
+@@ -956,6 +983,9 @@ class StorageManager:
+             with self._adapters_lock:
+                 adapter = self._l2_adapters.pop(adapter_id)
+                 self._adapter_descriptors.pop(adapter_id, None)
++            # Waits for any synchronous L1 flush using the removed adapter
++            # before adapter.close() releases its native resources.
++            self._sync_l1_writeback_adapters()
+             adapter.close()
+             logger.info("Deleted L2 adapter %d", adapter_id)
+ 
+@@ -1121,6 +1151,21 @@ class StorageManager:
+             return False
+         return True
+ 
++    def _sync_l1_writeback_adapters(self) -> None:
++        """Publish the current adapter set to the optional L1 writeback tier."""
++        config = self._eviction_config
++        if not (config.write_back_on_evict or config.periodic_flush_interval > 0):
++            return
++        with self._adapters_lock:
++            adapters = dict(self._l2_adapters)
++        self._eviction_controller.set_l2_adapters(adapters)
++        if config.emergency_evict_for_prefetch:
++            self._prefetch_controller.set_l1_eviction_controller(
++                self._eviction_controller
++                if self._eviction_controller.has_l2_flush_adapter()
++                else None
++            )
++
+     def _unwrap_reconfigurable_l2_adapter(
+         self,
+         adapter: L2AdapterInterface,
+diff --git a/lmcache/v1/multiprocess/futures.py b/lmcache/v1/multiprocess/futures.py
+index beadae5505e4062d95b3e5f083d8e72b6bdf06d1..ab5195eec56aa3fcd9b52550aac52dc6133680b4 100644
+--- a/lmcache/v1/multiprocess/futures.py
++++ b/lmcache/v1/multiprocess/futures.py
+@@ -14,6 +14,7 @@ class MessagingFuture(Generic[T]):
+     def __init__(self):
+         self.is_done_ = threading.Event()
+         self.result_ = None
++        self.exception_: BaseException | None = None
+ 
+     def query(self) -> bool:
+         """
+@@ -54,6 +55,8 @@ class MessagingFuture(Generic[T]):
+         flag = self.wait(timeout)
+         if not flag:
+             raise LMCacheTimeoutError("Future result not available within timeout")
++        if self.exception_ is not None:
++            raise self.exception_
+         return self.result_
+ 
+     def set_result(self, result: T) -> None:
+@@ -68,6 +71,13 @@ class MessagingFuture(Generic[T]):
+         self.result_ = result
+         self.is_done_.set()
+ 
++    def set_exception(self, exception: BaseException) -> None:
++        """Complete the future with an exception from the messaging system."""
++        if not isinstance(exception, BaseException):
++            raise TypeError("exception must derive from BaseException")
++        self.exception_ = exception
++        self.is_done_.set()
++
+     def to_cuda_future(
+         self,
+         device: Any | None = None,
+diff --git a/lmcache/v1/multiprocess/mq.py b/lmcache/v1/multiprocess/mq.py
+index 271ff93b2a933f6c0f70f95a95d6f2249e7636c1..a5d0d0cf7322a523a9a8b89a0c5af2e2466109b1 100644
+--- a/lmcache/v1/multiprocess/mq.py
++++ b/lmcache/v1/multiprocess/mq.py
+@@ -40,6 +40,26 @@ T = TypeVar("T")
+ # Internal type used for the client-server communication
+ RequestUID = int
+ 
++_ERROR_RESPONSE_MARKER = b"LMCACHE_RPC_ERROR_V1"
++_MAX_REMOTE_ERROR_MESSAGE_BYTES = 4096
++
++
++class RemoteHandlerError(RuntimeError):
++    """A request handler failed in the remote LMCache process."""
++
++    def __init__(
++        self, request_type: RequestType, error_type: str, message: str
++    ) -> None:
++        self.request_type = request_type
++        self.error_type = error_type
++        self.remote_message = message
++        super().__init__(f"{request_type.name} handler failed: {error_type}: {message}")
++
++
++class _RemoteErrorPayload(msgspec.Struct, frozen=True):
++    error_type: str
++    message: str
++
+ 
+ # Helper functions
+ def encode_request_uid(uid: RequestUID) -> bytes:
+@@ -346,7 +366,28 @@ class MessageQueueClient:
+ 
+         if request_uid in self.pending_futures:
+             future = self.pending_futures.pop(request_uid)
+-            if b_response:
++            if b_response and b_response[0] == _ERROR_RESPONSE_MARKER:
++                if len(b_response) != 2:
++                    future.set_exception(
++                        RuntimeError("Malformed LMCache RPC error response")
++                    )
++                    return
++                try:
++                    error = msgspec_decode(b_response[1], cls=_RemoteErrorPayload)
++                except Exception:
++                    future.set_exception(
++                        RuntimeError("Failed to decode LMCache RPC error response")
++                    )
++                    logger.exception("Failed to decode RPC error response")
++                    return
++                future.set_exception(
++                    RemoteHandlerError(
++                        request_type=request_type,
++                        error_type=error.error_type,
++                        message=error.message,
++                    )
++                )
++            elif b_response:
+                 response = msgspec_decode(b_response[0], cls=response_cls)
+                 future.set_result(response)
+             else:
+@@ -516,6 +557,24 @@ class MessageQueueServer:
+         # Thread pools assigned via add_normal_thread_pool / add_affinity_thread_pool
+         self.extra_pools: list[ThreadPoolExecutor | AffinityThreadPool] = []
+ 
++    def _queue_error_response(
++        self, prefix_frames: list[bytes], exception: BaseException
++    ) -> None:
++        """Return a bounded error response without touching ZMQ off-thread."""
++        message = str(exception).encode("utf-8")[:_MAX_REMOTE_ERROR_MESSAGE_BYTES]
++        payload = _RemoteErrorPayload(
++            error_type=type(exception).__name__,
++            message=message.decode("utf-8", errors="replace"),
++        )
++        self.output_queue.put(
++            prefix_frames
++            + [
++                _ERROR_RESPONSE_MARKER,
++                msgspec_encode(payload, cls=_RemoteErrorPayload),
++            ]
++        )
++        self._output_efd.notify()
++
+     def _call_sync_handler(
+         self,
+         handler_entry: SyncRequestHandler[Any],
+@@ -571,8 +630,9 @@ class MessageQueueServer:
+                 self.output_queue.put(frames_to_send)
+                 self._output_efd.notify()
+ 
+-            except Exception:
++            except Exception as exc:
+                 logger.exception("Error in blocking handler")
++                self._queue_error_response(prefix_frames, exc)
+ 
+         future.add_done_callback(_notify_response)
+ 
+@@ -619,13 +679,23 @@ class MessageQueueServer:
+                             payloads=payloads,
+                             prefix_frames=[identity, b_request_uid, b_request_type],
+                         )
+-                    except Exception:
++                    except Exception as exc:
+                         logger.exception("Error handling request %s", request_type)
++                        self._queue_error_response(
++                            [identity, b_request_uid, b_request_type], exc
++                        )
+                 else:
+                     logger.error(
+                         "No handler registered for request type %s", request_type
+                     )
+                     logger.error("Available handlers: %s", list(self.handlers.keys()))
++                    self._queue_error_response(
++                        [identity, b_request_uid, b_request_type],
++                        RuntimeError(
++                            "No handler registered for request type "
++                            f"{request_type.name}"
++                        ),
++                    )
+ 
+             # Send the responses
+             if outbound_state and outbound_state & zmq.POLLIN:
+diff --git a/tests/v1/distributed/test_fs_native_startup_scan.py b/tests/v1/distributed/test_fs_native_startup_scan.py
+new file mode 100644
+index 0000000000000000000000000000000000000000..796c27e183c9ff0bc923b4d5fbe7e7dfdb6957bc
+--- /dev/null
++++ b/tests/v1/distributed/test_fs_native_startup_scan.py
+@@ -0,0 +1,78 @@
++# SPDX-License-Identifier: Apache-2.0
++"""Restart accounting for the native filesystem L2 adapter."""
++
++# Standard
++import os
++
++# Third Party
++import pytest
++
++# First Party
++from lmcache.v1.distributed.api import ObjectKey
++from lmcache.v1.distributed.l2_adapters.fs_l2_adapter import (
++    _object_key_to_filename,
++)
++from lmcache.v1.distributed.l2_adapters.fs_native_l2_adapter import (
++    _scan_existing_fs_native_files,
++)
++
++
++def _key(chunk_id: int) -> ObjectKey:
++    return ObjectKey(
++        chunk_hash=ObjectKey.IntHash2Bytes(chunk_id),
++        model_name="test-model",
++        kv_rank=0,
++    )
++
++
++def _write(root, key: ObjectKey, size: int, mtime_ns: int) -> None:
++    path = root / _object_key_to_filename(key)
++    path.write_bytes(b"x" * size)
++    os.utime(path, ns=(mtime_ns, mtime_ns))
++
++
++def test_scan_returns_oldest_to_newest_keys_and_sizes(tmp_path):
++    newer = _key(2)
++    older = _key(1)
++    _write(tmp_path, newer, 200, 2_000_000_000)
++    _write(tmp_path, older, 100, 1_000_000_000)
++
++    keys, sizes = _scan_existing_fs_native_files(str(tmp_path))
++
++    assert keys == [older, newer]
++    assert sizes == [100, 200]
++
++
++def test_scan_skips_foreign_empty_and_temporary_files(tmp_path):
++    valid = _key(1)
++    _write(tmp_path, valid, 100, 1_000_000_000)
++    (tmp_path / "not-a-cache-file.data").write_bytes(b"x")
++    (tmp_path / _object_key_to_filename(_key(2))).write_bytes(b"")
++    (tmp_path / "pending.tmp").write_bytes(b"x")
++
++    keys, sizes = _scan_existing_fs_native_files(str(tmp_path))
++
++    assert keys == [valid]
++    assert sizes == [100]
++
++
++def test_scan_missing_directory_returns_empty(tmp_path):
++    assert _scan_existing_fs_native_files(str(tmp_path / "missing")) == ([], [])
++
++
++def test_scan_fails_closed_when_existing_file_cannot_be_inspected(
++    tmp_path, monkeypatch
++):
++    path = tmp_path / "broken.data"
++    path.write_bytes(b"x")
++    original_stat = type(path).stat
++
++    def fail_data_stat(self, *args, **kwargs):
++        if self == path:
++            raise OSError("injected stat failure")
++        return original_stat(self, *args, **kwargs)
++
++    monkeypatch.setattr(type(path), "stat", fail_data_stat)
++
++    with pytest.raises(RuntimeError, match="Could not inspect cache file"):
++        _scan_existing_fs_native_files(str(tmp_path))
+diff --git a/tests/v1/distributed/test_l1_manager.py b/tests/v1/distributed/test_l1_manager.py
+index fea845f903879a84856058ac107589a4b21e0fc7..5b0fb89bc77f4b274f8a27bc48c876aa3c7b54bb 100644
+--- a/tests/v1/distributed/test_l1_manager.py
++++ b/tests/v1/distributed/test_l1_manager.py
+@@ -132,18 +132,6 @@ def basic_layout():
+     )
+ 
+ 
+-@pytest.fixture
+-def large_layout():
+-    """Create a large MemoryLayoutDesc that will exhaust small memory.
+-
+-    Each allocation is 8MB (2M elements * 4 bytes).
+-    """
+-    return MemoryLayoutDesc(
+-        shapes=[torch.Size([2048, 1024])],  # 2M elements * 4 bytes = 8MB
+-        dtypes=[torch.float32],
+-    )
+-
+-
+ def make_object_key(chunk_hash: int, model_name: str = "test_model", kv_rank: int = 0):
+     """Helper to create ObjectKey instances."""
+     hash_bytes = ObjectKey.IntHash2Bytes(chunk_hash)
+@@ -879,14 +867,23 @@ class TestReserveWrite:
+ 
+         manager.close()
+ 
+-    def test_reserve_write_out_of_memory(self, small_l1_config, large_layout):
+-        """Test that reserve_write returns OUT_OF_MEMORY when allocation fails."""
++    def test_reserve_write_out_of_memory(self, small_l1_config):
++        """Test that reserve_write returns OUT_OF_MEMORY when allocation fails.
++
++        Uses an object larger than the whole pool; a batch that partially
++        fits allocates the longest prefix instead (see
++        tests/v1/distributed/test_l1_manager_partial_alloc.py).
++        """
+         manager = L1Manager(small_l1_config)
+         keys = [make_object_key(i) for i in range(10)]
+         is_temporary = [False] * 10
+ 
+-        # Request more memory than available (8MB * 10 = 80MB > 64MB)
+-        result = manager.reserve_write(keys, is_temporary, large_layout)
++        # A single object (128MB) exceeds the 64MB pool.
++        oversized_layout = MemoryLayoutDesc(
++            shapes=[torch.Size([2048 * 16, 1024])],
++            dtypes=[torch.float32],
++        )
++        result = manager.reserve_write(keys, is_temporary, oversized_layout)
+ 
+         # All keys should return OUT_OF_MEMORY
+         for key in keys:
+diff --git a/tests/v1/distributed/test_l1_manager_partial_alloc.py b/tests/v1/distributed/test_l1_manager_partial_alloc.py
+new file mode 100644
+index 0000000000000000000000000000000000000000..30ddc3fba0ce10c957ad6375874fac7df9cc8585
+--- /dev/null
++++ b/tests/v1/distributed/test_l1_manager_partial_alloc.py
+@@ -0,0 +1,151 @@
++# SPDX-License-Identifier: Apache-2.0
++"""Partial-prefix allocation behavior of ``L1Manager.reserve_write``.
++
++A batch whose full allocation does not fit must not fail every key
++(all-or-nothing would collapse large L2->L1 restores to zero prefix hits):
++the longest prefix that fits is allocated and only the tail reports
++OUT_OF_MEMORY. Uses the CPU shared-memory allocator, no GPU required.
++"""
++
++# Standard
++from collections.abc import Iterator
++from types import SimpleNamespace
++
++# Third Party
++import pytest
++import torch
++
++# First Party
++from lmcache.v1.distributed.api import MemoryLayoutDesc, ObjectKey
++from lmcache.v1.distributed.config import (
++    L1ManagerConfig,
++    L1MemoryManagerConfig,
++)
++from lmcache.v1.distributed.error import L1Error
++from lmcache.v1.distributed.l1_manager import L1Manager
++
++POOL_BYTES = 64 * 1024 * 1024
++
++# 8MB per object: ten of them cannot fit in the 64MB pool, most can.
++OBJECT_LAYOUT = MemoryLayoutDesc(
++    shapes=[torch.Size([2048, 1024])],
++    dtypes=[torch.float32],
++)
++
++# A single 128MB object exceeds the whole pool.
++OVERSIZED_LAYOUT = MemoryLayoutDesc(
++    shapes=[torch.Size([2048 * 16, 1024])],
++    dtypes=[torch.float32],
++)
++
++
++@pytest.fixture
++def manager() -> Iterator[L1Manager]:
++    config = L1ManagerConfig(
++        memory_config=L1MemoryManagerConfig(
++            size_in_bytes=POOL_BYTES,
++            use_lazy=False,
++            init_size_in_bytes=POOL_BYTES,
++            align_bytes=0x1000,
++        ),
++        write_ttl_seconds=600,
++        read_ttl_seconds=300,
++    )
++    manager = L1Manager(config)
++    yield manager
++    manager.close()
++
++
++def _make_keys(count: int) -> list[ObjectKey]:
++    return [
++        ObjectKey(
++            chunk_hash=ObjectKey.IntHash2Bytes(i),
++            model_name="test_model",
++            kv_rank=0,
++        )
++        for i in range(count)
++    ]
++
++
++def test_reserve_write_allocates_longest_prefix_on_oom(manager: L1Manager) -> None:
++    """When the full batch does not fit, a non-empty prefix succeeds and
++    only the tail reports OUT_OF_MEMORY; every requested key keeps an
++    explicit per-key result."""
++    keys = _make_keys(10)
++    result = manager.reserve_write(keys, [False] * 10, OBJECT_LAYOUT)
++
++    assert set(result) == set(keys)
++    statuses = [result[key][0] for key in keys]
++    num_success = statuses.count(L1Error.SUCCESS)
++    assert 0 < num_success < 10
++
++    # The successful keys form a prefix in request order.
++    assert statuses == [L1Error.SUCCESS] * num_success + [L1Error.OUT_OF_MEMORY] * (
++        10 - num_success
++    )
++    for key in keys[:num_success]:
++        assert result[key][1] is not None
++    for key in keys[num_success:]:
++        assert result[key][1] is None
++
++
++def test_partial_prefix_is_committable(manager: L1Manager) -> None:
++    """The allocated prefix stays usable: finish_write succeeds for it."""
++    keys = _make_keys(10)
++    result = manager.reserve_write(keys, [False] * 10, OBJECT_LAYOUT)
++    successful = [key for key in keys if result[key][0] == L1Error.SUCCESS]
++    assert successful
++
++    finish_result = manager.finish_write(successful)
++    for key in successful:
++        assert finish_result[key] == L1Error.SUCCESS
++
++
++def test_reserve_write_all_oom_when_nothing_fits(manager: L1Manager) -> None:
++    """An object larger than the pool still fails every key."""
++    keys = _make_keys(3)
++    result = manager.reserve_write(keys, [False] * 3, OVERSIZED_LAYOUT)
++
++    for key in keys:
++        assert result[key][0] == L1Error.OUT_OF_MEMORY
++        assert result[key][1] is None
++
++
++def test_single_key_batch_keeps_all_or_nothing(manager: L1Manager) -> None:
++    """A one-key batch has no prefix to fall back to; it simply fails."""
++    keys = _make_keys(1)
++    result = manager.reserve_write(keys, [False], OVERSIZED_LAYOUT)
++
++    assert result[keys[0]] == (L1Error.OUT_OF_MEMORY, None)
++
++
++def test_largest_prefix_search_does_not_stop_at_a_smaller_fit() -> None:
++    """The OOM fallback finds the maximum, rather than accepting a midpoint."""
++
++    class BoundedMemoryManager:
++        def __init__(self, capacity: int) -> None:
++            self.capacity = capacity
++            self.allocate_counts: list[int] = []
++
++        def allocate(self, _layout: MemoryLayoutDesc, count: int):
++            self.allocate_counts.append(count)
++            if count > self.capacity:
++                return L1Error.OUT_OF_MEMORY, []
++            return L1Error.SUCCESS, [object() for _ in range(count)]
++
++        def free(self, _objects: list[object]) -> L1Error:
++            return L1Error.SUCCESS
++
++    memory_manager = BoundedMemoryManager(capacity=7)
++    manager = SimpleNamespace(_memory_manager=memory_manager)
++
++    err, objects = L1Manager._allocate_largest_prefix(
++        manager,
++        OBJECT_LAYOUT,
++        10,  # type: ignore[arg-type]
++    )
++
++    assert err == L1Error.SUCCESS
++    assert len(objects) == 7
++    assert memory_manager.allocate_counts[-1] == 7
++    assert 8 in memory_manager.allocate_counts
+diff --git a/tests/v1/distributed/test_l1_write_back_eviction.py b/tests/v1/distributed/test_l1_write_back_eviction.py
+new file mode 100644
+index 0000000000000000000000000000000000000000..b677516e37c31959421ea88f777a734d7f61bd0d
+--- /dev/null
++++ b/tests/v1/distributed/test_l1_write_back_eviction.py
+@@ -0,0 +1,609 @@
++# SPDX-License-Identifier: Apache-2.0
++"""Opt-in L1 write-back tier.
++
++With ``EvictionConfig.write_back_on_evict`` enabled, L1 eviction flushes
++readable objects to L2 synchronously and deletes them from L1 only once
++every key in the batch is durable. ``periodic_flush_interval`` adds a
++below-watermark backup flush that keeps the L1 copy.
++``emergency_evict_for_prefetch`` lets the prefetch controller make room
++for large restores through the same write-back path.
++
++Uses the CPU shared-memory allocator; no GPU required.
++"""
++
++# Standard
++from collections.abc import Iterator
++import argparse
++import threading
++import time
++
++# Third Party
++import pytest
++import torch
++
++# First Party
++from lmcache.v1.distributed.api import MemoryLayoutDesc, ObjectKey
++from lmcache.v1.distributed.config import (
++    EvictionConfig,
++    L1ManagerConfig,
++    L1MemoryManagerConfig,
++    StorageManagerConfig,
++    add_storage_manager_args,
++    parse_args_to_config,
++)
++from lmcache.v1.distributed.error import L1Error
++from lmcache.v1.distributed.internal_api import (
++    EvictionAction,
++    EvictionDestination,
++)
++from lmcache.v1.distributed.l1_manager import L1Manager
++from lmcache.v1.distributed.storage_controllers.eviction_controller import (
++    L1EvictionController,
++)
++from lmcache.v1.distributed.storage_controllers.prefetch_controller import (
++    InFlightPrefetchRequest,
++    PrefetchController,
++    PrefetchPhase,
++)
++from lmcache.v1.distributed.storage_controllers.prefetch_policy import (
++    DefaultPrefetchPolicy,
++)
++from lmcache.v1.mp_observability.config import add_observability_args
++
++POOL_BYTES = 8 * 1024 * 1024
++
++# 1MB per object so a handful of objects create real memory pressure.
++OBJECT_LAYOUT = MemoryLayoutDesc(
++    shapes=[torch.Size([256, 1024])],
++    dtypes=[torch.float32],
++)
++
++
++class FakeSyncStoreAdapter:
++    """L2 adapter double exposing only the synchronous store path.
++
++    ``result`` overrides the returned tuple; by default every key is
++    reported durable.
++    """
++
++    def __init__(self) -> None:
++        self.stored_batches: list[list[ObjectKey]] = []
++        self.result: tuple[bool, int, int] | None = None
++
++    def store_objects_sync(
++        self,
++        keys: list[ObjectKey],
++        objects: list,
++        timeout: float | None = None,
++    ) -> tuple[bool, int, int]:
++        self.stored_batches.append(list(keys))
++        if self.result is not None:
++            return self.result
++        return True, len(keys), sum(obj.get_size() for obj in objects)
++
++
++class BlockingSyncStoreAdapter(FakeSyncStoreAdapter):
++    def __init__(self) -> None:
++        super().__init__()
++        self.entered = threading.Event()
++        self.release = threading.Event()
++
++    def store_objects_sync(self, keys, objects, timeout=None):
++        self.entered.set()
++        if not self.release.wait(timeout=timeout or 5.0):
++            return False, 0, 0
++        return super().store_objects_sync(keys, objects, timeout=timeout)
++
++
++@pytest.fixture
++def l1_manager() -> Iterator[L1Manager]:
++    config = L1ManagerConfig(
++        memory_config=L1MemoryManagerConfig(
++            size_in_bytes=POOL_BYTES,
++            use_lazy=False,
++            init_size_in_bytes=POOL_BYTES,
++            align_bytes=0x1000,
++        ),
++        write_ttl_seconds=600,
++        read_ttl_seconds=300,
++    )
++    manager = L1Manager(config)
++    yield manager
++    manager.close()
++
++
++def _make_controller(
++    l1_manager: L1Manager,
++    adapter: FakeSyncStoreAdapter,
++    **config_kwargs,
++) -> L1EvictionController:
++    config = EvictionConfig(eviction_policy="LRU", **config_kwargs)
++    return L1EvictionController(
++        l1_manager=l1_manager,
++        eviction_config=config,
++        l2_adapters={0: adapter},
++    )
++
++
++def _make_keys(count: int) -> list[ObjectKey]:
++    return [
++        ObjectKey(
++            chunk_hash=ObjectKey.IntHash2Bytes(i),
++            model_name="test_model",
++            kv_rank=0,
++        )
++        for i in range(count)
++    ]
++
++
++def _store_keys(l1_manager: L1Manager, keys: list[ObjectKey]) -> None:
++    result = l1_manager.reserve_write(keys, [False] * len(keys), OBJECT_LAYOUT)
++    for key in keys:
++        assert result[key][0] == L1Error.SUCCESS
++    l1_manager.finish_write(keys)
++
++
++def _readable_keys(l1_manager: L1Manager, keys: list[ObjectKey]) -> list[ObjectKey]:
++    result = l1_manager.reserve_read(keys)
++    readable = [
++        key
++        for key in keys
++        if result.get(key) is not None and result[key][0] == L1Error.SUCCESS
++    ]
++    if readable:
++        l1_manager.finish_read(readable)
++    return readable
++
++
++class TestWriteBackOnEvict:
++    def test_flush_then_delete(self, l1_manager):
++        """A durable flush deletes the batch from L1."""
++        adapter = FakeSyncStoreAdapter()
++        controller = _make_controller(l1_manager, adapter, write_back_on_evict=True)
++        keys = _make_keys(3)
++        _store_keys(l1_manager, keys)
++
++        controller.execute_eviction_action(
++            EvictionAction(keys=keys, destination=EvictionDestination.L2_CACHE)
++        )
++
++        assert adapter.stored_batches == [keys]
++        assert _readable_keys(l1_manager, keys) == []
++
++    def test_failed_flush_preserves_l1(self, l1_manager):
++        """A failed flush keeps every readable key in L1 and opens the
++        circuit breaker."""
++        adapter = FakeSyncStoreAdapter()
++        adapter.result = (False, 0, 0)
++        controller = _make_controller(l1_manager, adapter, write_back_on_evict=True)
++        keys = _make_keys(3)
++        _store_keys(l1_manager, keys)
++
++        controller.execute_eviction_action(
++            EvictionAction(keys=keys, destination=EvictionDestination.L2_CACHE)
++        )
++
++        assert _readable_keys(l1_manager, keys) == keys
++        status = controller.report_status()
++        assert status["sync_flush_failures"] == 1
++        assert status["sync_flush_backoff_seconds"] > 0.0
++
++    def test_partial_flush_preserves_l1(self, l1_manager):
++        """A partial persist is not durable; the batch stays in L1."""
++        adapter = FakeSyncStoreAdapter()
++        adapter.result = (False, 2, 1024)
++        controller = _make_controller(l1_manager, adapter, write_back_on_evict=True)
++        keys = _make_keys(3)
++        _store_keys(l1_manager, keys)
++
++        controller.execute_eviction_action(
++            EvictionAction(keys=keys, destination=EvictionDestination.L2_CACHE)
++        )
++
++        assert _readable_keys(l1_manager, keys) == keys
++
++    def test_missing_sync_adapter_fails_closed(self, l1_manager):
++        config = EvictionConfig(eviction_policy="LRU", write_back_on_evict=True)
++        controller = L1EvictionController(
++            l1_manager=l1_manager,
++            eviction_config=config,
++            l2_adapters={0: object()},
++        )
++        keys = _make_keys(2)
++        _store_keys(l1_manager, keys)
++
++        controller.execute_eviction_action(
++            EvictionAction(keys=keys, destination=EvictionDestination.L2_CACHE)
++        )
++
++        assert controller.has_l2_flush_adapter() is False
++        assert _readable_keys(l1_manager, keys) == keys
++
++    def test_reserve_read_failure_is_not_deleted(self, l1_manager, monkeypatch):
++        adapter = FakeSyncStoreAdapter()
++        controller = _make_controller(l1_manager, adapter, write_back_on_evict=True)
++        keys = _make_keys(1)
++        _store_keys(l1_manager, keys)
++        monkeypatch.setattr(
++            l1_manager,
++            "reserve_read",
++            lambda _keys: {keys[0]: (L1Error.KEY_IS_LOCKED, None)},
++        )
++
++        controller.execute_eviction_action(
++            EvictionAction(keys=keys, destination=EvictionDestination.L2_CACHE)
++        )
++
++        monkeypatch.undo()
++        assert adapter.stored_batches == []
++        assert _readable_keys(l1_manager, keys) == keys
++
++    def test_adapter_replacement_waits_for_active_flush(self, l1_manager):
++        adapter = BlockingSyncStoreAdapter()
++        controller = _make_controller(l1_manager, adapter, write_back_on_evict=True)
++        keys = _make_keys(1)
++        _store_keys(l1_manager, keys)
++        flush = threading.Thread(
++            target=lambda: controller.execute_eviction_action(
++                EvictionAction(keys=keys, destination=EvictionDestination.L2_CACHE)
++            )
++        )
++        replaced = threading.Event()
++        replace = threading.Thread(
++            target=lambda: (
++                controller.set_l2_adapters({}),
++                replaced.set(),
++            )
++        )
++
++        flush.start()
++        assert adapter.entered.wait(timeout=5.0)
++        replace.start()
++        time.sleep(0.05)
++        assert not replaced.is_set()
++
++        adapter.release.set()
++        flush.join(timeout=5.0)
++        replace.join(timeout=5.0)
++
++        assert replaced.is_set()
++        assert not flush.is_alive()
++        assert not replace.is_alive()
++
++
++class TestEmergencyEvict:
++    def test_emergency_evict_frees_bytes_via_write_back(self, l1_manager):
++        """emergency_evict_bytes flushes LRU victims to L2 and frees L1."""
++        adapter = FakeSyncStoreAdapter()
++        controller = _make_controller(l1_manager, adapter, write_back_on_evict=True)
++        keys = _make_keys(6)
++        _store_keys(l1_manager, keys)
++
++        used_before, total = l1_manager.get_memory_usage()
++        free_before = total - used_before
++
++        free_after = controller.emergency_evict_bytes(
++            free_before + 2 * 1024 * 1024, requester="test"
++        )
++
++        assert free_after > free_before
++        assert adapter.stored_batches
++        evicted = [k for batch in adapter.stored_batches for k in batch]
++        assert set(evicted) <= set(keys)
++        assert len(evicted) < len(keys)
++        # Evicted keys are gone from L1.
++        assert not set(evicted) & set(_readable_keys(l1_manager, keys))
++
++    def test_emergency_evict_noop_when_enough_free(self, l1_manager):
++        adapter = FakeSyncStoreAdapter()
++        controller = _make_controller(l1_manager, adapter, write_back_on_evict=True)
++        keys = _make_keys(2)
++        _store_keys(l1_manager, keys)
++
++        controller.emergency_evict_bytes(1024, requester="test")
++
++        assert adapter.stored_batches == []
++        assert _readable_keys(l1_manager, keys) == keys
++
++    def test_emergency_evict_skips_scan_during_backoff(self, l1_manager, monkeypatch):
++        adapter = FakeSyncStoreAdapter()
++        controller = _make_controller(l1_manager, adapter, write_back_on_evict=True)
++        keys = _make_keys(6)
++        _store_keys(l1_manager, keys)
++        controller._sync_flush_backoff_until = time.monotonic() + 60
++        monkeypatch.setattr(
++            controller._eviction_policy,
++            "get_eviction_actions",
++            lambda *args, **kwargs: pytest.fail("eviction scan should be skipped"),
++        )
++
++        used, total = l1_manager.get_memory_usage()
++        free = total - used
++        assert controller.emergency_evict_bytes(free + 1024) == free
++
++    def test_emergency_evict_has_bounded_store_wait(self, l1_manager):
++        adapter = BlockingSyncStoreAdapter()
++        controller = _make_controller(l1_manager, adapter, write_back_on_evict=True)
++        controller._EMERGENCY_FLUSH_TIMEOUT_SECONDS = 0.05
++        keys = _make_keys(6)
++        _store_keys(l1_manager, keys)
++        used, total = l1_manager.get_memory_usage()
++
++        start = time.monotonic()
++        free_after = controller.emergency_evict_bytes(total - used + 1024)
++        elapsed = time.monotonic() - start
++
++        assert adapter.entered.is_set()
++        assert elapsed < 0.5
++        assert free_after == total - used
++        assert _readable_keys(l1_manager, keys) == keys
++        status = controller.report_status()
++        assert status["sync_flush_failures"] == 0
++        assert status["sync_flush_backoff_seconds"] == 0.0
++
++
++class TestPeriodicBackupFlush:
++    def test_backup_flush_keeps_l1_copy(self, l1_manager):
++        """The periodic backup flush copies keys to L2 without deleting
++        them from L1."""
++        adapter = FakeSyncStoreAdapter()
++        controller = _make_controller(l1_manager, adapter, periodic_flush_interval=0.1)
++        keys = _make_keys(3)
++        _store_keys(l1_manager, keys)
++
++        controller.start()
++        try:
++            deadline = time.monotonic() + 5.0
++            while not adapter.stored_batches and time.monotonic() < deadline:
++                time.sleep(0.1)
++        finally:
++            controller.stop()
++
++        assert adapter.stored_batches
++        flushed = {k for batch in adapter.stored_batches for k in batch}
++        assert flushed <= set(keys)
++        assert _readable_keys(l1_manager, keys) == keys
++
++    def test_backup_batches_rotate_without_full_snapshot(self, l1_manager):
++        adapter = FakeSyncStoreAdapter()
++        controller = _make_controller(l1_manager, adapter)
++        keys = _make_keys(6)
++        _store_keys(l1_manager, keys)
++
++        for _ in range(3):
++            controller._backup_to_l2_no_delete(batch_limit=2)
++
++        assert [len(batch) for batch in adapter.stored_batches] == [2, 2, 2]
++        assert {key for batch in adapter.stored_batches for key in batch} == set(keys)
++
++    def test_backup_flush_has_bounded_store_wait(self, l1_manager):
++        adapter = BlockingSyncStoreAdapter()
++        controller = _make_controller(l1_manager, adapter)
++        controller._PERIODIC_FLUSH_TIMEOUT_SECONDS = 0.05
++        keys = _make_keys(2)
++        _store_keys(l1_manager, keys)
++
++        start = time.monotonic()
++        controller._backup_to_l2_no_delete(batch_limit=2)
++        elapsed = time.monotonic() - start
++
++        assert adapter.entered.is_set()
++        assert elapsed < 0.5
++        assert _readable_keys(l1_manager, keys) == keys
++
++    def test_evictable_batch_scan_wraps_and_is_bounded(self, l1_manager):
++        keys = _make_keys(5)
++        _store_keys(l1_manager, keys)
++        assert l1_manager.reserve_read([keys[0]])[keys[0]][0] == L1Error.SUCCESS
++        try:
++            first, cursor = l1_manager.get_evictable_keys(
++                limit=2,
++                cursor=0,
++                scan_limit=2,
++            )
++            second, cursor = l1_manager.get_evictable_keys(
++                limit=2,
++                cursor=cursor,
++                scan_limit=2,
++            )
++            third, _ = l1_manager.get_evictable_keys(
++                limit=2,
++                cursor=cursor,
++                scan_limit=2,
++            )
++        finally:
++            l1_manager.finish_read([keys[0]])
++
++        assert first == [keys[1]]
++        assert second == keys[2:4]
++        assert third == [keys[4]]
++
++
++class _RecordingEvictor:
++    """Eviction-controller double recording emergency_evict_bytes calls."""
++
++    def __init__(self) -> None:
++        self.calls: list[tuple[int, str]] = []
++
++    def emergency_evict_bytes(self, target_free_bytes: int, requester: str = "") -> int:
++        self.calls.append((target_free_bytes, requester))
++        return target_free_bytes
++
++
++@pytest.fixture
++def prefetch_controller(l1_manager: L1Manager) -> Iterator[PrefetchController]:
++    controller = PrefetchController(
++        l1_manager=l1_manager,
++        l2_adapters=[],
++        adapter_descriptors=[],
++        policy=DefaultPrefetchPolicy(),
++    )
++    yield controller
++    # The loop thread was never started, so stop() cannot join it.
++    controller._submission_efd.close()
++    controller._adapter_ctrl_efd.close()
++
++
++def _make_request(keys: list[ObjectKey]) -> InFlightPrefetchRequest:
++    return InFlightPrefetchRequest(
++        request_id=7,
++        keys=keys,
++        layout_desc=OBJECT_LAYOUT,
++        phase=PrefetchPhase.PLAN_AND_LOAD,
++    )
++
++
++class TestPrefetchMakeRoom:
++    def test_make_room_asks_evictor_when_short(self, l1_manager, prefetch_controller):
++        """A restore that does not fit in free L1 asks for eviction."""
++        controller = prefetch_controller
++        evictor = _RecordingEvictor()
++        controller.set_l1_eviction_controller(evictor)
++        resident = _make_keys(6)
++        _store_keys(l1_manager, resident)
++
++        restore_keys = [
++            ObjectKey(
++                chunk_hash=ObjectKey.IntHash2Bytes(100 + i),
++                model_name="test_model",
++                kv_rank=0,
++            )
++            for i in range(4)
++        ]
++        controller._make_room_for_restore(_make_request(restore_keys), restore_keys)
++
++        assert len(evictor.calls) == 1
++        target, requester = evictor.calls[0]
++        assert target > 0
++        assert "prefetch_request=7" in requester
++
++    def test_make_room_noop_when_space_available(self, l1_manager, prefetch_controller):
++        controller = prefetch_controller
++        evictor = _RecordingEvictor()
++        controller.set_l1_eviction_controller(evictor)
++
++        keys = _make_keys(2)
++        controller._make_room_for_restore(_make_request(keys), keys)
++
++        assert evictor.calls == []
++
++    def test_make_room_noop_without_evictor(self, l1_manager, prefetch_controller):
++        controller = prefetch_controller
++        keys = _make_keys(2)
++
++        controller._make_room_for_restore(_make_request(keys), keys)
++
++    def test_eviction_controller_can_be_disconnected(self, prefetch_controller):
++        evictor = _RecordingEvictor()
++        prefetch_controller.set_l1_eviction_controller(evictor)
++        prefetch_controller.set_l1_eviction_controller(None)
++
++        assert prefetch_controller._l1_eviction_controller is None
++
++    def test_short_retention_policy_degrades_to_temporary(
++        self, prefetch_controller, monkeypatch
++    ):
++        keys = _make_keys(3)
++        monkeypatch.setattr(
++            prefetch_controller._policy,
++            "select_l1_retentions",
++            lambda _keys: [True],
++        )
++
++        assert prefetch_controller._select_l1_retentions(7, keys) == [
++            False,
++            False,
++            False,
++        ]
++
++    def test_retry_recovers_oom_reservations(self, l1_manager, prefetch_controller):
++        """OOM reservations are retried once after emergency eviction."""
++        controller = prefetch_controller
++        evictor = _RecordingEvictor()
++        controller.set_l1_eviction_controller(evictor)
++        keys = _make_keys(2)
++        write_results = {key: (L1Error.OUT_OF_MEMORY, None) for key in keys}
++
++        merged = controller._retry_oom_reservations(
++            _make_request(keys), keys, [True, True], write_results
++        )
++
++        assert len(evictor.calls) == 1
++        for key in keys:
++            err, mem_obj = merged[key]
++            assert err == L1Error.SUCCESS
++            assert mem_obj is not None
++        l1_manager.finish_write(keys)
++
++    def test_retry_noop_when_all_reserved(self, l1_manager, prefetch_controller):
++        controller = prefetch_controller
++        evictor = _RecordingEvictor()
++        controller.set_l1_eviction_controller(evictor)
++        keys = _make_keys(2)
++        result = l1_manager.reserve_write(keys, [False, False], OBJECT_LAYOUT)
++
++        merged = controller._retry_oom_reservations(
++            _make_request(keys), keys, [True, True], result
++        )
++
++        assert evictor.calls == []
++        assert merged is result
++        l1_manager.finish_write(keys)
++
++
++class TestConfigPlumbing:
++    def test_parser_populates_write_back_fields(self):
++        parser = argparse.ArgumentParser()
++        add_storage_manager_args(parser)
++        add_observability_args(parser)
++        args = parser.parse_args(
++            [
++                "--l1-size-gb",
++                "1",
++                "--eviction-policy",
++                "LRU",
++                "--write-back-on-evict",
++                "--periodic-flush-interval",
++                "30.0",
++                "--emergency-evict-for-prefetch",
++            ]
++        )
++        config = parse_args_to_config(args)
++        assert config.eviction_config.write_back_on_evict is True
++        assert config.eviction_config.periodic_flush_interval == 30.0
++        assert config.eviction_config.emergency_evict_for_prefetch is True
++
++    def test_defaults_are_disabled(self):
++        parser = argparse.ArgumentParser()
++        add_storage_manager_args(parser)
++        add_observability_args(parser)
++        args = parser.parse_args(["--l1-size-gb", "1", "--eviction-policy", "LRU"])
++        config = parse_args_to_config(args)
++        assert config.eviction_config.write_back_on_evict is False
++        assert config.eviction_config.periodic_flush_interval == 0.0
++        assert config.eviction_config.emergency_evict_for_prefetch is False
++
++    @pytest.mark.parametrize(
++        "eviction_config",
++        [
++            EvictionConfig(
++                eviction_policy="LRU",
++                periodic_flush_interval=-1.0,
++            ),
++            EvictionConfig(
++                eviction_policy="LRU",
++                emergency_evict_for_prefetch=True,
++            ),
++        ],
++    )
++    def test_invalid_writeback_config_is_rejected(self, eviction_config):
++        with pytest.raises(ValueError):
++            StorageManagerConfig(
++                l1_manager_config=L1ManagerConfig(
++                    memory_config=L1MemoryManagerConfig(
++                        size_in_bytes=POOL_BYTES,
++                        use_lazy=False,
++                    )
++                ),
++                eviction_config=eviction_config,
++            )
+diff --git a/tests/v1/distributed/test_native_connector_l2_adapter.py b/tests/v1/distributed/test_native_connector_l2_adapter.py
+index dc16cdd1ae0161bf2306759cd2b72614a93c83fc..ff992bee7592a1814c760dea510728e8c96a850b 100644
+--- a/tests/v1/distributed/test_native_connector_l2_adapter.py
++++ b/tests/v1/distributed/test_native_connector_l2_adapter.py
+@@ -10,6 +10,7 @@ C++ IStorageConnector interface, so no Redis or C++ build is needed.
+ import ctypes
+ import select
+ import threading
++import time
+ 
+ # Third Party
+ import pytest
+@@ -56,6 +57,9 @@ class MockNativeConnector:
+         self._completions: list[tuple[int, bool, str, list[bool] | None]] = []
+         self._lock = threading.Lock()
+         self._closed = False
++        self.report_set_per_key_results = True
++        self.fail_set_keys: set[str] = set()
++        self.suppress_set_completion = False
+ 
+     def event_fd(self) -> int:
+         return self._efd.fileno()
+@@ -66,9 +70,21 @@ class MockNativeConnector:
+             self._next_id += 1
+ 
+         try:
++            results = []
+             for key, mv in zip(keys, memoryviews, strict=False):
++                if key in self.fail_set_keys:
++                    results.append(False)
++                    continue
+                 self._store[key] = bytes(mv)
+-            self._push_completion(fid, True, "", None)
++                results.append(True)
++            ok = all(results)
++            if not self.suppress_set_completion:
++                self._push_completion(
++                    fid,
++                    ok,
++                    "" if ok else "injected set failure",
++                    results if self.report_set_per_key_results else None,
++                )
+         except Exception as e:
+             self._push_completion(fid, False, str(e), None)
+ 
+@@ -155,6 +171,27 @@ class MockNativeConnector:
+             pass
+ 
+ 
++class DeferredExistsConnector(MockNativeConnector):
++    """Hold EXISTS completion to expose the submit-to-lock race window."""
++
++    def __init__(self):
++        super().__init__()
++        self.pending_exists: tuple[int, list[str]] | None = None
++
++    def submit_batch_exists(self, keys: list[str]) -> int:
++        with self._lock:
++            fid = self._next_id
++            self._next_id += 1
++        self.pending_exists = (fid, list(keys))
++        return fid
++
++    def complete_exists(self) -> None:
++        assert self.pending_exists is not None
++        fid, keys = self.pending_exists
++        self.pending_exists = None
++        self._push_completion(fid, True, "", [key in self._store for key in keys])
++
++
+ # =============================================================================
+ # Test Fixtures
+ # =============================================================================
+@@ -203,6 +240,14 @@ def adapter():
+     adp.close()
+ 
+ 
++@pytest.fixture
++def adapter_and_mock():
++    mock_client = MockNativeConnector()
++    adp = NativeConnectorL2Adapter(mock_client)
++    yield adp, mock_client
++    adp.close()
++
++
+ # =============================================================================
+ # ObjectKey Serialization Tests
+ # =============================================================================
+@@ -1182,6 +1227,91 @@ class TestDeleteInterface:
+     def test_delete_empty_keys(self, adapter):
+         adapter.delete([])  # should not raise
+ 
++    def test_delete_skips_lookup_locked_keys(self, adapter):
++        """Keys lookup-locked by an in-flight prefetch survive delete();
++        unlocked keys in the same batch are still deleted, and the locked
++        key becomes deletable again after unlock."""
++        keys = [create_object_key(i) for i in range(2)]
++        objs = [create_memory_obj(fill_value=float(i)) for i in range(2)]
++        store_fd = adapter.get_store_event_fd()
++        lookup_fd = adapter.get_lookup_and_lock_event_fd()
++
++        adapter.submit_store_task(keys, objs)
++        wait_for_event_fd(store_fd, timeout=5.0)
++        adapter.pop_completed_store_tasks()
++
++        # An in-flight prefetch holds a lookup lock on keys[0].
++        task_id = adapter.submit_lookup_and_lock_task([keys[0]], _EMPTY_LAYOUT)
++        wait_for_event_fd(lookup_fd, timeout=5.0)
++        bitmap = adapter.query_lookup_and_lock_result(task_id)
++        assert bitmap.test(0) is True
++
++        adapter.delete(keys)
++
++        # keys[0] survived, keys[1] is gone. This lookup takes another
++        # lock on keys[0].
++        task_id = adapter.submit_lookup_and_lock_task(keys, _EMPTY_LAYOUT)
++        wait_for_event_fd(lookup_fd, timeout=5.0)
++        bitmap = adapter.query_lookup_and_lock_result(task_id)
++        assert bitmap.test(0) is True
++        assert bitmap.test(1) is False
++
++        # Release both locks; the key is deletable again.
++        adapter.submit_unlock([keys[0]])
++        adapter.submit_unlock([keys[0]])
++        adapter.delete([keys[0]])
++
++        task_id = adapter.submit_lookup_and_lock_task([keys[0]], _EMPTY_LAYOUT)
++        wait_for_event_fd(lookup_fd, timeout=5.0)
++        bitmap = adapter.query_lookup_and_lock_result(task_id)
++        assert bitmap.test(0) is False
++
++    def test_delete_all_keys_locked_is_noop(self, adapter):
++        """delete() returns without submitting when every key is locked."""
++        key = create_object_key(1)
++        obj = create_memory_obj()
++        store_fd = adapter.get_store_event_fd()
++        lookup_fd = adapter.get_lookup_and_lock_event_fd()
++
++        adapter.submit_store_task([key], [obj])
++        wait_for_event_fd(store_fd, timeout=5.0)
++        adapter.pop_completed_store_tasks()
++
++        task_id = adapter.submit_lookup_and_lock_task([key], _EMPTY_LAYOUT)
++        wait_for_event_fd(lookup_fd, timeout=5.0)
++        assert adapter.query_lookup_and_lock_result(task_id).test(0) is True
++
++        adapter.delete([key])
++
++        task_id = adapter.submit_lookup_and_lock_task([key], _EMPTY_LAYOUT)
++        wait_for_event_fd(lookup_fd, timeout=5.0)
++        assert adapter.query_lookup_and_lock_result(task_id).test(0) is True
++        adapter.submit_unlock([key])
++        adapter.submit_unlock([key])
++
++    def test_delete_skips_lookup_that_has_not_completed(self):
++        """Eviction cannot enter between lookup submission and lock acquire."""
++        client = DeferredExistsConnector()
++        adapter = NativeConnectorL2Adapter(client)
++        key = create_object_key(1)
++        obj = create_memory_obj()
++
++        try:
++            adapter.submit_store_task([key], [obj])
++            wait_for_event_fd(adapter.get_store_event_fd(), timeout=5.0)
++            adapter.pop_completed_store_tasks()
++
++            task_id = adapter.submit_lookup_and_lock_task([key], _EMPTY_LAYOUT)
++            adapter.delete([key])
++            assert _object_key_to_string(key) in client._store
++
++            client.complete_exists()
++            wait_for_event_fd(adapter.get_lookup_and_lock_event_fd(), timeout=5.0)
++            assert adapter.query_lookup_and_lock_result(task_id).test(0) is True
++            adapter.submit_unlock([key])
++        finally:
++            adapter.close()
++
+     def test_delete_batch(self, adapter):
+         keys = [create_object_key(i) for i in range(5)]
+         objs = [create_memory_obj(fill_value=float(i)) for i in range(5)]
+@@ -1294,7 +1424,6 @@ class TestUsageTracking:
+         # 400 bytes / 2000 bytes = 0.2
+         assert usage.usage_fraction == pytest.approx(0.2)
+         assert usage.total_bytes_used == 400
+-
+     def test_get_usage_after_delete(self, adapter_with_capacity):
+         adp = adapter_with_capacity
+         store_fd = adp.get_store_event_fd()
+@@ -1358,3 +1487,136 @@ class TestUsageTracking:
+         usage = adp.get_usage()
+         assert usage.usage_fraction == pytest.approx(0.2)
+         assert usage.total_bytes_used == 400
++
++
++# =============================================================================
++# Durable Store Tests
++# =============================================================================
++
++
++class _BlockingStoreListener:
++    def __init__(self):
++        self.entered = threading.Event()
++        self.release = threading.Event()
++
++    def on_l2_keys_stored(self, keys, sizes) -> None:
++        self.entered.set()
++        assert self.release.wait(timeout=5.0)
++
++
++class TestStoreObjectsSync:
++    def test_success_uses_private_completion(self, adapter):
++        keys = [create_object_key(i) for i in range(2)]
++        objs = [create_memory_obj(fill_value=float(i)) for i in range(2)]
++
++        ok, persisted, bytes_written = adapter.store_objects_sync(keys, objs)
++
++        assert ok is True
++        assert persisted == 2
++        assert bytes_written == sum(obj.get_size() for obj in objs)
++        assert adapter.get_usage().total_bytes_used == bytes_written
++        assert adapter.pop_completed_store_tasks() == {}
++
++    def test_partial_failure_accounts_only_persisted_keys(self, adapter_and_mock):
++        adapter, mock_client = adapter_and_mock
++        keys = [create_object_key(i) for i in range(2)]
++        objs = [create_memory_obj(fill_value=float(i)) for i in range(2)]
++        mock_client.fail_set_keys = {_object_key_to_string(keys[1])}
++
++        ok, persisted, bytes_written = adapter.store_objects_sync(keys, objs)
++
++        assert ok is False
++        assert persisted == 1
++        assert bytes_written == objs[0].get_size()
++        assert adapter.get_usage().total_bytes_used == objs[0].get_size()
++
++    def test_async_partial_failure_uses_per_key_results(self, adapter_and_mock):
++        adapter, mock_client = adapter_and_mock
++        keys = [create_object_key(i) for i in range(2)]
++        objs = [create_memory_obj(fill_value=float(i)) for i in range(2)]
++        mock_client.fail_set_keys = {_object_key_to_string(keys[1])}
++
++        task_id = adapter.submit_store_task(keys, objs)
++        assert wait_for_event_fd(adapter.get_store_event_fd(), timeout=5.0)
++
++        result = adapter.pop_completed_store_tasks()[task_id]
++        assert result.is_successful() is False
++        assert adapter.get_usage().total_bytes_used == objs[0].get_size()
++
++    def test_batch_fallback_without_per_key_results(self, adapter_and_mock):
++        adapter, mock_client = adapter_and_mock
++        mock_client.report_set_per_key_results = False
++        keys = [create_object_key(i) for i in range(2)]
++        objs = [create_memory_obj(fill_value=float(i)) for i in range(2)]
++
++        ok, persisted, bytes_written = adapter.store_objects_sync(keys, objs)
++
++        assert ok is True
++        assert persisted == 2
++        assert bytes_written == sum(obj.get_size() for obj in objs)
++
++    def test_validates_inputs(self, adapter):
++        with pytest.raises(ValueError, match="length mismatch"):
++            adapter.store_objects_sync([create_object_key(1)], [])
++        with pytest.raises(ValueError, match="timeout must be positive"):
++            adapter.store_objects_sync(
++                [create_object_key(1)], [create_memory_obj()], timeout=0
++            )
++        assert adapter.store_objects_sync([], []) == (True, 0, 0)
++
++    def test_real_timeout_cleans_pending_operation(self, adapter_and_mock):
++        adapter, mock_client = adapter_and_mock
++        mock_client.suppress_set_completion = True
++
++        result = adapter.store_objects_sync(
++            [create_object_key(1)], [create_memory_obj()], timeout=0.05
++        )
++
++        assert result == (False, 0, 0)
++        assert adapter._pending_sync_store_events == {}
++        assert adapter._pending_ops == {}
++
++    def test_completion_at_timeout_does_not_wait_for_observer(self, adapter):
++        listener = _BlockingStoreListener()
++        adapter.register_listener(listener)
++        result = []
++        worker = threading.Thread(
++            target=lambda: result.append(
++                adapter.store_objects_sync(
++                    [create_object_key(1)],
++                    [create_memory_obj()],
++                    timeout=0.05,
++                )
++            )
++        )
++        worker.start()
++        assert listener.entered.wait(timeout=5.0)
++        time.sleep(0.1)
++        assert not worker.is_alive()
++        assert result[0][0] is True
++        assert adapter.get_usage().total_bytes_used == result[0][2]
++
++        listener.release.set()
++        worker.join(timeout=5.0)
++
++        assert not worker.is_alive()
++
++    def test_close_unblocks_waiter(self, adapter_and_mock):
++        adapter, mock_client = adapter_and_mock
++        mock_client.suppress_set_completion = True
++        result = []
++        worker = threading.Thread(
++            target=lambda: result.append(
++                adapter.store_objects_sync(
++                    [create_object_key(1)], [create_memory_obj()], timeout=10.0
++                )
++            )
++        )
++        worker.start()
++        time.sleep(0.05)
++
++        adapter.close()
++        worker.join(timeout=5.0)
++
++        assert not worker.is_alive()
++        assert result == [(False, 0, 0)]
+diff --git a/tests/v1/distributed/test_native_connector_restart_accounting.py b/tests/v1/distributed/test_native_connector_restart_accounting.py
+new file mode 100644
+index 0000000000000000000000000000000000000000..dc5d6c68c3fcb236bafd2bfdf9a2b8c9582e00d8
+--- /dev/null
++++ b/tests/v1/distributed/test_native_connector_restart_accounting.py
+@@ -0,0 +1,66 @@
++# SPDX-License-Identifier: Apache-2.0
++"""Restart accounting behavior shared by native L2 connectors."""
++
++# Third Party
++import pytest
++
++# First Party
++from tests.v1.distributed.test_native_connector_l2_adapter import (
++    adapter,
++    create_object_key,
++)
++
++
++class _RecordingL2Listener:
++    def __init__(self):
++        self.stored = []
++
++    def on_l2_keys_stored(self, keys, sizes) -> None:
++        self.stored.append((list(keys), list(sizes)))
++
++
++class TestPrimeExistingKeys:
++    def test_priming_accounts_deduplicated_usage(self, adapter):
++        key = create_object_key(1)
++
++        adapter.prime_existing_keys([key, key], [100, 999])
++
++        assert adapter.get_usage().total_bytes_used == 100
++        assert adapter._key_sizes == {key: 100}
++
++    def test_first_listener_receives_startup_snapshot_once(self, adapter):
++        keys = [create_object_key(1), create_object_key(2)]
++        adapter.prime_existing_keys(keys, [100, 200])
++        first = _RecordingL2Listener()
++        second = _RecordingL2Listener()
++
++        adapter.register_listener(first)
++        adapter.register_listener(second)
++
++        assert first.stored == [(keys, [100, 200])]
++        assert second.stored == []
++        assert adapter.get_usage().total_bytes_used == 300
++
++    def test_empty_snapshot_is_consumed_without_callback(self, adapter):
++        adapter.prime_existing_keys([], [])
++        listener = _RecordingL2Listener()
++
++        adapter.register_listener(listener)
++
++        assert listener.stored == []
++
++    def test_rejects_invalid_or_repeated_priming(self, adapter):
++        with pytest.raises(ValueError, match="length mismatch"):
++            adapter.prime_existing_keys([create_object_key(1)], [1, 2])
++        with pytest.raises(ValueError, match="must be positive"):
++            adapter.prime_existing_keys([create_object_key(1)], [0])
++
++        adapter.prime_existing_keys([], [])
++        with pytest.raises(RuntimeError, match="already primed"):
++            adapter.prime_existing_keys([], [])
++
++    def test_rejects_priming_after_listener_registration(self, adapter):
++        adapter.register_listener(_RecordingL2Listener())
++
++        with pytest.raises(RuntimeError, match="before listeners"):
++            adapter.prime_existing_keys([], [])
+diff --git a/tests/v1/distributed/test_native_fs_connector_results.py b/tests/v1/distributed/test_native_fs_connector_results.py
+new file mode 100644
+index 0000000000000000000000000000000000000000..458fcf0edfcf8a04ab13a4431248640e557cb8c3
+--- /dev/null
++++ b/tests/v1/distributed/test_native_fs_connector_results.py
+@@ -0,0 +1,54 @@
++# SPDX-License-Identifier: Apache-2.0
++"""Native FS connector completion semantics.
++
++These tests exercise the compiled extension. They are skipped when the
++optional native FS module is not part of the test environment.
++"""
++
++# Standard
++import select
++import time
++
++# Third Party
++import pytest
++
++lmcache_fs = pytest.importorskip("lmcache.lmcache_fs")
++
++
++def _wait_for_completion(client, timeout: float = 5.0):
++    poller = select.poll()
++    poller.register(client.event_fd(), select.POLLIN)
++    deadline = time.monotonic() + timeout
++    while time.monotonic() < deadline:
++        if poller.poll(50):
++            completions = client.drain_completions()
++            if completions:
++                return completions
++    raise AssertionError("native connector completion timed out")
++
++
++def test_batch_set_reports_partial_results_and_continues(tmp_path):
++    client = lmcache_fs.LMCacheFSClient(str(tmp_path), 1)
++    try:
++        buffers = [bytearray(b"first"), bytearray(b"bad"), bytearray(b"last")]
++        keys = [
++            "model@00000000@01",
++            "malformed-key",
++            "model@00000000@03",
++        ]
++
++        future_id = client.submit_batch_set(
++            keys,
++            [memoryview(buffer) for buffer in buffers],
++        )
++        completions = _wait_for_completion(client)
++
++        assert len(completions) == 1
++        completed_id, ok, error, results = completions[0]
++        assert completed_id == future_id
++        assert ok is False
++        assert "partially failed" in error
++        assert results == [True, False, True]
++        assert len(list(tmp_path.glob("*.data"))) == 2
++    finally:
++        client.close()
+diff --git a/tests/v1/distributed/test_native_fs_key_compatibility.py b/tests/v1/distributed/test_native_fs_key_compatibility.py
+new file mode 100644
+index 0000000000000000000000000000000000000000..d18fba4e8f8c662a3826f1a8182ac681ca9a0584
+--- /dev/null
++++ b/tests/v1/distributed/test_native_fs_key_compatibility.py
+@@ -0,0 +1,55 @@
++# SPDX-License-Identifier: Apache-2.0
++"""ObjectKey compatibility of the compiled native FS connector."""
++
++# Standard
++import select
++import time
++
++# Third Party
++import pytest
++
++lmcache_fs = pytest.importorskip("lmcache.lmcache_fs")
++
++
++def _wait_for_completion(client, timeout: float = 5.0):
++    poller = select.poll()
++    poller.register(client.event_fd(), select.POLLIN)
++    deadline = time.monotonic() + timeout
++    while time.monotonic() < deadline:
++        if poller.poll(50):
++            completions = client.drain_completions()
++            if completions:
++                return completions[0]
++    raise AssertionError("native connector completion timed out")
++
++
++@pytest.mark.parametrize(
++    ("wire_key", "filename"),
++    [
++        ("model@00000000@aabb", "model@0x00000000@aabb.data"),
++        (
++            "model@00000000@aabb@salt",
++            "model@0x00000000@aabb@salt.data",
++        ),
++        (
++            "model@00000000@2@aabb",
++            "model@0x00000000@2@aabb.data",
++        ),
++        (
++            "model@00000000@2@aabb@salt",
++            "model@0x00000000@2@aabb@salt.data",
++        ),
++    ],
++)
++def test_legacy_and_current_key_shapes(wire_key, filename, tmp_path):
++    client = lmcache_fs.LMCacheFSClient(str(tmp_path), 1)
++    try:
++        payload = bytearray(b"payload")
++        future_id = client.submit_batch_set([wire_key], [memoryview(payload)])
++        completed_id, ok, error, _results = _wait_for_completion(client)
++
++        assert completed_id == future_id
++        assert ok, error
++        assert (tmp_path / filename).read_bytes() == payload
++    finally:
++        client.close()
+diff --git a/tests/v1/distributed/test_native_fs_odirect.py b/tests/v1/distributed/test_native_fs_odirect.py
+new file mode 100644
+index 0000000000000000000000000000000000000000..1d5118eca102011208e580b447f3d034cb8afd13
+--- /dev/null
++++ b/tests/v1/distributed/test_native_fs_odirect.py
+@@ -0,0 +1,80 @@
++# SPDX-License-Identifier: Apache-2.0
++"""O_DIRECT behavior of the compiled native FS connector."""
++
++# Standard
++import ctypes
++import select
++import time
++
++# Third Party
++import pytest
++
++lmcache_fs = pytest.importorskip("lmcache.lmcache_fs")
++
++
++def _aligned_view(size: int, alignment: int = 4096):
++    storage = bytearray(size + alignment)
++    address = ctypes.addressof(ctypes.c_char.from_buffer(storage))
++    offset = (-address) % alignment
++    return storage, memoryview(storage)[offset : offset + size]
++
++
++def _wait_for_completion(client, timeout: float = 5.0):
++    poller = select.poll()
++    poller.register(client.event_fd(), select.POLLIN)
++    deadline = time.monotonic() + timeout
++    while time.monotonic() < deadline:
++        if poller.poll(50):
++            completions = client.drain_completions()
++            if completions:
++                return completions[0]
++    raise AssertionError("native connector completion timed out")
++
++
++def test_odirect_falls_back_for_misaligned_buffer_address(tmp_path):
++    client = lmcache_fs.LMCacheFSClient(str(tmp_path), 1, "", True)
++    try:
++        payload_storage = bytearray(4097)
++        payload = memoryview(payload_storage)[1:]
++        payload[:] = b"x" * len(payload)
++        key = "model@00000000@01"
++
++        store_id = client.submit_batch_set([key], [payload])
++        completed_id, ok, error, _results = _wait_for_completion(client)
++        assert completed_id == store_id
++        assert ok, error
++
++        loaded_storage = bytearray(4097)
++        loaded = memoryview(loaded_storage)[1:]
++        load_id = client.submit_batch_get([key], [loaded])
++        completed_id, ok, error, results = _wait_for_completion(client)
++        assert completed_id == load_id
++        assert ok, error
++        assert results == [True]
++        assert loaded == payload
++    finally:
++        client.close()
++
++
++def test_odirect_falls_back_for_misaligned_readahead_split(tmp_path):
++    client = lmcache_fs.LMCacheFSClient(str(tmp_path), 1, "", True, 4095)
++    try:
++        payload_storage, payload = _aligned_view(8192)
++        payload[:] = b"x" * len(payload)
++        key = "model@00000000@02"
++
++        store_id = client.submit_batch_set([key], [payload])
++        completed_id, ok, error, _results = _wait_for_completion(client)
++        assert completed_id == store_id
++        assert ok, error
++
++        loaded_storage, loaded = _aligned_view(8192)
++        load_id = client.submit_batch_get([key], [loaded])
++        completed_id, ok, error, results = _wait_for_completion(client)
++        assert completed_id == load_id
++        assert ok, error
++        assert results == [True]
++        assert loaded == payload
++        del payload_storage, loaded_storage
++    finally:
++        client.close()
+diff --git a/tests/v1/distributed/test_prefetch_controller.py b/tests/v1/distributed/test_prefetch_controller.py
+index 09c06c5819646d20d65485ee446793a1a9a7f9d0..e86ac177a07f19f54bb6417858dea1d4ff116cfd 100644
+--- a/tests/v1/distributed/test_prefetch_controller.py
++++ b/tests/v1/distributed/test_prefetch_controller.py
+@@ -35,6 +35,9 @@ from lmcache.v1.distributed.l2_adapters.mock_l2_adapter import (
+     MockL2Adapter,
+     MockL2AdapterConfig,
+ )
++from lmcache.v1.distributed.storage_controllers import (
++    prefetch_controller as prefetch_controller_module,
++)
+ from lmcache.v1.distributed.storage_controllers.prefetch_controller import (
+     PrefetchController,
+     build_trim_mask,
+@@ -363,7 +366,7 @@ class TestSingleAdapterPrefetch:
+         ctrl.stop()
+         adapter.close()
+ 
+-    def test_fault_inject_load_gap_segmented_vs_prefix(self, l1_manager):
++    def test_fault_inject_load_gap_segmented_vs_prefix(self, l1_manager, monkeypatch):
+         """fault_inject (load fails at index 2) drives the segmented path.
+ 
+         Lookup reports all 5 keys present; the *load* of index 2 fails (the L2
+@@ -371,6 +374,14 @@ class TestSingleAdapterPrefetch:
+         post-gap keys {0,1,3,4}; PREFIX truncates at the hole to {0,1}. Distinct
+         key ranges per policy keep the shared L1 from serving the second pass.
+         """
++        warning_messages: list[str] = []
++
++        def capture_warning(message, *args, **_kwargs):
++            warning_messages.append(message % args)
++
++        monkeypatch.setattr(
++            prefetch_controller_module.logger, "warning", capture_warning
++        )
+         layout = make_layout()
+         for base, trim, expected in (
+             (0, TrimPolicy.SEGMENTED_PREFIX, [0, 1, 3, 4]),
+@@ -402,6 +413,11 @@ class TestSingleAdapterPrefetch:
+             ctrl.stop()
+             fault.close()
+ 
++        assert any(
++            "1/5 plan keys failed to load from L2" in message and "sample:" in message
++            for message in warning_messages
++        )
++
+     def test_key0_missing(self, l1_manager):
+         """L2 has keys {1,2,3} but not 0 → prefix = 0, nothing loaded."""
+         adapter = make_adapter()
+diff --git a/tests/v1/multiprocess/test_futures.py b/tests/v1/multiprocess/test_futures.py
+index 53cf694bc5c29ee852c5511d2753b6a8a676511a..c9086609ec879d9ed6fcceab478da9c5c7117d49 100644
+--- a/tests/v1/multiprocess/test_futures.py
++++ b/tests/v1/multiprocess/test_futures.py
+@@ -173,6 +173,27 @@ def test_messaging_future_complex_type():
+     thread.join()
+ 
+ 
++def test_messaging_future_exception_is_re_raised():
++    """A remote messaging failure completes the future instead of hanging it."""
++    future = MessagingFuture[int]()
++    error = RuntimeError("remote operation failed")
++
++    future.set_exception(error)
++
++    assert future.query()
++    assert future.wait(timeout=0.1)
++    with pytest.raises(RuntimeError, match="remote operation failed") as exc_info:
++        future.result(timeout=0.1)
++    assert exc_info.value is error
++
++
++def test_messaging_future_rejects_non_exception():
++    future = MessagingFuture[int]()
++
++    with pytest.raises(TypeError, match="must derive from BaseException"):
++        future.set_exception("not an exception")  # type: ignore[arg-type]
++
++
+ # ==============================================================================
+ # CUDAMessagingFuture Tests
+ # ==============================================================================
+diff --git a/tests/v1/multiprocess/test_mq.py b/tests/v1/multiprocess/test_mq.py
+index 75ff9cd7a0630391f0515622e36e1f38fe243764..93ef515bfc0c3a66feda76720178b2dd140a7211 100644
+--- a/tests/v1/multiprocess/test_mq.py
++++ b/tests/v1/multiprocess/test_mq.py
+@@ -21,6 +21,7 @@ from lmcache.v1.multiprocess.mq import (
+     BlockingRequestHandler,
+     MessageQueueClient,
+     MessageQueueServer,
++    RemoteHandlerError,
+ )
+ from lmcache.v1.multiprocess.protocol import (
+     RequestType,
+@@ -683,6 +684,58 @@ def test_shared_loop_dispatch():
+         server.close()
+ 
+ 
++def test_sync_handler_failure_completes_future_and_loop_recovers():
++    context = zmq.Context.instance()
++    server = MessageQueueServer("tcp://127.0.0.1:16021", context)
++    add_handler_helper(
++        server, RequestType.NOOP, test_mq_handler_helpers.failing_noop_handler
++    )
++    server.start()
++    client = MessageQueueClient("tcp://127.0.0.1:16021", context)
++
++    try:
++        failed = client.submit_request(RequestType.NOOP, [])
++        with pytest.raises(
++            RemoteHandlerError, match="intentional sync handler failure"
++        ) as exc_info:
++            failed.result(timeout=2)
++        assert exc_info.value.request_type is RequestType.NOOP
++        assert exc_info.value.error_type == "ValueError"
++
++        server.add_sync_handler(
++            RequestType.NOOP, [], test_mq_handler_helpers.noop_handler
++        )
++        assert (
++            client.submit_request(RequestType.NOOP, []).result(timeout=2) == "NOOP_OK"
++        )
++    finally:
++        client.close()
++        server.close()
++
++
++def test_blocking_handler_failure_completes_future():
++    context = zmq.Context.instance()
++    server = MessageQueueServer("tcp://127.0.0.1:16022", context)
++    add_handler_helper(
++        server, RequestType.LOOKUP, test_mq_handler_helpers.failing_lookup_handler
++    )
++    server.add_normal_thread_pool([RequestType.LOOKUP], max_workers=1)
++    server.start()
++    client = MessageQueueClient("tcp://127.0.0.1:16022", context)
++
++    try:
++        future = client.submit_request(RequestType.LOOKUP, [create_cache_key(1), 1])
++        with pytest.raises(
++            RemoteHandlerError, match="intentional blocking handler failure"
++        ) as exc_info:
++            future.result(timeout=2)
++        assert exc_info.value.request_type is RequestType.LOOKUP
++        assert exc_info.value.error_type == "OSError"
++    finally:
++        client.close()
++        server.close()
++
++
+ def test_shared_loop_recreate():
+     """
+     Test that closing all clients and creating new ones starts a fresh loop.
+diff --git a/tests/v1/multiprocess/test_mq_handler_helpers.py b/tests/v1/multiprocess/test_mq_handler_helpers.py
+index b1d65251d3fd0a615bc256fb483cf78a4a8ef16e..9837df531ef7414473af86834bc63afcb7f842c0 100644
+--- a/tests/v1/multiprocess/test_mq_handler_helpers.py
++++ b/tests/v1/multiprocess/test_mq_handler_helpers.py
+@@ -29,6 +29,11 @@ def noop_handler() -> str:
+     return "NOOP_OK"
+ 
+ 
++def failing_noop_handler() -> str:
++    """Raise a deterministic error for RPC error propagation tests."""
++    raise ValueError("intentional sync handler failure")
++
++
+ # ==============================================================================
+ # REGISTER_KV_CACHE Request Handlers
+ # ==============================================================================
+@@ -203,6 +208,12 @@ def lookup_handler(key: KeyType, tp_size: int) -> None:
+     assert isinstance(tp_size, int), f"Expected tp_size to be int, got {type(tp_size)}"
+ 
+ 
++def failing_lookup_handler(key: KeyType, tp_size: int) -> None:
++    """Raise a deterministic error from a blocking request handler."""
++    del key, tp_size
++    raise OSError("intentional blocking handler failure")
++
++
+ # ==============================================================================
+ # FREE_LOOKUP_LOCKS Request Handlers
+ # ==============================================================================
+diff --git a/tests/v1/test_vllm_mp_adapter.py b/tests/v1/test_vllm_mp_adapter.py
+index d64ca9ec7061a0714cba7c9c488e3fb0cef9179a..ddf180a64dd9e6b9d8f4af4114324bc927fbf12f 100644
+--- a/tests/v1/test_vllm_mp_adapter.py
++++ b/tests/v1/test_vllm_mp_adapter.py
+@@ -782,3 +782,65 @@ def test_recover_callback_rebuilds_transfer_ctx_without_closing_previous(
+     assert len(contexts) == 3
+     assert adapter.transfer_ctx is contexts[2]
+     contexts[1].close.assert_not_called()
++
++
++def _finished_retrieve_future(result: object) -> MagicMock:
++    """Build a completed retrieve future; an Exception *result* makes
++    ``result()`` raise it."""
++    future = MagicMock(name="retrieve_future")
++    future.query.return_value = True
++    if isinstance(result, Exception):
++        future.result.side_effect = result
++    else:
++        future.result.return_value = result
++    return future
++
++
++def test_failed_retrieve_marks_blocks_invalid(fake_adapter) -> None:
++    """A retrieve the healthy server answers with ``result=False`` is
++    reported finished AND its block ids are surfaced through
++    ``get_block_ids_with_load_errors`` so the scheduler recomputes them
++    instead of decoding over never-written blocks."""
++    adapter, _send_mock, _ = fake_adapter
++    adapter.retrieve_futures["req-1"] = (
++        _finished_retrieve_future(False),
++        [3, 4, 5],
++    )
++
++    ret_stores, finished_retrieves = adapter.get_finished(set())
++
++    assert ret_stores == set()
++    assert finished_retrieves == {"req-1"}
++    assert adapter.get_block_ids_with_load_errors() == {3, 4, 5}
++    # The error set is consumed on read.
++    assert adapter.get_block_ids_with_load_errors() == set()
++    assert adapter.retrieve_failure_count == 1
++
++
++def test_raising_retrieve_future_contained_as_failure(fake_adapter) -> None:
++    """A retrieve future whose ``result()`` raises must not propagate out
++    of ``get_finished`` (that would kill the engine step); it lands on the
++    same failure path as ``result=False``."""
++    adapter, _send_mock, _ = fake_adapter
++    adapter.retrieve_futures["req-1"] = (
++        _finished_retrieve_future(RuntimeError("ipc receive failed")),
++        [7, 8],
++    )
++
++    _ret_stores, finished_retrieves = adapter.get_finished(set())
++
++    assert finished_retrieves == {"req-1"}
++    assert adapter.get_block_ids_with_load_errors() == {7, 8}
++    assert adapter.retrieve_failure_count == 1
++
++
++def test_successful_retrieve_marks_no_blocks_invalid(fake_adapter) -> None:
++    """A successful retrieve reports no load errors."""
++    adapter, _send_mock, _ = fake_adapter
++    adapter.retrieve_futures["req-1"] = (_finished_retrieve_future(True), [1, 2])
++
++    _ret_stores, finished_retrieves = adapter.get_finished(set())
++
++    assert finished_retrieves == {"req-1"}
++    assert adapter.get_block_ids_with_load_errors() == set()
++    assert adapter.retrieve_failure_count == 0
+diff --git a/tests/v1/test_vllm_mp_connector_metadata.py b/tests/v1/test_vllm_mp_connector_metadata.py
+new file mode 100644
+index 0000000000000000000000000000000000000000..45d427bd561aed4dcc953eda04259e2854008e15
+--- /dev/null
++++ b/tests/v1/test_vllm_mp_connector_metadata.py
+@@ -0,0 +1,133 @@
++# SPDX-License-Identifier: Apache-2.0
++"""Unit tests for ``LMCacheMPRequestMetadata.GetRetrieveMetadata``.
++
++The retrieve op must only be emitted when the tracker's allocated block ids
++actually cover the retrieve token range in every engine group:
++``slice_block_ids_per_group`` validates chunk alignment only, and its plain
++Python slice truncates silently, so an uncovered range would otherwise emit
++an op with too few block ids.
++"""
++
++# Standard
++from types import SimpleNamespace
++
++# Third Party
++import pytest
++
++# First Party
++from lmcache.integration.vllm.lmcache_mp_connector import (
++    LMCacheMPRequestMetadata,
++    LMCacheMPRequestState,
++    LMCacheMPRequestTracker,
++)
++
++CHUNK_TOKENS = 64
++
++
++def _tracker(
++    num_tokens: int,
++    lmcache_hit_tokens: int,
++    vllm_hit_tokens: int,
++    allocated_block_ids: dict[int, list[int]],
++) -> LMCacheMPRequestTracker:
++    """Build a tracker that is ready for retrieving over *num_tokens*."""
++    request = SimpleNamespace(
++        request_id="req-1",
++        cache_salt="",
++        all_token_ids=list(range(num_tokens)),
++    )
++    tracker = LMCacheMPRequestTracker(request)
++    tracker.num_lmcache_hit_tokens = lmcache_hit_tokens
++    tracker.num_vllm_hit_tokens = vllm_hit_tokens
++    tracker.allocated_block_ids = allocated_block_ids
++    tracker.state = LMCacheMPRequestState.WAITING_FOR_LOAD
++    return tracker
++
++
++@pytest.mark.parametrize(
++    ("group_tokens_per_block", "allocated_block_ids", "expected_block_ids"),
++    [
++        # Single group, plain geometry: 64 tokens / 16 tokens per block.
++        ([16], {0: [0, 1, 2, 3]}, [[0, 1, 2, 3]]),
++        # Single group, DCP-scaled: one manager block id covers 64 tokens.
++        ([64], {0: [5]}, [[5]]),
++        # Hybrid geometries: each group sliced by its own tokens-per-block.
++        ([16, 32], {0: [0, 1, 2, 3], 1: [10, 11]}, [[0, 1, 2, 3], [10, 11]]),
++        # Extra allocated blocks beyond the range are fine (and not emitted).
++        ([16], {0: [0, 1, 2, 3, 4, 5]}, [[0, 1, 2, 3]]),
++    ],
++)
++def test_retrieve_metadata_emitted_when_allocation_covers_range(
++    group_tokens_per_block: list[int],
++    allocated_block_ids: dict[int, list[int]],
++    expected_block_ids: list[list[int]],
++) -> None:
++    tracker = _tracker(
++        num_tokens=CHUNK_TOKENS,
++        lmcache_hit_tokens=CHUNK_TOKENS,
++        vllm_hit_tokens=0,
++        allocated_block_ids=allocated_block_ids,
++    )
++
++    metadata = LMCacheMPRequestMetadata.GetRetrieveMetadata(
++        tracker, CHUNK_TOKENS, group_tokens_per_block
++    )
++
++    assert metadata is not None
++    assert metadata.direction == "RETRIEVE"
++    assert metadata.op.start == 0
++    assert metadata.op.end == CHUNK_TOKENS
++    assert metadata.op.block_ids == expected_block_ids
++
++
++@pytest.mark.parametrize(
++    ("group_tokens_per_block", "allocated_block_ids"),
++    [
++        # One block short in the only group.
++        ([16], {0: [0, 1, 2]}),
++        # DCP-scaled group with no allocation at all.
++        ([64], {0: []}),
++        # Group 0 covered, group 1 one block short.
++        ([16, 32], {0: [0, 1, 2, 3], 1: [10]}),
++        # Group key missing entirely (counts as zero blocks).
++        ([16, 16], {0: [0, 1, 2, 3]}),
++    ],
++)
++def test_retrieve_metadata_suppressed_when_allocation_short(
++    group_tokens_per_block: list[int],
++    allocated_block_ids: dict[int, list[int]],
++) -> None:
++    """Any engine group whose allocation does not cover the retrieve range
++    suppresses the op entirely: the request falls back to recompute instead
++    of retrieving over silently truncated block-id lists."""
++    tracker = _tracker(
++        num_tokens=CHUNK_TOKENS,
++        lmcache_hit_tokens=CHUNK_TOKENS,
++        vllm_hit_tokens=0,
++        allocated_block_ids=allocated_block_ids,
++    )
++
++    metadata = LMCacheMPRequestMetadata.GetRetrieveMetadata(
++        tracker, CHUNK_TOKENS, group_tokens_per_block
++    )
++
++    assert metadata is None
++
++
++def test_retrieve_metadata_skip_tokens_preserved_on_emitted_op() -> None:
++    """vLLM-hit tokens inside the first chunk round the start down and are
++    carried as skip_first_n_tokens; coverage is still checked against the
++    chunk-aligned end."""
++    tracker = _tracker(
++        num_tokens=CHUNK_TOKENS,
++        lmcache_hit_tokens=CHUNK_TOKENS,
++        vllm_hit_tokens=16,
++        allocated_block_ids={0: [0, 1, 2, 3]},
++    )
++
++    metadata = LMCacheMPRequestMetadata.GetRetrieveMetadata(tracker, CHUNK_TOKENS, [16])
++
++    assert metadata is not None
++    assert metadata.op.start == 0
++    assert metadata.op.end == CHUNK_TOKENS
++    assert metadata.op.skip_first_n_tokens == 16

--- a/patches/releases/gilded-gnosis-v20-r13/sparkinfer/integration.lock.json
+++ b/patches/releases/gilded-gnosis-v20-r13/sparkinfer/integration.lock.json
@@ -1,0 +1,26 @@
+{
+  "base": {
+    "commit": "36cade0bd8d87a26b7eb2fc8cc46188496465a06",
+    "ref": "refs/heads/master",
+    "repository": "https://github.com/local-inference-lab/sparkinfer.git"
+  },
+  "manifest": {
+    "sha256": "00c85ab5d23d720ace006be444e48c91cc4f538981f1400b727edc0b9ff23d1c"
+  },
+  "name": "gilded-gnosis-v20-sparkinfer",
+  "pull_requests": [
+    {
+      "disposition": "merged",
+      "head": "06032ce74afba49a683d01339ed2c971568cec3f",
+      "number": 92,
+      "ref": "refs/pull/92/head",
+      "title": "Stabilize Trellis arena memory profiling"
+    }
+  ],
+  "result": {
+    "patch": "integration.patch",
+    "patch_sha256": "15c745921ccf8eb65fb269474865ec77f01d076509bbce063dd3759aff1bef2d",
+    "tree": "a2ea6083713c15dcf7e2d2bcc74fbece837ff84d"
+  },
+  "schema_version": 1
+}

--- a/patches/releases/gilded-gnosis-v20-r13/sparkinfer/integration.patch
+++ b/patches/releases/gilded-gnosis-v20-r13/sparkinfer/integration.patch
@@ -1,0 +1,493 @@
+diff --git a/sparkinfer/moe/fused_moe/_impl.py b/sparkinfer/moe/fused_moe/_impl.py
+index 2a340db1bcffd61d368922d681ac795715496cee..185419719a9c7ae7bd9e59358c5b7f3dd172c976 100644
+--- a/sparkinfer/moe/fused_moe/_impl.py
++++ b/sparkinfer/moe/fused_moe/_impl.py
+@@ -858,6 +858,14 @@ class TPMoEScratchPlan:
+     launch_plan: TPMoEPlan
+     _core_workspace_plan: _TPCoreWorkspacePlan
+     _scratch_specs: tuple[ScratchBufferSpec, ...]
++    _prewarmed_fused_launches: tuple[tuple[int, object], ...] = field(
++        default=(), repr=False
++    )
++    _prewarmed_topk_sum_launches: tuple[
++        tuple[torch.dtype, bool, object], ...
++    ] = field(
++        default=(), repr=False
++    )
+ 
+     @property
+     def full_rotation(self) -> bool:
+@@ -946,6 +954,8 @@ class TPMoEScratchPlan:
+             layer_idx=layer_idx,
+             route_expert_map=route_expert_map,
+             output_expert_map=output_expert_map,
++            fused_launch=None,
++            topk_sum_launch=None,
+         )
+ 
+ 
+@@ -1882,11 +1892,12 @@ def _arena_core_token_counts(
+     num_topk: int,
+     core_token_counts: tuple[int, ...] | None,
+     quant_mode: str,
++    bucket_w4a16_tokens: bool = True,
+ ) -> tuple[int, ...]:
+     max_tokens = max(int(max_tokens), 1)
+     num_topk = max(int(num_topk), 1)
+     quant_mode = _normalize_quant_mode(quant_mode)
+-    if quant_mode == "w4a16":
++    if quant_mode == "w4a16" and bucket_w4a16_tokens:
+         from sparkinfer.moe._shared.kernels.w4a16.host import (
+             route_pack_token_capacity,
+         )
+@@ -1898,7 +1909,7 @@ def _arena_core_token_counts(
+         normalized = tuple(
+             max(int(token_count), 1) for token_count in core_token_counts
+         )
+-        if quant_mode == "w4a16":
++        if quant_mode == "w4a16" and bucket_w4a16_tokens:
+             normalized = tuple(
+                 route_pack_token_capacity(token_count, num_topk)
+                 for token_count in normalized
+@@ -1910,7 +1921,7 @@ def _arena_core_token_counts(
+     max_micro_tokens = micro_cutover_pairs // num_topk
+     if max_micro_tokens >= 1:
+         micro_boundary_tokens = min(max_tokens, max_micro_tokens)
+-        if quant_mode == "w4a16":
++        if quant_mode == "w4a16" and bucket_w4a16_tokens:
+             micro_boundary_tokens = route_pack_token_capacity(
+                 micro_boundary_tokens,
+                 num_topk,
+@@ -2194,6 +2205,8 @@ def _build_tp_moe_fp4_binding_from_views(
+     layer_idx: int | None = None,
+     route_expert_map: torch.Tensor | None = None,
+     output_expert_map: torch.Tensor | None = None,
++    fused_launch: object | None = None,
++    topk_sum_launch: object | None = None,
+ ) -> TPMoEFP4Binding:
+     if not isinstance(experts, SPARKINFERFP4ExpertWeights):
+         raise TypeError("experts must come from prepare_sparkinfer_fp4_moe_weights")
+@@ -2385,6 +2398,8 @@ def _build_tp_moe_fp4_binding_from_views(
+             route_block_size_m=plan.route_block_size_m,
+             route_expert_map=route_expert_map,
+             output_expert_map=output_expert_map,
++            fused_launch=fused_launch,
++            topk_sum_launch=topk_sum_launch,
+         )
+ 
+     if plan.implementation == "micro":
+@@ -6070,6 +6085,12 @@ def plan_tp_moe_arena_layout(
+         num_topk=num_topk,
+         core_token_counts=core_token_counts,
+         quant_mode=quant_mode,
++        # Trellis plans one fixed caller-owned capacity and its route-pack
++        # wrapper already falls back to that exact capacity when the supplied
++        # buffers are smaller than the generic compile bucket. Rounding a
++        # 3072-token EXL3 plan to 4096 therefore reserves roughly 320 MiB of
++        # unreachable activation scratch without reducing launch variants.
++        bucket_w4a16_tokens=source_format != "exl3_trellis_mcg",
+     )
+     route_num_experts = int(
+         route_num_experts if route_num_experts is not None else weight_E
+@@ -6137,6 +6158,213 @@ def plan_tp_moe_arena_layout(
+     )
+ 
+ 
++def _plan_full_rotation_w4a16_launches(
++    *,
++    caps: TPMoEScratchCaps,
++    core_plan: _TPCoreWorkspacePlan,
++    capacity_tokens: int,
++) -> tuple[
++    tuple[tuple[int, object], ...],
++    tuple[tuple[torch.dtype, bool, object], ...],
++]:
++    """Compile the fixed Trellis launches before serving memory profiling.
++
++    The caller-owned scratch path cannot use the mutable workspace prewarm
++    dictionaries.  Keeping the launch objects on the immutable scratch plan
++    preserves the old Trellis API contract and prevents first-use compilation
++    from being charged as peak activation memory by vLLM.
++    """
++    if not core_plan.full_rotation:
++        return (), ()
++    if caps.quant_mode != "w4a16":
++        raise RuntimeError("full-rotation TP MoE requires W4A16 execution")
++    if core_plan.device.type != "cuda":
++        return (), ()
++    if not torch.cuda.is_available():
++        raise RuntimeError("CUDA must be available before planning Trellis MoE")
++    if torch.cuda.is_current_stream_capturing():
++        raise RuntimeError("Trellis launch planning cannot run during capture")
++
++    from sparkinfer.moe._shared.kernels.w4a16.host import (
++        max_packed_route_slots,
++    )
++    from sparkinfer.moe._shared.kernels.w4a16.kernel import (
++        _DEFAULT_MAX_SHARED_MEM,
++        compile_w4a16_fused_moe,
++        compile_w4a16_topk_sum,
++        pack_topk_routes_by_expert,
++    )
++
++    capacity_tokens = max(int(capacity_tokens), 1)
++    if not core_plan.route_block_size_m:
++        raise RuntimeError(
++            "Trellis launch planning requires the arena's route_block_size_m"
++        )
++    block_size_m = int(core_plan.route_block_size_m)
++    weight_layout = _normalize_w4a16_weight_layout(
++        caps.w4a16_weight_layout
++        or _w4a16_weight_layout_for_source(caps.source_format)
++    )
++    scale_format = _normalize_w4a16_scale_format(
++        caps.w4a16_scale_format
++        or _w4a16_scale_format_for_source(caps.source_format)
++    )
++    if weight_layout != "trellis3_t256" or scale_format != "e4m3_k32":
++        raise RuntimeError(
++            "full-rotation Trellis launch planning requires "
++            "weight_layout='trellis3_t256' and scale_format='e4m3_k32'; "
++            f"got weight_layout={weight_layout!r}, scale_format={scale_format!r}"
++        )
++    w13_layout = "trellis3_t256_proj"
++    capacity_route_slots = max_packed_route_slots(
++        capacity_tokens * core_plan.num_topk,
++        block_size_m,
++        core_plan.route_E,
++    )
++    capacity_m_blocks = (
++        capacity_route_slots + block_size_m - 1
++    ) // block_size_m
++    rotation_input_dtype = _w4a16_element_dtype(core_plan.dtype)
++
++    with torch.cuda.device(core_plan.device):
++        props = torch.cuda.get_device_properties(core_plan.device)
++        sms = int(props.multi_processor_count)
++        max_shared_mem = int(
++            getattr(
++                props,
++                "shared_memory_per_block_optin",
++                _DEFAULT_MAX_SHARED_MEM,
++            )
++        )
++        # Decode plans are deliberately exact-M: the unified API's measured
++        # speedup over the retired Trellis wrapper comes from specializing the
++        # small live shapes instead of always launching its M=32 capacity
++        # kernel.  Large prefill plans retain one capacity launch.
++        fused_token_counts = (
++            tuple(range(1, capacity_tokens + 1))
++            if capacity_tokens <= 32
++            else (capacity_tokens,)
++        )
++
++        def compile_fused(token_count: int) -> object:
++            return compile_w4a16_fused_moe(
++                size_m=token_count,
++                hidden_size=core_plan.k,
++                intermediate_size=core_plan.n,
++                num_experts=core_plan.weight_E,
++                top_k=core_plan.num_topk,
++                activation=core_plan.activation,
++                apply_router_weight_on_input=caps.apply_router_weight_on_input,
++                zero_fc2_output=False,
++                moe_block_size=block_size_m,
++                # Match the lazy unified path: specialize the live M while
++                # retaining the caller-owned route arena's full grid capacity.
++                max_m_blocks=capacity_m_blocks,
++                element_dtype="fp16",
++                fast_math=caps.w4a16_fast_math,
++                sms=sms,
++                max_shared_mem=max_shared_mem,
++                swiglu_limit=core_plan.swiglu_limit,
++                swiglu_alpha=core_plan.swiglu_alpha,
++                swiglu_beta=core_plan.swiglu_beta,
++                weight_layout=weight_layout,
++                scale_format=scale_format,
++                w13_layout=w13_layout,
++                trellis_bits=core_plan.trellis_bits,
++                force_tile_config=core_plan.trellis_tile_config,
++                intermediate_rotation=True,
++                full_rotation=True,
++                rotation_input_dtype=rotation_input_dtype,
++            )
++
++        fused_launches = tuple(
++            (token_count, compile_fused(token_count))
++            for token_count in fused_token_counts
++        )
++        topk_sum_launches = tuple(
++            (
++                ids_dtype,
++                mapped,
++                compile_w4a16_topk_sum(
++                    m=capacity_tokens,
++                    topk=core_plan.num_topk,
++                    hidden_size=core_plan.k,
++                    element_dtype="fp16",
++                    full_rotation=True,
++                    num_experts=core_plan.weight_E,
++                    route_num_experts=(core_plan.route_E if mapped else 0),
++                    route_ids_dtype=ids_dtype,
++                    use_expert_map=mapped,
++                ),
++            )
++            for ids_dtype in (torch.int32, torch.int64)
++            for mapped in (False, True)
++        )
++        for mapped in (False, True):
++            route_pack_key = (
++                core_plan.device.type,
++                int(torch.cuda.current_device()),
++                capacity_tokens * core_plan.num_topk,
++                int(block_size_m),
++                int(core_plan.route_E),
++                mapped,
++            )
++            if route_pack_key in _W4A16_ROUTE_PACK_PREWARMED:
++                continue
++            dummy_topk_ids = torch.zeros(
++                capacity_tokens,
++                core_plan.num_topk,
++                dtype=torch.int32,
++                device=core_plan.device,
++            )
++            packed_route_indices = torch.empty(
++                capacity_route_slots,
++                dtype=torch.int32,
++                device=core_plan.device,
++            )
++            block_expert_ids = torch.empty(
++                capacity_m_blocks,
++                dtype=torch.int32,
++                device=core_plan.device,
++            )
++            packed_route_count = torch.empty(
++                1,
++                dtype=torch.int32,
++                device=core_plan.device,
++            )
++            expert_offsets = torch.empty(
++                core_plan.route_E + 1,
++                dtype=torch.int32,
++                device=core_plan.device,
++            )
++            expert_counts = torch.empty(
++                core_plan.route_E,
++                dtype=torch.int32,
++                device=core_plan.device,
++            )
++            expert_map = None
++            if mapped:
++                expert_map = torch.arange(
++                    core_plan.route_E,
++                    dtype=torch.int32,
++                    device=core_plan.device,
++                )
++            pack_topk_routes_by_expert(
++                dummy_topk_ids,
++                block_size_m,
++                core_plan.route_E,
++                expert_map=expert_map,
++                packed_route_indices=packed_route_indices,
++                block_expert_ids=block_expert_ids,
++                packed_route_count=packed_route_count,
++                expert_offsets=expert_offsets,
++                expert_counts=expert_counts,
++            )
++            torch.cuda.current_stream(core_plan.device).synchronize()
++            _W4A16_ROUTE_PACK_PREWARMED.add(route_pack_key)
++    return fused_launches, topk_sum_launches
++
++
+ def plan_tp_moe_scratch(caps: TPMoEScratchCaps) -> TPMoEScratchPlan:
+     deterministic_output = caps.deterministic_output
+     if deterministic_output is None:
+@@ -6203,6 +6431,11 @@ def plan_tp_moe_scratch(caps: TPMoEScratchCaps) -> TPMoEScratchPlan:
+         swiglu_alpha=launch_plan.swiglu_alpha,
+         swiglu_beta=launch_plan.swiglu_beta,
+     )
++    fused_launches, topk_sum_launches = _plan_full_rotation_w4a16_launches(
++        caps=caps,
++        core_plan=core_workspace_plan,
++        capacity_tokens=capacity_tokens,
++    )
+     return TPMoEScratchPlan(
+         caps=caps,
+         layout=layout,
+@@ -6215,6 +6448,12 @@ def plan_tp_moe_scratch(caps: TPMoEScratchCaps) -> TPMoEScratchPlan:
+                 device=torch.device(caps.device),
+             ),
+         ),
++        # Keep strong references to the launches primed in the module caches,
++        # but leave the runtime binding unresolved.  ``run_w4a16_moe`` uses a
++        # None launch as a dispatch signal and then gets these exact objects
++        # from its compile cache without doing first-use JIT work.
++        _prewarmed_fused_launches=fused_launches,
++        _prewarmed_topk_sum_launches=topk_sum_launches,
+     )
+ 
+ 
+diff --git a/tests/moe/test_tp_moe_scratch_bindings.py b/tests/moe/test_tp_moe_scratch_bindings.py
+index c885570b92d9d92aaf5e46055f4f5b6128ef8c1c..3e2e463bb73b405084b900316c84a0fc8f109a7f 100644
+--- a/tests/moe/test_tp_moe_scratch_bindings.py
++++ b/tests/moe/test_tp_moe_scratch_bindings.py
+@@ -525,6 +525,158 @@ def test_w4a16_scratch_plan_uses_route_pack_capacity_buckets(
+     assert plan_4080.shapes_and_dtypes() == plan_4096.shapes_and_dtypes()
+ 
+ 
++def test_trellis_scratch_plan_preserves_exact_fixed_capacity(
++    monkeypatch: pytest.MonkeyPatch,
++) -> None:
++    """Trellis must not pay the generic W4A16 compile-bucket memory cost."""
++    monkeypatch.setattr(tp_moe_impl, "get_num_sm", lambda _device: 188)
++    weight_plan = plan_sparkinfer_fp4_moe_weights(
++        quant_modes="w4a16",
++        source_format="exl3_trellis_mcg",
++        activation="silu",
++        params_dtype=torch.bfloat16,
++        num_experts=256,
++        hidden_size=6144,
++        intermediate_size=512,
++        trellis_bits=3,
++        trellis_tile_config=(64, 256, 64, 256),
++    )
++    plan = plan_tp_moe_scratch(
++        TPMoEScratchCaps(
++            max_tokens=3072,
++            core_token_counts=(3072,),
++            num_topk=8,
++            route_num_experts=0,
++            device="cpu",
++            weight_plan=weight_plan,
++            quant_mode="w4a16",
++            w4a16_block_size_m=64,
++        )
++    )
++
++    assert plan.layout.core_token_counts[0] == 3072
++    assert 4096 not in plan.layout.core_token_counts
++    assert plan.layout.route_workspace_nbytes == 0
++    # This GLM-5.2 Trellis geometry currently needs 1054.16 MiB. Keep a small
++    # alignment margin while rejecting the much larger generic 4096-token
++    # bucket that this fixed-capacity path exists to avoid.
++    min_fixed_capacity_bytes = 1000 * (1 << 20)
++    max_fixed_capacity_bytes = 1060 * (1 << 20)
++    assert (
++        min_fixed_capacity_bytes
++        < plan.layout.core_workspace_nbytes
++        < max_fixed_capacity_bytes
++    )
++    assert plan.layout.total_nbytes == plan.layout.core_workspace_nbytes
++
++
++@pytest.mark.skipif(not torch.cuda.is_available(), reason="requires CUDA")
++def test_trellis_launch_planner_compiles_fixed_launch_matrix() -> None:
++    """The real planner must cover every fixed decode and route-pack variant."""
++    weight_plan = plan_sparkinfer_fp4_moe_weights(
++        quant_modes="w4a16",
++        source_format="exl3_trellis_mcg",
++        activation="silu",
++        params_dtype=torch.bfloat16,
++        num_experts=8,
++        hidden_size=128,
++        intermediate_size=128,
++        trellis_bits=3,
++        trellis_tile_config=(64, 128, 64, 128),
++    )
++    plan = plan_tp_moe_scratch(
++        TPMoEScratchCaps(
++            max_tokens=4,
++            core_token_counts=(4,),
++            num_topk=2,
++            route_num_experts=8,
++            device="cuda",
++            weight_plan=weight_plan,
++            quant_mode="w4a16",
++            w4a16_block_size_m=8,
++        )
++    )
++
++    assert tuple(tokens for tokens, _launch in plan._prewarmed_fused_launches) == (
++        1,
++        2,
++        3,
++        4,
++    )
++    assert {
++        (ids_dtype, mapped)
++        for ids_dtype, mapped, _launch in plan._prewarmed_topk_sum_launches
++    } == {
++        (torch.int32, False),
++        (torch.int32, True),
++        (torch.int64, False),
++        (torch.int64, True),
++    }
++
++
++def test_trellis_scratch_plan_prewarms_without_forcing_runtime_dispatch(
++    monkeypatch: pytest.MonkeyPatch,
++) -> None:
++    fused_launches = tuple((tokens, object()) for tokens in range(1, 5))
++    sums = tuple(
++        (ids_dtype, mapped, object())
++        for ids_dtype in (torch.int32, torch.int64)
++        for mapped in (False, True)
++    )
++    monkeypatch.setattr(tp_moe_impl, "get_num_sm", lambda _device: 188)
++    monkeypatch.setattr(
++        tp_moe_impl,
++        "_plan_full_rotation_w4a16_launches",
++        lambda **_kwargs: (fused_launches, sums),
++    )
++    weight_plan = plan_sparkinfer_fp4_moe_weights(
++        quant_modes="w4a16",
++        source_format="exl3_trellis_mcg",
++        activation="silu",
++        params_dtype=torch.bfloat16,
++        num_experts=8,
++        hidden_size=128,
++        intermediate_size=128,
++        trellis_bits=3,
++        trellis_tile_config=(64, 128, 64, 128),
++    )
++    plan = plan_tp_moe_scratch(
++        TPMoEScratchCaps(
++            max_tokens=4,
++            core_token_counts=(4,),
++            num_topk=2,
++            route_num_experts=0,
++            device="cpu",
++            weight_plan=weight_plan,
++            quant_mode="w4a16",
++            w4a16_block_size_m=8,
++        )
++    )
++    tensors = _runtime_tensors(n=128)
++    captured = {}
++
++    def _capture_binding(**kwargs):
++        captured.update(kwargs)
++        return SimpleNamespace()
++
++    monkeypatch.setattr(
++        tp_moe_impl,
++        "_build_tp_moe_fp4_binding_from_views",
++        _capture_binding,
++    )
++    output_expert_map = torch.arange(8, dtype=torch.int32)
++    plan.bind(
++        scratch=_scratch_for_plan(plan),
++        **_binding_args(tensors, _experts(tensors, weight_plan)),
++        output_expert_map=output_expert_map,
++    )
++
++    assert plan._prewarmed_fused_launches == fused_launches
++    assert plan._prewarmed_topk_sum_launches == sums
++    assert captured["fused_launch"] is None
++    assert captured["topk_sum_launch"] is None
++
++
+ def test_w4a16_topk6_bucket_binds_with_planned_scratch(
+     monkeypatch: pytest.MonkeyPatch,
+ ) -> None:

--- a/patches/releases/gilded-gnosis-v20-r13/vllm/integration.lock.json
+++ b/patches/releases/gilded-gnosis-v20-r13/vllm/integration.lock.json
@@ -1,0 +1,47 @@
+{
+  "base": {
+    "commit": "f978d009fab996617f9a3cadef36ce727bcd83cd",
+    "ref": "refs/heads/dev/gilded-gnosis",
+    "repository": "https://github.com/local-inference-lab/vllm.git"
+  },
+  "manifest": {
+    "sha256": "b9961c7b0495e224c314ff3cd58dbc979066ef710e68cbb1022169c6bb9d01a9"
+  },
+  "name": "gilded-gnosis-v20",
+  "pull_requests": [
+    {
+      "disposition": "merged",
+      "head": "99bf3f13f13012b72d6d67e49572d686b45b2833",
+      "number": 145,
+      "ref": "refs/pull/145/head",
+      "title": "GLM-5.2 calibrated NVFP4 MLA KV outer scales"
+    },
+    {
+      "disposition": "merged",
+      "head": "2c14a58a21c724f08d01d988b9972d10c77ed4c0",
+      "number": 175,
+      "ref": "refs/pull/175/head",
+      "title": "Shard sparse prefill queries and halve result traffic"
+    },
+    {
+      "disposition": "merged",
+      "head": "e55627045ac68aa2ab87273e26a0cc190b6e2b78",
+      "number": 190,
+      "ref": "refs/pull/190/head",
+      "title": "Add EXL3 Trellis backend for rank-sliced MoE checkpoints"
+    },
+    {
+      "disposition": "merged",
+      "head": "703af3ffd6ae60e4b99abbd5fa8a5a03d629c7e7",
+      "number": 198,
+      "ref": "refs/pull/198/head",
+      "title": "Measure repeatable activation peak after kernel warmup"
+    }
+  ],
+  "result": {
+    "patch": "integration.patch",
+    "patch_sha256": "f48ee2b7f0f955b284877b29fab47b983ba5442cf44fb3e25d416faf6eae719e",
+    "tree": "69ba80b9e49b5ad6740f8b3d5d0e592213b25959"
+  },
+  "schema_version": 1
+}

--- a/patches/releases/gilded-gnosis-v20-r13/vllm/integration.patch
+++ b/patches/releases/gilded-gnosis-v20-r13/vllm/integration.patch
@@ -1,0 +1,4025 @@
+diff --git a/kv-scales/README.md b/kv-scales/README.md
+new file mode 100644
+index 0000000000000000000000000000000000000000..36b37d5aa188027675ec9eaa447e9597b3921e4c
+--- /dev/null
++++ b/kv-scales/README.md
+@@ -0,0 +1,49 @@
++# GLM-5.2 NVFP4 MLA KV outer scales
++
++Per-layer calibration for the `nvfp4_ds_mla` KV cache writer
++(`VLLM_NVFP4_MLA_SCALES_FILE`, format `nvfp4_ds_mla_outer_scale_v1`).
++
++GLM-5.2's post-RMSNorm 512-dim `kv_c` latent spans a ~240x amplitude range
++across layers. With the default outer scale of 1.0, shallow layers quantize
++with E4M3 block scales at or below the subnormal floor, and shallow-layer KV
++error is strongly amplified downstream. `s_l = max_abs(kv_c_normed) / (6*448)`
++re-centers every layer so its largest block scale lands at the top of the
++E4M3 range.
++
++## Files
++
++- `glm52-nvfp4-nf3-hybrid_mla_outer_scales_v1.json` — calibrated on
++  `madeby561/GLM-5.2-MXFP8-NVFP4-NF3-Hybrid` (K64R16), Salesforce/wikitext
++  (wikitext-2-raw-v1, test), 2048-token context, TP4; per-layer envelope with
++  an independent community capture of the same base model for shallow-layer
++  headroom. `max_abs` per layer is included for auditability.
++
++## Usage
++
++```bash
++VLLM_NVFP4_MLA_SCALES_FILE=/path/to/glm52-nvfp4-nf3-hybrid_mla_outer_scales_v1.json \
++  ./serve-glm52.sh   # nvfp4_ds_mla + B12X_MLA_SPARSE only; inert otherwise
++```
++
++## Results (teacher-forced prefill KLD vs BF16 reference, 5 fresh boots each)
++
++| KV config | mean +/- sd | max ctx (4x96GB) |
++|---|---|---|
++| fp8_ds_mla | 0.1263 +/- 0.0030 | 373k |
++| nvfp4_ds_mla + scales, bf16 rope | 0.1345 +/- 0.0035 | 550k |
++| nvfp4_ds_mla + scales, fp8 rope (`KV_FP8_ROPE=1`) | 0.1356 +/- 0.0054 | 600k+ |
++| nvfp4_ds_mla, no scales, bf16 rope | 0.158 | 550k |
++| nvfp4_ds_mla, no scales, fp8 rope | 0.168 | 600k+ |
++
++Protocol: local-inference-lab/rtx6kpro `benchmarks/glm52-kld-evaluation.md`
++(festr2 2026-07-08 reference logits, one fixed 2048-token window, 2047
++positions, full 154,880 vocab, `KL(ref || candidate)`).
++
++## Cache invalidation (required)
++
++CuTeDSL folds the outer-scale multiply out of the kernel when `latent_scale`
++traces at exactly 1.0. b12x builds without the identity/dynamic compile-spec
++fact (see lukealonso/b12x PR "mla: split latent_scale identity/dynamic
++compile-cache entries") replay stale identity cubins from persistent compile
++caches, silently dropping the restore. Clear mounted b12x compile caches once
++when enabling scales on such builds.
+diff --git a/kv-scales/glm52-nvfp4-nf3-hybrid_mla_outer_scales_v1.json b/kv-scales/glm52-nvfp4-nf3-hybrid_mla_outer_scales_v1.json
+new file mode 100644
+index 0000000000000000000000000000000000000000..7ae9d9351c4e8de79f6387b5f64a5fa9618bf155
+--- /dev/null
++++ b/kv-scales/glm52-nvfp4-nf3-hybrid_mla_outer_scales_v1.json
+@@ -0,0 +1,178 @@
++{
++ "format": "nvfp4_ds_mla_outer_scale_v1",
++ "num_layers": 78,
++ "latent_dim": 512,
++ "denominator": 2688.0,
++ "formula": "s_l = max_abs(kv_c_normed) / (6 * 448)",
++ "model": "madeby561/GLM-5.2-MXFP8-NVFP4-NF3-Hybrid (local K64R16 build; own capture)",
++ "dataset": {
++  "name": "Salesforce/wikitext",
++  "config": "wikitext-2-raw-v1",
++  "split": "test",
++  "context_length": 2048,
++  "windows": 1,
++  "note": "the canonical festr2-0708 census window"
++ },
++ "created_utc": "2026-07-20T16:40:43.312260+00:00",
++ "hook": "mla.py kv_a_layernorm output (bind-mount capture patch), per-TP-rank agreement checked",
++ "max_abs": [
++  0.04833984375,
++  0.021728515625,
++  0.03662109375,
++  0.1005859375,
++  0.023681640625,
++  0.03515625,
++  0.046875,
++  0.033203125,
++  0.259765625,
++  0.1474609375,
++  0.7734375,
++  1.0,
++  1.1171875,
++  0.150390625,
++  0.76171875,
++  0.392578125,
++  0.25390625,
++  0.455078125,
++  0.80859375,
++  0.80078125,
++  0.96875,
++  0.78515625,
++  0.58203125,
++  0.330078125,
++  0.89453125,
++  0.73046875,
++  1.0390625,
++  1.578125,
++  1.0078125,
++  0.92578125,
++  1.25,
++  1.5859375,
++  1.234375,
++  1.9140625,
++  1.9453125,
++  1.7578125,
++  1.7890625,
++  2.546875,
++  2.296875,
++  2.4375,
++  1.921875,
++  2.171875,
++  2.875,
++  2.546875,
++  2.765625,
++  3.234375,
++  2.5625,
++  3.390625,
++  2.40625,
++  2.546875,
++  3.09375,
++  2.90625,
++  3.671875,
++  2.46875,
++  2.609375,
++  2.359375,
++  3.078125,
++  3.171875,
++  2.578125,
++  2.359375,
++  3.890625,
++  2.953125,
++  4.09375,
++  4.09375,
++  5.0625,
++  5.1875,
++  2.984375,
++  2.875,
++  2.984375,
++  3.296875,
++  3.828125,
++  2.859375,
++  3.59375,
++  3.734375,
++  4.25,
++  4.1875,
++  4.84375,
++  3.75
++ ],
++ "scales": [
++  1.7983572823660715e-05,
++  8.083525158110119e-06,
++  1.3623918805803572e-05,
++  3.742036365327381e-05,
++  8.810134161086309e-06,
++  1.3078962053571428e-05,
++  1.743861607142857e-05,
++  1.2352353050595238e-05,
++  9.663899739583333e-05,
++  5.485897972470238e-05,
++  0.00028773716517857144,
++  0.0003720238095238095,
++  0.00041562034970238094,
++  5.5948893229166664e-05,
++  0.0002833775111607143,
++  0.00014604840959821428,
++  9.445917038690477e-05,
++  0.00016929989769345238,
++  0.00030081612723214287,
++  0.0002979096912202381,
++  0.0003603980654761905,
++  0.00029209681919642856,
++  0.00021652948288690475,
++  0.0001227969215029762,
++  0.00033278692336309525,
++  0.00027175176711309525,
++  0.0003865559895833333,
++  0.0005871000744047619,
++  0.0003749302455357143,
++  0.0003444126674107143,
++  0.0004650297619047619,
++  0.0005900065104166666,
++  0.0004592168898809524,
++  0.0007120768229166666,
++  0.0007237025669642857,
++  0.0006539481026785714,
++  0.0006655738467261905,
++  0.0009474981398809524,
++  0.0008544921875,
++  0.0009068080357142857,
++  0.0007149832589285714,
++  0.0008079892113095238,
++  0.0010695684523809525,
++  0.0009474981398809524,
++  0.0010288783482142857,
++  0.0012032645089285715,
++  0.0009533110119047619,
++  0.0012613932291666667,
++  0.0008951822916666666,
++  0.0009474981398809524,
++  0.0011509486607142857,
++  0.0010811941964285715,
++  0.001366024925595238,
++  0.0009184337797619048,
++  0.0009707496279761905,
++  0.0008777436755952381,
++  0.0011451357886904762,
++  0.0011800130208333333,
++  0.0009591238839285714,
++  0.0008777436755952381,
++  0.0014474051339285715,
++  0.0010986328125,
++  0.0015229724702380952,
++  0.0015229724702380952,
++  0.0018833705357142857,
++  0.001929873511904762,
++  0.001110258556547619,
++  0.0010695684523809525,
++  0.001110258556547619,
++  0.0012265159970238095,
++  0.0014241536458333333,
++  0.0010637555803571428,
++  0.0013369605654761905,
++  0.0013892764136904762,
++  0.0015811011904761905,
++  0.0015578497023809525,
++  0.0018019903273809525,
++  0.0013950892857142857
++ ]
++}
+\ No newline at end of file
+diff --git a/serve-glm52.sh b/serve-glm52.sh
+index 68f7501b3d618dea5c4ae93047b281cd56efd85d..8933ad62d752aabbc9f2e6a80bc3b17945afef41 100755
+--- a/serve-glm52.sh
++++ b/serve-glm52.sh
+@@ -107,6 +107,8 @@ MOE_BACKEND="${MOE_BACKEND:-b12x}"
+ MOE_SPEC_BACKEND="${MOE_SPEC_BACKEND:-b12x}"
+ ATTENTION_BACKEND="${ATTENTION_BACKEND:-B12X_MLA_SPARSE}"
+ KV_CACHE_DTYPE="${KV_CACHE_DTYPE:-fp8}"
++# Calibrated per-layer outer scales for nvfp4_ds_mla KV (empty = disabled).
++export VLLM_NVFP4_MLA_SCALES_FILE="${VLLM_NVFP4_MLA_SCALES_FILE:-}"
+ GLM51_PROFILE="${GLM51_PROFILE:-0}"
+ GLM52_CAUSAL_CASCADE="${GLM52_CAUSAL_CASCADE:-0}"
+ GLM52_DSPARK="${GLM52_DSPARK:-0}"
+diff --git a/tests/distributed/test_query_split_groups.py b/tests/distributed/test_query_split_groups.py
+new file mode 100644
+index 0000000000000000000000000000000000000000..d0dd36e26c8665a1d777aa23a925cddf7fc004cd
+--- /dev/null
++++ b/tests/distributed/test_query_split_groups.py
+@@ -0,0 +1,60 @@
++# SPDX-License-Identifier: Apache-2.0
++# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
++
++import pytest
++
++from vllm.distributed.parallel_state import _get_query_split_group_ranks
++
++
++@pytest.mark.parametrize(
++    ("tp_groups", "dcp_size", "expected"),
++    [
++        (
++            [list(range(8))],
++            4,
++            [[0, 4], [1, 5], [2, 6], [3, 7]],
++        ),
++        (
++            [list(range(8))],
++            2,
++            [[0, 2, 4, 6], [1, 3, 5, 7]],
++        ),
++        (
++            [list(range(8)), list(range(8, 16))],
++            4,
++            [
++                [0, 4],
++                [1, 5],
++                [2, 6],
++                [3, 7],
++                [8, 12],
++                [9, 13],
++                [10, 14],
++                [11, 15],
++            ],
++        ),
++        (
++            [list(range(8))],
++            8,
++            [[0], [1], [2], [3], [4], [5], [6], [7]],
++        ),
++        (
++            [list(range(8))],
++            1,
++            [list(range(8))],
++        ),
++    ],
++)
++def test_get_query_split_group_ranks(tp_groups, dcp_size, expected):
++    assert _get_query_split_group_ranks(tp_groups, dcp_size) == expected
++
++
++@pytest.mark.parametrize("dcp_size", [0, -1])
++def test_get_query_split_group_ranks_rejects_nonpositive_dcp(dcp_size):
++    with pytest.raises(ValueError, match="must be positive"):
++        _get_query_split_group_ranks([[0, 1]], dcp_size)
++
++
++def test_get_query_split_group_ranks_rejects_partial_dcp_group():
++    with pytest.raises(ValueError, match="must be divisible"):
++        _get_query_split_group_ranks([[0, 1, 2]], 2)
+diff --git a/tests/model_executor/layers/test_mla_cache_format.py b/tests/model_executor/layers/test_mla_cache_format.py
+index 9a128a5fc7e900d5fa9904e1f5815efbc82e8ac0..5c50e3e6ae877a91cb0479d4912aaa52f8525940 100644
+--- a/tests/model_executor/layers/test_mla_cache_format.py
++++ b/tests/model_executor/layers/test_mla_cache_format.py
+@@ -14,10 +14,17 @@ from vllm.model_executor.layers.mla_cache_format import (
+ )
+ 
+ 
+-def test_cache_format_envs_are_registered():
++def test_cache_format_envs_are_registered(monkeypatch):
+     assert NVFP4_MLA_DYNAMIC_SCALE_ENV in envs.environment_variables
+     assert NVFP4_MLA_SCALES_ENV in envs.environment_variables
+ 
++    scales_file = envs.environment_variables[NVFP4_MLA_SCALES_ENV]
++    monkeypatch.delenv(NVFP4_MLA_SCALES_ENV, raising=False)
++    assert scales_file() == ""
++
++    monkeypatch.setenv(NVFP4_MLA_SCALES_ENV, "  /tmp/static-scales.json  ")
++    assert scales_file() == "/tmp/static-scales.json"
++
+ 
+ def test_from_env_captures_one_server_static_mode(monkeypatch):
+     monkeypatch.setenv(NVFP4_MLA_DYNAMIC_SCALE_ENV, "1")
+diff --git a/tests/model_executor/layers/test_sparse_attn_indexer_b12x.py b/tests/model_executor/layers/test_sparse_attn_indexer_b12x.py
+index dda32a85ded7044b9c1011efae7a1ba5816d36a0..a7c46870760307887e06666d1f7b662380a20833 100644
+--- a/tests/model_executor/layers/test_sparse_attn_indexer_b12x.py
++++ b/tests/model_executor/layers/test_sparse_attn_indexer_b12x.py
+@@ -288,6 +288,88 @@ def _install_fake_b12x_dcp_merge(monkeypatch, run_row_topk, *, world_size: int):
+     )
+ 
+ 
++def test_query_split_gathers_indices_in_place_without_scores():
++    calls: list[tuple[int, int]] = []
++
++    class FakePyNccl:
++        disabled = False
++
++        def all_gather(self, output, input_):
++            calls.append((output.data_ptr(), input_.data_ptr()))
++            rows = input_.shape[0]
++            output[:rows].fill_(10)
++            output[rows:].fill_(20)
++
++    group = types.SimpleNamespace(
++        world_size=2,
++        rank_in_group=1,
++        device_communicator=types.SimpleNamespace(pynccl_comm=FakePyNccl()),
++    )
++    gathered_indices = torch.full((4, 3), -1, dtype=torch.int32)
++    local_indices = gathered_indices[2:]
++    local_indices.fill_(20)
++    scores = torch.arange(12, dtype=torch.float32).reshape(4, 3)
++    scores_before = scores.clone()
++
++    indexer_mod._query_split_all_gather_indices(group, local_indices, gathered_indices)
++
++    assert calls == [(gathered_indices.data_ptr(), local_indices.data_ptr())]
++    assert gathered_indices.tolist() == [[10] * 3, [10] * 3, [20] * 3, [20] * 3]
++    assert torch.equal(scores, scores_before)
++
++
++def test_query_split_copies_aliased_input_for_torch_distributed_fallback(
++    monkeypatch,
++):
++    calls: list[tuple[int, int]] = []
++
++    def fake_all_gather_into_tensor(output, input_, *, group):
++        assert group == "device-group"
++        calls.append((output.data_ptr(), input_.data_ptr()))
++        rows = input_.shape[0]
++        output[:rows].fill_(10)
++        output[rows:].copy_(input_)
++
++    monkeypatch.setattr(
++        torch.distributed,
++        "all_gather_into_tensor",
++        fake_all_gather_into_tensor,
++    )
++    group = types.SimpleNamespace(
++        world_size=2,
++        rank_in_group=1,
++        device_communicator=types.SimpleNamespace(
++            pynccl_comm=types.SimpleNamespace(disabled=True),
++            device_group="device-group",
++        ),
++    )
++    gathered_indices = torch.full((4, 3), -1, dtype=torch.int32)
++    local_indices = gathered_indices[2:]
++    local_indices.fill_(20)
++    local_ptr = local_indices.data_ptr()
++
++    indexer_mod._query_split_all_gather_indices(
++        group,
++        local_indices,
++        gathered_indices,
++    )
++
++    assert calls[0][0] == gathered_indices.data_ptr()
++    assert calls[0][1] != local_ptr
++    assert gathered_indices.tolist() == [[10] * 3, [10] * 3, [20] * 3, [20] * 3]
++
++
++def test_query_split_rejects_non_aliasing_local_indices():
++    group = types.SimpleNamespace(world_size=2, rank_in_group=0)
++    gathered_indices = torch.empty((4, 3), dtype=torch.int32)
++    local_indices = torch.empty((2, 3), dtype=torch.int32)
++
++    with pytest.raises(RuntimeError, match="must alias"):
++        indexer_mod._query_split_all_gather_indices(
++            group, local_indices, gathered_indices
++        )
++
++
+ @pytest.mark.parametrize(
+     "page_stride0",
+     [
+@@ -1434,9 +1516,12 @@ def test_b12x_schedule_metadata_uses_canonical_indexer_import(monkeypatch):
+     monkeypatch.setattr(
+         mla_indexer_mod.envs,
+         "VLLM_USE_B12X_SPARSE_INDEXER",
+-        True,
++        False,
+     )
+     builder = object.__new__(mla_indexer_mod.DeepseekV32IndexerMetadataBuilder)
++    # Backend selection is resolved once in __init__. The metadata path must
++    # use that result even when the legacy environment flag is unset.
++    builder.use_b12x_sparse_indexer = True
+     builder.scheduler_metadata_buffer = torch.zeros((5, 2), dtype=torch.int32)
+     builder.kv_cache_spec = types.SimpleNamespace(storage_block_size=64)
+     builder.num_sms = 4
+@@ -1459,6 +1544,27 @@ def test_b12x_schedule_metadata_uses_canonical_indexer_import(monkeypatch):
+     ]
+ 
+ 
++def test_b12x_schedule_metadata_respects_cached_backend_choice(monkeypatch):
++    from vllm.v1.attention.backends.mla import indexer as mla_indexer_mod
++
++    monkeypatch.setattr(
++        mla_indexer_mod.envs,
++        "VLLM_USE_B12X_SPARSE_INDEXER",
++        True,
++    )
++    builder = object.__new__(mla_indexer_mod.DeepseekV32IndexerMetadataBuilder)
++    builder.use_b12x_sparse_indexer = False
++
++    result = builder._maybe_build_b12x_schedule_metadata(
++        seq_lens=torch.tensor([64], dtype=torch.int32),
++        block_table=torch.zeros((1, 1), dtype=torch.int32),
++        num_decode_tokens=1,
++        requires_padding=False,
++    )
++
++    assert result is None
++
++
+ def test_mtp_variable_decode_preserves_block_table_alignment_padding():
+     from vllm.v1.attention.backends.mla import indexer as mla_indexer_mod
+ 
+diff --git a/tests/model_executor/test_eagle_quantization.py b/tests/model_executor/test_eagle_quantization.py
+index 72c189d8331324baba6da5de56f1d6d5917189bb..423273182cfef26ae58e2784ab1a65e1eae393bf 100644
+--- a/tests/model_executor/test_eagle_quantization.py
++++ b/tests/model_executor/test_eagle_quantization.py
+@@ -1,6 +1,7 @@
+ # SPDX-License-Identifier: Apache-2.0
+ # SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+ 
++from types import SimpleNamespace
+ from unittest.mock import Mock, patch
+ 
+ import pytest
+@@ -54,6 +55,49 @@ def test_get_draft_quant_config_without_draft_model():
+     assert result is None
+ 
+ 
++def test_dense_exl3_draft_skips_rank_sliced_hydration():
++    quant_config = Mock()
++    quant_config.get_name.return_value = "exl3"
++    draft_model_config = SimpleNamespace(
++        model="dense-exl3-draft",
++        hf_config=SimpleNamespace(),
++    )
++    vllm_config = SimpleNamespace(
++        speculative_config=SimpleNamespace(draft_model_config=draft_model_config),
++        load_config=object(),
++        model_config=SimpleNamespace(hf_config=SimpleNamespace()),
++    )
++
++    with patch.object(VllmConfig, "get_quantization_config", return_value=quant_config):
++        result = get_draft_quant_config(vllm_config)
++
++    assert result is quant_config
++    quant_config.maybe_update_config.assert_not_called()
++
++
++def test_rank_sliced_exl3_draft_hydrates_from_target_metadata():
++    quant_config = Mock()
++    quant_config.get_name.return_value = "exl3"
++    target_hf = SimpleNamespace(hybrid_tr3_tail={"tp": 4})
++    draft_model_config = SimpleNamespace(
++        model="rank-sliced-draft",
++        hf_config=SimpleNamespace(),
++    )
++    vllm_config = SimpleNamespace(
++        speculative_config=SimpleNamespace(draft_model_config=draft_model_config),
++        load_config=object(),
++        model_config=SimpleNamespace(hf_config=target_hf),
++    )
++
++    with patch.object(VllmConfig, "get_quantization_config", return_value=quant_config):
++        result = get_draft_quant_config(vllm_config)
++
++    assert result is quant_config
++    quant_config.maybe_update_config.assert_called_once_with(
++        "rank-sliced-draft", hf_config=target_hf
++    )
++
++
+ @torch.inference_mode()
+ @pytest.mark.parametrize("device", DEVICES)
+ def test_fc_layer_quant_config_usage(default_vllm_config, dist_init, device) -> None:
+diff --git a/tests/quantization/test_exl3.py b/tests/quantization/test_exl3.py
+new file mode 100644
+index 0000000000000000000000000000000000000000..e9c8055bf6db4c9ba01c5922f08da281da91d4e1
+--- /dev/null
++++ b/tests/quantization/test_exl3.py
+@@ -0,0 +1,374 @@
++# SPDX-License-Identifier: Apache-2.0
++# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
++
++from types import SimpleNamespace
++
++import pytest
++import torch
++
++import vllm.model_executor.layers.quantization.exl3 as exl3_module
++import vllm.model_executor.parameter as parameter_module
++from vllm.config import CompilationMode
++from vllm.model_executor.layers.fused_moe import MoEActivation
++from vllm.model_executor.layers.quantization import get_quantization_config
++from vllm.model_executor.layers.quantization.exl3 import (
++    Exl3Config,
++    Exl3MoEMethod,
++    Exl3MoEParameter,
++)
++from vllm.model_executor.models import glm4_moe
++
++
++def _rank_sliced_metadata(**overrides):
++    metadata = {
++        "format": "exl3-trellis",
++        "bits": 3.0,
++        "codebook": "mcg",
++        "experts_per_layer": 256,
++        "moe_layers": [3, 77],
++        "tensor_schema": (
++            "model.layers.{L}.mlp.experts.{E}.{proj}.rank{r}.{trellis|suh|svh|mcg}"
++        ),
++        "tp": 4,
++    }
++    metadata.update(overrides)
++    return metadata
++
++
++def test_rank_sliced_checkpoint_selects_exl3_override():
++    hf_config = SimpleNamespace(hybrid_tr3_tail=_rank_sliced_metadata())
++
++    assert get_quantization_config("exl3") is Exl3Config
++    assert (
++        Exl3Config.override_quantization_method(
++            {"quant_method": "modelopt"}, None, hf_config
++        )
++        == "exl3"
++    )
++    assert (
++        Exl3Config.override_quantization_method(
++            {"quant_method": "modelopt"}, "fp8", hf_config
++        )
++        is None
++    )
++
++
++def test_glm_model_retains_quant_config_for_weight_loading(monkeypatch):
++    pp_group = SimpleNamespace(is_first_rank=False, is_last_rank=False)
++    monkeypatch.setattr(glm4_moe, "get_pp_group", lambda: pp_group)
++    monkeypatch.setattr(
++        glm4_moe,
++        "make_layers",
++        lambda *args, **kwargs: (0, 0, torch.nn.ModuleList()),
++    )
++    monkeypatch.setattr(
++        glm4_moe,
++        "make_empty_intermediate_tensors_factory",
++        lambda *args, **kwargs: object(),
++    )
++    quant_config = object()
++    vllm_config = SimpleNamespace(
++        model_config=SimpleNamespace(
++            hf_config=SimpleNamespace(
++                vocab_size=1,
++                hidden_size=8,
++                num_hidden_layers=0,
++            )
++        ),
++        cache_config=object(),
++        quant_config=quant_config,
++        parallel_config=SimpleNamespace(enable_eplb=False),
++        compilation_config=SimpleNamespace(mode=CompilationMode.NONE),
++    )
++
++    model = glm4_moe.Glm4MoeModel(vllm_config=vllm_config)
++
++    assert model.quant_config is quant_config
++
++
++@pytest.mark.parametrize(
++    ("overrides", "message"),
++    [
++        ({"codebook": "mul1"}, "MCG codebook"),
++        ({"moe_layers": [77, 3]}, "moe_layers"),
++        ({"tensor_schema": "unsupported"}, "tensor schema"),
++    ],
++)
++def test_rank_sliced_metadata_fails_closed(overrides, message):
++    config = Exl3Config()
++    hf_config = SimpleNamespace(hybrid_tr3_tail=_rank_sliced_metadata(**overrides))
++
++    with pytest.raises(ValueError, match=message):
++        config.maybe_update_config("unused", hf_config)
++
++
++def test_rank_sliced_metadata_admits_only_declared_moe_layers():
++    config = Exl3Config()
++    config.maybe_update_config(
++        "unused",
++        SimpleNamespace(hybrid_tr3_tail=_rank_sliced_metadata()),
++    )
++
++    assert config._moe_prefix_is_exl3("model.layers.3.mlp.experts")
++    assert config._moe_prefix_is_exl3("model.layers.77.mlp.experts")
++    assert not config._moe_prefix_is_exl3("model.layers.2.mlp.experts")
++    assert not config._moe_prefix_is_exl3("model.layers.78.mlp.experts")
++    assert (
++        config.codebook_for_prefix("model.layers.10.mlp.experts.0.gate_proj") == "mcg"
++    )
++
++
++def test_rank_sliced_weight_name_keeps_only_local_tp_rank(monkeypatch):
++    config = Exl3Config()
++    config.maybe_update_config(
++        "unused",
++        SimpleNamespace(hybrid_tr3_tail=_rank_sliced_metadata()),
++    )
++    monkeypatch.setattr(exl3_module, "get_tensor_model_parallel_rank", lambda: 2)
++    prefix = "model.layers.3.mlp.experts.17.gate_proj"
++
++    assert (
++        config.normalize_rank_sliced_weight_name(f"{prefix}.rank2.trellis")
++        == f"{prefix}.trellis"
++    )
++    assert config.normalize_rank_sliced_weight_name(f"{prefix}.rank1.trellis") is None
++    assert (
++        config.normalize_rank_sliced_weight_name("model.embed_tokens.weight")
++        == "model.embed_tokens.weight"
++    )
++
++
++def test_rank_sliced_parameter_preallocates_projection_major_slab(monkeypatch):
++    monkeypatch.setattr(parameter_module, "get_tensor_model_parallel_rank", lambda: 0)
++    monkeypatch.setattr(
++        parameter_module, "get_tensor_model_parallel_world_size", lambda: 1
++    )
++    param = Exl3MoEParameter(
++        weight_loader=lambda *args, **kwargs: None,
++        num_experts=3,
++        shard_ids=("w1", "w3"),
++        preallocate=True,
++    )
++    w1 = torch.arange(8, dtype=torch.int16).reshape(2, 2, 2)
++    w3 = w1 + 20
++
++    param.load_exl3_weight(w1, expert_id=1, shard_id="w1")
++    param.load_exl3_weight(w3, expert_id=2, shard_id="w3")
++
++    assert param.exl3_backing is not None
++    assert tuple(param.exl3_backing.shape) == (2, 3, 2, 2, 2)
++    assert (
++        param.exl3_tensors[(1, "w1")].data_ptr() == param.exl3_backing[0, 1].data_ptr()
++    )
++    assert (
++        param.exl3_tensors[(2, "w3")].data_ptr() == param.exl3_backing[1, 2].data_ptr()
++    )
++    torch.testing.assert_close(param.exl3_tensors[(1, "w1")], w1)
++    torch.testing.assert_close(param.exl3_tensors[(2, "w3")], w3)
++
++
++def test_rank_sliced_weights_use_unified_fused_moe_contract(monkeypatch):
++    experts = 2
++    hidden = intermediate = 128
++    bits = 3
++    slabs = {
++        "w13_trellis": torch.zeros(
++            (2, experts, hidden // 16, intermediate // 16, 16 * bits),
++            dtype=torch.int16,
++        ),
++        "w2_trellis": torch.zeros(
++            (experts, intermediate // 16, hidden // 16, 16 * bits),
++            dtype=torch.int16,
++        ),
++        "w13_suh": torch.ones((2, experts, hidden), dtype=torch.float16),
++        "w13_svh": torch.ones((2, experts, intermediate), dtype=torch.float16),
++        "w2_suh": torch.ones((experts, intermediate), dtype=torch.float16),
++        "w2_svh": torch.ones((experts, hidden), dtype=torch.float16),
++    }
++
++    class FakeFusedMoe:
++        def __init__(self):
++            self.plan_kwargs = None
++            self.prepare_kwargs = None
++
++        def plan_weights(self, **kwargs):
++            self.plan_kwargs = kwargs
++            return SimpleNamespace(source_format=kwargs["source_format"])
++
++        def prepare_weights(self, **kwargs):
++            self.prepare_kwargs = kwargs
++            return SimpleNamespace(plan=kwargs["plan"])
++
++    api = FakeFusedMoe()
++    monkeypatch.setattr(exl3_module, "_load_sparkinfer_fused_moe", lambda: api)
++    method = object.__new__(Exl3MoEMethod)
++    method.quant_config = SimpleNamespace(bits=float(bits))
++    method._rank_sliced_backing = lambda _layer, name: slabs[name]
++    marker = torch.tensor(0xCBAC1FED - (1 << 32), dtype=torch.int32)
++    layer = SimpleNamespace(
++        local_num_experts=experts,
++        exl3_hidden_size=hidden,
++        exl3_intermediate_size_per_partition=intermediate,
++        exl3_params_dtype=torch.float16,
++        activation=MoEActivation.SILU,
++        w13_mcg=SimpleNamespace(exl3_tensors={(0, "w1"): marker}),
++    )
++
++    method._prepare_rank_sliced_weights(layer)
++
++    assert api.plan_kwargs == {
++        "quant_modes": "w4a16",
++        "source_format": "exl3_trellis_mcg",
++        "activation": "silu",
++        "params_dtype": torch.float16,
++        "num_experts": experts,
++        "hidden_size": hidden,
++        "intermediate_size": intermediate,
++        "w13_layout": "w13",
++        "trellis_bits": bits,
++        "trellis_tile_config": (64, 128, 64, 128),
++    }
++    assert api.prepare_kwargs["plan"] is layer.exl3_trellis_weights.plan
++    assert api.prepare_kwargs["params_dtype"] == torch.float16
++    assert api.prepare_kwargs["w1_fp4"] is slabs["w13_trellis"]
++    assert api.prepare_kwargs["w2_fp4"] is slabs["w2_trellis"]
++    assert api.prepare_kwargs["trellis_mcg"] is marker
++
++
++def test_rank_sliced_runtime_scope_is_per_owning_model():
++    """Target and rank-sliced MTP draft layers must not share a cached runtime.
++
++    The rank-sliced runtime cache stores mutable Trellis/prefill scratch and
++    parity staging buffers. A target MoE layer and an MTP draft layer of the same
++    model have identical shapes, topk and planner settings, so a shape-only key
++    would hand the draft the target's scratch and break the target/draft
++    isolation their independently captured CUDA graphs depend on.
++    """
++    target_config = SimpleNamespace()
++    draft_config = SimpleNamespace()
++
++    target_scope = exl3_module._runtime_scope_id(target_config)
++    draft_scope = exl3_module._runtime_scope_id(draft_config)
++
++    # Distinct owning configs must never collide...
++    assert target_scope != draft_scope
++    # ...and the scope must be stable, so every layer of one model keeps sharing
++    # a single runtime (the prefill arena is ~1 GiB; per-layer runtimes would not
++    # fit on a 75+ layer model).
++    assert exl3_module._runtime_scope_id(target_config) == target_scope
++    assert exl3_module._runtime_scope_id(draft_config) == draft_scope
++
++
++def test_rank_sliced_runtime_key_differs_across_models_with_same_shape():
++    """Two same-shape layers owned by different models get different cache keys."""
++
++    def _key(quant_config):
++        # Mirrors the scope-prefixed key built in Exl3MoEMethod._rank_sliced_runtime
++        # for two layers whose shape/planner components are byte-for-byte equal.
++        return (
++            exl3_module._runtime_scope_id(quant_config),
++            0,  # device index
++            torch.bfloat16,
++            5120,  # hidden size
++            768,  # intermediate size per partition
++            64,  # local experts
++            8,  # topk
++            3072,  # max batched tokens
++        )
++
++    target_config = SimpleNamespace()
++    draft_config = SimpleNamespace()
++
++    target_key = _key(target_config)
++    draft_key = _key(draft_config)
++
++    assert target_key != draft_key
++    # Everything except the leading scope is identical, proving the scope is the
++    # only thing preventing the collision.
++    assert target_key[1:] == draft_key[1:]
++    # Same owner -> same key, so target layers still share one runtime.
++    assert _key(target_config) == target_key
++
++
++def test_rank_sliced_window_defaults_to_min_capturable_m(monkeypatch) -> None:
++    """Every rank-sliced layer must cover small rows without an env workaround.
++
++    Regression test for the boot failure reported in vLLM #183: with the Trellis
++    window left at its historical default of 4, CUDA-graph capture of an EXL3
++    rank-sliced MTP draft reaches the eager parity path at m=1,2,3 and the engine
++    cannot start:
++
++        RuntimeError: EXL3 eager parity path entered during CUDA graph capture
++        (m=3); capture sizes must lie inside the Trellis window [4, 32]
++
++    It was invariant to num_speculative_tokens and to cudagraph_capture_sizes,
++    because m here is the draft's row count per step, not a target batch size.
++    Target profiling can also produce m=3, so role-dependent defaults merely
++    move the same failure from the draft to MTP0. The backend declares one
++    capability floor and uses it for both roles.
++    """
++    from types import SimpleNamespace
++
++    from vllm.model_executor.layers.quantization import exl3 as exl3_mod
++
++    monkeypatch.delenv("VLLM_EXL3_TRELLIS_MIN_M", raising=False)
++
++    # The GLM-5.2 MTP head is named exactly like a target layer, so the role
++    # comes from the exl3_is_draft stamp applied by load_eagle_model -- name
++    # inspection alone cannot classify it.
++    draft = SimpleNamespace(
++        layer_name="model.layers.78.mlp.experts", exl3_is_draft=True
++    )
++    target = SimpleNamespace(layer_name="model.layers.30.mlp.experts")
++
++    assert exl3_mod._is_draft_layer(draft)
++    assert not exl3_mod._is_draft_layer(target)
++    # Unstamped draft with a distinctive prefix still classifies via fallback.
++    assert exl3_mod._is_draft_layer(
++        SimpleNamespace(layer_name="model.layers.0.mtp.mlp.experts")
++    )
++    # A stamp always wins over the name, in both directions.
++    assert not exl3_mod._is_draft_layer(
++        SimpleNamespace(layer_name="model.layers.0.mtp.experts", exl3_is_draft=False)
++    )
++
++    def resolved():
++        return exl3_mod._positive_env_int(
++            "VLLM_EXL3_TRELLIS_MIN_M", exl3_mod._DEFAULT_TRELLIS_MIN_M
++        )
++
++    assert resolved() == exl3_mod._DEFAULT_TRELLIS_MIN_M
++    assert resolved() == exl3_mod.MIN_CAPTURABLE_TRELLIS_M == 1
++
++    # An explicit value remains authoritative as a diagnostic kill switch.
++    monkeypatch.setenv("VLLM_EXL3_TRELLIS_MIN_M", "4")
++    assert resolved() == 4
++
++
++def test_draft_role_stamp_wins_over_name() -> None:
++    """The exl3_is_draft stamp set in create_weights is authoritative.
++
++    Forward/plan/capture time has no current vllm config, so the role cannot be
++    inferred there; create_weights stamps it from runner_type while the
++    construction context is live. Stamped values must win over any name
++    heuristic in both directions.
++    """
++    from types import SimpleNamespace
++
++    from vllm.model_executor.layers.quantization import exl3 as exl3_mod
++
++    # GLM-5.2 MTP head: named like a target, stamped draft.
++    assert exl3_mod._is_draft_layer(
++        SimpleNamespace(layer_name="model.layers.78.mlp.experts", exl3_is_draft=True)
++    )
++    # Target stamped False keeps its role even with a suspicious name.
++    assert not exl3_mod._is_draft_layer(
++        SimpleNamespace(layer_name="model.layers.0.mtp.experts", exl3_is_draft=False)
++    )
++    # Unstamped layers fall back to the name heuristic.
++    assert exl3_mod._is_draft_layer(
++        SimpleNamespace(layer_name="model.layers.0.mtp.mlp.experts")
++    )
++    assert not exl3_mod._is_draft_layer(
++        SimpleNamespace(layer_name="model.layers.30.mlp.experts")
++    )
+diff --git a/tests/quantization/test_exl3_prefill_plan.py b/tests/quantization/test_exl3_prefill_plan.py
+new file mode 100644
+index 0000000000000000000000000000000000000000..c55be20ee366173ca5bc5d96d3fb6090b8dd11b4
+--- /dev/null
++++ b/tests/quantization/test_exl3_prefill_plan.py
+@@ -0,0 +1,286 @@
++# SPDX-License-Identifier: Apache-2.0
++# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
++
++"""Dispatch-contract tests for the dual-plan rank-sliced EXL3 MoE runtime.
++
++The planned Trellis API and the ExLlamaV3 extension are mocked; these tests
++prove backend policy only:
++
++* decode window m in [min, max] binds the decode plan;
++* max < m <= capacity binds the prefill plan (block_size_m=64 by default);
++* m < min stays on the parity path with chunk-capped staging buffers;
++* VLLM_EXL3_PREFILL_TRELLIS=0 restores the single-plan parity behavior
++  with full-capacity staging;
++* m above planned capacity raises.
++
++CPU-only; no CUDA, sparkinfer, or exllamav3_ext required.
++"""
++
++import os
++from types import SimpleNamespace
++
++import pytest
++import torch
++
++import vllm.model_executor.layers.quantization.exl3 as exl3_module
++from vllm.model_executor.layers.quantization.exl3 import Exl3MoEMethod
++
++HIDDEN = 128
++INTERMEDIATE = 128
++EXPERTS = 8
++TOPK = 4
++MAX_BATCHED = 256
++
++
++class _FakePlan:
++    def __init__(self, caps):
++        self.caps = caps
++
++    def scratch_specs(self):
++        return (
++            SimpleNamespace(
++                shape=(64,),
++                dtype=torch.uint8,
++                device=self.caps["device"],
++            ),
++        )
++
++
++class _FakeFusedMoeApi:
++    def __init__(self):
++        self.planned = []
++        self.bound = []
++
++    def Caps(self, **kwargs):
++        return kwargs
++
++    def plan(self, caps):
++        plan = _FakePlan(caps)
++        self.planned.append(caps)
++        return plan
++
++    def bind(self, plan, *, scratch, a, experts, topk_weights, topk_ids):
++        del scratch, experts, topk_weights, topk_ids
++        self.bound.append((plan, int(a.shape[0])))
++        return SimpleNamespace(plan=plan, m=int(a.shape[0]))
++
++    def run(self, *, binding):
++        return torch.zeros((binding.m, HIDDEN), dtype=torch.float32)
++
++
++class _FakeExt:
++    """Parity extension without exl3_moe_fused: chunk loop only."""
++
++    def __init__(self):
++        self.moe_calls = []
++
++    def exl3_moe_max_concurrency(self, device):
++        del device
++        return 2
++
++    def exl3_moe(self, xh, out32, *args):
++        del args
++        self.moe_calls.append((int(xh.shape[0]), int(out32.shape[0])))
++
++
++def _make_layer():
++    return SimpleNamespace(
++        exl3_max_num_batched_tokens=MAX_BATCHED,
++        exl3_hidden_size=HIDDEN,
++        exl3_intermediate_size_per_partition=INTERMEDIATE,
++        local_num_experts=EXPERTS,
++        exl3_trellis_tile_config=(64, 128, 64, 128),
++        exl3_trellis_weights=SimpleNamespace(plan=object()),
++        exl3_pointer_tables=(),
++        exl3_expert_map=torch.arange(EXPERTS, dtype=torch.int64),
++    )
++
++
++def _make_method():
++    method = object.__new__(Exl3MoEMethod)
++    method.quant_config = SimpleNamespace(
++        bits=3.0,
++        rank_sliced_metadata={"tp": 4},
++    )
++    return method
++
++
++class _Harness:
++    def __init__(self, env=None):
++        self._env = dict(env or {})
++        self._saved_env = {}
++        self._saved_capturing = None
++        self.api = _FakeFusedMoeApi()
++        self.ext = _FakeExt()
++
++    def __enter__(self):
++        for name, value in self._env.items():
++            self._saved_env[name] = os.environ.get(name)
++            if value is None:
++                os.environ.pop(name, None)
++            else:
++                os.environ[name] = value
++        self._saved_loaders = (
++            exl3_module._load_sparkinfer_fused_moe,
++            exl3_module._load_exl3_ext,
++        )
++        exl3_module._load_sparkinfer_fused_moe = lambda: self.api
++        exl3_module._load_exl3_ext = lambda: self.ext
++        self._saved_capturing = torch.cuda.is_current_stream_capturing
++        torch.cuda.is_current_stream_capturing = lambda: False
++        self._saved_current_device = torch.cuda.current_device
++        torch.cuda.current_device = lambda: 0
++        exl3_module._RANK_SLICED_RUNTIMES.clear()
++        return self
++
++    def __exit__(self, *exc):
++        (
++            exl3_module._load_sparkinfer_fused_moe,
++            exl3_module._load_exl3_ext,
++        ) = self._saved_loaders
++        torch.cuda.is_current_stream_capturing = self._saved_capturing
++        torch.cuda.current_device = self._saved_current_device
++        for name, value in self._saved_env.items():
++            if value is None:
++                os.environ.pop(name, None)
++            else:
++                os.environ[name] = value
++        exl3_module._RANK_SLICED_RUNTIMES.clear()
++        return False
++
++    def planned_caps(self):
++        return self.api.planned
++
++
++def _apply(method, layer, m):
++    x = torch.zeros((m, HIDDEN), dtype=torch.bfloat16)
++    weights = torch.zeros((m, TOPK), dtype=torch.float32)
++    ids = torch.zeros((m, TOPK), dtype=torch.int64)
++    return method._apply_rank_sliced(layer, x, weights, ids)
++
++
++def test_dual_plan_construction_and_dispatch():
++    with _Harness() as h:
++        method = _make_method()
++        layer = _make_layer()
++
++        out = _apply(method, layer, 16)
++        assert out.dtype == torch.bfloat16 and out.shape == (16, HIDDEN)
++        # Two plans: decode (32, block 8) then prefill (capacity, block 64).
++        assert [
++            (caps["max_tokens"], caps["w4a16_block_size_m"])
++            for caps in h.planned_caps()
++        ] == [(32, 8), (MAX_BATCHED, 64)]
++        assert all(caps["route_num_experts"] == 0 for caps in h.planned_caps())
++        assert h.api.bound[-1][0].caps["max_tokens"] == 32
++
++        _apply(method, layer, 200)
++        assert h.api.bound[-1][0].caps["max_tokens"] == MAX_BATCHED
++        assert h.api.bound[-1][1] == 200
++        assert not h.ext.moe_calls
++
++        _apply(method, layer, 2)
++        assert h.api.bound[-1][0].caps["max_tokens"] == 32
++        assert h.api.bound[-1][1] == 2
++        assert not h.ext.moe_calls
++
++        runtime = next(iter(exl3_module._RANK_SLICED_RUNTIMES.values()))
++        assert runtime["parity_rows"] == 128
++        assert runtime["xh"].shape[0] == 128
++        assert runtime["token_sorted"].numel() == 128 * TOPK
++
++        # Batches above the scheduler contract must fail before allocating a
++        # replacement runtime or a larger Trellis arena during serving.
++        runtime_keys = tuple(exl3_module._RANK_SLICED_RUNTIMES)
++        runtime_count = len(exl3_module._RANK_SLICED_RUNTIMES)
++        plan_count = len(h.planned_caps())
++        with pytest.raises(
++            ValueError,
++            match=rf"m={MAX_BATCHED + 1}, capacity={MAX_BATCHED}",
++        ):
++            _apply(method, layer, MAX_BATCHED + 1)
++        assert tuple(exl3_module._RANK_SLICED_RUNTIMES) == runtime_keys
++        assert len(exl3_module._RANK_SLICED_RUNTIMES) == runtime_count
++        assert len(h.planned_caps()) == plan_count
++
++
++def test_prefill_trellis_disabled_restores_parity():
++    with _Harness(env={"VLLM_EXL3_PREFILL_TRELLIS": "0"}) as h:
++        method = _make_method()
++        layer = _make_layer()
++
++        _apply(method, layer, 200)
++        # Single decode plan only; large m runs the parity chunk loop.
++        assert [
++            (caps["max_tokens"], caps["w4a16_block_size_m"])
++            for caps in h.planned_caps()
++        ] == [(32, 8)]
++        assert not h.api.bound
++        assert h.ext.moe_calls == [(128, 128), (72, 72)]
++
++        runtime = next(iter(exl3_module._RANK_SLICED_RUNTIMES.values()))
++        assert runtime["prefill_plan"] is None
++        assert runtime["parity_rows"] == MAX_BATCHED
++        assert runtime["xh"].shape[0] == MAX_BATCHED
++
++
++def test_prefill_block_m_env_override():
++    with _Harness(env={"VLLM_EXL3_PREFILL_BLOCK_M": "48"}) as h:
++        method = _make_method()
++        layer = _make_layer()
++        _apply(method, layer, 40)
++        assert h.planned_caps()[-1]["w4a16_block_size_m"] == 48
++        assert h.api.bound[-1][0].caps["max_tokens"] == MAX_BATCHED
++
++
++def test_parity_window_capacity_is_validated_before_planning():
++    env = {
++        "VLLM_EXL3_TRELLIS_MIN_M": "160",
++        "VLLM_EXL3_TRELLIS_MAX_M": "192",
++        "VLLM_EXL3_PREFILL_CHUNK": "128",
++    }
++    with _Harness(env=env) as h:
++        with pytest.raises(ValueError, match="cannot cover the EXL3 parity window"):
++            _apply(_make_method(), _make_layer(), 16)
++        assert not h.planned_caps()
++
++
++def test_disabled_prefill_plan_keeps_full_parity_capacity():
++    env = {
++        "VLLM_EXL3_TRELLIS_MIN_M": "160",
++        "VLLM_EXL3_TRELLIS_MAX_M": "192",
++        "VLLM_EXL3_PREFILL_CHUNK": "128",
++        "VLLM_EXL3_PREFILL_TRELLIS": "0",
++    }
++    with _Harness(env=env):
++        _apply(_make_method(), _make_layer(), 159)
++        runtime = next(iter(exl3_module._RANK_SLICED_RUNTIMES.values()))
++        assert runtime["parity_rows"] == MAX_BATCHED
++
++
++def test_explicit_parity_path_guarded_against_capture():
++    with _Harness(env={"VLLM_EXL3_TRELLIS_MIN_M": "4"}) as h:
++        method = _make_method()
++        layer = _make_layer()
++        # Plan eagerly, then flip into "capturing" state.
++        _apply(method, layer, 16)
++        torch.cuda.is_current_stream_capturing = lambda: True
++        # Both trellis plans stay capture-safe.
++        _apply(method, layer, 16)
++        _apply(method, layer, 200)
++        assert h.api.bound[-1][1] == 200
++        # The eager parity path must refuse to be recorded.
++        try:
++            _apply(method, layer, 2)
++        except RuntimeError as err:
++            assert "capture" in str(err)
++        else:
++            raise AssertionError("parity path must raise during capture")
++
++
++if __name__ == "__main__":
++    test_dual_plan_construction_and_dispatch()
++    test_prefill_trellis_disabled_restores_parity()
++    test_prefill_block_m_env_override()
++    test_explicit_parity_path_guarded_against_capture()
++    print("EXL3_PREFILL_PLAN_TESTS_OK")
+diff --git a/tests/v1/structured_output/test_reasoning_structured_output.py b/tests/v1/structured_output/test_reasoning_structured_output.py
+index 861e919c102a698d905f1da9ad6c5da09c576e6f..5e0713519aedabd9af535068fab7409f6ff51a6d 100644
+--- a/tests/v1/structured_output/test_reasoning_structured_output.py
++++ b/tests/v1/structured_output/test_reasoning_structured_output.py
+@@ -241,6 +241,116 @@ class TestReasoningStructuredOutput:
+         assert structured_req.reasoning_ended is True
+         assert result is True
+ 
++    def test_should_advance_reasoning_just_ended_with_spec_decode_json(
++        self,
++        manager_with_reasoner,
++        mock_request_with_structured_output,
++    ):
++        """When reasoning ends this step under speculative decoding, advance
++        immediately for every structured type, not just structural tags: the
++        step may already contain accepted post-marker content, and deferring
++        leaves the grammar one token behind the sampled stream (#48228)."""
++        structured_req = mock_request_with_structured_output.structured_output_request
++        structured_req.reasoning_ended = False
++        structured_req.structured_output_key = (
++            StructuredOutputOptions.JSON,
++            '{"type": "object"}',
++        )
++        reasoner = MockReasoner(tokenizer=Mock())
++        reasoner.is_reasoning_end_streaming.return_value = True
++        structured_req.reasoner = reasoner
++
++        manager_with_reasoner.vllm_config.speculative_config = Mock()
++
++        result = manager_with_reasoner.should_advance(
++            mock_request_with_structured_output
++        )
++
++        assert structured_req.reasoning_ended is True
++        assert result is True
++        assert isinstance(structured_req.reasoning_end_token_index, int)
++
++    def test_should_advance_detects_end_from_new_token_ids(
++        self,
++        manager_with_reasoner,
++        mock_request_with_structured_output,
++    ):
++        """new_token_ids is the authoritative step delta: with speculative
++        decoding, num_computed_tokens is pre-incremented past accepted draft
++        tokens, so the counter-derived window misses the end marker (#34650)."""
++        end_token_id, content_token_id = 42, 99
++        request = mock_request_with_structured_output
++        structured_req = request.structured_output_request
++        structured_req.reasoning_ended = False
++        reasoner = MockReasoner(tokenizer=Mock())
++        reasoner.is_reasoning_end_streaming.side_effect = (
++            lambda input_ids, delta_ids: end_token_id in list(delta_ids)
++        )
++        structured_req.reasoner = reasoner
++
++        request.all_token_ids = request.prompt_token_ids + [
++            7,
++            end_token_id,
++            content_token_id,
++        ]
++        # Spec decode pre-incremented past the accepted tokens: the
++        # counter-derived window all_token_ids[num_computed_tokens:] is empty.
++        request.num_computed_tokens = len(request.all_token_ids)
++        request.num_output_placeholders = 0
++
++        # The counter fallback misses the marker...
++        assert manager_with_reasoner.should_advance(request) is False
++        assert structured_req.reasoning_ended is False
++
++        # ...the explicit step delta does not (no spec config here, so the
++        # advance itself is still deferred to the next step).
++        result = manager_with_reasoner.should_advance(
++            request, [end_token_id, content_token_id]
++        )
++        assert structured_req.reasoning_ended is True
++        assert result is False
++
++    def test_should_advance_straddle_step_trims_and_advances_same_step(
++        self,
++        manager_with_reasoner,
++        mock_request_with_structured_output,
++    ):
++        """A speculative step accepting [</think>, "{"] must advance the
++        grammar with exactly the post-marker content in the same step;
++        otherwise the next bitmask is computed from the un-advanced grammar
++        and re-forces the content token, doubling it in the output (#48228)."""
++        end_token_id, content_token_id = 42, 99
++        request = mock_request_with_structured_output
++        structured_req = request.structured_output_request
++        structured_req.reasoning_ended = False
++        structured_req.structured_output_key = (
++            StructuredOutputOptions.JSON,
++            '{"type": "object"}',
++        )
++        reasoner = MockReasoner(tokenizer=Mock())
++        reasoner.is_reasoning_end_streaming.side_effect = (
++            lambda input_ids, delta_ids: end_token_id in list(delta_ids)
++        )
++        structured_req.reasoner = reasoner
++        manager_with_reasoner.vllm_config.speculative_config = Mock()
++
++        new_token_ids = [end_token_id, content_token_id]
++        request.all_token_ids = request.prompt_token_ids + [
++            7,
++            end_token_id,
++            content_token_id,
++        ]
++        request.num_computed_tokens = len(request.all_token_ids)
++        request.num_output_placeholders = 0
++
++        assert manager_with_reasoner.should_advance(request, new_token_ids) is True
++        assert structured_req.reasoning_end_token_index == (
++            len(request.all_token_ids) - 2
++        )
++        assert manager_with_reasoner.trim_reasoning_for_advance(
++            request, new_token_ids
++        ) == [content_token_id]
++
+     def test_should_advance_reasoning_already_ended(
+         self,
+         manager_with_reasoner,
+diff --git a/tests/v1/worker/test_gpu_worker.py b/tests/v1/worker/test_gpu_worker.py
+index 088bdc2614d5351fbc0eb6e7998ab1e3f5827052..ca7d18a9d07dc6477e72745b2dd00d2549b15f55 100644
+--- a/tests/v1/worker/test_gpu_worker.py
++++ b/tests/v1/worker/test_gpu_worker.py
+@@ -111,6 +111,7 @@ def test_memory_profile_replays_model_after_kernel_warmup(
+ ):
+     worker = object.__new__(Worker)
+     calls = []
++    worker.device = "cuda:0"
+     worker.model_runner = SimpleNamespace(
+         profile_run=lambda: calls.append("profile"),
+     )
+@@ -127,10 +128,21 @@ def test_memory_profile_replays_model_after_kernel_warmup(
+         "_warmup_kernels_once",
+         lambda: calls.append("kernel_warmup"),
+     )
++    monkeypatch.setattr(
++        gpu_worker_module.torch.accelerator,
++        "reset_peak_memory_stats",
++        lambda device: calls.append(("reset_peak", device)),
++    )
+ 
+     worker._profile_model_with_kernel_warmup()
+ 
+-    assert calls == ["profile", "compressor", "kernel_warmup", "profile"]
++    assert calls == [
++        "profile",
++        "compressor",
++        "kernel_warmup",
++        ("reset_peak", "cuda:0"),
++        "profile",
++    ]
+ 
+ 
+ @pytest.mark.parametrize("video_backend", [None, "opencv"])
+diff --git a/vllm/config/model.py b/vllm/config/model.py
+index 159083f58859a35d5341fde0fa0b556f0d2e4d64..d573fac4142d822be9cc0859ad688771ae3f5bda 100644
+--- a/vllm/config/model.py
++++ b/vllm/config/model.py
+@@ -1052,6 +1052,10 @@ class ModelConfig:
+                 "awq_marlin",
+                 "inc",
+                 "moe_wna16",
++                # Rank-sliced EXL3 checkpoints retain a ModelOpt dispatch tag
++                # for backward compatibility, so EXL3 must inspect metadata
++                # before the ModelOpt overrides claim them.
++                "exl3",
+                 # Must precede modelopt_fp4: hybrid checkpoints are
+                 # modelopt-tagged NVFP4 plus a hybrid_bit_map.
+                 "nvfp4_nf3_hybrid",
+diff --git a/vllm/distributed/parallel_state.py b/vllm/distributed/parallel_state.py
+index 0f2ef8564b652448109d58d3423c766214fd177d..54da6ac47a4653681b9849115e6d2e84aa852af6 100644
+--- a/vllm/distributed/parallel_state.py
++++ b/vllm/distributed/parallel_state.py
+@@ -1950,6 +1950,41 @@ def init_distributed_environment(
+             _INNER_DP_WORLD = _WORLD
+ 
+ 
++def _get_query_split_group_ranks(
++    tp_group_ranks: list[list[int]], dcp_size: int
++) -> list[list[int]]:
++    """Transpose DCP groups within each independent TP cohort.
++
++    Args:
++        tp_group_ranks: Independent TP cohorts expressed as global ranks.
++        dcp_size: Number of consecutive ranks in each DCP group.
++
++    Returns:
++        Groups joining the same DCP-rank position across each TP cohort.
++
++    Raises:
++        ValueError: If ``dcp_size`` is nonpositive or does not divide a TP
++            cohort.
++    """
++    if dcp_size <= 0:
++        raise ValueError(f"dcp_size must be positive, got {dcp_size}")
++
++    query_split_ranks: list[list[int]] = []
++    for tp_ranks in tp_group_ranks:
++        if len(tp_ranks) % dcp_size != 0:
++            raise ValueError(
++                f"TP group size {len(tp_ranks)} must be divisible by "
++                f"dcp_size {dcp_size}"
++            )
++        dcp_groups = [
++            tp_ranks[start : start + dcp_size]
++            for start in range(0, len(tp_ranks), dcp_size)
++        ]
++        for dcp_rank in range(dcp_size):
++            query_split_ranks.append([group[dcp_rank] for group in dcp_groups])
++    return query_split_ranks
++
++
+ def initialize_model_parallel(
+     tensor_model_parallel_size: int = 1,
+     pipeline_model_parallel_size: int = 1,
+@@ -2073,17 +2108,16 @@ def initialize_model_parallel(
+         group_name="dcp",
+     )
+ 
+-    # Build the query-split groups for the indexer query split (Fix A).
+-    # Ranks sharing the same dcp_rank (position within their DCP group)
+-    # form a query-split group.  At TP=8/DCP=2 the DCP groups are
+-    # {0,1},{2,3},{4,5},{6,7} and the query-split groups are
+-    # {0,2,4,6} (dcp_rank=0) and {1,3,5,7} (dcp_rank=1).
++    # Build query-split groups for the sparse indexer. Ranks sharing the same
++    # dcp_rank form one group. This also applies to DCP=1: all TP ranks hold
++    # the same indexer inputs, so they can divide query rows and all-gather
++    # only the exact int32 top-k result.
+     global _QUERY_SPLIT
+     assert _QUERY_SPLIT is None, "query split group is already initialized"
+-    if decode_context_model_parallel_size > 1 and envs.VLLM_DCP_QUERY_SPLIT:
+-        query_split_ranks: list[list[int]] = []
+-        for dcp_rank_idx in range(decode_context_model_parallel_size):
+-            query_split_ranks.append([grp[dcp_rank_idx] for grp in group_ranks])
++    if envs.VLLM_DCP_QUERY_SPLIT:
++        query_split_ranks = _get_query_split_group_ranks(
++            tp_group_ranks, decode_context_model_parallel_size
++        )
+         _QUERY_SPLIT = init_model_parallel_group(
+             query_split_ranks,
+             get_world_group().local_rank,
+diff --git a/vllm/envs.py b/vllm/envs.py
+index a62f1b3d41b5aeeb009e04680c97d4048a4a43ad..3167a840af0635f4222e3a7467397c1502ccf084 100755
+--- a/vllm/envs.py
++++ b/vllm/envs.py
+@@ -2278,6 +2278,21 @@ environment_variables: dict[str, Callable[[], Any]] = {
+     # Each entry is VAR_NAME or VAR_NAME:<suffix> (suffix appended to
+     # RDMA device name). Must be set together with VLLM_GPU_NIC_PCIE_MAPPING.
+     "VLLM_NIC_SELECTION_VARS": lambda: os.getenv("VLLM_NIC_SELECTION_VARS", ""),
++    # --- EXL3 Trellis MoE runtime knobs (read directly by
++    # model_executor/layers/quantization/exl3.py; registered here so startup
++    # does not flag them as unknown). All are passthrough: consuming code
++    # applies its own defaults (the Trellis window minimum is 1 for both target
++    # and draft layers; an explicit value is a diagnostic override).
++    "VLLM_EXL3_TRELLIS_MIN_M": lambda: os.getenv("VLLM_EXL3_TRELLIS_MIN_M"),
++    "VLLM_EXL3_TRELLIS_MAX_M": lambda: os.getenv("VLLM_EXL3_TRELLIS_MAX_M"),
++    "VLLM_EXL3_TRELLIS_BLOCK_M": lambda: os.getenv("VLLM_EXL3_TRELLIS_BLOCK_M"),
++    "VLLM_EXL3_PREFILL_CHUNK": lambda: os.getenv("VLLM_EXL3_PREFILL_CHUNK"),
++    "VLLM_EXL3_PREFILL_TRELLIS": lambda: os.getenv("VLLM_EXL3_PREFILL_TRELLIS"),
++    "VLLM_EXL3_PREFILL_BLOCK_M": lambda: os.getenv("VLLM_EXL3_PREFILL_BLOCK_M"),
++    # Prebuilt exllamav3 extension location and torch-ABI compatibility shim.
++    "VLLM_EXL3_EXT_PATH": lambda: os.getenv("VLLM_EXL3_EXT_PATH"),
++    "VLLM_EXL3_ABI_SHIM": lambda: os.getenv("VLLM_EXL3_ABI_SHIM"),
++
+ }
+ 
+ 
+diff --git a/vllm/model_executor/layers/fused_moe/routed_experts.py b/vllm/model_executor/layers/fused_moe/routed_experts.py
+index 3585f5c553a30483f0ab6f9285e89be731b31c61..9cd850d31a48c1361b530b110710b9ac22f6e146 100644
+--- a/vllm/model_executor/layers/fused_moe/routed_experts.py
++++ b/vllm/model_executor/layers/fused_moe/routed_experts.py
+@@ -1,6 +1,7 @@
+ # SPDX-License-Identifier: Apache-2.0
+ # SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+ 
++import re
+ from collections.abc import Callable, Iterable
+ from enum import Enum
+ from typing import TYPE_CHECKING, Any, Literal, cast, overload
+@@ -37,6 +38,10 @@ if TYPE_CHECKING:
+ 
+ logger = init_logger(__name__)
+ 
++# Per-expert checkpoint names carry an explicit expert index ("experts.{i}.");
++# fused pre-fused-checkpoint entries never do (see build_expert_params_mapping).
++_PER_EXPERT_IDX_RE = re.compile(r"experts\.\d+\.")
++
+ 
+ class FusedMoeWeightScaleSupported(Enum):
+     TENSOR = "tensor"
+@@ -943,14 +948,24 @@ class RoutedExperts(PluggableLayer):
+         unpadded_hidden = self.moe_config.hidden_dim_unpadded
+         for expert_name, loaded_weight in weights:
+             qual_name = f"{self.layer_name}.{expert_name}"
+-            # Fused expert weights can be identified by their 3D tensors
+-            is_fused = loaded_weight.dim() == 3
++            # Fused expert weights are 3D tensors matched against a *fused*
++            # mapping entry. Rank alone is not decisive: per-expert tensors of
++            # some quantized formats (e.g. EXL3 trellis [K/16, N/16, 16*bpw])
++            # are also rank-3 and must not be routed down the fused
++            # transpose/chunk path. Fused entries are exactly those whose
++            # weight_name carries no per-expert index.
++            is_fused_rank = loaded_weight.dim() == 3
++            is_fused = False
+             matched = False
+             for param_name, weight_name, expert_id, shard_id in expert_mapping:
+                 if weight_name not in qual_name:
+                     if matched and is_fused:
+                         break
+                     continue
++                is_fused = (
++                    is_fused_rank
++                    and _PER_EXPERT_IDX_RE.search(weight_name) is None
++                )
+                 matched = True
+                 weight_name = qual_name.replace(weight_name, param_name)
+                 param_name = weight_name.removeprefix(f"{self.layer_name}.")
+diff --git a/vllm/model_executor/layers/quantization/__init__.py b/vllm/model_executor/layers/quantization/__init__.py
+index 6793b957c79236ba45a5aadacf4981aefb42e32c..9cefb4f3672821b5875abdd64b9a2dad83dac8c1 100644
+--- a/vllm/model_executor/layers/quantization/__init__.py
++++ b/vllm/model_executor/layers/quantization/__init__.py
+@@ -14,6 +14,7 @@ QuantizationMethods = Literal[
+     "auto_awq",
+     "fp8",
+     "fbgemm_fp8",
++    "exl3",
+     "fp_quant",
+     "modelopt",
+     "modelopt_fp4",
+@@ -123,6 +124,7 @@ def get_quantization_config(quantization: str) -> type[QuantizationConfig]:
+         CompressedTensorsConfig,
+     )
+     from .experts_int8 import ExpertsInt8Config
++    from .exl3 import Exl3Config
+     from .fbgemm_fp8 import FBGEMMFp8Config
+     from .fp8 import Fp8Config
+     from .fp_quant import FPQuantConfig
+@@ -146,6 +148,7 @@ def get_quantization_config(quantization: str) -> type[QuantizationConfig]:
+         "auto_awq": AutoAWQConfig,
+         "fp8": Fp8Config,
+         "fbgemm_fp8": FBGEMMFp8Config,
++        "exl3": Exl3Config,
+         "fp_quant": FPQuantConfig,
+         "modelopt": ModelOptFp8Config,
+         "modelopt_fp4": ModelOptNvFp4Config,
+diff --git a/vllm/model_executor/layers/quantization/exl3.py b/vllm/model_executor/layers/quantization/exl3.py
+new file mode 100644
+index 0000000000000000000000000000000000000000..8deb036c8fea981c2497cfe39540c67f99fff8a0
+--- /dev/null
++++ b/vllm/model_executor/layers/quantization/exl3.py
+@@ -0,0 +1,1971 @@
++# SPDX-License-Identifier: Apache-2.0
++# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
++
++"""EXL3 (ExLlamaV3 trellis) quantization support.
++
++Rank-sliced routed-expert checkpoints use Sparkinfer's unified planned
++``fused_moe`` API for the Trellis decode/prefill windows and the ExLlamaV3
++extension for the small eager parity window. Generic dense and non-rank-sliced
++MoE checkpoints use the
++bit-faithful ``exllamav3_ext.exl3_gemm`` parity path. Every logical checkpoint
++matrix is dispatched independently: vLLM's packed QKV and gate/up modules are
++not treated as one EXL3 matrix because each source matrix owns its Hadamard
++vectors and codebook marker.
++
++Both dependencies are imported lazily. Importing this module, parsing
++checkpoint metadata, or compiling it with ``py_compile`` does not load either
++one or initialize CUDA.
++"""
++
++from __future__ import annotations
++
++import ctypes
++import importlib
++import os
++import re
++import sys
++from typing import TYPE_CHECKING, Any
++
++import torch
++from transformers import PretrainedConfig
++
++from vllm.config import get_current_vllm_config_or_none
++from vllm.distributed import (
++    get_tensor_model_parallel_rank,
++    get_tensor_model_parallel_world_size,
++)
++from vllm.logger import init_logger
++from vllm.model_executor.layers.fused_moe import (
++    FusedMoEMethodBase,
++    FusedMoEQuantConfig,
++    MoEActivation,
++    RoutedExperts,
++)
++from vllm.model_executor.layers.linear import (
++    LinearBase,
++    LinearMethodBase,
++    QKVParallelLinear,
++    ReplicatedLinear,
++    UnquantizedLinearMethod,
++)
++from vllm.model_executor.layers.quantization.base_config import (
++    QuantizationConfig,
++    QuantizeMethodBase,
++)
++from vllm.model_executor.parameter import BasevLLMParameter
++from vllm.transformers_utils.repo_utils import get_hf_file_to_dict
++
++if TYPE_CHECKING:
++    from vllm.model_executor.layers.fused_moe.runner.shared_experts import (
++        SharedExperts,
++    )
++    from vllm.model_executor.models.utils import WeightsMapper
++
++logger = init_logger(__name__)
++
++_MCG_SENTINEL = 0xCBAC1FED
++_MUL1_SENTINEL = 0x83DCD12D
++_HADAMARD_BLOCK = 128
++_EXL3_EXT: Any | None = None
++_SPARKINFER_FUSED_MOE_API: Any | None = None
++_RANK_SLICED_RUNTIMES: dict[tuple[Any, ...], dict[str, Any]] = {}
++_NEXT_RUNTIME_SCOPE_ID = 0
++
++
++# Smallest m the Trellis kernel path can service, and therefore the smallest
++# row count an EXL3 rank-sliced MoE layer can be CUDA-graph captured at. A
++# capture-size selector may read this to align its sizes with the backend
++# instead of failing at capture time.
++MIN_CAPTURABLE_TRELLIS_M = 1
++
++# Target execution also reaches m=1..3 during profiling and small-batch decode.
++# Keep every supported row count on the native path by default; operators may
++# still raise the threshold explicitly as a diagnostic kill switch.
++_DEFAULT_TRELLIS_MIN_M = MIN_CAPTURABLE_TRELLIS_M
++
++
++def _is_draft_layer(layer: Any) -> bool:
++    """True for a rank-sliced MTP/nextn/eagle draft MoE layer.
++
++    The role is stamped (``exl3_is_draft = True``) on every draft-owned module
++    by ``load_eagle_model`` at draft construction, which is the single funnel
++    every speculator draft passes through. It is NOT inferable here: a
++    GLM-5.2-style MTP head is an extra decoder layer named exactly like a
++    target layer (``model.layers.78.*`` with ``num_hidden_layers = 78``), and
++    this function runs at plan/capture/forward time, when
++    ``set_current_vllm_config`` has already exited and
++    ``get_current_vllm_config_or_none()`` returns None -- so both name and
++    layer-index inference silently fail. The substring fallback below covers
++    drafts built outside ``load_eagle_model``.
++    """
++    stamped = getattr(layer, "exl3_is_draft", None)
++    if stamped is not None:
++        return bool(stamped)
++    name = str(getattr(layer, "layer_name", "") or getattr(layer, "prefix", ""))
++    return any(
++        token in name
++        for token in (".mtp", "mtp.", "nextn", "eagle", "draft", "speculator")
++    )
++
++
++def _runtime_owner_token(quant_config: Any, layer: Any) -> tuple[int, bool]:
++    """Runtime-cache owner identity: (config scope, is_draft).
++
++    Adding the role makes target/draft isolation independent of whether the model
++    file happened to mint a separate quant config.
++    """
++    return (_runtime_scope_id(quant_config), _is_draft_layer(layer))
++
++
++def _runtime_scope_id(quant_config: Any) -> int:
++    """Stable identity for the model that owns a rank-sliced runtime.
++
++    A cached runtime owns mutable Trellis/prefill scratch plus parity staging and
++    sort buffers, so an entry must never be shared across models. A target MoE
++    layer and a rank-sliced MTP draft layer have identical shapes, topk and
++    planner settings -- both read ``max_num_batched_tokens`` from the same
++    scheduler config -- so a shape-only key makes the draft reuse the target's
++    scratch. That defeats the target/draft resource isolation their
++    independently captured CUDA graphs rely on.
++
++    Scoping by the owning quant config is deliberately coarser than per-layer:
++    the draft is built with its own ``Exl3Config`` while every layer of one model
++    shares a single config, so each model gets exactly one runtime. The prefill
++    arena alone is ~1 GiB, so per-layer runtimes would cost tens of GiB per rank
++    on a 75+ layer model and are not affordable.
++    """
++    global _NEXT_RUNTIME_SCOPE_ID
++    scope = getattr(quant_config, "_exl3_runtime_scope_id", None)
++    if scope is not None:
++        return scope
++    scope = _NEXT_RUNTIME_SCOPE_ID
++    _NEXT_RUNTIME_SCOPE_ID += 1
++    try:
++        quant_config._exl3_runtime_scope_id = scope  # noqa: SLF001
++    except AttributeError:
++        # Frozen/slotted config: fall back to object identity. Configs live for
++        # the process lifetime, so reuse-after-GC aliasing is not a concern here.
++        return id(quant_config)
++    return scope
++
++
++_RANK_SLICED_FORMAT = "exl3-trellis"
++_RANK_SLICED_WEIGHT_RE = re.compile(
++    r"^(?P<prefix>.+)\.rank(?P<rank>\d+)\."
++    r"(?P<field>trellis|suh|svh|mcg|mul1)$"
++)
++
++ShardId = str | int | tuple[int, ...] | None
++
++
++def _load_exl3_ext() -> Any:
++    """Load the existing ExLlamaV3 extension only from an actual CUDA call."""
++
++    global _EXL3_EXT
++    if _EXL3_EXT is not None:
++        return _EXL3_EXT
++
++    shim = os.environ.get("VLLM_EXL3_ABI_SHIM")
++    if shim:
++        ctypes.CDLL(shim, mode=ctypes.RTLD_GLOBAL)
++
++    ext_path = os.environ.get("VLLM_EXL3_EXT_PATH")
++    if ext_path:
++        search_dir = ext_path if os.path.isdir(ext_path) else os.path.dirname(ext_path)
++        if search_dir and search_dir not in sys.path:
++            sys.path.insert(0, search_dir)
++
++    try:
++        ext = importlib.import_module("exllamav3_ext")
++    except Exception as exc:
++        hint = (
++            "Set VLLM_EXL3_EXT_PATH to the directory containing "
++            "exllamav3_ext*.so (and VLLM_EXL3_ABI_SHIM when the local "
++            "PyTorch ABI shim is required)."
++        )
++        raise RuntimeError(f"Unable to import exllamav3_ext. {hint}") from exc
++
++    if not hasattr(ext, "exl3_gemm"):
++        raise RuntimeError(
++            "The imported exllamav3_ext does not export exl3_gemm; rebuild the "
++            "track_a_retile extension used by this overlay."
++        )
++    _EXL3_EXT = ext
++    return ext
++
++
++def _load_sparkinfer_fused_moe() -> Any:
++    """Resolve the public unified MoE API lazily."""
++
++    global _SPARKINFER_FUSED_MOE_API
++    if _SPARKINFER_FUSED_MOE_API is not None:
++        return _SPARKINFER_FUSED_MOE_API
++    try:
++        from sparkinfer.moe import fused_moe
++    except Exception as exc:
++        raise RuntimeError(
++            "Rank-sliced EXL3 requires the exl3_trellis_mcg source in "
++            "sparkinfer.moe.fused_moe. Install a matching Sparkinfer build."
++        ) from exc
++    _SPARKINFER_FUSED_MOE_API = fused_moe
++    return fused_moe
++
++
++def _positive_env_int(name: str, default: int) -> int:
++    # An env var that is present but blank means "unset". Compose and Kubernetes
++    # both render an unset variable as the empty string, so int("") would abort
++    # engine startup with a bare
++    #   ValueError: invalid literal for int() with base 10: ''
++    # that names neither the variable nor the fix.
++    raw = os.environ.get(name)
++    if raw is None or not raw.strip():
++        return default
++    try:
++        value = int(raw.strip())
++    except ValueError:
++        raise ValueError(
++            f"{name} must be a positive integer or unset, got {raw!r}"
++        ) from None
++    if value <= 0:
++        raise ValueError(f"{name} must be positive, got {value}")
++    return value
++
++
++@torch.library.custom_op(
++    "vllm::exl3_gemm",
++    mutates_args=(),
++    device_types="cuda",
++)
++def _exl3_gemm(
++    x: torch.Tensor,
++    trellis: torch.Tensor,
++    suh: torch.Tensor,
++    svh: torch.Tensor,
++    mcg: bool,
++    mul1: bool,
++) -> torch.Tensor:
++    """Opaque torch op around the bit-faithful ExLlamaV3 dense call."""
++
++    ext = _load_exl3_ext()
++    output = torch.empty(
++        (x.shape[0], trellis.shape[1] * 16),
++        dtype=torch.float16,
++        device=x.device,
++    )
++    x_had = torch.empty_like(x)
++    ext.exl3_gemm(
++        x,
++        trellis,
++        output,
++        suh,
++        x_had,
++        svh,
++        -1,
++        mcg,
++        mul1,
++        0,
++    )
++    return output
++
++
++@_exl3_gemm.register_fake
++def _exl3_gemm_fake(
++    x: torch.Tensor,
++    trellis: torch.Tensor,
++    suh: torch.Tensor,
++    svh: torch.Tensor,
++    mcg: bool,
++    mul1: bool,
++) -> torch.Tensor:
++    del suh, svh, mcg, mul1
++    return torch.empty(
++        (x.shape[0], trellis.shape[1] * 16),
++        dtype=torch.float16,
++        device=x.device,
++    )
++
++
++class Exl3Config(QuantizationConfig):
++    """Configuration for modern and legacy EXL3 trellis checkpoints."""
++
++    def __init__(
++        self,
++        bits: float | None = None,
++        head_bits: float | None = None,
++        codebook: str | None = None,
++        version: str | None = None,
++        tensor_storage: dict[str, Any] | None = None,
++    ) -> None:
++        super().__init__()
++        self.bits = bits
++        self.head_bits = head_bits
++        self.codebook = codebook
++        self.version = version
++        self.tensor_storage = tensor_storage or {}
++        self._eager_checked = False
++        self.rank_sliced_metadata: dict[str, Any] | None = None
++
++    def get_name(self) -> str:
++        return "exl3"
++
++    def get_supported_act_dtypes(self) -> list[torch.dtype]:
++        # The kernel boundary is always fp16.  BF16 model activations are cast
++        # in apply() and converted back after the fp16 bias addition.
++        return [torch.float16, torch.bfloat16]
++
++    @classmethod
++    def get_min_capability(cls) -> int:
++        return 80
++
++    @staticmethod
++    def get_config_filenames() -> list[str]:
++        return ["quantization_config.json"]
++
++    @classmethod
++    def from_config(cls, config: dict[str, Any]) -> Exl3Config:
++        return cls(
++            bits=config.get("bits"),
++            head_bits=config.get("head_bits"),
++            codebook=config.get("codebook"),
++            version=config.get("version"),
++            tensor_storage=config.get("tensor_storage"),
++        )
++
++    @classmethod
++    def override_quantization_method(
++        cls,
++        hf_quant_cfg: dict[str, Any],
++        user_quant: str | None,
++        hf_config: PretrainedConfig | None = None,
++    ) -> str | None:
++        del hf_quant_cfg
++        if user_quant is not None and user_quant != "exl3":
++            return None
++        metadata = getattr(hf_config, "hybrid_tr3_tail", None)
++        if isinstance(metadata, dict) and metadata.get("format") == _RANK_SLICED_FORMAT:
++            return "exl3"
++        return None
++
++    def maybe_update_config(
++        self,
++        model_name: str,
++        hf_config: PretrainedConfig | None = None,
++        revision: str | None = None,
++    ) -> None:
++        rank_sliced = getattr(hf_config, "hybrid_tr3_tail", None)
++        if (
++            isinstance(rank_sliced, dict)
++            and rank_sliced.get("format") == _RANK_SLICED_FORMAT
++        ):
++            self._configure_rank_sliced(rank_sliced)
++            return
++
++        # vLLM returns the summary embedded in config.json without consulting
++        # get_config_filenames().  Hydrate the per-module records explicitly.
++        if not self.tensor_storage:
++            resolved_revision = revision
++            if resolved_revision is None and hf_config is not None:
++                resolved_revision = getattr(hf_config, "_commit_hash", None)
++            config = get_hf_file_to_dict(
++                "quantization_config.json",
++                model_name,
++                revision=resolved_revision,
++            )
++            if not config or not config.get("tensor_storage"):
++                raise ValueError(
++                    "EXL3 requires quantization_config.json with a non-empty "
++                    "tensor_storage map. For branch-indexed Hugging Face repos, "
++                    "download/serve an actual bpw revision rather than main."
++                )
++            self.bits = config.get("bits", self.bits)
++            self.head_bits = config.get("head_bits", self.head_bits)
++            self.codebook = config.get("codebook", self.codebook)
++            self.version = config.get("version", self.version)
++            self.tensor_storage = config["tensor_storage"]
++
++        self._validate_storage_metadata()
++        self._force_independent_lm_head(hf_config)
++
++    def _configure_rank_sliced(self, metadata: dict[str, Any]) -> None:
++        required = {
++            "bits",
++            "codebook",
++            "experts_per_layer",
++            "moe_layers",
++            "tensor_schema",
++            "tp",
++        }
++        missing = sorted(required.difference(metadata))
++        if missing:
++            raise ValueError(
++                "rank-sliced EXL3 metadata is missing: " + ", ".join(missing)
++            )
++        if metadata["codebook"] != "mcg":
++            raise ValueError(
++                "rank-sliced EXL3 currently requires the MCG codebook, got "
++                f"{metadata['codebook']!r}"
++            )
++        layers = metadata["moe_layers"]
++        if (
++            not isinstance(layers, list)
++            or len(layers) != 2
++            or int(layers[0]) < 0
++            or int(layers[1]) < int(layers[0])
++        ):
++            raise ValueError("rank-sliced EXL3 moe_layers must be [first, last]")
++        expected_schema = (
++            "model.layers.{L}.mlp.experts.{E}.{proj}.rank{r}.{trellis|suh|svh|mcg}"
++        )
++        if metadata["tensor_schema"] != expected_schema:
++            raise ValueError(
++                "unsupported rank-sliced EXL3 tensor schema: "
++                f"{metadata['tensor_schema']!r}"
++            )
++        self.rank_sliced_metadata = dict(metadata)
++        self.bits = float(metadata["bits"])
++        self.codebook = str(metadata["codebook"])
++        self.version = str(metadata.get("exllamav3_version", "rank-sliced"))
++
++    def apply_vllm_mapper(self, hf_to_vllm_mapper: WeightsMapper) -> None:
++        # Keep both spellings: loader prefixes use vLLM names, while packed
++        # source-matrix discovery intentionally refers to the unstacked HF name.
++        mapped = hf_to_vllm_mapper.apply_dict(self.tensor_storage)
++        self.tensor_storage = {**self.tensor_storage, **mapped}
++
++    def _validate_storage_metadata(self) -> None:
++        bad: list[str] = []
++        exl3_count = 0
++        for prefix, entry in self.tensor_storage.items():
++            if entry.get("quant_format") != "exl3":
++                continue
++            exl3_count += 1
++            stored = entry.get("stored_tensors", {})
++            suffixes = {name.rsplit(".", 1)[-1] for name in stored}
++            required = {"trellis"}
++            if not ({"suh", "su"} & suffixes):
++                required.add("suh|su")
++            if not ({"svh", "sv"} & suffixes):
++                required.add("svh|sv")
++            missing = [name for name in required if name not in suffixes]
++            if missing:
++                bad.append(f"{prefix}: missing {','.join(sorted(missing))}")
++            if {"mcg", "mul1"} <= suffixes:
++                bad.append(f"{prefix}: both mcg and mul1 are present")
++        if not exl3_count:
++            raise ValueError("quantization_config.json has no EXL3 tensor records")
++        if bad:
++            raise ValueError("Invalid EXL3 tensor metadata: " + "; ".join(bad[:16]))
++
++    def _force_independent_lm_head(self, hf_config: PretrainedConfig | None) -> None:
++        if hf_config is None or not self.has_quantized_lm_head():
++            return
++        configs: list[Any] = [hf_config]
++        try:
++            text_config = hf_config.get_text_config()
++        except (AttributeError, TypeError):
++            text_config = None
++        if text_config is not None and text_config is not hf_config:
++            configs.append(text_config)
++        changed = False
++        for config in configs:
++            if getattr(config, "tie_word_embeddings", False):
++                config.tie_word_embeddings = False
++                changed = True
++        if changed:
++            logger.warning_once(
++                "EXL3 metadata contains an independently quantized lm_head; "
++                "overriding tie_word_embeddings so vLLM instantiates it."
++            )
++
++    def _require_enforce_eager(self) -> None:
++        if self.rank_sliced_metadata is not None:
++            # The routed-expert fast path is eagerly planned before graph
++            # capture. Only its large-M parity fallback remains eager.
++            return
++        # exllamav3_ext's exl3_gemm autotunes with timing launches on the first
++        # call per (m-bucket, k, n, K) shape hash; under CUDA-graph capture
++        # those launches fault, and m-bucketing means a warmup pass cannot
++        # reliably cover every bucket. Fail fast at build time instead of
++        # faulting mid-capture.
++        if self._eager_checked:
++            return
++        self._eager_checked = True
++        vllm_config = get_current_vllm_config_or_none()
++        if vllm_config is None:
++            return
++        if not vllm_config.model_config.enforce_eager:
++            raise ValueError(
++                "The EXL3 quantization backend requires eager execution: "
++                "pass --enforce-eager (enforce_eager=True). exl3_gemm "
++                "autotunes with timing launches on first use per shape "
++                "bucket, which is incompatible with CUDA-graph capture."
++            )
++
++    def get_quant_method(
++        self, layer: torch.nn.Module, prefix: str
++    ) -> QuantizeMethodBase | None:
++        self._require_enforce_eager()
++        is_lm_head = layer.__class__.__name__ == "ParallelLMHead"
++        if is_lm_head and not prefix:
++            prefix = "lm_head"
++        if isinstance(layer, LinearBase) or is_lm_head:
++            if not self._linear_prefix_is_exl3(prefix):
++                return UnquantizedLinearMethod()
++            return Exl3LinearMethod(self)
++        if isinstance(layer, RoutedExperts):
++            if not self._moe_prefix_is_exl3(prefix, layer):
++                return None
++            return Exl3MoEMethod(self, layer.moe_config)
++        return None
++
++    def _storage_entry(self, prefix: str) -> dict[str, Any] | None:
++        candidates = [prefix]
++        if prefix.startswith("model."):
++            candidates.append(prefix.removeprefix("model."))
++        else:
++            candidates.append(f"model.{prefix}")
++
++        # Multimodal wrappers often add an extra `model` or `language_model`
++        # segment relative to vLLM's text-only module — interior
++        # (`model.language_model.layers...`) or leading
++        # (`language_model.lm_head`), so leading segments collapse too.
++        parts = prefix.split(".")
++        for removable in ("model", "language_model"):
++            for idx in range(0, len(parts) - 1):
++                if parts[idx] != removable:
++                    continue
++                collapsed = ".".join(parts[:idx] + parts[idx + 1 :])
++                candidates.extend((collapsed, f"model.{collapsed}"))
++                if collapsed.startswith("model."):
++                    candidates.append(collapsed.removeprefix("model."))
++
++        for candidate in dict.fromkeys(candidates):
++            entry = self.tensor_storage.get(candidate)
++            if entry is not None:
++                return entry
++        return None
++
++    def _is_exl3_prefix(self, prefix: str) -> bool:
++        entry = self._storage_entry(prefix)
++        return entry is not None and entry.get("quant_format") == "exl3"
++
++    def _linear_prefix_is_exl3(self, prefix: str) -> bool:
++        if self._is_exl3_prefix(prefix):
++            return True
++        leaf = prefix.rsplit(".", 1)[-1]
++        source_leaves = self.packed_modules_mapping.get(leaf)
++        if not source_leaves:
++            return False
++        base = prefix.rsplit(".", 1)[0] if "." in prefix else ""
++        return all(
++            self._is_exl3_prefix(f"{base}.{source}" if base else source)
++            for source in source_leaves
++        )
++
++    def _moe_prefix_is_exl3(
++        self, prefix: str, layer: torch.nn.Module | None = None
++    ) -> bool:
++        if self.rank_sliced_metadata is not None:
++            match = re.search(r"layers\.(\d+)\b", prefix)
++            if match is None:
++                return False
++            first, last = (int(v) for v in self.rank_sliced_metadata["moe_layers"])
++            return first <= int(match.group(1)) <= last
++        # Use the layer's checkpoint projection names (the same fields
++        # _validate_codebooks keys off) so remapped-projection MoE
++        # checkpoints are still detected; fall back to the defaults when the
++        # layer variant does not carry them.
++        projections = tuple(
++            getattr(layer, attr, default)
++            for attr, default in (
++                ("ckpt_gate_proj_name", "gate_proj"),
++                ("ckpt_up_proj_name", "up_proj"),
++                ("ckpt_down_proj_name", "down_proj"),
++            )
++        )
++        expert_prefixes = (f"{prefix}.0", f"{prefix}.experts.0")
++        return any(
++            all(
++                self._is_exl3_prefix(f"{expert}.{projection}")
++                for projection in projections
++            )
++            for expert in expert_prefixes
++        )
++
++    def codebook_for_prefix(self, prefix: str) -> str | None:
++        if self.rank_sliced_metadata is not None:
++            match = re.search(r"layers\.(\d+)\b", prefix)
++            if match is None:
++                return None
++            first, last = (int(v) for v in self.rank_sliced_metadata["moe_layers"])
++            return "mcg" if first <= int(match.group(1)) <= last else None
++        entry = self._storage_entry(prefix)
++        if entry is None:
++            return None
++        suffixes = {name.rsplit(".", 1)[-1] for name in entry.get("stored_tensors", {})}
++        if "mcg" in suffixes:
++            return "mcg"
++        if "mul1" in suffixes:
++            return "mul1"
++        return None
++
++    def has_quantized_lm_head(self) -> bool:
++        return self._is_exl3_prefix("lm_head")
++
++    def normalize_rank_sliced_weight_name(self, name: str) -> str | None:
++        """Drop non-local TP payloads and remove the serialized rank segment."""
++        if self.rank_sliced_metadata is None:
++            return name
++        match = _RANK_SLICED_WEIGHT_RE.match(name)
++        if match is None:
++            return name
++        if int(match.group("rank")) != get_tensor_model_parallel_rank():
++            return None
++        return f"{match.group('prefix')}.{match.group('field')}"
++
++
++class Exl3Parameter(BasevLLMParameter):
++    """Zero-sized parameter holding independently shaped EXL3 components."""
++
++    def __new__(cls, *, weight_loader):
++        data = torch.empty(0, dtype=torch.uint8)
++        return super().__new__(cls, data=data, weight_loader=weight_loader)
++
++    def __init__(self, *, weight_loader):
++        self.exl3_tensors: dict[ShardId, torch.Tensor] = {}
++        super().__init__(data=self.data, weight_loader=weight_loader)
++
++    def load_exl3_weight(
++        self,
++        loaded_weight: torch.Tensor,
++        shard_id: ShardId = None,
++    ) -> None:
++        self.exl3_tensors[shard_id] = loaded_weight.contiguous()
++
++
++def _exl3_weight_loader(
++    param: Exl3Parameter,
++    loaded_weight: torch.Tensor,
++    loaded_shard_id: ShardId = None,
++) -> None:
++    param.load_exl3_weight(loaded_weight, loaded_shard_id)
++
++
++class Exl3LinearMethod(LinearMethodBase):
++    def __init__(self, quant_config: Exl3Config) -> None:
++        self.quant_config = quant_config
++
++    def create_weights(
++        self,
++        layer: torch.nn.Module,
++        input_size_per_partition: int,
++        output_partition_sizes: list[int],
++        input_size: int,
++        output_size: int,
++        params_dtype: torch.dtype,
++        **extra_weight_attrs,
++    ) -> None:
++        del params_dtype, extra_weight_attrs
++        if layer.__class__.__name__ == "ParallelLMHead":
++            org = getattr(layer, "org_vocab_size", None)
++            total = getattr(layer, "num_embeddings", None)
++            if org is not None and total is not None and org != total:
++                raise NotImplementedError(
++                    "EXL3 lm_head with added vocabulary is unsupported: the "
++                    f"trellis tensor covers the original {org} rows but the "
++                    f"layer allocates {total}; TP slicing would silently "
++                    "misalign. Strip --lora-extra-vocab-size / added tokens "
++                    "or leave lm_head unquantized."
++                )
++        # Respect the layer's effective topology. disable_tp linears set their
++        # own tp_size=1, while ReplicatedLinear carries full weights even when
++        # the process-wide tensor group is larger than one.
++        if isinstance(layer, ReplicatedLinear):
++            layer.exl3_tp_rank = 0
++            layer.exl3_tp_size = 1
++        else:
++            layer.exl3_tp_rank = getattr(
++                layer, "tp_rank", get_tensor_model_parallel_rank()
++            )
++            layer.exl3_tp_size = getattr(
++                layer, "tp_size", get_tensor_model_parallel_world_size()
++            )
++        layer.exl3_input_size = input_size
++        layer.exl3_input_size_per_partition = input_size_per_partition
++        layer.exl3_output_size = output_size
++        layer.exl3_output_partition_sizes = output_partition_sizes
++        layer.exl3_shard_ids = self._shard_ids_for_layer(layer, output_partition_sizes)
++        layer.exl3_parallel_mode = (
++            "row" if input_size_per_partition != input_size else "column"
++        )
++        source_prefixes = self._source_prefixes_for_layer(layer, layer.exl3_shard_ids)
++        layer.exl3_expected_codebooks = {
++            shard_id: self.quant_config.codebook_for_prefix(source_prefix)
++            for shard_id, source_prefix in zip(
++                layer.exl3_shard_ids, source_prefixes, strict=True
++            )
++        }
++
++        # su/sv are legacy packed sign bitfields.  Modern checkpoints load
++        # suh/svh directly.
++        for name in ("suh", "svh", "su", "sv", "trellis", "mcg", "mul1"):
++            layer.register_parameter(
++                name,
++                Exl3Parameter(weight_loader=_exl3_weight_loader),
++            )
++
++    def process_weights_after_loading(self, layer: torch.nn.Module) -> None:
++        self._materialize_legacy_hadamard(layer)
++        missing: list[str] = []
++        for attr in ("suh", "svh", "trellis"):
++            param = getattr(layer, attr)
++            for shard_id in layer.exl3_shard_ids:
++                if shard_id not in param.exl3_tensors:
++                    missing.append(f"{attr}[{shard_id!r}]")
++        for shard_id in layer.exl3_shard_ids:
++            expected = layer.exl3_expected_codebooks[shard_id]
++            has_mcg = shard_id in layer.mcg.exl3_tensors
++            has_mul1 = shard_id in layer.mul1.exl3_tensors
++            if has_mcg and has_mul1:
++                missing.append(f"codebook[{shard_id!r}]=both mcg and mul1")
++            elif expected == "mcg" and not has_mcg:
++                missing.append(f"mcg[{shard_id!r}]")
++            elif expected == "mul1" and not has_mul1:
++                missing.append(f"mul1[{shard_id!r}]")
++            elif expected is None and (has_mcg or has_mul1):
++                missing.append(f"unexpected codebook[{shard_id!r}]")
++        if missing:
++            prefix = getattr(layer, "prefix", layer.__class__.__name__)
++            raise ValueError(
++                f"Missing or inconsistent EXL3 tensors for {prefix}: "
++                + ", ".join(missing)
++            )
++
++        self._validate_loaded_tensors(layer)
++        self._shard_tensors_for_tensor_parallel(layer)
++        self._validate_loaded_tensors(layer)
++
++        # device_loading_context has moved the zero-sized registered parameter
++        # to the model target device.  Its device is the safest destination for
++        # the tensors kept in the side dictionaries.
++        device = layer.trellis.device
++        for attr in ("suh", "svh", "trellis", "mcg", "mul1"):
++            param = getattr(layer, attr)
++            for shard_id, tensor in list(param.exl3_tensors.items()):
++                param.exl3_tensors[shard_id] = tensor.to(
++                    device=device, non_blocking=True
++                ).contiguous()
++
++    def apply(
++        self,
++        layer: torch.nn.Module,
++        x: torch.Tensor,
++        bias: torch.Tensor | None = None,
++    ) -> torch.Tensor:
++        original_shape = x.shape[:-1]
++        original_dtype = x.dtype
++        x_2d = x.reshape(-1, x.shape[-1]).to(torch.float16).contiguous()
++        outputs = [
++            self._apply_one(layer, x_2d, shard_id) for shard_id in layer.exl3_shard_ids
++        ]
++        output = outputs[0] if len(outputs) == 1 else torch.cat(outputs, dim=-1)
++        if bias is not None:
++            output = output + bias.to(dtype=output.dtype)
++        output = output.reshape(*original_shape, output.shape[-1])
++        return output if output.dtype == original_dtype else output.to(original_dtype)
++
++    @staticmethod
++    def _unpack_signs(bitfield: torch.Tensor) -> torch.Tensor:
++        words = bitfield.contiguous().view(torch.uint16).to(torch.int32)
++        masks = 1 << torch.arange(16, device=words.device, dtype=torch.int32)
++        negative = (words.unsqueeze(-1) & masks) != 0
++        return (
++            torch.where(
++                negative,
++                torch.tensor(-1.0, device=words.device, dtype=torch.float16),
++                torch.tensor(1.0, device=words.device, dtype=torch.float16),
++            )
++            .flatten()
++            .contiguous()
++        )
++
++    @classmethod
++    def _materialize_legacy_hadamard(cls, layer: torch.nn.Module) -> None:
++        for packed_name, half_name in (("su", "suh"), ("sv", "svh")):
++            packed = getattr(layer, packed_name).exl3_tensors
++            half = getattr(layer, half_name).exl3_tensors
++            for shard_id in layer.exl3_shard_ids:
++                if shard_id not in half and shard_id in packed:
++                    half[shard_id] = cls._unpack_signs(packed[shard_id])
++
++    @staticmethod
++    def _validate_marker(tensor: torch.Tensor, expected: int, name: str) -> None:
++        if tensor.dtype != torch.int32 or tensor.numel() != 1:
++            raise ValueError(f"EXL3 {name} must be a scalar int32 sentinel")
++        value = int(tensor.reshape(()).item()) & 0xFFFFFFFF
++        if value != expected:
++            raise ValueError(
++                f"Invalid EXL3 {name} sentinel 0x{value:08x}; expected 0x{expected:08x}"
++            )
++
++    @classmethod
++    def _validate_loaded_tensors(cls, layer: torch.nn.Module) -> None:
++        for shard_id in layer.exl3_shard_ids:
++            trellis = layer.trellis.exl3_tensors[shard_id]
++            suh = layer.suh.exl3_tensors[shard_id]
++            svh = layer.svh.exl3_tensors[shard_id]
++            if trellis.dtype != torch.int16 or trellis.ndim != 3:
++                raise ValueError("EXL3 trellis must be rank-3 int16")
++            if trellis.shape[2] % 16 or not 1 <= trellis.shape[2] // 16 <= 8:
++                raise ValueError(
++                    f"Invalid EXL3 trellis bit width {trellis.shape[2]} / 16"
++                )
++            if suh.dtype != torch.float16 or suh.ndim != 1:
++                raise ValueError("EXL3 suh must be rank-1 float16")
++            if svh.dtype != torch.float16 or svh.ndim != 1:
++                raise ValueError("EXL3 svh must be rank-1 float16")
++            k = trellis.shape[0] * 16
++            n = trellis.shape[1] * 16
++            if suh.numel() != k or svh.numel() != n:
++                raise ValueError(
++                    "EXL3 dimensions disagree: "
++                    f"trellis={tuple(trellis.shape)}, suh={suh.numel()}, "
++                    f"svh={svh.numel()}"
++                )
++            if k % _HADAMARD_BLOCK or n % _HADAMARD_BLOCK:
++                raise ValueError(
++                    f"EXL3 kernel dimensions must be {_HADAMARD_BLOCK}-aligned, "
++                    f"got K={k}, N={n}"
++                )
++            if shard_id in layer.mcg.exl3_tensors:
++                cls._validate_marker(
++                    layer.mcg.exl3_tensors[shard_id], _MCG_SENTINEL, "mcg"
++                )
++            if shard_id in layer.mul1.exl3_tensors:
++                cls._validate_marker(
++                    layer.mul1.exl3_tensors[shard_id], _MUL1_SENTINEL, "mul1"
++                )
++
++    @staticmethod
++    def _slice_exl3_tensor(
++        tensor: torch.Tensor,
++        *,
++        dim: int,
++        start: int,
++        size: int,
++    ) -> torch.Tensor:
++        if start % _HADAMARD_BLOCK or size % _HADAMARD_BLOCK:
++            axis = "output" if dim == 1 else "input"
++            raise ValueError(
++                f"EXL3 TP {axis} slice must be {_HADAMARD_BLOCK}-aligned, "
++                f"got start={start}, size={size}"
++            )
++        return tensor.narrow(dim, start // 16, size // 16).contiguous()
++
++    @staticmethod
++    def _output_shard_size(layer: torch.nn.Module, shard_id: ShardId) -> int:
++        if shard_id is None:
++            return layer.exl3_output_partition_sizes[0]
++        if isinstance(shard_id, str) and shard_id in ("q", "k", "v"):
++            return layer.exl3_output_partition_sizes[{"q": 0, "k": 1, "v": 2}[shard_id]]
++        if isinstance(shard_id, tuple):
++            return sum(layer.exl3_output_partition_sizes[idx] for idx in shard_id)
++        if isinstance(shard_id, int):
++            return layer.exl3_output_partition_sizes[shard_id]
++        return layer.exl3_output_partition_sizes[layer.exl3_shard_ids.index(shard_id)]
++
++    @staticmethod
++    def _qkv_output_start(
++        layer: torch.nn.Module, shard_id: ShardId, shard_size: int
++    ) -> int:
++        if shard_id in ("k", "v"):
++            shard_rank = layer.exl3_tp_rank // layer.num_kv_head_replicas
++        else:
++            shard_rank = layer.exl3_tp_rank
++        return shard_rank * shard_size
++
++    @classmethod
++    def _shard_tensors_for_tensor_parallel(cls, layer: torch.nn.Module) -> None:
++        if layer.exl3_tp_size == 1:
++            return
++        if layer.exl3_parallel_mode == "row":
++            start = layer.exl3_tp_rank * layer.exl3_input_size_per_partition
++            size = layer.exl3_input_size_per_partition
++            for shard_id in layer.exl3_shard_ids:
++                layer.suh.exl3_tensors[shard_id] = (
++                    layer.suh.exl3_tensors[shard_id].narrow(0, start, size).contiguous()
++                )
++                layer.trellis.exl3_tensors[shard_id] = cls._slice_exl3_tensor(
++                    layer.trellis.exl3_tensors[shard_id],
++                    dim=0,
++                    start=start,
++                    size=size,
++                )
++            return
++
++        already_sharded = cls._expand_tuple_output_shards(layer)
++        for shard_id in layer.exl3_shard_ids:
++            if shard_id in already_sharded:
++                continue
++            size = cls._output_shard_size(layer, shard_id)
++            start = cls._qkv_output_start(layer, shard_id, size)
++            layer.svh.exl3_tensors[shard_id] = (
++                layer.svh.exl3_tensors[shard_id].narrow(0, start, size).contiguous()
++            )
++            layer.trellis.exl3_tensors[shard_id] = cls._slice_exl3_tensor(
++                layer.trellis.exl3_tensors[shard_id],
++                dim=1,
++                start=start,
++                size=size,
++            )
++
++    @classmethod
++    def _expand_tuple_output_shards(cls, layer: torch.nn.Module) -> set[int]:
++        tuples = [sid for sid in layer.exl3_shard_ids if isinstance(sid, tuple)]
++        if not tuples:
++            return set()
++
++        expanded_ids: list[ShardId] = []
++        component_ids: set[int] = set()
++        for shard_id in layer.exl3_shard_ids:
++            if isinstance(shard_id, tuple):
++                expanded_ids.extend(shard_id)
++                component_ids.update(shard_id)
++            else:
++                expanded_ids.append(shard_id)
++
++        for tuple_id in tuples:
++            full_offsets: dict[int, int] = {}
++            offset = 0
++            for idx in tuple_id:
++                full_offsets[idx] = offset
++                offset += layer.exl3_output_partition_sizes[idx] * layer.exl3_tp_size
++            for idx in tuple_id:
++                size = layer.exl3_output_partition_sizes[idx]
++                start = full_offsets[idx] + layer.exl3_tp_rank * size
++                layer.suh.exl3_tensors[idx] = layer.suh.exl3_tensors[tuple_id]
++                layer.svh.exl3_tensors[idx] = (
++                    layer.svh.exl3_tensors[tuple_id].narrow(0, start, size).contiguous()
++                )
++                layer.trellis.exl3_tensors[idx] = cls._slice_exl3_tensor(
++                    layer.trellis.exl3_tensors[tuple_id],
++                    dim=1,
++                    start=start,
++                    size=size,
++                )
++                layer.exl3_expected_codebooks[idx] = layer.exl3_expected_codebooks[
++                    tuple_id
++                ]
++                for marker in ("mcg", "mul1"):
++                    tensors = getattr(layer, marker).exl3_tensors
++                    if tuple_id in tensors:
++                        tensors[idx] = tensors[tuple_id]
++            for attr in ("suh", "svh", "trellis", "mcg", "mul1"):
++                getattr(layer, attr).exl3_tensors.pop(tuple_id, None)
++            layer.exl3_expected_codebooks.pop(tuple_id, None)
++
++        layer.exl3_shard_ids = expanded_ids
++        return component_ids
++
++    @staticmethod
++    def _shard_ids_for_layer(
++        layer: torch.nn.Module,
++        output_partition_sizes: list[int],
++    ) -> list[ShardId]:
++        if len(output_partition_sizes) == 1:
++            return [None]
++        prefix = getattr(layer, "prefix", "")
++        if isinstance(layer, QKVParallelLinear) and len(output_partition_sizes) == 3:
++            return ["q", "k", "v"]
++        if prefix.endswith("in_proj_qkvz"):
++            return [(0, 1, 2), 3]
++        return list(range(len(output_partition_sizes)))
++
++    def _source_prefixes_for_layer(
++        self, layer: torch.nn.Module, shard_ids: list[ShardId]
++    ) -> list[str]:
++        prefix = getattr(layer, "prefix", "")
++        if len(shard_ids) == 1:
++            return [prefix or "lm_head"]
++        leaf = prefix.rsplit(".", 1)[-1]
++        base = prefix.rsplit(".", 1)[0] if "." in prefix else ""
++        sources = self.quant_config.packed_modules_mapping.get(leaf)
++        if sources and len(sources) == len(shard_ids):
++            return [f"{base}.{source}" if base else source for source in sources]
++        raise ValueError(
++            f"EXL3 does not know the source matrices for packed layer {prefix}; "
++            "add it to the model's packed_modules_mapping."
++        )
++
++    @staticmethod
++    def _apply_one(
++        layer: torch.nn.Module, x: torch.Tensor, shard_id: ShardId
++    ) -> torch.Tensor:
++        trellis = layer.trellis.exl3_tensors[shard_id]
++        packed_k = trellis.shape[0] * 16
++        if x.shape[-1] > packed_k:
++            raise ValueError(
++                f"EXL3 input width {x.shape[-1]} exceeds packed K={packed_k}"
++            )
++        if x.shape[-1] < packed_k:
++            x = torch.nn.functional.pad(x, (0, packed_k - x.shape[-1]))
++        output = _exl3_gemm(
++            x,
++            trellis,
++            layer.suh.exl3_tensors[shard_id],
++            layer.svh.exl3_tensors[shard_id],
++            shard_id in layer.mcg.exl3_tensors,
++            shard_id in layer.mul1.exl3_tensors,
++        )
++        logical_n = Exl3LinearMethod._output_shard_size(layer, shard_id)
++        if output.shape[-1] < logical_n:
++            raise ValueError(
++                f"EXL3 packed N={output.shape[-1]} is below logical N={logical_n}"
++            )
++        return output[..., :logical_n]
++
++
++class Exl3MoEParameter(BasevLLMParameter):
++    """EXL3 tensors keyed by expert/projection, optionally in one GPU slab."""
++
++    def __new__(
++        cls,
++        *,
++        weight_loader,
++        num_experts: int = 0,
++        shard_ids: tuple[str, ...] = (),
++        preallocate: bool = False,
++    ):
++        del num_experts, shard_ids, preallocate
++        data = torch.empty(0, dtype=torch.uint8)
++        return super().__new__(cls, data=data, weight_loader=weight_loader)
++
++    def __init__(
++        self,
++        *,
++        weight_loader,
++        num_experts: int = 0,
++        shard_ids: tuple[str, ...] = (),
++        preallocate: bool = False,
++    ):
++        self.exl3_tensors: dict[tuple[int, str], torch.Tensor] = {}
++        self.exl3_backing: torch.Tensor | None = None
++        self.exl3_num_experts = int(num_experts)
++        self.exl3_shard_ids = tuple(shard_ids)
++        self.exl3_preallocate = bool(preallocate)
++        super().__init__(data=self.data, weight_loader=weight_loader)
++
++    def load_exl3_weight(
++        self,
++        loaded_weight: torch.Tensor,
++        *,
++        expert_id: int,
++        shard_id: str,
++    ) -> None:
++        key = (int(expert_id), str(shard_id))
++        if not self.exl3_preallocate:
++            self.exl3_tensors[key] = loaded_weight.contiguous()
++            return
++        if self.exl3_num_experts <= 0 or shard_id not in self.exl3_shard_ids:
++            raise ValueError(
++                f"invalid EXL3 slab key expert={expert_id}, shard={shard_id!r}"
++            )
++        if not 0 <= int(expert_id) < self.exl3_num_experts:
++            raise ValueError(
++                f"EXL3 expert {expert_id} is outside [0, {self.exl3_num_experts})"
++            )
++        if self.device.type == "meta":
++            raise RuntimeError("rank-sliced EXL3 slabs cannot be allocated on meta")
++        if self.exl3_backing is None:
++            prefix = (
++                (len(self.exl3_shard_ids), self.exl3_num_experts)
++                if len(self.exl3_shard_ids) > 1
++                else (self.exl3_num_experts,)
++            )
++            self.exl3_backing = torch.empty(
++                prefix + tuple(loaded_weight.shape),
++                dtype=loaded_weight.dtype,
++                device=self.device,
++            )
++        shard_index = self.exl3_shard_ids.index(shard_id)
++        target = (
++            self.exl3_backing[shard_index, expert_id]
++            if len(self.exl3_shard_ids) > 1
++            else self.exl3_backing[expert_id]
++        )
++        if tuple(target.shape) != tuple(loaded_weight.shape):
++            raise ValueError(
++                "rank-sliced EXL3 tensor shape changed within one slab: "
++                f"expected={tuple(target.shape)}, got={tuple(loaded_weight.shape)}"
++            )
++        target.copy_(loaded_weight, non_blocking=True)
++        self.exl3_tensors[key] = target
++
++
++def _exl3_moe_weight_loader(
++    param: Exl3MoEParameter,
++    loaded_weight: torch.Tensor,
++    weight_name: str,
++    shard_id: str,
++    expert_id: int,
++    return_success: bool = False,
++) -> bool | None:
++    del weight_name
++    param.load_exl3_weight(
++        loaded_weight,
++        expert_id=expert_id,
++        shard_id=shard_id,
++    )
++    return True if return_success else None
++
++
++# Model loaders (e.g. llama4-style paths) check this attribute before routing
++# expert tensors through a param's weight_loader with MoE kwargs.
++_exl3_moe_weight_loader.supports_moe_loading = True  # type: ignore[attr-defined]
++
++
++class Exl3MoEMethod(FusedMoEMethodBase):
++    """Correctness MoE path: route, then use three dense EXL3 GEMMs/expert."""
++
++    def __init__(self, quant_config: Exl3Config, moe) -> None:
++        super().__init__(moe)
++        self.quant_config = quant_config
++
++    def create_weights(
++        self,
++        layer: RoutedExperts,
++        num_experts: int,
++        hidden_size: int,
++        intermediate_size_per_partition: int,
++        params_dtype: torch.dtype,
++        **extra_weight_attrs,
++    ) -> None:
++        del extra_weight_attrs
++        if params_dtype not in (torch.bfloat16, torch.float16):
++            raise ValueError(
++                f"EXL3 MoE requires BF16 or FP16 activations, got {params_dtype}"
++            )
++        if self.moe.moe_parallel_config.use_ep:
++            raise NotImplementedError(
++                "EXL3 correctness MoE currently supports TP but not expert parallelism"
++            )
++        if self.moe.has_bias:
++            raise NotImplementedError(
++                "EXL3 correctness MoE does not yet support expert biases"
++            )
++        layer.exl3_tp_rank = self.moe.moe_parallel_config.tp_rank
++        layer.exl3_tp_size = self.moe.moe_parallel_config.tp_size
++        layer.exl3_hidden_size = hidden_size
++        layer.exl3_intermediate_size_per_partition = intermediate_size_per_partition
++        layer.exl3_params_dtype = params_dtype
++        rank_sliced = self.quant_config.rank_sliced_metadata is not None
++        if rank_sliced:
++            checkpoint_tp = int(self.quant_config.rank_sliced_metadata["tp"])
++            if checkpoint_tp != layer.exl3_tp_size:
++                raise ValueError(
++                    "rank-sliced EXL3 checkpoint TP does not match runtime: "
++                    f"checkpoint={checkpoint_tp}, runtime={layer.exl3_tp_size}"
++                )
++            expected_experts = int(
++                self.quant_config.rank_sliced_metadata["experts_per_layer"]
++            )
++            if expected_experts != num_experts:
++                raise ValueError(
++                    "rank-sliced EXL3 expert count does not match the model: "
++                    f"checkpoint={expected_experts}, model={num_experts}"
++                )
++            vllm_config = get_current_vllm_config_or_none()
++            scheduler_config = (
++                vllm_config.scheduler_config if vllm_config is not None else None
++            )
++            # No silent fallback: a wrong capacity here puts the target and the
++            # rank-sliced MTP draft on different plans with no error, which is
++            # exactly the class of mismatch that corrupts only at scale.
++            if (
++                scheduler_config is None
++                or getattr(scheduler_config, "max_num_batched_tokens", None) is None
++            ):
++                raise ValueError(
++                    "EXL3 rank-sliced MoE requires scheduler_config."
++                    "max_num_batched_tokens to plan its Trellis arena; refusing to "
++                    "guess a capacity."
++                )
++            layer.exl3_max_num_batched_tokens = int(
++                scheduler_config.max_num_batched_tokens
++            )
++            # Stamp the layer role while the model-construction config context
++            # is still active. Forward time (the profile pass and CUDA graph
++            # capture) runs with no current vllm config, so neither name- nor
++            # index-based detection can resolve the role there -- a GLM-5.2
++            # style MTP head is named exactly like a target layer
++            # (model.layers.<num_hidden_layers>.*). runner_type is minted as
++            # "draft" for every model-backed speculator draft
++            # (SpeculativeConfig.__post_init__ -> ModelConfig(runner="draft")),
++            # which also covers speculators that bypass load_eagle_model.
++            layer.exl3_is_draft = (
++                getattr(vllm_config.model_config, "runner_type", None) == "draft"
++            )
++        for prefix, shard_ids in (("w13", ("w1", "w3")), ("w2", ("w2",))):
++            for suffix in ("suh", "svh", "trellis", "mcg", "mul1"):
++                layer.register_parameter(
++                    f"{prefix}_{suffix}",
++                    Exl3MoEParameter(
++                        weight_loader=_exl3_moe_weight_loader,
++                        num_experts=num_experts,
++                        shard_ids=shard_ids,
++                        preallocate=rank_sliced and suffix in {"suh", "svh", "trellis"},
++                    ),
++                )
++
++    def process_weights_after_loading(self, layer: RoutedExperts) -> None:
++        required = {"w13": ("w1", "w3"), "w2": ("w2",)}
++        missing: list[str] = []
++        for prefix, shard_ids in required.items():
++            for attr in ("suh", "svh", "trellis"):
++                tensors = getattr(layer, f"{prefix}_{attr}").exl3_tensors
++                for expert_id in range(layer.local_num_experts):
++                    for shard_id in shard_ids:
++                        if (expert_id, shard_id) not in tensors:
++                            missing.append(f"{prefix}_{attr}[{expert_id},{shard_id}]")
++        if missing:
++            raise ValueError(
++                f"Missing EXL3 MoE tensors for {layer.layer_name}: "
++                + ", ".join(missing[:32])
++                + (" ..." if len(missing) > 32 else "")
++            )
++        self._validate_codebooks(layer)
++        if self.quant_config.rank_sliced_metadata is None:
++            self._shard_tensors_for_tensor_parallel(layer)
++        device = layer.w13_trellis.device
++        for prefix in ("w13", "w2"):
++            for attr in ("suh", "svh", "trellis", "mcg", "mul1"):
++                param = getattr(layer, f"{prefix}_{attr}")
++                for key, tensor in list(param.exl3_tensors.items()):
++                    param.exl3_tensors[key] = tensor.to(
++                        device=device, non_blocking=True
++                    ).contiguous()
++        self._validate_moe_shapes(layer)
++
++        if self.quant_config.rank_sliced_metadata is not None:
++            self._prepare_rank_sliced_weights(layer)
++            return
++
++    def _validate_codebooks(self, layer: RoutedExperts) -> None:
++        projections = {
++            "w1": layer.ckpt_gate_proj_name,
++            "w2": layer.ckpt_down_proj_name,
++            "w3": layer.ckpt_up_proj_name,
++        }
++        for expert_id in range(layer.local_num_experts):
++            for shard_id, projection in projections.items():
++                prefix = f"{layer.layer_name}.{expert_id}.{projection}"
++                expected = self.quant_config.codebook_for_prefix(prefix)
++                group = "w2" if shard_id == "w2" else "w13"
++                key = (expert_id, shard_id)
++                has_mcg = key in getattr(layer, f"{group}_mcg").exl3_tensors
++                has_mul1 = key in getattr(layer, f"{group}_mul1").exl3_tensors
++                if has_mcg and has_mul1:
++                    raise ValueError(f"EXL3 MoE {prefix} has both codebooks")
++                if expected == "mcg" and not has_mcg:
++                    raise ValueError(f"EXL3 MoE {prefix} is missing mcg")
++                if expected == "mul1" and not has_mul1:
++                    raise ValueError(f"EXL3 MoE {prefix} is missing mul1")
++                if expected is None and (has_mcg or has_mul1):
++                    raise ValueError(
++                        f"EXL3 MoE {prefix} has an unexpected codebook marker"
++                    )
++                if has_mcg:
++                    Exl3LinearMethod._validate_marker(
++                        getattr(layer, f"{group}_mcg").exl3_tensors[key],
++                        _MCG_SENTINEL,
++                        "mcg",
++                    )
++                if has_mul1:
++                    Exl3LinearMethod._validate_marker(
++                        getattr(layer, f"{group}_mul1").exl3_tensors[key],
++                        _MUL1_SENTINEL,
++                        "mul1",
++                    )
++
++    @classmethod
++    def _shard_tensors_for_tensor_parallel(cls, layer: RoutedExperts) -> None:
++        if layer.exl3_tp_size == 1:
++            return
++        start = layer.exl3_tp_rank * layer.exl3_intermediate_size_per_partition
++        size = layer.exl3_intermediate_size_per_partition
++        for expert_id in range(layer.local_num_experts):
++            for shard_id in ("w1", "w3"):
++                key = (expert_id, shard_id)
++                layer.w13_svh.exl3_tensors[key] = (
++                    layer.w13_svh.exl3_tensors[key].narrow(0, start, size).contiguous()
++                )
++                layer.w13_trellis.exl3_tensors[key] = (
++                    Exl3LinearMethod._slice_exl3_tensor(
++                        layer.w13_trellis.exl3_tensors[key],
++                        dim=1,
++                        start=start,
++                        size=size,
++                    )
++                )
++            key = (expert_id, "w2")
++            layer.w2_suh.exl3_tensors[key] = (
++                layer.w2_suh.exl3_tensors[key].narrow(0, start, size).contiguous()
++            )
++            layer.w2_trellis.exl3_tensors[key] = Exl3LinearMethod._slice_exl3_tensor(
++                layer.w2_trellis.exl3_tensors[key],
++                dim=0,
++                start=start,
++                size=size,
++            )
++
++    @staticmethod
++    def _validate_moe_shapes(layer: RoutedExperts) -> None:
++        for expert_id in range(layer.local_num_experts):
++            for group, shard_ids in (("w13", ("w1", "w3")), ("w2", ("w2",))):
++                for shard_id in shard_ids:
++                    key = (expert_id, shard_id)
++                    trellis = getattr(layer, f"{group}_trellis").exl3_tensors[key]
++                    suh = getattr(layer, f"{group}_suh").exl3_tensors[key]
++                    svh = getattr(layer, f"{group}_svh").exl3_tensors[key]
++                    if (
++                        trellis.dtype != torch.int16
++                        or trellis.ndim != 3
++                        or trellis.shape[2] % 16
++                        or not 1 <= trellis.shape[2] // 16 <= 8
++                        or suh.dtype != torch.float16
++                        or suh.ndim != 1
++                        or svh.dtype != torch.float16
++                        or svh.ndim != 1
++                        or suh.numel() != trellis.shape[0] * 16
++                        or svh.numel() != trellis.shape[1] * 16
++                        or (trellis.shape[0] * 16) % _HADAMARD_BLOCK
++                        or (trellis.shape[1] * 16) % _HADAMARD_BLOCK
++                    ):
++                        raise ValueError(
++                            f"Invalid EXL3 MoE tensors for expert={expert_id}, "
++                            f"projection={shard_id}"
++                        )
++
++    @staticmethod
++    def _rank_sliced_backing(
++        layer: RoutedExperts,
++        param_name: str,
++    ) -> torch.Tensor:
++        param = getattr(layer, param_name)
++        backing = param.exl3_backing
++        if backing is None or not backing.is_contiguous():
++            raise RuntimeError(
++                f"rank-sliced EXL3 parameter {param_name} has no contiguous slab"
++            )
++        for (expert_id, shard_id), tensor in param.exl3_tensors.items():
++            shard_index = param.exl3_shard_ids.index(shard_id)
++            expected = (
++                backing[shard_index, expert_id]
++                if len(param.exl3_shard_ids) > 1
++                else backing[expert_id]
++            )
++            if tensor.data_ptr() != expected.data_ptr():
++                raise RuntimeError(
++                    "rank-sliced EXL3 expert payload lost its slab alias: "
++                    f"{param_name}[{expert_id},{shard_id}]"
++                )
++        return backing
++
++    @staticmethod
++    def _pointer_table(slab: torch.Tensor) -> torch.Tensor:
++        if slab.ndim < 2 or not slab[0].is_contiguous():
++            raise RuntimeError("EXL3 pointer-table rows must be contiguous")
++        step = slab.stride(0) * slab.element_size()
++        base = slab.data_ptr()
++        return torch.tensor(
++            [base + expert_id * step for expert_id in range(slab.shape[0])],
++            dtype=torch.int64,
++            device=slab.device,
++        )
++
++    @staticmethod
++    def _trellis_tile_config(hidden_size: int, intermediate_size: int):
++        if hidden_size % 128 or intermediate_size % 128:
++            raise ValueError(
++                "rank-sliced EXL3 full rotations require hidden and "
++                "intermediate dimensions divisible by 128"
++            )
++        if hidden_size % 256 == 0 and intermediate_size % 256 == 0:
++            return (64, 256, 64, 256)
++        return (64, 128, 64, 128)
++
++    def _prepare_rank_sliced_weights(self, layer: RoutedExperts) -> None:
++        api = _load_sparkinfer_fused_moe()
++        num_experts = int(layer.local_num_experts)
++        hidden_size = int(layer.exl3_hidden_size)
++        intermediate_size = int(layer.exl3_intermediate_size_per_partition)
++        bits = int(self.quant_config.bits or 0)
++        if float(bits) != self.quant_config.bits or bits not in (3, 4, 5, 6):
++            raise ValueError(
++                "rank-sliced EXL3 requires an integral 3/4/5/6 bitrate, got "
++                f"{self.quant_config.bits!r}"
++            )
++
++        w13 = self._rank_sliced_backing(layer, "w13_trellis")
++        w2 = self._rank_sliced_backing(layer, "w2_trellis")
++        gate_suh, up_suh = self._rank_sliced_backing(layer, "w13_suh")
++        gate_svh, up_svh = self._rank_sliced_backing(layer, "w13_svh")
++        down_suh = self._rank_sliced_backing(layer, "w2_suh")
++        down_svh = self._rank_sliced_backing(layer, "w2_svh")
++        expected_w13 = (
++            2,
++            num_experts,
++            hidden_size // 16,
++            intermediate_size // 16,
++            16 * bits,
++        )
++        expected_w2 = (
++            num_experts,
++            intermediate_size // 16,
++            hidden_size // 16,
++            16 * bits,
++        )
++        if tuple(w13.shape) != expected_w13 or tuple(w2.shape) != expected_w2:
++            raise ValueError(
++                "rank-sliced EXL3 slab geometry mismatch: "
++                f"w13={tuple(w13.shape)}, w2={tuple(w2.shape)}, "
++                f"expected={expected_w13}/{expected_w2}"
++            )
++
++        intermediate_rotations = torch.empty(
++            (num_experts, 3 * intermediate_size),
++            dtype=torch.float16,
++            device=w13.device,
++        )
++        intermediate_rotations[:, :intermediate_size].copy_(gate_svh)
++        intermediate_rotations[:, intermediate_size : 2 * intermediate_size].copy_(
++            up_svh
++        )
++        intermediate_rotations[:, 2 * intermediate_size :].copy_(down_suh)
++        tile_config = self._trellis_tile_config(hidden_size, intermediate_size)
++        marker = layer.w13_mcg.exl3_tensors[(0, "w1")]
++        weight_plan = api.plan_weights(
++            quant_modes="w4a16",
++            source_format="exl3_trellis_mcg",
++            activation=layer.activation.value,
++            params_dtype=layer.exl3_params_dtype,
++            num_experts=num_experts,
++            hidden_size=hidden_size,
++            intermediate_size=intermediate_size,
++            w13_layout="w13",
++            trellis_bits=bits,
++            trellis_tile_config=tile_config,
++        )
++        layer.exl3_trellis_weights = api.prepare_weights(
++            plan=weight_plan,
++            params_dtype=layer.exl3_params_dtype,
++            w1_fp4=w13,
++            w2_fp4=w2,
++            gate_suh=gate_suh,
++            up_suh=up_suh,
++            intermediate_rotations=intermediate_rotations,
++            down_svh=down_svh,
++            trellis_mcg=marker,
++        )
++
++        slabs = (
++            w13[0],
++            gate_suh,
++            gate_svh,
++            w13[1],
++            up_suh,
++            up_svh,
++            w2,
++            down_suh,
++            down_svh,
++        )
++        layer.exl3_pointer_tables = tuple(self._pointer_table(slab) for slab in slabs)
++        layer.exl3_expert_map = torch.arange(
++            num_experts,
++            dtype=torch.int64,
++            device=w13.device,
++        )
++        layer.exl3_trellis_tile_config = tile_config
++
++    def get_fused_moe_quant_config(
++        self, layer: RoutedExperts
++    ) -> FusedMoEQuantConfig | None:
++        del layer
++        return None
++
++    @property
++    def topk_indices_dtype(self) -> torch.dtype | None:
++        return torch.long
++
++    def _rank_sliced_runtime(
++        self,
++        layer: RoutedExperts,
++        x: torch.Tensor,
++        topk_ids: torch.Tensor,
++    ) -> dict[str, Any]:
++        # Rank-sliced target and draft layers both reach small row counts
++        # (typically m=1..3) during profiling, decode, or CUDA-graph capture. If
++        # m falls outside the Trellis window the eager parity path is reached;
++        # under capture that is illegal and during eager execution it adds an
++        # avoidable external-extension ABI dependency:
++        #
++        #   RuntimeError: EXL3 eager parity path entered during CUDA graph
++        #   capture (m=3); capture sizes must lie inside the Trellis window
++        #   [4, 32]
++        #
++        # The backend therefore owns one capability-based default for both
++        # roles. An explicit env value remains authoritative for diagnostics.
++        min_trellis_m = _positive_env_int(
++            "VLLM_EXL3_TRELLIS_MIN_M", _DEFAULT_TRELLIS_MIN_M
++        )
++        max_trellis_m = _positive_env_int("VLLM_EXL3_TRELLIS_MAX_M", 32)
++        block_m = _positive_env_int("VLLM_EXL3_TRELLIS_BLOCK_M", 8)
++        chunk = _positive_env_int("VLLM_EXL3_PREFILL_CHUNK", 128)
++        prefill_trellis = os.environ.get("VLLM_EXL3_PREFILL_TRELLIS", "1") == "1"
++        prefill_block_m = _positive_env_int("VLLM_EXL3_PREFILL_BLOCK_M", 64)
++        if min_trellis_m > max_trellis_m:
++            raise ValueError(
++                "VLLM_EXL3_TRELLIS_MIN_M cannot exceed VLLM_EXL3_TRELLIS_MAX_M"
++            )
++        # Batch-INVARIANT capacity. Including x.shape[0] here made the runtime
++        # cache key depend on the live batch, so any m above the planned capacity
++        # produced a cache MISS -- silently planning a fresh ~1 GiB arena mid-serve
++        # and making the capacity guard in _apply_rank_sliced unreachable. The
++        # planned capacity is a property of the layer, not of one forward pass.
++        max_batched_tokens = int(layer.exl3_max_num_batched_tokens)
++        prefill_plan_enabled = prefill_trellis and max_batched_tokens > max_trellis_m
++        parity_rows = (
++            min(chunk, max_batched_tokens)
++            if prefill_plan_enabled
++            else max_batched_tokens
++        )
++        max_parity_batch = min(max_batched_tokens, min_trellis_m - 1)
++        if max_parity_batch > parity_rows:
++            raise ValueError(
++                "VLLM_EXL3_PREFILL_CHUNK cannot cover the EXL3 parity window: "
++                f"chunk={chunk}, required_rows={max_parity_batch}. Increase "
++                "VLLM_EXL3_PREFILL_CHUNK or lower VLLM_EXL3_TRELLIS_MIN_M."
++            )
++        topk = int(topk_ids.shape[1])
++        device_index = x.device.index
++        key = (
++            # Owning model scope first: the cached runtime holds mutable scratch,
++            # so a target layer and a same-shape rank-sliced MTP draft layer must
++            # not share an entry (see _runtime_scope_id).
++            _runtime_owner_token(self.quant_config, layer),
++            device_index,
++            x.dtype,
++            int(layer.exl3_hidden_size),
++            int(layer.exl3_intermediate_size_per_partition),
++            int(layer.local_num_experts),
++            topk,
++            max_batched_tokens,
++            min_trellis_m,
++            max_trellis_m,
++            block_m,
++            chunk,
++            prefill_trellis,
++            prefill_block_m,
++            layer.exl3_trellis_tile_config,
++        )
++        runtime = _RANK_SLICED_RUNTIMES.get(key)
++        if runtime is not None:
++            return runtime
++        if torch.cuda.is_current_stream_capturing():
++            raise RuntimeError(
++                "Rank-sliced EXL3 runtime must be planned during the eager "
++                "profile pass before CUDA graph capture"
++            )
++
++        api = _load_sparkinfer_fused_moe()
++
++        def _plan_with_scratch(plan_max_tokens: int, plan_block_m: int):
++            caps = api.Caps(
++                max_tokens=plan_max_tokens,
++                num_topk=topk,
++                # vLLM supplies final top-k IDs/weights to bind(); the fused-MoE
++                # router workspace is unused. A zero route-workspace request
++                # still lets the W4A16 core derive route_E from weight_E.
++                route_num_experts=0,
++                device=x.device,
++                weight_plan=layer.exl3_trellis_weights.plan,
++                quant_mode="w4a16",
++                w4a16_block_size_m=plan_block_m,
++            )
++            plan = api.plan(caps)
++            scratch_spec = plan.scratch_specs()[0]
++            scratch = torch.empty(
++                scratch_spec.shape,
++                dtype=scratch_spec.dtype,
++                device=scratch_spec.device,
++            )
++            return plan, scratch
++
++        trellis_plan, trellis_scratch = _plan_with_scratch(max_trellis_m, block_m)
++        # Prefill batches (m > max_trellis_m) run through a second planned
++        # Trellis capacity instead of the eager ExLlamaV3 parity path. The
++        # large block keeps expert tiles streamed once per block of routed
++        # rows rather than once per 8-row block.
++        prefill_plan = None
++        prefill_scratch = None
++        if prefill_plan_enabled:
++            prefill_plan, prefill_scratch = _plan_with_scratch(
++                max_batched_tokens, prefill_block_m
++            )
++
++        ext = _load_exl3_ext()
++        required_ext = {
++            "exl3_moe",
++            "exl3_moe_max_concurrency",
++        }
++        missing_ext = sorted(name for name in required_ext if not hasattr(ext, name))
++        if missing_ext:
++            raise RuntimeError(
++                "The EXL3 extension lacks routed-expert entry points: "
++                + ", ".join(missing_ext)
++            )
++        concurrency = int(ext.exl3_moe_max_concurrency(torch.cuda.current_device()))
++        hidden_size = int(layer.exl3_hidden_size)
++        intermediate_size = int(layer.exl3_intermediate_size_per_partition)
++        num_experts = int(layer.local_num_experts)
++        device = x.device
++        # With the prefill plan live, the parity path only ever serves
++        # m < min_trellis_m, so its persistent staging shrinks to one chunk.
++        runtime = {
++            "api": api,
++            "trellis_plan": trellis_plan,
++            "trellis_scratch": trellis_scratch,
++            "prefill_plan": prefill_plan,
++            "prefill_scratch": prefill_scratch,
++            "ext": ext,
++            "min_trellis_m": min_trellis_m,
++            "max_trellis_m": max_trellis_m,
++            "max_batched_tokens": max_batched_tokens,
++            "parity_rows": parity_rows,
++            "topk": topk,
++            "chunk": chunk,
++            "xh": torch.empty(
++                (parity_rows, hidden_size),
++                dtype=torch.float16,
++                device=device,
++            ),
++            "out32": torch.empty(
++                (parity_rows, hidden_size),
++                dtype=torch.float32,
++                device=device,
++            ),
++            "tg": torch.empty(
++                (concurrency, chunk, hidden_size),
++                dtype=torch.float16,
++                device=device,
++            ),
++            "tu": torch.empty(
++                (concurrency, chunk, hidden_size),
++                dtype=torch.float16,
++                device=device,
++            ),
++            "ig": torch.empty(
++                (concurrency, chunk, intermediate_size),
++                dtype=torch.float16,
++                device=device,
++            ),
++            "iu": torch.empty(
++                (concurrency, chunk, intermediate_size),
++                dtype=torch.float16,
++                device=device,
++            ),
++            "expert_count": torch.empty(
++                num_experts + 1,
++                dtype=torch.int64,
++                device=device,
++            ),
++            "expert_offsets": torch.empty(
++                num_experts + 1,
++                dtype=torch.int64,
++                device=device,
++            ),
++            "token_sorted": torch.empty(
++                parity_rows * topk,
++                dtype=torch.int64,
++                device=device,
++            ),
++            "weight_sorted": torch.empty(
++                parity_rows * topk,
++                dtype=torch.float16,
++                device=device,
++            ),
++            "flat_token": torch.arange(
++                chunk,
++                dtype=torch.int64,
++                device=device,
++            ).repeat_interleave(topk),
++            "ones": torch.ones(
++                chunk * topk,
++                dtype=torch.int64,
++                device=device,
++            ),
++        }
++        _RANK_SLICED_RUNTIMES[key] = runtime
++        prefill_arena_mib = (
++            0.0
++            if prefill_scratch is None
++            else prefill_scratch.numel() * prefill_scratch.element_size() / (1 << 20)
++        )
++        logger.info_once(
++            "EXL3 rank-sliced runtime planned: Trellis m=%d..%d block_m=%d, "
++            "prefill %s capacity=%d chunk=%d topk=%d",
++            min_trellis_m,
++            max_trellis_m,
++            block_m,
++            (
++                f"trellis block_m={prefill_block_m} arena={prefill_arena_mib:.1f}MiB"
++                if prefill_plan is not None
++                else "parity"
++            ),
++            max_batched_tokens,
++            chunk,
++            topk,
++        )
++        return runtime
++
++    def _apply_rank_sliced(
++        self,
++        layer: RoutedExperts,
++        x: torch.Tensor,
++        topk_weights: torch.Tensor,
++        topk_ids: torch.Tensor,
++    ) -> torch.Tensor:
++        runtime = self._rank_sliced_runtime(layer, x, topk_ids)
++        m = int(x.shape[0])
++        if runtime["min_trellis_m"] <= m <= runtime["max_trellis_m"]:
++            binding = runtime["api"].bind(
++                runtime["trellis_plan"],
++                scratch=runtime["trellis_scratch"],
++                a=x,
++                experts=layer.exl3_trellis_weights,
++                topk_weights=topk_weights,
++                topk_ids=topk_ids,
++            )
++            output = runtime["api"].run(binding=binding)
++            return output.to(x.dtype)
++
++        if runtime["prefill_plan"] is not None and m > runtime["max_trellis_m"]:
++            if m > runtime["max_batched_tokens"]:
++                raise ValueError(
++                    "EXL3 batch exceeds its planned capacity: "
++                    f"m={m}, capacity={runtime['max_batched_tokens']}"
++                )
++            binding = runtime["api"].bind(
++                runtime["prefill_plan"],
++                scratch=runtime["prefill_scratch"],
++                a=x,
++                experts=layer.exl3_trellis_weights,
++                topk_weights=topk_weights,
++                topk_ids=topk_ids,
++            )
++            output = runtime["api"].run(binding=binding)
++            return output.to(x.dtype)
++
++        if torch.cuda.is_current_stream_capturing():
++            raise RuntimeError(
++                "EXL3 eager parity path entered during CUDA graph capture "
++                f"(m={m}); capture sizes must lie inside the Trellis window "
++                f"[{runtime['min_trellis_m']}, {runtime['max_trellis_m']}]. "
++                f"Layer {getattr(layer, 'layer_name', '<unknown>')!r} was "
++                f"classified as {'draft' if _is_draft_layer(layer) else 'target'}. "
++                "A rank-sliced draft layer should have had its window widened to "
++                f"MIN_CAPTURABLE_TRELLIS_M={MIN_CAPTURABLE_TRELLIS_M} "
++                "automatically; if VLLM_EXL3_TRELLIS_MIN_M is set explicitly, "
++                f"lower it to {MIN_CAPTURABLE_TRELLIS_M} or unset it."
++            )
++        if m > runtime["parity_rows"]:
++            raise ValueError(
++                "EXL3 batch exceeds its planned parity capacity: "
++                f"m={m}, capacity={runtime['parity_rows']}"
++            )
++        ext = runtime["ext"]
++        xh = runtime["xh"][:m]
++        xh.copy_(x)
++        out32 = runtime["out32"][:m]
++        out32.zero_()
++        chunk = int(runtime["chunk"])
++        pointer_args = layer.exl3_pointer_tables
++        if m > chunk and hasattr(ext, "exl3_moe_fused"):
++            ext.exl3_moe_fused(
++                xh,
++                out32,
++                topk_ids,
++                topk_weights,
++                layer.exl3_expert_map,
++                runtime["expert_count"],
++                runtime["expert_offsets"],
++                runtime["token_sorted"],
++                runtime["weight_sorted"],
++                runtime["tg"],
++                runtime["tu"],
++                runtime["ig"],
++                runtime["iu"],
++                0,
++                3,
++                3,
++                3,
++                *pointer_args,
++                True,
++                False,
++                True,
++                False,
++                True,
++                False,
++                0.0,
++                0,
++            )
++            return out32.to(x.dtype)
++
++        local_ids = layer.exl3_expert_map[topk_ids.long()]
++        half_weights = topk_weights.to(torch.float16)
++        topk = int(runtime["topk"])
++        for start in range(0, m, chunk):
++            current_m = min(chunk, m - start)
++            flat = local_ids[start : start + current_m].reshape(-1)
++            order = torch.argsort(flat)
++            route_count = current_m * topk
++            token_ids = runtime["flat_token"][:route_count].index_select(0, order)
++            route_weights = (
++                half_weights[start : start + current_m]
++                .reshape(-1)
++                .index_select(0, order)
++            )
++            counts = runtime["expert_count"]
++            counts.zero_()
++            counts.scatter_add_(0, flat, runtime["ones"][:route_count])
++            ext.exl3_moe(
++                xh[start : start + current_m],
++                out32[start : start + current_m],
++                counts,
++                token_ids,
++                route_weights,
++                runtime["tg"],
++                runtime["tu"],
++                runtime["ig"],
++                runtime["iu"],
++                0,
++                3,
++                3,
++                3,
++                *pointer_args,
++                True,
++                False,
++                True,
++                False,
++                True,
++                False,
++                0.0,
++            )
++        return out32.to(x.dtype)
++
++    def apply(
++        self,
++        layer: RoutedExperts,
++        x: torch.Tensor,
++        topk_weights: torch.Tensor,
++        topk_ids: torch.Tensor,
++        shared_experts: SharedExperts | None,
++        shared_experts_input: torch.Tensor | None,
++    ) -> torch.Tensor:
++        del shared_experts, shared_experts_input
++        if layer.activation != MoEActivation.SILU:
++            raise NotImplementedError(
++                f"EXL3 correctness MoE supports SiLU only, got {layer.activation}"
++            )
++        if layer.expert_map is not None:
++            raise NotImplementedError("EXL3 MoE expert maps/EPLB are not supported")
++        if layer.apply_router_weight_on_input:
++            raise NotImplementedError(
++                "EXL3 MoE does not support router weights applied on input"
++            )
++
++        original_shape = x.shape[:-1]
++        original_dtype = x.dtype
++        x_2d = x.reshape(-1, x.shape[-1]).contiguous()
++        ids = topk_ids.reshape(x_2d.shape[0], -1).contiguous()
++        weights = topk_weights.reshape_as(ids).to(torch.float32).contiguous()
++        if self.quant_config.rank_sliced_metadata is not None:
++            output = self._apply_rank_sliced(layer, x_2d, weights, ids)
++            return output.reshape(*original_shape, output.shape[-1])
++
++        x_2d = x_2d.to(torch.float16)
++        ids = ids.to(torch.long)
++        weights = weights.to(torch.float16)
++        output = torch.zeros(
++            (x_2d.shape[0], layer.hidden_size),
++            dtype=torch.float32,
++            device=x.device,
++        )
++        for expert_id in range(layer.local_num_experts):
++            positions = (ids == expert_id).nonzero(as_tuple=False)
++            if positions.shape[0] == 0:
++                continue
++            token_ids = positions[:, 0]
++            route_ids = positions[:, 1]
++            expert_input = x_2d.index_select(0, token_ids)
++            gate = self._apply_expert(layer, "w13", expert_input, expert_id, "w1")
++            up = self._apply_expert(layer, "w13", expert_input, expert_id, "w3")
++            hidden = torch.nn.functional.silu(gate) * up
++            expert_output = self._apply_expert(layer, "w2", hidden, expert_id, "w2")
++            route_weight = weights[token_ids, route_ids].unsqueeze(-1)
++            output.index_add_(
++                0,
++                token_ids,
++                (expert_output * route_weight).to(torch.float32),
++            )
++        output = output.reshape(*original_shape, output.shape[-1])
++        return output if output.dtype == original_dtype else output.to(original_dtype)
++
++    def apply_monolithic(
++        self,
++        layer: RoutedExperts,
++        x: torch.Tensor,
++        router_logits: torch.Tensor,
++        input_ids: torch.Tensor | None = None,
++    ) -> torch.Tensor:
++        del layer, x, router_logits, input_ids
++        raise NotImplementedError("EXL3 MoE uses vLLM's external router")
++
++    @staticmethod
++    def _apply_expert(
++        layer: RoutedExperts,
++        group: str,
++        x: torch.Tensor,
++        expert_id: int,
++        shard_id: str,
++    ) -> torch.Tensor:
++        key = (expert_id, shard_id)
++        trellis = getattr(layer, f"{group}_trellis").exl3_tensors[key]
++        packed_k = trellis.shape[0] * 16
++        if x.shape[-1] > packed_k:
++            raise ValueError(
++                f"EXL3 MoE input width {x.shape[-1]} exceeds packed K={packed_k}"
++            )
++        if x.shape[-1] < packed_k:
++            x = torch.nn.functional.pad(x, (0, packed_k - x.shape[-1]))
++        output = _exl3_gemm(
++            x,
++            trellis,
++            getattr(layer, f"{group}_suh").exl3_tensors[key],
++            getattr(layer, f"{group}_svh").exl3_tensors[key],
++            key in getattr(layer, f"{group}_mcg").exl3_tensors,
++            key in getattr(layer, f"{group}_mul1").exl3_tensors,
++        )
++        logical_n = (
++            layer.hidden_size
++            if shard_id == "w2"
++            else layer.exl3_intermediate_size_per_partition
++        )
++        if output.shape[-1] < logical_n:
++            raise ValueError(
++                f"EXL3 MoE packed N={output.shape[-1]} is below logical N={logical_n}"
++            )
++        return output[..., :logical_n]
++
++
++__all__ = ["Exl3Config", "Exl3LinearMethod", "Exl3MoEMethod"]
+diff --git a/vllm/model_executor/layers/sparse_attn_indexer.py b/vllm/model_executor/layers/sparse_attn_indexer.py
+index 3c1c1cd0e70f801fb94ac65fb5a99afed01f8dea..9ad66a9e7c964dafcec62b4ede8c71c1aea7ee2a 100644
+--- a/vllm/model_executor/layers/sparse_attn_indexer.py
++++ b/vllm/model_executor/layers/sparse_attn_indexer.py
+@@ -411,13 +411,63 @@ def _dcp_all_gather_first_dim_into(
+     if device_group is not None:
+         import torch.distributed as dist
+ 
+-        dist.all_gather_into_tensor(output_tensor, input_tensor, group=device_group)
++        gather_input = input_tensor
++        input_start = input_tensor.data_ptr()
++        input_end = input_start + input_tensor.numel() * input_tensor.element_size()
++        output_start = output_tensor.data_ptr()
++        output_end = output_start + output_tensor.numel() * output_tensor.element_size()
++        if input_start < output_end and output_start < input_end:
++            # PyTorch does not document NCCL's in-place alias contract. Keep
++            # its fallback portable; the deployed PyNCCL path above remains
++            # zero-copy.
++            gather_input = input_tensor.clone()
++        dist.all_gather_into_tensor(output_tensor, gather_input, group=device_group)
+         return
+ 
+     gathered = group.all_gather(input_tensor, dim=0)
+     output_tensor.copy_(gathered)
+ 
+ 
++def _query_split_all_gather_indices(
++    group,
++    local_indices: torch.Tensor,
++    gathered_indices: torch.Tensor,
++) -> None:
++    """Restore query-split rows directly into their shared index buffer.
++
++    Args:
++        group: Query-split process group and rank metadata.
++        local_indices: Contiguous rank-local rows aliasing their output slot.
++        gathered_indices: Contiguous output containing every rank's rows.
++
++    Raises:
++        RuntimeError: If the buffers are noncontiguous, have incompatible
++            shapes, or do not satisfy the rank-local alias contract.
++    """
++    if group.world_size <= 1:
++        return
++    if not local_indices.is_contiguous() or not gathered_indices.is_contiguous():
++        raise RuntimeError("query-split top-k buffers must be contiguous")
++    if gathered_indices.shape[0] != local_indices.shape[0] * group.world_size:
++        raise RuntimeError("query-split output has an invalid row count")
++    if gathered_indices.shape[1:] != local_indices.shape[1:]:
++        raise RuntimeError("query-split output has an invalid trailing shape")
++
++    rank = int(group.rank_in_group)
++    expected_local = gathered_indices.narrow(
++        0, rank * local_indices.shape[0], local_indices.shape[0]
++    )
++    if expected_local.data_ptr() != local_indices.data_ptr():
++        raise RuntimeError(
++            "query-split local indices must alias their rank slot in the output"
++        )
++
++    # NCCL supports in-place all-gather when the send buffer aliases the
++    # rank-local slice of the receive buffer. The generic fallback in
++    # _dcp_all_gather_first_dim_into remains correct when PyNCCL is unavailable.
++    _dcp_all_gather_first_dim_into(group, local_indices, gathered_indices)
++
++
+ def _unpack_b12x_dcp_gathered_candidates(
+     gathered_candidates: torch.Tensor,
+     candidate_indices: torch.Tensor,
+@@ -1994,19 +2044,17 @@ def sparse_attn_indexer(
+                 if used_owner_merge:
+                     continue
+                 if qs_active:
+-                    gathered_indices = qs_group.all_gather(
+-                        topk_indices.contiguous(), dim=0
+-                    )
+-                    topk_indices_buffer[
++                    gathered_indices = topk_indices_buffer[
+                         chunk.token_start : chunk.token_end, :topk_tokens
+-                    ].copy_(gathered_indices)
+-                    if topk_scores is not None:
+-                        gathered_scores = qs_group.all_gather(
+-                            topk_scores.contiguous(), dim=0
+-                        )
+-                        topk_scores_buffer[
+-                            chunk.token_start : chunk.token_end, :topk_tokens
+-                        ].copy_(gathered_scores)
++                    ]
++                    _query_split_all_gather_indices(
++                        qs_group,
++                        topk_indices,
++                        gathered_indices,
++                    )
++                    # Scores are only needed for the DCP-local candidate merge
++                    # above. Sparse attention consumes the restored indices, so
++                    # gathering scores here would double query-split traffic.
+                 continue
+ 
+             cu_seqlen_ks = chunk.cu_seqlen_ks
+diff --git a/vllm/model_executor/models/deepseek_mtp.py b/vllm/model_executor/models/deepseek_mtp.py
+index e37303a1d36f82f5baa07c84f0a90f3876c53161..85f727ce91ca2516afb5b64fc62974241f536c66 100644
+--- a/vllm/model_executor/models/deepseek_mtp.py
++++ b/vllm/model_executor/models/deepseek_mtp.py
+@@ -741,7 +741,22 @@ class DeepSeekMTP(nn.Module, DeepseekV2MixtureOfExperts):
+         loaded_params: set[str] = set()
+         _pending_wk_fp8: dict = {}  # FP8 indexer wk dequant buffer
+         _pending_fp8_linear: dict = {}
++        # Rank-sliced EXL3 checkpoints ship one tensor per TP rank
++        # (`....rank{r}.{trellis|suh|svh|mcg}`), while Exl3MoEMethod registers a
++        # single fused param per projection group (`w13_mcg`, `w2_trellis`, ...).
++        # Strip the `.rank{r}` segment before expert mapping, exactly as the
++        # target model (deepseek_v2.load_weights) does; otherwise the MTP loader
++        # looks up `...routed_experts.w2_rank0.mcg` and KeyErrors.
++        rank_sliced_name = getattr(
++            self.quant_config,
++            "normalize_rank_sliced_weight_name",
++            None,
++        )
+         for name, loaded_weight in weights:
++            if rank_sliced_name is not None:
++                name = rank_sliced_name(name)
++                if name is None:
++                    continue
+             if "rotary_emb.inv_freq" in name:
+                 continue
+             spec_layer = get_spec_layer_idx_from_weight_name(self.config, name)
+diff --git a/vllm/model_executor/models/deepseek_v2.py b/vllm/model_executor/models/deepseek_v2.py
+index 21b43a3365105ad771f81a6305903fb08a92a221..d62bf2d89a8ff206d7301438159f3a6f5099b766 100644
+--- a/vllm/model_executor/models/deepseek_v2.py
++++ b/vllm/model_executor/models/deepseek_v2.py
+@@ -1578,6 +1578,7 @@ class DeepseekV2Model(nn.Module):
+         config = vllm_config.model_config.hf_config
+         quant_config = vllm_config.quant_config
+         self.config = config
++        self.quant_config = quant_config
+         self.device = current_platform.device_type
+         self.hidden_size = config.hidden_size
+         self.vocab_size = config.vocab_size
+@@ -1796,12 +1797,21 @@ class DeepseekV2Model(nn.Module):
+         pp_missing_layer_names = get_pp_missing_layer_names(self)
+         params_dict = dict(self.named_parameters())
+         loaded_params: set[str] = set()
++        rank_sliced_name = getattr(
++            self.quant_config,
++            "normalize_rank_sliced_weight_name",
++            None,
++        )
+         # With index_topk_freq>1 only some layers build an indexer, yet the
+         # checkpoint ships indexer weights for all of them; track the built ones.
+         indexer_present_prefixes = {
+             n.rsplit(".indexer.", 1)[0] for n in params_dict if ".indexer." in n
+         }
+         for name, loaded_weight in weights:
++            if rank_sliced_name is not None:
++                name = rank_sliced_name(name)
++                if name is None:
++                    continue
+             if "rotary_emb.inv_freq" in name:
+                 continue
+ 
+diff --git a/vllm/model_executor/models/glm4_moe.py b/vllm/model_executor/models/glm4_moe.py
+index 1c64ccaba45a965cb07faf120ca82b2642d932a8..e87a48209cbc87419a6e3228819eafe47c598360 100644
+--- a/vllm/model_executor/models/glm4_moe.py
++++ b/vllm/model_executor/models/glm4_moe.py
+@@ -418,6 +418,7 @@ class Glm4MoeModel(nn.Module):
+         quant_config = vllm_config.quant_config
+         enable_eplb = vllm_config.parallel_config.enable_eplb
+         self.config = config
++        self.quant_config = quant_config
+ 
+         self.vocab_size = config.vocab_size
+ 
+@@ -522,7 +523,16 @@ class Glm4MoeModel(nn.Module):
+         params_dict = dict(self.named_parameters())
+         loaded_params: set[str] = set()
+         expert_params_mapping = self.get_expert_mapping()
++        rank_sliced_name = getattr(
++            self.quant_config,
++            "normalize_rank_sliced_weight_name",
++            None,
++        )
+         for name, loaded_weight in weights:
++            if rank_sliced_name is not None:
++                name = rank_sliced_name(name)
++                if name is None:
++                    continue
+             spec_layer = get_spec_layer_idx_from_weight_name(self.config, name)
+             if spec_layer is not None:
+                 continue
+diff --git a/vllm/model_executor/models/utils.py b/vllm/model_executor/models/utils.py
+index 86dc72de76c2b12ba5de71dbf2dfd9934cc72535..be0c6fba8bc5895dad07099dda7a26de2b8a82aa 100644
+--- a/vllm/model_executor/models/utils.py
++++ b/vllm/model_executor/models/utils.py
+@@ -796,12 +796,39 @@ def get_draft_quant_config(vllm_config: VllmConfig) -> "QuantizationConfig | Non
+     draft_model_config = vllm_config.speculative_config.draft_model_config
+     draft_load_config = vllm_config.load_config
+ 
+-    return (
+-        VllmConfig.get_quantization_config(draft_model_config, draft_load_config)
+-        if draft_model_config
+-        else None
++    if not draft_model_config:
++        return None
++
++    quant_config = VllmConfig.get_quantization_config(
++        draft_model_config, draft_load_config
+     )
+ 
++    # EXL3 rank-sliced (hybrid_tr3_tail) metadata is hydrated by VllmConfig via
++    # Exl3Config.maybe_update_config() for the *target* model only. The draft/MTP
++    # quant config is built separately here, so without this call its
++    # rank_sliced_metadata stays None and a rank-sliced MTP MoE layer silently
++    # falls back to the stock (non-tr3) expert path, KeyError-ing on
++    # `...experts.routed_experts.wN_rankR.mcg`. Mirror the target-model call so
++    # the MTP layer's experts load through the tr3 path.
++    if (
++        quant_config is not None
++        and getattr(quant_config, "get_name", lambda: None)() == "exl3"
++    ):
++        draft_hf = getattr(draft_model_config, "hf_config", None)
++        target_hf = getattr(
++            getattr(vllm_config, "model_config", None), "hf_config", None
++        )
++        hf_config = draft_hf
++        if getattr(draft_hf, "hybrid_tr3_tail", None) is None:
++            hf_config = target_hf
++        if getattr(hf_config, "hybrid_tr3_tail", None) is not None:
++            quant_config.maybe_update_config(
++                draft_model_config.model,
++                hf_config=hf_config,
++            )
++
++    return quant_config
++
+ 
+ def extract_layer_index(layer_name: str, num_attn_module: int = 1) -> int:
+     """
+diff --git a/vllm/models/deepseek_v32/nvidia/attention.py b/vllm/models/deepseek_v32/nvidia/attention.py
+index dcf955ad59baa698258cdc1125340b70e0b38205..320d7251fc3200afcb5bd4018430119f0e0f4b72 100644
+--- a/vllm/models/deepseek_v32/nvidia/attention.py
++++ b/vllm/models/deepseek_v32/nvidia/attention.py
+@@ -398,7 +398,10 @@ class DeepseekV32Attention(MLAAttention):
+         assert isinstance(slot_mapping, dict)
+         mla_slot = slot_mapping.get(self.layer_name)
+ 
+-        if self.indexer is not None:
++        # index_k is None when skip_topk (MTP draft steps 1+ under
++        # index_share_for_mtp_iteration): treat this forward as a shared
++        # layer so the step-0 top-k is reused instead of cleared/recomputed.
++        if self.indexer is not None and index_k is not None:
+             has_indexer = True
+             indexer_k_norm_w = self.indexer.k_norm.weight
+             indexer_k_norm_bias = self.indexer.k_norm.bias
+@@ -456,7 +459,7 @@ class DeepseekV32Attention(MLAAttention):
+         q_nope = q_nope.transpose(0, 1)
+         ql_nope = torch.bmm(q_nope, self.W_UK_T).transpose(0, 1)
+ 
+-        if self.indexer is not None:
++        if self.indexer is not None and has_indexer:
+             index_q = self.indexer.wq_b(q_c)[0]
+             index_q = index_q.view(-1, self.indexer.n_head, self.indexer.head_dim)
+         else:
+@@ -478,7 +481,7 @@ class DeepseekV32Attention(MLAAttention):
+             quantize_mqa=self._fp8_query,
+         )
+ 
+-        if self.indexer is not None:
++        if self.indexer is not None and has_indexer:
+             sparse_attn_indexer(
+                 q_c,
+                 self.indexer.k_cache.prefix,
+diff --git a/vllm/v1/attention/backends/mla/indexer.py b/vllm/v1/attention/backends/mla/indexer.py
+index fa4fbcafd24a7a4668928974c5a445afdcfe76d4..e22a12097931357840b927a96df85a208e1cd044 100644
+--- a/vllm/v1/attention/backends/mla/indexer.py
++++ b/vllm/v1/attention/backends/mla/indexer.py
+@@ -297,12 +297,16 @@ def get_indexer_max_num_blocks_per_req(
+     return cdiv(max_model_len, block_size * effective_cp_world_size)
+ 
+ 
+-def _supports_varlen_paged_mqa_logits() -> bool:
+-    if (
+-        envs.VLLM_USE_B12X_SPARSE_INDEXER
+-        and current_platform.is_cuda()
+-        and current_platform.is_device_capability_family(120)
+-    ):
++def _supports_varlen_paged_mqa_logits(
++    use_b12x_sparse_indexer: bool | None = None,
++) -> bool:
++    if use_b12x_sparse_indexer is None and current_platform.is_cuda():
++        from vllm.model_executor.layers.sparse_attn_indexer import (
++            use_b12x_sparse_indexer as resolve_b12x_sparse_indexer,
++        )
++
++        use_b12x_sparse_indexer = resolve_b12x_sparse_indexer()
++    if use_b12x_sparse_indexer:
+         # B12X consumes the already-flattened rank-1 seq_lens and repeated
+         # block-table rows directly, so it does not need DeepGEMM's indices.
+         return True
+@@ -430,16 +434,30 @@ class DeepseekV32IndexerMetadataBuilder(AttentionMetadataBuilder):
+         # caches). Outside the SM100 family the FP8
+         # paged MQA logits kernel only supports next_n in (1, 2)
+         # (deepgemm smxx_fp8_fp4_paged_mqa_logits.hpp:233), so flatten there.
+-        self.use_flattening = not current_platform.is_device_capability_family(
+-            100
+-        ) and next_n not in (1, 2)
++        # The B12X / sparkinfer sparse indexer handles native next_n>2 on SM120
++        # directly (see sparse_attn_indexer warmup q_rows 1, 2, 4), so it must
++        # NOT be forced onto the DeepGEMM next_n<=2 flatten fallback. Flattening
++        # MTP-2/MTP-3 verification into rank-1 rows produced subtly wrong accepted
++        # tokens (code-gen syntax errors); the native (B, next_n) path keeps MTP
++        # correct. Use the canonical backend-aware predicate so this also holds
++        # when B12X is selected via --attention-backend B12X_MLA_SPARSE with the
++        # VLLM_USE_B12X_SPARSE_INDEXER env var unset (it also asserts SM120).
++        from vllm.model_executor.layers.sparse_attn_indexer import (
++            use_b12x_sparse_indexer,
++        )
++
++        self.use_b12x_sparse_indexer = use_b12x_sparse_indexer()
++        self.use_flattening = (
++            not current_platform.is_device_capability_family(100)
++            and next_n not in (1, 2)
++            and not self.use_b12x_sparse_indexer
++        )
+         # SM100 supports the varlen paged MQA logits kernel (indices-selected,
+         # next_n == 1 rows). Only compact spec-decode verification batches opt
+         # into it; uniform DFlash draft proposal should keep the native path.
+-        self.use_varlen = (
+-            _supports_varlen_paged_mqa_logits()
+-            and _uses_varlen_dspark_capacity(self.vllm_config)
+-        )
++        self.use_varlen = _supports_varlen_paged_mqa_logits(
++            self.use_b12x_sparse_indexer
++        ) and _uses_varlen_dspark_capacity(self.vllm_config)
+         logger.info_once(
+             "DSA indexer decode path: use_flattening=%s use_varlen=%s "
+             "(next_n=%d, use_fp4_indexer_cache=%s)",
+@@ -683,7 +701,7 @@ class DeepseekV32IndexerMetadataBuilder(AttentionMetadataBuilder):
+                 # their slot mappings stay padded and their outputs are ignored.
+                 padding_seq_len = (
+                     self.compress_ratio
+-                    if force_flatten and envs.VLLM_USE_B12X_SPARSE_INDEXER
++                    if force_flatten and self.use_b12x_sparse_indexer
+                     else 0
+                 )
+                 self.decode_seq_lens_buffer[actual_expanded:num_decode_tokens] = (
+@@ -818,7 +836,7 @@ class DeepseekV32IndexerMetadataBuilder(AttentionMetadataBuilder):
+         num_decode_tokens: int,
+         requires_padding: bool,
+     ) -> torch.Tensor | None:
+-        if not envs.VLLM_USE_B12X_SPARSE_INDEXER or requires_padding:
++        if not self.use_b12x_sparse_indexer or requires_padding:
+             return None
+ 
+         schedule_seq_lens = seq_lens
+@@ -981,7 +999,7 @@ class DeepseekV32IndexerMetadataBuilder(AttentionMetadataBuilder):
+             # slice below).
+             assert common_attn_metadata.seq_lens_cpu_upper_bound is not None
+             seq_lens_cpu = common_attn_metadata.seq_lens_cpu_upper_bound
+-            if envs.VLLM_USE_B12X_SPARSE_INDEXER:
++            if self.use_b12x_sparse_indexer:
+                 # The b12x paged prefill streams one supertile at a time and
+                 # row-shares the page table, which requires single-request
+                 # chunks. Budget each request by the supertile K window.
+@@ -1160,7 +1178,7 @@ class DeepseekV32IndexerMetadataBuilder(AttentionMetadataBuilder):
+ 
+             active_width: torch.Tensor | None = None
+             decode_topk_max_seq_len: int | None = None
+-            if envs.VLLM_USE_B12X_SPARSE_INDEXER:
++            if self.use_b12x_sparse_indexer:
+                 # Live scorer window in cache tokens. ceil(max_seq_len /
+                 # compress_ratio) is an upper bound on the max compressed
+                 # context across the batch, so windowing to it is
+diff --git a/vllm/v1/core/sched/scheduler.py b/vllm/v1/core/sched/scheduler.py
+index b30a08d98d2e6e8ef443363f6df78b6fd88402b2..187bd59678d75e7c11852eab344d3758de05b5a3 100644
+--- a/vllm/v1/core/sched/scheduler.py
++++ b/vllm/v1/core/sched/scheduler.py
+@@ -1756,7 +1756,9 @@ class Scheduler(SchedulerInterface):
+                 request.status = RequestStatus.FINISHED_STOPPED
+                 stopped = True
+ 
+-            if new_token_ids and self.structured_output_manager.should_advance(request):
++            if new_token_ids and self.structured_output_manager.should_advance(
++                request, new_token_ids
++            ):
+                 struct_output_request = request.structured_output_request
+                 assert struct_output_request is not None
+                 grammar = struct_output_request.grammar
+diff --git a/vllm/v1/structured_output/__init__.py b/vllm/v1/structured_output/__init__.py
+index 4dfe362da8ce162dbd2f85a63eb53e31885b28d2..9b038bb0e14bb7a072ecd8b15a94d13ab995e187 100644
+--- a/vllm/v1/structured_output/__init__.py
++++ b/vllm/v1/structured_output/__init__.py
+@@ -15,7 +15,6 @@ from vllm.v1.structured_output.backend_guidance import GuidanceBackend
+ from vllm.v1.structured_output.backend_types import (
+     StructuredOutputBackend,
+     StructuredOutputGrammar,
+-    StructuredOutputOptions,
+ )
+ from vllm.v1.structured_output.backend_xgrammar import XgrammarBackend
+ 
+@@ -370,7 +369,9 @@ class StructuredOutputManager:
+             return request.structured_output_request.reasoning_ended
+         return True
+ 
+-    def should_advance(self, request: "Request") -> bool:
++    def should_advance(
++        self, request: "Request", new_token_ids: Sequence[int] | None = None
++    ) -> bool:
+         if not request.use_structured_output:
+             return False
+ 
+@@ -393,33 +394,38 @@ class StructuredOutputManager:
+         if structured_req.reasoning_ended:
+             return True
+ 
+-        # Check if reasoning ends in *this* step
+-        delta_from = request.num_computed_tokens - request.num_output_placeholders
++        # Check if reasoning ends in *this* step. Prefer the caller's actual
++        # new_token_ids over reconstructing the step window from scheduler
++        # counters: with speculative decoding, num_computed_tokens is already
++        # advanced past the accepted draft tokens when this runs, so the
++        # counter-derived window can miss the reasoning-end marker.
+         all_token_ids = request.all_token_ids
+-        start = (
+-            delta_from if delta_from >= 0 else max(len(all_token_ids) + delta_from, 0)
+-        )
+-        if reasoner.is_reasoning_end_streaming(
+-            all_token_ids, itertools.islice(all_token_ids, start, None)
+-        ):
++        if new_token_ids is not None:
++            start = max(len(all_token_ids) - len(new_token_ids), 0)
++            delta: Iterable[int] = new_token_ids
++        else:
++            delta_from = request.num_computed_tokens - request.num_output_placeholders
++            start = (
++                delta_from
++                if delta_from >= 0
++                else max(len(all_token_ids) + delta_from, 0)
++            )
++            delta = itertools.islice(all_token_ids, start, None)
++        if reasoner.is_reasoning_end_streaming(all_token_ids, delta):
+             structured_req.reasoning_ended = True
+ 
+-            # Reasoning just ended this step. Defer FSM advance until the next
+-            # pass (see reasoning_ended check above) for JSON/regex/choice/grammar:
+-            # advancing on the closing boundary token can accept tokens that still
+-            # belong to the reasoning stream. Structural tags are the only safe
+-            # same-step exception: they model phased output (e.g. thinking tag ->
+-            # answer tag), and speculative decoding must run grammar.validate_tokens
+-            # on draft tokens produced immediately after that transition.
+-            if (
+-                self.vllm_config.speculative_config is not None
+-                and structured_req.structured_output_key[0]
+-                == StructuredOutputOptions.STRUCTURAL_TAG
+-            ):
+-                # The scheduler will advance the grammar with this step's
+-                # tokens right away, but the step still contains reasoning
+-                # content up to and including the end marker. Record where
+-                # it ends so trim_reasoning_for_advance() can drop it.
++            # Reasoning just ended this step. Without speculative decoding the
++            # boundary step ends at the marker, so deferring the FSM advance to
++            # the next pass (see reasoning_ended check above) is safe. With
++            # speculative decoding the same step can already contain accepted
++            # post-marker content (e.g. a drafted "{" verified right after the
++            # end marker); deferring would leave the grammar permanently one
++            # token behind the sampled stream, and the next bitmask would then
++            # force a duplicate of a token the model already emitted. Advance
++            # same-step for every structured type: trim_reasoning_for_advance()
++            # drops everything up to and including the marker, so the grammar
++            # never sees reasoning content.
++            if self.vllm_config.speculative_config is not None:
+                 structured_req.reasoning_end_token_index = (
+                     self._find_reasoning_end_index(reasoner, all_token_ids, start)
+                 )
+diff --git a/vllm/v1/worker/gpu_worker.py b/vllm/v1/worker/gpu_worker.py
+index 7c6900b3da8b455e8a7bb57fe0b0ae35d9362f85..194e5fe0c15d1d2b1a7db17a34e4f10f40f20a60 100644
+--- a/vllm/v1/worker/gpu_worker.py
++++ b/vllm/v1/worker/gpu_worker.py
+@@ -486,6 +486,12 @@ class Worker(WorkerBase):
+         )
+         self._warmup_kernels_once()
+ 
++        # The first pass may include one-time compiler or loader temporaries.
++        # Keep every persistent allocation initialized above, but exclude that
++        # startup-only high-water mark from the activation measurement. The
++        # second pass below establishes the repeatable serving peak.
++        torch.accelerator.reset_peak_memory_stats(self.device)
++
+         # Kernel warmup can create persistent modules and communication pools.
+         # A second pass is required so the measured peak contains both those
+         # allocations and the model's transient activation workspace.

--- a/tests/test-gilded-gnosis-release-composition.sh
+++ b/tests/test-gilded-gnosis-release-composition.sh
@@ -143,8 +143,18 @@ grep -Fxq \
   'sparkinfer_tree=35aebc6d46a0d3d4f7275b81251211864f410269' \
   <<<"${output_r12}"
 grep -Fxq \
+  'launcher_ref=513bd84a1d8f4b834ca343abb4189e82acb1df52' \
+  <<<"${output_r12}"
+grep -Fxq \
+  'launcher_commit=513bd84a1d8f4b834ca343abb4189e82acb1df52' \
+  <<<"${output_r12}"
+grep -Fxq \
   'lmcache_tree=175e59294436a02861e9e3ebedf7358edea4ed36' \
   <<<"${output_r12}"
+grep -Fxq \
+  'lmcache_repo=https://github.com/local-inference-lab/LMCache.git' \
+  <<<"${output_r12}"
+grep -Fxq 'lmcache_ref=release/v0.5.2-glm52-dcp-base' <<<"${output_r12}"
 grep -Fxq \
   'lmcache_commit=9cebd405d0caf4bebe01d694b5a8bf4e3e354314' \
   <<<"${output_r12}"
@@ -153,6 +163,56 @@ grep -Fxq \
   <<<"${output_r12}"
 grep -Fxq 'lmcache_version=0.5.2+glm52dcp.4' <<<"${output_r12}"
 grep -Fxq 'xgrammar_ref=v0.2.5' <<<"${output_r12}"
+grep -Fxq \
+  'xgrammar_commit=2ea71da4ccb997a06928c9fb69b99f330da56697' \
+  <<<"${output_r12}"
+grep -Fxq 'xgrammar_version=0.2.5' <<<"${output_r12}"
 grep -Fxq 'xgrammar_transformers5_compat=1' <<<"${output_r12}"
+
+output_r13="$(
+  cd "${repo_root}"
+  PRINT_RELEASE_CONFIG=1 VLLM_RELEASE_COMPOSITION=reproduce-r13 \
+    ./build-gilded-gnosis-v20-final-cu132.sh
+)"
+
+grep -Fxq 'composition=reproduce-r13' <<<"${output_r13}"
+grep -Fxq \
+  'image=voipmonitor/vllm:gilded-gnosis-v20-vllm69ba80b-sia2ea608-fi801d57a-cu132-20260730-r13' \
+  <<<"${output_r13}"
+grep -Fxq \
+  'version=0.11.2.dev280+gilded.gnosis.v20.vllm69ba80b.sia2ea608.fi801d57a.cu132.20260730.r13' \
+  <<<"${output_r13}"
+grep -Fxq \
+  'vllm_tree=69ba80b9e49b5ad6740f8b3d5d0e592213b25959' \
+  <<<"${output_r13}"
+grep -Fxq \
+  'sparkinfer_tree=a2ea6083713c15dcf7e2d2bcc74fbece837ff84d' \
+  <<<"${output_r13}"
+grep -Fxq \
+  'launcher_ref=513bd84a1d8f4b834ca343abb4189e82acb1df52' \
+  <<<"${output_r13}"
+grep -Fxq \
+  'launcher_commit=513bd84a1d8f4b834ca343abb4189e82acb1df52' \
+  <<<"${output_r13}"
+grep -Fxq \
+  'lmcache_tree=a5aa59cc8edca462a3f4c198d17fd2b9c1a7ffaa' \
+  <<<"${output_r13}"
+grep -Fxq \
+  'lmcache_repo=https://github.com/local-inference-lab/LMCache.git' \
+  <<<"${output_r13}"
+grep -Fxq 'lmcache_ref=release/v0.5.2-glm52-dcp-base' <<<"${output_r13}"
+grep -Fxq \
+  'lmcache_commit=9cebd405d0caf4bebe01d694b5a8bf4e3e354314' \
+  <<<"${output_r13}"
+grep -Fxq \
+  'lmcache_patch=releases/gilded-gnosis-v20-r13/lmcache/integration.patch' \
+  <<<"${output_r13}"
+grep -Fxq 'lmcache_version=0.5.2+glm52dcp.4' <<<"${output_r13}"
+grep -Fxq 'xgrammar_ref=v0.2.5' <<<"${output_r13}"
+grep -Fxq \
+  'xgrammar_commit=2ea71da4ccb997a06928c9fb69b99f330da56697' \
+  <<<"${output_r13}"
+grep -Fxq 'xgrammar_version=0.2.5' <<<"${output_r13}"
+grep -Fxq 'xgrammar_transformers5_compat=1' <<<"${output_r13}"
 
 echo 'Gilded Gnosis release composition: PASS'

--- a/tests/test-gilded-gnosis-release-composition.sh
+++ b/tests/test-gilded-gnosis-release-composition.sh
@@ -123,4 +123,36 @@ grep -Fxq 'lmcache_version=0.5.2+glm52dcp.4' <<<"${output_r11}"
 grep -Fxq 'xgrammar_ref=v0.2.5' <<<"${output_r11}"
 grep -Fxq 'xgrammar_transformers5_compat=1' <<<"${output_r11}"
 
+output_r12="$(
+  cd "${repo_root}"
+  PRINT_RELEASE_CONFIG=1 VLLM_RELEASE_COMPOSITION=reproduce-r12 \
+    ./build-gilded-gnosis-v20-final-cu132.sh
+)"
+
+grep -Fxq 'composition=reproduce-r12' <<<"${output_r12}"
+grep -Fxq \
+  'image=voipmonitor/vllm:gilded-gnosis-v20-vllmb46c3aa-si35aebc6-fi801d57a-cu132-20260730-r12' \
+  <<<"${output_r12}"
+grep -Fxq \
+  'version=0.11.2.dev280+gilded.gnosis.v20.vllmb46c3aa.si35aebc6.fi801d57a.cu132.20260730.r12' \
+  <<<"${output_r12}"
+grep -Fxq \
+  'vllm_tree=b46c3aac9421ec6c03b9dfcb5aacc8c1eb11f09b' \
+  <<<"${output_r12}"
+grep -Fxq \
+  'sparkinfer_tree=35aebc6d46a0d3d4f7275b81251211864f410269' \
+  <<<"${output_r12}"
+grep -Fxq \
+  'lmcache_tree=175e59294436a02861e9e3ebedf7358edea4ed36' \
+  <<<"${output_r12}"
+grep -Fxq \
+  'lmcache_commit=9cebd405d0caf4bebe01d694b5a8bf4e3e354314' \
+  <<<"${output_r12}"
+grep -Fxq \
+  'lmcache_patch=releases/gilded-gnosis-v20-r12/lmcache/integration.patch' \
+  <<<"${output_r12}"
+grep -Fxq 'lmcache_version=0.5.2+glm52dcp.4' <<<"${output_r12}"
+grep -Fxq 'xgrammar_ref=v0.2.5' <<<"${output_r12}"
+grep -Fxq 'xgrammar_transformers5_compat=1' <<<"${output_r12}"
+
 echo 'Gilded Gnosis release composition: PASS'


### PR DESCRIPTION
## Summary

- publish immutable r13 vLLM, SparkInfer, and LMCache composition locks
- incorporate the accepted review fixes in vLLM #190, SparkInfer #92, and LMCache #17
- add exact `reproduce-r13` build mode and pin the launcher, XGrammar, and all integration trees
- retain the r12 reproducer while making clean builds produce the reviewed r13 composition

## Published image

`voipmonitor/vllm:gilded-gnosis-v20-vllm69ba80b-sia2ea608-fi801d57a-cu132-20260730-r13`

Registry digest: `sha256:02796036c96a52fda0919aa260c45c70bc97d8e662a6ae5e614b5f987c20851b`

## Exact composition

- vLLM base: `f978d009fab996617f9a3cadef36ce727bcd83cd`
- vLLM integration tree: `69ba80b9e49b5ad6740f8b3d5d0e592213b25959`
- SparkInfer base: `36cade0bd8d87a26b7eb2fc8cc46188496465a06`
- SparkInfer integration tree: `a2ea6083713c15dcf7e2d2bcc74fbece837ff84d`
- LMCache base: `9cebd405d0caf4bebe01d694b5a8bf4e3e354314`
- LMCache integration tree: `a5aa59cc8edca462a3f4c198d17fd2b9c1a7ffaa`
- launcher: `513bd84a1d8f4b834ca343abb4189e82acb1df52`
- XGrammar: `v0.2.5` / `2ea71da4ccb997a06928c9fb69b99f330da56697`

## Validation

- release composition test, shell syntax checks, and Docker release tests pass
- build-time vLLM/SparkInfer/LMCache package and ABI gates pass
- XGrammar GLM required-tool regression passes
- EXL3 TP4/DCP4 MTP0: 48.61 tok/s, 834,560 KV tokens, zero errors
- EXL3 TP4/DCP4 MTP3: 101.92 tok/s, acceptance 0.7117, 485,888 KV tokens, zero errors
- both E2E runs used the standard in-image helper, no source mounts, and returned the expected correctness answer
- no performance regression against r11/r12 (MTP0 48.58/48.52; MTP3 101.02/100.82 tok/s)

Runtime PR merge authorization is intentionally outside this build PR.
