### PR TITLE
fix(glm52): tolerate and export optional LD_PRELOAD

### DIFF
--- a/launchers/glm52-pcie-runtime-env.sh
+++ b/launchers/glm52-pcie-runtime-env.sh
@@ -6,6 +6,7 @@ configure_glm52_pcie_runtime_env() {
   local pcie_dma_enabled="$1"
   local dma_wire_mode="$2"
   local nccl_path="${NCCL_LOCAL_INFERENCE_PATH:-/opt/libnccl-local-inference.so.2.30.4}"
+  local current_preload="${LD_PRELOAD:-}"
   local preload_entries
 
   export VLLM_ENABLE_PCIE_ALLREDUCE=1
@@ -21,10 +22,10 @@ configure_glm52_pcie_runtime_env() {
   export NCCL_P2P_LEVEL="${NCCL_P2P_LEVEL:-SYS}"
   export NCCL_IB_DISABLE="${NCCL_IB_DISABLE:-1}"
   if [[ -f "${nccl_path}" ]]; then
-    preload_entries=" ${LD_PRELOAD//:/ } "
+    preload_entries=" ${current_preload//:/ } "
     case "${preload_entries}" in
       *" ${nccl_path} "*) ;;
-      *) export LD_PRELOAD="${nccl_path}${LD_PRELOAD:+:${LD_PRELOAD}}" ;;
+      *) export LD_PRELOAD="${nccl_path}${current_preload:+:${current_preload}}" ;;
     esac
     export VLLM_NCCL_SO_PATH="${nccl_path}"
   fi

--- a/launchers/glm52-pcie-runtime-env.sh
+++ b/launchers/glm52-pcie-runtime-env.sh
@@ -25,8 +25,9 @@ configure_glm52_pcie_runtime_env() {
     preload_entries=" ${current_preload//:/ } "
     case "${preload_entries}" in
       *" ${nccl_path} "*) ;;
-      *) export LD_PRELOAD="${nccl_path}${current_preload:+:${current_preload}}" ;;
+      *) current_preload="${nccl_path}${current_preload:+:${current_preload}}" ;;
     esac
+    export LD_PRELOAD="${current_preload}"
     export VLLM_NCCL_SO_PATH="${nccl_path}"
   fi
 }

--- a/tests/test-glm52-pcie-calibration-helper.sh
+++ b/tests/test-glm52-pcie-calibration-helper.sh
@@ -190,4 +190,18 @@ unexported_preload_output="$(
 )"
 assert_contains "${unexported_preload_output}" "${calibrator}"
 
+unexported_other_output="$(
+  run_runtime_env_preload unexported /tmp/unexported-preload.so
+)"
+assert_contains \
+  "${unexported_other_output}" \
+  "${calibrator}:/tmp/unexported-preload.so"
+
+space_separated_output="$(
+  run_runtime_env_preload set "/tmp/first-preload.so /tmp/second-preload.so"
+)"
+assert_contains \
+  "${space_separated_output}" \
+  "${calibrator}:/tmp/first-preload.so /tmp/second-preload.so"
+
 echo "GLM-5.2 PCIe calibration helper: PASS"

--- a/tests/test-glm52-pcie-calibration-helper.sh
+++ b/tests/test-glm52-pcie-calibration-helper.sh
@@ -146,17 +146,36 @@ if run_helper DCP_CKV_GATHER_MAX_TOKENS=not-a-number >/dev/null; then
 fi
 
 runtime_env_script="${repo_root}/launchers/glm52-pcie-runtime-env.sh"
-preload_output="$(
+run_runtime_env_preload() {
+  local preload_state="$1"
+  local initial_preload="${2:-}"
+
   RUNTIME_ENV_SCRIPT="${runtime_env_script}" \
-  TEST_NCCL_PATH="${calibrator}" \
-  bash -c '
+    TEST_NCCL_PATH="${calibrator}" \
+    bash -c '
+    case "$1" in
+      unset) unset LD_PRELOAD ;;
+      empty) export LD_PRELOAD= ;;
+      set) export LD_PRELOAD="$2" ;;
+      *) exit 64 ;;
+    esac
+    set -u
     source "${RUNTIME_ENV_SCRIPT}"
     export NCCL_LOCAL_INFERENCE_PATH="${TEST_NCCL_PATH}"
-    export LD_PRELOAD=/tmp/existing-preload.so
     configure_glm52_pcie_runtime_env 1 0
     configure_glm52_pcie_runtime_env 1 0
     printf "%s\n" "${LD_PRELOAD}"
-  '
+  ' _ "${preload_state}" "${initial_preload}"
+}
+
+unset_preload_output="$(run_runtime_env_preload unset)"
+assert_contains "${unset_preload_output}" "${calibrator}"
+
+empty_preload_output="$(run_runtime_env_preload empty)"
+assert_contains "${empty_preload_output}" "${calibrator}"
+
+preload_output="$(
+  run_runtime_env_preload set /tmp/existing-preload.so
 )"
 assert_contains "${preload_output}" "${calibrator}:/tmp/existing-preload.so"
 

--- a/tests/test-glm52-pcie-calibration-helper.sh
+++ b/tests/test-glm52-pcie-calibration-helper.sh
@@ -157,7 +157,9 @@ run_runtime_env_preload() {
       unset) unset LD_PRELOAD ;;
       empty) export LD_PRELOAD= ;;
       set) export LD_PRELOAD="$2" ;;
-      unexported) LD_PRELOAD="$2" ;;
+      unexported)
+        unset LD_PRELOAD
+        LD_PRELOAD="$2" ;;
       *) exit 64 ;;
     esac
     set -u

--- a/tests/test-glm52-pcie-calibration-helper.sh
+++ b/tests/test-glm52-pcie-calibration-helper.sh
@@ -157,6 +157,7 @@ run_runtime_env_preload() {
       unset) unset LD_PRELOAD ;;
       empty) export LD_PRELOAD= ;;
       set) export LD_PRELOAD="$2" ;;
+      unexported) LD_PRELOAD="$2" ;;
       *) exit 64 ;;
     esac
     set -u
@@ -164,6 +165,11 @@ run_runtime_env_preload() {
     export NCCL_LOCAL_INFERENCE_PATH="${TEST_NCCL_PATH}"
     configure_glm52_pcie_runtime_env 1 0
     configure_glm52_pcie_runtime_env 1 0
+    [[ "$(declare -p LD_PRELOAD)" == "declare -x "* ]] || {
+      printf "LD_PRELOAD was not exported: %s\n" \
+        "$(declare -p LD_PRELOAD)" >&2
+      exit 65
+    }
     printf "%s\n" "${LD_PRELOAD}"
   ' _ "${preload_state}" "${initial_preload}"
 }
@@ -178,5 +184,10 @@ preload_output="$(
   run_runtime_env_preload set /tmp/existing-preload.so
 )"
 assert_contains "${preload_output}" "${calibrator}:/tmp/existing-preload.so"
+
+unexported_preload_output="$(
+  run_runtime_env_preload unexported "${calibrator}"
+)"
+assert_contains "${unexported_preload_output}" "${calibrator}"
 
 echo "GLM-5.2 PCIe calibration helper: PASS"


### PR DESCRIPTION
## Summary

- normalize optional `LD_PRELOAD` through `${LD_PRELOAD:-}` before the helper reads it under `set -u`;
- prepend the local NCCL shim exactly once while preserving existing entries;
- always export the final value, including when an already-correct value was initially shell-local;
- add regression coverage for unset, empty, exported, unexported, inherited, and idempotent calls.

Fixes #12.

## Why this matters

The r14 source at exact base `2464cc03d0298493bf345bbc797f77c4455efda8` exits with `LD_PRELOAD: unbound variable` before PCIe calibration when the runtime does not supply this optional variable. The turnkey then loses the measured transport posture through its fallback path.

## Exact provenance

- GPU-qualified implementation head: `5eee240d6c32e08516287380131c96ca7493f0f6`
- Current PR head: `03e38c8d3c8233f751e44cd317a156c4c48b9986`
- Base: `2464cc03d0298493bf345bbc797f77c4455efda8`

The only change after `5eee240` is a test-fixture correction requested in review: the `unexported` case now clears an inherited export attribute before assigning the shell-local value. Runtime files are unchanged.

## Validation

Retained Vast field host:

- 4x RTX PRO 6000 Blackwell 96 GB
- NVIDIA driver 610.43.02 / CUDA UMD 13.3
- real turnkey calibration helper and local NCCL shim path

Passed:

- exact parent failure reproduction;
- repaired real-host helper gate;
- Bash 3.2 and 5.3 promotion checks;
- full Bash 5.3 matrices for unset, empty, exported, unexported, and inherited values;
- existing-shim and prepend/preserve behavior;
- two consecutive calls remain byte-for-byte idempotent;
- colon-, space-, and metacharacter-containing values are preserved;
- child processes inherit the exported value;
- `bash -n`, ShellCheck, and `git diff --check`;
- 14 Python PCIe-calibration tests.

The exact component was included in the repaired GLM-5.2 runtime that passed startup, graph capture, 13/13 API checks twice, 20/20 cold 65K/126K needles, bounded C1/C2/C4/C8 serving, GSM8K 96/100, GPQA 44/50, and complete GPU release within 19 seconds. This is a correctness/reliability fix; no independent PP/TG or VRAM gain is attributed to this PR.

The final appliance was built afterward from unchanged runtime files and passed [CI run 30646550906](https://github.com/malaiwah/glm52-exl3-vast/actions/runs/30646550906), but that published digest was not separately GPU-booted.

## Evidence

- [Immutable reviewer guide](https://github.com/malaiwah/glm52-exl3-vast/blob/d821001f97dd15f0ae6ace626cc1f334a2069553/docs/field-review-results/2026-07-30-vast-46335896/COUNTER-VALIDATION.md)
- [Repair campaign ledger](https://github.com/malaiwah/glm52-exl3-vast/blob/d821001f97dd15f0ae6ace626cc1f334a2069553/docs/field-review-results/2026-07-30-vast-46335896/UPSTREAM-REPAIR-CAMPAIGN.md)
- [Immutable raw artifacts](https://github.com/malaiwah/glm52-exl3-vast/tree/5c76a2536e7fc9a5f1cb6bf182531889f5385e65/docs/field-review-results/2026-07-30-vast-46335896/artifacts)

Changes, tests, and evidence were prepared with Codex assistance. Human maintainer review is requested.
