### PR TITLE
[r17] Publish audited Gilded Gnosis composition

### DIFF
--- a/Dockerfile.vllm-b12x-cu132
+++ b/Dockerfile.vllm-b12x-cu132
@@ -554,6 +554,26 @@ RUN git clone --filter=blob:none "${B12X_REPO}" /tmp/b12x-src \
  && python -m pip install --no-deps --force-reinstall . \
  && rm -rf /tmp/b12x-src
 
+# Runtime CUDA sources are JIT-compiled from the installed package. Fail the
+# image build if a quoted local include was omitted from the wheel.
+RUN python - <<'PY'
+import re
+import site
+from pathlib import Path
+
+roots = [
+    Path(entry) / "sparkinfer" / "comm" / "pcie"
+    for entry in site.getsitepackages()
+    if (Path(entry) / "sparkinfer" / "comm" / "pcie").is_dir()
+]
+assert len(roots) == 1, roots
+include_re = re.compile(r'^\s*#include\s+"([^"]+)"', re.MULTILINE)
+for source in roots[0].glob("*.cu"):
+    for include in include_re.findall(source.read_text(encoding="utf-8")):
+        dependency = source.parent / include
+        assert dependency.is_file(), f"{source.name} includes missing {include}"
+PY
+
 # =============================================================================
 # Stage 2d: build vLLM on top of cached FlashInfer/DeepGEMM/B12X.
 # =============================================================================

--- a/build-gilded-gnosis-v20-final-cu132.sh
+++ b/build-gilded-gnosis-v20-final-cu132.sh
@@ -273,8 +273,13 @@ export VLLM_PATCH_URL=
 export SPARKINFER_VERSION="${SPARKINFER_VERSION:-1.0.1}"
 
 export LAUNCHER_REPO="${LAUNCHER_REPO:-https://github.com/local-inference-lab/blackwell-llm-docker.git}"
-export LAUNCHER_REF="${LAUNCHER_REF:-513bd84a1d8f4b834ca343abb4189e82acb1df52}"
-export LAUNCHER_COMMIT="${LAUNCHER_COMMIT:-513bd84a1d8f4b834ca343abb4189e82acb1df52}"
+if [[ "${composition_mode}" == "clean" || "${composition_mode}" == "reproduce-r17" ]]; then
+  export LAUNCHER_REF="${LAUNCHER_REF:-16482e1d3195f9880dc888da47b73ea28499575b}"
+  export LAUNCHER_COMMIT="${LAUNCHER_COMMIT:-16482e1d3195f9880dc888da47b73ea28499575b}"
+else
+  export LAUNCHER_REF="${LAUNCHER_REF:-513bd84a1d8f4b834ca343abb4189e82acb1df52}"
+  export LAUNCHER_COMMIT="${LAUNCHER_COMMIT:-513bd84a1d8f4b834ca343abb4189e82acb1df52}"
+fi
 export VLLM_REQUIRED_LAUNCHERS="serve-gilded-gnosis.sh serve-fathomless-firmament.sh serve-glm52-v16.sh serve-glm52-v18.sh serve-glm52-v19.sh serve-glm52-hybrid-v17.sh serve-glm52-hybrid-v18.sh serve-glm52-hybrid-v19.sh glm52-dcp-prefill-policy.sh glm52-pcie-runtime-env.sh glm52-pcie-calibration.py glm52-lmcache-wrapper.sh"
 
 export CUTLASS_REF="${CUTLASS_REF:-e6233cbac5d7c7a865c19c91cd684ceece19513c}"

--- a/build-gilded-gnosis-v20-final-cu132.sh
+++ b/build-gilded-gnosis-v20-final-cu132.sh
@@ -101,8 +101,18 @@ if [[ "${composition_mode}" == "clean" ]]; then
     --output-dir "${lmcache_composition_dir}" >/dev/null
   configure_lmcache_composition "${lmcache_composition_dir}" 1
 
-  export IMAGE="${IMAGE:-voipmonitor/vllm:gilded-gnosis-v20-vllm${VLLM_INTEGRATION_TREE:0:7}-si${SPARKINFER_INTEGRATION_TREE:0:7}-fi801d57a-cu132-${release_date}-r16}"
-  export VLLM_BUILD_VERSION="${VLLM_BUILD_VERSION:-0.11.2.dev280+gilded.gnosis.v20.vllm${VLLM_INTEGRATION_TREE:0:7}.si${SPARKINFER_INTEGRATION_TREE:0:7}.fi801d57a.cu132.${release_date}.r16}"
+  export IMAGE="${IMAGE:-voipmonitor/vllm:gilded-gnosis-v20-vllm${VLLM_INTEGRATION_TREE:0:7}-si${SPARKINFER_INTEGRATION_TREE:0:7}-fi801d57a-cu132-${release_date}-r17}"
+  export VLLM_BUILD_VERSION="${VLLM_BUILD_VERSION:-0.11.2.dev280+gilded.gnosis.v20.vllm${VLLM_INTEGRATION_TREE:0:7}.si${SPARKINFER_INTEGRATION_TREE:0:7}.fi801d57a.cu132.${release_date}.r17}"
+elif [[ "${composition_mode}" == "reproduce-r17" ]]; then
+  configure_vllm_composition \
+    "patches/releases/gilded-gnosis-v20-r17/vllm" 0
+  configure_sparkinfer_composition \
+    "patches/releases/gilded-gnosis-v20-r17/sparkinfer" 0
+  configure_lmcache_composition \
+    "patches/releases/gilded-gnosis-v20-r17/lmcache" 0
+
+  export IMAGE="${IMAGE:-voipmonitor/vllm:gilded-gnosis-v20-vllmdb29328-sicfde478-fi801d57a-cu132-20260801-r17}"
+  export VLLM_BUILD_VERSION="${VLLM_BUILD_VERSION:-0.11.2.dev280+gilded.gnosis.v20.vllmdb29328.sicfde478.fi801d57a.cu132.20260801.r17}"
 elif [[ "${composition_mode}" == "reproduce-r16" ]]; then
   configure_vllm_composition \
     "patches/releases/gilded-gnosis-v20-r16/vllm" 0
@@ -277,7 +287,7 @@ export TRITON_KERNELS_REF=
 export TRITON_KERNELS_COMMIT=
 
 export XGRAMMAR_REPO="${XGRAMMAR_REPO:-https://github.com/mlc-ai/xgrammar.git}"
-if [[ "${composition_mode}" == "clean" || "${composition_mode}" == "reproduce-r8" || "${composition_mode}" == "reproduce-r9" || "${composition_mode}" == "reproduce-r11" || "${composition_mode}" == "reproduce-r12" || "${composition_mode}" == "reproduce-r13" || "${composition_mode}" == "reproduce-r14" || "${composition_mode}" == "reproduce-r15" || "${composition_mode}" == "reproduce-r16" ]]; then
+if [[ "${composition_mode}" == "clean" || "${composition_mode}" == "reproduce-r8" || "${composition_mode}" == "reproduce-r9" || "${composition_mode}" == "reproduce-r11" || "${composition_mode}" == "reproduce-r12" || "${composition_mode}" == "reproduce-r13" || "${composition_mode}" == "reproduce-r14" || "${composition_mode}" == "reproduce-r15" || "${composition_mode}" == "reproduce-r16" || "${composition_mode}" == "reproduce-r17" ]]; then
   export XGRAMMAR_REF="${XGRAMMAR_REF:-v0.2.5}"
   export XGRAMMAR_COMMIT="${XGRAMMAR_COMMIT:-2ea71da4ccb997a06928c9fb69b99f330da56697}"
   export XGRAMMAR_VERSION="${XGRAMMAR_VERSION:-0.2.5}"
@@ -294,7 +304,7 @@ fi
 export INSTANTTENSOR_REPO="${INSTANTTENSOR_REPO:-https://github.com/scitix/InstantTensor.git}"
 export INSTANTTENSOR_REF="${INSTANTTENSOR_REF:-85e7c5f5539d9c006ee0c26bc1b5233c65251b6b}"
 export INSTANTTENSOR_COMMIT="${INSTANTTENSOR_COMMIT:-85e7c5f5539d9c006ee0c26bc1b5233c65251b6b}"
-if [[ "${composition_mode}" == "clean" || "${composition_mode}" == "reproduce-r11" || "${composition_mode}" == "reproduce-r12" || "${composition_mode}" == "reproduce-r13" || "${composition_mode}" == "reproduce-r14" || "${composition_mode}" == "reproduce-r15" || "${composition_mode}" == "reproduce-r16" ]]; then
+if [[ "${composition_mode}" == "clean" || "${composition_mode}" == "reproduce-r11" || "${composition_mode}" == "reproduce-r12" || "${composition_mode}" == "reproduce-r13" || "${composition_mode}" == "reproduce-r14" || "${composition_mode}" == "reproduce-r15" || "${composition_mode}" == "reproduce-r16" || "${composition_mode}" == "reproduce-r17" ]]; then
   export LMCACHE_BUILD_VERSION="${LMCACHE_BUILD_VERSION:-0.5.2+glm52dcp.4}"
 elif [[ "${composition_mode}" == "reproduce-r6" ]]; then
   export LMCACHE_REPO="${LMCACHE_REPO:-https://github.com/LMCache/LMCache.git}"

--- a/build-gilded-gnosis-v20-final-cu132.sh
+++ b/build-gilded-gnosis-v20-final-cu132.sh
@@ -274,8 +274,8 @@ export SPARKINFER_VERSION="${SPARKINFER_VERSION:-1.0.1}"
 
 export LAUNCHER_REPO="${LAUNCHER_REPO:-https://github.com/local-inference-lab/blackwell-llm-docker.git}"
 if [[ "${composition_mode}" == "clean" || "${composition_mode}" == "reproduce-r17" ]]; then
-  export LAUNCHER_REF="${LAUNCHER_REF:-16482e1d3195f9880dc888da47b73ea28499575b}"
-  export LAUNCHER_COMMIT="${LAUNCHER_COMMIT:-16482e1d3195f9880dc888da47b73ea28499575b}"
+  export LAUNCHER_REF="${LAUNCHER_REF:-ec0279f1c2ccf06656df21d65c7a18984c45fcd8}"
+  export LAUNCHER_COMMIT="${LAUNCHER_COMMIT:-ec0279f1c2ccf06656df21d65c7a18984c45fcd8}"
 else
   export LAUNCHER_REF="${LAUNCHER_REF:-513bd84a1d8f4b834ca343abb4189e82acb1df52}"
   export LAUNCHER_COMMIT="${LAUNCHER_COMMIT:-513bd84a1d8f4b834ca343abb4189e82acb1df52}"

--- a/build-gilded-gnosis-v20-final-cu132.sh
+++ b/build-gilded-gnosis-v20-final-cu132.sh
@@ -111,8 +111,8 @@ elif [[ "${composition_mode}" == "reproduce-r17" ]]; then
   configure_lmcache_composition \
     "patches/releases/gilded-gnosis-v20-r17/lmcache" 0
 
-  export IMAGE="${IMAGE:-voipmonitor/vllm:gilded-gnosis-v20-vllmdb29328-sicfde478-fi801d57a-cu132-20260801-r17}"
-  export VLLM_BUILD_VERSION="${VLLM_BUILD_VERSION:-0.11.2.dev280+gilded.gnosis.v20.vllmdb29328.sicfde478.fi801d57a.cu132.20260801.r17}"
+  export IMAGE="${IMAGE:-voipmonitor/vllm:gilded-gnosis-v20-vllmdb29328-sib2bff71-fi801d57a-cu132-20260801-r17}"
+  export VLLM_BUILD_VERSION="${VLLM_BUILD_VERSION:-0.11.2.dev280+gilded.gnosis.v20.vllmdb29328.sib2bff71.fi801d57a.cu132.20260801.r17}"
 elif [[ "${composition_mode}" == "reproduce-r16" ]]; then
   configure_vllm_composition \
     "patches/releases/gilded-gnosis-v20-r16/vllm" 0

--- a/launchers/glm52-pcie-runtime-env.sh
+++ b/launchers/glm52-pcie-runtime-env.sh
@@ -6,6 +6,7 @@ configure_glm52_pcie_runtime_env() {
   local pcie_dma_enabled="$1"
   local dma_wire_mode="$2"
   local nccl_path="${NCCL_LOCAL_INFERENCE_PATH:-/opt/libnccl-local-inference.so.2.30.4}"
+  local current_preload="${LD_PRELOAD:-}"
   local preload_entries
 
   export VLLM_ENABLE_PCIE_ALLREDUCE=1
@@ -21,10 +22,10 @@ configure_glm52_pcie_runtime_env() {
   export NCCL_P2P_LEVEL="${NCCL_P2P_LEVEL:-SYS}"
   export NCCL_IB_DISABLE="${NCCL_IB_DISABLE:-1}"
   if [[ -f "${nccl_path}" ]]; then
-    preload_entries=" ${LD_PRELOAD//:/ } "
+    preload_entries=" ${current_preload//:/ } "
     case "${preload_entries}" in
       *" ${nccl_path} "*) ;;
-      *) export LD_PRELOAD="${nccl_path}${LD_PRELOAD:+:${LD_PRELOAD}}" ;;
+      *) export LD_PRELOAD="${nccl_path}${current_preload:+:${current_preload}}" ;;
     esac
     export VLLM_NCCL_SO_PATH="${nccl_path}"
   fi

--- a/launchers/glm52-pcie-runtime-env.sh
+++ b/launchers/glm52-pcie-runtime-env.sh
@@ -25,8 +25,9 @@ configure_glm52_pcie_runtime_env() {
     preload_entries=" ${current_preload//:/ } "
     case "${preload_entries}" in
       *" ${nccl_path} "*) ;;
-      *) export LD_PRELOAD="${nccl_path}${current_preload:+:${current_preload}}" ;;
+      *) current_preload="${nccl_path}${current_preload:+:${current_preload}}" ;;
     esac
+    export LD_PRELOAD="${current_preload}"
     export VLLM_NCCL_SO_PATH="${nccl_path}"
   fi
 }

--- a/manifests/sparkinfer/gilded-gnosis-v20.json
+++ b/manifests/sparkinfer/gilded-gnosis-v20.json
@@ -11,7 +11,7 @@
     },
     {
       "number": 105,
-      "head": "caa643c8546121214493d052221f16c62f69f719",
+      "head": "45033eebcf5bb184587a35c528a62721a46acdf5",
       "title": "Harden replay and CUDA IPC lifecycle"
     },
     {

--- a/manifests/sparkinfer/gilded-gnosis-v20.json
+++ b/manifests/sparkinfer/gilded-gnosis-v20.json
@@ -8,6 +8,16 @@
       "number": 106,
       "head": "35588fb570d23713bcb2a81749d0fdf3c4396ace",
       "title": "Honor compressed cache physical page stride"
+    },
+    {
+      "number": 105,
+      "head": "caa643c8546121214493d052221f16c62f69f719",
+      "title": "Harden replay and CUDA IPC lifecycle"
+    },
+    {
+      "number": 110,
+      "head": "01917253eb3925a01c8123ed859d49880e27f961",
+      "title": "Harden W4A16 planning, tails, and capture resolution"
     }
   ]
 }

--- a/manifests/vllm/gilded-gnosis-v20.json
+++ b/manifests/vllm/gilded-gnosis-v20.json
@@ -33,6 +33,16 @@
       "number": 218,
       "head": "3b89c7a113f92522aa07cc3271422c04e458d771",
       "title": "Align native SWA/MTP retention and shared-prefix tails"
+    },
+    {
+      "number": 216,
+      "head": "52201611719edf67f18bc0cbec17802880a4afb7",
+      "title": "Isolate semantic PCIe graph channels"
+    },
+    {
+      "number": 222,
+      "head": "6206ac40fbd75be0ed18817bde64a63b6b838d2f",
+      "title": "Shape-aware mixed EXL3 decode and bounded serial prefill"
     }
   ]
 }

--- a/patches/releases/gilded-gnosis-v20-r17/lmcache/integration.lock.json
+++ b/patches/releases/gilded-gnosis-v20-r17/lmcache/integration.lock.json
@@ -1,0 +1,96 @@
+{
+  "base": {
+    "commit": "9cebd405d0caf4bebe01d694b5a8bf4e3e354314",
+    "ref": "refs/heads/release/v0.5.2-glm52-dcp-base",
+    "repository": "https://github.com/local-inference-lab/LMCache.git"
+  },
+  "manifest": {
+    "sha256": "89df49b01c9b077898a7141ac86581887a3b1e2bada744e8c891213e7d0caa03"
+  },
+  "name": "gilded-gnosis-v20-lmcache",
+  "pull_requests": [
+    {
+      "disposition": "merged",
+      "head": "7b7583aef55e98ba05a6c199e71601d78552e794",
+      "number": 7,
+      "ref": "refs/pull/7/head",
+      "title": "Return bounded LMCache MP RPC handler errors"
+    },
+    {
+      "disposition": "merged",
+      "head": "31c4175d2134518e5b43fe8f4a7d072df6043a13",
+      "number": 8,
+      "ref": "refs/pull/8/head",
+      "title": "Recover failed MP retrieves by recomputing invalid blocks"
+    },
+    {
+      "disposition": "merged",
+      "head": "c3b73de74d855f6263deea8b6c6c4dde87e6e5b9",
+      "number": 9,
+      "ref": "refs/pull/9/head",
+      "title": "Restore the largest exact L1 prefix after allocation failure"
+    },
+    {
+      "disposition": "merged",
+      "head": "59186798bb5859b7add7bcac81dff9f2fd4037ab",
+      "number": 10,
+      "ref": "refs/pull/10/head",
+      "title": "Protect native lookup keys from concurrent deletion"
+    },
+    {
+      "disposition": "merged",
+      "head": "2cee5a2c1ef7e80028e94b1bc4bfbfc02e2c2a8d",
+      "number": 11,
+      "ref": "refs/pull/11/head",
+      "title": "Log bounded prefetch failure key samples"
+    },
+    {
+      "disposition": "merged",
+      "head": "baf1345106ebe568a116a35fdcee36bfec73da57",
+      "number": 12,
+      "ref": "refs/pull/12/head",
+      "title": "Return native per-key store results"
+    },
+    {
+      "disposition": "merged",
+      "head": "d4dce69bf90362953cf9ac9a86cccc186b3219dc",
+      "number": 13,
+      "ref": "refs/pull/13/head",
+      "title": "Enforce native filesystem O_DIRECT alignment"
+    },
+    {
+      "disposition": "merged",
+      "head": "502b3c60f2e61625d6e32a31d0d725eedc620792",
+      "number": 14,
+      "ref": "refs/pull/14/head",
+      "title": "Support current and legacy native filesystem object-group keys"
+    },
+    {
+      "disposition": "merged",
+      "head": "7892d42a6996df855fe743edb271fa154503bef8",
+      "number": 15,
+      "ref": "refs/pull/15/head",
+      "title": "Make native stores durable before reporting completion"
+    },
+    {
+      "disposition": "merged",
+      "head": "e6c2708fe8ae8a96d3c66e83bf4b548c734fbb13",
+      "number": 16,
+      "ref": "refs/pull/16/head",
+      "title": "Restore native filesystem capacity accounting after restart"
+    },
+    {
+      "disposition": "merged",
+      "head": "f9639e2094f70955a1145bfd7219b6fdd39ee143",
+      "number": 17,
+      "ref": "refs/pull/17/head",
+      "title": "Add bounded L1 writeback to durable storage"
+    }
+  ],
+  "result": {
+    "patch": "integration.patch",
+    "patch_sha256": "34a0b73b2603ce2fb8c6d9383551871e23981ff2c0b837c000961c38afe73337",
+    "tree": "a5aa59cc8edca462a3f4c198d17fd2b9c1a7ffaa"
+  },
+  "schema_version": 1
+}

--- a/patches/releases/gilded-gnosis-v20-r17/lmcache/integration.patch
+++ b/patches/releases/gilded-gnosis-v20-r17/lmcache/integration.patch
@@ -1,0 +1,4028 @@
+diff --git a/csrc/storage_backends/connector_base.h b/csrc/storage_backends/connector_base.h
+index c2cd35a174a1225c467d1479ea347b0d6e5ebd0e..0df7677cef0d0172a7cb60f7c9f3599cb189b555 100644
+--- a/csrc/storage_backends/connector_base.h
++++ b/csrc/storage_backends/connector_base.h
+@@ -111,6 +111,9 @@ class ConnectorBase : public IStorageConnector {
+     auto [batch_future_id, batch_state, num_tiles, tile_size] =
+         prepare_batch_operation(num_items, Op::BATCH_TILE_SET);
+ 
++    // pre-allocate per-key results so partial store failures are visible
++    batch_state->per_key_results.assign(num_items, 0);
++
+     // fan out work to threads
+     for (size_t tile_idx = 0; tile_idx < num_tiles; ++tile_idx) {
+       auto tile_req = create_tile_request(
+@@ -326,10 +329,30 @@ class ConnectorBase : public IStorageConnector {
+       }
+     }
+   }
++  // Records a per-key result for every key in the tile (continuing past
++  // failures instead of aborting the tile), then rethrows so batch-level
++  // ok=false semantics are preserved for consumers that ignore per-key
++  // results.
+   virtual void do_batch_set(ConnectionType& conn, const Request& req) {
++    bool any_failed = false;
++    std::string first_error;
+     for (size_t i = 0; i < req.keys.size(); ++i) {
+-      do_single_set(conn, req.keys[i], req.buf_ptrs[i], req.buf_lens[i],
+-                    req.batch_chunk_num_bytes);
++      try {
++        do_single_set(conn, req.keys[i], req.buf_ptrs[i], req.buf_lens[i],
++                      req.batch_chunk_num_bytes);
++        req.batch->per_key_results[req.start_idx + i] = 1;
++      } catch (const std::exception& e) {
++        req.batch->per_key_results[req.start_idx + i] = 0;
++        if (!any_failed) {
++          any_failed = true;
++          first_error = e.what();
++        }
++        fprintf(stderr, "[LMCache SET] key %s failed: %s\n",
++                req.keys[i].c_str(), e.what());
++      }
++    }
++    if (any_failed) {
++      throw std::runtime_error("batch set partially failed: " + first_error);
+     }
+   }
+   virtual void do_batch_exists(ConnectionType& conn, const Request& req) {
+@@ -612,9 +635,10 @@ class ConnectorBase : public IStorageConnector {
+         std::lock_guard<std::mutex> lk(req.batch->err_mu);
+         batch_comp.error = req.batch->first_error;
+       }
+-      // for batch exists and batch get, move per-key results
++      // move per-key results for every op that records them
+       if (req.batch->batch_op == Op::BATCH_TILE_EXISTS ||
+           req.batch->batch_op == Op::BATCH_TILE_GET ||
++          req.batch->batch_op == Op::BATCH_TILE_SET ||
+           req.batch->batch_op == Op::BATCH_TILE_DELETE) {
+         batch_comp.result_bytes = std::move(req.batch->per_key_results);
+       }
+diff --git a/csrc/storage_backends/fs/connector.cpp b/csrc/storage_backends/fs/connector.cpp
+index e54d98f54f5428afad363cf1c5f5f380cdd8fffb..727ed016f10ae0b0c6e863c4234439dbaac0e7f8 100644
+--- a/csrc/storage_backends/fs/connector.cpp
++++ b/csrc/storage_backends/fs/connector.cpp
+@@ -2,10 +2,22 @@
+ 
+ #include "connector.h"
+ #include <cerrno>
++#include <cstdint>
+ #include <cstdio>
+ #include <stdexcept>
+ #include <string>
+ 
++namespace {
++// O_DIRECT requires the buffer ADDRESS to be block-aligned as well as the
++// length; a misaligned address fails the read/write with EINVAL. Buffers
++// come from Python and carry no alignment guarantee, so fall back to
++// buffered I/O whenever either constraint is unmet.
++bool odirect_eligible(const void* buf, size_t len, size_t disk_block_size) {
++  return disk_block_size > 0 && len % disk_block_size == 0 &&
++         reinterpret_cast<uintptr_t>(buf) % disk_block_size == 0;
++}
++}  // namespace
++
+ namespace lmcache {
+ namespace connector {
+ 
+@@ -27,22 +39,23 @@ std::string FSConnector::replace_all(const std::string& str,
+ 
+ std::string FSConnector::key_to_filename(const std::string& key) {
+   // Input key format (from _object_key_to_string):
+-  //   Unsalted: <model_name>@<kv_rank_hex>@<chunk_hash_hex>
+-  //   Salted  : <model_name>@<kv_rank_hex>@<chunk_hash_hex>@<cache_salt>
++  //   Legacy unsalted: <model_name>@<kv_rank_hex>@<chunk_hash_hex>
++  //   Legacy salted  : <model_name>@<kv_rank_hex>@<chunk_hash_hex>@<cache_salt>
++  //   Current unsalted:
++  //     <model_name>@<kv_rank_hex>@<object_group_id_hex>@<chunk_hash_hex>
++  //   Current salted appends @<cache_salt> to the current unsalted shape.
+   //
+   // Output filename (matching fs_l2_adapter.py._object_key_to_filename):
+   //   Unsalted: <model_name_safe>@0x<kv_rank_hex>@<chunk_hash_hex>.data
+   //   Salted  :
+   //   <model_name_safe>@0x<kv_rank_hex>@<chunk_hash_hex>@<cache_salt>.data
+   //
+-  // The unsalted 3-field shape is bit-identical to the pre-cache_salt
+-  // format, so existing cache directories remain valid.
+-  //
+-  // NOTE: both model_name and cache_salt are forbidden from containing
+-  // '@' (invariant enforced on the Python side), so splitting on '@'
+-  // is unambiguous — no marker, no rsplit.
++  // Four fields are intentionally not interpreted: that shape can mean a
++  // legacy salted key or a current unsalted key, and both map correctly by
++  // preserving every field after kv_rank verbatim.
+ 
+-  // Split on '@' — must yield 3 (unsalted) or 4 (salted) fields.
++  // Split on '@'. Current ObjectKey serialization has four or five fields;
++  // three-field legacy keys remain readable for cache compatibility.
+   std::vector<std::string> parts;
+   size_t start = 0;
+   for (size_t pos = 0; pos <= key.size(); ++pos) {
+@@ -51,34 +64,28 @@ std::string FSConnector::key_to_filename(const std::string& key) {
+       start = pos + 1;
+     }
+   }
+-  if (parts.size() != 3 && parts.size() != 4) {
++  if (parts.size() < 3 || parts.size() > 5) {
+     throw std::runtime_error(
+-        "FSConnector: malformed key (expected 3 or 4 '@'-separated fields): " +
++        "FSConnector: malformed key (expected 3 to 5 '@'-separated fields): " +
+         key);
+   }
+ 
+   const std::string& model_name = parts[0];
+   const std::string& kv_rank_hex = parts[1];
+-  const std::string& chunk_hash = parts[2];
+-  const std::string cache_salt = parts.size() == 4 ? parts[3] : std::string();
+ 
+   // Replace '/' with '-SEP-' for filesystem safety
+   std::string safe_model = replace_all(model_name, "/", PATH_SLASH_REPLACEMENT);
+ 
+-  // Emit filename. Salt is appended at the tail so the unsalted shape
+-  // matches what older builds wrote to disk.
++  // Emit the model and normalized rank, preserving all remaining fields.
+   std::string result;
+-  result.reserve(safe_model.size() + kv_rank_hex.size() + chunk_hash.size() +
+-                 cache_salt.size() + 32);
++  result.reserve(key.size() + 16);
+   result += safe_model;
+   result += KEY_SEP;
+   result += "0x";
+   result += kv_rank_hex;
+-  result += KEY_SEP;
+-  result += chunk_hash;
+-  if (!cache_salt.empty()) {
++  for (size_t i = 2; i < parts.size(); ++i) {
+     result += KEY_SEP;
+-    result += cache_salt;
++    result += parts[i];
+   }
+   result += FILE_EXT;
+   return result;
+@@ -174,8 +181,11 @@ void FSConnector::do_single_get(WorkerFSConn& conn, const std::string& key,
+   int flags = O_RDONLY;
+   bool do_odirect = conn.use_odirect;
+   if (do_odirect) {
+-    bool aligned = conn.disk_block_size > 0 && len % conn.disk_block_size == 0;
+-    if (aligned) {
++    const bool split_aligned = conn.disk_block_size > 0 &&
++                               (conn.read_ahead_size == 0 ||
++                                len <= conn.read_ahead_size ||
++                                conn.read_ahead_size % conn.disk_block_size == 0);
++    if (odirect_eligible(buf, len, conn.disk_block_size) && split_aligned) {
+ #ifdef O_DIRECT
+       flags |= O_DIRECT;
+ #endif
+@@ -243,8 +253,7 @@ void FSConnector::do_single_set(WorkerFSConn& conn, const std::string& key,
+   int flags = O_CREAT | O_WRONLY | O_TRUNC;
+   bool do_odirect = conn.use_odirect;
+   if (do_odirect) {
+-    bool aligned = conn.disk_block_size > 0 && len % conn.disk_block_size == 0;
+-    if (aligned) {
++    if (odirect_eligible(buf, len, conn.disk_block_size)) {
+ #ifdef O_DIRECT
+       flags |= O_DIRECT;
+ #endif
+diff --git a/csrc/storage_backends/fs/connector.h b/csrc/storage_backends/fs/connector.h
+index 03b7b9cc5e0a2cac7ab9e39404d80c760b4e9018..7b9010947c18de36684317ed7c2628c3d2be0161 100644
+--- a/csrc/storage_backends/fs/connector.h
++++ b/csrc/storage_backends/fs/connector.h
+@@ -21,7 +21,9 @@ static constexpr const char* FILE_EXT = ".data";
+ static constexpr const char* TMP_EXT = ".tmp";
+ 
+ // Per-worker connection state for the FS connector.
+-// Each worker maintains its own I/O buffer for O_DIRECT.
++// O_DIRECT engages per request only when both the transfer length and the
++// caller's buffer address are multiples of the disk block size; anything
++// else falls back to buffered I/O.
+ struct WorkerFSConn {
+   std::filesystem::path base_path;
+   std::filesystem::path tmp_dir;  // empty if not configured
+@@ -52,17 +54,20 @@ class FSConnector : public ConnectorBase<WorkerFSConn> {
+   // Build the filesystem-safe filename from a serialized key string.
+   //
+   // Input key (from NativeConnectorL2Adapter._object_key_to_string):
+-  //   Unsalted: "{model}@{kv_rank:08x}@{hash.hex()}"
+-  //   Salted  : "{model}@{kv_rank:08x}@{hash.hex()}@{cache_salt}"
++  //   Current unsalted:
++  //     "{model}@{kv_rank:08x}@{object_group:x}@{hash.hex()}"
++  //   Current salted appends "@{cache_salt}". Legacy three/four-field keys
++  //   without object_group_id remain supported.
+   //
+   // Output filename (matching fs_l2_adapter.py._object_key_to_filename):
+-  //   Unsalted: "{safe_model}@{kv_rank:#010x}@{hash.hex()}.data"
+-  //   Salted  : "{safe_model}@{kv_rank:#010x}@{hash.hex()}@{cache_salt}.data"
++  //   Current unsalted:
++  //     "{safe_model}@{kv_rank:#010x}@{object_group:x}@{hash.hex()}.data"
++  //   Current salted appends "@{cache_salt}" before ".data".
+   //
+   // Differences from the input: '/' in model becomes '-SEP-', kv_rank
+-  // gains a '0x' prefix, and '.data' is appended. Both model_name and
+-  // cache_salt are forbidden from containing '@' (enforced on the
+-  // Python side), so the parse is unambiguous.
++  // gains a '0x' prefix, and '.data' is appended. All fields after kv_rank
++  // are preserved because four fields can represent either a legacy salted
++  // key or a current unsalted key.
+   static std::string key_to_filename(const std::string& key);
+ 
+   static std::string replace_all(const std::string& str,
+diff --git a/csrc/storage_backends/mooncake/connector.cpp b/csrc/storage_backends/mooncake/connector.cpp
+index 685fa4165b188b517a5c0de50753e5ae2e596d6f..0d5109e0dbb5595476806071d62c6dedd6f2bf98 100644
+--- a/csrc/storage_backends/mooncake/connector.cpp
++++ b/csrc/storage_backends/mooncake/connector.cpp
+@@ -173,12 +173,23 @@ void MooncakeConnector::do_batch_set(WorkerMooncakeConn& conn,
+       conn.client->batch_put_from(req.keys, req.buf_ptrs, req.buf_lens);
+   ensure_batch_result_size(results, req.keys.size(), "batch_put_from");
+ 
++  // Record per-key results before failing the tile so partial store
++  // failures stay visible to consumers that honor them.
++  size_t first_failed = results.size();
+   for (size_t i = 0; i < results.size(); ++i) {
+-    if (results[i] != 0) {
+-      throw std::runtime_error("Mooncake batch_put_from failed for key: " +
+-                               req.keys[i]);
++    if (results[i] == 0) {
++      req.batch->per_key_results[req.start_idx + i] = 1;
++    } else {
++      req.batch->per_key_results[req.start_idx + i] = 0;
++      if (first_failed == results.size()) {
++        first_failed = i;
++      }
+     }
+   }
++  if (first_failed != results.size()) {
++    throw std::runtime_error("Mooncake batch_put_from failed for key: " +
++                             req.keys[first_failed]);
++  }
+ }
+ 
+ void MooncakeConnector::do_batch_exists(WorkerMooncakeConn& conn,
+diff --git a/lmcache/integration/vllm/lmcache_mp_connector.py b/lmcache/integration/vllm/lmcache_mp_connector.py
+index d268070c3c0daa534a616c88312f8da7b5c665de..21af3747ede9f78c608841a692acc9c25e0bbc29 100644
+--- a/lmcache/integration/vllm/lmcache_mp_connector.py
++++ b/lmcache/integration/vllm/lmcache_mp_connector.py
+@@ -464,6 +464,42 @@ class LMCacheMPRequestMetadata:
+             "number of LMCache hit tokens. "
+         )
+         if end_token_idx > start_token_idx:
++            # allocated_block_ids must cover [start_token_idx, end_token_idx)
++            # in every engine group. slice_block_ids_per_group() validates
++            # chunk alignment only; its plain Python slice truncates
++            # silently, so a tracker primed with LMCache hit counts on a
++            # scheduling pass whose allocation never materialised would emit
++            # a retrieve op with too few block ids. The MP server fails
++            # closed on the short list, wasting a doomed round-trip and
++            # relying on the failure being surfaced at all. Suppress the op
++            # instead so the request recomputes cleanly. Never clamp
++            # end_token_idx: a clamped retrieve completes a load vLLM does
++            # not expect and re-creates the desync downstream.
++            # One allocated id of group g covers group_tokens_per_block[g]
++            # global token positions (KV-spec block_size, DCP-scaled), the
++            # same arithmetic GetStoreMetadata uses to bound its
++            # allocated_tokens.
++            for group_idx, tokens_per_block in enumerate(group_tokens_per_block):
++                allocated = len(tracker.allocated_block_ids.get(group_idx, []))
++                if allocated * tokens_per_block < end_token_idx:
++                    logger.warning(
++                        "LMCache retrieve suppressed for request_id=%s: "
++                        "engine group %d has %d allocated block(s) x %d "
++                        "tokens/block = %d tokens < end_token_idx=%d "
++                        "(start_token_idx=%d, vllm_hit_tokens=%d, "
++                        "lmcache_hit_tokens=%d) -- tracker/allocation "
++                        "desync; falling back to recompute.",
++                        tracker.request_id,
++                        group_idx,
++                        allocated,
++                        tokens_per_block,
++                        allocated * tokens_per_block,
++                        end_token_idx,
++                        start_token_idx,
++                        tracker.num_vllm_hit_tokens,
++                        tracker.num_lmcache_hit_tokens,
++                    )
++                    return None
+             block_ids = slice_block_ids_per_group(
+                 tracker.allocated_block_ids,
+                 group_tokens_per_block,
+diff --git a/lmcache/integration/vllm/vllm_multi_process_adapter.py b/lmcache/integration/vllm/vllm_multi_process_adapter.py
+index d74fe3af02cbefc7755c8446434a36034c681ef3..dd5aa0e6033292eaad06dd8f0b7961d58cf6b2f1 100644
+--- a/lmcache/integration/vllm/vllm_multi_process_adapter.py
++++ b/lmcache/integration/vllm/vllm_multi_process_adapter.py
+@@ -1173,8 +1173,11 @@ class LMCacheMPWorkerAdapter:
+         self.store_events: dict[str, list[_IpcEvent]] = {}
+         self.retrieve_events: dict[str, _IpcEvent] = {}
+ 
+-        # Block IDs that failed due to retrieve timeout
++        # Block IDs of failed retrieves (timeout, server-reported failure,
++        # or raising future), consumed by get_block_ids_with_load_errors().
+         self.error_block_ids: set[int] = set()
++        # Total failed retrieves on this worker, for log-based diagnostics.
++        self.retrieve_failure_count: int = 0
+ 
+         # Retrieve request ids dropped by the unhealthy early-return of
+         # submit_retrieve_request. get_finished must still report each id
+@@ -1657,6 +1660,9 @@ class LMCacheMPWorkerAdapter:
+             - The second set contains the finished retrieve request ids,
+                 including retrieves dropped at submit time while unhealthy
+                 (reported exactly once; blocks already in error_block_ids).
++                A failed retrieve (server result False or a raising future)
++                is reported finished with its block ids recorded in
++                error_block_ids so the scheduler recomputes them.
+ 
+         Notes:
+             When enabling async scheduling in vLLM, the same request ID may appear
+@@ -1701,19 +1707,45 @@ class LMCacheMPWorkerAdapter:
+ 
+         finished_stores = self._poll_store_futures()
+         finished_retrieves = set()
+-        for request_id, (r_future, _) in self.retrieve_futures.items():
++        for request_id, (r_future, r_block_ids) in self.retrieve_futures.items():
+             if not r_future.query():
+                 continue
+ 
+-            r_result = r_future.result()
++            try:
++                r_result = r_future.result()
++            except Exception as exc:
++                # A raising future must not propagate out of get_finished
++                # (that would kill the engine step); contain it as a failed
++                # retrieve on the standard failure path.
++                logger.error(
++                    "LMCache retrieve future raised for request_id=%s: %r "
++                    "-- treating as failed retrieve.",
++                    request_id,
++                    exc,
++                )
++                r_result = False
+             finished_retrieves.add(request_id)
+ 
+             if not r_result:
++                # Surface the failure to the scheduler. Reporting the
++                # request finished without recording the failed span would
++                # ACK the load as successful: the request then decodes over
++                # never-written GPU blocks and the phantom blocks enter the
++                # shared prefix cache. error_block_ids feeds
++                # get_block_ids_with_load_errors() ->
++                # kv_connector_output.invalid_block_ids -> scheduler
++                # recompute. The MP server collapses per-key results into
++                # one bool, so marking the op's whole span is
++                # conservative-correct for partial failures too.
++                self.error_block_ids.update(r_block_ids)
++                self.retrieve_failure_count += 1
+                 logger.error(
+-                    "Something went wrong when processing the "
+-                    "retrieve request for request_id=%s, result=%s",
++                    "LMCache retrieve failed for request_id=%s: %d block(s) "
++                    "marked invalid for scheduler recompute "
++                    "(total retrieve failures this worker: %d)",
+                     request_id,
+-                    r_result,
++                    len(r_block_ids),
++                    self.retrieve_failure_count,
+                 )
+ 
+         # Store futures and events are removed together by _poll_store_futures.
+@@ -1758,8 +1790,8 @@ class LMCacheMPWorkerAdapter:
+ 
+     def get_block_ids_with_load_errors(self) -> set[int]:
+         """
+-        Returns the block IDs that failed due to retrieve timeout,
+-        then clears the internal set.
++        Returns the block IDs of failed retrieves (timeout, server-reported
++        failure, or raising future), then clears the internal set.
+         """
+         errors = self.error_block_ids.copy()
+         self.error_block_ids.clear()
+diff --git a/lmcache/v1/distributed/config.py b/lmcache/v1/distributed/config.py
+index de36535a57df7ceb8ca8bbb97276c4733e568270..ac11158668fdbfd00f36512cc08a90b7f42860b4 100644
+--- a/lmcache/v1/distributed/config.py
++++ b/lmcache/v1/distributed/config.py
+@@ -226,6 +226,21 @@ class EvictionConfig:
+     extra_logging_interval: float = field(default=10.0)
+     """ Seconds between L1 memory usage log lines when extra logging is enabled. """
+ 
++    write_back_on_evict: bool = field(default=False)
++    """ Flush evicted L1 objects to L2 synchronously and delete them from L1
++    only once every key in the batch is durable; without this, eviction
++    discards the objects. Requires an L2 adapter with store_objects_sync(). """
++
++    periodic_flush_interval: float = field(default=0.0)
++    """ Seconds between periodic L1-to-L2 backup flush scans while below the
++    eviction watermark (0 disables). Backup keeps the L1 copy; only L2 gains
++    a copy, so a restart or session expiry no longer costs a cold prefill. """
++
++    emergency_evict_for_prefetch: bool = field(default=False)
++    """ Allow the prefetch controller to synchronously evict LRU L1 keys to
++    make room for large L2-to-L1 restores. Effective only together with
++    write_back_on_evict, so victims are persisted before deletion. """
++
+ 
+ @dataclass
+ class StorageManagerConfig:
+@@ -296,6 +311,12 @@ def validate_storage_manager_config(config: StorageManagerConfig) -> None:
+         ValueError: If mutually exclusive L1 tiers are both configured, or
+             hybrid L1 is paired with incompatible L2 adapters.
+     """
++    eviction = config.eviction_config
++    if eviction.periodic_flush_interval < 0:
++        raise ValueError("periodic_flush_interval must be >= 0")
++    if eviction.emergency_evict_for_prefetch and not eviction.write_back_on_evict:
++        raise ValueError("emergency_evict_for_prefetch requires write_back_on_evict")
++
+     if (
+         config.l1_manager_config.gds_l1_config is not None
+         and config.l1_manager_config.memory_config.devdax_path
+@@ -471,6 +492,28 @@ def add_storage_manager_args(
+         help="The fraction of memory to evict when triggered (0.0 to 1.0). "
+         "Default is 0.2.",
+     )
++    eviction_group.add_argument(
++        "--write-back-on-evict",
++        action="store_true",
++        help="Flush evicted L1 objects to L2 synchronously and delete them "
++        "from L1 only once every key in the batch is durable. Requires an "
++        "L2 adapter with a synchronous store path.",
++    )
++    eviction_group.add_argument(
++        "--periodic-flush-interval",
++        type=float,
++        default=0.0,
++        help="Seconds between periodic L1-to-L2 backup flush scans while "
++        "below the eviction watermark (0 disables). The backup keeps the "
++        "L1 copy; only L2 gains a copy.",
++    )
++    eviction_group.add_argument(
++        "--emergency-evict-for-prefetch",
++        action="store_true",
++        help="Allow the prefetch controller to synchronously evict LRU L1 "
++        "keys to make room for large L2-to-L1 restores. Effective only "
++        "together with --write-back-on-evict.",
++    )
+ 
+     # L2 Policies
+     # Import here to break circular dependency:
+@@ -596,6 +639,11 @@ def parse_args_to_config(
+         eviction_ratio=args.eviction_ratio,
+         extra_logging_enabled=getattr(args, "enable_extra_logging", False),
+         extra_logging_interval=getattr(args, "extra_logging_interval", 10.0),
++        write_back_on_evict=getattr(args, "write_back_on_evict", False),
++        periodic_flush_interval=getattr(args, "periodic_flush_interval", 0.0),
++        emergency_evict_for_prefetch=getattr(
++            args, "emergency_evict_for_prefetch", False
++        ),
+     )
+ 
+     l2_adapter_config = parse_args_to_l2_adapters_config(args)
+diff --git a/lmcache/v1/distributed/l1_manager.py b/lmcache/v1/distributed/l1_manager.py
+index 44cf55f615f2bf491bdf72784ac152a7ee422457..4a2be000b86a576759cb3d5579acbc45181b14e7 100644
+--- a/lmcache/v1/distributed/l1_manager.py
++++ b/lmcache/v1/distributed/l1_manager.py
+@@ -5,6 +5,7 @@ Managing objects and memory for L1 cache
+ 
+ # Standard
+ from dataclasses import dataclass
++from itertools import chain, islice
+ from typing import Literal
+ import threading
+ 
+@@ -462,6 +463,11 @@ class L1Manager:
+         Errors:
+             KEY_NOT_WRITABLE: The key exists but is not writable.
+             OUT_OF_MEMORY: Not enough memory to allocate for the object.
++
++        Note:
++            When the full batch does not fit, the longest prefix of the
++            to-be-allocated keys that fits is allocated and the remaining
++            keys report OUT_OF_MEMORY.
+         """
+         need_to_allocate: list[tuple[ObjectKey, bool]] = []
+         ret: dict[ObjectKey, L1OperationResult] = {}
+@@ -499,6 +505,26 @@ class L1Manager:
+             layout_desc, len(need_to_allocate)
+         )
+ 
++        # A full-batch allocation failure would fail every key even when
++        # most of the batch fits, collapsing large L2->L1 restores to zero
++        # prefix hits and forcing full re-prefills upstream. Fall back to
++        # allocating the longest prefix that fits; callers already handle
++        # per-key OOM (prefetch trims to the contiguous prefix, the store
++        # path skips failed keys).
++        if err != L1Error.SUCCESS and len(need_to_allocate) > 1:
++            if allocated_objs:
++                self._memory_manager.free(allocated_objs)
++                allocated_objs = []
++            err, allocated_objs = self._allocate_largest_prefix(
++                layout_desc, len(need_to_allocate)
++            )
++            if err == L1Error.SUCCESS:
++                logger.warning(
++                    "Partial L1 allocation: %d/%d objects (prefix) allocated",
++                    len(allocated_objs),
++                    len(need_to_allocate),
++                )
++
+         if err != L1Error.SUCCESS:
+             for key, _ in need_to_allocate:
+                 ret[key] = (L1Error.OUT_OF_MEMORY, None)
+@@ -508,6 +534,10 @@ class L1Manager:
+                 self._memory_manager.free(allocated_objs)
+ 
+         else:
++            # Mark any unallocated tail as OOM so every requested key keeps
++            # an explicit per-key result.
++            for key, _ in need_to_allocate[len(allocated_objs) :]:
++                ret[key] = (L1Error.OUT_OF_MEMORY, None)
+             for (key, is_temp), mem_obj in zip(
+                 need_to_allocate, allocated_objs, strict=False
+             ):
+@@ -531,6 +561,41 @@ class L1Manager:
+         )
+         return ret
+ 
++    def _allocate_largest_prefix(
++        self, layout_desc: MemoryLayoutDesc, want: int
++    ) -> tuple[L1Error, list[MemoryObj]]:
++        """Allocate the largest prefix below an already-failed full batch.
++
++        L1 allocators have an all-or-nothing batch contract. While holding the
++        L1 manager lock, allocation feasibility is therefore monotonic: if a
++        batch of size ``n`` fits, every smaller batch also fits. Binary search
++        finds the maximum without relying on byte estimates that can be wrong
++        for alignment or fragmented free lists. Successful probes are freed
++        before the final allocation.
++
++        This recovery path runs only after the ``want`` allocation failed, so
++        normal reservations still perform exactly one allocation.
++        """
++        low = 1
++        high = want - 1
++        largest = 0
++
++        while low <= high:
++            candidate = (low + high) // 2
++            err, objects = self._memory_manager.allocate(layout_desc, candidate)
++            if err == L1Error.SUCCESS:
++                largest = candidate
++                self._memory_manager.free(objects)
++                low = candidate + 1
++            else:
++                if objects:
++                    self._memory_manager.free(objects)
++                high = candidate - 1
++
++        if largest == 0:
++            return L1Error.OUT_OF_MEMORY, []
++        return self._memory_manager.allocate(layout_desc, largest)
++
+     @l1_mgr_synchronized
+     def finish_write(
+         self,
+@@ -793,6 +858,59 @@ class L1Manager:
+             locked_count,
+         )
+ 
++    @l1_mgr_synchronized
++    def get_evictable_keys(
++        self,
++        limit: int,
++        cursor: int = 0,
++        scan_limit: int | None = None,
++    ) -> tuple[list[ObjectKey], int]:
++        """Return a bounded, rotating batch of evictable keys.
++
++        ``cursor`` is an insertion-order offset returned by the previous call.
++        The scan wraps once and inspects at most ``scan_limit`` entries, so a
++        periodic backup cannot materialize the complete L1 keyspace while the
++        manager lock is held. Concurrent insertions or removals may shift the
++        offset, but every returned key is revalidated by ``reserve_read``.
++
++        Args:
++            limit: Maximum number of keys to return.
++            cursor: Insertion-order offset at which to resume scanning.
++            scan_limit: Maximum entries to inspect. Defaults to four batches.
++
++        Returns:
++            A pair of the eligible keys and the cursor for the next call.
++        """
++        if limit <= 0 or not self._objects:
++            return [], 0
++
++        object_count = len(self._objects)
++        start = cursor % object_count
++        max_scan = min(
++            object_count,
++            max(limit, scan_limit if scan_limit is not None else limit * 4),
++        )
++        ordered_keys = chain(
++            islice(self._objects, start, None),
++            islice(self._objects, 0, start),
++        )
++        keys: list[ObjectKey] = []
++        scanned = 0
++        for key in ordered_keys:
++            scanned += 1
++            if self.is_key_evictable(key):
++                keys.append(key)
++                if len(keys) >= limit:
++                    break
++            if scanned >= max_scan:
++                break
++        return keys, (start + scanned) % object_count
++
++    @l1_mgr_synchronized
++    def num_objects(self) -> int:
++        """Return the number of objects currently tracked in L1."""
++        return len(self._objects)
++
+     def is_key_evictable(self, key: ObjectKey) -> bool:
+         """Check if a key is eligible for eviction (not locked).
+ 
+diff --git a/lmcache/v1/distributed/l2_adapters/base.py b/lmcache/v1/distributed/l2_adapters/base.py
+index 1838553e285ce0f2c7a0b3d9a3180b6ad57ed499..910cec00199586224936da8b0323a02659cc74c1 100644
+--- a/lmcache/v1/distributed/l2_adapters/base.py
++++ b/lmcache/v1/distributed/l2_adapters/base.py
+@@ -354,13 +354,8 @@ class L2AdapterInterface(ABC):
+         """Register a listener to receive L2 adapter events."""
+         self._listeners.append(listener)
+ 
+-    def _notify_keys_stored(self, keys: list[ObjectKey], sizes: list[int]) -> None:
+-        """Update byte accounting and notify listeners that ``keys`` were
+-        stored. ``sizes[i]`` is the byte size of ``keys[i]``.
+-
+-        Accounting is held under ``_usage_lock``; listener callbacks fire
+-        outside the lock so a slow listener cannot stall further notifies.
+-        """
++    def _account_keys_stored(self, keys: list[ObjectKey], sizes: list[int]) -> None:
++        """Apply stored-key byte accounting without invoking listeners."""
+         # Aggregate per-salt deltas before touching
+         # ``_bytes_by_cache_salt`` — one dict read/write per unique
+         # salt instead of one per key. This matters when the registry is
+@@ -377,9 +372,26 @@ class L2AdapterInterface(ABC):
+                 self._bytes_by_cache_salt[salt] = (
+                     self._bytes_by_cache_salt.get(salt, 0) + d
+                 )
++
++    def _notify_keys_stored_listeners(
++        self,
++        keys: list[ObjectKey],
++        sizes: list[int],
++    ) -> None:
++        """Notify stored-key observers after accounting is committed."""
+         for listener in self._listeners:
+             listener.on_l2_keys_stored(keys, sizes)
+ 
++    def _notify_keys_stored(self, keys: list[ObjectKey], sizes: list[int]) -> None:
++        """Update byte accounting and notify listeners that ``keys`` were
++        stored. ``sizes[i]`` is the byte size of ``keys[i]``.
++
++        Accounting is held under ``_usage_lock``; listener callbacks fire
++        outside the lock so a slow listener cannot stall further notifies.
++        """
++        self._account_keys_stored(keys, sizes)
++        self._notify_keys_stored_listeners(keys, sizes)
++
+     def _notify_keys_accessed(self, keys: list[ObjectKey]) -> None:
+         # ``_notify_keys_accessed`` carries no byte impact — only LRU
+         # bookkeeping cares about it, so no accounting is needed here.
+diff --git a/lmcache/v1/distributed/l2_adapters/fs_native_l2_adapter.py b/lmcache/v1/distributed/l2_adapters/fs_native_l2_adapter.py
+index 2d703499d20c5aa1c0ecc8e1f0667f2bf857c6a2..dacdead73b3eb1a34bec530fe14c535759607b2a 100644
+--- a/lmcache/v1/distributed/l2_adapters/fs_native_l2_adapter.py
++++ b/lmcache/v1/distributed/l2_adapters/fs_native_l2_adapter.py
+@@ -10,9 +10,11 @@ Backed by the native C++ filesystem connector wrapped with
+ from __future__ import annotations
+ 
+ # Standard
++from pathlib import Path
+ from typing import TYPE_CHECKING, Optional
+ 
+ if TYPE_CHECKING:
++    from lmcache.v1.distributed.api import ObjectKey
+     from lmcache.v1.distributed.internal_api import (
+         L1MemoryDesc,
+     )
+@@ -158,7 +160,7 @@ def _create_fs_native_l2_adapter(
+         config.use_odirect,
+         config.read_ahead_size,
+     )
+-    return NativeConnectorL2Adapter(
++    adapter = NativeConnectorL2Adapter(
+         native_client,
+         max_capacity_gb=config.max_capacity_gb,
+         type_name="FSNativeL2Adapter",
+@@ -169,6 +171,53 @@ def _create_fs_native_l2_adapter(
+             "read_ahead_size": config.read_ahead_size,
+         },
+     )
++    try:
++        keys, sizes = _scan_existing_fs_native_files(config.base_path)
++        adapter.prime_existing_keys(keys, sizes)
++    except Exception:
++        adapter.close()
++        raise
++    return adapter
++
++
++def _scan_existing_fs_native_files(
++    base_path: str,
++) -> tuple[list["ObjectKey"], list[int]]:
++    """Recover durable keys and sizes, ordered from oldest to newest."""
++    # First Party
++    from lmcache.v1.distributed.l2_adapters.fs_l2_adapter import (
++        _filename_to_object_key,
++    )
++
++    root = Path(base_path)
++    if not root.is_dir():
++        return [], []
++
++    entries: list[tuple[int, str, ObjectKey, int]] = []
++    for path in root.glob("*.data"):
++        try:
++            if not path.is_file():
++                continue
++            key = _filename_to_object_key(path.name)
++            if key is None:
++                logger.warning("Ignoring unrecognized cache file: %s", path)
++                continue
++            stat = path.stat()
++            if stat.st_size <= 0:
++                logger.warning("Ignoring empty cache file: %s", path)
++                continue
++            entries.append((stat.st_mtime_ns, path.name, key, stat.st_size))
++        except OSError as exc:
++            # Silently omitting a durable object would under-report usage and
++            # seed an incomplete eviction index. Fail adapter construction so
++            # the operator can repair the directory or retry the startup scan.
++            raise RuntimeError(f"Could not inspect cache file {path}: {exc}") from exc
++
++    entries.sort(key=lambda entry: (entry[0], entry[1]))
++    return (
++        [entry[2] for entry in entries],
++        [entry[3] for entry in entries],
++    )
+ 
+ 
+ register_l2_adapter_type("fs_native", FSNativeL2AdapterConfig)
+diff --git a/lmcache/v1/distributed/l2_adapters/native_connector_l2_adapter.py b/lmcache/v1/distributed/l2_adapters/native_connector_l2_adapter.py
+index c10d3802dfbdba50b6a49e4d764ebf10a567a0df..e3a73e35d5f5316f9d9dd0dcbc5d57b949661be6 100644
+--- a/lmcache/v1/distributed/l2_adapters/native_connector_l2_adapter.py
++++ b/lmcache/v1/distributed/l2_adapters/native_connector_l2_adapter.py
+@@ -30,7 +30,7 @@ import threading
+ from lmcache.logging import init_logger
+ from lmcache.native_storage_ops import Bitmap
+ from lmcache.v1.distributed.api import MemoryLayoutDesc, ObjectKey
+-from lmcache.v1.distributed.internal_api import L2StoreResult
++from lmcache.v1.distributed.internal_api import L2AdapterListener, L2StoreResult
+ from lmcache.v1.distributed.l2_adapters.base import (
+     L2AdapterInterface,
+     L2TaskId,
+@@ -98,6 +98,7 @@ class NativeConnectorL2Adapter(L2AdapterInterface):
+ 
+     # Operation type tags for the pending-ops map
+     _OP_STORE = "store"
++    _OP_SYNC_STORE = "sync_store"
+     _OP_LOOKUP = "lookup"
+     _OP_LOAD = "load"
+     _OP_DELETE = "delete"
+@@ -144,6 +145,12 @@ class NativeConnectorL2Adapter(L2AdapterInterface):
+         # Pending delete events for synchronous delete() calls
+         self._pending_delete_events: dict[L2TaskId, threading.Event] = {}
+ 
++        # Synchronous stores use private completions so StoreController cannot
++        # consume another thread's result from _completed_stores.
++        self._pending_sync_store_events: dict[
++            L2TaskId, tuple[threading.Event, dict[str, Any]]
++        ] = {}
++
+         # Per-key size tracking. ``_key_sizes`` lets us look up byte sizes
+         # at delete time (the native completion only carries booleans, not
+         # sizes) so we can pass them to ``_notify_keys_deleted``. Aggregate
+@@ -154,6 +161,12 @@ class NativeConnectorL2Adapter(L2AdapterInterface):
+         # demux thread can fire ``_notify_keys_stored(keys, sizes)``.
+         self._pending_store_sizes: dict[int, tuple[list[ObjectKey], list[int]]] = {}
+ 
++        # A filesystem factory may prime durable objects before the eviction
++        # listener exists. Keep one temporary startup snapshot for that first
++        # listener; _key_sizes remains the sole long-lived key index.
++        self._startup_primed = False
++        self._startup_replay: tuple[list[ObjectKey], list[int]] | None = None
++
+         # Task ID counter
+         self._next_task_id: L2TaskId = 0
+ 
+@@ -219,6 +232,71 @@ class NativeConnectorL2Adapter(L2AdapterInterface):
+             self._completed_stores = {}
+         return completed
+ 
++    def store_objects_sync(
++        self,
++        keys: list[ObjectKey],
++        objects: list[MemoryObj],
++        timeout: float | None = None,
++    ) -> tuple[bool, int, int]:
++        """Persist objects and wait for their native backend completion.
++
++        Returns ``(success, persisted_count, bytes_written)``. ``success`` is
++        true only when every key persisted, while the other fields account
++        for successful keys in a partially failed batch.
++        """
++        if len(keys) != len(objects):
++            raise ValueError("keys and objects length mismatch")
++        if not keys:
++            return True, 0, 0
++        if timeout is not None and timeout <= 0:
++            raise ValueError("timeout must be positive")
++
++        key_strings = [_object_key_to_string(key) for key in keys]
++        memviews = [_obj_to_memoryview(obj) for obj in objects]
++        per_key_sizes = [obj.get_size() for obj in objects]
++        done_event = threading.Event()
++        result: dict[str, Any] = {
++            "ok": False,
++            "persisted_count": 0,
++            "bytes_written": 0,
++        }
++
++        with self._lock:
++            task_id = self._get_next_task_id()
++            future_id = int(self._client.submit_batch_set(key_strings, memviews))
++            self._pending_ops[future_id] = (
++                self._OP_SYNC_STORE,
++                task_id,
++                len(keys),
++                None,
++            )
++            self._pending_store_sizes[future_id] = (list(keys), per_key_sizes)
++            self._pending_sync_store_events[task_id] = (done_event, result)
++
++        wait_timeout = (
++            timeout if timeout is not None else max(30.0, min(300.0, len(keys) * 5.0))
++        )
++        if not done_event.wait(timeout=wait_timeout):
++            with self._lock:
++                self._pending_sync_store_events.pop(task_id, None)
++                for fid, entry in list(self._pending_ops.items()):
++                    if entry[1] == task_id:
++                        self._pending_ops.pop(fid, None)
++                        self._pending_store_sizes.pop(fid, None)
++                        break
++            logger.warning(
++                "store_objects_sync() timed out after %.1fs for %d keys",
++                wait_timeout,
++                len(keys),
++            )
++            return False, 0, 0
++
++        return (
++            bool(result["ok"]),
++            int(result["persisted_count"]),
++            int(result["bytes_written"]),
++        )
++
+     # ---------------------------------------------------------------
+     # Lookup and Lock Interface
+     # ---------------------------------------------------------------
+@@ -297,22 +375,46 @@ class NativeConnectorL2Adapter(L2AdapterInterface):
+         tracking stays in sync.
+ 
+         No-op if the connector does not expose ``submit_batch_delete``
+-        or if the key list is empty.
++        or if the key list is empty. Keys currently lookup-locked by an
++        in-flight prefetch are skipped: the load task would race the
++        unlink and fail with a phantom not_found.
+         """
+         if not keys or not self._has_delete:
+             return
+ 
+-        key_strings = [_object_key_to_string(k) for k in keys]
+         done_event = threading.Event()
+ 
+         with self._lock:
++            # A key becomes lookup-locked only when the native EXISTS
++            # completion is demultiplexed. Protect pending lookup keys as
++            # well, otherwise eviction can delete a key between lookup
++            # submission and lock acquisition. Filtering and delete submit
++            # stay in one critical section so a new lookup cannot enter that
++            # same gap.
++            protected_keys = set(self._locked_keys)
++            for op_type, _task_id, _num_keys, op_keys in self._pending_ops.values():
++                if op_type == self._OP_LOOKUP and op_keys is not None:
++                    protected_keys.update(op_keys)
++
++            delete_keys = [key for key in keys if key not in protected_keys]
++            skipped_count = len(keys) - len(delete_keys)
++            if skipped_count:
++                logger.info(
++                    "delete(): skipping %d lookup-pending or locked keys; %d remain",
++                    skipped_count,
++                    len(delete_keys),
++                )
++            if not delete_keys:
++                return
++
++            key_strings = [_object_key_to_string(k) for k in delete_keys]
+             task_id = self._get_next_task_id()
+             future_id = int(self._client.submit_batch_delete(key_strings))
+             self._pending_ops[future_id] = (
+                 self._OP_DELETE,
+                 task_id,
+-                len(keys),
+-                list(keys),
++                len(delete_keys),
++                delete_keys,
+             )
+             self._pending_delete_events[task_id] = done_event
+ 
+@@ -328,7 +430,7 @@ class NativeConnectorL2Adapter(L2AdapterInterface):
+                         break
+             logger.warning(
+                 "delete() timed out after 30s for %d keys",
+-                len(keys),
++                len(delete_keys),
+             )
+             return
+ 
+@@ -345,6 +447,52 @@ class NativeConnectorL2Adapter(L2AdapterInterface):
+     # Status Interface
+     # ---------------------------------------------------------------
+ 
++    def prime_existing_keys(
++        self,
++        keys: list[ObjectKey],
++        sizes: list[int],
++    ) -> None:
++        """Account durable objects discovered before adapter registration."""
++        if len(keys) != len(sizes):
++            raise ValueError("keys and sizes length mismatch")
++
++        unique: dict[ObjectKey, int] = {}
++        for key, size in zip(keys, sizes, strict=True):
++            if size <= 0:
++                raise ValueError("existing object sizes must be positive")
++            unique.setdefault(key, int(size))
++
++        primed_keys = list(unique)
++        primed_sizes = list(unique.values())
++        with self._lock:
++            if self._startup_primed:
++                raise RuntimeError("existing keys were already primed")
++            if self._listeners:
++                raise RuntimeError("existing keys must be primed before listeners")
++            self._startup_primed = True
++            self._key_sizes.update(unique)
++            self._startup_replay = (primed_keys, primed_sizes)
++
++        # No listener is registered during factory construction. This uses
++        # the common accounting implementation without retaining a second
++        # byte-accounting path in this adapter.
++        if primed_keys:
++            self._notify_keys_stored(primed_keys, primed_sizes)
++            logger.info(
++                "Startup scan primed %.2f GB in %d existing objects",
++                sum(primed_sizes) / 1e9,
++                len(primed_keys),
++            )
++
++    def register_listener(self, listener: L2AdapterListener) -> None:
++        """Register a listener and replay the one-time startup snapshot."""
++        with self._lock:
++            replay = self._startup_replay
++            self._startup_replay = None
++        if replay is not None and replay[0]:
++            listener.on_l2_keys_stored(*replay)
++        super().register_listener(listener)
++
+     def report_status(self) -> dict[str, Any]:
+         """Return a status dict for this native-connector L2 adapter.
+ 
+@@ -372,6 +520,14 @@ class NativeConnectorL2Adapter(L2AdapterInterface):
+         self._stop.set()
+         self._demux_thread.join(timeout=5)
+ 
++        with self._lock:
++            sync_events = [
++                event for event, _result in self._pending_sync_store_events.values()
++            ]
++            self._pending_sync_store_events.clear()
++        for event in sync_events:
++            event.set()
++
+         self._client.close()
+ 
+         self._store_efd.close()
+@@ -425,6 +581,7 @@ class NativeConnectorL2Adapter(L2AdapterInterface):
+             # the caller unblocks and calls ``get_usage()``, the base
+             # class's byte counters already reflect the deletion.
+             delete_done_events: list[threading.Event] = []
++            sync_store_done_events: list[threading.Event] = []
+ 
+             with self._lock:
+                 for (
+@@ -449,12 +606,30 @@ class NativeConnectorL2Adapter(L2AdapterInterface):
+                         lookup_keys,
+                     ) = entry
+ 
+-                    if op_type == self._OP_STORE:
++                    if op_type in (self._OP_STORE, self._OP_SYNC_STORE):
+                         store_info = self._pending_store_sizes.pop(fid, None)
+                         task_bytes = 0
+-                        if ok and store_info is not None:
++                        persisted_count = 0
++                        completion_ok = False
++                        if store_info is not None:
+                             store_keys, sizes = store_info
+-                            for key, size in zip(store_keys, sizes, strict=True):
++                            if result_bools is None:
++                                stored_flags = [bool(ok)] * len(store_keys)
++                            else:
++                                stored_flags = [bool(value) for value in result_bools]
++                                if len(stored_flags) < len(store_keys):
++                                    stored_flags.extend(
++                                        [False] * (len(store_keys) - len(stored_flags))
++                                    )
++                                elif len(stored_flags) > len(store_keys):
++                                    stored_flags = stored_flags[: len(store_keys)]
++                            completion_ok = bool(ok) and all(stored_flags)
++                            for key, size, stored in zip(
++                                store_keys, sizes, stored_flags, strict=True
++                            ):
++                                if not stored:
++                                    continue
++                                persisted_count += 1
+                                 # First-store wins for byte accounting:
+                                 # a re-store of an existing key adds 0
+                                 # bytes (the backend already holds it).
+@@ -470,8 +645,21 @@ class NativeConnectorL2Adapter(L2AdapterInterface):
+                                 else:
+                                     keys_stored.append(key)
+                                     sizes_stored.append(0)
+-                        self._completed_stores[task_id] = L2StoreResult(ok, task_bytes)
+-                        self._store_efd.notify()
++                        if op_type == self._OP_STORE:
++                            self._completed_stores[task_id] = L2StoreResult(
++                                completion_ok, task_bytes
++                            )
++                            self._store_efd.notify()
++                        else:
++                            sync_entry = self._pending_sync_store_events.pop(
++                                task_id, None
++                            )
++                            if sync_entry is not None:
++                                sync_event, sync_result = sync_entry
++                                sync_result["ok"] = completion_ok
++                                sync_result["persisted_count"] = persisted_count
++                                sync_result["bytes_written"] = task_bytes
++                                sync_store_done_events.append(sync_event)
+ 
+                     elif op_type == self._OP_LOOKUP:
+                         bitmap = Bitmap(num_keys)
+@@ -519,10 +707,17 @@ class NativeConnectorL2Adapter(L2AdapterInterface):
+                         if evt is not None:
+                             delete_done_events.append(evt)
+ 
+-            # Fire listener notifications outside the lock so a slow
+-            # listener cannot stall further demux iterations.
++            # Commit byte accounting before releasing synchronous callers.
++            if keys_stored:
++                self._account_keys_stored(keys_stored, sizes_stored)
++            for evt in sync_store_done_events:
++                evt.set()
++
++            # Observer callbacks remain outside the lock and after synchronous
++            # durability completion. A slow observer must not defeat a caller's
++            # store timeout after persistence and accounting have committed.
+             if keys_stored:
+-                self._notify_keys_stored(keys_stored, sizes_stored)
++                self._notify_keys_stored_listeners(keys_stored, sizes_stored)
+             if keys_accessed:
+                 self._notify_keys_accessed(keys_accessed)
+             if keys_deleted:
+diff --git a/lmcache/v1/distributed/storage_controllers/eviction_controller.py b/lmcache/v1/distributed/storage_controllers/eviction_controller.py
+index 8624207de385ab334a102852b6d1b7c19d3182b0..899d8bf2166c2451fde6605dc839fa912e0e22f5 100644
+--- a/lmcache/v1/distributed/storage_controllers/eviction_controller.py
++++ b/lmcache/v1/distributed/storage_controllers/eviction_controller.py
+@@ -6,7 +6,10 @@ from __future__ import annotations
+ # Standard
+ from abc import abstractmethod
+ from collections import Counter
++from enum import Enum, auto
+ from typing import TYPE_CHECKING
++import inspect
++import math
+ import threading
+ import time
+ 
+@@ -16,6 +19,7 @@ from lmcache.v1.distributed.api import ObjectKey
+ from lmcache.v1.distributed.config import EvictionConfig
+ from lmcache.v1.distributed.eviction import L1EvictionPolicy, L2EvictionPolicy
+ from lmcache.v1.distributed.eviction_policy import CreateEvictionPolicy
++from lmcache.v1.distributed.error import L1Error
+ from lmcache.v1.distributed.internal_api import (
+     EvictionAction,
+     EvictionDestination,
+@@ -33,6 +37,12 @@ if TYPE_CHECKING:
+ logger = init_logger(__name__)
+ 
+ 
++class _SyncFlushResult(Enum):
++    SUCCESS = auto()
++    FAILURE = auto()
++    DEADLINE_EXHAUSTED = auto()
++
++
+ class EvictionController(StorageControllerInterface):
+     """
+     Abstract base class for eviction controllers.
+@@ -92,12 +102,33 @@ class L1EvictionController(EvictionController):
+     Uses an L1EvictionPolicy bridge to keep the eviction policy up-to-date
+     with L1 manager events, and periodically triggers eviction based on
+     L1 memory usage.
++
++    With ``EvictionConfig.write_back_on_evict`` enabled and L2 adapters
++    injected via ``set_l2_adapters``, eviction actions target
++    ``EvictionDestination.L2_CACHE``: readable objects are synchronously
++    persisted to L2 in bounded batches and deleted from L1 only once every
++    key in the batch is durable. Repeated flush failures open a circuit
++    breaker that pauses write-back instead of retrying every second.
++
++    ``EvictionConfig.periodic_flush_interval`` additionally enables a
++    below-watermark backup flush that copies evictable L1 keys to L2
++    without deleting them from L1.
+     """
+ 
++    # Bounded batches keep each blocking sync-store call short.
++    _SYNC_FLUSH_BATCH_SIZE = 128
++    # Keys per periodic backup flush cycle.
++    _BACKUP_FLUSH_BATCH_SIZE = 128
++    # A prefetch request must not stall the controller indefinitely on L2.
++    _EMERGENCY_FLUSH_TIMEOUT_SECONDS = 1.0
++    # Periodic backup runs under the flush lock and must remain stoppable.
++    _PERIODIC_FLUSH_TIMEOUT_SECONDS = 5.0
++
+     def __init__(
+         self,
+         l1_manager: L1Manager,
+         eviction_config: EvictionConfig,
++        l2_adapters: dict[int, L2AdapterInterface] | None = None,
+     ):
+         super().__init__()
+         self._eviction_config = eviction_config
+@@ -108,13 +139,101 @@ class L1EvictionController(EvictionController):
+         self._event_bus = get_event_bus()
+         self._last_extra_log = time.monotonic()
+ 
++        self._write_back_enabled = bool(eviction_config.write_back_on_evict)
++        self._l2_adapters: dict[int, L2AdapterInterface] = {}
++        self._l2_adapter_supports_timeout: dict[int, bool] = {}
++        self._l2_adapters_lock = threading.Lock()
++        # Serializes all synchronous L2 flushes and adapter-set replacement.
++        # StorageManager can therefore remove an adapter only after any L1
++        # writeback currently using it has finished.
++        self._flush_lock = threading.Lock()
++        # Sync-flush circuit breaker: a dead L2 must not cause a
++        # multi-thousand-key synchronous retry and warning storm every
++        # second.
++        self._sync_flush_failures: int = 0
++        self._sync_flush_backoff_until: float = 0.0
++        self._last_backup_flush = time.monotonic()
++        self._backup_flush_cursor: int = 0
++        # Serializes emergency evictions from concurrent callers.
++        self._emergency_evict_lock = threading.Lock()
++        if self._write_back_enabled:
++            # Writeback must fail closed. Register the L2 destination even
++            # before a compatible adapter exists so policy never falls back
++            # to DISCARD when persistence is unavailable.
++            self._eviction_policy.register_eviction_destination(
++                EvictionDestination.L2_CACHE
++            )
++        if l2_adapters:
++            self.set_l2_adapters(l2_adapters)
++
++    def set_l2_adapters(self, l2_adapters: dict[int, L2AdapterInterface]) -> None:
++        """Late-inject L2 adapters after StorageManager creates them.
++
++        Only adapters with an explicit synchronous durability contract are
++        eligible. The L2 eviction destination itself is registered at
++        construction so enabled writeback always fails closed.
++        """
++        compatible: dict[int, L2AdapterInterface] = {}
++        supports_timeout: dict[int, bool] = {}
++        for adapter_id, adapter in l2_adapters.items():
++            sync_store = getattr(adapter, "store_objects_sync", None)
++            if not callable(sync_store):
++                continue
++            compatible[adapter_id] = adapter
++            try:
++                supports_timeout[adapter_id] = (
++                    "timeout" in inspect.signature(sync_store).parameters
++                )
++            except (TypeError, ValueError):
++                supports_timeout[adapter_id] = False
++        ignored = sorted(set(l2_adapters) - set(compatible))
++        if ignored:
++            logger.warning(
++                "L1 writeback ignored adapters without store_objects_sync: %s",
++                ignored,
++            )
++        with self._flush_lock:
++            with self._l2_adapters_lock:
++                self._l2_adapters = compatible
++                self._l2_adapter_supports_timeout = supports_timeout
++
++    def has_l2_flush_adapter(self) -> bool:
++        """Return whether a synchronous durability backend is available."""
++        return bool(self._snapshot_l2_adapters())
++
++    def _snapshot_l2_adapters(self) -> list[tuple[int, L2AdapterInterface]]:
++        with self._l2_adapters_lock:
++            return list(self._l2_adapters.items())
++
++    def _snapshot_l2_flush_adapters(
++        self,
++    ) -> list[tuple[int, L2AdapterInterface, bool]]:
++        with self._l2_adapters_lock:
++            return [
++                (
++                    adapter_id,
++                    adapter,
++                    self._l2_adapter_supports_timeout.get(adapter_id, False),
++                )
++                for adapter_id, adapter in self._l2_adapters.items()
++            ]
++
+     def report_status(self) -> dict:
++        adapters = self._snapshot_l2_adapters()
+         return {
+             "is_healthy": self._thread.is_alive(),
+             "thread_alive": self._thread.is_alive(),
+             "eviction_policy": self._eviction_config.eviction_policy,
+             "trigger_watermark": self._eviction_config.trigger_watermark,
+             "eviction_ratio": self._eviction_config.eviction_ratio,
++            "write_back_enabled": self._write_back_enabled,
++            "l2_flush_enabled": bool(adapters),
++            "l2_flush_adapter_ids": [adapter_id for adapter_id, _ in adapters],
++            "periodic_flush_interval": (self._eviction_config.periodic_flush_interval),
++            "sync_flush_failures": self._sync_flush_failures,
++            "sync_flush_backoff_seconds": max(
++                0.0, self._sync_flush_backoff_until - time.monotonic()
++            ),
+         }
+ 
+     def _publish_skipped(self, usage: float, watermark: float) -> None:
+@@ -160,6 +279,7 @@ class L1EvictionController(EvictionController):
+     def eviction_loop(self):
+         watermark = self._eviction_config.trigger_watermark
+         eviction_ratio = self._eviction_config.eviction_ratio
++        backup_interval = self._eviction_config.periodic_flush_interval
+ 
+         while not self._stop_flag.is_set():
+             time.sleep(1)
+@@ -168,6 +288,13 @@ class L1EvictionController(EvictionController):
+                 self._maybe_log_memory_usage(used_bytes, total_bytes)
+             usage = 0 if total_bytes == 0 else used_bytes / total_bytes
+             if usage < watermark:
++                if (
++                    backup_interval > 0
++                    and self._snapshot_l2_adapters()
++                    and time.monotonic() - self._last_backup_flush >= backup_interval
++                ):
++                    self._last_backup_flush = time.monotonic()
++                    self._backup_to_l2_no_delete(self._BACKUP_FLUSH_BATCH_SIZE)
+                 logger.debug(
+                     "L1 memory usage %.2f below watermark %.2f; skipping eviction.",
+                     usage,
+@@ -176,6 +303,13 @@ class L1EvictionController(EvictionController):
+                 self._publish_skipped(usage, watermark)
+                 continue
+ 
++            if (
++                self._write_back_enabled
++                and time.monotonic() < self._sync_flush_backoff_until
++            ):
++                self._publish_skipped(usage, watermark)
++                continue
++
+             logger.info(
+                 "L1 memory usage %.2f above watermark %.2f; triggering eviction.",
+                 usage,
+@@ -190,13 +324,340 @@ class L1EvictionController(EvictionController):
+             self._publish_triggered(usage, watermark)
+ 
+     def execute_eviction_action(self, action: EvictionAction):
+-        if action.destination == EvictionDestination.DISCARD:
++        if action.destination == EvictionDestination.L2_CACHE:
++            self._flush_to_l2_then_delete(action.keys)
++        elif action.destination == EvictionDestination.DISCARD:
+             self._l1_manager.delete(action.keys)
+         else:
+             logger.error("Unsupported eviction destination: %s", action.destination)
+             logger.error("Treating it as DISCARD.")
+             self._l1_manager.delete(action.keys)
+ 
++    def emergency_evict_bytes(self, target_free_bytes: int, requester: str = "") -> int:
++        """Synchronously evict LRU L1 keys until at least
++        ``target_free_bytes`` bytes are free.
++
++        Victims take the normal eviction path, so with write-back enabled
++        they are flushed to L2 before deletion. Intended for the prefetch
++        controller when a large L2-to-L1 restore cannot reserve L1 buffers.
++
++        Args:
++            target_free_bytes: The free-space goal in bytes.
++            requester: Optional label for logging.
++
++        Returns:
++            The free byte count after eviction.
++        """
++        deadline = time.monotonic() + self._EMERGENCY_FLUSH_TIMEOUT_SECONDS
++        if not self._emergency_evict_lock.acquire(
++            timeout=self._EMERGENCY_FLUSH_TIMEOUT_SECONDS
++        ):
++            used, total = self._l1_manager.get_memory_usage()
++            return max(0, total - used)
++        try:
++            used, total = self._l1_manager.get_memory_usage()
++            free = max(0, total - used)
++            if free >= target_free_bytes:
++                return free
++            deficit = target_free_bytes - free
++            num_objects = self._l1_manager.num_objects()
++            if num_objects <= 0:
++                return free
++            if self._write_back_enabled and (
++                time.monotonic() < self._sync_flush_backoff_until
++                or not self.has_l2_flush_adapter()
++            ):
++                return free
++            per_key = max(1, used // num_objects)
++            need_keys = math.ceil(deficit / per_key)
++            need_keys += max(1, math.ceil(need_keys / 8))
++            tracked = num_objects
++            get_tracked = getattr(self._eviction_policy, "get_num_tracked_keys", None)
++            if callable(get_tracked):
++                tracked = max(1, int(get_tracked()))
++            ratio = min(1.0, need_keys / max(tracked, 1))
++            start = time.monotonic()
++            actions = self._eviction_policy.get_eviction_actions(
++                ratio,
++                key_eligible_filter=self._l1_manager.is_key_evictable,
++            )
++            evicted_keys = 0
++            for action in actions:
++                evicted_keys += len(action.keys)
++                if action.destination == EvictionDestination.L2_CACHE:
++                    self._flush_to_l2_then_delete(action.keys, deadline=deadline)
++                else:
++                    self.execute_eviction_action(action)
++                if time.monotonic() >= deadline:
++                    break
++            used_after, total_after = self._l1_manager.get_memory_usage()
++            free_after = max(0, total_after - used_after)
++            logger.info(
++                "Emergency L1 eviction%s: wanted %.0f MB free, evicted %d "
++                "keys in %.0f ms; free %.0f MB -> %.0f MB",
++                (" for " + requester) if requester else "",
++                target_free_bytes / 1e6,
++                evicted_keys,
++                (time.monotonic() - start) * 1000.0,
++                free / 1e6,
++                free_after / 1e6,
++            )
++            return free_after
++        finally:
++            self._emergency_evict_lock.release()
++
++    def _flush_to_l2_then_delete(
++        self,
++        keys: list[ObjectKey],
++        deadline: float | None = None,
++    ) -> None:
++        """Persist bounded batches to L2 and delete only fully durable
++        batches from L1.
++
++        The native adapter reports a store successful only when every key
++        persisted, so this method conservatively retains the whole readable
++        batch on any partial failure. Repeated failures open the circuit
++        breaker with exponential backoff.
++        """
++        if deadline is None:
++            self._flush_lock.acquire()
++        else:
++            remaining = deadline - time.monotonic()
++            if remaining <= 0 or not self._flush_lock.acquire(timeout=remaining):
++                return
++        try:
++            if not keys:
++                return
++            if time.monotonic() < self._sync_flush_backoff_until:
++                return
++
++            all_ok = True
++            deadline_exhausted = False
++            for start in range(0, len(keys), self._SYNC_FLUSH_BATCH_SIZE):
++                if deadline is not None and time.monotonic() >= deadline:
++                    deadline_exhausted = True
++                    break
++                batch = keys[start : start + self._SYNC_FLUSH_BATCH_SIZE]
++                result = self._flush_one_l2_batch_then_delete(batch, deadline=deadline)
++                if result == _SyncFlushResult.DEADLINE_EXHAUSTED:
++                    deadline_exhausted = True
++                    break
++                if result == _SyncFlushResult.FAILURE:
++                    all_ok = False
++                    break
++
++            if deadline_exhausted:
++                logger.debug(
++                    "L1-to-L2 emergency flush exhausted its time budget; "
++                    "remaining L1 keys preserved"
++                )
++            elif all_ok:
++                self._sync_flush_failures = 0
++                self._sync_flush_backoff_until = 0.0
++            else:
++                self._sync_flush_failures += 1
++                delay = min(60.0, float(2 ** min(self._sync_flush_failures, 6)))
++                self._sync_flush_backoff_until = time.monotonic() + delay
++                logger.warning(
++                    "L1-to-L2 flush circuit breaker: failure=%d, retry in %.0fs; "
++                    "remaining L1 keys preserved",
++                    self._sync_flush_failures,
++                    delay,
++                )
++        finally:
++            self._flush_lock.release()
++
++    def _flush_one_l2_batch_then_delete(
++        self,
++        keys: list[ObjectKey],
++        deadline: float | None = None,
++    ) -> _SyncFlushResult:
++        """Flush one batch to L2; delete from L1 only when fully durable.
++
++        Returns:
++            SUCCESS when every readable key was persisted (or none were
++            readable), FAILURE for an actual persistence failure, and
++            DEADLINE_EXHAUSTED when an emergency flush consumed its budget.
++        """
++        if not keys:
++            return _SyncFlushResult.SUCCESS
++
++        read_result = self._l1_manager.reserve_read(keys)
++        readable_keys: list[ObjectKey] = []
++        readable_objs = []
++        for key in keys:
++            entry = read_result.get(key)
++            if (
++                entry is not None
++                and entry[0] == L1Error.SUCCESS
++                and entry[1] is not None
++            ):
++                readable_keys.append(key)
++                readable_objs.append(entry[1])
++
++        flushed = not readable_keys
++        deadline_exhausted = False
++        if readable_keys:
++            try:
++                for (
++                    idx,
++                    adapter,
++                    supports_timeout,
++                ) in self._snapshot_l2_flush_adapters():
++                    sync_store = adapter.store_objects_sync
++                    try:
++                        if deadline is None:
++                            result = sync_store(readable_keys, readable_objs)
++                        else:
++                            remaining = deadline - time.monotonic()
++                            if remaining <= 0:
++                                deadline_exhausted = True
++                                break
++                            if not supports_timeout:
++                                logger.warning(
++                                    "Emergency L1 writeback skipped adapter %d: "
++                                    "store_objects_sync has no timeout contract",
++                                    idx,
++                                )
++                                continue
++                            result = sync_store(
++                                readable_keys,
++                                readable_objs,
++                                timeout=remaining,
++                            )
++                        ok, persisted_count, bytes_written = result
++                    except Exception:
++                        if deadline is not None and time.monotonic() >= deadline:
++                            deadline_exhausted = True
++                            break
++                        logger.exception(
++                            "L1-to-L2 flush: sync store failed on adapter %d", idx
++                        )
++                        continue
++                    if not ok and deadline is not None and time.monotonic() >= deadline:
++                        deadline_exhausted = True
++                        break
++                    # Never delete unless every readable key is durable.
++                    if ok and persisted_count == len(readable_keys):
++                        flushed = True
++                        logger.info(
++                            "L1-to-L2 flush: sync persisted %d/%d keys "
++                            "(%d bytes) via adapter %d",
++                            persisted_count,
++                            len(readable_keys),
++                            bytes_written,
++                            idx,
++                        )
++                        break
++                    logger.warning(
++                        "L1-to-L2 flush: adapter %d partial/failed persist "
++                        "(%d/%d keys, %d bytes)",
++                        idx,
++                        persisted_count,
++                        len(readable_keys),
++                        bytes_written,
++                    )
++            finally:
++                self._l1_manager.finish_read(readable_keys)
++
++        # Only keys we read and then fully persisted may be deleted. A key
++        # that failed reserve_read can have become locked after candidate
++        # selection and must never be treated as absent.
++        keys_to_delete = list(readable_keys) if flushed else []
++        if not flushed and readable_keys:
++            logger.warning(
++                "L1-to-L2 flush: preserving %d readable keys after failed persist",
++                len(readable_keys),
++            )
++
++        if keys_to_delete:
++            result = self._l1_manager.delete(keys_to_delete)
++            not_deleted = [k for k, err in result.items() if err != L1Error.SUCCESS]
++            if not_deleted:
++                logger.debug(
++                    "L1-to-L2 flush: %d keys not deleted, likely still locked",
++                    len(not_deleted),
++                )
++        if deadline_exhausted:
++            return _SyncFlushResult.DEADLINE_EXHAUSTED
++        if flushed:
++            return _SyncFlushResult.SUCCESS
++        return _SyncFlushResult.FAILURE
++
++    def _backup_to_l2_no_delete(self, batch_limit: int) -> None:
++        """Flush evictable L1 keys to L2 without deleting them from L1.
++
++        A backup, not an eviction: keys remain in L1 for fast access while
++        L2 gains a copy, so losing L1 (session expiry, restart) no longer
++        costs a cold prefill. A rotating cursor spreads repeated scans over
++        the whole L1 keyspace instead of hammering the first ``batch_limit``
++        insertion-ordered keys forever. Adapters skip keys they already
++        hold, so the flush is idempotent.
++        """
++        with self._flush_lock:
++            self._backup_to_l2_no_delete_locked(batch_limit)
++
++    def _backup_to_l2_no_delete_locked(self, batch_limit: int) -> None:
++        """Implementation of periodic backup under ``_flush_lock``."""
++        batch, self._backup_flush_cursor = self._l1_manager.get_evictable_keys(
++            limit=batch_limit,
++            cursor=self._backup_flush_cursor,
++        )
++        if not batch:
++            return
++
++        read_result = self._l1_manager.reserve_read(batch)
++        readable_keys: list[ObjectKey] = []
++        readable_objs = []
++        for key in batch:
++            entry = read_result.get(key)
++            if (
++                entry is not None
++                and entry[0] == L1Error.SUCCESS
++                and entry[1] is not None
++            ):
++                readable_keys.append(key)
++                readable_objs.append(entry[1])
++
++        if not readable_keys:
++            return
++
++        persisted_keys = 0
++        persisted_bytes = 0
++        try:
++            for idx, adapter, supports_timeout in self._snapshot_l2_flush_adapters():
++                if not supports_timeout:
++                    logger.warning(
++                        "Periodic L2 backup skipped adapter %d: "
++                        "store_objects_sync has no timeout contract",
++                        idx,
++                    )
++                    continue
++                sync_store = adapter.store_objects_sync
++                try:
++                    ok, persisted, written = sync_store(
++                        readable_keys,
++                        readable_objs,
++                        timeout=self._PERIODIC_FLUSH_TIMEOUT_SECONDS,
++                    )
++                    if ok and persisted == len(readable_keys):
++                        persisted_keys = persisted
++                        persisted_bytes = written
++                        break
++                except Exception:
++                    logger.exception("Periodic L2 backup: sync store failed on %d", idx)
++        finally:
++            self._l1_manager.finish_read(readable_keys)
++
++        if persisted_bytes > 0:
++            logger.info(
++                "Periodic L2 backup: persisted %d keys (%d new bytes, "
++                "%d evictable in L1, none deleted)",
++                persisted_keys,
++                persisted_bytes,
++                len(batch),
++            )
++
+ 
+ class L2AdapterEvictionState:
+     """Per-adapter eviction state: its own policy, listener, and config."""
+diff --git a/lmcache/v1/distributed/storage_controllers/prefetch_controller.py b/lmcache/v1/distributed/storage_controllers/prefetch_controller.py
+index 2138a33aa01ce95d7926bd4f6bcda79ae7d1955a..46239e518abaee70412223ec76eaa89f934a4bbe 100644
+--- a/lmcache/v1/distributed/storage_controllers/prefetch_controller.py
++++ b/lmcache/v1/distributed/storage_controllers/prefetch_controller.py
+@@ -55,6 +55,9 @@ from lmcache.v1.platform import (
+ 
+ if TYPE_CHECKING:
+     # First Party
++    from lmcache.v1.distributed.storage_controllers.eviction_controller import (
++        L1EvictionController,
++    )
+     from lmcache.v1.memory_management import MemoryObj
+ 
+ logger = init_logger(__name__)
+@@ -121,6 +124,17 @@ def trim_load_plan_with_mask(
+     return trimmed_plan
+ 
+ 
++def _layout_nbytes(layout_desc: MemoryLayoutDesc) -> int:
++    """Return the byte size of one object with the given layout."""
++    total = 0
++    for shape, dtype in zip(layout_desc.shapes, layout_desc.dtypes, strict=True):
++        numel = 1
++        for dim in shape:
++            numel *= int(dim)
++        total += numel * dtype.itemsize
++    return total
++
++
+ # Poll timeout in milliseconds for the prefetch loop
+ PREFETCH_LOOP_POLL_TIMEOUT_MS = 500
+ 
+@@ -227,6 +241,11 @@ class PrefetchController(StorageControllerInterface):
+         self._policy = policy
+         self._max_in_flight = max_in_flight
+ 
++        # Optional L1 eviction controller for emergency make-room before
++        # large restores; injected by StorageManager when
++        # EvictionConfig.emergency_evict_for_prefetch is enabled.
++        self._l1_eviction_controller: "L1EvictionController | None" = None
++
+         # Adapters that are being drained and will be removed after all
+         # the in-flight operations are done.
+         self._draining: dict[int, threading.Event] = {}
+@@ -847,6 +866,25 @@ class PrefetchController(StorageControllerInterface):
+     # =========================================================================
+     # Load phase
+     # =========================================================================
++    def _select_l1_retentions(
++        self,
++        request_id: int,
++        keys: list[ObjectKey],
++    ) -> list[bool]:
++        """Return one retention decision per key, degrading safely on a
++        malformed policy result."""
++        retentions = self._policy.select_l1_retentions(keys)
++        if len(retentions) != len(keys):
++            logger.error(
++                "Prefetch request %d: policy returned %d retentions for "
++                "%d keys; defaulting to temporary entries",
++                request_id,
++                len(retentions),
++                len(keys),
++            )
++            return [False] * len(keys)
++        return retentions
++
+     def _transition_to_load_phase(self, request: InFlightPrefetchRequest) -> None:
+         """Compute load plan, reserve L1 buffers, and submit load tasks."""
+         request.phase = PrefetchPhase.PLAN_AND_LOAD
+@@ -899,15 +937,23 @@ class PrefetchController(StorageControllerInterface):
+         if request.mode is PrefetchMode.WARM:
+             retentions = [True] * len(keys_to_reserve)
+         else:
+-            retentions = self._policy.select_l1_retentions(
++            retentions = self._select_l1_retentions(
++                request.request_id,
+                 keys_to_reserve,
+             )
++            # Non-WARM only: a WARM warm-up must never trigger emergency
++            # eviction of other sessions' chunks.
++            self._make_room_for_restore(request, keys_to_reserve)
+         write_results = l1_mgr.reserve_write(
+             keys=keys_to_reserve,
+             is_temporary=[not r for r in retentions],
+             layout_desc=request.layout_desc,
+             mode="new",
+         )
++        if request.mode is not PrefetchMode.WARM:
++            write_results = self._retry_oom_reservations(
++                request, keys_to_reserve, retentions, write_results
++            )
+ 
+         # Step 4: filter to successfully reserved keys
+         reserved_key_set: set[ObjectKey] = set()
+@@ -1038,6 +1084,123 @@ class PrefetchController(StorageControllerInterface):
+             len(reserved_key_set),
+         )
+ 
++    def set_l1_eviction_controller(
++        self,
++        controller: "L1EvictionController | None",
++    ) -> None:
++        """Enable emergency L1 eviction for large restores.
++
++        With a controller injected, a non-WARM restore that would not fit
++        in free L1 space synchronously evicts LRU keys (write-back first)
++        before reserving, and retries OOM reservations once. Pass ``None``
++        after the last synchronous L2 adapter is removed to disable this path.
++        """
++        self._l1_eviction_controller = controller
++
++    # Never let a single restore claim more than this fraction of L1: a
++    # huge context must not wipe every hot chunk of the running sessions.
++    _EMERGENCY_EVICT_MAX_L1_FRACTION = 0.6
++    # Headroom per object for alignment and allocator bookkeeping.
++    _PER_OBJECT_HEADROOM_BYTES = 8192
++
++    def _make_room_for_restore(
++        self,
++        request: InFlightPrefetchRequest,
++        keys_to_reserve: list[ObjectKey],
++    ) -> None:
++        """Pre-evict LRU L1 chunks so the upcoming reserve_write for this
++        restore can succeed. No-op unless an eviction controller was
++        injected via ``set_l1_eviction_controller``."""
++        evictor = self._l1_eviction_controller
++        if evictor is None or not keys_to_reserve:
++            return
++        per_obj = _layout_nbytes(request.layout_desc)
++        if per_obj <= 0:
++            return
++        used, total = self._l1_manager.get_memory_usage()
++        need = (per_obj + self._PER_OBJECT_HEADROOM_BYTES) * len(keys_to_reserve)
++        need = min(need, int(total * self._EMERGENCY_EVICT_MAX_L1_FRACTION))
++        free = max(0, total - used)
++        if free >= need:
++            return
++        try:
++            evictor.emergency_evict_bytes(
++                need, requester=f"prefetch_request={request.request_id}"
++            )
++        except Exception:
++            logger.exception(
++                "Emergency eviction failed for prefetch request %d",
++                request.request_id,
++            )
++
++    def _retry_oom_reservations(
++        self,
++        request: InFlightPrefetchRequest,
++        keys_to_reserve: list[ObjectKey],
++        retentions: list[bool],
++        write_results: dict[ObjectKey, tuple[L1Error, "MemoryObj | None"]],
++    ) -> dict[ObjectKey, tuple[L1Error, "MemoryObj | None"]]:
++        """One retry round for keys whose reservation failed with
++        OUT_OF_MEMORY: evict the missing amount, reserve just those keys
++        again, and merge the results. No-op unless an eviction controller
++        was injected."""
++        evictor = self._l1_eviction_controller
++        if evictor is None:
++            return write_results
++        oom_keys: list[ObjectKey] = []
++        retention_by_key = dict(zip(keys_to_reserve, retentions, strict=True))
++        for key in keys_to_reserve:
++            entry = write_results.get(key)
++            if entry is None:
++                oom_keys.append(key)
++                continue
++            err, mem_obj = entry
++            if err == L1Error.OUT_OF_MEMORY or (
++                err == L1Error.SUCCESS and mem_obj is None
++            ):
++                oom_keys.append(key)
++        if not oom_keys:
++            return write_results
++        per_obj = _layout_nbytes(request.layout_desc)
++        if per_obj <= 0:
++            return write_results
++        _, total = self._l1_manager.get_memory_usage()
++        need = (per_obj + self._PER_OBJECT_HEADROOM_BYTES) * len(oom_keys)
++        need = min(need, int(total * self._EMERGENCY_EVICT_MAX_L1_FRACTION))
++        try:
++            evictor.emergency_evict_bytes(
++                need, requester=f"prefetch_request={request.request_id}/retry"
++            )
++        except Exception:
++            logger.exception(
++                "Emergency eviction retry failed for prefetch request %d",
++                request.request_id,
++            )
++            return write_results
++        retry_results = self._l1_manager.reserve_write(
++            keys=oom_keys,
++            is_temporary=[not retention_by_key[k] for k in oom_keys],
++            layout_desc=request.layout_desc,
++            mode="new",
++        )
++        recovered = sum(
++            1
++            for k in oom_keys
++            if retry_results.get(k)
++            and retry_results[k][0] == L1Error.SUCCESS
++            and retry_results[k][1] is not None
++        )
++        if recovered:
++            logger.info(
++                "Retry recovered %d/%d OOM reservations for prefetch request %d",
++                recovered,
++                len(oom_keys),
++                request.request_id,
++            )
++        merged = dict(write_results)
++        merged.update(retry_results)
++        return merged
++
+     def _update_lookup_results(
+         self, request_id: PrefetchRequestId, prefix_hit_count: int
+     ) -> None:
+@@ -1181,6 +1344,17 @@ class PrefetchController(StorageControllerInterface):
+         # added once the serde PR lands and adapters can distinguish
+         # deserialization errors from missing objects.
+         if failed_keys:
++            # These keys were reported present by the L2 lookup but the load
++            # returned no data. Sample a few so the on-disk state can be
++            # inspected post hoc.
++            logger.warning(
++                "Prefetch request %d: %d/%d plan keys failed to load from "
++                "L2 (lookup hit, load empty); sample: %s",
++                request.request_id,
++                len(failed_keys),
++                len(request.write_reserved_keys),
++                [str(k)[:160] for k in failed_keys[:3]],
++            )
+             self._event_bus.publish(
+                 Event(
+                     event_type=EventType.L2_PREFETCH_FAILED,
+diff --git a/lmcache/v1/distributed/storage_manager.py b/lmcache/v1/distributed/storage_manager.py
+index 3054e2441c5c7d98d817ca7a1f9ac30b4a7e92d7..a7da312a475264ddd1c829ad73937fc103cbf1a8 100644
+--- a/lmcache/v1/distributed/storage_manager.py
++++ b/lmcache/v1/distributed/storage_manager.py
+@@ -66,6 +66,7 @@ logger = init_logger(__name__)
+ 
+ class StorageManager:
+     def __init__(self, config: StorageManagerConfig):
++        self._eviction_config = config.eviction_config
+         self._l1_manager = L1Manager(config.l1_manager_config)
+         self._event_bus = get_event_bus()
+ 
+@@ -154,6 +155,31 @@ class StorageManager:
+         )
+         self._prefetch_controller.start()
+ 
++        # Opt-in L1 write-back tier: wire L2 adapters into the L1 eviction
++        # controller so evicted or periodically backed-up chunks are flushed
++        # to L2, and optionally let the prefetch controller trigger
++        # emergency eviction to make room for large restores.
++        eviction_config = config.eviction_config
++        wants_l1_write_back = (
++            eviction_config.write_back_on_evict
++            or eviction_config.periodic_flush_interval > 0
++        )
++        if wants_l1_write_back:
++            self._sync_l1_writeback_adapters()
++            if not self._eviction_controller.has_l2_flush_adapter():
++                logger.warning(
++                    "write_back_on_evict / periodic_flush_interval is set but "
++                    "no L2 adapter exposes store_objects_sync"
++                )
++        if (
++            eviction_config.emergency_evict_for_prefetch
++            and not self._eviction_controller.has_l2_flush_adapter()
++        ):
++            logger.warning(
++                "emergency_evict_for_prefetch has no synchronous L2 "
++                "adapter; inactive until one is added"
++            )
++
+         # L2 usage gauge — one observation per adapter, tagged by
+         # ``l2_name``.  Parallel to L1Manager's ``l1_memory_usage_bytes``.
+         register_gauge(
+@@ -904,6 +930,7 @@ class StorageManager:
+             with self._adapters_lock:
+                 self._l2_adapters[adapter_id] = adapter
+                 self._adapter_descriptors[adapter_id] = descriptor
++            self._sync_l1_writeback_adapters()
+             self._store_controller.add_adapter(adapter_id, adapter, descriptor)
+             self._prefetch_controller.add_adapter(adapter_id, adapter, descriptor)
+             if self._should_enable_l2_eviction(adapter, config.eviction_config):
+@@ -956,6 +983,9 @@ class StorageManager:
+             with self._adapters_lock:
+                 adapter = self._l2_adapters.pop(adapter_id)
+                 self._adapter_descriptors.pop(adapter_id, None)
++            # Waits for any synchronous L1 flush using the removed adapter
++            # before adapter.close() releases its native resources.
++            self._sync_l1_writeback_adapters()
+             adapter.close()
+             logger.info("Deleted L2 adapter %d", adapter_id)
+ 
+@@ -1121,6 +1151,21 @@ class StorageManager:
+             return False
+         return True
+ 
++    def _sync_l1_writeback_adapters(self) -> None:
++        """Publish the current adapter set to the optional L1 writeback tier."""
++        config = self._eviction_config
++        if not (config.write_back_on_evict or config.periodic_flush_interval > 0):
++            return
++        with self._adapters_lock:
++            adapters = dict(self._l2_adapters)
++        self._eviction_controller.set_l2_adapters(adapters)
++        if config.emergency_evict_for_prefetch:
++            self._prefetch_controller.set_l1_eviction_controller(
++                self._eviction_controller
++                if self._eviction_controller.has_l2_flush_adapter()
++                else None
++            )
++
+     def _unwrap_reconfigurable_l2_adapter(
+         self,
+         adapter: L2AdapterInterface,
+diff --git a/lmcache/v1/multiprocess/futures.py b/lmcache/v1/multiprocess/futures.py
+index beadae5505e4062d95b3e5f083d8e72b6bdf06d1..ab5195eec56aa3fcd9b52550aac52dc6133680b4 100644
+--- a/lmcache/v1/multiprocess/futures.py
++++ b/lmcache/v1/multiprocess/futures.py
+@@ -14,6 +14,7 @@ class MessagingFuture(Generic[T]):
+     def __init__(self):
+         self.is_done_ = threading.Event()
+         self.result_ = None
++        self.exception_: BaseException | None = None
+ 
+     def query(self) -> bool:
+         """
+@@ -54,6 +55,8 @@ class MessagingFuture(Generic[T]):
+         flag = self.wait(timeout)
+         if not flag:
+             raise LMCacheTimeoutError("Future result not available within timeout")
++        if self.exception_ is not None:
++            raise self.exception_
+         return self.result_
+ 
+     def set_result(self, result: T) -> None:
+@@ -68,6 +71,13 @@ class MessagingFuture(Generic[T]):
+         self.result_ = result
+         self.is_done_.set()
+ 
++    def set_exception(self, exception: BaseException) -> None:
++        """Complete the future with an exception from the messaging system."""
++        if not isinstance(exception, BaseException):
++            raise TypeError("exception must derive from BaseException")
++        self.exception_ = exception
++        self.is_done_.set()
++
+     def to_cuda_future(
+         self,
+         device: Any | None = None,
+diff --git a/lmcache/v1/multiprocess/mq.py b/lmcache/v1/multiprocess/mq.py
+index 271ff93b2a933f6c0f70f95a95d6f2249e7636c1..a5d0d0cf7322a523a9a8b89a0c5af2e2466109b1 100644
+--- a/lmcache/v1/multiprocess/mq.py
++++ b/lmcache/v1/multiprocess/mq.py
+@@ -40,6 +40,26 @@ T = TypeVar("T")
+ # Internal type used for the client-server communication
+ RequestUID = int
+ 
++_ERROR_RESPONSE_MARKER = b"LMCACHE_RPC_ERROR_V1"
++_MAX_REMOTE_ERROR_MESSAGE_BYTES = 4096
++
++
++class RemoteHandlerError(RuntimeError):
++    """A request handler failed in the remote LMCache process."""
++
++    def __init__(
++        self, request_type: RequestType, error_type: str, message: str
++    ) -> None:
++        self.request_type = request_type
++        self.error_type = error_type
++        self.remote_message = message
++        super().__init__(f"{request_type.name} handler failed: {error_type}: {message}")
++
++
++class _RemoteErrorPayload(msgspec.Struct, frozen=True):
++    error_type: str
++    message: str
++
+ 
+ # Helper functions
+ def encode_request_uid(uid: RequestUID) -> bytes:
+@@ -346,7 +366,28 @@ class MessageQueueClient:
+ 
+         if request_uid in self.pending_futures:
+             future = self.pending_futures.pop(request_uid)
+-            if b_response:
++            if b_response and b_response[0] == _ERROR_RESPONSE_MARKER:
++                if len(b_response) != 2:
++                    future.set_exception(
++                        RuntimeError("Malformed LMCache RPC error response")
++                    )
++                    return
++                try:
++                    error = msgspec_decode(b_response[1], cls=_RemoteErrorPayload)
++                except Exception:
++                    future.set_exception(
++                        RuntimeError("Failed to decode LMCache RPC error response")
++                    )
++                    logger.exception("Failed to decode RPC error response")
++                    return
++                future.set_exception(
++                    RemoteHandlerError(
++                        request_type=request_type,
++                        error_type=error.error_type,
++                        message=error.message,
++                    )
++                )
++            elif b_response:
+                 response = msgspec_decode(b_response[0], cls=response_cls)
+                 future.set_result(response)
+             else:
+@@ -516,6 +557,24 @@ class MessageQueueServer:
+         # Thread pools assigned via add_normal_thread_pool / add_affinity_thread_pool
+         self.extra_pools: list[ThreadPoolExecutor | AffinityThreadPool] = []
+ 
++    def _queue_error_response(
++        self, prefix_frames: list[bytes], exception: BaseException
++    ) -> None:
++        """Return a bounded error response without touching ZMQ off-thread."""
++        message = str(exception).encode("utf-8")[:_MAX_REMOTE_ERROR_MESSAGE_BYTES]
++        payload = _RemoteErrorPayload(
++            error_type=type(exception).__name__,
++            message=message.decode("utf-8", errors="replace"),
++        )
++        self.output_queue.put(
++            prefix_frames
++            + [
++                _ERROR_RESPONSE_MARKER,
++                msgspec_encode(payload, cls=_RemoteErrorPayload),
++            ]
++        )
++        self._output_efd.notify()
++
+     def _call_sync_handler(
+         self,
+         handler_entry: SyncRequestHandler[Any],
+@@ -571,8 +630,9 @@ class MessageQueueServer:
+                 self.output_queue.put(frames_to_send)
+                 self._output_efd.notify()
+ 
+-            except Exception:
++            except Exception as exc:
+                 logger.exception("Error in blocking handler")
++                self._queue_error_response(prefix_frames, exc)
+ 
+         future.add_done_callback(_notify_response)
+ 
+@@ -619,13 +679,23 @@ class MessageQueueServer:
+                             payloads=payloads,
+                             prefix_frames=[identity, b_request_uid, b_request_type],
+                         )
+-                    except Exception:
++                    except Exception as exc:
+                         logger.exception("Error handling request %s", request_type)
++                        self._queue_error_response(
++                            [identity, b_request_uid, b_request_type], exc
++                        )
+                 else:
+                     logger.error(
+                         "No handler registered for request type %s", request_type
+                     )
+                     logger.error("Available handlers: %s", list(self.handlers.keys()))
++                    self._queue_error_response(
++                        [identity, b_request_uid, b_request_type],
++                        RuntimeError(
++                            "No handler registered for request type "
++                            f"{request_type.name}"
++                        ),
++                    )
+ 
+             # Send the responses
+             if outbound_state and outbound_state & zmq.POLLIN:
+diff --git a/tests/v1/distributed/test_fs_native_startup_scan.py b/tests/v1/distributed/test_fs_native_startup_scan.py
+new file mode 100644
+index 0000000000000000000000000000000000000000..796c27e183c9ff0bc923b4d5fbe7e7dfdb6957bc
+--- /dev/null
++++ b/tests/v1/distributed/test_fs_native_startup_scan.py
+@@ -0,0 +1,78 @@
++# SPDX-License-Identifier: Apache-2.0
++"""Restart accounting for the native filesystem L2 adapter."""
++
++# Standard
++import os
++
++# Third Party
++import pytest
++
++# First Party
++from lmcache.v1.distributed.api import ObjectKey
++from lmcache.v1.distributed.l2_adapters.fs_l2_adapter import (
++    _object_key_to_filename,
++)
++from lmcache.v1.distributed.l2_adapters.fs_native_l2_adapter import (
++    _scan_existing_fs_native_files,
++)
++
++
++def _key(chunk_id: int) -> ObjectKey:
++    return ObjectKey(
++        chunk_hash=ObjectKey.IntHash2Bytes(chunk_id),
++        model_name="test-model",
++        kv_rank=0,
++    )
++
++
++def _write(root, key: ObjectKey, size: int, mtime_ns: int) -> None:
++    path = root / _object_key_to_filename(key)
++    path.write_bytes(b"x" * size)
++    os.utime(path, ns=(mtime_ns, mtime_ns))
++
++
++def test_scan_returns_oldest_to_newest_keys_and_sizes(tmp_path):
++    newer = _key(2)
++    older = _key(1)
++    _write(tmp_path, newer, 200, 2_000_000_000)
++    _write(tmp_path, older, 100, 1_000_000_000)
++
++    keys, sizes = _scan_existing_fs_native_files(str(tmp_path))
++
++    assert keys == [older, newer]
++    assert sizes == [100, 200]
++
++
++def test_scan_skips_foreign_empty_and_temporary_files(tmp_path):
++    valid = _key(1)
++    _write(tmp_path, valid, 100, 1_000_000_000)
++    (tmp_path / "not-a-cache-file.data").write_bytes(b"x")
++    (tmp_path / _object_key_to_filename(_key(2))).write_bytes(b"")
++    (tmp_path / "pending.tmp").write_bytes(b"x")
++
++    keys, sizes = _scan_existing_fs_native_files(str(tmp_path))
++
++    assert keys == [valid]
++    assert sizes == [100]
++
++
++def test_scan_missing_directory_returns_empty(tmp_path):
++    assert _scan_existing_fs_native_files(str(tmp_path / "missing")) == ([], [])
++
++
++def test_scan_fails_closed_when_existing_file_cannot_be_inspected(
++    tmp_path, monkeypatch
++):
++    path = tmp_path / "broken.data"
++    path.write_bytes(b"x")
++    original_stat = type(path).stat
++
++    def fail_data_stat(self, *args, **kwargs):
++        if self == path:
++            raise OSError("injected stat failure")
++        return original_stat(self, *args, **kwargs)
++
++    monkeypatch.setattr(type(path), "stat", fail_data_stat)
++
++    with pytest.raises(RuntimeError, match="Could not inspect cache file"):
++        _scan_existing_fs_native_files(str(tmp_path))
+diff --git a/tests/v1/distributed/test_l1_manager.py b/tests/v1/distributed/test_l1_manager.py
+index fea845f903879a84856058ac107589a4b21e0fc7..5b0fb89bc77f4b274f8a27bc48c876aa3c7b54bb 100644
+--- a/tests/v1/distributed/test_l1_manager.py
++++ b/tests/v1/distributed/test_l1_manager.py
+@@ -132,18 +132,6 @@ def basic_layout():
+     )
+ 
+ 
+-@pytest.fixture
+-def large_layout():
+-    """Create a large MemoryLayoutDesc that will exhaust small memory.
+-
+-    Each allocation is 8MB (2M elements * 4 bytes).
+-    """
+-    return MemoryLayoutDesc(
+-        shapes=[torch.Size([2048, 1024])],  # 2M elements * 4 bytes = 8MB
+-        dtypes=[torch.float32],
+-    )
+-
+-
+ def make_object_key(chunk_hash: int, model_name: str = "test_model", kv_rank: int = 0):
+     """Helper to create ObjectKey instances."""
+     hash_bytes = ObjectKey.IntHash2Bytes(chunk_hash)
+@@ -879,14 +867,23 @@ class TestReserveWrite:
+ 
+         manager.close()
+ 
+-    def test_reserve_write_out_of_memory(self, small_l1_config, large_layout):
+-        """Test that reserve_write returns OUT_OF_MEMORY when allocation fails."""
++    def test_reserve_write_out_of_memory(self, small_l1_config):
++        """Test that reserve_write returns OUT_OF_MEMORY when allocation fails.
++
++        Uses an object larger than the whole pool; a batch that partially
++        fits allocates the longest prefix instead (see
++        tests/v1/distributed/test_l1_manager_partial_alloc.py).
++        """
+         manager = L1Manager(small_l1_config)
+         keys = [make_object_key(i) for i in range(10)]
+         is_temporary = [False] * 10
+ 
+-        # Request more memory than available (8MB * 10 = 80MB > 64MB)
+-        result = manager.reserve_write(keys, is_temporary, large_layout)
++        # A single object (128MB) exceeds the 64MB pool.
++        oversized_layout = MemoryLayoutDesc(
++            shapes=[torch.Size([2048 * 16, 1024])],
++            dtypes=[torch.float32],
++        )
++        result = manager.reserve_write(keys, is_temporary, oversized_layout)
+ 
+         # All keys should return OUT_OF_MEMORY
+         for key in keys:
+diff --git a/tests/v1/distributed/test_l1_manager_partial_alloc.py b/tests/v1/distributed/test_l1_manager_partial_alloc.py
+new file mode 100644
+index 0000000000000000000000000000000000000000..30ddc3fba0ce10c957ad6375874fac7df9cc8585
+--- /dev/null
++++ b/tests/v1/distributed/test_l1_manager_partial_alloc.py
+@@ -0,0 +1,151 @@
++# SPDX-License-Identifier: Apache-2.0
++"""Partial-prefix allocation behavior of ``L1Manager.reserve_write``.
++
++A batch whose full allocation does not fit must not fail every key
++(all-or-nothing would collapse large L2->L1 restores to zero prefix hits):
++the longest prefix that fits is allocated and only the tail reports
++OUT_OF_MEMORY. Uses the CPU shared-memory allocator, no GPU required.
++"""
++
++# Standard
++from collections.abc import Iterator
++from types import SimpleNamespace
++
++# Third Party
++import pytest
++import torch
++
++# First Party
++from lmcache.v1.distributed.api import MemoryLayoutDesc, ObjectKey
++from lmcache.v1.distributed.config import (
++    L1ManagerConfig,
++    L1MemoryManagerConfig,
++)
++from lmcache.v1.distributed.error import L1Error
++from lmcache.v1.distributed.l1_manager import L1Manager
++
++POOL_BYTES = 64 * 1024 * 1024
++
++# 8MB per object: ten of them cannot fit in the 64MB pool, most can.
++OBJECT_LAYOUT = MemoryLayoutDesc(
++    shapes=[torch.Size([2048, 1024])],
++    dtypes=[torch.float32],
++)
++
++# A single 128MB object exceeds the whole pool.
++OVERSIZED_LAYOUT = MemoryLayoutDesc(
++    shapes=[torch.Size([2048 * 16, 1024])],
++    dtypes=[torch.float32],
++)
++
++
++@pytest.fixture
++def manager() -> Iterator[L1Manager]:
++    config = L1ManagerConfig(
++        memory_config=L1MemoryManagerConfig(
++            size_in_bytes=POOL_BYTES,
++            use_lazy=False,
++            init_size_in_bytes=POOL_BYTES,
++            align_bytes=0x1000,
++        ),
++        write_ttl_seconds=600,
++        read_ttl_seconds=300,
++    )
++    manager = L1Manager(config)
++    yield manager
++    manager.close()
++
++
++def _make_keys(count: int) -> list[ObjectKey]:
++    return [
++        ObjectKey(
++            chunk_hash=ObjectKey.IntHash2Bytes(i),
++            model_name="test_model",
++            kv_rank=0,
++        )
++        for i in range(count)
++    ]
++
++
++def test_reserve_write_allocates_longest_prefix_on_oom(manager: L1Manager) -> None:
++    """When the full batch does not fit, a non-empty prefix succeeds and
++    only the tail reports OUT_OF_MEMORY; every requested key keeps an
++    explicit per-key result."""
++    keys = _make_keys(10)
++    result = manager.reserve_write(keys, [False] * 10, OBJECT_LAYOUT)
++
++    assert set(result) == set(keys)
++    statuses = [result[key][0] for key in keys]
++    num_success = statuses.count(L1Error.SUCCESS)
++    assert 0 < num_success < 10
++
++    # The successful keys form a prefix in request order.
++    assert statuses == [L1Error.SUCCESS] * num_success + [L1Error.OUT_OF_MEMORY] * (
++        10 - num_success
++    )
++    for key in keys[:num_success]:
++        assert result[key][1] is not None
++    for key in keys[num_success:]:
++        assert result[key][1] is None
++
++
++def test_partial_prefix_is_committable(manager: L1Manager) -> None:
++    """The allocated prefix stays usable: finish_write succeeds for it."""
++    keys = _make_keys(10)
++    result = manager.reserve_write(keys, [False] * 10, OBJECT_LAYOUT)
++    successful = [key for key in keys if result[key][0] == L1Error.SUCCESS]
++    assert successful
++
++    finish_result = manager.finish_write(successful)
++    for key in successful:
++        assert finish_result[key] == L1Error.SUCCESS
++
++
++def test_reserve_write_all_oom_when_nothing_fits(manager: L1Manager) -> None:
++    """An object larger than the pool still fails every key."""
++    keys = _make_keys(3)
++    result = manager.reserve_write(keys, [False] * 3, OVERSIZED_LAYOUT)
++
++    for key in keys:
++        assert result[key][0] == L1Error.OUT_OF_MEMORY
++        assert result[key][1] is None
++
++
++def test_single_key_batch_keeps_all_or_nothing(manager: L1Manager) -> None:
++    """A one-key batch has no prefix to fall back to; it simply fails."""
++    keys = _make_keys(1)
++    result = manager.reserve_write(keys, [False], OVERSIZED_LAYOUT)
++
++    assert result[keys[0]] == (L1Error.OUT_OF_MEMORY, None)
++
++
++def test_largest_prefix_search_does_not_stop_at_a_smaller_fit() -> None:
++    """The OOM fallback finds the maximum, rather than accepting a midpoint."""
++
++    class BoundedMemoryManager:
++        def __init__(self, capacity: int) -> None:
++            self.capacity = capacity
++            self.allocate_counts: list[int] = []
++
++        def allocate(self, _layout: MemoryLayoutDesc, count: int):
++            self.allocate_counts.append(count)
++            if count > self.capacity:
++                return L1Error.OUT_OF_MEMORY, []
++            return L1Error.SUCCESS, [object() for _ in range(count)]
++
++        def free(self, _objects: list[object]) -> L1Error:
++            return L1Error.SUCCESS
++
++    memory_manager = BoundedMemoryManager(capacity=7)
++    manager = SimpleNamespace(_memory_manager=memory_manager)
++
++    err, objects = L1Manager._allocate_largest_prefix(
++        manager,
++        OBJECT_LAYOUT,
++        10,  # type: ignore[arg-type]
++    )
++
++    assert err == L1Error.SUCCESS
++    assert len(objects) == 7
++    assert memory_manager.allocate_counts[-1] == 7
++    assert 8 in memory_manager.allocate_counts
+diff --git a/tests/v1/distributed/test_l1_write_back_eviction.py b/tests/v1/distributed/test_l1_write_back_eviction.py
+new file mode 100644
+index 0000000000000000000000000000000000000000..b677516e37c31959421ea88f777a734d7f61bd0d
+--- /dev/null
++++ b/tests/v1/distributed/test_l1_write_back_eviction.py
+@@ -0,0 +1,609 @@
++# SPDX-License-Identifier: Apache-2.0
++"""Opt-in L1 write-back tier.
++
++With ``EvictionConfig.write_back_on_evict`` enabled, L1 eviction flushes
++readable objects to L2 synchronously and deletes them from L1 only once
++every key in the batch is durable. ``periodic_flush_interval`` adds a
++below-watermark backup flush that keeps the L1 copy.
++``emergency_evict_for_prefetch`` lets the prefetch controller make room
++for large restores through the same write-back path.
++
++Uses the CPU shared-memory allocator; no GPU required.
++"""
++
++# Standard
++from collections.abc import Iterator
++import argparse
++import threading
++import time
++
++# Third Party
++import pytest
++import torch
++
++# First Party
++from lmcache.v1.distributed.api import MemoryLayoutDesc, ObjectKey
++from lmcache.v1.distributed.config import (
++    EvictionConfig,
++    L1ManagerConfig,
++    L1MemoryManagerConfig,
++    StorageManagerConfig,
++    add_storage_manager_args,
++    parse_args_to_config,
++)
++from lmcache.v1.distributed.error import L1Error
++from lmcache.v1.distributed.internal_api import (
++    EvictionAction,
++    EvictionDestination,
++)
++from lmcache.v1.distributed.l1_manager import L1Manager
++from lmcache.v1.distributed.storage_controllers.eviction_controller import (
++    L1EvictionController,
++)
++from lmcache.v1.distributed.storage_controllers.prefetch_controller import (
++    InFlightPrefetchRequest,
++    PrefetchController,
++    PrefetchPhase,
++)
++from lmcache.v1.distributed.storage_controllers.prefetch_policy import (
++    DefaultPrefetchPolicy,
++)
++from lmcache.v1.mp_observability.config import add_observability_args
++
++POOL_BYTES = 8 * 1024 * 1024
++
++# 1MB per object so a handful of objects create real memory pressure.
++OBJECT_LAYOUT = MemoryLayoutDesc(
++    shapes=[torch.Size([256, 1024])],
++    dtypes=[torch.float32],
++)
++
++
++class FakeSyncStoreAdapter:
++    """L2 adapter double exposing only the synchronous store path.
++
++    ``result`` overrides the returned tuple; by default every key is
++    reported durable.
++    """
++
++    def __init__(self) -> None:
++        self.stored_batches: list[list[ObjectKey]] = []
++        self.result: tuple[bool, int, int] | None = None
++
++    def store_objects_sync(
++        self,
++        keys: list[ObjectKey],
++        objects: list,
++        timeout: float | None = None,
++    ) -> tuple[bool, int, int]:
++        self.stored_batches.append(list(keys))
++        if self.result is not None:
++            return self.result
++        return True, len(keys), sum(obj.get_size() for obj in objects)
++
++
++class BlockingSyncStoreAdapter(FakeSyncStoreAdapter):
++    def __init__(self) -> None:
++        super().__init__()
++        self.entered = threading.Event()
++        self.release = threading.Event()
++
++    def store_objects_sync(self, keys, objects, timeout=None):
++        self.entered.set()
++        if not self.release.wait(timeout=timeout or 5.0):
++            return False, 0, 0
++        return super().store_objects_sync(keys, objects, timeout=timeout)
++
++
++@pytest.fixture
++def l1_manager() -> Iterator[L1Manager]:
++    config = L1ManagerConfig(
++        memory_config=L1MemoryManagerConfig(
++            size_in_bytes=POOL_BYTES,
++            use_lazy=False,
++            init_size_in_bytes=POOL_BYTES,
++            align_bytes=0x1000,
++        ),
++        write_ttl_seconds=600,
++        read_ttl_seconds=300,
++    )
++    manager = L1Manager(config)
++    yield manager
++    manager.close()
++
++
++def _make_controller(
++    l1_manager: L1Manager,
++    adapter: FakeSyncStoreAdapter,
++    **config_kwargs,
++) -> L1EvictionController:
++    config = EvictionConfig(eviction_policy="LRU", **config_kwargs)
++    return L1EvictionController(
++        l1_manager=l1_manager,
++        eviction_config=config,
++        l2_adapters={0: adapter},
++    )
++
++
++def _make_keys(count: int) -> list[ObjectKey]:
++    return [
++        ObjectKey(
++            chunk_hash=ObjectKey.IntHash2Bytes(i),
++            model_name="test_model",
++            kv_rank=0,
++        )
++        for i in range(count)
++    ]
++
++
++def _store_keys(l1_manager: L1Manager, keys: list[ObjectKey]) -> None:
++    result = l1_manager.reserve_write(keys, [False] * len(keys), OBJECT_LAYOUT)
++    for key in keys:
++        assert result[key][0] == L1Error.SUCCESS
++    l1_manager.finish_write(keys)
++
++
++def _readable_keys(l1_manager: L1Manager, keys: list[ObjectKey]) -> list[ObjectKey]:
++    result = l1_manager.reserve_read(keys)
++    readable = [
++        key
++        for key in keys
++        if result.get(key) is not None and result[key][0] == L1Error.SUCCESS
++    ]
++    if readable:
++        l1_manager.finish_read(readable)
++    return readable
++
++
++class TestWriteBackOnEvict:
++    def test_flush_then_delete(self, l1_manager):
++        """A durable flush deletes the batch from L1."""
++        adapter = FakeSyncStoreAdapter()
++        controller = _make_controller(l1_manager, adapter, write_back_on_evict=True)
++        keys = _make_keys(3)
++        _store_keys(l1_manager, keys)
++
++        controller.execute_eviction_action(
++            EvictionAction(keys=keys, destination=EvictionDestination.L2_CACHE)
++        )
++
++        assert adapter.stored_batches == [keys]
++        assert _readable_keys(l1_manager, keys) == []
++
++    def test_failed_flush_preserves_l1(self, l1_manager):
++        """A failed flush keeps every readable key in L1 and opens the
++        circuit breaker."""
++        adapter = FakeSyncStoreAdapter()
++        adapter.result = (False, 0, 0)
++        controller = _make_controller(l1_manager, adapter, write_back_on_evict=True)
++        keys = _make_keys(3)
++        _store_keys(l1_manager, keys)
++
++        controller.execute_eviction_action(
++            EvictionAction(keys=keys, destination=EvictionDestination.L2_CACHE)
++        )
++
++        assert _readable_keys(l1_manager, keys) == keys
++        status = controller.report_status()
++        assert status["sync_flush_failures"] == 1
++        assert status["sync_flush_backoff_seconds"] > 0.0
++
++    def test_partial_flush_preserves_l1(self, l1_manager):
++        """A partial persist is not durable; the batch stays in L1."""
++        adapter = FakeSyncStoreAdapter()
++        adapter.result = (False, 2, 1024)
++        controller = _make_controller(l1_manager, adapter, write_back_on_evict=True)
++        keys = _make_keys(3)
++        _store_keys(l1_manager, keys)
++
++        controller.execute_eviction_action(
++            EvictionAction(keys=keys, destination=EvictionDestination.L2_CACHE)
++        )
++
++        assert _readable_keys(l1_manager, keys) == keys
++
++    def test_missing_sync_adapter_fails_closed(self, l1_manager):
++        config = EvictionConfig(eviction_policy="LRU", write_back_on_evict=True)
++        controller = L1EvictionController(
++            l1_manager=l1_manager,
++            eviction_config=config,
++            l2_adapters={0: object()},
++        )
++        keys = _make_keys(2)
++        _store_keys(l1_manager, keys)
++
++        controller.execute_eviction_action(
++            EvictionAction(keys=keys, destination=EvictionDestination.L2_CACHE)
++        )
++
++        assert controller.has_l2_flush_adapter() is False
++        assert _readable_keys(l1_manager, keys) == keys
++
++    def test_reserve_read_failure_is_not_deleted(self, l1_manager, monkeypatch):
++        adapter = FakeSyncStoreAdapter()
++        controller = _make_controller(l1_manager, adapter, write_back_on_evict=True)
++        keys = _make_keys(1)
++        _store_keys(l1_manager, keys)
++        monkeypatch.setattr(
++            l1_manager,
++            "reserve_read",
++            lambda _keys: {keys[0]: (L1Error.KEY_IS_LOCKED, None)},
++        )
++
++        controller.execute_eviction_action(
++            EvictionAction(keys=keys, destination=EvictionDestination.L2_CACHE)
++        )
++
++        monkeypatch.undo()
++        assert adapter.stored_batches == []
++        assert _readable_keys(l1_manager, keys) == keys
++
++    def test_adapter_replacement_waits_for_active_flush(self, l1_manager):
++        adapter = BlockingSyncStoreAdapter()
++        controller = _make_controller(l1_manager, adapter, write_back_on_evict=True)
++        keys = _make_keys(1)
++        _store_keys(l1_manager, keys)
++        flush = threading.Thread(
++            target=lambda: controller.execute_eviction_action(
++                EvictionAction(keys=keys, destination=EvictionDestination.L2_CACHE)
++            )
++        )
++        replaced = threading.Event()
++        replace = threading.Thread(
++            target=lambda: (
++                controller.set_l2_adapters({}),
++                replaced.set(),
++            )
++        )
++
++        flush.start()
++        assert adapter.entered.wait(timeout=5.0)
++        replace.start()
++        time.sleep(0.05)
++        assert not replaced.is_set()
++
++        adapter.release.set()
++        flush.join(timeout=5.0)
++        replace.join(timeout=5.0)
++
++        assert replaced.is_set()
++        assert not flush.is_alive()
++        assert not replace.is_alive()
++
++
++class TestEmergencyEvict:
++    def test_emergency_evict_frees_bytes_via_write_back(self, l1_manager):
++        """emergency_evict_bytes flushes LRU victims to L2 and frees L1."""
++        adapter = FakeSyncStoreAdapter()
++        controller = _make_controller(l1_manager, adapter, write_back_on_evict=True)
++        keys = _make_keys(6)
++        _store_keys(l1_manager, keys)
++
++        used_before, total = l1_manager.get_memory_usage()
++        free_before = total - used_before
++
++        free_after = controller.emergency_evict_bytes(
++            free_before + 2 * 1024 * 1024, requester="test"
++        )
++
++        assert free_after > free_before
++        assert adapter.stored_batches
++        evicted = [k for batch in adapter.stored_batches for k in batch]
++        assert set(evicted) <= set(keys)
++        assert len(evicted) < len(keys)
++        # Evicted keys are gone from L1.
++        assert not set(evicted) & set(_readable_keys(l1_manager, keys))
++
++    def test_emergency_evict_noop_when_enough_free(self, l1_manager):
++        adapter = FakeSyncStoreAdapter()
++        controller = _make_controller(l1_manager, adapter, write_back_on_evict=True)
++        keys = _make_keys(2)
++        _store_keys(l1_manager, keys)
++
++        controller.emergency_evict_bytes(1024, requester="test")
++
++        assert adapter.stored_batches == []
++        assert _readable_keys(l1_manager, keys) == keys
++
++    def test_emergency_evict_skips_scan_during_backoff(self, l1_manager, monkeypatch):
++        adapter = FakeSyncStoreAdapter()
++        controller = _make_controller(l1_manager, adapter, write_back_on_evict=True)
++        keys = _make_keys(6)
++        _store_keys(l1_manager, keys)
++        controller._sync_flush_backoff_until = time.monotonic() + 60
++        monkeypatch.setattr(
++            controller._eviction_policy,
++            "get_eviction_actions",
++            lambda *args, **kwargs: pytest.fail("eviction scan should be skipped"),
++        )
++
++        used, total = l1_manager.get_memory_usage()
++        free = total - used
++        assert controller.emergency_evict_bytes(free + 1024) == free
++
++    def test_emergency_evict_has_bounded_store_wait(self, l1_manager):
++        adapter = BlockingSyncStoreAdapter()
++        controller = _make_controller(l1_manager, adapter, write_back_on_evict=True)
++        controller._EMERGENCY_FLUSH_TIMEOUT_SECONDS = 0.05
++        keys = _make_keys(6)
++        _store_keys(l1_manager, keys)
++        used, total = l1_manager.get_memory_usage()
++
++        start = time.monotonic()
++        free_after = controller.emergency_evict_bytes(total - used + 1024)
++        elapsed = time.monotonic() - start
++
++        assert adapter.entered.is_set()
++        assert elapsed < 0.5
++        assert free_after == total - used
++        assert _readable_keys(l1_manager, keys) == keys
++        status = controller.report_status()
++        assert status["sync_flush_failures"] == 0
++        assert status["sync_flush_backoff_seconds"] == 0.0
++
++
++class TestPeriodicBackupFlush:
++    def test_backup_flush_keeps_l1_copy(self, l1_manager):
++        """The periodic backup flush copies keys to L2 without deleting
++        them from L1."""
++        adapter = FakeSyncStoreAdapter()
++        controller = _make_controller(l1_manager, adapter, periodic_flush_interval=0.1)
++        keys = _make_keys(3)
++        _store_keys(l1_manager, keys)
++
++        controller.start()
++        try:
++            deadline = time.monotonic() + 5.0
++            while not adapter.stored_batches and time.monotonic() < deadline:
++                time.sleep(0.1)
++        finally:
++            controller.stop()
++
++        assert adapter.stored_batches
++        flushed = {k for batch in adapter.stored_batches for k in batch}
++        assert flushed <= set(keys)
++        assert _readable_keys(l1_manager, keys) == keys
++
++    def test_backup_batches_rotate_without_full_snapshot(self, l1_manager):
++        adapter = FakeSyncStoreAdapter()
++        controller = _make_controller(l1_manager, adapter)
++        keys = _make_keys(6)
++        _store_keys(l1_manager, keys)
++
++        for _ in range(3):
++            controller._backup_to_l2_no_delete(batch_limit=2)
++
++        assert [len(batch) for batch in adapter.stored_batches] == [2, 2, 2]
++        assert {key for batch in adapter.stored_batches for key in batch} == set(keys)
++
++    def test_backup_flush_has_bounded_store_wait(self, l1_manager):
++        adapter = BlockingSyncStoreAdapter()
++        controller = _make_controller(l1_manager, adapter)
++        controller._PERIODIC_FLUSH_TIMEOUT_SECONDS = 0.05
++        keys = _make_keys(2)
++        _store_keys(l1_manager, keys)
++
++        start = time.monotonic()
++        controller._backup_to_l2_no_delete(batch_limit=2)
++        elapsed = time.monotonic() - start
++
++        assert adapter.entered.is_set()
++        assert elapsed < 0.5
++        assert _readable_keys(l1_manager, keys) == keys
++
++    def test_evictable_batch_scan_wraps_and_is_bounded(self, l1_manager):
++        keys = _make_keys(5)
++        _store_keys(l1_manager, keys)
++        assert l1_manager.reserve_read([keys[0]])[keys[0]][0] == L1Error.SUCCESS
++        try:
++            first, cursor = l1_manager.get_evictable_keys(
++                limit=2,
++                cursor=0,
++                scan_limit=2,
++            )
++            second, cursor = l1_manager.get_evictable_keys(
++                limit=2,
++                cursor=cursor,
++                scan_limit=2,
++            )
++            third, _ = l1_manager.get_evictable_keys(
++                limit=2,
++                cursor=cursor,
++                scan_limit=2,
++            )
++        finally:
++            l1_manager.finish_read([keys[0]])
++
++        assert first == [keys[1]]
++        assert second == keys[2:4]
++        assert third == [keys[4]]
++
++
++class _RecordingEvictor:
++    """Eviction-controller double recording emergency_evict_bytes calls."""
++
++    def __init__(self) -> None:
++        self.calls: list[tuple[int, str]] = []
++
++    def emergency_evict_bytes(self, target_free_bytes: int, requester: str = "") -> int:
++        self.calls.append((target_free_bytes, requester))
++        return target_free_bytes
++
++
++@pytest.fixture
++def prefetch_controller(l1_manager: L1Manager) -> Iterator[PrefetchController]:
++    controller = PrefetchController(
++        l1_manager=l1_manager,
++        l2_adapters=[],
++        adapter_descriptors=[],
++        policy=DefaultPrefetchPolicy(),
++    )
++    yield controller
++    # The loop thread was never started, so stop() cannot join it.
++    controller._submission_efd.close()
++    controller._adapter_ctrl_efd.close()
++
++
++def _make_request(keys: list[ObjectKey]) -> InFlightPrefetchRequest:
++    return InFlightPrefetchRequest(
++        request_id=7,
++        keys=keys,
++        layout_desc=OBJECT_LAYOUT,
++        phase=PrefetchPhase.PLAN_AND_LOAD,
++    )
++
++
++class TestPrefetchMakeRoom:
++    def test_make_room_asks_evictor_when_short(self, l1_manager, prefetch_controller):
++        """A restore that does not fit in free L1 asks for eviction."""
++        controller = prefetch_controller
++        evictor = _RecordingEvictor()
++        controller.set_l1_eviction_controller(evictor)
++        resident = _make_keys(6)
++        _store_keys(l1_manager, resident)
++
++        restore_keys = [
++            ObjectKey(
++                chunk_hash=ObjectKey.IntHash2Bytes(100 + i),
++                model_name="test_model",
++                kv_rank=0,
++            )
++            for i in range(4)
++        ]
++        controller._make_room_for_restore(_make_request(restore_keys), restore_keys)
++
++        assert len(evictor.calls) == 1
++        target, requester = evictor.calls[0]
++        assert target > 0
++        assert "prefetch_request=7" in requester
++
++    def test_make_room_noop_when_space_available(self, l1_manager, prefetch_controller):
++        controller = prefetch_controller
++        evictor = _RecordingEvictor()
++        controller.set_l1_eviction_controller(evictor)
++
++        keys = _make_keys(2)
++        controller._make_room_for_restore(_make_request(keys), keys)
++
++        assert evictor.calls == []
++
++    def test_make_room_noop_without_evictor(self, l1_manager, prefetch_controller):
++        controller = prefetch_controller
++        keys = _make_keys(2)
++
++        controller._make_room_for_restore(_make_request(keys), keys)
++
++    def test_eviction_controller_can_be_disconnected(self, prefetch_controller):
++        evictor = _RecordingEvictor()
++        prefetch_controller.set_l1_eviction_controller(evictor)
++        prefetch_controller.set_l1_eviction_controller(None)
++
++        assert prefetch_controller._l1_eviction_controller is None
++
++    def test_short_retention_policy_degrades_to_temporary(
++        self, prefetch_controller, monkeypatch
++    ):
++        keys = _make_keys(3)
++        monkeypatch.setattr(
++            prefetch_controller._policy,
++            "select_l1_retentions",
++            lambda _keys: [True],
++        )
++
++        assert prefetch_controller._select_l1_retentions(7, keys) == [
++            False,
++            False,
++            False,
++        ]
++
++    def test_retry_recovers_oom_reservations(self, l1_manager, prefetch_controller):
++        """OOM reservations are retried once after emergency eviction."""
++        controller = prefetch_controller
++        evictor = _RecordingEvictor()
++        controller.set_l1_eviction_controller(evictor)
++        keys = _make_keys(2)
++        write_results = {key: (L1Error.OUT_OF_MEMORY, None) for key in keys}
++
++        merged = controller._retry_oom_reservations(
++            _make_request(keys), keys, [True, True], write_results
++        )
++
++        assert len(evictor.calls) == 1
++        for key in keys:
++            err, mem_obj = merged[key]
++            assert err == L1Error.SUCCESS
++            assert mem_obj is not None
++        l1_manager.finish_write(keys)
++
++    def test_retry_noop_when_all_reserved(self, l1_manager, prefetch_controller):
++        controller = prefetch_controller
++        evictor = _RecordingEvictor()
++        controller.set_l1_eviction_controller(evictor)
++        keys = _make_keys(2)
++        result = l1_manager.reserve_write(keys, [False, False], OBJECT_LAYOUT)
++
++        merged = controller._retry_oom_reservations(
++            _make_request(keys), keys, [True, True], result
++        )
++
++        assert evictor.calls == []
++        assert merged is result
++        l1_manager.finish_write(keys)
++
++
++class TestConfigPlumbing:
++    def test_parser_populates_write_back_fields(self):
++        parser = argparse.ArgumentParser()
++        add_storage_manager_args(parser)
++        add_observability_args(parser)
++        args = parser.parse_args(
++            [
++                "--l1-size-gb",
++                "1",
++                "--eviction-policy",
++                "LRU",
++                "--write-back-on-evict",
++                "--periodic-flush-interval",
++                "30.0",
++                "--emergency-evict-for-prefetch",
++            ]
++        )
++        config = parse_args_to_config(args)
++        assert config.eviction_config.write_back_on_evict is True
++        assert config.eviction_config.periodic_flush_interval == 30.0
++        assert config.eviction_config.emergency_evict_for_prefetch is True
++
++    def test_defaults_are_disabled(self):
++        parser = argparse.ArgumentParser()
++        add_storage_manager_args(parser)
++        add_observability_args(parser)
++        args = parser.parse_args(["--l1-size-gb", "1", "--eviction-policy", "LRU"])
++        config = parse_args_to_config(args)
++        assert config.eviction_config.write_back_on_evict is False
++        assert config.eviction_config.periodic_flush_interval == 0.0
++        assert config.eviction_config.emergency_evict_for_prefetch is False
++
++    @pytest.mark.parametrize(
++        "eviction_config",
++        [
++            EvictionConfig(
++                eviction_policy="LRU",
++                periodic_flush_interval=-1.0,
++            ),
++            EvictionConfig(
++                eviction_policy="LRU",
++                emergency_evict_for_prefetch=True,
++            ),
++        ],
++    )
++    def test_invalid_writeback_config_is_rejected(self, eviction_config):
++        with pytest.raises(ValueError):
++            StorageManagerConfig(
++                l1_manager_config=L1ManagerConfig(
++                    memory_config=L1MemoryManagerConfig(
++                        size_in_bytes=POOL_BYTES,
++                        use_lazy=False,
++                    )
++                ),
++                eviction_config=eviction_config,
++            )
+diff --git a/tests/v1/distributed/test_native_connector_l2_adapter.py b/tests/v1/distributed/test_native_connector_l2_adapter.py
+index dc16cdd1ae0161bf2306759cd2b72614a93c83fc..ff992bee7592a1814c760dea510728e8c96a850b 100644
+--- a/tests/v1/distributed/test_native_connector_l2_adapter.py
++++ b/tests/v1/distributed/test_native_connector_l2_adapter.py
+@@ -10,6 +10,7 @@ C++ IStorageConnector interface, so no Redis or C++ build is needed.
+ import ctypes
+ import select
+ import threading
++import time
+ 
+ # Third Party
+ import pytest
+@@ -56,6 +57,9 @@ class MockNativeConnector:
+         self._completions: list[tuple[int, bool, str, list[bool] | None]] = []
+         self._lock = threading.Lock()
+         self._closed = False
++        self.report_set_per_key_results = True
++        self.fail_set_keys: set[str] = set()
++        self.suppress_set_completion = False
+ 
+     def event_fd(self) -> int:
+         return self._efd.fileno()
+@@ -66,9 +70,21 @@ class MockNativeConnector:
+             self._next_id += 1
+ 
+         try:
++            results = []
+             for key, mv in zip(keys, memoryviews, strict=False):
++                if key in self.fail_set_keys:
++                    results.append(False)
++                    continue
+                 self._store[key] = bytes(mv)
+-            self._push_completion(fid, True, "", None)
++                results.append(True)
++            ok = all(results)
++            if not self.suppress_set_completion:
++                self._push_completion(
++                    fid,
++                    ok,
++                    "" if ok else "injected set failure",
++                    results if self.report_set_per_key_results else None,
++                )
+         except Exception as e:
+             self._push_completion(fid, False, str(e), None)
+ 
+@@ -155,6 +171,27 @@ class MockNativeConnector:
+             pass
+ 
+ 
++class DeferredExistsConnector(MockNativeConnector):
++    """Hold EXISTS completion to expose the submit-to-lock race window."""
++
++    def __init__(self):
++        super().__init__()
++        self.pending_exists: tuple[int, list[str]] | None = None
++
++    def submit_batch_exists(self, keys: list[str]) -> int:
++        with self._lock:
++            fid = self._next_id
++            self._next_id += 1
++        self.pending_exists = (fid, list(keys))
++        return fid
++
++    def complete_exists(self) -> None:
++        assert self.pending_exists is not None
++        fid, keys = self.pending_exists
++        self.pending_exists = None
++        self._push_completion(fid, True, "", [key in self._store for key in keys])
++
++
+ # =============================================================================
+ # Test Fixtures
+ # =============================================================================
+@@ -203,6 +240,14 @@ def adapter():
+     adp.close()
+ 
+ 
++@pytest.fixture
++def adapter_and_mock():
++    mock_client = MockNativeConnector()
++    adp = NativeConnectorL2Adapter(mock_client)
++    yield adp, mock_client
++    adp.close()
++
++
+ # =============================================================================
+ # ObjectKey Serialization Tests
+ # =============================================================================
+@@ -1182,6 +1227,91 @@ class TestDeleteInterface:
+     def test_delete_empty_keys(self, adapter):
+         adapter.delete([])  # should not raise
+ 
++    def test_delete_skips_lookup_locked_keys(self, adapter):
++        """Keys lookup-locked by an in-flight prefetch survive delete();
++        unlocked keys in the same batch are still deleted, and the locked
++        key becomes deletable again after unlock."""
++        keys = [create_object_key(i) for i in range(2)]
++        objs = [create_memory_obj(fill_value=float(i)) for i in range(2)]
++        store_fd = adapter.get_store_event_fd()
++        lookup_fd = adapter.get_lookup_and_lock_event_fd()
++
++        adapter.submit_store_task(keys, objs)
++        wait_for_event_fd(store_fd, timeout=5.0)
++        adapter.pop_completed_store_tasks()
++
++        # An in-flight prefetch holds a lookup lock on keys[0].
++        task_id = adapter.submit_lookup_and_lock_task([keys[0]], _EMPTY_LAYOUT)
++        wait_for_event_fd(lookup_fd, timeout=5.0)
++        bitmap = adapter.query_lookup_and_lock_result(task_id)
++        assert bitmap.test(0) is True
++
++        adapter.delete(keys)
++
++        # keys[0] survived, keys[1] is gone. This lookup takes another
++        # lock on keys[0].
++        task_id = adapter.submit_lookup_and_lock_task(keys, _EMPTY_LAYOUT)
++        wait_for_event_fd(lookup_fd, timeout=5.0)
++        bitmap = adapter.query_lookup_and_lock_result(task_id)
++        assert bitmap.test(0) is True
++        assert bitmap.test(1) is False
++
++        # Release both locks; the key is deletable again.
++        adapter.submit_unlock([keys[0]])
++        adapter.submit_unlock([keys[0]])
++        adapter.delete([keys[0]])
++
++        task_id = adapter.submit_lookup_and_lock_task([keys[0]], _EMPTY_LAYOUT)
++        wait_for_event_fd(lookup_fd, timeout=5.0)
++        bitmap = adapter.query_lookup_and_lock_result(task_id)
++        assert bitmap.test(0) is False
++
++    def test_delete_all_keys_locked_is_noop(self, adapter):
++        """delete() returns without submitting when every key is locked."""
++        key = create_object_key(1)
++        obj = create_memory_obj()
++        store_fd = adapter.get_store_event_fd()
++        lookup_fd = adapter.get_lookup_and_lock_event_fd()
++
++        adapter.submit_store_task([key], [obj])
++        wait_for_event_fd(store_fd, timeout=5.0)
++        adapter.pop_completed_store_tasks()
++
++        task_id = adapter.submit_lookup_and_lock_task([key], _EMPTY_LAYOUT)
++        wait_for_event_fd(lookup_fd, timeout=5.0)
++        assert adapter.query_lookup_and_lock_result(task_id).test(0) is True
++
++        adapter.delete([key])
++
++        task_id = adapter.submit_lookup_and_lock_task([key], _EMPTY_LAYOUT)
++        wait_for_event_fd(lookup_fd, timeout=5.0)
++        assert adapter.query_lookup_and_lock_result(task_id).test(0) is True
++        adapter.submit_unlock([key])
++        adapter.submit_unlock([key])
++
++    def test_delete_skips_lookup_that_has_not_completed(self):
++        """Eviction cannot enter between lookup submission and lock acquire."""
++        client = DeferredExistsConnector()
++        adapter = NativeConnectorL2Adapter(client)
++        key = create_object_key(1)
++        obj = create_memory_obj()
++
++        try:
++            adapter.submit_store_task([key], [obj])
++            wait_for_event_fd(adapter.get_store_event_fd(), timeout=5.0)
++            adapter.pop_completed_store_tasks()
++
++            task_id = adapter.submit_lookup_and_lock_task([key], _EMPTY_LAYOUT)
++            adapter.delete([key])
++            assert _object_key_to_string(key) in client._store
++
++            client.complete_exists()
++            wait_for_event_fd(adapter.get_lookup_and_lock_event_fd(), timeout=5.0)
++            assert adapter.query_lookup_and_lock_result(task_id).test(0) is True
++            adapter.submit_unlock([key])
++        finally:
++            adapter.close()
++
+     def test_delete_batch(self, adapter):
+         keys = [create_object_key(i) for i in range(5)]
+         objs = [create_memory_obj(fill_value=float(i)) for i in range(5)]
+@@ -1294,7 +1424,6 @@ class TestUsageTracking:
+         # 400 bytes / 2000 bytes = 0.2
+         assert usage.usage_fraction == pytest.approx(0.2)
+         assert usage.total_bytes_used == 400
+-
+     def test_get_usage_after_delete(self, adapter_with_capacity):
+         adp = adapter_with_capacity
+         store_fd = adp.get_store_event_fd()
+@@ -1358,3 +1487,136 @@ class TestUsageTracking:
+         usage = adp.get_usage()
+         assert usage.usage_fraction == pytest.approx(0.2)
+         assert usage.total_bytes_used == 400
++
++
++# =============================================================================
++# Durable Store Tests
++# =============================================================================
++
++
++class _BlockingStoreListener:
++    def __init__(self):
++        self.entered = threading.Event()
++        self.release = threading.Event()
++
++    def on_l2_keys_stored(self, keys, sizes) -> None:
++        self.entered.set()
++        assert self.release.wait(timeout=5.0)
++
++
++class TestStoreObjectsSync:
++    def test_success_uses_private_completion(self, adapter):
++        keys = [create_object_key(i) for i in range(2)]
++        objs = [create_memory_obj(fill_value=float(i)) for i in range(2)]
++
++        ok, persisted, bytes_written = adapter.store_objects_sync(keys, objs)
++
++        assert ok is True
++        assert persisted == 2
++        assert bytes_written == sum(obj.get_size() for obj in objs)
++        assert adapter.get_usage().total_bytes_used == bytes_written
++        assert adapter.pop_completed_store_tasks() == {}
++
++    def test_partial_failure_accounts_only_persisted_keys(self, adapter_and_mock):
++        adapter, mock_client = adapter_and_mock
++        keys = [create_object_key(i) for i in range(2)]
++        objs = [create_memory_obj(fill_value=float(i)) for i in range(2)]
++        mock_client.fail_set_keys = {_object_key_to_string(keys[1])}
++
++        ok, persisted, bytes_written = adapter.store_objects_sync(keys, objs)
++
++        assert ok is False
++        assert persisted == 1
++        assert bytes_written == objs[0].get_size()
++        assert adapter.get_usage().total_bytes_used == objs[0].get_size()
++
++    def test_async_partial_failure_uses_per_key_results(self, adapter_and_mock):
++        adapter, mock_client = adapter_and_mock
++        keys = [create_object_key(i) for i in range(2)]
++        objs = [create_memory_obj(fill_value=float(i)) for i in range(2)]
++        mock_client.fail_set_keys = {_object_key_to_string(keys[1])}
++
++        task_id = adapter.submit_store_task(keys, objs)
++        assert wait_for_event_fd(adapter.get_store_event_fd(), timeout=5.0)
++
++        result = adapter.pop_completed_store_tasks()[task_id]
++        assert result.is_successful() is False
++        assert adapter.get_usage().total_bytes_used == objs[0].get_size()
++
++    def test_batch_fallback_without_per_key_results(self, adapter_and_mock):
++        adapter, mock_client = adapter_and_mock
++        mock_client.report_set_per_key_results = False
++        keys = [create_object_key(i) for i in range(2)]
++        objs = [create_memory_obj(fill_value=float(i)) for i in range(2)]
++
++        ok, persisted, bytes_written = adapter.store_objects_sync(keys, objs)
++
++        assert ok is True
++        assert persisted == 2
++        assert bytes_written == sum(obj.get_size() for obj in objs)
++
++    def test_validates_inputs(self, adapter):
++        with pytest.raises(ValueError, match="length mismatch"):
++            adapter.store_objects_sync([create_object_key(1)], [])
++        with pytest.raises(ValueError, match="timeout must be positive"):
++            adapter.store_objects_sync(
++                [create_object_key(1)], [create_memory_obj()], timeout=0
++            )
++        assert adapter.store_objects_sync([], []) == (True, 0, 0)
++
++    def test_real_timeout_cleans_pending_operation(self, adapter_and_mock):
++        adapter, mock_client = adapter_and_mock
++        mock_client.suppress_set_completion = True
++
++        result = adapter.store_objects_sync(
++            [create_object_key(1)], [create_memory_obj()], timeout=0.05
++        )
++
++        assert result == (False, 0, 0)
++        assert adapter._pending_sync_store_events == {}
++        assert adapter._pending_ops == {}
++
++    def test_completion_at_timeout_does_not_wait_for_observer(self, adapter):
++        listener = _BlockingStoreListener()
++        adapter.register_listener(listener)
++        result = []
++        worker = threading.Thread(
++            target=lambda: result.append(
++                adapter.store_objects_sync(
++                    [create_object_key(1)],
++                    [create_memory_obj()],
++                    timeout=0.05,
++                )
++            )
++        )
++        worker.start()
++        assert listener.entered.wait(timeout=5.0)
++        time.sleep(0.1)
++        assert not worker.is_alive()
++        assert result[0][0] is True
++        assert adapter.get_usage().total_bytes_used == result[0][2]
++
++        listener.release.set()
++        worker.join(timeout=5.0)
++
++        assert not worker.is_alive()
++
++    def test_close_unblocks_waiter(self, adapter_and_mock):
++        adapter, mock_client = adapter_and_mock
++        mock_client.suppress_set_completion = True
++        result = []
++        worker = threading.Thread(
++            target=lambda: result.append(
++                adapter.store_objects_sync(
++                    [create_object_key(1)], [create_memory_obj()], timeout=10.0
++                )
++            )
++        )
++        worker.start()
++        time.sleep(0.05)
++
++        adapter.close()
++        worker.join(timeout=5.0)
++
++        assert not worker.is_alive()
++        assert result == [(False, 0, 0)]
+diff --git a/tests/v1/distributed/test_native_connector_restart_accounting.py b/tests/v1/distributed/test_native_connector_restart_accounting.py
+new file mode 100644
+index 0000000000000000000000000000000000000000..dc5d6c68c3fcb236bafd2bfdf9a2b8c9582e00d8
+--- /dev/null
++++ b/tests/v1/distributed/test_native_connector_restart_accounting.py
+@@ -0,0 +1,66 @@
++# SPDX-License-Identifier: Apache-2.0
++"""Restart accounting behavior shared by native L2 connectors."""
++
++# Third Party
++import pytest
++
++# First Party
++from tests.v1.distributed.test_native_connector_l2_adapter import (
++    adapter,
++    create_object_key,
++)
++
++
++class _RecordingL2Listener:
++    def __init__(self):
++        self.stored = []
++
++    def on_l2_keys_stored(self, keys, sizes) -> None:
++        self.stored.append((list(keys), list(sizes)))
++
++
++class TestPrimeExistingKeys:
++    def test_priming_accounts_deduplicated_usage(self, adapter):
++        key = create_object_key(1)
++
++        adapter.prime_existing_keys([key, key], [100, 999])
++
++        assert adapter.get_usage().total_bytes_used == 100
++        assert adapter._key_sizes == {key: 100}
++
++    def test_first_listener_receives_startup_snapshot_once(self, adapter):
++        keys = [create_object_key(1), create_object_key(2)]
++        adapter.prime_existing_keys(keys, [100, 200])
++        first = _RecordingL2Listener()
++        second = _RecordingL2Listener()
++
++        adapter.register_listener(first)
++        adapter.register_listener(second)
++
++        assert first.stored == [(keys, [100, 200])]
++        assert second.stored == []
++        assert adapter.get_usage().total_bytes_used == 300
++
++    def test_empty_snapshot_is_consumed_without_callback(self, adapter):
++        adapter.prime_existing_keys([], [])
++        listener = _RecordingL2Listener()
++
++        adapter.register_listener(listener)
++
++        assert listener.stored == []
++
++    def test_rejects_invalid_or_repeated_priming(self, adapter):
++        with pytest.raises(ValueError, match="length mismatch"):
++            adapter.prime_existing_keys([create_object_key(1)], [1, 2])
++        with pytest.raises(ValueError, match="must be positive"):
++            adapter.prime_existing_keys([create_object_key(1)], [0])
++
++        adapter.prime_existing_keys([], [])
++        with pytest.raises(RuntimeError, match="already primed"):
++            adapter.prime_existing_keys([], [])
++
++    def test_rejects_priming_after_listener_registration(self, adapter):
++        adapter.register_listener(_RecordingL2Listener())
++
++        with pytest.raises(RuntimeError, match="before listeners"):
++            adapter.prime_existing_keys([], [])
+diff --git a/tests/v1/distributed/test_native_fs_connector_results.py b/tests/v1/distributed/test_native_fs_connector_results.py
+new file mode 100644
+index 0000000000000000000000000000000000000000..458fcf0edfcf8a04ab13a4431248640e557cb8c3
+--- /dev/null
++++ b/tests/v1/distributed/test_native_fs_connector_results.py
+@@ -0,0 +1,54 @@
++# SPDX-License-Identifier: Apache-2.0
++"""Native FS connector completion semantics.
++
++These tests exercise the compiled extension. They are skipped when the
++optional native FS module is not part of the test environment.
++"""
++
++# Standard
++import select
++import time
++
++# Third Party
++import pytest
++
++lmcache_fs = pytest.importorskip("lmcache.lmcache_fs")
++
++
++def _wait_for_completion(client, timeout: float = 5.0):
++    poller = select.poll()
++    poller.register(client.event_fd(), select.POLLIN)
++    deadline = time.monotonic() + timeout
++    while time.monotonic() < deadline:
++        if poller.poll(50):
++            completions = client.drain_completions()
++            if completions:
++                return completions
++    raise AssertionError("native connector completion timed out")
++
++
++def test_batch_set_reports_partial_results_and_continues(tmp_path):
++    client = lmcache_fs.LMCacheFSClient(str(tmp_path), 1)
++    try:
++        buffers = [bytearray(b"first"), bytearray(b"bad"), bytearray(b"last")]
++        keys = [
++            "model@00000000@01",
++            "malformed-key",
++            "model@00000000@03",
++        ]
++
++        future_id = client.submit_batch_set(
++            keys,
++            [memoryview(buffer) for buffer in buffers],
++        )
++        completions = _wait_for_completion(client)
++
++        assert len(completions) == 1
++        completed_id, ok, error, results = completions[0]
++        assert completed_id == future_id
++        assert ok is False
++        assert "partially failed" in error
++        assert results == [True, False, True]
++        assert len(list(tmp_path.glob("*.data"))) == 2
++    finally:
++        client.close()
+diff --git a/tests/v1/distributed/test_native_fs_key_compatibility.py b/tests/v1/distributed/test_native_fs_key_compatibility.py
+new file mode 100644
+index 0000000000000000000000000000000000000000..d18fba4e8f8c662a3826f1a8182ac681ca9a0584
+--- /dev/null
++++ b/tests/v1/distributed/test_native_fs_key_compatibility.py
+@@ -0,0 +1,55 @@
++# SPDX-License-Identifier: Apache-2.0
++"""ObjectKey compatibility of the compiled native FS connector."""
++
++# Standard
++import select
++import time
++
++# Third Party
++import pytest
++
++lmcache_fs = pytest.importorskip("lmcache.lmcache_fs")
++
++
++def _wait_for_completion(client, timeout: float = 5.0):
++    poller = select.poll()
++    poller.register(client.event_fd(), select.POLLIN)
++    deadline = time.monotonic() + timeout
++    while time.monotonic() < deadline:
++        if poller.poll(50):
++            completions = client.drain_completions()
++            if completions:
++                return completions[0]
++    raise AssertionError("native connector completion timed out")
++
++
++@pytest.mark.parametrize(
++    ("wire_key", "filename"),
++    [
++        ("model@00000000@aabb", "model@0x00000000@aabb.data"),
++        (
++            "model@00000000@aabb@salt",
++            "model@0x00000000@aabb@salt.data",
++        ),
++        (
++            "model@00000000@2@aabb",
++            "model@0x00000000@2@aabb.data",
++        ),
++        (
++            "model@00000000@2@aabb@salt",
++            "model@0x00000000@2@aabb@salt.data",
++        ),
++    ],
++)
++def test_legacy_and_current_key_shapes(wire_key, filename, tmp_path):
++    client = lmcache_fs.LMCacheFSClient(str(tmp_path), 1)
++    try:
++        payload = bytearray(b"payload")
++        future_id = client.submit_batch_set([wire_key], [memoryview(payload)])
++        completed_id, ok, error, _results = _wait_for_completion(client)
++
++        assert completed_id == future_id
++        assert ok, error
++        assert (tmp_path / filename).read_bytes() == payload
++    finally:
++        client.close()
+diff --git a/tests/v1/distributed/test_native_fs_odirect.py b/tests/v1/distributed/test_native_fs_odirect.py
+new file mode 100644
+index 0000000000000000000000000000000000000000..1d5118eca102011208e580b447f3d034cb8afd13
+--- /dev/null
++++ b/tests/v1/distributed/test_native_fs_odirect.py
+@@ -0,0 +1,80 @@
++# SPDX-License-Identifier: Apache-2.0
++"""O_DIRECT behavior of the compiled native FS connector."""
++
++# Standard
++import ctypes
++import select
++import time
++
++# Third Party
++import pytest
++
++lmcache_fs = pytest.importorskip("lmcache.lmcache_fs")
++
++
++def _aligned_view(size: int, alignment: int = 4096):
++    storage = bytearray(size + alignment)
++    address = ctypes.addressof(ctypes.c_char.from_buffer(storage))
++    offset = (-address) % alignment
++    return storage, memoryview(storage)[offset : offset + size]
++
++
++def _wait_for_completion(client, timeout: float = 5.0):
++    poller = select.poll()
++    poller.register(client.event_fd(), select.POLLIN)
++    deadline = time.monotonic() + timeout
++    while time.monotonic() < deadline:
++        if poller.poll(50):
++            completions = client.drain_completions()
++            if completions:
++                return completions[0]
++    raise AssertionError("native connector completion timed out")
++
++
++def test_odirect_falls_back_for_misaligned_buffer_address(tmp_path):
++    client = lmcache_fs.LMCacheFSClient(str(tmp_path), 1, "", True)
++    try:
++        payload_storage = bytearray(4097)
++        payload = memoryview(payload_storage)[1:]
++        payload[:] = b"x" * len(payload)
++        key = "model@00000000@01"
++
++        store_id = client.submit_batch_set([key], [payload])
++        completed_id, ok, error, _results = _wait_for_completion(client)
++        assert completed_id == store_id
++        assert ok, error
++
++        loaded_storage = bytearray(4097)
++        loaded = memoryview(loaded_storage)[1:]
++        load_id = client.submit_batch_get([key], [loaded])
++        completed_id, ok, error, results = _wait_for_completion(client)
++        assert completed_id == load_id
++        assert ok, error
++        assert results == [True]
++        assert loaded == payload
++    finally:
++        client.close()
++
++
++def test_odirect_falls_back_for_misaligned_readahead_split(tmp_path):
++    client = lmcache_fs.LMCacheFSClient(str(tmp_path), 1, "", True, 4095)
++    try:
++        payload_storage, payload = _aligned_view(8192)
++        payload[:] = b"x" * len(payload)
++        key = "model@00000000@02"
++
++        store_id = client.submit_batch_set([key], [payload])
++        completed_id, ok, error, _results = _wait_for_completion(client)
++        assert completed_id == store_id
++        assert ok, error
++
++        loaded_storage, loaded = _aligned_view(8192)
++        load_id = client.submit_batch_get([key], [loaded])
++        completed_id, ok, error, results = _wait_for_completion(client)
++        assert completed_id == load_id
++        assert ok, error
++        assert results == [True]
++        assert loaded == payload
++        del payload_storage, loaded_storage
++    finally:
++        client.close()
+diff --git a/tests/v1/distributed/test_prefetch_controller.py b/tests/v1/distributed/test_prefetch_controller.py
+index 09c06c5819646d20d65485ee446793a1a9a7f9d0..e86ac177a07f19f54bb6417858dea1d4ff116cfd 100644
+--- a/tests/v1/distributed/test_prefetch_controller.py
++++ b/tests/v1/distributed/test_prefetch_controller.py
+@@ -35,6 +35,9 @@ from lmcache.v1.distributed.l2_adapters.mock_l2_adapter import (
+     MockL2Adapter,
+     MockL2AdapterConfig,
+ )
++from lmcache.v1.distributed.storage_controllers import (
++    prefetch_controller as prefetch_controller_module,
++)
+ from lmcache.v1.distributed.storage_controllers.prefetch_controller import (
+     PrefetchController,
+     build_trim_mask,
+@@ -363,7 +366,7 @@ class TestSingleAdapterPrefetch:
+         ctrl.stop()
+         adapter.close()
+ 
+-    def test_fault_inject_load_gap_segmented_vs_prefix(self, l1_manager):
++    def test_fault_inject_load_gap_segmented_vs_prefix(self, l1_manager, monkeypatch):
+         """fault_inject (load fails at index 2) drives the segmented path.
+ 
+         Lookup reports all 5 keys present; the *load* of index 2 fails (the L2
+@@ -371,6 +374,14 @@ class TestSingleAdapterPrefetch:
+         post-gap keys {0,1,3,4}; PREFIX truncates at the hole to {0,1}. Distinct
+         key ranges per policy keep the shared L1 from serving the second pass.
+         """
++        warning_messages: list[str] = []
++
++        def capture_warning(message, *args, **_kwargs):
++            warning_messages.append(message % args)
++
++        monkeypatch.setattr(
++            prefetch_controller_module.logger, "warning", capture_warning
++        )
+         layout = make_layout()
+         for base, trim, expected in (
+             (0, TrimPolicy.SEGMENTED_PREFIX, [0, 1, 3, 4]),
+@@ -402,6 +413,11 @@ class TestSingleAdapterPrefetch:
+             ctrl.stop()
+             fault.close()
+ 
++        assert any(
++            "1/5 plan keys failed to load from L2" in message and "sample:" in message
++            for message in warning_messages
++        )
++
+     def test_key0_missing(self, l1_manager):
+         """L2 has keys {1,2,3} but not 0 → prefix = 0, nothing loaded."""
+         adapter = make_adapter()
+diff --git a/tests/v1/multiprocess/test_futures.py b/tests/v1/multiprocess/test_futures.py
+index 53cf694bc5c29ee852c5511d2753b6a8a676511a..c9086609ec879d9ed6fcceab478da9c5c7117d49 100644
+--- a/tests/v1/multiprocess/test_futures.py
++++ b/tests/v1/multiprocess/test_futures.py
+@@ -173,6 +173,27 @@ def test_messaging_future_complex_type():
+     thread.join()
+ 
+ 
++def test_messaging_future_exception_is_re_raised():
++    """A remote messaging failure completes the future instead of hanging it."""
++    future = MessagingFuture[int]()
++    error = RuntimeError("remote operation failed")
++
++    future.set_exception(error)
++
++    assert future.query()
++    assert future.wait(timeout=0.1)
++    with pytest.raises(RuntimeError, match="remote operation failed") as exc_info:
++        future.result(timeout=0.1)
++    assert exc_info.value is error
++
++
++def test_messaging_future_rejects_non_exception():
++    future = MessagingFuture[int]()
++
++    with pytest.raises(TypeError, match="must derive from BaseException"):
++        future.set_exception("not an exception")  # type: ignore[arg-type]
++
++
+ # ==============================================================================
+ # CUDAMessagingFuture Tests
+ # ==============================================================================
+diff --git a/tests/v1/multiprocess/test_mq.py b/tests/v1/multiprocess/test_mq.py
+index 75ff9cd7a0630391f0515622e36e1f38fe243764..93ef515bfc0c3a66feda76720178b2dd140a7211 100644
+--- a/tests/v1/multiprocess/test_mq.py
++++ b/tests/v1/multiprocess/test_mq.py
+@@ -21,6 +21,7 @@ from lmcache.v1.multiprocess.mq import (
+     BlockingRequestHandler,
+     MessageQueueClient,
+     MessageQueueServer,
++    RemoteHandlerError,
+ )
+ from lmcache.v1.multiprocess.protocol import (
+     RequestType,
+@@ -683,6 +684,58 @@ def test_shared_loop_dispatch():
+         server.close()
+ 
+ 
++def test_sync_handler_failure_completes_future_and_loop_recovers():
++    context = zmq.Context.instance()
++    server = MessageQueueServer("tcp://127.0.0.1:16021", context)
++    add_handler_helper(
++        server, RequestType.NOOP, test_mq_handler_helpers.failing_noop_handler
++    )
++    server.start()
++    client = MessageQueueClient("tcp://127.0.0.1:16021", context)
++
++    try:
++        failed = client.submit_request(RequestType.NOOP, [])
++        with pytest.raises(
++            RemoteHandlerError, match="intentional sync handler failure"
++        ) as exc_info:
++            failed.result(timeout=2)
++        assert exc_info.value.request_type is RequestType.NOOP
++        assert exc_info.value.error_type == "ValueError"
++
++        server.add_sync_handler(
++            RequestType.NOOP, [], test_mq_handler_helpers.noop_handler
++        )
++        assert (
++            client.submit_request(RequestType.NOOP, []).result(timeout=2) == "NOOP_OK"
++        )
++    finally:
++        client.close()
++        server.close()
++
++
++def test_blocking_handler_failure_completes_future():
++    context = zmq.Context.instance()
++    server = MessageQueueServer("tcp://127.0.0.1:16022", context)
++    add_handler_helper(
++        server, RequestType.LOOKUP, test_mq_handler_helpers.failing_lookup_handler
++    )
++    server.add_normal_thread_pool([RequestType.LOOKUP], max_workers=1)
++    server.start()
++    client = MessageQueueClient("tcp://127.0.0.1:16022", context)
++
++    try:
++        future = client.submit_request(RequestType.LOOKUP, [create_cache_key(1), 1])
++        with pytest.raises(
++            RemoteHandlerError, match="intentional blocking handler failure"
++        ) as exc_info:
++            future.result(timeout=2)
++        assert exc_info.value.request_type is RequestType.LOOKUP
++        assert exc_info.value.error_type == "OSError"
++    finally:
++        client.close()
++        server.close()
++
++
+ def test_shared_loop_recreate():
+     """
+     Test that closing all clients and creating new ones starts a fresh loop.
+diff --git a/tests/v1/multiprocess/test_mq_handler_helpers.py b/tests/v1/multiprocess/test_mq_handler_helpers.py
+index b1d65251d3fd0a615bc256fb483cf78a4a8ef16e..9837df531ef7414473af86834bc63afcb7f842c0 100644
+--- a/tests/v1/multiprocess/test_mq_handler_helpers.py
++++ b/tests/v1/multiprocess/test_mq_handler_helpers.py
+@@ -29,6 +29,11 @@ def noop_handler() -> str:
+     return "NOOP_OK"
+ 
+ 
++def failing_noop_handler() -> str:
++    """Raise a deterministic error for RPC error propagation tests."""
++    raise ValueError("intentional sync handler failure")
++
++
+ # ==============================================================================
+ # REGISTER_KV_CACHE Request Handlers
+ # ==============================================================================
+@@ -203,6 +208,12 @@ def lookup_handler(key: KeyType, tp_size: int) -> None:
+     assert isinstance(tp_size, int), f"Expected tp_size to be int, got {type(tp_size)}"
+ 
+ 
++def failing_lookup_handler(key: KeyType, tp_size: int) -> None:
++    """Raise a deterministic error from a blocking request handler."""
++    del key, tp_size
++    raise OSError("intentional blocking handler failure")
++
++
+ # ==============================================================================
+ # FREE_LOOKUP_LOCKS Request Handlers
+ # ==============================================================================
+diff --git a/tests/v1/test_vllm_mp_adapter.py b/tests/v1/test_vllm_mp_adapter.py
+index d64ca9ec7061a0714cba7c9c488e3fb0cef9179a..ddf180a64dd9e6b9d8f4af4114324bc927fbf12f 100644
+--- a/tests/v1/test_vllm_mp_adapter.py
++++ b/tests/v1/test_vllm_mp_adapter.py
+@@ -782,3 +782,65 @@ def test_recover_callback_rebuilds_transfer_ctx_without_closing_previous(
+     assert len(contexts) == 3
+     assert adapter.transfer_ctx is contexts[2]
+     contexts[1].close.assert_not_called()
++
++
++def _finished_retrieve_future(result: object) -> MagicMock:
++    """Build a completed retrieve future; an Exception *result* makes
++    ``result()`` raise it."""
++    future = MagicMock(name="retrieve_future")
++    future.query.return_value = True
++    if isinstance(result, Exception):
++        future.result.side_effect = result
++    else:
++        future.result.return_value = result
++    return future
++
++
++def test_failed_retrieve_marks_blocks_invalid(fake_adapter) -> None:
++    """A retrieve the healthy server answers with ``result=False`` is
++    reported finished AND its block ids are surfaced through
++    ``get_block_ids_with_load_errors`` so the scheduler recomputes them
++    instead of decoding over never-written blocks."""
++    adapter, _send_mock, _ = fake_adapter
++    adapter.retrieve_futures["req-1"] = (
++        _finished_retrieve_future(False),
++        [3, 4, 5],
++    )
++
++    ret_stores, finished_retrieves = adapter.get_finished(set())
++
++    assert ret_stores == set()
++    assert finished_retrieves == {"req-1"}
++    assert adapter.get_block_ids_with_load_errors() == {3, 4, 5}
++    # The error set is consumed on read.
++    assert adapter.get_block_ids_with_load_errors() == set()
++    assert adapter.retrieve_failure_count == 1
++
++
++def test_raising_retrieve_future_contained_as_failure(fake_adapter) -> None:
++    """A retrieve future whose ``result()`` raises must not propagate out
++    of ``get_finished`` (that would kill the engine step); it lands on the
++    same failure path as ``result=False``."""
++    adapter, _send_mock, _ = fake_adapter
++    adapter.retrieve_futures["req-1"] = (
++        _finished_retrieve_future(RuntimeError("ipc receive failed")),
++        [7, 8],
++    )
++
++    _ret_stores, finished_retrieves = adapter.get_finished(set())
++
++    assert finished_retrieves == {"req-1"}
++    assert adapter.get_block_ids_with_load_errors() == {7, 8}
++    assert adapter.retrieve_failure_count == 1
++
++
++def test_successful_retrieve_marks_no_blocks_invalid(fake_adapter) -> None:
++    """A successful retrieve reports no load errors."""
++    adapter, _send_mock, _ = fake_adapter
++    adapter.retrieve_futures["req-1"] = (_finished_retrieve_future(True), [1, 2])
++
++    _ret_stores, finished_retrieves = adapter.get_finished(set())
++
++    assert finished_retrieves == {"req-1"}
++    assert adapter.get_block_ids_with_load_errors() == set()
++    assert adapter.retrieve_failure_count == 0
+diff --git a/tests/v1/test_vllm_mp_connector_metadata.py b/tests/v1/test_vllm_mp_connector_metadata.py
+new file mode 100644
+index 0000000000000000000000000000000000000000..45d427bd561aed4dcc953eda04259e2854008e15
+--- /dev/null
++++ b/tests/v1/test_vllm_mp_connector_metadata.py
+@@ -0,0 +1,133 @@
++# SPDX-License-Identifier: Apache-2.0
++"""Unit tests for ``LMCacheMPRequestMetadata.GetRetrieveMetadata``.
++
++The retrieve op must only be emitted when the tracker's allocated block ids
++actually cover the retrieve token range in every engine group:
++``slice_block_ids_per_group`` validates chunk alignment only, and its plain
++Python slice truncates silently, so an uncovered range would otherwise emit
++an op with too few block ids.
++"""
++
++# Standard
++from types import SimpleNamespace
++
++# Third Party
++import pytest
++
++# First Party
++from lmcache.integration.vllm.lmcache_mp_connector import (
++    LMCacheMPRequestMetadata,
++    LMCacheMPRequestState,
++    LMCacheMPRequestTracker,
++)
++
++CHUNK_TOKENS = 64
++
++
++def _tracker(
++    num_tokens: int,
++    lmcache_hit_tokens: int,
++    vllm_hit_tokens: int,
++    allocated_block_ids: dict[int, list[int]],
++) -> LMCacheMPRequestTracker:
++    """Build a tracker that is ready for retrieving over *num_tokens*."""
++    request = SimpleNamespace(
++        request_id="req-1",
++        cache_salt="",
++        all_token_ids=list(range(num_tokens)),
++    )
++    tracker = LMCacheMPRequestTracker(request)
++    tracker.num_lmcache_hit_tokens = lmcache_hit_tokens
++    tracker.num_vllm_hit_tokens = vllm_hit_tokens
++    tracker.allocated_block_ids = allocated_block_ids
++    tracker.state = LMCacheMPRequestState.WAITING_FOR_LOAD
++    return tracker
++
++
++@pytest.mark.parametrize(
++    ("group_tokens_per_block", "allocated_block_ids", "expected_block_ids"),
++    [
++        # Single group, plain geometry: 64 tokens / 16 tokens per block.
++        ([16], {0: [0, 1, 2, 3]}, [[0, 1, 2, 3]]),
++        # Single group, DCP-scaled: one manager block id covers 64 tokens.
++        ([64], {0: [5]}, [[5]]),
++        # Hybrid geometries: each group sliced by its own tokens-per-block.
++        ([16, 32], {0: [0, 1, 2, 3], 1: [10, 11]}, [[0, 1, 2, 3], [10, 11]]),
++        # Extra allocated blocks beyond the range are fine (and not emitted).
++        ([16], {0: [0, 1, 2, 3, 4, 5]}, [[0, 1, 2, 3]]),
++    ],
++)
++def test_retrieve_metadata_emitted_when_allocation_covers_range(
++    group_tokens_per_block: list[int],
++    allocated_block_ids: dict[int, list[int]],
++    expected_block_ids: list[list[int]],
++) -> None:
++    tracker = _tracker(
++        num_tokens=CHUNK_TOKENS,
++        lmcache_hit_tokens=CHUNK_TOKENS,
++        vllm_hit_tokens=0,
++        allocated_block_ids=allocated_block_ids,
++    )
++
++    metadata = LMCacheMPRequestMetadata.GetRetrieveMetadata(
++        tracker, CHUNK_TOKENS, group_tokens_per_block
++    )
++
++    assert metadata is not None
++    assert metadata.direction == "RETRIEVE"
++    assert metadata.op.start == 0
++    assert metadata.op.end == CHUNK_TOKENS
++    assert metadata.op.block_ids == expected_block_ids
++
++
++@pytest.mark.parametrize(
++    ("group_tokens_per_block", "allocated_block_ids"),
++    [
++        # One block short in the only group.
++        ([16], {0: [0, 1, 2]}),
++        # DCP-scaled group with no allocation at all.
++        ([64], {0: []}),
++        # Group 0 covered, group 1 one block short.
++        ([16, 32], {0: [0, 1, 2, 3], 1: [10]}),
++        # Group key missing entirely (counts as zero blocks).
++        ([16, 16], {0: [0, 1, 2, 3]}),
++    ],
++)
++def test_retrieve_metadata_suppressed_when_allocation_short(
++    group_tokens_per_block: list[int],
++    allocated_block_ids: dict[int, list[int]],
++) -> None:
++    """Any engine group whose allocation does not cover the retrieve range
++    suppresses the op entirely: the request falls back to recompute instead
++    of retrieving over silently truncated block-id lists."""
++    tracker = _tracker(
++        num_tokens=CHUNK_TOKENS,
++        lmcache_hit_tokens=CHUNK_TOKENS,
++        vllm_hit_tokens=0,
++        allocated_block_ids=allocated_block_ids,
++    )
++
++    metadata = LMCacheMPRequestMetadata.GetRetrieveMetadata(
++        tracker, CHUNK_TOKENS, group_tokens_per_block
++    )
++
++    assert metadata is None
++
++
++def test_retrieve_metadata_skip_tokens_preserved_on_emitted_op() -> None:
++    """vLLM-hit tokens inside the first chunk round the start down and are
++    carried as skip_first_n_tokens; coverage is still checked against the
++    chunk-aligned end."""
++    tracker = _tracker(
++        num_tokens=CHUNK_TOKENS,
++        lmcache_hit_tokens=CHUNK_TOKENS,
++        vllm_hit_tokens=16,
++        allocated_block_ids={0: [0, 1, 2, 3]},
++    )
++
++    metadata = LMCacheMPRequestMetadata.GetRetrieveMetadata(tracker, CHUNK_TOKENS, [16])
++
++    assert metadata is not None
++    assert metadata.op.start == 0
++    assert metadata.op.end == CHUNK_TOKENS
++    assert metadata.op.skip_first_n_tokens == 16

--- a/patches/releases/gilded-gnosis-v20-r17/sparkinfer/integration.lock.json
+++ b/patches/releases/gilded-gnosis-v20-r17/sparkinfer/integration.lock.json
@@ -1,0 +1,40 @@
+{
+  "base": {
+    "commit": "b0976b7fd46b5d34357a5f615822b86792676feb",
+    "ref": "refs/heads/master",
+    "repository": "https://github.com/local-inference-lab/sparkinfer.git"
+  },
+  "manifest": {
+    "sha256": "38d44effeb4d2c14a81fd7f0717a47469e00f34e798e66f9753a85d3861eea58"
+  },
+  "name": "gilded-gnosis-v20-sparkinfer",
+  "pull_requests": [
+    {
+      "disposition": "merged",
+      "head": "35588fb570d23713bcb2a81749d0fdf3c4396ace",
+      "number": 106,
+      "ref": "refs/pull/106/head",
+      "title": "Honor compressed cache physical page stride"
+    },
+    {
+      "disposition": "merged",
+      "head": "caa643c8546121214493d052221f16c62f69f719",
+      "number": 105,
+      "ref": "refs/pull/105/head",
+      "title": "Harden replay and CUDA IPC lifecycle"
+    },
+    {
+      "disposition": "merged",
+      "head": "01917253eb3925a01c8123ed859d49880e27f961",
+      "number": 110,
+      "ref": "refs/pull/110/head",
+      "title": "Harden W4A16 planning, tails, and capture resolution"
+    }
+  ],
+  "result": {
+    "patch": "integration.patch",
+    "patch_sha256": "a244c1c788f9c5b8a2f679ce0bf15c0d990812d765a7c929cb97a7df44fdeabb",
+    "tree": "cfde4787facf7e32248beb8011a1aa0048b4c33c"
+  },
+  "schema_version": 1
+}

--- a/patches/releases/gilded-gnosis-v20-r17/sparkinfer/integration.lock.json
+++ b/patches/releases/gilded-gnosis-v20-r17/sparkinfer/integration.lock.json
@@ -5,7 +5,7 @@
     "repository": "https://github.com/local-inference-lab/sparkinfer.git"
   },
   "manifest": {
-    "sha256": "38d44effeb4d2c14a81fd7f0717a47469e00f34e798e66f9753a85d3861eea58"
+    "sha256": "f4b0bab203898fc1cb8e74975c5de4fb68ad504ec4018cb24ab03eb746a26d3b"
   },
   "name": "gilded-gnosis-v20-sparkinfer",
   "pull_requests": [
@@ -18,7 +18,7 @@
     },
     {
       "disposition": "merged",
-      "head": "caa643c8546121214493d052221f16c62f69f719",
+      "head": "45033eebcf5bb184587a35c528a62721a46acdf5",
       "number": 105,
       "ref": "refs/pull/105/head",
       "title": "Harden replay and CUDA IPC lifecycle"
@@ -33,8 +33,8 @@
   ],
   "result": {
     "patch": "integration.patch",
-    "patch_sha256": "a244c1c788f9c5b8a2f679ce0bf15c0d990812d765a7c929cb97a7df44fdeabb",
-    "tree": "cfde4787facf7e32248beb8011a1aa0048b4c33c"
+    "patch_sha256": "e89b1d2bde073dffc7f4de910ac3f7d75d4a00f8e48b55ee09b42e8126ce6e55",
+    "tree": "b2bff719ba1be0a5d30cb39cba795f0812db0f3d"
   },
   "schema_version": 1
 }

--- a/patches/releases/gilded-gnosis-v20-r17/sparkinfer/integration.patch
+++ b/patches/releases/gilded-gnosis-v20-r17/sparkinfer/integration.patch
@@ -1,0 +1,15663 @@
+diff --git a/benchmarks/benchmark_pcie_oneshot_control_node.py b/benchmarks/benchmark_pcie_oneshot_control_node.py
+new file mode 100644
+index 0000000000000000000000000000000000000000..78d705eba932907288f1bbd987492db8e3afd0b0
+--- /dev/null
++++ b/benchmarks/benchmark_pcie_oneshot_control_node.py
+@@ -0,0 +1,1167 @@
++"""Immutable one-run worker for the PCIe oneshot control-node A/B harness.
++
++Use ``run_pcie_oneshot_control_node_ab.py`` rather than comparing two ad-hoc
++JSON files. That external controller invokes this exact file for both source
++trees in an alternating AB/BA sequence and validates every recorded contract.
++
++This harness intentionally measures only the plain staged one-shot all-reduce
++at 64 KiB by default. A public-head comparison is a net algorithm comparison;
++it must not be described as isolated control-node launch overhead or generalized
++to fused RMSNorm / two-shot collectives without their own measurements.
++"""
++
++from __future__ import annotations
++
++import argparse
++import hashlib
++import importlib
++import json
++import math
++import os
++import platform
++import socket
++import subprocess
++import sys
++import threading
++import time
++from datetime import datetime, timedelta, timezone
++from pathlib import Path
++from typing import Callable, Sequence
++
++import torch
++import torch.distributed as dist
++from cuda.bindings import runtime as cudart
++
++SCHEMA_NAME = "sparkinfer.pcie_oneshot_control_node.run"
++SCHEMA_VERSION = 2
++DTYPE_NAME = "bfloat16"
++TOP_LEVEL_KEYS = {
++    "schema",
++    "contract",
++    "scope",
++    "identity",
++    "provenance",
++    "software",
++    "hardware",
++    "environment",
++    "per_rank",
++    "distributed_critical_path",
++}
++CONTRACT_KEYS = {
++    "world_size",
++    "numel",
++    "dtype",
++    "warmup",
++    "iters",
++    "preflight_replays",
++}
++SCOPE_KEYS = {
++    "operation",
++    "staging",
++    "size_bytes",
++    "comparison_semantics",
++    "excluded_paths",
++}
++IDENTITY_KEYS = {
++    "label",
++    "variant",
++    "run_index",
++    "implementation_root",
++    "implementation_git_sha",
++    "implementation_git_dirty",
++    "harness_sha256",
++    "controller_sha256",
++    "controller_argv_sha256",
++    "worker_argv",
++    "worker_argv_sha256",
++    "started_at_utc",
++}
++PROVENANCE_KEYS = {
++    "module_path",
++    "module_sha256",
++    "cuda_source_path",
++    "cuda_source_sha256",
++    "extension_path",
++    "extension_sha256",
++    "extension_build_root",
++    "extension_build_manifest",
++    "extension_build_manifest_sha256",
++    "fresh_extension_cache",
++    "post_run_verified",
++}
++METRIC_KEYS = {"cold_us", "mean_us", "p50_us", "p95_us", "min_us", "max_us"}
++RANK_MODE_KEYS = METRIC_KEYS | {"samples_us"}
++CRITICAL_MODE_KEYS = METRIC_KEYS | {"samples_us"}
++SOFTWARE_KEYS = {
++    "python",
++    "platform",
++    "torch",
++    "torch_cuda",
++    "cuda_runtime_version",
++    "cuda_driver_version",
++    "nvcc_version",
++}
++HARDWARE_KEYS = {
++    "hostname",
++    "devices",
++    "nvidia_smi_identity",
++    "nvidia_smi_sample_fields",
++    "nvidia_smi_samples",
++    "nvidia_smi_topology",
++}
++DEVICE_KEYS = {
++    "index",
++    "name",
++    "uuid",
++    "compute_capability",
++    "total_memory_bytes",
++    "multi_processor_count",
++}
++NVIDIA_QUERY_KEYS = {"fields", "returncode", "rows", "stderr"}
++NVIDIA_SAMPLE_KEYS = {"monotonic_ns", "phase", "query"}
++NVIDIA_TOPOLOGY_KEYS = {"returncode", "stdout", "stderr"}
++GRAPH_STRUCTURE_KEYS = {
++    "kernel_nodes",
++    "direct_control_worker_edge",
++    "control_grid",
++    "control_block",
++    "worker_grid",
++    "worker_block",
++}
++NVIDIA_IDENTITY_FIELDS = ("index", "uuid", "name", "driver_version")
++NVIDIA_SMI_FIELDS = (
++    "index",
++    "uuid",
++    "name",
++    "driver_version",
++    "pstate",
++    "power.limit",
++    "power.draw",
++    "clocks.current.sm",
++    "clocks.current.memory",
++    "clocks.max.sm",
++    "clocks.max.memory",
++    "utilization.gpu",
++    "utilization.memory",
++    "temperature.gpu",
++    "clocks_event_reasons.active",
++)
++EXPLICIT_ENV_KEYS = {
++    "CUDA_DEVICE_ORDER",
++    "CUDA_LAUNCH_BLOCKING",
++    "CUDA_MODULE_LOADING",
++    "CUDA_VISIBLE_DEVICES",
++    "CUBLAS_WORKSPACE_CONFIG",
++    "NCCL_P2P_DISABLE",
++    "NCCL_P2P_LEVEL",
++    "NVIDIA_VISIBLE_DEVICES",
++    "OMP_NUM_THREADS",
++    "PYTORCH_CUDA_ALLOC_CONF",
++    "TORCH_EXTENSIONS_DIR",
++}
++
++
++def _parse_args() -> argparse.Namespace:
++    parser = argparse.ArgumentParser()
++    parser.add_argument("--label", required=True)
++    parser.add_argument("--variant", choices=("baseline", "candidate"), required=True)
++    parser.add_argument("--run-index", type=int, required=True)
++    parser.add_argument("--implementation-root", type=Path, required=True)
++    parser.add_argument("--expected-git-sha", required=True)
++    parser.add_argument("--expected-graph-kernel-nodes", type=int, required=True)
++    parser.add_argument("--numel", type=int, default=32768)
++    parser.add_argument("--warmup", type=int, default=100)
++    parser.add_argument("--iters", type=int, default=1000)
++    parser.add_argument("--sampler-interval", type=float, default=0.2)
++    parser.add_argument("--preflight-replays", type=int, default=4)
++    parser.add_argument("--distributed-timeout-seconds", type=float, default=300.0)
++    parser.add_argument("--controller-sha256", required=True)
++    parser.add_argument("--controller-argv-sha256", required=True)
++    parser.add_argument("--output", type=Path, required=True)
++    parser.add_argument("--allow-dirty", action="store_true")
++    return parser.parse_args()
++
++
++def _run_command(
++    args: list[str],
++    *,
++    cwd: Path | None = None,
++    timeout: float = 30.0,
++) -> str:
++    result = subprocess.run(
++        args,
++        cwd=cwd,
++        check=True,
++        text=True,
++        stdout=subprocess.PIPE,
++        stderr=subprocess.PIPE,
++        timeout=timeout,
++    )
++    return result.stdout.strip()
++
++
++def _git_identity(root: Path) -> tuple[str, bool]:
++    sha = _run_command(["git", "rev-parse", "HEAD"], cwd=root)
++    dirty = bool(_run_command(["git", "status", "--porcelain=v1"], cwd=root))
++    return sha, dirty
++
++
++def _sha256(path: Path) -> str:
++    digest = hashlib.sha256()
++    with path.open("rb") as handle:
++        for block in iter(lambda: handle.read(1024 * 1024), b""):
++            digest.update(block)
++    return digest.hexdigest()
++
++
++def _json_sha256(value: object) -> str:
++    rendered = json.dumps(
++        value,
++        sort_keys=True,
++        separators=(",", ":"),
++    ).encode("utf-8")
++    return hashlib.sha256(rendered).hexdigest()
++
++
++def _extension_build_manifest(build_root: Path) -> list[dict[str, object]]:
++    """Hash every durable input/output in one fresh JIT extension directory."""
++
++    entries = []
++    for path in sorted(build_root.rglob("*")):
++        if not path.is_file() or path.name in {".ninja_deps", ".ninja_log", "lock"}:
++            continue
++        entries.append(
++            {
++                "path": str(path.relative_to(build_root)),
++                "size_bytes": path.stat().st_size,
++                "sha256": _sha256(path),
++            }
++        )
++    if not entries:
++        raise RuntimeError(f"extension build manifest is empty: {build_root}")
++    return entries
++
++
++def _verified_implementation(
++    implementation_root: Path,
++) -> tuple[object, type, dict[str, object]]:
++    """Import, build, and bind the implementation to exact source/binary hashes."""
++
++    module = importlib.import_module("sparkinfer.comm.pcie.pcie_oneshot")
++    module_path = Path(module.__file__).resolve()
++    expected_module = (
++        implementation_root / "sparkinfer/comm/pcie/pcie_oneshot.py"
++    ).resolve()
++    if module_path != expected_module:
++        raise RuntimeError(
++            f"imported PCIe oneshot module {module_path} != {expected_module}"
++        )
++    cuda_source = module_path.with_suffix(".cu")
++    if not cuda_source.is_file():
++        raise RuntimeError(f"PCIe oneshot CUDA source is missing: {cuda_source}")
++
++    extension = module._load_extension()
++    extension_path = Path(extension.__file__).resolve()
++    build_root = extension_path.parent
++    expected_cache = Path(os.environ["TORCH_EXTENSIONS_DIR"]).resolve()
++    if not extension_path.is_relative_to(expected_cache):
++        raise RuntimeError(
++            f"loaded extension {extension_path} is outside fresh cache {expected_cache}"
++        )
++    manifest = _extension_build_manifest(build_root)
++    provenance = {
++        "module_path": str(module_path),
++        "module_sha256": _sha256(module_path),
++        "cuda_source_path": str(cuda_source),
++        "cuda_source_sha256": _sha256(cuda_source),
++        "extension_path": str(extension_path),
++        "extension_sha256": _sha256(extension_path),
++        "extension_build_root": str(build_root),
++        "extension_build_manifest": manifest,
++        "extension_build_manifest_sha256": _json_sha256(manifest),
++        "fresh_extension_cache": True,
++        "post_run_verified": False,
++    }
++    return module, module.PCIeOneshotAllReducePool, provenance
++
++
++def _verify_post_run_provenance(
++    provenance: dict[str, object],
++    *,
++    implementation_root: Path,
++    expected_git_sha: str,
++) -> None:
++    git_sha, git_dirty = _git_identity(implementation_root)
++    if git_sha != expected_git_sha or git_dirty:
++        raise RuntimeError("implementation Git identity changed during benchmark")
++    checks = (
++        ("module_path", "module_sha256"),
++        ("cuda_source_path", "cuda_source_sha256"),
++        ("extension_path", "extension_sha256"),
++    )
++    for path_key, digest_key in checks:
++        if _sha256(Path(provenance[path_key])) != provenance[digest_key]:
++            raise RuntimeError(f"{path_key} changed during benchmark")
++    manifest = _extension_build_manifest(Path(provenance["extension_build_root"]))
++    if manifest != provenance["extension_build_manifest"]:
++        raise RuntimeError("extension build manifest changed during benchmark")
++    if _json_sha256(manifest) != provenance["extension_build_manifest_sha256"]:
++        raise RuntimeError("extension build manifest digest changed during benchmark")
++    provenance["post_run_verified"] = True
++
++
++def _cuda_version(call: Callable[[], tuple[object, int]]) -> int:
++    result, version = call()
++    if result != cudart.cudaError_t.cudaSuccess:
++        raise RuntimeError(f"CUDA version query failed: {result}")
++    return int(version)
++
++
++def _nvidia_smi_query(fields: tuple[str, ...]) -> dict[str, object]:
++    command = [
++        "nvidia-smi",
++        f"--query-gpu={','.join(fields)}",
++        "--format=csv,noheader,nounits",
++    ]
++    try:
++        result = subprocess.run(
++            command,
++            check=False,
++            text=True,
++            stdout=subprocess.PIPE,
++            stderr=subprocess.PIPE,
++            timeout=10,
++        )
++    except subprocess.TimeoutExpired as exc:
++        return {
++            "fields": list(fields),
++            "returncode": -1,
++            "rows": [],
++            "stderr": f"nvidia-smi timed out after {exc.timeout}s",
++        }
++    return {
++        "fields": list(fields),
++        "returncode": result.returncode,
++        "rows": [
++            [value.strip() for value in line.split(",")]
++            for line in result.stdout.splitlines()
++            if line.strip()
++        ],
++        "stderr": result.stderr.strip(),
++    }
++
++
++def _nvidia_smi_topology() -> dict[str, object]:
++    try:
++        result = subprocess.run(
++            ["nvidia-smi", "topo", "-m"],
++            check=False,
++            text=True,
++            stdout=subprocess.PIPE,
++            stderr=subprocess.PIPE,
++            timeout=10,
++        )
++    except subprocess.TimeoutExpired as exc:
++        return {
++            "returncode": -1,
++            "stdout": "",
++            "stderr": f"nvidia-smi topology timed out after {exc.timeout}s",
++        }
++    return {
++        "returncode": result.returncode,
++        "stdout": result.stdout.rstrip(),
++        "stderr": result.stderr.strip(),
++    }
++
++
++class _NvidiaSmiSampler:
++    def __init__(self, interval: float) -> None:
++        self.interval = interval
++        self.samples: list[dict[str, object]] = []
++        self._stop = threading.Event()
++        self._lock = threading.Lock()
++        self._phase = "unmarked"
++        self._thread = threading.Thread(target=self._run, daemon=True)
++
++    def _sample(self) -> None:
++        sample = {
++            "monotonic_ns": time.monotonic_ns(),
++            "phase": self._phase,
++            "query": _nvidia_smi_query(NVIDIA_SMI_FIELDS),
++        }
++        with self._lock:
++            self.samples.append(sample)
++
++    def _run(self) -> None:
++        while not self._stop.is_set():
++            self._sample()
++            self._stop.wait(self.interval)
++
++    def start(self) -> None:
++        self._thread.start()
++
++    def mark_phase(self, phase: str) -> None:
++        self._phase = phase
++        # A short timing phase must still contribute telemetry.
++        self._sample()
++
++    def stop(self) -> None:
++        self._stop.set()
++        self._thread.join(timeout=15)
++        if self._thread.is_alive():
++            raise RuntimeError("nvidia-smi sampler thread did not stop within 15s")
++        self._phase = "final"
++        self._sample()
++
++
++def _environment_toggles() -> dict[str, str]:
++    return {
++        key: value
++        for key, value in sorted(os.environ.items())
++        if key in EXPLICIT_ENV_KEYS
++        or key.startswith("SPARKINFER_")
++        or key.startswith("NCCL_")
++        or key.startswith("TORCH_NCCL_")
++    }
++
++
++def _dim3_list(value: object) -> list[int]:
++    return [int(value.x), int(value.y), int(value.z)]
++
++
++def _graph_kernel_structure(
++    graph: torch.cuda.CUDAGraph,
++    *,
++    expected_kernel_nodes: int,
++) -> dict[str, object]:
++    """Prove the candidate's 1x1 control node directly orders its worker."""
++
++    graph_handle = graph.raw_cuda_graph()
++    result, _, num_nodes = cudart.cudaGraphGetNodes(graph_handle)
++    if result != cudart.cudaError_t.cudaSuccess:
++        raise RuntimeError(f"cudaGraphGetNodes(size) failed: {result}")
++    result, nodes, returned_nodes = cudart.cudaGraphGetNodes(
++        graph_handle,
++        num_nodes,
++    )
++    if result != cudart.cudaError_t.cudaSuccess or returned_nodes != num_nodes:
++        raise RuntimeError(
++            f"cudaGraphGetNodes(data) failed: {result}, {returned_nodes=}, {num_nodes=}"
++        )
++    kernel_type = cudart.cudaGraphNodeType.cudaGraphNodeTypeKernel
++    kernel_nodes = []
++    for node in nodes[:num_nodes]:
++        result, node_type = cudart.cudaGraphNodeGetType(node)
++        if result != cudart.cudaError_t.cudaSuccess:
++            raise RuntimeError(f"cudaGraphNodeGetType failed: {result}")
++        if node_type == kernel_type:
++            kernel_nodes.append(node)
++    if len(kernel_nodes) != expected_kernel_nodes:
++        raise AssertionError(
++            f"graph has {len(kernel_nodes)} kernel nodes, expected "
++            f"{expected_kernel_nodes}"
++        )
++
++    edge_query = cudart.cudaGraphGetEdges(graph_handle)
++    if edge_query[0] != cudart.cudaError_t.cudaSuccess:
++        raise RuntimeError(f"cudaGraphGetEdges(size) failed: {edge_query[0]}")
++    num_edges = int(edge_query[-1])
++    edges = cudart.cudaGraphGetEdges(graph_handle, num_edges)
++    result, from_nodes, to_nodes, returned_edges = (
++        edges[0],
++        edges[1],
++        edges[2],
++        edges[-1],
++    )
++    if result != cudart.cudaError_t.cudaSuccess or returned_edges != num_edges:
++        raise RuntimeError(
++            f"cudaGraphGetEdges(data) failed: {result}, {returned_edges=}, {num_edges=}"
++        )
++    kernel_edges = []
++    for source, destination in zip(
++        from_nodes[:num_edges],
++        to_nodes[:num_edges],
++        strict=True,
++    ):
++        result, source_type = cudart.cudaGraphNodeGetType(source)
++        if result != cudart.cudaError_t.cudaSuccess:
++            raise RuntimeError(f"source cudaGraphNodeGetType failed: {result}")
++        result, destination_type = cudart.cudaGraphNodeGetType(destination)
++        if result != cudart.cudaError_t.cudaSuccess:
++            raise RuntimeError(f"destination cudaGraphNodeGetType failed: {result}")
++        if source_type == kernel_type and destination_type == kernel_type:
++            kernel_edges.append((source, destination))
++
++    def geometry(node: object) -> tuple[list[int], list[int]]:
++        result, params = cudart.cudaGraphKernelNodeGetParams(node)
++        if result != cudart.cudaError_t.cudaSuccess and hasattr(
++            cudart, "cudaGraphNodeGetParams"
++        ):
++            fallback_result, node_params = cudart.cudaGraphNodeGetParams(node)
++            if fallback_result != cudart.cudaError_t.cudaSuccess:
++                raise RuntimeError(
++                    "cudaGraphKernelNodeGetParams failed: "
++                    f"{result}; cudaGraphNodeGetParams failed: {fallback_result}"
++                )
++            result, params = fallback_result, node_params.kernel
++        if result != cudart.cudaError_t.cudaSuccess:
++            raise RuntimeError(f"cudaGraphKernelNodeGetParams failed: {result}")
++        return _dim3_list(params.gridDim), _dim3_list(params.blockDim)
++
++    if expected_kernel_nodes == 2:
++        if len(kernel_edges) != 1:
++            raise AssertionError(
++                "staged candidate graph must contain one direct control-to-worker "
++                f"kernel edge, found {len(kernel_edges)}"
++            )
++        control, worker = map(geometry, kernel_edges[0])
++        if control != ([1, 1, 1], [1, 1, 1]):
++            raise AssertionError(f"control kernel is not <<<1,1>>>: {control}")
++        if worker[0][0] <= 1 or worker[1][0] < 64:
++            raise AssertionError(f"worker launch geometry is implausible: {worker}")
++        direct_edge = True
++    elif expected_kernel_nodes == 1:
++        if kernel_edges:
++            raise AssertionError("one-kernel baseline graph has a kernel edge")
++        control = (None, None)
++        worker = geometry(kernel_nodes[0])
++        direct_edge = False
++    else:
++        raise AssertionError(
++            "plain staged A/B contract supports only one-node baseline and "
++            "two-node candidate graphs"
++        )
++    return {
++        "kernel_nodes": len(kernel_nodes),
++        "direct_control_worker_edge": direct_edge,
++        "control_grid": control[0],
++        "control_block": control[1],
++        "worker_grid": worker[0],
++        "worker_block": worker[1],
++    }
++
++
++def _measure(
++    operation: Callable[[], None],
++    *,
++    stream: torch.cuda.Stream,
++    warmup: int,
++    iters: int,
++) -> tuple[float, list[float]]:
++    cold_start = torch.cuda.Event(enable_timing=True)
++    cold_end = torch.cuda.Event(enable_timing=True)
++    cold_start.record(stream)
++    operation()
++    cold_end.record(stream)
++    stream.synchronize()
++    cold_us = float(cold_start.elapsed_time(cold_end) * 1000)
++
++    for _ in range(warmup):
++        operation()
++    stream.synchronize()
++
++    starts = [torch.cuda.Event(enable_timing=True) for _ in range(iters)]
++    ends = [torch.cuda.Event(enable_timing=True) for _ in range(iters)]
++    for start, end in zip(starts, ends, strict=True):
++        start.record(stream)
++        operation()
++        end.record(stream)
++    stream.synchronize()
++    samples = [
++        float(start.elapsed_time(end) * 1000)
++        for start, end in zip(starts, ends, strict=True)
++    ]
++    return cold_us, samples
++
++
++def _mutating_replay_preflight(
++    operation: Callable[[], None],
++    *,
++    inp: torch.Tensor,
++    out: torch.Tensor,
++    stream: torch.cuda.Stream,
++    rank: int,
++    world_size: int,
++    replays: int,
++) -> None:
++    """Expose stale-slot reuse by validating changing data on both slot parities."""
++
++    if replays < 4:
++        raise ValueError("mutating preflight requires at least four replays")
++    rank_sum = world_size * (world_size + 1) // 2
++    for iteration in range(replays):
++        multiplier = iteration + 1
++        with torch.cuda.stream(stream):
++            inp.fill_(multiplier * (rank + 1))
++            operation()
++        stream.synchronize()
++        torch.testing.assert_close(
++            out,
++            torch.full_like(out, multiplier * rank_sum),
++            rtol=0,
++            atol=0,
++        )
++
++
++def _summary(samples: list[float]) -> dict[str, float]:
++    if not samples:
++        raise ValueError("cannot summarize an empty latency vector")
++    ordered = sorted(samples)
++
++    def percentile(fraction: float) -> float:
++        index = max(0, math.ceil(fraction * len(ordered)) - 1)
++        return ordered[index]
++
++    return {
++        "mean_us": sum(ordered) / len(ordered),
++        "p50_us": percentile(0.50),
++        "p95_us": percentile(0.95),
++        "min_us": ordered[0],
++        "max_us": ordered[-1],
++    }
++
++
++def _gather_rank_metrics(
++    eager_cold_us: float,
++    eager_samples: list[float],
++    graph_cold_us: float,
++    graph_samples: list[float],
++    graph_structure: dict[str, object],
++    device: torch.device,
++) -> list[dict[str, object]]:
++    if len(eager_samples) != len(graph_samples) or not eager_samples:
++        raise ValueError("eager/graph latency vectors must be non-empty and aligned")
++    control_grid = graph_structure["control_grid"] or [0, 0, 0]
++    control_block = graph_structure["control_block"] or [0, 0, 0]
++    structure_values = [
++        float(graph_structure["kernel_nodes"]),
++        float(bool(graph_structure["direct_control_worker_edge"])),
++        *map(float, control_grid),
++        *map(float, control_block),
++        *map(float, graph_structure["worker_grid"]),
++        *map(float, graph_structure["worker_block"]),
++    ]
++    if len(structure_values) != 14:
++        raise AssertionError("graph structure encoding must contain 14 values")
++    local = torch.tensor(
++        [
++            eager_cold_us,
++            *eager_samples,
++            graph_cold_us,
++            *graph_samples,
++            *structure_values,
++        ],
++        device=device,
++        dtype=torch.float64,
++    )
++    gathered = [torch.empty_like(local) for _ in range(dist.get_world_size())]
++    dist.all_gather(gathered, local)
++
++    result = []
++    for rank, values_tensor in enumerate(gathered):
++        values = values_tensor.cpu().tolist()
++        iters = len(eager_samples)
++        rank_eager_samples = values[1 : 1 + iters]
++        graph_cold_index = 1 + iters
++        rank_graph_samples = values[graph_cold_index + 1 : graph_cold_index + 1 + iters]
++        structure = values[graph_cold_index + 1 + iters :]
++        eager_summary = _summary(rank_eager_samples)
++        graph_summary = _summary(rank_graph_samples)
++        has_control = bool(int(structure[1]))
++        result.append(
++            {
++                "rank": rank,
++                "eager": {
++                    "cold_us": values[0],
++                    **eager_summary,
++                    "samples_us": rank_eager_samples,
++                },
++                "graph": {
++                    "cold_us": values[graph_cold_index],
++                    **graph_summary,
++                    "samples_us": rank_graph_samples,
++                },
++                "graph_structure": {
++                    "kernel_nodes": int(structure[0]),
++                    "direct_control_worker_edge": has_control,
++                    "control_grid": [int(v) for v in structure[2:5]]
++                    if has_control
++                    else None,
++                    "control_block": [int(v) for v in structure[5:8]]
++                    if has_control
++                    else None,
++                    "worker_grid": [int(v) for v in structure[8:11]],
++                    "worker_block": [int(v) for v in structure[11:14]],
++                },
++            }
++        )
++    return result
++
++
++def _distributed_critical_path(
++    per_rank: Sequence[dict[str, object]],
++) -> dict[str, object]:
++    """Summarize max-rank latency at each aligned timed iteration."""
++
++    if not per_rank:
++        raise ValueError("distributed critical path requires at least one rank")
++    result: dict[str, object] = {}
++    for mode in ("eager", "graph"):
++        rank_vectors = [list(row[mode]["samples_us"]) for row in per_rank]
++        lengths = {len(samples) for samples in rank_vectors}
++        if len(lengths) != 1 or not lengths or next(iter(lengths)) == 0:
++            raise ValueError(f"{mode} rank latency vectors are empty or misaligned")
++        critical_samples = [
++            max(rank_samples[index] for rank_samples in rank_vectors)
++            for index in range(next(iter(lengths)))
++        ]
++        result[mode] = {
++            "cold_us": max(float(row[mode]["cold_us"]) for row in per_rank),
++            **_summary(critical_samples),
++            "samples_us": critical_samples,
++        }
++    return result
++
++
++def _device_metadata() -> list[dict[str, object]]:
++    devices = []
++    for index in range(torch.cuda.device_count()):
++        props = torch.cuda.get_device_properties(index)
++        devices.append(
++            {
++                "index": index,
++                "name": props.name,
++                "uuid": str(getattr(props, "uuid", "unavailable")),
++                "compute_capability": [props.major, props.minor],
++                "total_memory_bytes": props.total_memory,
++                "multi_processor_count": props.multi_processor_count,
++            }
++        )
++    return devices
++
++
++def _validate_record(
++    record: dict[str, object],
++    contract: dict[str, object],
++    *,
++    expected_graph_kernel_nodes: int,
++) -> None:
++    if set(record) != TOP_LEVEL_KEYS:
++        raise ValueError(
++            f"benchmark schema keys differ: {set(record) ^ TOP_LEVEL_KEYS}"
++        )
++    if record["schema"] != {"name": SCHEMA_NAME, "version": SCHEMA_VERSION}:
++        raise ValueError(f"unsupported benchmark schema: {record['schema']}")
++    if set(record["contract"]) != CONTRACT_KEYS or record["contract"] != contract:
++        raise ValueError(
++            f"benchmark contract mismatch: {record['contract']} != {contract}"
++        )
++    scope = record["scope"]
++    if set(scope) != SCOPE_KEYS:
++        raise ValueError("benchmark scope schema mismatch")
++    if (
++        scope["operation"] != "plain_oneshot_all_reduce"
++        or scope["staging"] != "double_buffered_eager_ipc"
++        or int(scope["size_bytes"]) != int(contract["numel"]) * torch.bfloat16.itemsize
++        or "net algorithm" not in str(scope["comparison_semantics"]).lower()
++        or scope["excluded_paths"]
++        != ["fused_add_rms_norm", "twoshot_reduce_scatter", "twoshot_all_gather"]
++    ):
++        raise ValueError(
++            f"benchmark scope is not the narrow staged-path contract: {scope}"
++        )
++    if set(record["identity"]) != IDENTITY_KEYS:
++        raise ValueError("benchmark identity schema mismatch")
++    if set(record["provenance"]) != PROVENANCE_KEYS:
++        raise ValueError("benchmark provenance schema mismatch")
++    provenance = record["provenance"]
++    if not provenance["fresh_extension_cache"] or not provenance["post_run_verified"]:
++        raise ValueError("benchmark extension provenance was not freshly verified")
++    manifest = provenance["extension_build_manifest"]
++    if not isinstance(manifest, list) or not manifest:
++        raise ValueError("benchmark extension build manifest is empty")
++    for entry in manifest:
++        if set(entry) != {"path", "size_bytes", "sha256"}:
++            raise ValueError("benchmark extension manifest entry schema mismatch")
++    if _json_sha256(manifest) != provenance["extension_build_manifest_sha256"]:
++        raise ValueError("benchmark extension manifest digest mismatch")
++    if set(record["software"]) != SOFTWARE_KEYS:
++        raise ValueError("benchmark software schema mismatch")
++    if set(record["hardware"]) != HARDWARE_KEYS:
++        raise ValueError("benchmark hardware schema mismatch")
++    if not isinstance(record["environment"], dict):
++        raise ValueError("benchmark environment must be an object")
++    if not isinstance(record["per_rank"], list) or len(record["per_rank"]) != int(
++        contract["world_size"]
++    ):
++        raise ValueError("benchmark per-rank cardinality mismatch")
++    hardware = record["hardware"]
++    if not isinstance(hardware["devices"], list) or not hardware["devices"]:
++        raise ValueError("benchmark device inventory must be a non-empty list")
++    for device in hardware["devices"]:
++        if set(device) != DEVICE_KEYS:
++            raise ValueError("benchmark device schema mismatch")
++    identity_query = hardware["nvidia_smi_identity"]
++    if set(identity_query) != NVIDIA_QUERY_KEYS:
++        raise ValueError("benchmark NVIDIA identity schema mismatch")
++    if identity_query["fields"] != list(NVIDIA_IDENTITY_FIELDS):
++        raise ValueError("benchmark NVIDIA identity field contract mismatch")
++    if identity_query["returncode"] != 0:
++        raise ValueError(f"benchmark NVIDIA identity query failed: {identity_query}")
++    if len(identity_query["rows"]) != len(hardware["devices"]):
++        raise ValueError("benchmark NVIDIA identity/device cardinality mismatch")
++    if any(len(row) != len(NVIDIA_IDENTITY_FIELDS) for row in identity_query["rows"]):
++        raise ValueError("benchmark NVIDIA identity row schema mismatch")
++    if hardware["nvidia_smi_sample_fields"] != list(NVIDIA_SMI_FIELDS):
++        raise ValueError("benchmark NVIDIA sample field contract mismatch")
++    if (
++        not isinstance(hardware["nvidia_smi_samples"], list)
++        or not hardware["nvidia_smi_samples"]
++    ):
++        raise ValueError("benchmark NVIDIA samples must be a non-empty list")
++    successful_samples = 0
++    successful_phases: set[str] = set()
++    for sample in hardware["nvidia_smi_samples"]:
++        if set(sample) != NVIDIA_SAMPLE_KEYS:
++            raise ValueError("benchmark NVIDIA sample schema mismatch")
++        if set(sample["query"]) != NVIDIA_QUERY_KEYS:
++            raise ValueError("benchmark NVIDIA sample query schema mismatch")
++        if sample["query"]["fields"] != list(NVIDIA_SMI_FIELDS):
++            raise ValueError("benchmark NVIDIA sample query field mismatch")
++        if sample["query"]["returncode"] == 0:
++            successful_samples += 1
++            if not sample["query"]["rows"]:
++                raise ValueError("successful NVIDIA telemetry sample has zero rows")
++            successful_phases.add(str(sample["phase"]))
++            if any(
++                len(row) != len(NVIDIA_SMI_FIELDS) for row in sample["query"]["rows"]
++            ):
++                raise ValueError("benchmark NVIDIA sample row schema mismatch")
++            if len(sample["query"]["rows"]) != len(hardware["devices"]):
++                raise ValueError("benchmark NVIDIA sample/device cardinality mismatch")
++    if successful_samples == 0:
++        raise ValueError("benchmark collected no successful NVIDIA telemetry samples")
++    required_phases = {"mutating_preflight", "eager_timing", "graph_timing"}
++    if not required_phases <= successful_phases:
++        raise ValueError(
++            "benchmark lacks successful phase telemetry: "
++            f"{required_phases - successful_phases}"
++        )
++    topology = hardware["nvidia_smi_topology"]
++    if set(topology) != NVIDIA_TOPOLOGY_KEYS:
++        raise ValueError("benchmark NVIDIA topology schema mismatch")
++    if topology["returncode"] != 0 or not topology["stdout"]:
++        raise ValueError(f"benchmark NVIDIA topology query failed: {topology}")
++    for row in record["per_rank"]:
++        if set(row) != {"rank", "eager", "graph", "graph_structure"}:
++            raise ValueError("per-rank schema mismatch")
++        if set(row["eager"]) != RANK_MODE_KEYS:
++            raise ValueError("eager metric schema mismatch")
++        if set(row["graph"]) != RANK_MODE_KEYS:
++            raise ValueError("graph metric schema mismatch")
++        for mode in ("eager", "graph"):
++            samples = row[mode]["samples_us"]
++            if not isinstance(samples, list) or len(samples) != int(contract["iters"]):
++                raise ValueError(f"per-rank {mode} sample vector length mismatch")
++            if any(
++                not math.isfinite(float(value)) or float(value) <= 0
++                for value in samples
++            ):
++                raise ValueError(f"per-rank {mode} samples must be finite and positive")
++            expected_summary = _summary([float(value) for value in samples])
++            for key, expected in expected_summary.items():
++                if float(row[mode][key]) != expected:
++                    raise ValueError(f"per-rank {mode} {key} summary mismatch")
++        structure = row["graph_structure"]
++        if set(structure) != GRAPH_STRUCTURE_KEYS:
++            raise ValueError("graph structure schema mismatch")
++        if int(structure["kernel_nodes"]) != expected_graph_kernel_nodes:
++            raise ValueError("graph kernel-node count mismatch")
++        if expected_graph_kernel_nodes == 2:
++            if (
++                structure["direct_control_worker_edge"] is not True
++                or structure["control_grid"] != [1, 1, 1]
++                or structure["control_block"] != [1, 1, 1]
++            ):
++                raise ValueError("candidate graph lacks direct <<<1,1>>> control edge")
++        elif (
++            structure["direct_control_worker_edge"] is not False
++            or structure["control_grid"] is not None
++            or structure["control_block"] is not None
++        ):
++            raise ValueError("baseline graph unexpectedly records a control node")
++    if {int(row["rank"]) for row in record["per_rank"]} != set(
++        range(int(contract["world_size"]))
++    ):
++        raise ValueError("per-rank identities do not match world size")
++    critical_path = record["distributed_critical_path"]
++    if set(critical_path) != {"eager", "graph"}:
++        raise ValueError("distributed critical-path mode schema mismatch")
++    for mode in ("eager", "graph"):
++        if set(critical_path[mode]) != CRITICAL_MODE_KEYS:
++            raise ValueError(f"distributed {mode} critical-path schema mismatch")
++    expected_critical_path = _distributed_critical_path(record["per_rank"])
++    if critical_path != expected_critical_path:
++        raise ValueError(
++            "distributed critical path was not derived from aligned rank maxima"
++        )
++
++
++def main() -> None:
++    args = _parse_args()
++    if (
++        args.iters <= 0
++        or args.warmup < 0
++        or args.numel != 32768
++        or args.run_index < 0
++        or args.expected_graph_kernel_nodes not in (1, 2)
++        or args.preflight_replays < 4
++        or args.distributed_timeout_seconds <= 0
++    ):
++        raise ValueError(
++            "this narrow harness requires 32,768 BF16 elements (64 KiB), "
++            "at least four preflight replays, one/two graph nodes, positive "
++            "iterations/timeout, and non-negative warmup/run-index"
++        )
++    if args.sampler_interval <= 0:
++        raise ValueError("sampler interval must be positive")
++
++    implementation_root = args.implementation_root.resolve()
++    git_sha, git_dirty = _git_identity(implementation_root)
++    if git_sha != args.expected_git_sha:
++        raise ValueError(f"implementation SHA {git_sha} != {args.expected_git_sha}")
++    if git_dirty and not args.allow_dirty:
++        raise ValueError(f"implementation worktree is dirty: {implementation_root}")
++
++    dist.init_process_group(
++        "nccl",
++        timeout=timedelta(seconds=args.distributed_timeout_seconds),
++    )
++    rank = dist.get_rank()
++    world_size = dist.get_world_size()
++    local_rank = int(os.environ["LOCAL_RANK"])
++    torch.cuda.set_device(local_rank)
++    device = torch.device(f"cuda:{local_rank}")
++    _, pool_type, provenance = _verified_implementation(implementation_root)
++    contract = {
++        "world_size": world_size,
++        "numel": args.numel,
++        "dtype": DTYPE_NAME,
++        "warmup": args.warmup,
++        "iters": args.iters,
++        "preflight_replays": args.preflight_replays,
++    }
++    started_at = datetime.now(timezone.utc).isoformat()
++    sampler = _NvidiaSmiSampler(args.sampler_interval) if rank == 0 else None
++
++    pool = None
++    try:
++        nbytes = args.numel * torch.bfloat16.itemsize
++        pool = pool_type.from_process_group(
++            process_group=dist.group.WORLD,
++            device=device,
++            max_input_bytes=nbytes,
++            max_size=nbytes,
++        )
++        eager_channel_id = "eager:control-node-benchmark"
++        graph_channel_id = "graph:control-node-benchmark"
++        pool.prepare_channels((eager_channel_id, graph_channel_id))
++        stream = torch.cuda.Stream(device=device)
++        channel = pool.for_stream(stream, channel_id=eager_channel_id)
++        eager_inp = torch.full(
++            (args.numel,),
++            rank + 1,
++            dtype=torch.bfloat16,
++            device=device,
++        )
++        eager_out = torch.empty_like(eager_inp)
++
++        def eager_operation() -> None:
++            with torch.cuda.stream(stream):
++                channel.all_reduce(eager_inp, out=eager_out)
++
++        graph_inp = torch.full_like(eager_inp, rank + 1)
++        graph_out = torch.empty_like(graph_inp)
++        graph = torch.cuda.CUDAGraph(keep_graph=True)
++        with (
++            pool.capture(stream, channel_id=graph_channel_id) as graph_channel,
++            torch.cuda.graph(
++                graph,
++                stream=stream,
++            ),
++        ):
++            graph_channel.all_reduce(graph_inp, out=graph_out)
++        graph_structure = _graph_kernel_structure(
++            graph,
++            expected_kernel_nodes=args.expected_graph_kernel_nodes,
++        )
++
++        def graph_operation() -> None:
++            with torch.cuda.stream(stream):
++                graph.replay()
++
++        # JIT compilation and graph construction are complete. Telemetry starts
++        # here and every correctness/timing phase receives an explicit marker.
++        if sampler is not None:
++            sampler.start()
++            sampler.mark_phase("mutating_preflight")
++        _mutating_replay_preflight(
++            eager_operation,
++            inp=eager_inp,
++            out=eager_out,
++            stream=stream,
++            rank=rank,
++            world_size=world_size,
++            replays=args.preflight_replays,
++        )
++        _mutating_replay_preflight(
++            graph_operation,
++            inp=graph_inp,
++            out=graph_out,
++            stream=stream,
++            rank=rank,
++            world_size=world_size,
++            replays=args.preflight_replays,
++        )
++
++        with torch.cuda.stream(stream):
++            eager_inp.fill_(rank + 1)
++        stream.synchronize()
++        dist.barrier()
++        if sampler is not None:
++            sampler.mark_phase("eager_timing")
++        eager_cold_us, eager_samples = _measure(
++            eager_operation,
++            stream=stream,
++            warmup=args.warmup,
++            iters=args.iters,
++        )
++        expected = world_size * (world_size + 1) // 2
++        torch.testing.assert_close(
++            eager_out,
++            torch.full_like(eager_out, expected),
++            rtol=0,
++            atol=0,
++        )
++
++        with torch.cuda.stream(stream):
++            graph_inp.fill_(rank + 1)
++        stream.synchronize()
++        dist.barrier()
++        if sampler is not None:
++            sampler.mark_phase("graph_timing")
++        graph_cold_us, graph_samples = _measure(
++            graph_operation,
++            stream=stream,
++            warmup=args.warmup,
++            iters=args.iters,
++        )
++        torch.testing.assert_close(
++            graph_out,
++            torch.full_like(graph_out, expected),
++            rtol=0,
++            atol=0,
++        )
++
++        per_rank = _gather_rank_metrics(
++            eager_cold_us,
++            eager_samples,
++            graph_cold_us,
++            graph_samples,
++            graph_structure,
++            device,
++        )
++        observed_nodes = {
++            int(row["graph_structure"]["kernel_nodes"]) for row in per_rank
++        }
++        if observed_nodes != {args.expected_graph_kernel_nodes}:
++            raise AssertionError(
++                f"rank graph-node counts {observed_nodes} do not match "
++                f"{args.expected_graph_kernel_nodes}"
++            )
++        torch.cuda.synchronize(device)
++        dist.barrier()
++        _verify_post_run_provenance(
++            provenance,
++            implementation_root=implementation_root,
++            expected_git_sha=args.expected_git_sha,
++        )
++
++        if sampler is not None:
++            sampler.mark_phase("provenance_and_finalize")
++            sampler.stop()
++        if rank == 0:
++            harness_path = Path(__file__).resolve()
++            worker_argv = list(sys.argv)
++            record = {
++                "schema": {"name": SCHEMA_NAME, "version": SCHEMA_VERSION},
++                "contract": contract,
++                "scope": {
++                    "operation": "plain_oneshot_all_reduce",
++                    "staging": "double_buffered_eager_ipc",
++                    "size_bytes": nbytes,
++                    "comparison_semantics": (
++                        "net algorithm comparison between public baseline and "
++                        "candidate; not isolated launch overhead"
++                    ),
++                    "excluded_paths": [
++                        "fused_add_rms_norm",
++                        "twoshot_reduce_scatter",
++                        "twoshot_all_gather",
++                    ],
++                },
++                "identity": {
++                    "label": args.label,
++                    "variant": args.variant,
++                    "run_index": args.run_index,
++                    "implementation_root": str(implementation_root),
++                    "implementation_git_sha": git_sha,
++                    "implementation_git_dirty": git_dirty,
++                    "harness_sha256": _sha256(harness_path),
++                    "controller_sha256": args.controller_sha256,
++                    "controller_argv_sha256": args.controller_argv_sha256,
++                    "worker_argv": worker_argv,
++                    "worker_argv_sha256": _json_sha256(worker_argv),
++                    "started_at_utc": started_at,
++                },
++                "provenance": provenance,
++                "software": {
++                    "python": platform.python_version(),
++                    "platform": platform.platform(),
++                    "torch": torch.__version__,
++                    "torch_cuda": torch.version.cuda,
++                    "cuda_runtime_version": _cuda_version(cudart.cudaRuntimeGetVersion),
++                    "cuda_driver_version": _cuda_version(cudart.cudaDriverGetVersion),
++                    "nvcc_version": _run_command(["nvcc", "--version"]),
++                },
++                "hardware": {
++                    "hostname": socket.gethostname(),
++                    "devices": _device_metadata(),
++                    "nvidia_smi_identity": _nvidia_smi_query(NVIDIA_IDENTITY_FIELDS),
++                    "nvidia_smi_sample_fields": list(NVIDIA_SMI_FIELDS),
++                    "nvidia_smi_samples": sampler.samples,
++                    "nvidia_smi_topology": _nvidia_smi_topology(),
++                },
++                "environment": _environment_toggles(),
++                "per_rank": per_rank,
++                "distributed_critical_path": _distributed_critical_path(per_rank),
++            }
++            _validate_record(
++                record,
++                contract,
++                expected_graph_kernel_nodes=args.expected_graph_kernel_nodes,
++            )
++            rendered = json.dumps(record, indent=2, sort_keys=True)
++            print(rendered, flush=True)
++            args.output.parent.mkdir(parents=True, exist_ok=True)
++            args.output.write_text(rendered + "\n", encoding="utf-8")
++    finally:
++        if sampler is not None and sampler._thread.is_alive():
++            sampler.stop()
++        if pool is not None:
++            pool.close()
++        dist.destroy_process_group()
++
++
++if __name__ == "__main__":
++    main()
+diff --git a/benchmarks/run_pcie_oneshot_control_node_ab.py b/benchmarks/run_pcie_oneshot_control_node_ab.py
+new file mode 100644
+index 0000000000000000000000000000000000000000..42e9a4c7d7e79c7f448caa793dd592380570fb1b
+--- /dev/null
++++ b/benchmarks/run_pcie_oneshot_control_node_ab.py
+@@ -0,0 +1,825 @@
++"""Run repeated immutable AB/BA measurements with one external harness.
++
++The measurement script lives outside both implementation worktrees and is
++hashed into every record. Each pair reverses execution order (AB, then BA) to
++reduce monotonic thermal/clock drift. Raw records are schema- and
++contract-validated before the aggregate report is written.
++"""
++
++from __future__ import annotations
++
++import argparse
++import hashlib
++import json
++import math
++import os
++import signal
++import statistics
++import subprocess
++import sys
++from contextlib import suppress
++from pathlib import Path
++
++
++RUN_SCHEMA = {"name": "sparkinfer.pcie_oneshot_control_node.run", "version": 2}
++SUITE_SCHEMA = {"name": "sparkinfer.pcie_oneshot_control_node.ab_suite", "version": 2}
++RUN_TOP_LEVEL_KEYS = {
++    "schema",
++    "contract",
++    "scope",
++    "identity",
++    "provenance",
++    "software",
++    "hardware",
++    "environment",
++    "per_rank",
++    "distributed_critical_path",
++}
++CONTRACT_KEYS = {
++    "world_size",
++    "numel",
++    "dtype",
++    "warmup",
++    "iters",
++    "preflight_replays",
++}
++SCOPE_KEYS = {
++    "operation",
++    "staging",
++    "size_bytes",
++    "comparison_semantics",
++    "excluded_paths",
++}
++METRICS = ("mean_us", "p50_us", "p95_us")
++IDENTITY_KEYS = {
++    "label",
++    "variant",
++    "run_index",
++    "implementation_root",
++    "implementation_git_sha",
++    "implementation_git_dirty",
++    "harness_sha256",
++    "controller_sha256",
++    "controller_argv_sha256",
++    "worker_argv",
++    "worker_argv_sha256",
++    "started_at_utc",
++}
++PROVENANCE_KEYS = {
++    "module_path",
++    "module_sha256",
++    "cuda_source_path",
++    "cuda_source_sha256",
++    "extension_path",
++    "extension_sha256",
++    "extension_build_root",
++    "extension_build_manifest",
++    "extension_build_manifest_sha256",
++    "fresh_extension_cache",
++    "post_run_verified",
++}
++SOFTWARE_KEYS = {
++    "python",
++    "platform",
++    "torch",
++    "torch_cuda",
++    "cuda_runtime_version",
++    "cuda_driver_version",
++    "nvcc_version",
++}
++HARDWARE_KEYS = {
++    "hostname",
++    "devices",
++    "nvidia_smi_identity",
++    "nvidia_smi_sample_fields",
++    "nvidia_smi_samples",
++    "nvidia_smi_topology",
++}
++METRIC_KEYS = {"cold_us", "mean_us", "p50_us", "p95_us", "min_us", "max_us"}
++RANK_MODE_KEYS = METRIC_KEYS | {"samples_us"}
++CRITICAL_MODE_KEYS = METRIC_KEYS | {"samples_us"}
++GRAPH_STRUCTURE_KEYS = {
++    "kernel_nodes",
++    "direct_control_worker_edge",
++    "control_grid",
++    "control_block",
++    "worker_grid",
++    "worker_block",
++}
++DEVICE_KEYS = {
++    "index",
++    "name",
++    "uuid",
++    "compute_capability",
++    "total_memory_bytes",
++    "multi_processor_count",
++}
++NVIDIA_QUERY_KEYS = {"fields", "returncode", "rows", "stderr"}
++NVIDIA_SAMPLE_KEYS = {"monotonic_ns", "phase", "query"}
++NVIDIA_TOPOLOGY_KEYS = {"returncode", "stdout", "stderr"}
++NVIDIA_IDENTITY_FIELDS = ["index", "uuid", "name", "driver_version"]
++NVIDIA_SMI_FIELDS = [
++    "index",
++    "uuid",
++    "name",
++    "driver_version",
++    "pstate",
++    "power.limit",
++    "power.draw",
++    "clocks.current.sm",
++    "clocks.current.memory",
++    "clocks.max.sm",
++    "clocks.max.memory",
++    "utilization.gpu",
++    "utilization.memory",
++    "temperature.gpu",
++    "clocks_event_reasons.active",
++]
++SUITE_TOP_LEVEL_KEYS = {
++    "schema",
++    "contract",
++    "controller",
++    "harness",
++    "implementations",
++    "sequence",
++    "records",
++    "paired_deltas",
++    "paired_summary",
++    "aggregate",
++}
++CONTROLLER_KEYS = {"source_path", "sha256", "argv", "argv_sha256"}
++HARNESS_KEYS = {
++    "source_path",
++    "frozen_path",
++    "sha256",
++    "identical_for_all_runs",
++}
++IMPLEMENTATION_KEYS = {"root", "git_sha"}
++
++
++def _parse_args() -> argparse.Namespace:
++    parser = argparse.ArgumentParser()
++    parser.add_argument("--baseline-worktree", type=Path, required=True)
++    parser.add_argument("--candidate-worktree", type=Path, required=True)
++    parser.add_argument("--pairs", type=int, default=4)
++    parser.add_argument("--world-size", type=int, default=4)
++    parser.add_argument("--numel", type=int, default=32768)
++    parser.add_argument("--warmup", type=int, default=100)
++    parser.add_argument("--iters", type=int, default=1000)
++    parser.add_argument("--sampler-interval", type=float, default=0.2)
++    parser.add_argument("--preflight-replays", type=int, default=4)
++    parser.add_argument("--run-timeout-seconds", type=float, default=1800.0)
++    parser.add_argument("--distributed-timeout-seconds", type=float, default=300.0)
++    parser.add_argument("--output-dir", type=Path, required=True)
++    parser.add_argument("--output", type=Path, required=True)
++    parser.add_argument(
++        "--harness",
++        type=Path,
++        default=Path(__file__).with_name("benchmark_pcie_oneshot_control_node.py"),
++    )
++    return parser.parse_args()
++
++
++def _run(
++    args: list[str],
++    *,
++    cwd: Path | None = None,
++    env: dict[str, str] | None = None,
++    timeout: float = 60.0,
++) -> str:
++    process = subprocess.Popen(
++        args,
++        cwd=cwd,
++        env=env,
++        text=True,
++        stdout=subprocess.PIPE,
++        stderr=subprocess.STDOUT,
++        start_new_session=True,
++    )
++    try:
++        stdout, _ = process.communicate(timeout=timeout)
++    except subprocess.TimeoutExpired:
++        with suppress(ProcessLookupError):
++            os.killpg(process.pid, signal.SIGTERM)
++        try:
++            stdout, _ = process.communicate(timeout=10)
++        except subprocess.TimeoutExpired:
++            with suppress(ProcessLookupError):
++                os.killpg(process.pid, signal.SIGKILL)
++            stdout, _ = process.communicate()
++        raise TimeoutError(
++            f"command exceeded {timeout:.1f}s and its process group was terminated: "
++            f"{' '.join(args)}\n{stdout}"
++        ) from None
++    if process.returncode != 0:
++        raise RuntimeError(
++            f"command failed ({process.returncode}): {' '.join(args)}\n{stdout}"
++        )
++    return stdout.strip()
++
++
++def _git_sha(worktree: Path) -> str:
++    sha = _run(["git", "rev-parse", "HEAD"], cwd=worktree)
++    dirty = _run(["git", "status", "--porcelain=v1"], cwd=worktree)
++    if dirty:
++        raise ValueError(f"benchmark worktree is dirty: {worktree}\n{dirty}")
++    return sha
++
++
++def _sha256(path: Path) -> str:
++    digest = hashlib.sha256()
++    with path.open("rb") as handle:
++        for block in iter(lambda: handle.read(1024 * 1024), b""):
++            digest.update(block)
++    return digest.hexdigest()
++
++
++def _json_sha256(value: object) -> str:
++    rendered = json.dumps(
++        value,
++        sort_keys=True,
++        separators=(",", ":"),
++    ).encode("utf-8")
++    return hashlib.sha256(rendered).hexdigest()
++
++
++def _expected_contract(args: argparse.Namespace) -> dict[str, object]:
++    return {
++        "world_size": args.world_size,
++        "numel": args.numel,
++        "dtype": "bfloat16",
++        "warmup": args.warmup,
++        "iters": args.iters,
++        "preflight_replays": args.preflight_replays,
++    }
++
++
++def _summary(samples: list[float]) -> dict[str, float]:
++    if not samples:
++        raise ValueError("cannot summarize an empty latency vector")
++    ordered = sorted(float(value) for value in samples)
++
++    def percentile(fraction: float) -> float:
++        return ordered[max(0, math.ceil(fraction * len(ordered)) - 1)]
++
++    return {
++        "mean_us": sum(ordered) / len(ordered),
++        "p50_us": percentile(0.50),
++        "p95_us": percentile(0.95),
++        "min_us": ordered[0],
++        "max_us": ordered[-1],
++    }
++
++
++def _distributed_critical_path(
++    per_rank: list[dict[str, object]],
++) -> dict[str, object]:
++    result = {}
++    for mode in ("eager", "graph"):
++        vectors = [list(row[mode]["samples_us"]) for row in per_rank]
++        lengths = {len(vector) for vector in vectors}
++        if len(lengths) != 1 or not lengths or next(iter(lengths)) == 0:
++            raise ValueError(f"{mode} rank vectors are empty or misaligned")
++        critical = [
++            max(float(vector[index]) for vector in vectors)
++            for index in range(next(iter(lengths)))
++        ]
++        result[mode] = {
++            "cold_us": max(float(row[mode]["cold_us"]) for row in per_rank),
++            **_summary(critical),
++            "samples_us": critical,
++        }
++    return result
++
++
++def _validate_run(
++    record: dict[str, object],
++    *,
++    contract: dict[str, object],
++    variant: str,
++    sha: str,
++    run_index: int,
++    harness_sha256: str,
++    expected_nodes: int,
++    implementation_root: Path,
++    controller_sha256: str,
++    controller_argv_sha256: str,
++    extension_dir: Path,
++) -> None:
++    if set(record) != RUN_TOP_LEVEL_KEYS:
++        raise ValueError(f"run schema keys differ: {set(record) ^ RUN_TOP_LEVEL_KEYS}")
++    if record["schema"] != RUN_SCHEMA:
++        raise ValueError(f"run schema mismatch: {record['schema']}")
++    if set(record["contract"]) != CONTRACT_KEYS or record["contract"] != contract:
++        raise ValueError(f"run contract mismatch: {record['contract']} != {contract}")
++    scope = record["scope"]
++    if set(scope) != SCOPE_KEYS:
++        raise ValueError("run scope schema mismatch")
++    if (
++        scope["operation"] != "plain_oneshot_all_reduce"
++        or scope["staging"] != "double_buffered_eager_ipc"
++        or int(scope["size_bytes"]) != int(contract["numel"]) * 2
++        or "net algorithm" not in str(scope["comparison_semantics"]).lower()
++        or scope["excluded_paths"]
++        != ["fused_add_rms_norm", "twoshot_reduce_scatter", "twoshot_all_gather"]
++    ):
++        raise ValueError(f"run scope is too broad or malformed: {scope}")
++    identity = record["identity"]
++    if set(identity) != IDENTITY_KEYS:
++        raise ValueError("run identity schema mismatch")
++    expected_identity = {
++        "label": f"{variant}-{sha[:12]}-{run_index}",
++        "variant": variant,
++        "run_index": run_index,
++        "implementation_root": str(implementation_root),
++        "implementation_git_sha": sha,
++        "implementation_git_dirty": False,
++        "harness_sha256": harness_sha256,
++        "controller_sha256": controller_sha256,
++        "controller_argv_sha256": controller_argv_sha256,
++    }
++    for key, expected in expected_identity.items():
++        if identity[key] != expected:
++            raise ValueError(f"identity {key}={identity[key]!r}, expected {expected!r}")
++    if _json_sha256(identity["worker_argv"]) != identity["worker_argv_sha256"]:
++        raise ValueError("worker argv digest mismatch")
++    provenance = record["provenance"]
++    if set(provenance) != PROVENANCE_KEYS:
++        raise ValueError("run provenance schema mismatch")
++    expected_module = (
++        implementation_root / "sparkinfer/comm/pcie/pcie_oneshot.py"
++    ).resolve()
++    expected_source = expected_module.with_suffix(".cu")
++    if Path(provenance["module_path"]).resolve() != expected_module:
++        raise ValueError("run imported module does not belong to implementation root")
++    if Path(provenance["cuda_source_path"]).resolve() != expected_source:
++        raise ValueError("run CUDA source does not belong to implementation root")
++    if (
++        not Path(provenance["extension_path"])
++        .resolve()
++        .is_relative_to(extension_dir.resolve())
++    ):
++        raise ValueError("run extension binary is outside its fresh cache")
++    if not provenance["fresh_extension_cache"] or not provenance["post_run_verified"]:
++        raise ValueError("run extension provenance was not freshly post-verified")
++    for path_key, digest_key in (
++        ("module_path", "module_sha256"),
++        ("cuda_source_path", "cuda_source_sha256"),
++        ("extension_path", "extension_sha256"),
++    ):
++        if _sha256(Path(provenance[path_key])) != provenance[digest_key]:
++            raise ValueError(f"run {path_key} digest mismatch")
++    manifest = provenance["extension_build_manifest"]
++    if not isinstance(manifest, list) or not manifest:
++        raise ValueError("run extension build manifest is empty")
++    for entry in manifest:
++        if set(entry) != {"path", "size_bytes", "sha256"}:
++            raise ValueError("run extension manifest entry schema mismatch")
++    if _json_sha256(manifest) != provenance["extension_build_manifest_sha256"]:
++        raise ValueError("run extension build manifest digest mismatch")
++    if set(record["software"]) != SOFTWARE_KEYS:
++        raise ValueError("run software schema mismatch")
++    if set(record["hardware"]) != HARDWARE_KEYS:
++        raise ValueError("run hardware schema mismatch")
++    if not isinstance(record["environment"], dict):
++        raise ValueError("run environment must be an object")
++    if not isinstance(record["per_rank"], list) or len(record["per_rank"]) != int(
++        contract["world_size"]
++    ):
++        raise ValueError("run per-rank cardinality mismatch")
++    hardware = record["hardware"]
++    if not isinstance(hardware["devices"], list) or not hardware["devices"]:
++        raise ValueError("run device inventory must be a non-empty list")
++    for device in hardware["devices"]:
++        if set(device) != DEVICE_KEYS:
++            raise ValueError("run device schema mismatch")
++    identity_query = hardware["nvidia_smi_identity"]
++    if set(identity_query) != NVIDIA_QUERY_KEYS:
++        raise ValueError("run NVIDIA identity schema mismatch")
++    if identity_query["fields"] != NVIDIA_IDENTITY_FIELDS:
++        raise ValueError("run NVIDIA identity field contract mismatch")
++    if identity_query["returncode"] != 0:
++        raise ValueError(f"run NVIDIA identity query failed: {identity_query}")
++    if len(identity_query["rows"]) != len(hardware["devices"]):
++        raise ValueError("run NVIDIA identity/device cardinality mismatch")
++    if any(len(row) != len(NVIDIA_IDENTITY_FIELDS) for row in identity_query["rows"]):
++        raise ValueError("run NVIDIA identity row schema mismatch")
++    if hardware["nvidia_smi_sample_fields"] != NVIDIA_SMI_FIELDS:
++        raise ValueError("run NVIDIA sample field contract mismatch")
++    if (
++        not isinstance(hardware["nvidia_smi_samples"], list)
++        or not hardware["nvidia_smi_samples"]
++    ):
++        raise ValueError("run NVIDIA samples must be a non-empty list")
++    successful_samples = 0
++    successful_phases: set[str] = set()
++    for sample in hardware["nvidia_smi_samples"]:
++        if set(sample) != NVIDIA_SAMPLE_KEYS:
++            raise ValueError("run NVIDIA sample schema mismatch")
++        if set(sample["query"]) != NVIDIA_QUERY_KEYS:
++            raise ValueError("run NVIDIA sample query schema mismatch")
++        if sample["query"]["fields"] != NVIDIA_SMI_FIELDS:
++            raise ValueError("run NVIDIA sample query field mismatch")
++        if sample["query"]["returncode"] == 0:
++            successful_samples += 1
++            if not sample["query"]["rows"]:
++                raise ValueError("successful NVIDIA sample has zero rows")
++            successful_phases.add(str(sample["phase"]))
++            if any(
++                len(row) != len(NVIDIA_SMI_FIELDS) for row in sample["query"]["rows"]
++            ):
++                raise ValueError("run NVIDIA sample row schema mismatch")
++            if len(sample["query"]["rows"]) != len(hardware["devices"]):
++                raise ValueError("run NVIDIA sample/device cardinality mismatch")
++    if successful_samples == 0:
++        raise ValueError("run collected no successful NVIDIA telemetry samples")
++    required_phases = {"mutating_preflight", "eager_timing", "graph_timing"}
++    if not required_phases <= successful_phases:
++        raise ValueError(
++            f"run lacks successful phase telemetry: {required_phases - successful_phases}"
++        )
++    topology = hardware["nvidia_smi_topology"]
++    if set(topology) != NVIDIA_TOPOLOGY_KEYS:
++        raise ValueError("run NVIDIA topology schema mismatch")
++    if topology["returncode"] != 0 or not topology["stdout"]:
++        raise ValueError(f"run NVIDIA topology query failed: {topology}")
++    for row in record["per_rank"]:
++        if set(row) != {"rank", "eager", "graph", "graph_structure"}:
++            raise ValueError("run per-rank schema mismatch")
++        if set(row["eager"]) != RANK_MODE_KEYS:
++            raise ValueError("run per-rank eager metric schema mismatch")
++        if set(row["graph"]) != RANK_MODE_KEYS:
++            raise ValueError("run per-rank graph metric schema mismatch")
++        for mode in ("eager", "graph"):
++            samples = row[mode]["samples_us"]
++            if not isinstance(samples, list) or len(samples) != int(contract["iters"]):
++                raise ValueError(f"run per-rank {mode} sample length mismatch")
++            if any(
++                not math.isfinite(float(value)) or float(value) <= 0
++                for value in samples
++            ):
++                raise ValueError(f"run per-rank {mode} samples are invalid")
++            expected_summary = _summary(samples)
++            for key, expected in expected_summary.items():
++                if float(row[mode][key]) != expected:
++                    raise ValueError(f"run per-rank {mode} {key} mismatch")
++        structure = row["graph_structure"]
++        if set(structure) != GRAPH_STRUCTURE_KEYS:
++            raise ValueError("run graph structure schema mismatch")
++        if int(structure["kernel_nodes"]) != expected_nodes:
++            raise ValueError("observed graph-node count differs across ranks")
++        if expected_nodes == 2:
++            if (
++                structure["direct_control_worker_edge"] is not True
++                or structure["control_grid"] != [1, 1, 1]
++                or structure["control_block"] != [1, 1, 1]
++            ):
++                raise ValueError("candidate graph lacks direct <<<1,1>>> control edge")
++        elif (
++            structure["direct_control_worker_edge"] is not False
++            or structure["control_grid"] is not None
++            or structure["control_block"] is not None
++        ):
++            raise ValueError("baseline graph unexpectedly records a control node")
++    if {int(row["rank"]) for row in record["per_rank"]} != set(
++        range(int(contract["world_size"]))
++    ):
++        raise ValueError("run rank identities do not match world size")
++    critical_path = record["distributed_critical_path"]
++    if set(critical_path) != {"eager", "graph"}:
++        raise ValueError("run distributed critical-path mode schema mismatch")
++    for mode in ("eager", "graph"):
++        if set(critical_path[mode]) != CRITICAL_MODE_KEYS:
++            raise ValueError(f"run distributed {mode} schema mismatch")
++    if critical_path != _distributed_critical_path(record["per_rank"]):
++        raise ValueError("run critical path is not the aligned per-iteration rank MAX")
++
++
++def _outside_worktrees(path: Path, roots: tuple[Path, ...], label: str) -> Path:
++    resolved = path.resolve()
++    for root in roots:
++        if resolved == root or resolved.is_relative_to(root):
++            raise ValueError(f"{label} must be outside measured worktree {root}")
++    return resolved
++
++
++def _stable_environment(record: dict[str, object]) -> dict[str, object]:
++    environment = dict(record["environment"])
++    environment.pop("TORCH_EXTENSIONS_DIR", None)
++    return environment
++
++
++def _stable_hardware(record: dict[str, object]) -> dict[str, object]:
++    hardware = record["hardware"]
++    return {
++        "hostname": hardware["hostname"],
++        "devices": hardware["devices"],
++        "nvidia_smi_identity": hardware["nvidia_smi_identity"],
++        "nvidia_smi_sample_fields": hardware["nvidia_smi_sample_fields"],
++        "nvidia_smi_topology": hardware["nvidia_smi_topology"],
++    }
++
++
++def _paired_deltas(records: list[dict[str, object]]) -> list[dict[str, object]]:
++    deltas = []
++    for pair_index in range(len(records) // 2):
++        pair = records[2 * pair_index : 2 * pair_index + 2]
++        by_variant = {record["identity"]["variant"]: record for record in pair}
++        if set(by_variant) != {"baseline", "candidate"}:
++            raise ValueError(f"pair {pair_index} does not contain one A and one B")
++        delta = {"pair_index": pair_index, "metrics": {}}
++        for mode in ("eager", "graph"):
++            delta["metrics"][mode] = {}
++            for metric in METRICS:
++                before = float(
++                    by_variant["baseline"]["distributed_critical_path"][mode][metric]
++                )
++                after = float(
++                    by_variant["candidate"]["distributed_critical_path"][mode][metric]
++                )
++                delta["metrics"][mode][metric] = {
++                    "baseline_us": before,
++                    "candidate_us": after,
++                    "delta_us": after - before,
++                    "delta_percent": (after / before - 1) * 100,
++                }
++        deltas.append(delta)
++    return deltas
++
++
++def _paired_summary(deltas: list[dict[str, object]]) -> dict[str, object]:
++    """Descriptive paired uncertainty; this harness makes no significance claim."""
++
++    result = {}
++    for mode in ("eager", "graph"):
++        result[mode] = {}
++        for metric in METRICS:
++            values = [
++                float(delta["metrics"][mode][metric]["delta_us"]) for delta in deltas
++            ]
++            mean = statistics.mean(values)
++            stdev = statistics.stdev(values) if len(values) > 1 else 0.0
++            margin = 1.96 * stdev / math.sqrt(len(values)) if len(values) > 1 else None
++            result[mode][metric] = {
++                "pairs": len(values),
++                "mean_delta_us": mean,
++                "sample_stdev_us": stdev,
++                "normal_approx_95ci_us": [mean - margin, mean + margin]
++                if margin is not None
++                else None,
++                "interpretation": "descriptive_only",
++            }
++    return result
++
++
++def _aggregate(records: list[dict[str, object]]) -> dict[str, object]:
++    result = {}
++    for variant in ("baseline", "candidate"):
++        variant_records = [
++            record for record in records if record["identity"]["variant"] == variant
++        ]
++        result[variant] = {}
++        for mode in ("eager", "graph"):
++            result[variant][mode] = {}
++            for metric in METRICS:
++                values = [
++                    float(record["distributed_critical_path"][mode][metric])
++                    for record in variant_records
++                ]
++                result[variant][mode][metric] = {
++                    "mean_us": statistics.mean(values),
++                    "median_us": statistics.median(values),
++                    "min_us": min(values),
++                    "max_us": max(values),
++                }
++    return result
++
++
++def main() -> None:
++    args = _parse_args()
++    if (
++        args.pairs <= 0
++        or args.world_size <= 0
++        or args.numel != 32768
++        or args.warmup < 0
++        or args.iters <= 0
++        or args.sampler_interval <= 0
++        or args.preflight_replays < 4
++        or args.run_timeout_seconds <= 0
++        or args.distributed_timeout_seconds <= 0
++    ):
++        raise ValueError(
++            "invalid A/B contract: this harness is scoped to 32,768 BF16 "
++            "elements (64 KiB) and requires positive timeouts/iterations plus "
++            "at least four mutating preflight replays"
++        )
++    controller_path = Path(__file__).resolve()
++    controller_sha256 = _sha256(controller_path)
++    controller_argv = list(sys.argv)
++    controller_argv_sha256 = _json_sha256(controller_argv)
++    baseline_root = args.baseline_worktree.resolve()
++    candidate_root = args.candidate_worktree.resolve()
++    harness_source = args.harness.resolve()
++    roots = (baseline_root, candidate_root)
++    if baseline_root == candidate_root:
++        raise ValueError("baseline and candidate worktrees must differ")
++    output_dir = _outside_worktrees(args.output_dir, roots, "output directory")
++    output = _outside_worktrees(args.output, roots, "suite output")
++    if not harness_source.is_file():
++        raise ValueError(f"harness does not exist: {harness_source}")
++    baseline_sha = _git_sha(baseline_root)
++    candidate_sha = _git_sha(candidate_root)
++    if baseline_sha == candidate_sha:
++        raise ValueError("baseline and candidate Git SHAs must differ")
++    harness_sha256 = _sha256(harness_source)
++    contract = _expected_contract(args)
++    output_dir.mkdir(parents=True, exist_ok=True)
++    harness = output_dir / f"harness-{harness_sha256[:16]}.py"
++    harness_bytes = harness_source.read_bytes()
++    if harness.exists() and harness.read_bytes() != harness_bytes:
++        raise ValueError(f"frozen harness collision at {harness}")
++    if not harness.exists():
++        harness.write_bytes(harness_bytes)
++    if _sha256(harness) != harness_sha256:
++        raise ValueError("frozen harness hash differs from source harness")
++
++    variants = {
++        "baseline": {
++            "root": baseline_root,
++            "sha": baseline_sha,
++            "expected_nodes": 1,
++        },
++        "candidate": {
++            "root": candidate_root,
++            "sha": candidate_sha,
++            "expected_nodes": 2,
++        },
++    }
++    records = []
++    sequence = []
++    for pair_index in range(args.pairs):
++        order = (
++            ("baseline", "candidate")
++            if pair_index % 2 == 0
++            else ("candidate", "baseline")
++        )
++        for variant in order:
++            run_index = len(sequence)
++            sequence.append(variant)
++            config = variants[variant]
++            raw_path = output_dir / f"{run_index:02d}-{variant}.json"
++            extension_dir = (
++                output_dir
++                / "torch-extensions"
++                / f"{run_index:02d}-{variant}-{config['sha'][:12]}"
++            )
++            extension_dir.parent.mkdir(parents=True, exist_ok=True)
++            extension_dir.mkdir(exist_ok=False)
++            env = dict(os.environ)
++            existing_pythonpath = env.get("PYTHONPATH")
++            env["PYTHONPATH"] = str(config["root"]) + (
++                os.pathsep + existing_pythonpath if existing_pythonpath else ""
++            )
++            env["TORCH_EXTENSIONS_DIR"] = str(extension_dir)
++            command = [
++                sys.executable,
++                "-m",
++                "torch.distributed.run",
++                "--standalone",
++                f"--nproc-per-node={args.world_size}",
++                str(harness),
++                "--label",
++                f"{variant}-{config['sha'][:12]}-{run_index}",
++                "--variant",
++                variant,
++                "--run-index",
++                str(run_index),
++                "--implementation-root",
++                str(config["root"]),
++                "--expected-git-sha",
++                config["sha"],
++                "--expected-graph-kernel-nodes",
++                str(config["expected_nodes"]),
++                "--numel",
++                str(args.numel),
++                "--warmup",
++                str(args.warmup),
++                "--iters",
++                str(args.iters),
++                "--sampler-interval",
++                str(args.sampler_interval),
++                "--preflight-replays",
++                str(args.preflight_replays),
++                "--distributed-timeout-seconds",
++                str(args.distributed_timeout_seconds),
++                "--controller-sha256",
++                controller_sha256,
++                "--controller-argv-sha256",
++                controller_argv_sha256,
++                "--output",
++                str(raw_path),
++            ]
++            print(
++                f"[{run_index + 1}/{2 * args.pairs}] {variant} {config['sha'][:12]}",
++                flush=True,
++            )
++            _run(
++                command,
++                cwd=config["root"],
++                env=env,
++                timeout=args.run_timeout_seconds,
++            )
++            record = json.loads(raw_path.read_text(encoding="utf-8"))
++            _validate_run(
++                record,
++                contract=contract,
++                variant=variant,
++                sha=config["sha"],
++                run_index=run_index,
++                harness_sha256=harness_sha256,
++                expected_nodes=config["expected_nodes"],
++                implementation_root=config["root"],
++                controller_sha256=controller_sha256,
++                controller_argv_sha256=controller_argv_sha256,
++                extension_dir=extension_dir,
++            )
++            records.append(record)
++
++    software_fingerprints = {
++        json.dumps(record["software"], sort_keys=True) for record in records
++    }
++    hardware_fingerprints = {
++        json.dumps(_stable_hardware(record), sort_keys=True) for record in records
++    }
++    environment_fingerprints = {
++        json.dumps(_stable_environment(record), sort_keys=True) for record in records
++    }
++    if len(software_fingerprints) != 1:
++        raise ValueError("software stack changed during alternating A/B suite")
++    if len(hardware_fingerprints) != 1:
++        raise ValueError(
++            "hardware/driver/topology changed during alternating A/B suite"
++        )
++    if len(environment_fingerprints) != 1:
++        raise ValueError("environment toggles changed during alternating A/B suite")
++
++    paired_deltas = _paired_deltas(records)
++    suite = {
++        "schema": SUITE_SCHEMA,
++        "contract": contract,
++        "controller": {
++            "source_path": str(controller_path),
++            "sha256": controller_sha256,
++            "argv": controller_argv,
++            "argv_sha256": controller_argv_sha256,
++        },
++        "harness": {
++            "source_path": str(harness_source),
++            "frozen_path": str(harness),
++            "sha256": harness_sha256,
++            "identical_for_all_runs": True,
++        },
++        "implementations": {
++            "baseline": {"root": str(baseline_root), "git_sha": baseline_sha},
++            "candidate": {"root": str(candidate_root), "git_sha": candidate_sha},
++        },
++        "sequence": sequence,
++        "records": records,
++        "paired_deltas": paired_deltas,
++        "paired_summary": _paired_summary(paired_deltas),
++        "aggregate": _aggregate(records),
++    }
++    if set(suite) != SUITE_TOP_LEVEL_KEYS:
++        raise ValueError("suite top-level schema mismatch")
++    if suite["schema"] != SUITE_SCHEMA or suite["contract"] != contract:
++        raise ValueError("suite identity/contract mismatch")
++    if set(suite["controller"]) != CONTROLLER_KEYS:
++        raise ValueError("suite controller schema mismatch")
++    if (
++        _sha256(Path(suite["controller"]["source_path"]))
++        != suite["controller"]["sha256"]
++    ):
++        raise ValueError("suite controller source digest mismatch")
++    if _json_sha256(suite["controller"]["argv"]) != suite["controller"]["argv_sha256"]:
++        raise ValueError("suite controller argv digest mismatch")
++    if set(suite["harness"]) != HARNESS_KEYS:
++        raise ValueError("suite harness schema mismatch")
++    if set(suite["implementations"]) != {"baseline", "candidate"}:
++        raise ValueError("suite implementation variants mismatch")
++    for implementation in suite["implementations"].values():
++        if set(implementation) != IMPLEMENTATION_KEYS:
++            raise ValueError("suite implementation schema mismatch")
++    if len(suite["sequence"]) != args.pairs * 2:
++        raise ValueError("suite sequence cardinality mismatch")
++    if len(suite["records"]) != args.pairs * 2:
++        raise ValueError("suite record cardinality mismatch")
++    if len(suite["paired_deltas"]) != args.pairs:
++        raise ValueError("suite paired-delta cardinality mismatch")
++    rendered = json.dumps(suite, indent=2, sort_keys=True)
++    output.parent.mkdir(parents=True, exist_ok=True)
++    output.write_text(rendered + "\n", encoding="utf-8")
++    print(rendered, flush=True)
++
++
++if __name__ == "__main__":
++    main()
+diff --git a/sparkinfer/_lib/compiler.py b/sparkinfer/_lib/compiler.py
+index 3357d377d044a3450d87f2e384aa831c7a3b8256..9bba8af21c6a6cc27e164aadee9a1d1f3275292b 100644
+--- a/sparkinfer/_lib/compiler.py
++++ b/sparkinfer/_lib/compiler.py
+@@ -2648,6 +2648,15 @@ def compile(
+     compiled = _memory_cache_get(memory_cache_key)
+     if compiled is not None:
+         return compiled
++    from sparkinfer._lib.runtime_control import (
++        raise_if_kernel_resolution_frozen,
++    )
++
++    raise_if_kernel_resolution_frozen(
++        "cute.compile",
++        target=func,
++        cache_key=compile_spec if compile_spec is not None else memory_cache_key,
++    )
+ 
+     post_engine_start_log = _cute_compile_post_engine_start_log_enabled()
+     payload = _compile_disk_cache_payload(
+@@ -2720,15 +2729,6 @@ def compile(
+ 
+             with _MEMORY_CACHE_LOCK:
+                 _COMPILE_MISSES += 1
+-            from sparkinfer._lib.runtime_control import (
+-                raise_if_kernel_resolution_frozen,
+-            )
+-
+-            raise_if_kernel_resolution_frozen(
+-                "cute.compile",
+-                target=func,
+-                cache_key=compile_spec if compile_spec is not None else payload,
+-            )
+             call_kwargs = {
+                 k: v for k, v in kwargs.items() if k != "__dsl_compile_options_key"
+             }
+@@ -2770,15 +2770,6 @@ def compile(
+ 
+     with _MEMORY_CACHE_LOCK:
+         _COMPILE_MISSES += 1
+-    from sparkinfer._lib.runtime_control import (
+-        raise_if_kernel_resolution_frozen,
+-    )
+-
+-    raise_if_kernel_resolution_frozen(
+-        "cute.compile",
+-        target=func,
+-        cache_key=compile_spec if compile_spec is not None else payload,
+-    )
+     call_kwargs = {k: v for k, v in kwargs.items() if k != "__dsl_compile_options_key"}
+     compiled = _call_cute_compile(
+         compile_callable,
+diff --git a/sparkinfer/attention/_shared/mla/compressed_api.py b/sparkinfer/attention/_shared/mla/compressed_api.py
+index ba7e57736b70f4d97ed95289ceb74b159e37a4f6..4136b59bd67739009d8f4ba4480a0ed420ea77b4 100644
+--- a/sparkinfer/attention/_shared/mla/compressed_api.py
++++ b/sparkinfer/attention/_shared/mla/compressed_api.py
+@@ -16,6 +16,7 @@ from .compressed_config import (
+     compressed_mla_split_chunks_for_contract,
+ )
+ from .compressed_reference import (
++    COMPRESSED_MLA_BYTES_PER_TOKEN,
+     COMPRESSED_MLA_DSV4_PAGE_SIZE,
+     COMPRESSED_MLA_HEAD_DIM,
+     compressed_mla_page_nbytes,
+@@ -523,11 +524,14 @@ def _validate_compressed_cache_layout(
+     page_size = int(page_size)
+     if page_size <= 0:
+         raise ValueError(f"{name} page_size must be positive, got {page_size}")
+-    expected_page_nbytes = compressed_mla_page_nbytes(page_size)
+-    if int(cache.shape[1]) != expected_page_nbytes:
++    payload_nbytes = page_size * COMPRESSED_MLA_BYTES_PER_TOKEN
++    padded_page_nbytes = compressed_mla_page_nbytes(page_size)
++    page_nbytes = int(cache.shape[1])
++    if page_nbytes not in (payload_nbytes, padded_page_nbytes):
+         raise ValueError(
+-            f"{name} page byte width must be {expected_page_nbytes} for page_size "
+-            f"{page_size}, got {int(cache.shape[1])}"
++            f"{name} page byte width must be the contiguous payload "
++            f"{payload_nbytes} or padded width {padded_page_nbytes} for "
++            f"page_size {page_size}, got {page_nbytes}"
+         )
+ 
+ 
+diff --git a/sparkinfer/attention/_shared/mla/compressed_reference.py b/sparkinfer/attention/_shared/mla/compressed_reference.py
+index ab21b4607b3ad863b8d1c7730f9eef68b16cbbea..07f3a655bd279d95f8ad4830bdd96d08d402ffbb 100644
+--- a/sparkinfer/attention/_shared/mla/compressed_reference.py
++++ b/sparkinfer/attention/_shared/mla/compressed_reference.py
+@@ -5,10 +5,11 @@ vector, a 64-dimension BF16 RoPE vector, and seven UE8M0 scale bytes for the
+ noPE groups.  Within each page the token payloads are packed first, followed by
+ the per-token scale region:
+ 
+-    [page_size * 576 payload bytes][page_size * 8 scale bytes][padding]
++    [page_size * 576 payload bytes][page_size * 8 scale bytes][optional padding]
+ 
+-The padding rounds page byte size up to a 576-byte multiple, matching the
+-SGLang memory-pool contract.
++SGLang rounds the page byte size up to a 576-byte multiple. vLLM may instead
++use a contiguous allocation whose page stride ends immediately after the scale
++region. Both layouts contain the same compressed-MLA payload.
+ """
+ 
+ from __future__ import annotations
+diff --git a/sparkinfer/attention/_shared/mla/kernel.py b/sparkinfer/attention/_shared/mla/kernel.py
+index 0568a3cd6ac442d6d28ed26e3a59b07e1d486ccf..108d87842a620189aa5670f2d97eb2edb6ba5874 100644
+--- a/sparkinfer/attention/_shared/mla/kernel.py
++++ b/sparkinfer/attention/_shared/mla/kernel.py
+@@ -2319,7 +2319,7 @@ def _cache_block_stride_bytes(
+     record_bytes: int | None = None,
+ ) -> int:
+     from sparkinfer.attention._shared.mla.compressed_reference import (
+-        compressed_mla_page_nbytes,
++        COMPRESSED_MLA_BYTES_PER_TOKEN,
+     )
+ 
+     if int(model_type) == int(ModelType.GLM_NSA):
+@@ -2328,12 +2328,9 @@ def _cache_block_stride_bytes(
+         rec = int(record_bytes) if record_bytes is not None else _GLM_KV_GMEM_STRIDE
+         expected = int(page_size) * rec
+     else:
+-        expected = int(compressed_mla_page_nbytes(int(page_size)))
+-    # Contiguous inputs are flattened before launch, so their original rank is
+-    # not a physical-layout contract and the standard page stride applies.
+-    # Packed vLLM page views are non-contiguous and carry the physical
+-    # per-block stride in dimension 0.
+-    if not cache.is_contiguous() and cache.ndim >= 2:
++        expected = int(page_size) * COMPRESSED_MLA_BYTES_PER_TOKEN
++    # Use the tensor's physical page stride for exact-payload and padded views.
++    if cache.ndim >= 2:
+         stride = int(cache.stride(0)) * int(cache.element_size())
+         if stride < expected:
+             raise ValueError(
+diff --git a/sparkinfer/attention/_shared/mla/prefill.py b/sparkinfer/attention/_shared/mla/prefill.py
+index b5f396fc1a6758009dc82c247e08d5766fe85118..87bff79dc0f9583b4a43621fae3b34d3ee5e6f11 100644
+--- a/sparkinfer/attention/_shared/mla/prefill.py
++++ b/sparkinfer/attention/_shared/mla/prefill.py
+@@ -48,7 +48,7 @@ def _cache_block_stride_bytes(
+     record_bytes: int | None = None,
+ ) -> int:
+     from sparkinfer.attention._shared.mla.compressed_reference import (
+-        compressed_mla_page_nbytes,
++        COMPRESSED_MLA_BYTES_PER_TOKEN,
+     )
+ 
+     if model_type == ModelType.GLM_NSA:
+@@ -57,12 +57,10 @@ def _cache_block_stride_bytes(
+         rec = int(record_bytes) if record_bytes is not None else _GLM_KV_GMEM_STRIDE
+         expected = int(page_size) * rec
+     else:
+-        expected = int(compressed_mla_page_nbytes(int(page_size)))
+-    # Contiguous inputs are flattened before launch, so their original rank is
+-    # not a physical-layout contract and the standard page stride applies.
+-    # Only packed, non-contiguous vLLM views preserve a real per-block stride in
+-    # dimension 0.
+-    if not cache.is_contiguous() and cache.ndim >= 2:
++        expected = int(page_size) * COMPRESSED_MLA_BYTES_PER_TOKEN
++    # The runtime page stride is part of the cache contract. It can be either
++    # the exact payload width or a larger packed/padded stride.
++    if cache.ndim >= 2:
+         stride = int(cache.stride(0)) * int(cache.element_size())
+         if stride < expected:
+             raise ValueError(
+diff --git a/sparkinfer/attention/_shared/mla/prefill_mg.py b/sparkinfer/attention/_shared/mla/prefill_mg.py
+index ea0f8987374dc5b918a9ad071fd0fcb1b5efd619..ac3edde5e3dfd114018943cc6452749d4b8459ce 100644
+--- a/sparkinfer/attention/_shared/mla/prefill_mg.py
++++ b/sparkinfer/attention/_shared/mla/prefill_mg.py
+@@ -198,7 +198,7 @@ def _cache_block_stride_bytes(
+     record_bytes: int | None = None,
+ ) -> int:
+     from sparkinfer.attention._shared.mla.compressed_reference import (
+-        compressed_mla_page_nbytes,
++        COMPRESSED_MLA_BYTES_PER_TOKEN,
+     )
+ 
+     if is_glm:
+@@ -207,12 +207,9 @@ def _cache_block_stride_bytes(
+         rec = int(record_bytes) if record_bytes is not None else _GLM_IO_STRIDE
+         expected = int(page_size) * rec
+     else:
+-        expected = int(compressed_mla_page_nbytes(int(page_size)))
+-    # Contiguous inputs are flattened before launch, so their original rank is
+-    # not a physical-layout contract and the standard page stride applies.
+-    # Packed vLLM page views are non-contiguous and carry the physical
+-    # per-block stride in dimension 0.
+-    if not cache.is_contiguous() and cache.ndim >= 2:
++        expected = int(page_size) * COMPRESSED_MLA_BYTES_PER_TOKEN
++    # Use the tensor's physical page stride for exact-payload and padded views.
++    if cache.ndim >= 2:
+         stride = int(cache.stride(0)) * int(cache.element_size())
+         if stride < expected:
+             raise ValueError(
+diff --git a/sparkinfer/comm/pcie/ipc_handle_registry.h b/sparkinfer/comm/pcie/ipc_handle_registry.h
+new file mode 100644
+index 0000000000000000000000000000000000000000..72a3c4ff1ef95548f5f0237298e591ac1da3efd0
+--- /dev/null
++++ b/sparkinfer/comm/pcie/ipc_handle_registry.h
+@@ -0,0 +1,63 @@
++#pragma once
++
++#include <map>
++#include <utility>
++
++namespace sparkinfer::pcie {
++
++// Owns imported IPC handles whose close routine reports an error code instead
++// of throwing. Successful closes clear their entries so repeated cleanup is
++// idempotent; failed entries remain available to an explicit retry.
++template <typename Key, typename Handle, typename Error, Error Success>
++class IpcHandleRegistry {
++ public:
++  using CloseFn = Error (*)(Handle) noexcept;
++  using Map = std::map<Key, Handle>;
++  using iterator = typename Map::iterator;
++
++  explicit IpcHandleRegistry(CloseFn close) noexcept : close_(close) {}
++
++  IpcHandleRegistry(const IpcHandleRegistry&) = delete;
++  IpcHandleRegistry& operator=(const IpcHandleRegistry&) = delete;
++  IpcHandleRegistry(IpcHandleRegistry&&) = delete;
++  IpcHandleRegistry& operator=(IpcHandleRegistry&&) = delete;
++
++  ~IpcHandleRegistry() noexcept {
++    (void)close_all_noexcept();
++  }
++
++  iterator find(const Key& key) {
++    return handles_.find(key);
++  }
++
++  iterator end() {
++    return handles_.end();
++  }
++
++  std::pair<iterator, bool> emplace(const Key& key, Handle handle) {
++    return handles_.emplace(key, handle);
++  }
++
++  Error close_all_noexcept() noexcept {
++    Error first_error = Success;
++    for (auto& entry : handles_) {
++      Handle& handle = entry.second;
++      if (handle == Handle{}) {
++        continue;
++      }
++      const Error error = close_(handle);
++      if (error == Success) {
++        handle = Handle{};
++      } else if (first_error == Success) {
++        first_error = error;
++      }
++    }
++    return first_error;
++  }
++
++ private:
++  Map handles_;
++  CloseFn close_;
++};
++
++}  // namespace sparkinfer::pcie
+diff --git a/sparkinfer/comm/pcie/pcie_dcp_a2a.cu b/sparkinfer/comm/pcie/pcie_dcp_a2a.cu
+index 2458198a8bf422ff4b37e6c92708fec504026b8d..b0e93064948d810bf0d06fbdc1d47fd1fb3c9aa4 100644
+--- a/sparkinfer/comm/pcie/pcie_dcp_a2a.cu
++++ b/sparkinfer/comm/pcie/pcie_dcp_a2a.cu
+@@ -20,6 +20,7 @@
+ #include <algorithm>
+ #include <array>
+ #include <cmath>
++#include <cstdint>
+ #include <cstdlib>
+ #include <sstream>
+ #include <stdexcept>
+@@ -66,6 +67,8 @@ static int dcp_block_limit_override() {
+ }
+ 
+ struct Signal {
++  alignas(128) FlagType staging_generation;
++  FlagType active_staging_slot;
+   alignas(128) FlagType self_counter[kMaxBlocks][kMaxRanks];
+   alignas(128) FlagType peer_counter[2][kMaxBlocks][kMaxRanks * kFlagStride];
+ };
+@@ -78,6 +81,10 @@ struct RankStaging {
+   void *ptrs[kMaxRanks];
+ };
+ 
++struct DoubleStaging {
++  RankStaging slots[2];
++};
++
+ template <typename T> struct __align__(16) Pack {
+   T values[8];
+ };
+@@ -97,6 +104,40 @@ static DINLINE FlagType load_flag(FlagType *address) {
+   return value;
+ }
+ 
++static DINLINE FlagType load_flag_gpu(FlagType *address) {
++  FlagType value;
++  asm volatile("ld.relaxed.gpu.global.u32 %0, [%1];"
++               : "=r"(value)
++               : "l"(address)
++               : "memory");
++  return value;
++}
++
++__global__ void advance_staging_slot_kernel(Signal *self) {
++  if (threadIdx.x == 0) {
++    const FlagType generation = self->staging_generation;
++    self->active_staging_slot = generation & FlagType{1};
++    self->staging_generation = generation + FlagType{1};
++  }
++}
++
++template <int world_size>
++DINLINE void select_staging(RankStaging &staging,
++                            const DoubleStaging &staging_options,
++                            Signal *self) {
++  if (threadIdx.x == 0) {
++    // The one-CTA control node runs earlier on this stream.  Every worker CTA
++    // therefore observes one operation-wide slot regardless of worker grid
++    // size or rank launch skew.
++    const int slot = int(load_flag_gpu(&self->active_staging_slot) & FlagType{1});
++#pragma unroll
++    for (int peer = 0; peer < world_size; ++peer) {
++      staging.ptrs[peer] = staging_options.slots[slot].ptrs[peer];
++    }
++  }
++  __syncthreads();
++}
++
+ // pre_sync orders in-kernel staging stores (from every warp of the block)
+ // before the flag post; without staging the flags can go out immediately.
+ template <int world_size, bool pre_sync>
+@@ -117,6 +158,16 @@ DINLINE void start_barrier(const RankSignals &signals, Signal *self, int rank) {
+   __syncthreads();
+ }
+ 
++DINLINE void test_post_barrier_delay(int rank, int delayed_rank,
++                                     uint64_t delay_cycles) {
++  if (delay_cycles != 0 && rank == delayed_rank && threadIdx.x == 0) {
++    const uint64_t start = clock64();
++    while (clock64() - start < delay_cycles) {
++    }
++  }
++  __syncthreads();
++}
++
+ DINLINE float to_float(half value) { return __half2float(value); }
+ DINLINE float to_float(nv_bfloat16 value) { return __bfloat162float(value); }
+ 
+@@ -149,14 +200,15 @@ template <typename T, int world_size>
+ __global__ void __launch_bounds__(512, 1)
+     dcp_lse_reduce_kernel(const T *__restrict__ local_output,
+                           const float *__restrict__ local_lse,
+-                          RankStaging staging, int64_t lse_offset,
++                          DoubleStaging staging_options, int64_t lse_offset,
+                           RankSignals signals, Signal *self,
+                           T *__restrict__ output, int rank, int batch,
+                           int total_heads, int head_dim,
+                           int64_t input_stride_batch,
+                           int64_t input_stride_head,
+                           int64_t output_stride_batch,
+-                          int64_t output_stride_head, bool natural_log) {
++                          int64_t output_stride_head, bool natural_log,
++                          int delayed_rank, uint64_t delay_cycles) {
+   constexpr int kPackElems = 8;
+   const int heads_per_rank = total_heads / world_size;
+   const int packs_per_head = head_dim / kPackElems;
+@@ -169,6 +221,9 @@ __global__ void __launch_bounds__(512, 1)
+   const auto *local_packs = reinterpret_cast<const Pack<T> *>(local_output);
+   auto *output_packs = reinterpret_cast<Pack<T> *>(output);
+ 
++  __shared__ RankStaging staging;
++  select_staging<world_size>(staging, staging_options, self);
++
+   auto *staging_out = reinterpret_cast<Pack<T> *>(staging.ptrs[rank]);
+   auto *staging_lse = reinterpret_cast<float *>(
+       reinterpret_cast<char *>(staging.ptrs[rank]) + lse_offset);
+@@ -192,6 +247,7 @@ __global__ void __launch_bounds__(512, 1)
+     }
+   }
+   start_barrier<world_size, true>(signals, self, rank);
++  test_post_barrier_delay(rank, delayed_rank, delay_cycles);
+ 
+   // Rotated source pointers so every later access uses a compile-time
+   // index; the self source reads the local tensors directly (still hot in
+@@ -286,9 +342,10 @@ __global__ void __launch_bounds__(512, 1)
+ template <typename T, int world_size>
+ __global__ void __launch_bounds__(512, 1)
+     all_gather_heads_kernel(const T *__restrict__ local_input,
+-                            RankStaging staging, RankSignals signals,
++                            DoubleStaging staging_options, RankSignals signals,
+                             Signal *self, T *__restrict__ output, int rank,
+-                            int batch, int local_heads, int head_dim) {
++                            int batch, int local_heads, int head_dim,
++                            int delayed_rank, uint64_t delay_cycles) {
+   constexpr int kPackElems = 8;
+   const int packs_per_head = head_dim / kPackElems;
+   const int total_heads = local_heads * world_size;
+@@ -299,6 +356,9 @@ __global__ void __launch_bounds__(512, 1)
+   const int warp_stride = gridDim.x * warps_per_block;
+   const auto *local_packs = reinterpret_cast<const Pack<T> *>(local_input);
+ 
++  __shared__ RankStaging staging;
++  select_staging<world_size>(staging, staging_options, self);
++
+   auto *staging_out = reinterpret_cast<Pack<T> *>(staging.ptrs[rank]);
+   for (int row = warp_first; row < rows; row += warp_stride) {
+     const int batch_index = row / total_heads;
+@@ -313,6 +373,7 @@ __global__ void __launch_bounds__(512, 1)
+     }
+   }
+   start_barrier<world_size, true>(signals, self, rank);
++  test_post_barrier_delay(rank, delayed_rank, delay_cycles);
+ 
+   auto *output_packs = reinterpret_cast<Pack<T> *>(output);
+   for (int row = warp_first; row < rows; row += warp_stride) {
+@@ -339,11 +400,11 @@ public:
+   int world_size_;
+   RankSignals signals_{};
+   Signal *self_signal_;
+-  RankStaging staging_[2]{};
++  DoubleStaging staging_{};
+   int64_t output_capacity_elems_;
+   int64_t lse_offset_;
+   int64_t lse_capacity_;
+-  int slot_ = 0;
++
+ 
+   PCIeDCPA2A(Signal **signals,
+              const std::vector<std::array<void *, 2>> &staging,
+@@ -354,8 +415,8 @@ public:
+         lse_capacity_(lse_capacity) {
+     for (int peer = 0; peer < world_size_; ++peer) {
+       signals_.signals[peer] = signals[peer];
+-      staging_[0].ptrs[peer] = staging[peer][0];
+-      staging_[1].ptrs[peer] = staging[peer][1];
++      staging_.slots[0].ptrs[peer] = staging[peer][0];
++      staging_.slots[1].ptrs[peer] = staging[peer][1];
+     }
+   }
+ 
+@@ -394,21 +455,27 @@ public:
+       throw std::runtime_error("threads must be a multiple of 32");
+     }
+ 
+-    // Staging happens inside the kernel (warp-per-row, before the start
+-    // barrier); no host staging memcpys are issued.
+-    const int slot = slot_++ % 2;
++    // Select one staging slot per execution in a graph-capturable device node.
++    // Worker CTA count may change large -> small -> large without leaving
++    // dormant per-block parity counters behind.
+     const int heads_per_rank = total_heads / world_size_;
+     const int rows = batch * heads_per_rank;
+     const int warps_per_block = threads / 32;
+     const int blocks = std::max(
+         1, std::min(block_limit, (rows + warps_per_block - 1) / warps_per_block));
++    advance_staging_slot_kernel<<<1, 1, 0, stream>>>(self_signal_);
++    CHECK_CUDA_SUCCESS(cudaGetLastError());
++    const int delayed_rank =
++        env_int("SPARKINFER_PCIE_DCP_TEST_DELAY_RANK", -1);
++    const uint64_t delay_cycles = static_cast<uint64_t>(std::max(
++        0, env_int("SPARKINFER_PCIE_DCP_TEST_POST_BARRIER_DELAY_CYCLES", 0)));
+ 
+ #define LAUNCH(world)                                                          \
+   dcp_lse_reduce_kernel<T, world><<<blocks, threads, 0, stream>>>(             \
+-      partial_output, partial_lse, staging_[slot], lse_offset_, signals_,      \
+-      self_signal_, output, rank_, batch, total_heads, head_dim,               \
++      partial_output, partial_lse, staging_, lse_offset_, signals_,           \
++      self_signal_, output, rank_, batch, total_heads, head_dim,              \
+       input_stride_batch, input_stride_head, output_stride_batch,              \
+-      output_stride_head, natural_log)
++      output_stride_head, natural_log, delayed_rank, delay_cycles)
+     switch (world_size_) {
+     case 2:
+       LAUNCH(2);
+@@ -455,18 +522,23 @@ public:
+       throw std::runtime_error("threads must be a multiple of 32");
+     }
+ 
+-    // Staging happens inside the kernel (warp-per-row, before the start
+-    // barrier); no host staging memcpy is issued.
+-    const int slot = slot_++ % 2;
++    // Slot ownership is published by a device control node, including for
++    // back-to-back eager launches and every CUDA graph replay.
+     const int rows = batch * total_heads;
+     const int warps_per_block = threads / 32;
+     const int blocks = std::max(
+         1, std::min(block_limit, (rows + warps_per_block - 1) / warps_per_block));
++    advance_staging_slot_kernel<<<1, 1, 0, stream>>>(self_signal_);
++    CHECK_CUDA_SUCCESS(cudaGetLastError());
++    const int delayed_rank =
++        env_int("SPARKINFER_PCIE_DCP_TEST_DELAY_RANK", -1);
++    const uint64_t delay_cycles = static_cast<uint64_t>(std::max(
++        0, env_int("SPARKINFER_PCIE_DCP_TEST_POST_BARRIER_DELAY_CYCLES", 0)));
+ 
+ #define LAUNCH(world)                                                          \
+   all_gather_heads_kernel<T, world><<<blocks, threads, 0, stream>>>(           \
+-      local_input, staging_[slot], signals_, self_signal_, output, rank_,      \
+-      batch, local_heads, head_dim)
++      local_input, staging_, signals_, self_signal_, output, rank_, batch,    \
++      local_heads, head_dim, delayed_rank, delay_cycles)
+     switch (world_size_) {
+     case 2:
+       LAUNCH(2);
+diff --git a/sparkinfer/comm/pcie/pcie_dcp_a2a.py b/sparkinfer/comm/pcie/pcie_dcp_a2a.py
+index 49f41ce26b4ed847f5915c6dfcfedcebe4ffaf74..2717d6f0624669e9829fbc6600f97166b35669c6 100644
+--- a/sparkinfer/comm/pcie/pcie_dcp_a2a.py
++++ b/sparkinfer/comm/pcie/pcie_dcp_a2a.py
+@@ -3,7 +3,7 @@
+ from __future__ import annotations
+ 
+ import os
+-from contextlib import contextmanager, suppress
++from contextlib import contextmanager
+ from dataclasses import dataclass
+ from functools import lru_cache
+ from pathlib import Path
+@@ -16,19 +16,32 @@ from torch.utils.cpp_extension import load
+ 
+ from ._cuda_ipc import CudaRTLibrary
+ from .pcie_oneshot import (
++    _ABANDONED_PCIE_RUNTIME_QUARANTINE,
++    _SINGLE_CHANNEL_ID,
+     IPC_SLAB_ALIGNMENT,
+     PCIeOneshotAllReduce,
++    _finish_collective_runtime_setup,
++    _raise_local_cleanup_errors,
+     _align_up,
++    _broadcast_gather_object,
++    _collective_capture_needs_preparation,
+     _coordinated_close_channels,
+     _current_stream_key,
++    _cuda_device_index,
+     _is_current_stream_capturing,
+     _normalize_device,
++    _normalize_logical_channel_id,
+     _OwnedSharedBuffer,
++    _finish_collective_unowned_runtime_setup,
++    _require_collective_contract,
++    _require_full_grid_residency,
++    _run_collective_preallocation_setup,
+ )
+ 
+ 
+ SUPPORTED_WORLD_SIZES = (2, 4, 8)
+ SUPPORTED_DTYPES = (torch.float16, torch.bfloat16)
++DCP_A2A_REQUIRED_SMS = 64
+ 
+ 
+ def _is_supported_bhd_layout(tensor: torch.Tensor) -> bool:
+@@ -37,15 +50,15 @@ def _is_supported_bhd_layout(tensor: torch.Tensor) -> bool:
+         return False
+     batch, heads, head_dim = (int(value) for value in tensor.shape)
+     stride_batch, stride_head, _ = (int(value) for value in tensor.stride())
+-    packed_token_major = (
+-        stride_batch == heads * head_dim and stride_head == head_dim
+-    )
++    packed_token_major = stride_batch == heads * head_dim and stride_head == head_dim
+     capacity_strided_head_major = (
+         stride_batch == head_dim
+         and stride_head >= batch * head_dim
+         and stride_head % 8 == 0
+     )
+     return packed_token_major or capacity_strided_head_major
++
++
+ @dataclass(frozen=True)
+ class _StagingLayout:
+     signal_bytes: int
+@@ -189,49 +202,252 @@ class PCIeDCPA2A:
+         ext_module=None,
+         stream_affine: bool = True,
+     ) -> None:
+-        if world_size not in SUPPORTED_WORLD_SIZES:
+-            raise ValueError(f"unsupported world size {world_size}")
+-        if not 0 <= rank < world_size:
+-            raise ValueError(f"invalid rank {rank} for world size {world_size}")
+-        if (
+-            len(signal_ptrs) != world_size
+-            or len(staging0_ptrs) != world_size
+-            or len(staging1_ptrs) != world_size
+-        ):
+-            raise ValueError("signal and staging pointers must match world size")
+-        if total_heads <= 0 or total_heads % world_size != 0:
+-            raise ValueError("total_heads must be divisible by world_size")
+-        if head_dim <= 0 or head_dim % 8 != 0:
+-            raise ValueError("head_dim must be a positive multiple of 8")
++        def normalize_and_validate():
++            device_obj = _normalize_device(device)
++            normalized_rank = int(rank)
++            normalized_world_size = int(world_size)
++            normalized_signals = tuple(int(ptr) for ptr in signal_ptrs)
++            normalized_staging0 = tuple(int(ptr) for ptr in staging0_ptrs)
++            normalized_staging1 = tuple(int(ptr) for ptr in staging1_ptrs)
++            normalized_max_batch = int(max_batch_size)
++            normalized_total_heads = int(total_heads)
++            normalized_head_dim = int(head_dim)
++            normalized_query_dim = int(
++                head_dim if query_head_dim is None else query_head_dim
++            )
++            normalized_output_capacity = int(output_capacity_elems)
++            normalized_lse_offset = int(lse_offset)
++            normalized_lse_capacity = int(lse_capacity)
++            if normalized_world_size not in SUPPORTED_WORLD_SIZES:
++                raise ValueError(f"unsupported world size {normalized_world_size}")
++            if not 0 <= normalized_rank < normalized_world_size:
++                raise ValueError(
++                    f"invalid rank {normalized_rank} for world size "
++                    f"{normalized_world_size}"
++                )
++            if (
++                len(normalized_signals) != normalized_world_size
++                or len(normalized_staging0) != normalized_world_size
++                or len(normalized_staging1) != normalized_world_size
++            ):
++                raise ValueError("signal and staging pointers must match world size")
++            if normalized_max_batch <= 0:
++                raise ValueError("max_batch_size must be positive")
++            if (
++                normalized_total_heads <= 0
++                or normalized_total_heads % normalized_world_size != 0
++            ):
++                raise ValueError("total_heads must be divisible by world_size")
++            if normalized_head_dim <= 0 or normalized_head_dim % 8 != 0:
++                raise ValueError("head_dim must be a positive multiple of 8")
++            if normalized_query_dim <= 0 or normalized_query_dim % 8 != 0:
++                raise ValueError("query_head_dim must be a positive multiple of 8")
++            required_output = (
++                normalized_max_batch
++                * normalized_total_heads
++                * max(normalized_head_dim, normalized_query_dim)
++            )
++            if normalized_output_capacity < required_output:
++                raise ValueError("output capacity is smaller than configured shape")
++            if normalized_lse_offset < 0:
++                raise ValueError("lse_offset must be non-negative")
++            if normalized_lse_capacity < normalized_max_batch * normalized_total_heads:
++                raise ValueError("LSE capacity is smaller than configured shape")
++            if ext_module is None and device_obj.type != "cuda":
++                raise ValueError("PCIe DCP A2A requires a CUDA device")
++            if device_obj.type == "cuda" and exchange_group is None:
++                raise ValueError(
++                    "exchange_group is required for a CUDA PCIe DCP A2A runtime; "
++                    "use from_exchange_group()"
++                )
++            if exchange_group is not None:
++                if device_obj.type != "cuda":
++                    raise ValueError("distributed PCIe DCP A2A requires a CUDA device")
++                group_rank = dist.get_rank(group=exchange_group)
++                group_world_size = dist.get_world_size(group=exchange_group)
++                if normalized_rank != group_rank:
++                    raise ValueError(
++                        f"supplied rank {normalized_rank} does not match process "
++                        f"group rank {group_rank}"
++                    )
++                if normalized_world_size != group_world_size:
++                    raise ValueError(
++                        f"supplied world size {normalized_world_size} does not "
++                        f"match process group size {group_world_size}"
++                    )
++            return (
++                device_obj,
++                normalized_rank,
++                normalized_world_size,
++                normalized_signals,
++                normalized_staging0,
++                normalized_staging1,
++                normalized_max_batch,
++                normalized_total_heads,
++                normalized_head_dim,
++                normalized_query_dim,
++                normalized_output_capacity,
++                normalized_lse_offset,
++                normalized_lse_capacity,
++            )
++
++        if exchange_group is not None:
++            normalized = _run_collective_preallocation_setup(
++                owner="PCIe DCP A2A direct constructor argument validation",
++                exchange_group=exchange_group,
++                setup=normalize_and_validate,
++            )
++        else:
++            normalized = normalize_and_validate()
++
++        self._initialize_prepared_state(
++            rank=normalized[1],
++            world_size=normalized[2],
++            device=normalized[0],
++            signal_ptrs=normalized[3],
++            staging0_ptrs=normalized[4],
++            staging1_ptrs=normalized[5],
++            max_batch_size=normalized[6],
++            total_heads=normalized[7],
++            head_dim=normalized[8],
++            query_head_dim=normalized[9],
++            output_capacity_elems=normalized[10],
++            lse_offset=normalized[11],
++            lse_capacity=normalized[12],
++            exchange_group=exchange_group,
++            ipc=ipc,
++            owned_buffers=owned_buffers,
++            ext_module=ext_module,
++            stream_affine=stream_affine,
++        )
++
++        if self.device.type == "cuda":
++            _require_full_grid_residency(
++                owner="PCIe DCP A2A direct constructor",
++                required_sms=DCP_A2A_REQUIRED_SMS,
++                device=self.device,
++                exchange_group=self.exchange_group,
++            )
++
++            def prepare():
++                return ext_module or _load_extension()
++
++            if self.exchange_group is None:
++                self._ext = prepare()
++            else:
++                self._ext = _run_collective_preallocation_setup(
++                    owner="PCIe DCP A2A direct constructor",
++                    exchange_group=self.exchange_group,
++                    setup=prepare,
++                )
++        else:
++            self._ext = self._ext or _load_extension()
++
++        if self.device.type == "cuda" and self.exchange_group is not None:
++            _require_collective_contract(
++                owner="PCIe DCP A2A direct constructor",
++                exchange_group=self.exchange_group,
++                contract=(
++                    self.world_size,
++                    self.max_batch_size,
++                    self.total_heads,
++                    self.head_dim,
++                    self.query_head_dim,
++                    self.output_capacity_elems,
++                    self.lse_offset,
++                    self.lse_capacity,
++                ),
++            )
++
++        init_error = self._initialize_native_runtime()
++        if self.device.type == "cuda" and self.exchange_group is not None:
+ 
++            def abort_native_runtime() -> None:
++                if self._ptr:
++                    self._ext.dispose(self._ptr)
++                    self._ptr = 0
++
++            _finish_collective_unowned_runtime_setup(
++                owner="PCIe DCP A2A direct constructor",
++                exchange_group=self.exchange_group,
++                local_error=init_error,
++                local_cleanup=abort_native_runtime,
++            )
++        elif init_error is not None:
++            raise init_error
++
++    def _initialize_prepared_state(
++        self,
++        *,
++        rank: int,
++        world_size: int,
++        device: torch.device,
++        signal_ptrs: Sequence[int],
++        staging0_ptrs: Sequence[int],
++        staging1_ptrs: Sequence[int],
++        max_batch_size: int,
++        total_heads: int,
++        head_dim: int,
++        query_head_dim: int,
++        output_capacity_elems: int,
++        lse_offset: int,
++        lse_capacity: int,
++        exchange_group: Optional[ProcessGroup],
++        ipc: Optional[CudaRTLibrary],
++        owned_buffers: Optional[Sequence[_OwnedSharedBuffer]],
++        ext_module,
++        stream_affine: bool,
++    ) -> None:
+         self.rank = int(rank)
+         self.world_size = int(world_size)
+-        self.device = _normalize_device(device)
++        self.device = device
+         self.exchange_group = exchange_group
+         self.max_batch_size = int(max_batch_size)
+         self.total_heads = int(total_heads)
+         self.head_dim = int(head_dim)
+-        self.query_head_dim = int(query_head_dim or head_dim)
+-        if self.query_head_dim <= 0 or self.query_head_dim % 8 != 0:
+-            raise ValueError("query_head_dim must be a positive multiple of 8")
++        self.query_head_dim = int(query_head_dim)
+         self.heads_per_rank = self.total_heads // self.world_size
++        self.output_capacity_elems = int(output_capacity_elems)
++        self.lse_offset = int(lse_offset)
++        self.lse_capacity = int(lse_capacity)
++        self._signal_ptrs = tuple(int(ptr) for ptr in signal_ptrs)
++        self._staging0_ptrs = tuple(int(ptr) for ptr in staging0_ptrs)
++        self._staging1_ptrs = tuple(int(ptr) for ptr in staging1_ptrs)
+         self._ipc = ipc
+         self._owned_buffers = list(owned_buffers or ())
+-        self._ext = ext_module or _load_extension()
++        self._ext = ext_module
+         self._stream_affine = bool(stream_affine)
+         self._owner_stream_key: Optional[int] = None
+         self._closed = False
+         self._ipc_imports_closed = False
+         self._ipc_exports_freed = False
+-        self._ptr = self._ext.init_dcp_a2a(
+-            list(signal_ptrs),
+-            list(staging0_ptrs),
+-            list(staging1_ptrs),
+-            int(output_capacity_elems),
+-            int(lse_offset),
+-            int(lse_capacity),
+-            self.rank,
+-        )
++        self._coordinated_close_complete = False
++        self._closed_ipc_import_indices: set[tuple[int, int]] = set()
++        self._ptr = 0
++
++    def _initialize_native_runtime(self) -> BaseException | None:
++        init_error: BaseException | None = None
++        try:
++            self._ptr = self._ext.init_dcp_a2a(
++                list(self._signal_ptrs),
++                list(self._staging0_ptrs),
++                list(self._staging1_ptrs),
++                self.output_capacity_elems,
++                self.lse_offset,
++                self.lse_capacity,
++                self.rank,
++            )
++        except Exception as exc:
++            init_error = exc
++        return init_error
++
++    @classmethod
++    def _from_prepared_factory(
++        cls, **kwargs
++    ) -> tuple["PCIeDCPA2A", BaseException | None]:
++        runtime = object.__new__(cls)
++        runtime._initialize_prepared_state(**kwargs)
++        return runtime, runtime._initialize_native_runtime()
+ 
+     @classmethod
+     def from_exchange_group(
+@@ -248,62 +464,130 @@ class PCIeDCPA2A:
+     ) -> "PCIeDCPA2A":
+         rank = dist.get_rank(group=exchange_group)
+         world_size = dist.get_world_size(group=exchange_group)
+-        device_obj = _normalize_device(device)
+-        if device_obj.type != "cuda":
+-            raise ValueError("PCIe DCP A2A requires a CUDA device")
+-
+-        ipc = CudaRTLibrary()
+-        ipc.cudaSetDevice(device_obj.index or 0)
+-        ext = ext_module or _load_extension()
+-        layout = _staging_layout(
+-            signal_bytes=int(ext.meta_size()),
+-            world_size=world_size,
+-            max_batch_size=max_batch_size,
+-            total_heads=total_heads,
+-            head_dim=head_dim,
+-            query_head_dim=query_head_dim,
++
++        def validate_factory_arguments():
++            device_obj = _normalize_device(device)
++            normalized_max_batch = int(max_batch_size)
++            normalized_total_heads = int(total_heads)
++            normalized_head_dim = int(head_dim)
++            normalized_query_dim = int(
++                head_dim if query_head_dim is None else query_head_dim
++            )
++            if world_size not in SUPPORTED_WORLD_SIZES:
++                raise ValueError(f"unsupported world size {world_size}")
++            if device_obj.type != "cuda":
++                raise ValueError("PCIe DCP A2A requires a CUDA device")
++            if normalized_max_batch <= 0:
++                raise ValueError("max_batch_size must be positive")
++            if normalized_total_heads <= 0 or normalized_total_heads % world_size != 0:
++                raise ValueError("total_heads must be divisible by world_size")
++            if normalized_head_dim <= 0 or normalized_head_dim % 8 != 0:
++                raise ValueError("head_dim must be a positive multiple of 8")
++            if normalized_query_dim <= 0 or normalized_query_dim % 8 != 0:
++                raise ValueError("query_head_dim must be a positive multiple of 8")
++            return (
++                device_obj,
++                normalized_max_batch,
++                normalized_total_heads,
++                normalized_head_dim,
++                normalized_query_dim,
++            )
++
++        (
++            device_obj,
++            max_batch_size,
++            total_heads,
++            head_dim,
++            query_head_dim,
++        ) = _run_collective_preallocation_setup(
++            owner="PCIe DCP A2A argument validation",
++            exchange_group=exchange_group,
++            setup=validate_factory_arguments,
+         )
+-        owned: list[_OwnedSharedBuffer] = []
+-        try:
+-            slab = PCIeOneshotAllReduce._allocate_shared_buffer(
+-                exchange_group,
+-                layout.slab_bytes,
+-                zero_fill=True,
+-                ipc=ipc,
+-            )
+-            owned.append(slab)
+-            return cls(
+-                rank=rank,
++
++        _require_full_grid_residency(
++            owner="PCIe DCP A2A",
++            required_sms=DCP_A2A_REQUIRED_SMS,
++            device=device_obj,
++            exchange_group=exchange_group,
++        )
++
++        def prepare():
++            prepared_ipc = CudaRTLibrary()
++            prepared_ipc.cudaSetDevice(_cuda_device_index(device_obj))
++            prepared_ext = ext_module or _load_extension()
++            layout = _staging_layout(
++                signal_bytes=int(prepared_ext.meta_size()),
+                 world_size=world_size,
+-                device=device_obj,
+-                signal_ptrs=slab.peer_ptrs,
+-                staging0_ptrs=tuple(
+-                    ptr + layout.staging0_offset for ptr in slab.peer_ptrs
+-                ),
+-                staging1_ptrs=tuple(
+-                    ptr + layout.staging1_offset for ptr in slab.peer_ptrs
+-                ),
+                 max_batch_size=max_batch_size,
+                 total_heads=total_heads,
+                 head_dim=head_dim,
+-                output_capacity_elems=layout.output_capacity_elems,
+-                lse_offset=layout.lse_offset,
+-                lse_capacity=layout.lse_capacity,
+                 query_head_dim=query_head_dim,
+-                exchange_group=exchange_group,
+-                ipc=ipc,
+-                owned_buffers=owned,
+-                ext_module=ext,
+-                stream_affine=stream_affine,
+-            )
+-        except Exception:
+-            for shared in owned:
+-                for ptr in shared.remote_ptrs:
+-                    with suppress(Exception):
+-                        ipc.cudaIpcCloseMemHandle(ptr)
+-                with suppress(Exception):
+-                    ipc.cudaFree(shared.local_ptr)
+-            raise
++            )
++            return prepared_ipc, prepared_ext, layout
++
++        ipc, ext, layout = _run_collective_preallocation_setup(
++            owner="PCIe DCP A2A",
++            exchange_group=exchange_group,
++            setup=prepare,
++        )
++        _require_collective_contract(
++            owner="PCIe DCP A2A channel layout",
++            exchange_group=exchange_group,
++            contract=(
++                int(max_batch_size),
++                int(total_heads),
++                int(head_dim),
++                int(query_head_dim),
++                layout,
++            ),
++        )
++        slab = PCIeOneshotAllReduce._allocate_shared_buffer(
++            exchange_group,
++            layout.slab_bytes,
++            zero_fill=True,
++            ipc=ipc,
++        )
++        runtime, init_error = cls._from_prepared_factory(
++            rank=rank,
++            world_size=world_size,
++            device=device_obj,
++            signal_ptrs=slab.peer_ptrs,
++            staging0_ptrs=tuple(ptr + layout.staging0_offset for ptr in slab.peer_ptrs),
++            staging1_ptrs=tuple(ptr + layout.staging1_offset for ptr in slab.peer_ptrs),
++            max_batch_size=max_batch_size,
++            total_heads=total_heads,
++            head_dim=head_dim,
++            output_capacity_elems=layout.output_capacity_elems,
++            lse_offset=layout.lse_offset,
++            lse_capacity=layout.lse_capacity,
++            query_head_dim=query_head_dim,
++            exchange_group=exchange_group,
++            ipc=ipc,
++            owned_buffers=[slab],
++            ext_module=ext,
++            stream_affine=stream_affine,
++        )
++
++        def abort_native_runtime() -> None:
++            pointer = getattr(runtime, "_ptr", 0)
++            if pointer:
++                ext.dispose(pointer)
++                runtime._ptr = 0
++
++        def detach_shared_ownership() -> None:
++            runtime._owned_buffers.clear()
++
++        _finish_collective_runtime_setup(
++            owner="PCIe DCP A2A",
++            exchange_group=exchange_group,
++            ipc=ipc,
++            shared=slab,
++            local_error=init_error,
++            local_cleanup=abort_native_runtime,
++            detach_shared_ownership=detach_shared_ownership,
++        )
++        return runtime
+ 
+     @classmethod
+     def from_process_group(
+@@ -386,9 +670,7 @@ class PCIeDCPA2A:
+                 f"output shape must be {expected_out}, got {tuple(out.shape)}"
+             )
+         if not _is_supported_bhd_layout(partial_output):
+-            raise ValueError(
+-                "partial_output must be packed token-major or head-major"
+-            )
++            raise ValueError("partial_output must be packed token-major or head-major")
+         if not partial_lse.is_contiguous():
+             raise ValueError("partial_lse must be contiguous")
+         if not _is_supported_bhd_layout(out):
+@@ -480,39 +762,112 @@ class PCIeDCPA2A:
+         )
+         return out
+ 
+-    def _close_ipc_imports(self) -> None:
++    def _closed_import_indices(self) -> set[tuple[int, int]]:
++        closed = getattr(self, "_closed_ipc_import_indices", None)
++        if closed is None:
++            closed = set()
++            self._closed_ipc_import_indices = closed
++        return closed
++
++    def _all_python_ipc_imports_closed(self, closed: set[tuple[int, int]]) -> bool:
++        if self._ipc is None:
++            return not any(shared.remote_ptrs for shared in self._owned_buffers)
++        return all(
++            (buffer_index, remote_index) in closed
++            for buffer_index, shared in enumerate(self._owned_buffers)
++            for remote_index, _ in enumerate(shared.remote_ptrs)
++        )
++
++    def _close_ipc_imports_strict(self) -> None:
+         if self._ipc_imports_closed:
+             return
+         self._closed = True
++        failures: list[tuple[str, Exception]] = []
+         if getattr(self, "_ptr", 0):
+-            with suppress(Exception):
++            try:
+                 self._ext.dispose(self._ptr)
+-            self._ptr = 0
++            except Exception as exc:
++                failures.append(("native runtime", exc))
++            else:
++                self._ptr = 0
++
++        closed = self._closed_import_indices()
+         if self._ipc is not None:
+-            for shared in self._owned_buffers:
+-                for ptr in shared.remote_ptrs:
+-                    with suppress(Exception):
++            for buffer_index, shared in enumerate(self._owned_buffers):
++                for remote_index, ptr in enumerate(shared.remote_ptrs):
++                    key = (buffer_index, remote_index)
++                    if key in closed:
++                        continue
++                    try:
+                         self._ipc.cudaIpcCloseMemHandle(ptr)
+-        self._ipc_imports_closed = True
++                    except Exception as exc:
++                        failures.append((f"CUDA IPC import {ptr}", exc))
++                    else:
++                        closed.add(key)
++        elif any(shared.remote_ptrs for shared in self._owned_buffers):
++            failures.append(
++                (
++                    "CUDA IPC imports",
++                    RuntimeError("CUDA runtime is unavailable for IPC unmap"),
++                )
++            )
+ 
+-    def _free_ipc_exports(self) -> None:
++        if (
++            not failures
++            and not getattr(self, "_ptr", 0)
++            and self._all_python_ipc_imports_closed(closed)
++        ):
++            self._ipc_imports_closed = True
++        if failures:
++            _raise_local_cleanup_errors("PCIe DCP A2A", "IPC import close", failures)
++
++    def _free_ipc_exports_strict(self) -> None:
+         if self._ipc_exports_freed:
+             return
+-        self._close_ipc_imports()
++        self._close_ipc_imports_strict()
++        failures: list[tuple[str, Exception]] = []
++        remaining = []
+         if self._ipc is not None:
+             for shared in self._owned_buffers:
+-                with suppress(Exception):
++                try:
+                     self._ipc.cudaFree(shared.local_ptr)
+-        self._owned_buffers.clear()
+-        self._ipc_exports_freed = True
++                except Exception as exc:
++                    remaining.append(shared)
++                    failures.append((f"CUDA IPC export {shared.local_ptr}", exc))
++        elif self._owned_buffers:
++            remaining = list(self._owned_buffers)
++            failures.append(
++                (
++                    "CUDA IPC exports",
++                    RuntimeError("CUDA runtime is unavailable for export free"),
++                )
++            )
++        self._owned_buffers = remaining
++        if not remaining:
++            self._ipc_exports_freed = True
++        if failures:
++            _raise_local_cleanup_errors("PCIe DCP A2A", "IPC export free", failures)
+ 
+     def close(self) -> None:
+-        self._close_ipc_imports()
+-        self._free_ipc_exports()
++        if getattr(self, "_coordinated_close_complete", False):
++            return
++        _coordinated_close_channels(
++            (self,),
++            exchange_group=self.exchange_group,
++            device=self.device,
++        )
+ 
+-    def __del__(self) -> None:
+-        with suppress(Exception):
+-            self.close()
++    def __del__(
++        self,
++        _quarantine: dict[int, object] = _ABANDONED_PCIE_RUNTIME_QUARANTINE,
++    ) -> None:
++        # Never unmap potentially in-flight CUDA work from GC. Retaining the
++        # complete object preserves both native ownership and Python IPC maps;
++        # explicit close() is the only synchronized teardown path.
++        if getattr(self, "_coordinated_close_complete", False):
++            return
++        if getattr(self, "_ptr", 0) or getattr(self, "_owned_buffers", ()):
++            _quarantine[id(self)] = self
+ 
+ 
+ class PCIeDCPA2APool:
+@@ -531,27 +886,115 @@ class PCIeDCPA2APool:
+         exchange_group: Optional[ProcessGroup] = None,
+         ext_module=None,
+         single_channel: bool = False,
++        max_concurrent_channels: int = 1,
+         channel_factory: Optional[Callable[[Optional[int]], PCIeDCPA2A]] = None,
+     ) -> None:
+-        if world_size not in SUPPORTED_WORLD_SIZES:
+-            raise ValueError(f"unsupported world size {world_size}")
+-        self.rank = int(rank)
+-        self.world_size = int(world_size)
+-        self.device = _normalize_device(device)
+-        self.max_batch_size = int(max_batch_size)
+-        self.total_heads = int(total_heads)
+-        self.head_dim = int(head_dim)
+-        self.query_head_dim = int(query_head_dim or head_dim)
++        def normalize_and_validate():
++            normalized_rank = int(rank)
++            normalized_world_size = int(world_size)
++            device_obj = _normalize_device(device)
++            normalized_max_batch = int(max_batch_size)
++            normalized_total_heads = int(total_heads)
++            normalized_head_dim = int(head_dim)
++            normalized_query_dim = int(
++                head_dim if query_head_dim is None else query_head_dim
++            )
++            normalized_single_channel = bool(single_channel)
++            normalized_max_concurrent_channels = int(max_concurrent_channels)
++            if normalized_world_size not in SUPPORTED_WORLD_SIZES:
++                raise ValueError(f"unsupported world size {normalized_world_size}")
++            if not 0 <= normalized_rank < normalized_world_size:
++                raise ValueError(
++                    f"invalid rank {normalized_rank} for world size "
++                    f"{normalized_world_size}"
++                )
++            if normalized_max_batch <= 0:
++                raise ValueError("max_batch_size must be positive")
++            if (
++                normalized_total_heads <= 0
++                or normalized_total_heads % normalized_world_size != 0
++            ):
++                raise ValueError("total_heads must be divisible by world_size")
++            if normalized_head_dim <= 0 or normalized_head_dim % 8 != 0:
++                raise ValueError("head_dim must be a positive multiple of 8")
++            if normalized_query_dim <= 0 or normalized_query_dim % 8 != 0:
++                raise ValueError("query_head_dim must be a positive multiple of 8")
++            if normalized_max_concurrent_channels <= 0:
++                raise ValueError("max_concurrent_channels must be positive")
++            if channel_factory is None:
++                if exchange_group is None:
++                    raise ValueError(
++                        "exchange_group is required unless channel_factory is set"
++                    )
++                if device_obj.type != "cuda":
++                    raise ValueError("PCIe DCP A2A pool requires a CUDA device")
++                group_rank = dist.get_rank(group=exchange_group)
++                group_world_size = dist.get_world_size(group=exchange_group)
++                if normalized_rank != group_rank:
++                    raise ValueError(
++                        f"supplied rank {normalized_rank} does not match process "
++                        f"group rank {group_rank}"
++                    )
++                if normalized_world_size != group_world_size:
++                    raise ValueError(
++                        f"supplied world size {normalized_world_size} does not "
++                        f"match process group size {group_world_size}"
++                    )
++            return (
++                normalized_rank,
++                normalized_world_size,
++                device_obj,
++                normalized_max_batch,
++                normalized_total_heads,
++                normalized_head_dim,
++                normalized_query_dim,
++                normalized_single_channel,
++                normalized_max_concurrent_channels,
++            )
++
++        if channel_factory is None and exchange_group is not None:
++            normalized = _run_collective_preallocation_setup(
++                owner="PCIe DCP A2A pool argument validation",
++                exchange_group=exchange_group,
++                setup=normalize_and_validate,
++            )
++        else:
++            normalized = normalize_and_validate()
++        (
++            self.rank,
++            self.world_size,
++            self.device,
++            self.max_batch_size,
++            self.total_heads,
++            self.head_dim,
++            self.query_head_dim,
++            self.single_channel,
++            self.max_concurrent_channels,
++        ) = normalized
+         self.exchange_group = exchange_group
+         self._ext = ext_module
+-        self.single_channel = bool(single_channel)
+         self._channel_factory = channel_factory
+         self._channels: dict[int, PCIeDCPA2A] = {}
++        self._logical_channels: dict[str, PCIeDCPA2A] = {}
++        self._captured_channel_ids: set[str] = set()
+         self._all_channels: list[PCIeDCPA2A] = []
+         self._capture_channel_stack: list[PCIeDCPA2A] = []
+         self._closed = False
+-        if channel_factory is None and exchange_group is None:
+-            raise ValueError("exchange_group is required unless channel_factory is set")
++        if channel_factory is None:
++            assert self.exchange_group is not None
++            _require_collective_contract(
++                owner="PCIe DCP A2A pool overlap contract",
++                exchange_group=self.exchange_group,
++                contract=self.max_concurrent_channels,
++            )
++            _require_full_grid_residency(
++                owner="PCIe DCP A2A pool",
++                required_sms=(DCP_A2A_REQUIRED_SMS * self.max_concurrent_channels),
++                device=self.device,
++                exchange_group=self.exchange_group,
++            )
++        if channel_factory is None and self.single_channel:
++            self.prepare_channels((_SINGLE_CHANNEL_ID,))
+ 
+     @classmethod
+     def from_exchange_group(
+@@ -565,6 +1008,7 @@ class PCIeDCPA2APool:
+         query_head_dim: Optional[int] = None,
+         ext_module=None,
+         single_channel: bool = False,
++        max_concurrent_channels: int = 1,
+     ) -> "PCIeDCPA2APool":
+         return cls(
+             rank=dist.get_rank(group=exchange_group),
+@@ -577,6 +1021,7 @@ class PCIeDCPA2APool:
+             exchange_group=exchange_group,
+             ext_module=ext_module,
+             single_channel=single_channel,
++            max_concurrent_channels=max_concurrent_channels,
+         )
+ 
+     @classmethod
+@@ -591,6 +1036,7 @@ class PCIeDCPA2APool:
+         query_head_dim: Optional[int] = None,
+         ext_module=None,
+         single_channel: bool = False,
++        max_concurrent_channels: int = 1,
+     ) -> "PCIeDCPA2APool":
+         return cls.from_exchange_group(
+             exchange_group=process_group,
+@@ -601,6 +1047,7 @@ class PCIeDCPA2APool:
+             query_head_dim=query_head_dim,
+             ext_module=ext_module,
+             single_channel=single_channel,
++            max_concurrent_channels=max_concurrent_channels,
+         )
+ 
+     def _new_channel(self, stream_key: Optional[int]) -> PCIeDCPA2A:
+@@ -622,17 +1069,71 @@ class PCIeDCPA2APool:
+         self._all_channels.append(channel)
+         return channel
+ 
+-    def checkpoint_channels(self) -> tuple[int, dict[int, PCIeDCPA2A]]:
++    def prepare_channels(self, channel_ids: Sequence[str]) -> None:
++        """Collectively allocate globally named channels in canonical order."""
++
++        if self._channel_factory is None:
++            assert self.exchange_group is not None
++
++            def normalize_and_validate() -> tuple[str, ...]:
++                if self._closed:
++                    raise RuntimeError("PCIeDCPA2APool is closed")
++                return tuple(
++                    sorted(
++                        {_normalize_logical_channel_id(value) for value in channel_ids}
++                    )
++                )
++
++            normalized = _run_collective_preallocation_setup(
++                owner="PCIe DCP A2A logical channel validation",
++                exchange_group=self.exchange_group,
++                setup=normalize_and_validate,
++            )
++            local_state = (normalized, tuple(sorted(self._logical_channels)))
++            gathered = _broadcast_gather_object(local_state, self.exchange_group)
++            if any(state != local_state for state in gathered):
++                raise RuntimeError(
++                    "PCIe DCP A2A logical channel preparation differs across "
++                    f"ranks: {gathered}"
++                )
++        else:
++            if self._closed:
++                raise RuntimeError("PCIeDCPA2APool is closed")
++            normalized = tuple(
++                sorted({_normalize_logical_channel_id(value) for value in channel_ids})
++            )
++
++        if not normalized:
++            return
++
++        for channel_id in normalized:
++            if channel_id in self._logical_channels:
++                continue
++            self._logical_channels[channel_id] = self._new_channel(None)
++
++    def checkpoint_channels(
++        self,
++    ) -> tuple[
++        int,
++        dict[int, PCIeDCPA2A],
++        dict[str, PCIeDCPA2A],
++        set[str],
++    ]:
+         """Snapshot channel ownership before a throwaway graph capture."""
+         if self._closed:
+             raise RuntimeError("PCIeDCPA2APool is closed")
+         if self._capture_channel_stack:
+             raise RuntimeError("cannot checkpoint channels during capture")
+-        return len(self._all_channels), dict(self._channels)
++        return (
++            len(self._all_channels),
++            dict(self._channels),
++            dict(self._logical_channels),
++            set(self._captured_channel_ids),
++        )
+ 
+     def rollback_channels(
+         self,
+-        checkpoint: tuple[int, dict[int, PCIeDCPA2A]],
++        checkpoint: tuple,
+     ) -> None:
+         """Close channels created after ``checkpoint`` and restore mappings.
+ 
+@@ -643,15 +1144,25 @@ class PCIeDCPA2APool:
+             raise RuntimeError("PCIeDCPA2APool is closed")
+         if self._capture_channel_stack:
+             raise RuntimeError("cannot roll back channels during capture")
+-        all_channels_len, channels = checkpoint
++        if len(checkpoint) == 2:
++            all_channels_len, channels = checkpoint
++            logical_channels = dict(self._logical_channels)
++            captured_channel_ids = set(self._captured_channel_ids)
++        elif len(checkpoint) == 4:
++            (
++                all_channels_len,
++                channels,
++                logical_channels,
++                captured_channel_ids,
++            ) = checkpoint
++        else:
++            raise ValueError("invalid channel checkpoint")
+         if not 0 <= all_channels_len <= len(self._all_channels):
+             raise ValueError("channel checkpoint does not belong to this pool")
+ 
+         retained = self._all_channels[:all_channels_len]
+         retained_ids = {id(channel) for channel in retained}
+         transient = self._all_channels[all_channels_len:]
+-        self._all_channels = retained
+-        self._channels = dict(channels)
+ 
+         channels_to_close = tuple(
+             dict.fromkeys(
+@@ -663,8 +1174,19 @@ class PCIeDCPA2APool:
+             exchange_group=self.exchange_group,
+             device=self.device,
+         )
++        # Ownership changes only after coordinated teardown succeeds.  A
++        # failed unmap/free remains reachable for an explicit retry.
++        self._all_channels = retained
++        self._channels = dict(channels)
++        self._logical_channels = dict(logical_channels)
++        self._captured_channel_ids = set(captured_channel_ids)
+ 
+-    def for_stream(self, stream: object = None) -> PCIeDCPA2A:
++    def for_stream(
++        self,
++        stream: object = None,
++        *,
++        channel_id: Optional[str] = None,
++    ) -> PCIeDCPA2A:
+         if self._closed:
+             raise RuntimeError("PCIeDCPA2APool is closed")
+         if self.single_channel:
+@@ -673,15 +1195,36 @@ class PCIeDCPA2APool:
+         else:
+             stream_key = _current_stream_key(self.device, stream)
+             key = 0 if stream_key is None else int(stream_key)
+-        if (
+-            not self.single_channel
+-            and _is_current_stream_capturing(self.device)
+-            and self._capture_channel_stack
+-        ):
+-            # Independent graph managers may reuse a torch-owned nested stream
+-            # key. The enclosing capture, not a stale key mapping, determines
+-            # which IPC channel is safe for this graph.
++        if not self.single_channel and self._capture_channel_stack:
++            # The semantic capture scope also owns vLLM's eager pre-capture
++            # warmup. During actual CUDA capture torch may use an ephemeral
++            # nested stream key, which must remain only a temporary alias;
++            # outside CUDA capture retain the normal stream-affinity check.
+             channel = self._capture_channel_stack[-1]
++            if not _is_current_stream_capturing(self.device):
++                channel._bind_stream_key(stream_key)
++            self._channels[key] = channel
++            return channel
++        if self._channel_factory is None:
++            if channel_id is None:
++                raise RuntimeError(
++                    "distributed PCIe DCP A2A eager use requires an explicit "
++                    "semantic channel_id shared by every rank"
++                )
++            logical_id = _normalize_logical_channel_id(channel_id)
++            channel = self._logical_channels.get(logical_id)
++            if channel is None:
++                raise RuntimeError(
++                    f"logical channel {logical_id!r} is not prepared; call "
++                    "prepare_channels() collectively before use"
++                )
++            mapped = self._channels.get(key)
++            if mapped is not None and mapped is not channel:
++                raise RuntimeError(
++                    f"CUDA stream key {key} is already bound to another logical "
++                    "PCIe DCP A2A channel"
++                )
++            channel._bind_stream_key(stream_key)
+             self._channels[key] = channel
+             return channel
+         channel = self._channels.get(key)
+@@ -717,8 +1260,9 @@ class PCIeDCPA2APool:
+         threads: int = 256,
+         block_limit: int = 16,
+         stream: object = None,
++        channel_id: Optional[str] = None,
+     ) -> torch.Tensor:
+-        channel = self.for_stream(stream)
++        channel = self.for_stream(stream, channel_id=channel_id)
+         if stream is not None and self.device.type == "cuda":
+             with torch.cuda.stream(stream):
+                 return channel.lse_reduce_scatter(
+@@ -746,8 +1290,9 @@ class PCIeDCPA2APool:
+         threads: int = 256,
+         block_limit: int = 16,
+         stream: object = None,
++        channel_id: Optional[str] = None,
+     ) -> torch.Tensor:
+-        channel = self.for_stream(stream)
++        channel = self.for_stream(stream, channel_id=channel_id)
+         if stream is not None and self.device.type == "cuda":
+             with torch.cuda.stream(stream):
+                 return channel.all_gather_heads(
+@@ -764,16 +1309,70 @@ class PCIeDCPA2APool:
+         )
+ 
+     @contextmanager
+-    def capture(self, stream: object = None):
+-        """Bind nested CUDA captures to the enclosing stream's channel."""
++    def capture(self, stream: object = None, *, channel_id: Optional[str] = None):
++        """Bind capture to a globally named channel.
++
++        Explicit unknown ids are prepared collectively and fail closed when
++        rank ids differ. Production callers should pre-prepare the full set of
++        independently replayable graph ids before entering any capture; after
++        that collective preparation, ranks may capture members of the agreed
++        catalog in different orders. Each graph must still replay with its
++        same-id peers using collectively compatible kernel sequences and
++        shapes.
++
++        Distributed pools require this semantic id. Local ordinals and stream
++        handles cannot identify target versus draft graphs across ranks.
++        """
++        previous_channels: Optional[dict[int, PCIeDCPA2A]] = None
++        if not self.single_channel and _is_current_stream_capturing(self.device):
++            raise RuntimeError(
++                "PCIe DCP A2A capture context must be entered before CUDA graph "
++                "capture starts"
++            )
+         if self.single_channel:
+-            channel = self.for_stream(stream)
++            channel = self.for_stream(
++                stream,
++                channel_id=_SINGLE_CHANNEL_ID if channel_id is None else channel_id,
++            )
++        elif self._channel_factory is None:
++            assert self.exchange_group is not None
++
++            def validate_capture_id() -> str:
++                if channel_id is None:
++                    raise RuntimeError(
++                        "distributed PCIe DCP A2A capture requires a stable "
++                        "semantic channel_id shared by every rank"
++                    )
++                logical_id = _normalize_logical_channel_id(channel_id)
++                if logical_id in self._captured_channel_ids:
++                    raise RuntimeError(
++                        f"logical channel {logical_id!r} was already captured; "
++                        "each independently replayable graph requires a unique id"
++                    )
++                return logical_id
++
++            logical_id = _run_collective_preallocation_setup(
++                owner="PCIe DCP A2A capture channel validation",
++                exchange_group=self.exchange_group,
++                setup=validate_capture_id,
++            )
++            needs_preparation = _collective_capture_needs_preparation(
++                owner="PCIe DCP A2A",
++                logical_id=logical_id,
++                prepared_channel_ids=self._logical_channels,
++                exchange_group=self.exchange_group,
++            )
++            if needs_preparation:
++                self.prepare_channels((logical_id,))
++            previous_channels = dict(self._channels)
++            stream_key = _current_stream_key(self.device, stream)
++            key = 0 if stream_key is None else int(stream_key)
++            channel = self._logical_channels[logical_id]
++            channel._bind_stream_key(stream_key)
++            self._channels[key] = channel
++            self._captured_channel_ids.add(logical_id)
+         else:
+-            if _is_current_stream_capturing(self.device):
+-                raise RuntimeError(
+-                    "PCIe DCP A2A capture context must be entered before CUDA "
+-                    "graph capture starts"
+-                )
++            previous_channels = dict(self._channels)
+             stream_key = _current_stream_key(self.device, stream)
+             key = 0 if stream_key is None else int(stream_key)
+             # Keep a graph-owned channel even when CUDA recycles the enclosing
+@@ -787,22 +1386,48 @@ class PCIeDCPA2APool:
+             popped = self._capture_channel_stack.pop()
+             if popped is not channel:
+                 raise RuntimeError("PCIe DCP A2A capture channel stack corrupted")
++            if previous_channels is not None:
++                # Captured graph nodes retain the channel through
++                # ``_all_channels``. Restore eager mappings and discard every
++                # nested capture-stream alias so a recycled stream key cannot
++                # hand this graph-owned channel to a later unwrapped capture.
++                for key, mapped in tuple(self._channels.items()):
++                    if mapped is not channel:
++                        continue
++                    previous = previous_channels.get(key)
++                    if previous is None:
++                        del self._channels[key]
++                    else:
++                        self._channels[key] = previous
+ 
+     def close(self) -> None:
+         if self._closed:
+             return
+-        self._closed = True
+         seen: set[int] = set()
++        channels = []
+         for channel in (*self._all_channels, *self._channels.values()):
+             if id(channel) not in seen:
+                 seen.add(id(channel))
+-                channel.close()
++                channels.append(channel)
++        _coordinated_close_channels(
++            channels,
++            exchange_group=self.exchange_group,
++            device=self.device,
++        )
++        self._closed = True
+         self._all_channels.clear()
+         self._channels.clear()
++        self._logical_channels.clear()
++        self._captured_channel_ids.clear()
+ 
+-    def __del__(self) -> None:
+-        with suppress(Exception):
+-            self.close()
++    def __del__(
++        self,
++        _quarantine: dict[int, object] = _ABANDONED_PCIE_RUNTIME_QUARANTINE,
++    ) -> None:
++        # Graphs may retain these channels after Python ownership disappears.
++        # Explicit close() is required for synchronization and peer teardown.
++        if not getattr(self, "_closed", True):
++            _quarantine[id(self)] = self
+ 
+ 
+ __all__ = [
+diff --git a/sparkinfer/comm/pcie/pcie_oneshot.cu b/sparkinfer/comm/pcie/pcie_oneshot.cu
+index fc01c8273ef0a5b90d601e8208804bd162e43de8..28396a643cd5ee3f7b4498f9041f440df276f273 100644
+--- a/sparkinfer/comm/pcie/pcie_oneshot.cu
++++ b/sparkinfer/comm/pcie/pcie_oneshot.cu
+@@ -23,6 +23,8 @@
+ #include <unordered_map>
+ #include <vector>
+ 
++#include "ipc_handle_registry.h"
++
+ #define CHECK_CUDA_SUCCESS(cmd)                                         \
+   do {                                                                  \
+     cudaError_t e = cmd;                                                \
+@@ -76,6 +78,8 @@ static bool oneshot_push_enabled() {
+ }
+ 
+ struct Signal {
++  alignas(128) FlagType staging_generation;
++  FlagType active_staging_slot;
+   alignas(128) FlagType self_counter[kMaxBlocks][kMaxRanks];
+   alignas(128) FlagType peer_counter[2][kMaxBlocks][kMaxRanks * kFlagStride];
+   alignas(128) FlagType rms_arrive[kMaxBlocks];
+@@ -87,6 +91,10 @@ struct __align__(16) RankData {
+   const void* __restrict__ ptrs[kMaxRanks];
+ };
+ 
++struct DoubleRankData {
++  RankData* slots[2];
++};
++
+ struct __align__(16) RankSignals {
+   Signal* signals[kMaxRanks];
+ };
+@@ -189,6 +197,28 @@ static DINLINE FlagType ld_flag_acquire_gpu(FlagType* flag_addr) {
+   return flag;
+ }
+ 
++__global__ void advance_staging_slot_kernel(Signal* self_sg) {
++  if (threadIdx.x == 0) {
++    const FlagType generation = self_sg->staging_generation;
++    self_sg->active_staging_slot = generation & FlagType{1};
++    self_sg->staging_generation = generation + FlagType{1};
++  }
++}
++
++template <int ngpus>
++DINLINE void select_rank_data(RankData& selected, const DoubleRankData& options, Signal* self_sg) {
++  if (threadIdx.x == 0) {
++    // A one-CTA control kernel publishes the slot on this same stream before
++    // the worker launch. Kernel completion is the ordering edge, so every CTA
++    // observes one launch-wide slot without a grid rendezvous.
++    const int slot = int(ld_flag_relaxed_gpu(&self_sg->active_staging_slot) & FlagType{1});
++    const RankData* source = options.slots[slot];
++#pragma unroll
++    for (int peer = 0; peer < ngpus; ++peer) selected.ptrs[peer] = source->ptrs[peer];
++  }
++  __syncthreads();
++}
++
+ template <int ngpus, bool is_start>
+ DINLINE void multi_gpu_barrier(const RankSignals& sg, Signal* self_sg, int rank) {
+   if constexpr (!is_start) __syncthreads();
+@@ -253,17 +283,23 @@ DINLINE float block_reduce_sum(float value, float* warp_sums) {
+ // sufficient for staging visibility.
+ template <typename T, int ngpus, bool stage_input>
+ __global__ void __launch_bounds__(512, 1) pcie_allreduce_kernel(
+-    RankData* _dp,
++    DoubleRankData data_options,
+     RankSignals sg,
+     Signal* self_sg,
+     const T* __restrict__ input,
+     T* __restrict__ result,
+-    T* __restrict__ self_staging,
+     int rank,
+     int size) {
+   using P = typename packed_t<T>::P;
+   using A = typename packed_t<T>::A;
+-  auto dp = *_dp;
++  RankData dp;
++  if constexpr (stage_input) {
++    __shared__ RankData selected;
++    select_rank_data<ngpus>(selected, data_options, self_sg);
++    dp = selected;
++  } else {
++    dp = *data_options.slots[0];
++  }
+   const P* rotated[ngpus];
+ #pragma unroll
+   for (int i = 0; i < ngpus; i++) {
+@@ -271,7 +307,8 @@ __global__ void __launch_bounds__(512, 1) pcie_allreduce_kernel(
+   }
+   if constexpr (stage_input) {
+     const P* input_p = reinterpret_cast<const P*>(input);
+-    P* staging_p = reinterpret_cast<P*>(self_staging);
++    P* staging_p =
++        reinterpret_cast<P*>(const_cast<void*>(dp.ptrs[rank]));
+     for (int idx = blockIdx.x * blockDim.x + threadIdx.x; idx < size; idx += gridDim.x * blockDim.x) {
+       staging_p[idx] = input_p[idx];
+     }
+@@ -304,7 +341,9 @@ constexpr int kModeRegistered = 0;
+ constexpr int kModeStagePull = 1;
+ constexpr int kModeStagePush = 2;
+ 
+-// Complete the allreduce, residual add, and RMSNorm in one launch.
++// Complete the allreduce, residual add, and RMSNorm in one worker launch.
++// Staged paths prepend one 1-CTA slot-control launch; the registered path
++// remains a single worker launch.
+ //
+ // Geometry is uniform: gridDim.x == rows * ctas_per_row and block b serves
+ // row b / ctas_per_row, owning columns {(b % ctas_per_row) * blockDim.x +
+@@ -323,12 +362,12 @@ constexpr int kModeStagePush = 2;
+ // only. Otherwise each CTA publishes one fp32 square-sum partial, crosses a
+ // sense-reversing per-row generation barrier, and normalizes its own columns
+ // from registers, so no CTA re-reads the row it just wrote. All CTAs of a
+-// row spin, which is safe for the same reason the cross-rank start barrier
+-// is: the grid never exceeds kMaxBlocks <= SM count, so every block is
+-// resident.
++// row spin. The host derives the concrete kernel's resident-grid capacity
++// from CUDA occupancy before capture and caps the multi-CTA grid to that
++// device-specific value; no SM-count or full-GPU assumption is baked in.
+ template <typename T, int ngpus, bool single_cta, int mode>
+ __global__ void __launch_bounds__(512, 1) pcie_allreduce_fused_add_rms_norm_kernel(
+-    RankData* _dp,
++    DoubleRankData data_options,
+     RankSignals sg,
+     Signal* self_sg,
+     const T* __restrict__ input,
+@@ -336,7 +375,6 @@ __global__ void __launch_bounds__(512, 1) pcie_allreduce_fused_add_rms_norm_kern
+     const T* __restrict__ weight,
+     T* __restrict__ output,
+     T* __restrict__ residual_output,
+-    T* __restrict__ self_staging,
+     int rank,
+     int hidden_packs,
+     int ctas_per_row,
+@@ -346,6 +384,14 @@ __global__ void __launch_bounds__(512, 1) pcie_allreduce_fused_add_rms_norm_kern
+   using A = typename packed_t<T>::A;
+   __shared__ float warp_sums[32];
+   __shared__ float s_inv_rms;
++  RankData dp;
++  if constexpr (mode == kModeRegistered) {
++    dp = *data_options.slots[0];
++  } else {
++    __shared__ RankData selected;
++    select_rank_data<ngpus>(selected, data_options, self_sg);
++    dp = selected;
++  }
+ 
+   const int row = single_cta ? blockIdx.x : blockIdx.x / ctas_per_row;
+   const int row_cta = single_cta ? 0 : blockIdx.x - row * ctas_per_row;
+@@ -355,7 +401,6 @@ __global__ void __launch_bounds__(512, 1) pcie_allreduce_fused_add_rms_norm_kern
+   const int max_packs = (hidden_packs + col_stride - 1) / col_stride;
+   const bool reg_norm = max_packs <= kRegPacks;
+ 
+-  auto dp = *_dp;
+   const P* rotated[ngpus];
+ #pragma unroll
+   for (int i = 0; i < ngpus; i++) {
+@@ -367,7 +412,7 @@ __global__ void __launch_bounds__(512, 1) pcie_allreduce_fused_add_rms_norm_kern
+   const P* weight_p = reinterpret_cast<const P*>(weight);
+   P* output_p = reinterpret_cast<P*>(output);
+   P* residual_output_p = reinterpret_cast<P*>(residual_output);
+-  P* staging_p = reinterpret_cast<P*>(self_staging);
++  P* staging_p = reinterpret_cast<P*>(const_cast<void*>(dp.ptrs[rank]));
+ 
+   // Sense-reversing row barrier: latch the generation before arriving.
+   // Launches are stream-serialized, so this read cannot race a peer CTA's
+@@ -550,10 +595,51 @@ __global__ void __launch_bounds__(512, 1) pcie_allreduce_fused_add_rms_norm_kern
+   }
+ }
+ 
++template <typename T, int ngpus, int mode>
++int fused_resident_grid_capacity(int threads) {
++  int blocks_per_sm = 0;
++  CHECK_CUDA_SUCCESS(cudaOccupancyMaxActiveBlocksPerMultiprocessor(
++      &blocks_per_sm,
++      pcie_allreduce_fused_add_rms_norm_kernel<T, ngpus, false, mode>,
++      threads,
++      0));
++  int device = 0;
++  int sm_count = 0;
++  CHECK_CUDA_SUCCESS(cudaGetDevice(&device));
++  CHECK_CUDA_SUCCESS(
++      cudaDeviceGetAttribute(&sm_count, cudaDevAttrMultiProcessorCount, device));
++  if (blocks_per_sm <= 0 || sm_count <= 0) {
++    throw std::runtime_error(
++        "CUDA reported no resident capacity for fused PCIe RMSNorm");
++  }
++  return blocks_per_sm * sm_count;
++}
++
++template <typename T, int ngpus>
++std::array<int, 3> fused_resident_capacities(int threads) {
++  return {
++      fused_resident_grid_capacity<T, ngpus, kModeRegistered>(threads),
++      fused_resident_grid_capacity<T, ngpus, kModeStagePull>(threads),
++      fused_resident_grid_capacity<T, ngpus, kModeStagePush>(threads),
++  };
++}
++
++static int cap_fused_ctas_per_row(int requested, int rows,
++                                  int resident_capacity) {
++  if (rows <= 0 || resident_capacity <= 0) {
++    throw std::runtime_error("invalid fused PCIe resident-grid capacity");
++  }
++  return std::max(
++      1, std::min(requested, std::max(1, resident_capacity / rows)));
++}
++
+ using IPC_KEY = std::array<uint8_t, sizeof(cudaIpcMemHandle_t)>;
+ 
+ class PCIeAllreduce {
+  public:
++  using IPCHandles =
++      sparkinfer::pcie::IpcHandleRegistry<IPC_KEY, char*, cudaError_t, cudaSuccess>;
++
+   int rank_;
+   int world_size_;
+ 
+@@ -563,31 +649,108 @@ class PCIeAllreduce {
+ 
+   RankData *d_rank_data_base_, *d_rank_data_end_;
+   std::vector<void*> graph_unreg_buffers_;
+-  std::map<IPC_KEY, char*> ipc_handles_;
++  IPCHandles ipc_handles_;
++
++  // [float, half, bf16][registered, pull, push], queried once during native
++  // runtime construction (outside CUDA graph capture) and reused by captures.
++  std::array<std::array<int, 3>, 3> fused_resident_capacity_{};
+ 
+   bool dbuf_enabled_ = false;
+-  int dbuf_slot_ = 0;
+-  void* dbuf_raw_[2][kMaxRanks] = {};
+-  RankData* dbuf_rd_[2] = {};
++  DoubleRankData dbuf_data_ = {};
+ 
+   PCIeAllreduce(Signal** signals, void* rank_data, size_t rank_data_sz, int rank, int world_size)
+       : rank_(rank),
+         world_size_(world_size),
+         self_sg_(signals[rank]),
+         d_rank_data_base_(reinterpret_cast<RankData*>(rank_data)),
+-        d_rank_data_end_(d_rank_data_base_ + rank_data_sz / sizeof(RankData)) {
++        d_rank_data_end_(d_rank_data_base_ + rank_data_sz / sizeof(RankData)),
++        ipc_handles_(&PCIeAllreduce::close_ipc_handle) {
+     for (int i = 0; i < world_size_; i++) sg_.signals[i] = signals[i];
++    const int threads = fused_threads();
++#define CACHE_CAPACITY(ngpus)                                                   \
++    do {                                                                        \
++      fused_resident_capacity_[0] = fused_resident_capacities<float, ngpus>(threads); \
++      fused_resident_capacity_[1] = fused_resident_capacities<half, ngpus>(threads);  \
++      fused_resident_capacity_[2] =                                             \
++          fused_resident_capacities<nv_bfloat16, ngpus>(threads);               \
++    } while (0)
++    switch (world_size_) {
++      case 2: CACHE_CAPACITY(2); break;
++      case 4: CACHE_CAPACITY(4); break;
++      case 6: CACHE_CAPACITY(6); break;
++      case 8: CACHE_CAPACITY(8); break;
++      case 10: CACHE_CAPACITY(10); break;
++      default:
++        throw std::invalid_argument("unsupported PCIe allreduce world size");
++    }
++#undef CACHE_CAPACITY
++    // Deterministic reduced-capacity/MIG-like validation may lower (never
++    // raise) CUDA's measured capacity. This is a test-only safety override.
++    const int test_capacity =
++        env_int("SPARKINFER_PCIE_TEST_RESIDENT_GRID_CAPACITY", 0);
++    if (test_capacity > 0) {
++      for (auto& dtype_capacities : fused_resident_capacity_) {
++        for (int& capacity : dtype_capacities) {
++          capacity = std::min(capacity, test_capacity);
++        }
++      }
++    }
++  }
++
++  template <typename T>
++  int fused_resident_capacity(int mode) const {
++    constexpr int dtype_index = std::is_same<T, float>::value
++                                    ? 0
++                                    : (std::is_same<T, half>::value ? 1 : 2);
++    if (mode < kModeRegistered || mode > kModeStagePush) {
++      throw std::runtime_error("invalid fused PCIe transport mode");
++    }
++    return fused_resident_capacity_[dtype_index][mode];
++  }
++
++  static cudaError_t close_ipc_handle(char* ptr) noexcept {
++    return cudaIpcCloseMemHandle(ptr);
+   }
+ 
+   char* open_ipc_handle(const void* ipc_handle) {
+-    auto [it, new_handle] = ipc_handles_.insert({*((IPC_KEY*)ipc_handle), nullptr});
+-    if (new_handle) {
+-      char* ipc_ptr;
+-      CHECK_CUDA_SUCCESS(cudaIpcOpenMemHandle(
+-          (void**)&ipc_ptr, *((const cudaIpcMemHandle_t*)ipc_handle), cudaIpcMemLazyEnablePeerAccess));
+-      it->second = ipc_ptr;
++    const auto& key = *reinterpret_cast<const IPC_KEY*>(ipc_handle);
++    auto existing = ipc_handles_.find(key);
++    if (existing != ipc_handles_.end()) {
++      return existing->second;
++    }
++
++    char* ipc_ptr;
++    CHECK_CUDA_SUCCESS(cudaIpcOpenMemHandle(
++        reinterpret_cast<void**>(&ipc_ptr),
++        *reinterpret_cast<const cudaIpcMemHandle_t*>(ipc_handle),
++        cudaIpcMemLazyEnablePeerAccess));
++    try {
++      auto [inserted, is_new] = ipc_handles_.emplace(key, ipc_ptr);
++      if (!is_new) {
++        // Defensively avoid double ownership if this insertion path changes.
++        (void)cudaIpcCloseMemHandle(ipc_ptr);
++        return inserted->second;
++      }
++      return inserted->second;
++    } catch (...) {
++      // Do not leak a successfully opened mapping if map allocation fails.
++      (void)cudaIpcCloseMemHandle(ipc_ptr);
++      throw;
++    }
++  }
++
++  cudaError_t close_ipc_handles_noexcept() noexcept {
++    return ipc_handles_.close_all_noexcept();
++  }
++
++  void close_ipc_handles_strict() {
++    const cudaError_t error = close_ipc_handles_noexcept();
++    if (error != cudaSuccess) {
++      const char* description = cudaGetErrorString(error);
++      throw std::runtime_error(
++          std::string("cudaIpcCloseMemHandle failed while disposing PCIe allreduce: ") +
++          (description == nullptr ? "unknown CUDA error" : description));
+     }
+-    return it->second;
+   }
+ 
+   std::pair<std::string, std::vector<int64_t>> get_graph_buffer_ipc_meta() {
+@@ -616,17 +779,14 @@ class PCIeAllreduce {
+     for (int s = 0; s < 2; s++) {
+       void** ptrs = s == 0 ? ptrs0 : ptrs1;
+       RankData data;
+-      for (int i = 0; i < world_size_; i++) {
+-        data.ptrs[i] = ptrs[i];
+-        dbuf_raw_[s][i] = ptrs[i];
+-      }
+-      dbuf_rd_[s] = d_rank_data_base_++;
+-      CHECK_CUDA_SUCCESS(cudaMemcpy(dbuf_rd_[s], &data, sizeof(RankData), cudaMemcpyHostToDevice));
++      for (int i = 0; i < world_size_; i++) data.ptrs[i] = ptrs[i];
++      dbuf_data_.slots[s] = d_rank_data_base_++;
++      CHECK_CUDA_SUCCESS(
++          cudaMemcpy(dbuf_data_.slots[s], &data, sizeof(RankData), cudaMemcpyHostToDevice));
+     }
+-    buffers_[ptrs0[rank_]] = dbuf_rd_[0];
+-    buffers_[ptrs1[rank_]] = dbuf_rd_[1];
++    buffers_[ptrs0[rank_]] = dbuf_data_.slots[0];
++    buffers_[ptrs1[rank_]] = dbuf_data_.slots[1];
+     dbuf_enabled_ = true;
+-    dbuf_slot_ = 0;
+   }
+ 
+   void register_buffer(void** ptrs) {
+@@ -678,18 +838,16 @@ class PCIeAllreduce {
+     if (block_limit > kMaxBlocks)
+       throw std::runtime_error("max supported block limit is " + std::to_string(kMaxBlocks));
+ 
+-    RankData* ptrs;
+-    T* staging = nullptr;
++    DoubleRankData data_options = {};
++    bool stage_input = false;
+     cudaStreamCaptureStatus status;
+     CHECK_CUDA_SUCCESS(cudaStreamIsCapturing(stream, &status));
+ 
+     if (dbuf_enabled_) {
+-      // The kernel stages the input into the eager slot itself; no host
+-      // staging memcpy is issued.
+-      int slot = dbuf_slot_ % 2;
+-      dbuf_slot_++;
+-      ptrs = dbuf_rd_[slot];
+-      staging = reinterpret_cast<T*>(dbuf_raw_[slot][rank_]);
++      // A captured control kernel advances the active eager slab on every
++      // execution, including CUDA graph replay.
++      data_options = dbuf_data_;
++      stage_input = true;
+     } else if (status == cudaStreamCaptureStatusActive) {
+       throw std::runtime_error(
+           "PCIe oneshot graph capture requires eager IPC buffers; construct the runtime with eager buffers or use "
+@@ -699,22 +857,27 @@ class PCIeAllreduce {
+       if (it == buffers_.end())
+         throw std::runtime_error(
+             "buffer address " + std::to_string(reinterpret_cast<uint64_t>(input)) + " is not registered!");
+-      ptrs = it->second;
++      data_options.slots[0] = it->second;
++      data_options.slots[1] = it->second;
+     }
+ 
+     size /= d;
+     int blocks = std::min(block_limit, (size + threads - 1) / threads);
+     blocks = std::max(blocks, 1);
++    if (stage_input) {
++      advance_staging_slot_kernel<<<1, 1, 0, stream>>>(self_sg_);
++      CHECK_CUDA_SUCCESS(cudaGetLastError());
++    }
+ 
+ #define KL(ngpus)                                                                                                     \
+   do {                                                                                                               \
+-    if (staging != nullptr) {                                                                                        \
++    if (stage_input) {                                                                                               \
+       pcie_allreduce_kernel<T, ngpus, true>                                                                          \
+-          <<<blocks, threads, 0, stream>>>(ptrs, sg_, self_sg_, input, output, staging, rank_, size);                \
++          <<<blocks, threads, 0, stream>>>(data_options, sg_, self_sg_, input, output, rank_, size);                 \
+     } else {                                                                                                         \
+       pcie_allreduce_kernel<T, ngpus, false>                                                                         \
+-          <<<blocks, threads, 0, stream>>>(ptrs, sg_, self_sg_, input, output, staging, rank_, size);                \
+-    }                                                                                                                 \
++          <<<blocks, threads, 0, stream>>>(data_options, sg_, self_sg_, input, output, rank_, size);                 \
++    }                                                                                                                \
+   } while (0)
+     switch (world_size_) {
+       case 2:
+@@ -735,6 +898,7 @@ class PCIeAllreduce {
+       default:
+         throw std::runtime_error("only supports (2,4,6,8,10) gpus, got " + std::to_string(world_size_));
+     }
++    CHECK_CUDA_SUCCESS(cudaGetLastError());
+ #undef KL
+   }
+ 
+@@ -757,17 +921,15 @@ class PCIeAllreduce {
+       throw std::runtime_error(
+           "fused allreduce RMSNorm requires hidden size to be a multiple of " + std::to_string(pack_size));
+ 
+-    RankData* ptrs;
+-    T* staging = nullptr;
++    DoubleRankData data_options = {};
++    bool use_eager_staging = false;
+     cudaStreamCaptureStatus status;
+     CHECK_CUDA_SUCCESS(cudaStreamIsCapturing(stream, &status));
+     if (dbuf_enabled_) {
+-      // The kernel stages the input into the eager slot itself; no host
+-      // staging memcpy is issued.
+-      int slot = dbuf_slot_ % 2;
+-      dbuf_slot_++;
+-      ptrs = dbuf_rd_[slot];
+-      staging = reinterpret_cast<T*>(dbuf_raw_[slot][rank_]);
++      // A captured control kernel advances the active eager slab on every
++      // execution, including CUDA graph replay.
++      data_options = dbuf_data_;
++      use_eager_staging = true;
+     } else if (status == cudaStreamCaptureStatusActive) {
+       throw std::runtime_error(
+           "PCIe oneshot graph capture requires eager IPC buffers; construct the runtime with eager buffers or use "
+@@ -777,7 +939,8 @@ class PCIeAllreduce {
+       if (it == buffers_.end())
+         throw std::runtime_error(
+             "buffer address " + std::to_string(reinterpret_cast<uint64_t>(input)) + " is not registered!");
+-      ptrs = it->second;
++      data_options.slots[0] = it->second;
++      data_options.slots[1] = it->second;
+     }
+ 
+     int rows = size / hidden_size;
+@@ -797,17 +960,27 @@ class PCIeAllreduce {
+       ctas_per_row = std::max(std::max(1, 3 / rows), min_ctas);
+     }
+     ctas_per_row = std::max(1, std::min(ctas_per_row, kMaxBlocks / rows));
++    const int mode = !use_eager_staging   ? kModeRegistered
++                     : oneshot_push_enabled() ? kModeStagePush
++                                              : kModeStagePull;
++    const int resident_capacity = fused_resident_capacity<T>(mode);
++    // Multi-CTA row barriers can only be used when the complete grid is
++    // simultaneously resident. This also handles reduced/MIG-like devices;
++    // fall back to the barrier-free single-CTA path when capacity is tight.
++    ctas_per_row =
++        cap_fused_ctas_per_row(ctas_per_row, rows, resident_capacity);
+     const int blocks = rows * ctas_per_row;
+     const bool single = ctas_per_row == 1;
+     const int shard_packs = size / pack_size;
+-    const int mode = staging == nullptr ? kModeRegistered
+-                     : oneshot_push_enabled() ? kModeStagePush
+-                                              : kModeStagePull;
++    if (use_eager_staging) {
++      advance_staging_slot_kernel<<<1, 1, 0, stream>>>(self_sg_);
++      CHECK_CUDA_SUCCESS(cudaGetLastError());
++    }
+ 
+ #define KL(ngpus, SINGLE, MODE)                                                                                       \
+-  pcie_allreduce_fused_add_rms_norm_kernel<T, ngpus, SINGLE, MODE><<<blocks, threads, 0, stream>>>(                   \
+-      ptrs, sg_, self_sg_, input, residual, weight, output, residual_output, staging, rank_, hidden_packs,            \
+-      ctas_per_row, shard_packs, epsilon);
++  pcie_allreduce_fused_add_rms_norm_kernel<T, ngpus, SINGLE, MODE>                                                    \
++      <<<blocks, threads, 0, stream>>>(data_options, sg_, self_sg_, input, residual, weight, output,                \
++                                       residual_output, rank_, hidden_packs, ctas_per_row, shard_packs, epsilon);
+ #define DISPATCH_MODE(ngpus, SINGLE)                                                                                  \
+   do {                                                                                                               \
+     if (mode == kModeStagePush) {                                                                                    \
+@@ -845,14 +1018,13 @@ class PCIeAllreduce {
+       default:
+         throw std::runtime_error("only supports (2,4,6,8,10) gpus, got " + std::to_string(world_size_));
+     }
++    CHECK_CUDA_SUCCESS(cudaGetLastError());
+ #undef DISPATCH
+ #undef DISPATCH_MODE
+ #undef KL
+   }
+ 
+-  ~PCIeAllreduce() {
+-    for (auto [_, ptr] : ipc_handles_) CHECK_CUDA_SUCCESS(cudaIpcCloseMemHandle(ptr));
+-  }
++  ~PCIeAllreduce() noexcept = default;
+ };
+ 
+ }  // namespace pcie_allreduce
+@@ -995,7 +1167,18 @@ static void all_reduce_fused_add_rms_norm(
+ }
+ 
+ static void dispose(fptr_t _fa) {
+-  delete reinterpret_cast<pcie_allreduce::PCIeAllreduce*>(_fa);
++  auto* fa = reinterpret_cast<pcie_allreduce::PCIeAllreduce*>(_fa);
++  if (fa == nullptr) return;
++  fa->close_ipc_handles_strict();
++  delete fa;
++}
++
++static bool dispose_best_effort(fptr_t _fa) noexcept {
++  auto* fa = reinterpret_cast<pcie_allreduce::PCIeAllreduce*>(_fa);
++  if (fa == nullptr) return true;
++  const cudaError_t error = fa->close_ipc_handles_noexcept();
++  delete fa;
++  return error == cudaSuccess;
+ }
+ 
+ static int64_t meta_size() {
+@@ -1046,7 +1229,14 @@ PYBIND11_MODULE(TORCH_EXTENSION_NAME, m) {
+       "all_reduce_fused_add_rms_norm",
+       &all_reduce_fused_add_rms_norm,
+       "PCIe allreduce fused with residual add and RMSNorm");
+-  m.def("dispose", &dispose, "dispose PCIe allreduce");
++  m.def(
++      "dispose",
++      &dispose,
++      "strictly dispose PCIe allreduce; retain it for retry if an IPC close fails");
++  m.def(
++      "dispose_best_effort",
++      &dispose_best_effort,
++      "nonthrowing PCIe allreduce dispose; return whether every native IPC import closed");
+   m.def("meta_size", &meta_size, "signal metadata size");
+   m.def("register_buffer", &register_buffer, "register IPC buffer");
+   m.def("register_pcie_buffers", &register_pcie_buffers, "register double-buffered IPC buffers");
+diff --git a/sparkinfer/comm/pcie/pcie_oneshot.py b/sparkinfer/comm/pcie/pcie_oneshot.py
+index d75a12abe06c1602d5dcbbbcf586ba0e688f535f..d3d1d17d0e6814d68ce99f29e501f7c83cf737b5 100644
+--- a/sparkinfer/comm/pcie/pcie_oneshot.py
++++ b/sparkinfer/comm/pcie/pcie_oneshot.py
+@@ -5,11 +5,12 @@ from __future__ import annotations
+ import logging
+ import os
+ import time
+-from contextlib import contextmanager, suppress
+-from dataclasses import dataclass
++from contextlib import contextmanager
++from dataclasses import dataclass, field
+ from functools import lru_cache
++from itertools import count
+ from pathlib import Path
+-from typing import Callable, Optional, Sequence
++from typing import Callable, Iterable, Optional, Sequence, TypeVar
+ 
+ import torch
+ import torch.distributed as dist
+@@ -28,6 +29,18 @@ DEFAULT_RANK_DATA_BYTES = 8 * 1024 * 1024
+ AUTOTUNE_CEILING = 1 * 1024 * 1024
+ AUTOTUNE_FINE_STEP = 8 * 1024
+ IPC_SLAB_ALIGNMENT = 256
++ONESHOT_REQUIRED_SMS = 36
++_SINGLE_CHANNEL_ID = "__single__"
++
++# CUDA graph nodes and the native runtime retain raw pointers into rank_data.
++# GC cannot synchronize arbitrary streams, so an abandoned runtime must keep
++# its complete Python ownership graph alive until process teardown.  Explicit
++# close() is the only path that removes this need.  A dict makes manual/finalizer
++# re-entry idempotent while the retained object prevents id reuse.
++_ABANDONED_PCIE_RUNTIME_QUARANTINE: dict[int, object] = {}
++_RETAINED_FAILED_IPC_EXPORTS: dict[tuple[int, int], "_RetryableIPCExport"] = {}
++_RETAINED_IPC_SETUP_GENERATIONS = count(1)
++_SetupResult = TypeVar("_SetupResult")
+ 
+ 
+ def parse_pcie_oneshot_max_size(value: str | int | None) -> Optional[int]:
+@@ -60,6 +73,12 @@ def _normalize_device(device: torch.device | int | str) -> torch.device:
+     return torch.device(device)
+ 
+ 
++def _cuda_device_index(device: torch.device) -> int:
++    if device.type != "cuda":
++        raise ValueError("expected a CUDA device")
++    return torch.cuda.current_device() if device.index is None else int(device.index)
++
++
+ def _current_stream_key(
+     device: torch.device | int | str, stream: object = None
+ ) -> Optional[int]:
+@@ -110,13 +129,88 @@ def _resolve_exchange_group(
+     return exchange_group if exchange_group is not None else process_group
+ 
+ 
++def _normalize_logical_channel_id(channel_id: str) -> str:
++    if not isinstance(channel_id, str):
++        raise TypeError("logical channel id must be a string")
++    normalized = channel_id.strip()
++    if not normalized:
++        raise ValueError("logical channel id must not be empty")
++    return normalized
++
++
++def _collective_capture_needs_preparation(
++    *,
++    owner: str,
++    logical_id: str,
++    prepared_channel_ids: Iterable[str],
++    exchange_group: ProcessGroup,
++) -> bool:
++    """Decide whether capture may use the prepared catalog without allocation.
++
++    Once every rank has prepared the same complete graph catalog, ranks may
++    capture those graphs in different orders.  Allocation remains collective:
++    a same-id unknown channel may use the convenience preparation path, while
++    any differing request that includes an unknown id fails before allocation.
++    """
++
++    catalog = tuple(sorted(prepared_channel_ids))
++    local_state = (logical_id, catalog)
++    gathered = _broadcast_gather_object(local_state, exchange_group)
++    if not gathered:
++        raise RuntimeError(f"{owner} capture contract returned no rank states")
++
++    requested_ids: list[str] = []
++    for group_rank, state in enumerate(gathered):
++        if not isinstance(state, (tuple, list)) or len(state) != 2:
++            raise RuntimeError(
++                f"invalid {owner} capture contract from group rank {group_rank}"
++            )
++        requested_id, peer_catalog = state
++        if not isinstance(requested_id, str) or not isinstance(
++            peer_catalog, (tuple, list)
++        ):
++            raise RuntimeError(
++                f"invalid {owner} capture contract from group rank {group_rank}"
++            )
++        peer_catalog = tuple(peer_catalog)
++        if any(not isinstance(value, str) for value in peer_catalog):
++            raise RuntimeError(
++                f"invalid {owner} capture contract from group rank {group_rank}"
++            )
++        if peer_catalog != catalog:
++            raise RuntimeError(
++                f"{owner} prepared channel catalog differs across ranks: {gathered}"
++            )
++        requested_ids.append(requested_id)
++
++    if all(requested_id in catalog for requested_id in requested_ids):
++        # The canonical catalog already fixed allocation order.  Current graph
++        # capture order is process-local and need not agree across ranks.
++        return False
++    if all(requested_id == requested_ids[0] for requested_id in requested_ids):
++        # Preserve the collective same-id convenience allocation path.
++        return True
++    raise RuntimeError(
++        f"{owner} capture requested unprepared logical channels in differing "
++        f"rank order: requested={tuple(requested_ids)}, prepared={catalog}; call "
++        "prepare_channels() collectively with the complete graph set first"
++    )
++
++
+ def _group_ranks(group: ProcessGroup) -> list[int]:
+     world_size = dist.get_world_size(group=group)
+     if hasattr(dist, "get_process_group_ranks"):
+-        ranks = sorted(dist.get_process_group_ranks(group=group))
++        # Process-group rank is an index into the order returned here.  Sorting
++        # silently changes that mapping for non-monotonic groups and makes the
++        # handle in slot N belong to a different peer than group rank N.
++        ranks = list(dist.get_process_group_ranks(group=group))
+         if len(ranks) != world_size:
+             raise RuntimeError("process-group rank list does not match world size")
+         return ranks
++    if hasattr(dist, "get_global_rank"):
++        return [
++            dist.get_global_rank(group, group_rank) for group_rank in range(world_size)
++        ]
+     return list(range(world_size))
+ 
+ 
+@@ -162,28 +256,885 @@ class _OwnedSharedBuffer:
+     remote_ptrs: tuple[int, ...]
+ 
+ 
++@dataclass
++class _RetryableIPCExport:
++    """Own a failed collective IPC setup until a coordinated retry succeeds.
++
++    The historical name is retained for compatibility with callers that only
++    need to retry a failed ``cudaFree``.  A setup can also own still-open peer
++    imports, a native runtime cleanup callback, and a collective participation
++    ticket after this rank has already released its local export.  Keeping the
++    ticket is important: a rank that succeeded locally must still join the
++    retry verdict so a peer can safely finish its rollback.
++    """
++
++    ipc: CudaRTLibrary
++    local_ptr: int
++    exchange_group: Optional[ProcessGroup] = None
++    owner: str = "PCIe shared buffer"
++    phase: str = "rollback"
++    remote_ptrs: list[int] = field(default_factory=list)
++    local_cleanup: Optional[Callable[[], None]] = None
++    state: str = "free"
++    _registry_key: tuple[int, int] | None = None
++
++    @property
++    def key(self) -> tuple[int, int]:
++        if self._registry_key is not None:
++            return self._registry_key
++        return id(self.ipc), int(self.local_ptr)
++
++    def retry(self) -> None:
++        key = self.key
++        if key not in _RETAINED_FAILED_IPC_EXPORTS:
++            return
++
++        if self.state == "native":
++            native_error: BaseException | None = None
++            if self.local_cleanup is not None:
++                try:
++                    self.local_cleanup()
++                except Exception as exc:
++                    native_error = exc
++                else:
++                    self.local_cleanup = None
++
++            if self.exchange_group is None:
++                if native_error is not None:
++                    raise RuntimeError(
++                        f"{self.owner} {self.phase} retry native cleanup failed; "
++                        "CUDA IPC ownership remains retained"
++                    ) from native_error
++            else:
++                native_statuses = _exchange_setup_failures(
++                    native_error,
++                    exchange_group=self.exchange_group,
++                    phase=f"{self.phase} retry native cleanup",
++                )
++                if any(native_statuses):
++                    raise RuntimeError(
++                        _setup_failure_message(
++                            self.owner,
++                            f"{self.phase} retry native cleanup",
++                            native_statuses,
++                            exports_retained=True,
++                        )
++                    ) from native_error
++            self.state = "unmap"
++
++        if self.state == "unmap":
++            failures: list[str] = []
++
++            remaining_remote_ptrs: list[int] = []
++            for ptr in self.remote_ptrs:
++                try:
++                    self.ipc.cudaIpcCloseMemHandle(ptr)
++                except Exception as exc:
++                    remaining_remote_ptrs.append(ptr)
++                    failures.append(
++                        f"CUDA IPC import {ptr}: {type(exc).__name__}: {exc}"
++                    )
++            self.remote_ptrs = remaining_remote_ptrs
++
++            local_error = RuntimeError(" | ".join(failures)) if failures else None
++            if self.exchange_group is None:
++                if local_error is not None:
++                    raise RuntimeError(
++                        f"{self.owner} {self.phase} retry failed; CUDA IPC "
++                        "ownership remains retained"
++                    ) from local_error
++            else:
++                statuses = _exchange_setup_failures(
++                    local_error,
++                    exchange_group=self.exchange_group,
++                    phase=f"{self.phase} retry unmap",
++                )
++                if any(statuses):
++                    raise RuntimeError(
++                        _setup_failure_message(
++                            self.owner,
++                            f"{self.phase} retry unmap",
++                            statuses,
++                            exports_retained=True,
++                        )
++                    ) from local_error
++            self.state = "free"
++
++        free_error: BaseException | None = None
++        if self.local_ptr:
++            ptr = self.local_ptr
++            try:
++                self.ipc.cudaFree(ptr)
++            except Exception as exc:
++                free_error = exc
++            else:
++                self.local_ptr = 0
++
++        if self.exchange_group is None:
++            if free_error is not None:
++                raise RuntimeError(
++                    f"{self.owner} {self.phase} retry export free failed; CUDA "
++                    "IPC ownership remains retained"
++                ) from free_error
++        else:
++            free_statuses = _exchange_setup_failures(
++                free_error,
++                exchange_group=self.exchange_group,
++                phase=f"{self.phase} retry export free",
++            )
++            if any(free_statuses):
++                raise RuntimeError(
++                    _setup_failure_message(
++                        self.owner,
++                        f"{self.phase} retry export free",
++                        free_statuses,
++                        exports_retained=True,
++                    )
++                ) from free_error
++
++        _RETAINED_FAILED_IPC_EXPORTS.pop(key, None)
++
++
++def _retain_failed_ipc_export(
++    ipc: CudaRTLibrary, local_ptr: int
++) -> _RetryableIPCExport:
++    key = id(ipc), int(local_ptr)
++    retained = _RETAINED_FAILED_IPC_EXPORTS.get(key)
++    if retained is None:
++        retained = _RetryableIPCExport(
++            ipc=ipc,
++            local_ptr=int(local_ptr),
++            _registry_key=key,
++        )
++        _RETAINED_FAILED_IPC_EXPORTS[key] = retained
++    return retained
++
++
++def _retain_failed_ipc_setup(
++    *,
++    ipc: CudaRTLibrary,
++    local_ptr: int,
++    exchange_group: ProcessGroup,
++    owner: str,
++    phase: str,
++    remote_ptrs: Sequence[int] = (),
++    local_cleanup: Optional[Callable[[], None]] = None,
++    state: str = "unmap",
++) -> _RetryableIPCExport:
++    """Retain every local resource and the rank's collective retry ticket."""
++
++    # A CUDA address is not an attempt identity: it may already have been freed
++    # on this rank while a peer still owns its export, then be reused by CUDA for
++    # a second failed setup.  Every collective failure therefore receives an
++    # independent process-local generation ticket.  The ticket need not match
++    # across ranks; it only keeps this rank participating in the same retry call.
++    key = id(ipc), -next(_RETAINED_IPC_SETUP_GENERATIONS)
++    retained = _RetryableIPCExport(
++        ipc=ipc,
++        local_ptr=int(local_ptr),
++        exchange_group=exchange_group,
++        owner=owner,
++        phase=phase,
++        remote_ptrs=list(dict.fromkeys(int(ptr) for ptr in remote_ptrs)),
++        local_cleanup=local_cleanup,
++        state=state,
++        _registry_key=key,
++    )
++    _RETAINED_FAILED_IPC_EXPORTS[key] = retained
++    return retained
++
++
++def _attach_retryable_setup(
++    error: RuntimeError, retained: _RetryableIPCExport
++) -> RuntimeError:
++    # Keep the old attribute for downstream code/tests and expose the broader
++    # meaning under a name that does not imply only cudaFree ownership.
++    error.retryable_export = retained  # type: ignore[attr-defined]
++    error.retryable_setup = retained  # type: ignore[attr-defined]
++    return error
++
++
++def _require_no_retained_ipc_setup(exchange_group: ProcessGroup) -> None:
++    """Serialize collective setup generations until rollback completes.
++
++    Retry tickets are process-local ownership objects, so allowing another IPC
++    setup on the same group would make it possible for ranks to retry different
++    generations in a different order.  Reject the new attempt collectively
++    before it allocates anything instead.
++    """
++
++    outstanding = tuple(
++        retained.key
++        for retained in _RETAINED_FAILED_IPC_EXPORTS.values()
++        if retained.exchange_group is exchange_group
++    )
++    local_error: BaseException | None = None
++    if outstanding:
++        local_error = RuntimeError(
++            "complete the retained CUDA IPC setup retry before starting "
++            f"another setup on this process group (tickets={outstanding})"
++        )
++    statuses = _exchange_setup_failures(
++        local_error,
++        exchange_group=exchange_group,
++        phase="retained CUDA IPC setup gate",
++    )
++    if any(statuses):
++        raise RuntimeError(
++            _setup_failure_message(
++                "PCIe shared buffer",
++                "retained CUDA IPC setup gate",
++                statuses,
++                exports_retained=True,
++            )
++        ) from local_error
++
++
++def _format_setup_error(error: BaseException | None) -> tuple[str, ...]:
++    if error is None:
++        return ()
++    return (f"{type(error).__name__}: {error}",)
++
++
++def _exchange_setup_failures(
++    local_error: BaseException | None,
++    *,
++    exchange_group: ProcessGroup,
++    phase: str,
++    exports_retained_on_exchange_failure: bool = True,
++) -> tuple[tuple[str, ...], ...]:
++    """Collect a setup verdict without allowing one rank to return early."""
++
++    try:
++        gathered = _broadcast_gather_object(
++            _format_setup_error(local_error), exchange_group
++        )
++    except Exception as exc:
++        retention = (
++            "; CUDA IPC exports were retained"
++            if exports_retained_on_exchange_failure
++            else ""
++        )
++        raise RuntimeError(
++            f"failed to exchange peer {phase} status{retention}"
++        ) from exc
++
++    statuses: list[tuple[str, ...]] = []
++    for group_rank, status in enumerate(gathered):
++        if not isinstance(status, (tuple, list)):
++            retention = (
++                "; CUDA IPC exports were retained"
++                if exports_retained_on_exchange_failure
++                else ""
++            )
++            raise RuntimeError(
++                f"invalid peer {phase} status from group rank {group_rank}{retention}"
++            )
++        statuses.append(tuple(str(item) for item in status))
++    return tuple(statuses)
++
++
++def _require_full_grid_residency(
++    *,
++    owner: str,
++    required_sms: int,
++    device: torch.device,
++    exchange_group: Optional[ProcessGroup],
++) -> None:
++    """Reject devices where a peer-waiting worker grid may not all reside.
++
++    The PCIe worker kernels use ``__launch_bounds__(512, 1)`` and zero dynamic
++    shared memory, so every visible SM can host at least one worker CTA.  A
++    device with at least the extension's maximum block count can therefore
++    make the complete grid resident regardless of block scheduling order.  We
++    intentionally reject smaller/MIG-like slices instead of assuming CUDA
++    schedules matching block indices in the same order on every rank.
++    """
++
++    local_error: BaseException | None = None
++    visible_sms = 0
++    try:
++        visible_sms = int(
++            torch.cuda.get_device_properties(device).multi_processor_count
++        )
++        test_visible_sms = int(
++            os.getenv("SPARKINFER_PCIE_TEST_VISIBLE_SM_COUNT", "0") or "0"
++        )
++        if test_visible_sms > 0:
++            visible_sms = min(visible_sms, test_visible_sms)
++        if visible_sms < required_sms:
++            raise RuntimeError(
++                f"{owner} requires at least {required_sms} visible SMs so every "
++                "peer-waiting CTA can be resident; this device/MIG slice exposes "
++                f"{visible_sms}"
++            )
++    except Exception as exc:
++        local_error = exc
++
++    if exchange_group is None:
++        if local_error is not None:
++            raise local_error
++        return
++
++    statuses = _exchange_setup_failures(
++        local_error,
++        exchange_group=exchange_group,
++        phase=f"{owner} resident-grid capability",
++        exports_retained_on_exchange_failure=False,
++    )
++    if any(statuses):
++        raise RuntimeError(
++            _setup_failure_message(
++                owner,
++                "resident-grid capability",
++                statuses,
++                exports_retained=False,
++            )
++        ) from local_error
++
++
++def _run_collective_preallocation_setup(
++    *,
++    owner: str,
++    exchange_group: ProcessGroup,
++    setup: Callable[[], _SetupResult],
++) -> _SetupResult:
++    """Run fallible local setup before any rank creates a CUDA IPC export."""
++
++    result: Optional[_SetupResult] = None
++    local_error: BaseException | None = None
++    try:
++        result = setup()
++    except Exception as exc:
++        local_error = exc
++
++    statuses = _exchange_setup_failures(
++        local_error,
++        exchange_group=exchange_group,
++        phase=f"{owner} pre-allocation setup",
++        exports_retained_on_exchange_failure=False,
++    )
++    if any(statuses):
++        raise RuntimeError(
++            _setup_failure_message(
++                owner,
++                "pre-allocation setup",
++                statuses,
++                exports_retained=False,
++            )
++        ) from local_error
++    assert result is not None
++    return result
++
++
++def _require_collective_contract(
++    *, owner: str, exchange_group: ProcessGroup, contract: object
++) -> None:
++    """Reject divergent rank-local layout/channel inputs before allocation."""
++
++    gathered = _broadcast_gather_object(contract, exchange_group)
++    if any(peer != contract for peer in gathered):
++        raise RuntimeError(f"{owner} contract differs across ranks: {gathered}")
++
++
++def _finish_collective_unowned_runtime_setup(
++    *,
++    owner: str,
++    exchange_group: ProcessGroup,
++    local_error: BaseException | None,
++    local_cleanup: Callable[[], None],
++) -> None:
++    """Coordinate direct-constructor init when pointer ownership is external."""
++
++    statuses = _exchange_setup_failures(
++        local_error,
++        exchange_group=exchange_group,
++        phase=f"{owner} native initialization",
++        exports_retained_on_exchange_failure=False,
++    )
++    if not any(statuses):
++        return
++
++    cleanup_error: BaseException | None = None
++    try:
++        local_cleanup()
++    except Exception as exc:
++        cleanup_error = exc
++    cleanup_statuses = _exchange_setup_failures(
++        cleanup_error,
++        exchange_group=exchange_group,
++        phase=f"{owner} native initialization rollback",
++        exports_retained_on_exchange_failure=False,
++    )
++    if any(cleanup_statuses):
++        raise RuntimeError(
++            _setup_failure_message(
++                owner,
++                "native initialization rollback",
++                cleanup_statuses,
++                exports_retained=False,
++            )
++        ) from (cleanup_error or local_error)
++    raise RuntimeError(
++        _setup_failure_message(
++            owner,
++            "native initialization",
++            statuses,
++            exports_retained=False,
++        )
++    ) from local_error
++
++
++def _setup_failure_message(
++    owner: str,
++    phase: str,
++    statuses: Sequence[Sequence[str]],
++    *,
++    exports_retained: bool,
++) -> str:
++    details = [
++        f"group rank {group_rank}: " + " | ".join(failures)
++        for group_rank, failures in enumerate(statuses)
++        if failures
++    ]
++    retention = "; CUDA IPC exports were retained" if exports_retained else ""
++    return f"{owner} {phase} failed{retention}: " + "; ".join(details)
++
++
++def _abort_collective_ipc_setup(
++    *,
++    owner: str,
++    setup_phase: str,
++    setup_statuses: Sequence[Sequence[str]],
++    exchange_group: ProcessGroup,
++    ipc: CudaRTLibrary,
++    local_ptr: int | None,
++    remote_ptrs: Sequence[int],
++    local_error: BaseException | None,
++    local_cleanup: Optional[Callable[[], None]] = None,
++) -> None:
++    """Undo a failed collective IPC setup without freeing a mapped export.
++
++    Every rank calls this function.  Each successfully opened import is closed
++    exactly once.  Export ownership is released only after every group rank
++    reports that all of its imports were unmapped; otherwise the raw CUDA
++    allocation is deliberately retained until context teardown.
++    """
++
++    retained_cleanup = local_cleanup
++    if local_cleanup is not None:
++        native_error: BaseException | None = None
++        try:
++            local_cleanup()
++        except Exception as exc:
++            native_error = exc
++        else:
++            retained_cleanup = None
++        try:
++            native_statuses = _exchange_setup_failures(
++                native_error,
++                exchange_group=exchange_group,
++                phase=f"{setup_phase} rollback native cleanup",
++            )
++        except Exception as exchange_error:
++            assert local_ptr is not None
++            retained = _retain_failed_ipc_setup(
++                ipc=ipc,
++                local_ptr=local_ptr,
++                exchange_group=exchange_group,
++                owner=owner,
++                phase=setup_phase,
++                remote_ptrs=remote_ptrs,
++                local_cleanup=retained_cleanup,
++                state="native",
++            )
++            error = RuntimeError(
++                _setup_failure_message(
++                    owner,
++                    f"{setup_phase} rollback native cleanup status exchange",
++                    setup_statuses,
++                    exports_retained=True,
++                )
++            )
++            raise _attach_retryable_setup(error, retained) from (
++                native_error or local_error or exchange_error
++            )
++        if any(native_statuses):
++            assert local_ptr is not None
++            retained = _retain_failed_ipc_setup(
++                ipc=ipc,
++                local_ptr=local_ptr,
++                exchange_group=exchange_group,
++                owner=owner,
++                phase=setup_phase,
++                remote_ptrs=remote_ptrs,
++                local_cleanup=retained_cleanup,
++                state="native",
++            )
++            error = RuntimeError(
++                _setup_failure_message(
++                    owner,
++                    f"{setup_phase} rollback native cleanup",
++                    native_statuses,
++                    exports_retained=True,
++                )
++            )
++            raise _attach_retryable_setup(error, retained) from (
++                native_error or local_error
++            )
++
++    unmap_failures: list[str] = []
++    remaining_remote_ptrs: list[int] = []
++    for ptr in remote_ptrs:
++        try:
++            ipc.cudaIpcCloseMemHandle(ptr)
++        except Exception as exc:
++            remaining_remote_ptrs.append(ptr)
++            unmap_failures.append(f"CUDA IPC import {ptr}: {type(exc).__name__}: {exc}")
++
++    try:
++        unmap_statuses = _exchange_setup_failures(
++            RuntimeError(" | ".join(unmap_failures)) if unmap_failures else None,
++            exchange_group=exchange_group,
++            phase=f"{setup_phase} rollback unmap",
++        )
++    except Exception as exchange_error:
++        assert local_ptr is not None
++        retained = _retain_failed_ipc_setup(
++            ipc=ipc,
++            local_ptr=local_ptr,
++            exchange_group=exchange_group,
++            owner=owner,
++            phase=setup_phase,
++            remote_ptrs=remaining_remote_ptrs,
++            local_cleanup=retained_cleanup,
++            state="unmap",
++        )
++        error = RuntimeError(
++            _setup_failure_message(
++                owner,
++                setup_phase,
++                setup_statuses,
++                exports_retained=True,
++            )
++        )
++        raise _attach_retryable_setup(error, retained) from (
++            local_error or exchange_error
++        )
++
++    if any(unmap_statuses):
++        assert local_ptr is not None
++        retained = _retain_failed_ipc_setup(
++            ipc=ipc,
++            local_ptr=local_ptr,
++            exchange_group=exchange_group,
++            owner=owner,
++            phase=setup_phase,
++            remote_ptrs=remaining_remote_ptrs,
++            local_cleanup=retained_cleanup,
++            state="unmap",
++        )
++        error = RuntimeError(
++            _setup_failure_message(
++                owner,
++                f"{setup_phase} rollback unmap",
++                unmap_statuses,
++                exports_retained=True,
++            )
++        )
++        raise _attach_retryable_setup(error, retained) from local_error
++
++    free_error: BaseException | None = None
++    live_local_ptr = int(local_ptr or 0)
++    if local_ptr is not None:
++        try:
++            ipc.cudaFree(local_ptr)
++        except Exception as exc:
++            free_error = exc
++        else:
++            live_local_ptr = 0
++    try:
++        free_statuses = _exchange_setup_failures(
++            free_error,
++            exchange_group=exchange_group,
++            phase=f"{setup_phase} rollback export free",
++        )
++    except Exception as exchange_error:
++        retained_export = _retain_failed_ipc_setup(
++            ipc=ipc,
++            local_ptr=live_local_ptr,
++            exchange_group=exchange_group,
++            owner=owner,
++            phase=setup_phase,
++            state="free",
++        )
++        error = RuntimeError(
++            _setup_failure_message(
++                owner,
++                f"{setup_phase} rollback export free status exchange",
++                setup_statuses,
++                exports_retained=True,
++            )
++        )
++        raise _attach_retryable_setup(error, retained_export) from (
++            free_error or local_error or exchange_error
++        )
++    if any(free_statuses):
++        retained_export = _retain_failed_ipc_setup(
++            ipc=ipc,
++            local_ptr=live_local_ptr,
++            exchange_group=exchange_group,
++            owner=owner,
++            phase=setup_phase,
++            state="free",
++        )
++        error = RuntimeError(
++            _setup_failure_message(
++                owner,
++                f"{setup_phase} rollback export free",
++                free_statuses,
++                exports_retained=True,
++            )
++        )
++        raise _attach_retryable_setup(error, retained_export) from (
++            local_error or free_error
++        )
++
++    error = RuntimeError(
++        _setup_failure_message(
++            owner,
++            setup_phase,
++            setup_statuses,
++            exports_retained=False,
++        )
++    )
++    raise error from local_error
++
++
++def _finish_collective_runtime_setup(
++    *,
++    owner: str,
++    exchange_group: ProcessGroup,
++    ipc: CudaRTLibrary,
++    shared: _OwnedSharedBuffer,
++    local_error: BaseException | None,
++    local_cleanup: Optional[Callable[[], None]] = None,
++    detach_shared_ownership: Optional[Callable[[], None]] = None,
++) -> None:
++    """Require every rank to construct its native runtime before returning."""
++
++    try:
++        statuses = _exchange_setup_failures(
++            local_error,
++            exchange_group=exchange_group,
++            phase=f"{owner} native initialization",
++        )
++    except Exception as exchange_error:
++        # A failed first verdict exchange cannot establish whether every rank
++        # observed the same outcome.  Do not locally dispose, unmap, or free:
++        # retain the complete native/import/export ownership set and the
++        # same-group generation gate until the caller deliberately coordinates
++        # retry() on every participating rank.  This is especially important
++        # for twoshot, whose runtime object is not constructed until after this
++        # verdict succeeds.
++        retained = _retain_failed_ipc_setup(
++            ipc=ipc,
++            local_ptr=shared.local_ptr,
++            exchange_group=exchange_group,
++            owner=owner,
++            phase="native initialization status exchange",
++            remote_ptrs=shared.remote_ptrs,
++            local_cleanup=local_cleanup,
++            state="native",
++        )
++        if detach_shared_ownership is not None:
++            detach_shared_ownership()
++        error = RuntimeError(
++            f"{owner} native initialization status exchange failed; CUDA IPC "
++            "native/import/export ownership was retained and retry must be "
++            "coordinated by every rank"
++        )
++        raise _attach_retryable_setup(error, retained) from exchange_error
++    if any(statuses):
++        try:
++            _abort_collective_ipc_setup(
++                owner=owner,
++                setup_phase="native initialization",
++                setup_statuses=statuses,
++                exchange_group=exchange_group,
++                ipc=ipc,
++                local_ptr=shared.local_ptr,
++                remote_ptrs=shared.remote_ptrs,
++                local_error=local_error,
++                local_cleanup=local_cleanup,
++            )
++        finally:
++            # Rollback either released the shared allocation or transferred it
++            # to a _RetryableIPCExport.  Prevent a partially constructed runtime
++            # finalizer from retaining or releasing the same resources again.
++            if detach_shared_ownership is not None:
++                detach_shared_ownership()
++
++
+ def _coordinated_close_channels(
+     channels: Sequence[object],
+     *,
+     exchange_group: Optional[ProcessGroup],
+     device: torch.device,
+ ) -> None:
+-    """Release exported CUDA IPC allocations after every peer unmaps them."""
++    """Strictly release exports only after every peer reports successful unmap."""
+     unique_channels = tuple(dict.fromkeys(channels))
+-    if exchange_group is None:
++    if not unique_channels:
++        return
++
++    if exchange_group is not None:
++        if device.type == "cuda":
++            torch.cuda.synchronize(device)
++        dist.barrier(group=exchange_group)
++
++    # Older DCP channels still expose the legacy best-effort protocol. Keep
++    # their existing ordering until they receive their own lifecycle migration;
++    # oneshot and twoshot opt into the strict peer-status protocol below.
++    uses_strict_protocol = any(
++        hasattr(channel, "_close_ipc_imports_strict") for channel in unique_channels
++    )
++    if not uses_strict_protocol:
+         for channel in unique_channels:
+-            channel.close()
++            channel._close_ipc_imports()
++        if exchange_group is not None:
++            dist.barrier(group=exchange_group)
++        for channel in unique_channels:
++            channel._free_ipc_exports()
++        if exchange_group is not None:
++            dist.barrier(group=exchange_group)
+         return
+ 
+-    if device.type == "cuda":
+-        torch.cuda.synchronize(device)
+-    dist.barrier(group=exchange_group)
+-    for channel in unique_channels:
+-        channel._close_ipc_imports()
+-    dist.barrier(group=exchange_group)
++    unmap_errors = _run_close_phase(
++        unique_channels,
++        strict_method="_close_ipc_imports_strict",
++        legacy_method="_close_ipc_imports",
++    )
++    unmap_status = _exchange_close_failures(
++        tuple(_format_close_error(index, error) for index, error in unmap_errors),
++        exchange_group=exchange_group,
++        phase="IPC unmap",
++    )
++    if any(unmap_status):
++        _raise_coordinated_close_error(
++            "IPC unmap",
++            unmap_status,
++            local_errors=unmap_errors,
++            exports_retained=True,
++        )
++
++    if exchange_group is not None:
++        dist.barrier(group=exchange_group)
++
++    free_errors = _run_close_phase(
++        unique_channels,
++        strict_method="_free_ipc_exports_strict",
++        legacy_method="_free_ipc_exports",
++    )
++    free_status = _exchange_close_failures(
++        tuple(_format_close_error(index, error) for index, error in free_errors),
++        exchange_group=exchange_group,
++        phase="IPC export free",
++    )
++    if any(free_status):
++        _raise_coordinated_close_error(
++            "IPC export free",
++            free_status,
++            local_errors=free_errors,
++            exports_retained=False,
++        )
++
++    if exchange_group is not None:
++        dist.barrier(group=exchange_group)
+     for channel in unique_channels:
+-        channel._free_ipc_exports()
+-    dist.barrier(group=exchange_group)
++        if hasattr(channel, "_close_ipc_imports_strict"):
++            channel._coordinated_close_complete = True
++
++
++def _run_close_phase(
++    channels: Sequence[object],
++    *,
++    strict_method: str,
++    legacy_method: str,
++) -> list[tuple[int, Exception]]:
++    errors: list[tuple[int, Exception]] = []
++    for index, channel in enumerate(channels):
++        method = getattr(channel, strict_method, None)
++        if method is None:
++            method = getattr(channel, legacy_method)
++        try:
++            method()
++        except Exception as exc:
++            errors.append((index, exc))
++    return errors
++
++
++def _format_close_error(index: int, error: Exception) -> str:
++    return f"channel {index}: {type(error).__name__}: {error}"
++
++
++def _exchange_close_failures(
++    local_failures: tuple[str, ...],
++    *,
++    exchange_group: Optional[ProcessGroup],
++    phase: str,
++) -> tuple[tuple[str, ...], ...]:
++    if exchange_group is None:
++        return (local_failures,)
++    try:
++        gathered = _broadcast_gather_object(local_failures, exchange_group)
++    except Exception as exc:
++        raise RuntimeError(
++            f"failed to exchange peer {phase} status; exported IPC allocations "
++            "were not freed"
++        ) from exc
++
++    statuses: list[tuple[str, ...]] = []
++    for rank_index, status in enumerate(gathered):
++        if not isinstance(status, (tuple, list)):
++            raise RuntimeError(
++                f"invalid peer {phase} status from group rank {rank_index}; "
++                "exported IPC allocations were not freed"
++            )
++        statuses.append(tuple(str(item) for item in status))
++    return tuple(statuses)
++
++
++def _raise_coordinated_close_error(
++    phase: str,
++    statuses: Sequence[Sequence[str]],
++    *,
++    local_errors: Sequence[tuple[int, Exception]],
++    exports_retained: bool,
++) -> None:
++    peer_details = []
++    for rank_index, failures in enumerate(statuses):
++        if failures:
++            peer_details.append(f"group rank {rank_index}: " + " | ".join(failures))
++    retention = "; exported IPC allocations were not freed" if exports_retained else ""
++    error = RuntimeError(
++        f"coordinated PCIe close failed during {phase}{retention}: "
++        + "; ".join(peer_details)
++    )
++    if local_errors:
++        raise error from local_errors[0][1]
++    raise error
++
++
++def _raise_local_cleanup_errors(
++    owner: str,
++    phase: str,
++    failures: Sequence[tuple[str, Exception]],
++) -> None:
++    details = "; ".join(
++        f"{resource}: {type(error).__name__}: {error}" for resource, error in failures
++    )
++    error = RuntimeError(f"{owner} {phase} failed: {details}")
++    raise error from failures[0][1]
+ 
+ 
+ @dataclass(frozen=True)
+@@ -276,6 +1227,7 @@ class PCIeOneshotAllReduce:
+         signal_ptrs: Sequence[int],
+         eager_buffer_ptrs0: Optional[Sequence[int]] = None,
+         eager_buffer_ptrs1: Optional[Sequence[int]] = None,
++        eager_buffer_bytes: Optional[int] = None,
+         exchange_group: Optional[ProcessGroup] = None,
+         process_group: Optional[ProcessGroup] = None,
+         ipc: Optional[CudaRTLibrary] = None,
+@@ -285,31 +1237,232 @@ class PCIeOneshotAllReduce:
+         ext_module=None,
+         stream_affine: bool = True,
+     ):
+-        if world_size not in SUPPORTED_WORLD_SIZES:
+-            raise ValueError(f"unsupported world size {world_size}")
+-        if rank < 0 or rank >= world_size:
+-            raise ValueError(f"invalid rank {rank} for world size {world_size}")
+-        if len(signal_ptrs) != world_size:
+-            raise ValueError("signal_ptrs must match world size")
+-        if (eager_buffer_ptrs0 is None) != (eager_buffer_ptrs1 is None):
+-            raise ValueError("eager buffers must be provided as a pair")
+-        if eager_buffer_ptrs0 is not None and len(eager_buffer_ptrs0) != world_size:
+-            raise ValueError("eager_buffer_ptrs0 must match world size")
+-        if eager_buffer_ptrs1 is not None and len(eager_buffer_ptrs1) != world_size:
+-            raise ValueError("eager_buffer_ptrs1 must match world size")
++        resolved_group = _resolve_exchange_group(exchange_group, process_group)
++
++        def normalize_and_validate():
++            device_obj = _normalize_device(device)
++            normalized_rank = int(rank)
++            normalized_world_size = int(world_size)
++            normalized_signals = tuple(int(ptr) for ptr in signal_ptrs)
++            normalized_eager0 = (
++                None
++                if eager_buffer_ptrs0 is None
++                else tuple(int(ptr) for ptr in eager_buffer_ptrs0)
++            )
++            normalized_eager1 = (
++                None
++                if eager_buffer_ptrs1 is None
++                else tuple(int(ptr) for ptr in eager_buffer_ptrs1)
++            )
++            normalized_max_size = int(max_size)
++            normalized_rank_data_bytes = int(rank_data_bytes)
++            normalized_eager_bytes = (
++                None if eager_buffer_bytes is None else int(eager_buffer_bytes)
++            )
++            if normalized_world_size not in SUPPORTED_WORLD_SIZES:
++                raise ValueError(f"unsupported world size {normalized_world_size}")
++            if not 0 <= normalized_rank < normalized_world_size:
++                raise ValueError(
++                    f"invalid rank {normalized_rank} for world size "
++                    f"{normalized_world_size}"
++                )
++            if len(normalized_signals) != normalized_world_size:
++                raise ValueError("signal_ptrs must match world size")
++            if (normalized_eager0 is None) != (normalized_eager1 is None):
++                raise ValueError("eager buffers must be provided as a pair")
++            if (
++                normalized_eager0 is not None
++                and len(normalized_eager0) != normalized_world_size
++            ):
++                raise ValueError("eager_buffer_ptrs0 must match world size")
++            if (
++                normalized_eager1 is not None
++                and len(normalized_eager1) != normalized_world_size
++            ):
++                raise ValueError("eager_buffer_ptrs1 must match world size")
++            if normalized_max_size <= 0:
++                raise ValueError("max_size must be positive")
++            if normalized_rank_data_bytes <= 0:
++                raise ValueError("rank_data_bytes must be positive")
++            if normalized_eager0 is not None:
++                if normalized_eager_bytes is None:
++                    raise ValueError(
++                        "eager_buffer_bytes is required with eager buffer pointers"
++                    )
++                if normalized_eager_bytes <= 0:
++                    raise ValueError("eager_buffer_bytes must be positive")
++                if normalized_max_size > normalized_eager_bytes:
++                    raise ValueError("max_size exceeds eager buffer capacity")
++            if ext_module is None and device_obj.type != "cuda":
++                raise ValueError("PCIe oneshot allreduce requires a CUDA device")
++            if device_obj.type == "cuda" and resolved_group is None:
++                raise ValueError(
++                    "exchange_group is required for a CUDA PCIe oneshot runtime; "
++                    "use from_exchange_group()"
++                )
++            if resolved_group is not None:
++                if device_obj.type != "cuda":
++                    raise ValueError(
++                        "distributed PCIe oneshot allreduce requires a CUDA device"
++                    )
++                group_rank = dist.get_rank(group=resolved_group)
++                group_world_size = dist.get_world_size(group=resolved_group)
++                if normalized_rank != group_rank:
++                    raise ValueError(
++                        f"supplied rank {normalized_rank} does not match process "
++                        f"group rank {group_rank}"
++                    )
++                if normalized_world_size != group_world_size:
++                    raise ValueError(
++                        f"supplied world size {normalized_world_size} does not "
++                        f"match process group size {group_world_size}"
++                    )
++            return (
++                device_obj,
++                normalized_rank,
++                normalized_world_size,
++                normalized_signals,
++                normalized_eager0,
++                normalized_eager1,
++                normalized_eager_bytes,
++                normalized_max_size,
++                normalized_rank_data_bytes,
++            )
++
++        if resolved_group is not None:
++            normalized = _run_collective_preallocation_setup(
++                owner="PCIe oneshot direct constructor argument validation",
++                exchange_group=resolved_group,
++                setup=normalize_and_validate,
++            )
++        else:
++            normalized = normalize_and_validate()
++
++        (
++            device_obj,
++            normalized_rank,
++            normalized_world_size,
++            normalized_signals,
++            normalized_eager0,
++            normalized_eager1,
++            normalized_eager_bytes,
++            normalized_max_size,
++            normalized_rank_data_bytes,
++        ) = normalized
++
++        self._initialize_prepared_state(
++            rank=normalized_rank,
++            world_size=normalized_world_size,
++            device=device_obj,
++            signal_ptrs=normalized_signals,
++            eager_buffer_ptrs0=normalized_eager0,
++            eager_buffer_ptrs1=normalized_eager1,
++            eager_buffer_bytes=normalized_eager_bytes,
++            exchange_group=resolved_group,
++            ipc=ipc,
++            owned_buffers=owned_buffers,
++            max_size=normalized_max_size,
++            rank_data_bytes=normalized_rank_data_bytes,
++            ext_module=ext_module,
++            stream_affine=stream_affine,
++        )
++
++        if self.device.type == "cuda":
++            _require_full_grid_residency(
++                owner="PCIe oneshot direct constructor",
++                required_sms=ONESHOT_REQUIRED_SMS,
++                device=self.device,
++                exchange_group=self.exchange_group,
++            )
++
++            def prepare() -> tuple[Optional[CudaRTLibrary], object]:
++                prepared_ipc = self._ipc
++                if prepared_ipc is None and (ext_module is None or owned_buffers):
++                    prepared_ipc = CudaRTLibrary()
++                if prepared_ipc is not None:
++                    prepared_ipc.cudaSetDevice(_cuda_device_index(self.device))
++                return prepared_ipc, ext_module or _load_extension()
++
++            if self.exchange_group is None:
++                self._ipc, self._ext = prepare()
++            else:
++                self._ipc, self._ext = _run_collective_preallocation_setup(
++                    owner="PCIe oneshot direct constructor",
++                    exchange_group=self.exchange_group,
++                    setup=prepare,
++                )
++        else:
++            self._ext = self._ext or _load_extension()
++
++        if self.device.type == "cuda" and self.exchange_group is not None:
++            _require_collective_contract(
++                owner="PCIe oneshot direct constructor",
++                exchange_group=self.exchange_group,
++                contract=(
++                    self.world_size,
++                    self.max_size,
++                    self.rank_data_bytes,
++                    self.eager_buffer_bytes,
++                    self._pending_eager_ptrs is not None,
++                ),
++            )
++
++        init_error = self._initialize_native_runtime()
++        if self.device.type == "cuda" and self.exchange_group is not None:
++
++            def abort_native_runtime() -> None:
++                if self._ptr:
++                    self._ext.dispose(self._ptr)
++                    self._ptr = 0
+ 
++            _finish_collective_unowned_runtime_setup(
++                owner="PCIe oneshot direct constructor",
++                exchange_group=self.exchange_group,
++                local_error=init_error,
++                local_cleanup=abort_native_runtime,
++            )
++        elif init_error is not None:
++            raise init_error
++
++    def _initialize_prepared_state(
++        self,
++        *,
++        rank: int,
++        world_size: int,
++        device: torch.device,
++        signal_ptrs: Sequence[int],
++        eager_buffer_ptrs0: Optional[Sequence[int]],
++        eager_buffer_ptrs1: Optional[Sequence[int]],
++        eager_buffer_bytes: Optional[int],
++        exchange_group: Optional[ProcessGroup],
++        ipc: Optional[CudaRTLibrary],
++        owned_buffers: Optional[Sequence[_OwnedSharedBuffer]],
++        max_size: int,
++        rank_data_bytes: int,
++        ext_module,
++        stream_affine: bool,
++    ) -> None:
+         self.rank = int(rank)
+         self.world_size = int(world_size)
+-        self.device = _normalize_device(device)
+-        self.exchange_group = _resolve_exchange_group(exchange_group, process_group)
+-        # Compatibility alias for older callers that still refer to this as
+-        # `process_group`.
+-        self.process_group = self.exchange_group
++        self.device = device
++        self.exchange_group = exchange_group
++        self.process_group = exchange_group
+         self.max_size = int(max_size)
++        self.rank_data_bytes = int(rank_data_bytes)
++        self.eager_buffer_bytes = (
++            None if eager_buffer_bytes is None else int(eager_buffer_bytes)
++        )
+         self._ipc = ipc
+-        if self._ipc is None and (ext_module is None or owned_buffers):
+-            self._ipc = CudaRTLibrary()
++        self._ext = ext_module
+         self._signal_ptrs = tuple(int(ptr) for ptr in signal_ptrs)
++        self._pending_eager_ptrs = (
++            None
++            if eager_buffer_ptrs0 is None or eager_buffer_ptrs1 is None
++            else (
++                tuple(int(ptr) for ptr in eager_buffer_ptrs0),
++                tuple(int(ptr) for ptr in eager_buffer_ptrs1),
++            )
++        )
+         self._owned_buffers = list(owned_buffers or [])
+         self._registered_input_ptrs: dict[int, tuple[int, ...]] = {}
+         self._stream_affine = bool(stream_affine)
+@@ -317,29 +1470,43 @@ class PCIeOneshotAllReduce:
+         self._closed = False
+         self._ipc_imports_closed = False
+         self._ipc_exports_freed = False
+-        self._ext = ext_module or _load_extension()
+-
+-        if ext_module is None and self.device.type != "cuda":
+-            raise ValueError("PCIe oneshot allreduce requires a CUDA device")
+-
+-        self.rank_data = torch.empty(
+-            rank_data_bytes, dtype=torch.uint8, device=self.device
+-        )
+-        self._ptr = self._ext.init_custom_ar(
+-            list(self._signal_ptrs), self.rank_data, self.rank
+-        )
+-
++        self._coordinated_close_complete = False
++        self._native_ipc_import_close_failed = False
++        self._closed_ipc_import_indices: set[tuple[int, int]] = set()
++        self._ptr = 0
+         self._eager_ptrs: Optional[tuple[tuple[int, ...], tuple[int, ...]]] = None
+-        if eager_buffer_ptrs0 is not None and eager_buffer_ptrs1 is not None:
+-            self._eager_ptrs = (
+-                tuple(int(ptr) for ptr in eager_buffer_ptrs0),
+-                tuple(int(ptr) for ptr in eager_buffer_ptrs1),
++
++    def _initialize_native_runtime(self) -> BaseException | None:
++        init_error: BaseException | None = None
++        try:
++            self.rank_data = torch.empty(
++                self.rank_data_bytes, dtype=torch.uint8, device=self.device
+             )
+-            self._ext.register_pcie_buffers(
+-                self._ptr,
+-                list(self._eager_ptrs[0]),
+-                list(self._eager_ptrs[1]),
++            self._ptr = self._ext.init_custom_ar(
++                list(self._signal_ptrs), self.rank_data, self.rank
+             )
++            if self._pending_eager_ptrs is not None:
++                self._eager_ptrs = self._pending_eager_ptrs
++                self._ext.register_pcie_buffers(
++                    self._ptr,
++                    list(self._eager_ptrs[0]),
++                    list(self._eager_ptrs[1]),
++                )
++        except Exception as exc:
++            init_error = exc
++        finally:
++            self._pending_eager_ptrs = None
++        return init_error
++
++    @classmethod
++    def _from_prepared_factory(
++        cls,
++        **kwargs,
++    ) -> tuple["PCIeOneshotAllReduce", BaseException | None]:
++        runtime = object.__new__(cls)
++        runtime._initialize_prepared_state(**kwargs)
++        init_error = runtime._initialize_native_runtime()
++        return runtime, init_error
+ 
+     @classmethod
+     def from_ipc(
+@@ -351,6 +1518,7 @@ class PCIeOneshotAllReduce:
+         signal_ptrs: Sequence[int],
+         eager_buffer_ptrs0: Optional[Sequence[int]] = None,
+         eager_buffer_ptrs1: Optional[Sequence[int]] = None,
++        eager_buffer_bytes: Optional[int] = None,
+         exchange_group: Optional[ProcessGroup] = None,
+         process_group: Optional[ProcessGroup] = None,
+         max_size: int = DEFAULT_MAX_SIZE,
+@@ -365,6 +1533,7 @@ class PCIeOneshotAllReduce:
+             signal_ptrs=signal_ptrs,
+             eager_buffer_ptrs0=eager_buffer_ptrs0,
+             eager_buffer_ptrs1=eager_buffer_ptrs1,
++            eager_buffer_bytes=eager_buffer_bytes,
+             exchange_group=exchange_group,
+             process_group=process_group,
+             max_size=max_size,
+@@ -387,50 +1556,114 @@ class PCIeOneshotAllReduce:
+     ) -> "PCIeOneshotAllReduce":
+         rank = dist.get_rank(group=exchange_group)
+         world_size = dist.get_world_size(group=exchange_group)
+-        if world_size not in SUPPORTED_WORLD_SIZES:
+-            raise ValueError(f"unsupported world size {world_size}")
+-
+-        device_obj = _normalize_device(device)
+-        if device_obj.type != "cuda":
+-            raise ValueError("PCIe oneshot requires a CUDA device")
+ 
+-        ipc = CudaRTLibrary()
+-        ipc.cudaSetDevice(device_obj.index or 0)
+-        ext = ext_module or _load_extension()
+-
+-        owned_buffers: list[_OwnedSharedBuffer] = []
+-        try:
+-            channel_buffers = cls._allocate_eager_channel_buffers(
+-                exchange_group,
+-                signal_bytes=ext.meta_size(),
+-                eager_buffer_bytes=eager_buffer_bytes,
+-                ipc=ipc,
++        def validate_factory_arguments():
++            device_obj = _normalize_device(device)
++            normalized_eager_bytes = int(eager_buffer_bytes)
++            normalized_max_size = int(max_size)
++            normalized_rank_data_bytes = int(rank_data_bytes)
++            if world_size not in SUPPORTED_WORLD_SIZES:
++                raise ValueError(f"unsupported world size {world_size}")
++            if device_obj.type != "cuda":
++                raise ValueError("PCIe oneshot requires a CUDA device")
++            if normalized_eager_bytes <= 0:
++                raise ValueError("eager_buffer_bytes must be positive")
++            if normalized_max_size <= 0:
++                raise ValueError("max_size must be positive")
++            if normalized_max_size > normalized_eager_bytes:
++                raise ValueError("max_size exceeds eager buffer capacity")
++            if normalized_rank_data_bytes <= 0:
++                raise ValueError("rank_data_bytes must be positive")
++            return (
++                device_obj,
++                normalized_eager_bytes,
++                normalized_max_size,
++                normalized_rank_data_bytes,
+             )
+-            owned_buffers.append(channel_buffers.owned_buffer)
+ 
+-            return cls(
+-                rank=rank,
+-                world_size=world_size,
+-                device=device_obj,
+-                signal_ptrs=channel_buffers.signal_ptrs,
+-                eager_buffer_ptrs0=channel_buffers.eager0_ptrs,
+-                eager_buffer_ptrs1=channel_buffers.eager1_ptrs,
++        device_obj, eager_buffer_bytes, max_size, rank_data_bytes = (
++            _run_collective_preallocation_setup(
++                owner="PCIe oneshot argument validation",
+                 exchange_group=exchange_group,
+-                ipc=ipc,
+-                owned_buffers=owned_buffers,
+-                max_size=max_size,
+-                rank_data_bytes=rank_data_bytes,
+-                ext_module=ext,
+-                stream_affine=stream_affine,
+-            )
+-        except Exception:
+-            for shared in owned_buffers:
+-                for ptr in shared.remote_ptrs:
+-                    with suppress(Exception):
+-                        ipc.cudaIpcCloseMemHandle(ptr)
+-                with suppress(Exception):
+-                    ipc.cudaFree(shared.local_ptr)
+-            raise
++                setup=validate_factory_arguments,
++            )
++        )
++
++        _require_full_grid_residency(
++            owner="PCIe oneshot",
++            required_sms=ONESHOT_REQUIRED_SMS,
++            device=device_obj,
++            exchange_group=exchange_group,
++        )
++
++        def prepare() -> tuple[CudaRTLibrary, object, int]:
++            prepared_ipc = CudaRTLibrary()
++            prepared_ipc.cudaSetDevice(_cuda_device_index(device_obj))
++            prepared_ext = ext_module or _load_extension()
++            return prepared_ipc, prepared_ext, int(prepared_ext.meta_size())
++
++        ipc, ext, signal_bytes = _run_collective_preallocation_setup(
++            owner="PCIe oneshot",
++            exchange_group=exchange_group,
++            setup=prepare,
++        )
++        _require_collective_contract(
++            owner="PCIe oneshot channel layout",
++            exchange_group=exchange_group,
++            contract=(
++                signal_bytes,
++                eager_buffer_bytes,
++                max_size,
++                rank_data_bytes,
++                _push_mode_enabled(),
++            ),
++        )
++
++        channel_buffers = cls._allocate_eager_channel_buffers(
++            exchange_group,
++            signal_bytes=signal_bytes,
++            eager_buffer_bytes=eager_buffer_bytes,
++            ipc=ipc,
++        )
++        owned_buffers = [channel_buffers.owned_buffer]
++        runtime, init_error = cls._from_prepared_factory(
++            rank=rank,
++            world_size=world_size,
++            device=device_obj,
++            signal_ptrs=channel_buffers.signal_ptrs,
++            eager_buffer_ptrs0=channel_buffers.eager0_ptrs,
++            eager_buffer_ptrs1=channel_buffers.eager1_ptrs,
++            eager_buffer_bytes=eager_buffer_bytes,
++            exchange_group=exchange_group,
++            ipc=ipc,
++            owned_buffers=owned_buffers,
++            max_size=max_size,
++            rank_data_bytes=rank_data_bytes,
++            ext_module=ext,
++            stream_affine=stream_affine,
++        )
++
++        def abort_native_runtime() -> None:
++            pointer = getattr(runtime, "_ptr", 0)
++            if pointer:
++                ext.dispose(pointer)
++                runtime._ptr = 0
++            if hasattr(runtime, "rank_data"):
++                del runtime.rank_data
++
++        def detach_shared_ownership() -> None:
++            runtime._owned_buffers.clear()
++
++        _finish_collective_runtime_setup(
++            owner="PCIe oneshot",
++            exchange_group=exchange_group,
++            ipc=ipc,
++            shared=channel_buffers.owned_buffer,
++            local_error=init_error,
++            local_cleanup=abort_native_runtime,
++            detach_shared_ownership=detach_shared_ownership,
++        )
++        return runtime
+ 
+     @classmethod
+     def from_process_group(
+@@ -440,7 +1673,7 @@ class PCIeOneshotAllReduce:
+         device: torch.device | int | str,
+         max_input_bytes: int = DEFAULT_MAX_SIZE,
+         eager_buffer_bytes: Optional[int] = None,
+-        max_size: int = DEFAULT_MAX_SIZE,
++        max_size: Optional[int] = None,
+         rank_data_bytes: int = DEFAULT_RANK_DATA_BYTES,
+         ext_module=None,
+         stream_affine: bool = True,
+@@ -451,7 +1684,7 @@ class PCIeOneshotAllReduce:
+             eager_buffer_bytes=max_input_bytes
+             if eager_buffer_bytes is None
+             else eager_buffer_bytes,
+-            max_size=max_size,
++            max_size=max_input_bytes if max_size is None else max_size,
+             rank_data_bytes=rank_data_bytes,
+             ext_module=ext_module,
+             stream_affine=stream_affine,
+@@ -465,42 +1698,193 @@ class PCIeOneshotAllReduce:
+         zero_fill: bool,
+         ipc: CudaRTLibrary,
+     ) -> _OwnedSharedBuffer:
+-        local_ptr = ipc.cudaMalloc(size_in_bytes)
+-        peer_ptrs: list[int] = []
+-        remote_ptrs: list[int] = []
++        _require_no_retained_ipc_setup(exchange_group)
++        local_ptr: int | None = None
++        local_handle: bytes | None = None
++        prepare_error: BaseException | None = None
+         try:
++            local_ptr = ipc.cudaMalloc(size_in_bytes)
+             if zero_fill:
+                 ipc.cudaMemset(local_ptr, 0, size_in_bytes)
+             local_handle = ipc.cudaIpcGetMemHandleBytes(local_ptr)
++        except Exception as exc:
++            prepare_error = exc
++
++        # A rank that cannot allocate or publish its export must not leave its
++        # peers blocked in the handle exchange.  No imports exist yet, so
++        # successful ranks can safely release their local allocation.
++        try:
++            prepare_statuses = _exchange_setup_failures(
++                prepare_error,
++                exchange_group=exchange_group,
++                phase="CUDA IPC export preparation",
++            )
++        except Exception as exchange_error:
++            retained = _retain_failed_ipc_setup(
++                ipc=ipc,
++                local_ptr=int(local_ptr or 0),
++                exchange_group=exchange_group,
++                owner="PCIe shared buffer",
++                phase="CUDA IPC export preparation",
++                state="unmap",
++            )
++            error = RuntimeError(
++                "failed to exchange CUDA IPC export preparation status; "
++                "CUDA IPC ownership was retained"
++            )
++            raise _attach_retryable_setup(error, retained) from (
++                prepare_error or exchange_error
++            )
++        if any(prepare_statuses):
++            free_error: BaseException | None = None
++            live_local_ptr = int(local_ptr or 0)
++            if local_ptr is not None:
++                try:
++                    ipc.cudaFree(local_ptr)
++                except Exception as exc:
++                    free_error = exc
++                else:
++                    live_local_ptr = 0
++            try:
++                free_statuses = _exchange_setup_failures(
++                    free_error,
++                    exchange_group=exchange_group,
++                    phase="CUDA IPC export preparation rollback",
++                )
++            except Exception as exchange_error:
++                retained_export = _retain_failed_ipc_setup(
++                    ipc=ipc,
++                    local_ptr=live_local_ptr,
++                    exchange_group=exchange_group,
++                    owner="PCIe shared buffer",
++                    phase="CUDA IPC export preparation",
++                    state="free",
++                )
++                error = RuntimeError(
++                    "failed to exchange CUDA IPC export rollback status; "
++                    "CUDA IPC ownership was retained"
++                )
++                raise _attach_retryable_setup(error, retained_export) from (
++                    free_error or prepare_error or exchange_error
++                )
++            if any(free_statuses):
++                retained_export = _retain_failed_ipc_setup(
++                    ipc=ipc,
++                    local_ptr=live_local_ptr,
++                    exchange_group=exchange_group,
++                    owner="PCIe shared buffer",
++                    phase="CUDA IPC export preparation",
++                    state="free",
++                )
++                error = RuntimeError(
++                    _setup_failure_message(
++                        "PCIe shared buffer",
++                        "export preparation rollback",
++                        free_statuses,
++                        exports_retained=True,
++                    )
++                )
++                raise _attach_retryable_setup(error, retained_export) from (
++                    prepare_error or free_error
++                )
++            raise RuntimeError(
++                _setup_failure_message(
++                    "PCIe shared buffer",
++                    "export preparation",
++                    prepare_statuses,
++                    exports_retained=False,
++                )
++            ) from prepare_error
++
++        assert local_ptr is not None
++        assert local_handle is not None
++        peer_ptrs: list[int] = []
++        remote_ptrs: list[int] = []
++        try:
+             world_size = dist.get_world_size(group=exchange_group)
+             rank = dist.get_rank(group=exchange_group)
+             handles = _broadcast_gather_object(local_handle, exchange_group)
+-            for idx, handle in enumerate(handles):
+-                if idx == rank:
+-                    peer_ptrs.append(local_ptr)
+-                else:
+-                    try:
+-                        remote_ptr = ipc.cudaIpcOpenMemHandleBytes(handle)
+-                    except Exception as exc:
+-                        raise RuntimeError(
+-                            f"failed to open CUDA IPC handle for peer rank {idx}"
+-                        ) from exc
+-                    peer_ptrs.append(remote_ptr)
+-                    remote_ptrs.append(remote_ptr)
+-            if len(peer_ptrs) != world_size:
+-                raise RuntimeError("failed to gather IPC handles for all ranks")
+-            return _OwnedSharedBuffer(
++        except Exception as exchange_error:
++            # No rank has opened an import before handle exchange completes.
++            # Retain both ownership and a collective retry ticket if progress
++            # is uncertain; peers may have completed the exchange already.
++            retained = _retain_failed_ipc_setup(
++                ipc=ipc,
++                local_ptr=local_ptr,
++                exchange_group=exchange_group,
++                owner="PCIe shared buffer",
++                phase="CUDA IPC handle exchange",
++                state="unmap",
++            )
++            error = RuntimeError(
++                "CUDA IPC handle exchange failed; CUDA IPC ownership was retained"
++            )
++            raise _attach_retryable_setup(error, retained) from exchange_error
++
++        open_error: BaseException | None = None
++        for idx, handle in enumerate(handles):
++            if idx == rank:
++                peer_ptrs.append(local_ptr)
++                continue
++            try:
++                remote_ptr = ipc.cudaIpcOpenMemHandleBytes(handle)
++            except Exception as exc:
++                if open_error is None:
++                    open_error = RuntimeError(
++                        f"failed to open CUDA IPC handle for peer group rank {idx}"
++                    )
++                    open_error.__cause__ = exc
++                # Preserve group-rank indexing while every rank completes the
++                # same open loop and reaches the collective verdict.
++                peer_ptrs.append(0)
++            else:
++                peer_ptrs.append(remote_ptr)
++                remote_ptrs.append(remote_ptr)
++
++        if len(handles) != world_size or len(peer_ptrs) != world_size:
++            open_error = open_error or RuntimeError(
++                "failed to gather CUDA IPC handles for every group rank"
++            )
++        try:
++            open_statuses = _exchange_setup_failures(
++                open_error,
++                exchange_group=exchange_group,
++                phase="CUDA IPC import open",
++            )
++        except Exception as exchange_error:
++            retained = _retain_failed_ipc_setup(
++                ipc=ipc,
++                local_ptr=local_ptr,
++                exchange_group=exchange_group,
++                owner="PCIe shared buffer",
++                phase="CUDA IPC import open",
++                remote_ptrs=remote_ptrs,
++                state="unmap",
++            )
++            error = RuntimeError(
++                "failed to exchange CUDA IPC import-open status; CUDA IPC "
++                "ownership was retained"
++            )
++            raise _attach_retryable_setup(error, retained) from (
++                open_error or exchange_error
++            )
++        if any(open_statuses):
++            _abort_collective_ipc_setup(
++                owner="PCIe shared buffer",
++                setup_phase="CUDA IPC import open",
++                setup_statuses=open_statuses,
++                exchange_group=exchange_group,
++                ipc=ipc,
+                 local_ptr=local_ptr,
+-                peer_ptrs=tuple(peer_ptrs),
+-                remote_ptrs=tuple(remote_ptrs),
++                remote_ptrs=remote_ptrs,
++                local_error=open_error,
+             )
+-        except Exception:
+-            for ptr in remote_ptrs:
+-                with suppress(Exception):
+-                    ipc.cudaIpcCloseMemHandle(ptr)
+-            with suppress(Exception):
+-                ipc.cudaFree(local_ptr)
+-            raise
++
++        return _OwnedSharedBuffer(
++            local_ptr=local_ptr,
++            peer_ptrs=tuple(peer_ptrs),
++            remote_ptrs=tuple(remote_ptrs),
++        )
+ 
+     @classmethod
+     def _allocate_eager_channel_buffers(
+@@ -860,6 +2244,9 @@ class PCIeOneshotAllReduce:
+         if self.device.type != "cuda":
+             raise ValueError("autotune requires a CUDA device")
+         bench_stream = torch.cuda.Stream(device=self.device)
++        effective_ceiling = int(ceiling_bytes)
++        if self.eager_buffer_bytes is not None:
++            effective_ceiling = min(effective_ceiling, self.eager_buffer_bytes)
+         crossover, results = _compute_crossover_size(
+             lambda size_bytes: self._bench_graph_latency(
+                 size_bytes,
+@@ -868,9 +2255,11 @@ class PCIeOneshotAllReduce:
+                 warmup,
+                 iters,
+             ),
+-            ceiling_bytes=ceiling_bytes,
++            ceiling_bytes=effective_ceiling,
+             fine_step_bytes=fine_step_bytes,
+         )
++        if self.eager_buffer_bytes is not None:
++            crossover = min(crossover, self.eager_buffer_bytes)
+         self.max_size = crossover
+ 
+         if self.rank == 0:
+@@ -896,40 +2285,172 @@ class PCIeOneshotAllReduce:
+             logger.info("\n".join(lines))
+         return crossover
+ 
+-    def _close_ipc_imports(self) -> None:
++    def _closed_import_indices(self) -> set[tuple[int, int]]:
++        closed = getattr(self, "_closed_ipc_import_indices", None)
++        if closed is None:
++            closed = set()
++            self._closed_ipc_import_indices = closed
++        return closed
++
++    def _all_python_ipc_imports_closed(self, closed: set[tuple[int, int]]) -> bool:
++        if self._ipc is None:
++            return not any(shared.remote_ptrs for shared in self._owned_buffers)
++        return all(
++            (buffer_index, remote_index) in closed
++            for buffer_index, shared in enumerate(self._owned_buffers)
++            for remote_index, _ in enumerate(shared.remote_ptrs)
++        )
++
++    def _close_ipc_imports_strict(self) -> None:
+         if self._ipc_imports_closed:
+             return
+         self._closed = True
++        failures: list[tuple[str, Exception]] = []
++        if getattr(self, "_native_ipc_import_close_failed", False):
++            failures.append(
++                (
++                    "native runtime",
++                    RuntimeError(
++                        "a native IPC import failed during best-effort teardown "
++                        "and can no longer be retried"
++                    ),
++                )
++            )
+         if getattr(self, "_ptr", 0):
+-            with suppress(Exception):
++            try:
+                 self._ext.dispose(self._ptr)
+-            self._ptr = 0
++            except Exception as exc:
++                failures.append(("native runtime", exc))
++            else:
++                self._ptr = 0
++
++        closed = self._closed_import_indices()
+         if self._ipc is not None:
+-            for shared in self._owned_buffers:
+-                for ptr in shared.remote_ptrs:
+-                    with suppress(Exception):
++            for buffer_index, shared in enumerate(self._owned_buffers):
++                for remote_index, ptr in enumerate(shared.remote_ptrs):
++                    key = (buffer_index, remote_index)
++                    if key in closed:
++                        continue
++                    try:
+                         self._ipc.cudaIpcCloseMemHandle(ptr)
+-        self._ipc_imports_closed = True
++                    except Exception as exc:
++                        failures.append((f"CUDA IPC import {ptr}", exc))
++                    else:
++                        closed.add(key)
++        elif any(shared.remote_ptrs for shared in self._owned_buffers):
++            failures.append(
++                (
++                    "CUDA IPC imports",
++                    RuntimeError("CUDA runtime is unavailable for IPC unmap"),
++                )
++            )
++
++        if (
++            not failures
++            and not getattr(self, "_ptr", 0)
++            and self._all_python_ipc_imports_closed(closed)
++        ):
++            self._ipc_imports_closed = True
++        if failures:
++            _raise_local_cleanup_errors("PCIe oneshot", "IPC import close", failures)
+ 
+-    def _free_ipc_exports(self) -> None:
++    def _close_ipc_imports_best_effort(self) -> None:
++        if self._ipc_imports_closed:
++            return
++        self._closed = True
++        native_imports_closed = not getattr(self, "_ptr", 0)
++        if getattr(self, "_ptr", 0):
++            dispose = getattr(self._ext, "dispose_best_effort", None)
++            if dispose is None:
++                dispose = self._ext.dispose
++            try:
++                result = dispose(self._ptr)
++            except Exception:
++                pass
++            else:
++                self._ptr = 0
++                # The native best-effort binding reports whether every graph
++                # import closed. Legacy/fake dispose methods return None and
++                # report failure by raising.
++                native_imports_closed = result is not False
++                if not native_imports_closed:
++                    self._native_ipc_import_close_failed = True
++
++        closed = self._closed_import_indices()
++        if self._ipc is not None:
++            for buffer_index, shared in enumerate(self._owned_buffers):
++                for remote_index, ptr in enumerate(shared.remote_ptrs):
++                    key = (buffer_index, remote_index)
++                    if key in closed:
++                        continue
++                    try:
++                        self._ipc.cudaIpcCloseMemHandle(ptr)
++                    except Exception:
++                        pass
++                    else:
++                        closed.add(key)
++
++        if (
++            native_imports_closed
++            and not getattr(self, "_ptr", 0)
++            and self._all_python_ipc_imports_closed(closed)
++        ):
++            self._ipc_imports_closed = True
++
++    def _free_ipc_exports_strict(self) -> None:
+         if self._ipc_exports_freed:
+             return
+-        self._close_ipc_imports()
++        self._close_ipc_imports_strict()
++        failures: list[tuple[str, Exception]] = []
++        remaining = []
+         if self._ipc is not None:
+             for shared in self._owned_buffers:
+-                with suppress(Exception):
++                try:
+                     self._ipc.cudaFree(shared.local_ptr)
+-        self._owned_buffers.clear()
+-        self._registered_input_ptrs.clear()
+-        self._ipc_exports_freed = True
++                except Exception as exc:
++                    remaining.append(shared)
++                    failures.append((f"CUDA IPC export {shared.local_ptr}", exc))
++        elif self._owned_buffers:
++            remaining = list(self._owned_buffers)
++            failures.append(
++                (
++                    "CUDA IPC exports",
++                    RuntimeError("CUDA runtime is unavailable for export free"),
++                )
++            )
++        self._owned_buffers = remaining
++        if not remaining:
++            self._registered_input_ptrs.clear()
++            self._ipc_exports_freed = True
++        if failures:
++            _raise_local_cleanup_errors("PCIe oneshot", "IPC export free", failures)
+ 
+     def close(self) -> None:
+-        self._close_ipc_imports()
+-        self._free_ipc_exports()
++        if getattr(self, "_coordinated_close_complete", False):
++            return
++        _coordinated_close_channels(
++            (self,),
++            exchange_group=self.exchange_group,
++            device=self.device,
++        )
+ 
+-    def __del__(self) -> None:
+-        with suppress(Exception):
+-            self.close()
++    def __del__(
++        self,
++        _quarantine: dict[int, object] = _ABANDONED_PCIE_RUNTIME_QUARANTINE,
++    ) -> None:
++        # GC cannot prove that work queued on an arbitrary CUDA stream has
++        # completed, and it must not synchronize or enter a distributed
++        # barrier.  Retain the whole runtime: rank_data is a torch allocation
++        # whose raw pointer is stored in the native object and captured graph
++        # arguments, so retaining only IPC mappings/exports is insufficient.
++        if getattr(self, "_coordinated_close_complete", False):
++            return
++        if (
++            getattr(self, "_ptr", 0)
++            or hasattr(self, "rank_data")
++            or getattr(self, "_owned_buffers", ())
++        ):
++            _quarantine[id(self)] = self
+ 
+ 
+ def _is_current_stream_capturing(device: torch.device) -> bool:
+@@ -964,42 +2485,145 @@ class PCIeOneshotAllReducePool:
+         ext_module=None,
+         ipc: Optional[CudaRTLibrary] = None,
+         single_channel: bool = False,
++        max_concurrent_channels: int = 1,
+         channel_factory: Optional[
+             Callable[[Optional[int]], PCIeOneshotAllReduce]
+         ] = None,
+     ):
+-        if world_size not in SUPPORTED_WORLD_SIZES:
+-            raise ValueError(f"unsupported world size {world_size}")
+-        if rank < 0 or rank >= world_size:
+-            raise ValueError(f"invalid rank {rank} for world size {world_size}")
++        resolved_group = _resolve_exchange_group(exchange_group, process_group)
++
++        def normalize_and_validate():
++            normalized_rank = int(rank)
++            normalized_world_size = int(world_size)
++            device_obj = _normalize_device(device)
++            normalized_eager_bytes = int(eager_buffer_bytes)
++            normalized_max_size = int(max_size)
++            normalized_rank_data_bytes = int(rank_data_bytes)
++            normalized_single_channel = bool(single_channel)
++            normalized_max_concurrent_channels = int(max_concurrent_channels)
++            if normalized_world_size not in SUPPORTED_WORLD_SIZES:
++                raise ValueError(f"unsupported world size {normalized_world_size}")
++            if not 0 <= normalized_rank < normalized_world_size:
++                raise ValueError(
++                    f"invalid rank {normalized_rank} for world size "
++                    f"{normalized_world_size}"
++                )
++            if normalized_eager_bytes <= 0:
++                raise ValueError("eager_buffer_bytes must be positive")
++            if normalized_max_size <= 0:
++                raise ValueError("max_size must be positive")
++            if normalized_max_size > normalized_eager_bytes:
++                raise ValueError("max_size exceeds eager buffer capacity")
++            if normalized_rank_data_bytes <= 0:
++                raise ValueError("rank_data_bytes must be positive")
++            if normalized_max_concurrent_channels <= 0:
++                raise ValueError("max_concurrent_channels must be positive")
++            if channel_factory is None:
++                if resolved_group is None:
++                    raise ValueError(
++                        "exchange_group is required unless channel_factory is provided"
++                    )
++                if device_obj.type != "cuda":
++                    raise ValueError("PCIe oneshot pool requires a CUDA device")
++                group_rank = dist.get_rank(group=resolved_group)
++                group_world_size = dist.get_world_size(group=resolved_group)
++                if normalized_rank != group_rank:
++                    raise ValueError(
++                        f"supplied rank {normalized_rank} does not match process "
++                        f"group rank {group_rank}"
++                    )
++                if normalized_world_size != group_world_size:
++                    raise ValueError(
++                        f"supplied world size {normalized_world_size} does not "
++                        f"match process group size {group_world_size}"
++                    )
++            return (
++                normalized_rank,
++                normalized_world_size,
++                device_obj,
++                normalized_eager_bytes,
++                normalized_max_size,
++                normalized_rank_data_bytes,
++                normalized_single_channel,
++                normalized_max_concurrent_channels,
++            )
+ 
+-        self.rank = int(rank)
+-        self.world_size = int(world_size)
+-        self.device = _normalize_device(device)
+-        self.exchange_group = _resolve_exchange_group(exchange_group, process_group)
++        if channel_factory is None and resolved_group is not None:
++            normalized = _run_collective_preallocation_setup(
++                owner="PCIe oneshot pool argument validation",
++                exchange_group=resolved_group,
++                setup=normalize_and_validate,
++            )
++        else:
++            normalized = normalize_and_validate()
++
++        (
++            self.rank,
++            self.world_size,
++            self.device,
++            self.eager_buffer_bytes,
++            self.max_size,
++            self.rank_data_bytes,
++            self.single_channel,
++            self.max_concurrent_channels,
++        ) = normalized
++        self.exchange_group = resolved_group
+         self.process_group = self.exchange_group
+-        self.eager_buffer_bytes = int(eager_buffer_bytes)
+-        self.max_size = int(max_size)
+-        self.rank_data_bytes = int(rank_data_bytes)
+-        self.single_channel = bool(single_channel)
+         self._channel_factory = channel_factory
+         self._channels: dict[int, PCIeOneshotAllReduce] = {}
++        self._logical_channels: dict[str, PCIeOneshotAllReduce] = {}
++        self._captured_channel_ids: set[str] = set()
+         self._all_channels: list[PCIeOneshotAllReduce] = []
+         self._capture_channel_stack: list[PCIeOneshotAllReduce] = []
+         self._closed = False
+ 
+         self._ipc = ipc
+         self._ext = ext_module
++        self._signal_bytes = 0
+         if self._channel_factory is None:
+-            if self.exchange_group is None:
+-                raise ValueError(
+-                    "exchange_group is required unless channel_factory is provided"
++            assert self.exchange_group is not None
++            _require_full_grid_residency(
++                owner="PCIe oneshot",
++                required_sms=(ONESHOT_REQUIRED_SMS * self.max_concurrent_channels),
++                device=self.device,
++                exchange_group=self.exchange_group,
++            )
++
++            def prepare() -> tuple[CudaRTLibrary, object, int]:
++                prepared_ipc = self._ipc or CudaRTLibrary()
++                prepared_ipc.cudaSetDevice(_cuda_device_index(self.device))
++                prepared_ext = self._ext or _load_extension()
++                return (
++                    prepared_ipc,
++                    prepared_ext,
++                    int(prepared_ext.meta_size()),
+                 )
+-            if self.device.type != "cuda":
+-                raise ValueError("PCIe oneshot pool requires a CUDA device")
+-            self._ipc = self._ipc or CudaRTLibrary()
+-            self._ipc.cudaSetDevice(self.device.index or 0)
+-            self._ext = self._ext or _load_extension()
++
++            self._ipc, self._ext, self._signal_bytes = (
++                _run_collective_preallocation_setup(
++                    owner="PCIe oneshot pool",
++                    exchange_group=self.exchange_group,
++                    setup=prepare,
++                )
++            )
++            _require_collective_contract(
++                owner="PCIe oneshot pool channel layout",
++                exchange_group=self.exchange_group,
++                contract=(
++                    self._signal_bytes,
++                    self.eager_buffer_bytes,
++                    self.max_size,
++                    self.rank_data_bytes,
++                    self.single_channel,
++                    self.max_concurrent_channels,
++                    _push_mode_enabled(),
++                ),
++            )
++            # A genuine single-channel pool has no independent eager/graph
++            # owners to name. Multi-channel distributed callers must prepare
++            # explicit semantic ids before their first eager operation.
++            if self.single_channel:
++                self.prepare_channels((_SINGLE_CHANNEL_ID,))
+ 
+     @classmethod
+     def from_exchange_group(
+@@ -1012,6 +2636,7 @@ class PCIeOneshotAllReducePool:
+         rank_data_bytes: int = DEFAULT_RANK_DATA_BYTES,
+         ext_module=None,
+         single_channel: bool = False,
++        max_concurrent_channels: int = 1,
+     ) -> "PCIeOneshotAllReducePool":
+         return cls(
+             rank=dist.get_rank(group=exchange_group),
+@@ -1023,6 +2648,7 @@ class PCIeOneshotAllReducePool:
+             rank_data_bytes=rank_data_bytes,
+             ext_module=ext_module,
+             single_channel=single_channel,
++            max_concurrent_channels=max_concurrent_channels,
+         )
+ 
+     @classmethod
+@@ -1033,10 +2659,11 @@ class PCIeOneshotAllReducePool:
+         device: torch.device | int | str,
+         max_input_bytes: int = DEFAULT_MAX_SIZE,
+         eager_buffer_bytes: Optional[int] = None,
+-        max_size: int = DEFAULT_MAX_SIZE,
++        max_size: Optional[int] = None,
+         rank_data_bytes: int = DEFAULT_RANK_DATA_BYTES,
+         ext_module=None,
+         single_channel: bool = False,
++        max_concurrent_channels: int = 1,
+     ) -> "PCIeOneshotAllReducePool":
+         return cls.from_exchange_group(
+             exchange_group=process_group,
+@@ -1044,10 +2671,11 @@ class PCIeOneshotAllReducePool:
+             eager_buffer_bytes=max_input_bytes
+             if eager_buffer_bytes is None
+             else eager_buffer_bytes,
+-            max_size=max_size,
++            max_size=max_input_bytes if max_size is None else max_size,
+             rank_data_bytes=rank_data_bytes,
+             ext_module=ext_module,
+             single_channel=single_channel,
++            max_concurrent_channels=max_concurrent_channels,
+         )
+ 
+     def _new_channel(self, stream_key: Optional[int]) -> PCIeOneshotAllReduce:
+@@ -1062,56 +2690,127 @@ class PCIeOneshotAllReducePool:
+         if self.exchange_group is None or self._ipc is None or self._ext is None:
+             raise RuntimeError("pool is not configured to allocate channels")
+ 
+-        owned_buffers: list[_OwnedSharedBuffer] = []
+-        try:
+-            channel_buffers = PCIeOneshotAllReduce._allocate_eager_channel_buffers(
+-                self.exchange_group,
+-                signal_bytes=self._ext.meta_size(),
+-                eager_buffer_bytes=self.eager_buffer_bytes,
+-                ipc=self._ipc,
+-            )
+-            owned_buffers.append(channel_buffers.owned_buffer)
++        channel_buffers = PCIeOneshotAllReduce._allocate_eager_channel_buffers(
++            self.exchange_group,
++            signal_bytes=self._signal_bytes,
++            eager_buffer_bytes=self.eager_buffer_bytes,
++            ipc=self._ipc,
++        )
++        owned_buffers = [channel_buffers.owned_buffer]
++        channel, init_error = PCIeOneshotAllReduce._from_prepared_factory(
++            rank=self.rank,
++            world_size=self.world_size,
++            device=self.device,
++            signal_ptrs=channel_buffers.signal_ptrs,
++            eager_buffer_ptrs0=channel_buffers.eager0_ptrs,
++            eager_buffer_ptrs1=channel_buffers.eager1_ptrs,
++            eager_buffer_bytes=self.eager_buffer_bytes,
++            exchange_group=self.exchange_group,
++            ipc=self._ipc,
++            owned_buffers=owned_buffers,
++            max_size=self.max_size,
++            rank_data_bytes=self.rank_data_bytes,
++            ext_module=self._ext,
++            stream_affine=not self.single_channel,
++        )
+ 
+-            channel = PCIeOneshotAllReduce(
+-                rank=self.rank,
+-                world_size=self.world_size,
+-                device=self.device,
+-                signal_ptrs=channel_buffers.signal_ptrs,
+-                eager_buffer_ptrs0=channel_buffers.eager0_ptrs,
+-                eager_buffer_ptrs1=channel_buffers.eager1_ptrs,
+-                exchange_group=self.exchange_group,
+-                ipc=self._ipc,
+-                owned_buffers=owned_buffers,
+-                max_size=self.max_size,
+-                rank_data_bytes=self.rank_data_bytes,
+-                ext_module=self._ext,
+-                stream_affine=not self.single_channel,
+-            )
+-        except Exception:
+-            for shared in owned_buffers:
+-                for ptr in shared.remote_ptrs:
+-                    with suppress(Exception):
+-                        self._ipc.cudaIpcCloseMemHandle(ptr)
+-                with suppress(Exception):
+-                    self._ipc.cudaFree(shared.local_ptr)
+-            raise
++        def abort_native_runtime() -> None:
++            pointer = getattr(channel, "_ptr", 0)
++            if pointer:
++                self._ext.dispose(pointer)
++                channel._ptr = 0
++            if hasattr(channel, "rank_data"):
++                del channel.rank_data
++
++        def detach_shared_ownership() -> None:
++            channel._owned_buffers.clear()
++
++        _finish_collective_runtime_setup(
++            owner="PCIe oneshot pool channel",
++            exchange_group=self.exchange_group,
++            ipc=self._ipc,
++            shared=channel_buffers.owned_buffer,
++            local_error=init_error,
++            local_cleanup=abort_native_runtime,
++            detach_shared_ownership=detach_shared_ownership,
++        )
+         channel._bind_stream_key(stream_key)
+         self._all_channels.append(channel)
+         return channel
+ 
++    def prepare_channels(self, channel_ids: Sequence[str]) -> None:
++        """Collectively allocate named channels in canonical order.
++
++        Local CUDA stream handles are process-local and cannot identify a
++        distributed channel. Every rank may supply the same set in any order;
++        the sorted logical ids define identical IPC allocation order.
++        """
++
++        if self._channel_factory is None:
++            assert self.exchange_group is not None
++
++            def normalize_and_validate() -> tuple[str, ...]:
++                if self._closed:
++                    raise RuntimeError("pool is closed")
++                return tuple(
++                    sorted(
++                        {_normalize_logical_channel_id(value) for value in channel_ids}
++                    )
++                )
++
++            # Normalize and validate through a status collective first.  A
++            # rank-local empty/invalid id must not return or raise while peers
++            # enter the subsequent contract exchange or IPC allocation.
++            normalized = _run_collective_preallocation_setup(
++                owner="PCIe oneshot logical channel validation",
++                exchange_group=self.exchange_group,
++                setup=normalize_and_validate,
++            )
++            local_state = (normalized, tuple(sorted(self._logical_channels)))
++            gathered = _broadcast_gather_object(local_state, self.exchange_group)
++            if any(state != local_state for state in gathered):
++                raise RuntimeError(
++                    "PCIe oneshot logical channel preparation differs across "
++                    f"ranks: {gathered}"
++                )
++        else:
++            if self._closed:
++                raise RuntimeError("pool is closed")
++            normalized = tuple(
++                sorted({_normalize_logical_channel_id(value) for value in channel_ids})
++            )
++
++        if not normalized:
++            return
++
++        for channel_id in normalized:
++            if channel_id in self._logical_channels:
++                continue
++            self._logical_channels[channel_id] = self._new_channel(None)
++
+     def checkpoint_channels(
+         self,
+-    ) -> tuple[int, dict[int, PCIeOneshotAllReduce]]:
++    ) -> tuple[
++        int,
++        dict[int, PCIeOneshotAllReduce],
++        dict[str, PCIeOneshotAllReduce],
++        set[str],
++    ]:
+         """Snapshot channel ownership before a throwaway graph capture."""
+         if self._closed:
+             raise RuntimeError("pool is closed")
+         if self._capture_channel_stack:
+             raise RuntimeError("cannot checkpoint channels during capture")
+-        return len(self._all_channels), dict(self._channels)
++        return (
++            len(self._all_channels),
++            dict(self._channels),
++            dict(self._logical_channels),
++            set(self._captured_channel_ids),
++        )
+ 
+     def rollback_channels(
+         self,
+-        checkpoint: tuple[int, dict[int, PCIeOneshotAllReduce]],
++        checkpoint: tuple,
+     ) -> None:
+         """Close channels created after ``checkpoint`` and restore mappings.
+ 
+@@ -1122,15 +2821,25 @@ class PCIeOneshotAllReducePool:
+             raise RuntimeError("pool is closed")
+         if self._capture_channel_stack:
+             raise RuntimeError("cannot roll back channels during capture")
+-        all_channels_len, channels = checkpoint
++        if len(checkpoint) == 2:
++            all_channels_len, channels = checkpoint
++            logical_channels = dict(self._logical_channels)
++            captured_channel_ids = set(self._captured_channel_ids)
++        elif len(checkpoint) == 4:
++            (
++                all_channels_len,
++                channels,
++                logical_channels,
++                captured_channel_ids,
++            ) = checkpoint
++        else:
++            raise ValueError("invalid channel checkpoint")
+         if not 0 <= all_channels_len <= len(self._all_channels):
+             raise ValueError("channel checkpoint does not belong to this pool")
+ 
+         retained = self._all_channels[:all_channels_len]
+         retained_ids = {id(channel) for channel in retained}
+         transient = self._all_channels[all_channels_len:]
+-        self._all_channels = retained
+-        self._channels = dict(channels)
+ 
+         channels_to_close = tuple(
+             dict.fromkeys(
+@@ -1142,14 +2851,27 @@ class PCIeOneshotAllReducePool:
+             exchange_group=self.exchange_group,
+             device=self.device,
+         )
++        self._all_channels = retained
++        self._channels = dict(channels)
++        self._logical_channels = dict(logical_channels)
++        self._captured_channel_ids = set(captured_channel_ids)
+ 
+-    def for_stream(self, stream: object = None) -> PCIeOneshotAllReduce:
++    def for_stream(
++        self,
++        stream: object = None,
++        *,
++        channel_id: Optional[str] = None,
++    ) -> PCIeOneshotAllReduce:
+         if self._closed:
+             raise RuntimeError("pool is closed")
+         if self.single_channel:
+             channel = self._channels.get(0)
+             if channel is not None:
+                 return channel
++            if self._channel_factory is None:
++                channel = self._logical_channels[_SINGLE_CHANNEL_ID]
++                self._channels[0] = channel
++                return channel
+             if _is_current_stream_capturing(self.device):
+                 raise RuntimeError(
+                     "PCIe oneshot pool has no channel to reuse during CUDA graph "
+@@ -1162,12 +2884,40 @@ class PCIeOneshotAllReducePool:
+ 
+         stream_key = _current_stream_key(self.device, stream)
+         channel_key = 0 if stream_key is None else int(stream_key)
+-        if _is_current_stream_capturing(self.device) and self._capture_channel_stack:
+-            # CUDA and torch/Inductor may recycle a nested capture stream key
+-            # between independent target and draft graph managers. The active
+-            # enclosing capture owns the channel even if that key still maps
+-            # to a channel captured by an earlier manager.
++        if self._capture_channel_stack:
++            # The semantic capture scope starts before vLLM's eager graph
++            # warmup. Route that warmup through the graph-owned channel too,
++            # even though CUDA capture has not started yet. Once CUDA capture
++            # begins, torch/Inductor may replace the enclosing stream with an
++            # ephemeral nested capture stream; that key is deliberately not
++            # made the channel's permanent owner because graph replay runs on
++            # the enclosing stream.
+             channel = self._capture_channel_stack[-1]
++            if not _is_current_stream_capturing(self.device):
++                channel._bind_stream_key(stream_key)
++            self._channels[channel_key] = channel
++            return channel
++
++        if self._channel_factory is None:
++            if channel_id is None:
++                raise RuntimeError(
++                    "distributed PCIe oneshot eager use requires an explicit "
++                    "semantic channel_id shared by every rank"
++                )
++            logical_id = _normalize_logical_channel_id(channel_id)
++            channel = self._logical_channels.get(logical_id)
++            if channel is None:
++                raise RuntimeError(
++                    f"logical channel {logical_id!r} is not prepared; call "
++                    "prepare_channels() collectively before use"
++                )
++            mapped = self._channels.get(channel_key)
++            if mapped is not None and mapped is not channel:
++                raise RuntimeError(
++                    f"CUDA stream key {channel_key} is already bound to another "
++                    "logical PCIe oneshot channel"
++                )
++            channel._bind_stream_key(stream_key)
+             self._channels[channel_key] = channel
+             return channel
+         channel = self._channels.get(channel_key)
+@@ -1208,8 +2958,9 @@ class PCIeOneshotAllReducePool:
+         out: Optional[torch.Tensor] = None,
+         peer_input_ptrs: Optional[Sequence[int]] = None,
+         stream: object = None,
++        channel_id: Optional[str] = None,
+     ) -> torch.Tensor:
+-        channel = self.for_stream(stream)
++        channel = self.for_stream(stream, channel_id=channel_id)
+         if stream is not None and self.device.type == "cuda":
+             with torch.cuda.stream(stream):
+                 return channel.all_reduce(inp, out=out, peer_input_ptrs=peer_input_ptrs)
+@@ -1226,8 +2977,9 @@ class PCIeOneshotAllReducePool:
+         residual_out: Optional[torch.Tensor] = None,
+         peer_input_ptrs: Optional[Sequence[int]] = None,
+         stream: object = None,
++        channel_id: Optional[str] = None,
+     ) -> tuple[torch.Tensor, torch.Tensor]:
+-        channel = self.for_stream(stream)
++        channel = self.for_stream(stream, channel_id=channel_id)
+ 
+         def run() -> tuple[torch.Tensor, torch.Tensor]:
+             return channel.all_reduce_fused_add_rms_norm(
+@@ -1246,21 +2998,78 @@ class PCIeOneshotAllReducePool:
+         return run()
+ 
+     @contextmanager
+-    def capture(self, stream: object = None):
++    def capture(self, stream: object = None, *, channel_id: Optional[str] = None):
++        """Capture on a globally named channel.
++
++        An explicit id names an independently replayable graph. First use of
++        an unprepared explicit id is a collective convenience path: every rank
++        must enter with the same id or all ranks fail closed. Production
++        callers that know the full graph set should call prepare_channels()
++        once before capture; after that collective preparation, ranks may
++        capture members of the agreed catalog in different orders. Each graph
++        must still replay with its same-id peers using collectively compatible
++        kernel sequences and shapes.
++
++        Distributed pools require this semantic id. A local capture ordinal or
++        CUDA stream handle cannot distinguish target and draft graphs when
++        ranks construct them in a different order, so guessing is unsafe.
++        """
++        previous_channels: Optional[dict[int, PCIeOneshotAllReduce]] = None
++        if not self.single_channel and _is_current_stream_capturing(self.device):
++            raise RuntimeError(
++                "PCIe oneshot capture context must be entered before CUDA graph "
++                "capture starts"
++            )
+         if self.single_channel:
+-            channel = self.for_stream(stream)
++            channel = self.for_stream(
++                stream,
++                channel_id=_SINGLE_CHANNEL_ID if channel_id is None else channel_id,
++            )
++        elif self._channel_factory is None:
++            assert self.exchange_group is not None
++
++            def validate_capture_id() -> str:
++                if channel_id is None:
++                    raise RuntimeError(
++                        "distributed PCIe oneshot capture requires a stable "
++                        "semantic channel_id shared by every rank"
++                    )
++                logical_id = _normalize_logical_channel_id(channel_id)
++                if logical_id in self._captured_channel_ids:
++                    raise RuntimeError(
++                        f"logical channel {logical_id!r} was already captured; "
++                        "each independently replayable graph requires a unique id"
++                    )
++                return logical_id
++
++            logical_id = _run_collective_preallocation_setup(
++                owner="PCIe oneshot capture channel validation",
++                exchange_group=self.exchange_group,
++                setup=validate_capture_id,
++            )
++            needs_preparation = _collective_capture_needs_preparation(
++                owner="PCIe oneshot",
++                logical_id=logical_id,
++                prepared_channel_ids=self._logical_channels,
++                exchange_group=self.exchange_group,
++            )
++            if needs_preparation:
++                self.prepare_channels((logical_id,))
++            previous_channels = dict(self._channels)
++            stream_key = _current_stream_key(self.device, stream)
++            channel_key = 0 if stream_key is None else int(stream_key)
++            channel = self._logical_channels[logical_id]
++            channel._bind_stream_key(stream_key)
++            self._channels[channel_key] = channel
++            self._captured_channel_ids.add(logical_id)
+         else:
+-            if _is_current_stream_capturing(self.device):
+-                raise RuntimeError(
+-                    "PCIe oneshot capture context must be entered before CUDA "
+-                    "graph capture starts"
+-                )
+             stream_key = _current_stream_key(self.device, stream)
+             channel_key = 0 if stream_key is None else int(stream_key)
+             # A CUDA stream handle can be recycled after one graph manager
+             # finishes capture. Graphs retain the channel pointers, so a new
+             # manager must receive a fresh channel even when the numeric stream
+             # key is identical. _all_channels keeps replaced channels alive.
++            previous_channels = dict(self._channels)
+             channel = self._new_channel(stream_key)
+             self._channels[channel_key] = channel
+         with channel.capture(stream=stream):
+@@ -1271,22 +3080,50 @@ class PCIeOneshotAllReducePool:
+                 popped = self._capture_channel_stack.pop()
+                 if popped is not channel:
+                     raise RuntimeError("PCIe oneshot capture channel stack corrupted")
++                if previous_channels is not None:
++                    # Graph nodes retain this channel through _all_channels.
++                    # Restore every alias in strict LIFO order so nested or
++                    # recycled torch capture-stream keys cannot escape into a
++                    # later independent/unwrapped capture.
++                    for key, mapped in tuple(self._channels.items()):
++                        if mapped is not channel:
++                            continue
++                        previous = previous_channels.get(key)
++                        if previous is None:
++                            del self._channels[key]
++                        else:
++                            self._channels[key] = previous
+ 
+     def close(self) -> None:
+         if self._closed:
+             return
+-        self._closed = True
+         seen: set[int] = set()
++        channels = []
+         for channel in (*self._all_channels, *self._channels.values()):
+             if id(channel) not in seen:
+                 seen.add(id(channel))
+-                channel.close()
++                channels.append(channel)
++        _coordinated_close_channels(
++            channels,
++            exchange_group=self.exchange_group,
++            device=self.device,
++        )
++        self._closed = True
+         self._all_channels.clear()
+         self._channels.clear()
++        self._logical_channels.clear()
++        self._captured_channel_ids.clear()
+ 
+-    def __del__(self) -> None:
+-        with suppress(Exception):
+-            self.close()
++    def __del__(
++        self,
++        _quarantine: dict[int, object] = _ABANDONED_PCIE_RUNTIME_QUARANTINE,
++    ) -> None:
++        # A pool may be collected while graph or stream work still references
++        # its channels.  Keep the whole pool (and therefore every channel and
++        # rank_data tensor) alive; never unmap, synchronize, or communicate
++        # from GC. Explicit close() clears ownership before finalization.
++        if not getattr(self, "_closed", True):
++            _quarantine[id(self)] = self
+ 
+ 
+ __all__ = [
+diff --git a/sparkinfer/comm/pcie/pcie_twoshot.cu b/sparkinfer/comm/pcie/pcie_twoshot.cu
+index 0df42ec8abd4b2097ba18afc14e08d809ed07bdc..df272d0b6844dce8dcc56ae8d405ac29d0135c87 100644
+--- a/sparkinfer/comm/pcie/pcie_twoshot.cu
++++ b/sparkinfer/comm/pcie/pcie_twoshot.cu
+@@ -31,6 +31,7 @@
+ #include <torch/all.h>
+ #include <torch/extension.h>
+ 
++#include <algorithm>
+ #include <array>
+ #include <sstream>
+ #include <stdexcept>
+@@ -57,6 +58,8 @@ using FlagType = uint32_t;
+ constexpr int kFlagStride = 32;
+ 
+ struct Signal {
++  alignas(128) FlagType staging_generation;
++  FlagType active_staging_slot;
+   alignas(128) FlagType self_counter[kMaxBlocks][kMaxRanks];
+   alignas(128) FlagType peer_counter[2][kMaxBlocks][kMaxRanks * kFlagStride];
+ };
+@@ -65,6 +68,10 @@ struct __align__(16) RankPtrs {
+   void* __restrict__ ptrs[kMaxRanks];
+ };
+ 
++struct DoubleRankPtrs {
++  RankPtrs slots[2];
++};
++
+ struct RankSignals {
+   Signal* signals[kMaxRanks];
+ };
+@@ -81,6 +88,33 @@ static DINLINE FlagType ld_flag_relaxed(FlagType* flag_addr) {
+   return flag;
+ }
+ 
++static DINLINE FlagType ld_flag_relaxed_gpu(FlagType* flag_addr) {
++  FlagType flag;
++  asm volatile("ld.relaxed.gpu.global.u32 %0, [%1];" : "=r"(flag) : "l"(flag_addr) : "memory");
++  return flag;
++}
++
++__global__ void advance_staging_slot_kernel(Signal* self_sg) {
++  if (threadIdx.x == 0) {
++    const FlagType generation = self_sg->staging_generation;
++    self_sg->active_staging_slot = generation & FlagType{1};
++    self_sg->staging_generation = generation + FlagType{1};
++  }
++}
++
++template <int ngpus>
++DINLINE void select_rank_ptrs(RankPtrs& selected, const DoubleRankPtrs& options, Signal* self_sg) {
++  if (threadIdx.x == 0) {
++    // A one-CTA control kernel publishes the slot on this same stream before
++    // the worker launch. Kernel completion is the ordering edge, so every CTA
++    // observes one launch-wide slot without a grid rendezvous.
++    const int slot = int(ld_flag_relaxed_gpu(&self_sg->active_staging_slot) & FlagType{1});
++#pragma unroll
++    for (int peer = 0; peer < ngpus; ++peer) selected.ptrs[peer] = options.slots[slot].ptrs[peer];
++  }
++  __syncthreads();
++}
++
+ // Block-pairwise barrier: after it returns, all prior writes from every
+ // rank's block blockIdx.x are visible to this block.
+ template <int ngpus>
+@@ -146,9 +180,11 @@ DINLINE void block_range(int64_t total, int64_t& begin, int64_t& end) {
+ template <int ngpus>
+ __global__ void __launch_bounds__(512, 1) rs_fp8_kernel(
+     const Fp8Pack* __restrict__ src_payload, const float* __restrict__ src_scale,
+-    RankPtrs staging, int64_t pack_stride, int64_t scale_offset, int64_t scale_stride,
+-    RankSignals sg, Signal* self_sg, nv_bfloat16* __restrict__ out, int rank,
+-    int rows_per_rank, int row_elems) {
++    DoubleRankPtrs staging_options, int64_t pack_stride, int64_t scale_offset,
++    int64_t scale_stride, RankSignals sg, Signal* self_sg,
++    nv_bfloat16* __restrict__ out, int rank, int rows_per_rank, int row_elems) {
++  __shared__ RankPtrs staging;
++  select_rank_ptrs<ngpus>(staging, staging_options, self_sg);
+   const int packs_per_row = row_elems / 16;
+   const int64_t shard_packs = int64_t(rows_per_rank) * packs_per_row;
+   int64_t begin, end;
+@@ -200,9 +236,11 @@ __global__ void __launch_bounds__(512, 1) rs_fp8_kernel(
+ template <int ngpus>
+ __global__ void __launch_bounds__(512, 1) ag_fp8_kernel(
+     const Fp8Pack* __restrict__ src_payload, const float* __restrict__ src_scale,
+-    RankPtrs staging, int64_t pack_stride, int64_t scale_offset, int64_t scale_stride,
+-    RankSignals sg, Signal* self_sg, nv_bfloat16* __restrict__ out, int rank,
+-    int rows_per_rank, int row_elems) {
++    DoubleRankPtrs staging_options, int64_t pack_stride, int64_t scale_offset,
++    int64_t scale_stride, RankSignals sg, Signal* self_sg,
++    nv_bfloat16* __restrict__ out, int rank, int rows_per_rank, int row_elems) {
++  __shared__ RankPtrs staging;
++  select_rank_ptrs<ngpus>(staging, staging_options, self_sg);
+   const int packs_per_row = row_elems / 16;
+   const int64_t shard_packs = int64_t(rows_per_rank) * packs_per_row;
+   int64_t begin, end;
+@@ -256,12 +294,11 @@ class PCIeTwoShot {
+   RankSignals sg_;
+   Signal* self_sg_;
+ 
+-  RankPtrs staging_[2];
++  DoubleRankPtrs staging_;
+   int64_t pack_stride_;   // Fp8Packs per src region
+   int64_t scale_offset_;  // bytes
+   int64_t scale_stride_;  // floats per src region
+   int64_t max_shard_packs_;
+-  int slot_ = 0;
+ 
+   PCIeTwoShot(Signal** signals, const std::vector<std::array<void*, 2>>& staging,
+               int64_t pack_stride, int64_t scale_offset, int64_t scale_stride, int rank,
+@@ -275,7 +312,7 @@ class PCIeTwoShot {
+         max_shard_packs_(pack_stride) {
+     for (int i = 0; i < world_size_; i++) {
+       sg_.signals[i] = signals[i];
+-      for (int s = 0; s < 2; s++) staging_[s].ptrs[i] = staging[i][s];
++      for (int s = 0; s < 2; s++) staging_.slots[s].ptrs[i] = staging[i][s];
+     }
+   }
+ 
+@@ -306,40 +343,56 @@ class PCIeTwoShot {
+       throw std::runtime_error("pcie_twoshot scale capacity exceeded");
+   }
+ 
++  void check_launch_config(int threads, int block_limit) const {
++    if (threads < world_size_ || threads > 1024 || threads % 32 != 0)
++      throw std::runtime_error(
++          "pcie_twoshot threads must be a multiple of 32 in [world size, 1024]");
++    if (block_limit <= 0)
++      throw std::runtime_error("pcie_twoshot block limit must be positive");
++    if (block_limit > kMaxBlocks)
++      throw std::runtime_error("pcie_twoshot block limit exceeds signal capacity");
++  }
++
+   void reduce_scatter(cudaStream_t stream, const void* payload, const void* scale, void* out,
+                       int64_t num_rows, int64_t row_elems, int threads, int block_limit) {
++    check_launch_config(threads, block_limit);
+     if (num_rows % world_size_ != 0)
+       throw std::runtime_error("num_rows must be divisible by world size");
+     const int64_t rows_per_rank = num_rows / world_size_;
+     check_shard(rows_per_rank, row_elems);
+-    const int s = slot_ % 2;
+-    slot_++;
+     const int64_t shard_packs = rows_per_rank * (row_elems / 16);
+     int blocks =
+         std::max<int64_t>(1, std::min<int64_t>(block_limit, (shard_packs + threads - 1) / threads));
++    advance_staging_slot_kernel<<<1, 1, 0, stream>>>(self_sg_);
++    CHECK_CUDA_SUCCESS(cudaGetLastError());
+     dispatch([&](auto ng) {
+       constexpr int ngpus = decltype(ng)::value;
+       rs_fp8_kernel<ngpus><<<blocks, threads, 0, stream>>>(
+-          reinterpret_cast<const Fp8Pack*>(payload), reinterpret_cast<const float*>(scale),
+-          staging_[s], pack_stride_, scale_offset_, scale_stride_, sg_, self_sg_,
+-          reinterpret_cast<nv_bfloat16*>(out), rank_, int(rows_per_rank), int(row_elems));
++          reinterpret_cast<const Fp8Pack*>(payload),
++          reinterpret_cast<const float*>(scale), staging_, pack_stride_, scale_offset_,
++          scale_stride_, sg_, self_sg_, reinterpret_cast<nv_bfloat16*>(out), rank_,
++          int(rows_per_rank), int(row_elems));
++      CHECK_CUDA_SUCCESS(cudaGetLastError());
+     });
+   }
+ 
+   void all_gather(cudaStream_t stream, const void* payload, const void* scale, void* out,
+                   int64_t rows_per_rank, int64_t row_elems, int threads, int block_limit) {
++    check_launch_config(threads, block_limit);
+     check_shard(rows_per_rank, row_elems);
+-    const int s = slot_ % 2;
+-    slot_++;
+     const int64_t shard_packs = rows_per_rank * (row_elems / 16);
+     int blocks =
+         std::max<int64_t>(1, std::min<int64_t>(block_limit, (shard_packs + threads - 1) / threads));
++    advance_staging_slot_kernel<<<1, 1, 0, stream>>>(self_sg_);
++    CHECK_CUDA_SUCCESS(cudaGetLastError());
+     dispatch([&](auto ng) {
+       constexpr int ngpus = decltype(ng)::value;
+       ag_fp8_kernel<ngpus><<<blocks, threads, 0, stream>>>(
+-          reinterpret_cast<const Fp8Pack*>(payload), reinterpret_cast<const float*>(scale),
+-          staging_[s], pack_stride_, scale_offset_, scale_stride_, sg_, self_sg_,
+-          reinterpret_cast<nv_bfloat16*>(out), rank_, int(rows_per_rank), int(row_elems));
++          reinterpret_cast<const Fp8Pack*>(payload),
++          reinterpret_cast<const float*>(scale), staging_, pack_stride_, scale_offset_,
++          scale_stride_, sg_, self_sg_, reinterpret_cast<nv_bfloat16*>(out), rank_,
++          int(rows_per_rank), int(row_elems));
++      CHECK_CUDA_SUCCESS(cudaGetLastError());
+     });
+   }
+ };
+diff --git a/sparkinfer/comm/pcie/pcie_twoshot.py b/sparkinfer/comm/pcie/pcie_twoshot.py
+index b24717088053595e559e35c8069b54a78064968f..88b192d327bd5f4494cd06799636f66941b9845a 100644
+--- a/sparkinfer/comm/pcie/pcie_twoshot.py
++++ b/sparkinfer/comm/pcie/pcie_twoshot.py
+@@ -11,7 +11,6 @@ a runtime instance must not be shared concurrently across CUDA streams.
+ from __future__ import annotations
+ 
+ import os
+-from contextlib import suppress
+ from functools import lru_cache
+ from pathlib import Path
+ from typing import Optional, Sequence
+@@ -23,15 +22,24 @@ from torch.utils.cpp_extension import load
+ 
+ from ._cuda_ipc import CudaRTLibrary
+ from .pcie_oneshot import (
++    _ABANDONED_PCIE_RUNTIME_QUARANTINE,
+     IPC_SLAB_ALIGNMENT,
++    PCIeOneshotAllReduce,
++    _finish_collective_runtime_setup,
++    _raise_local_cleanup_errors,
+     _align_up,
+-    _broadcast_gather_object,
++    _coordinated_close_channels,
++    _cuda_device_index,
+     _normalize_device,
+     _OwnedSharedBuffer,
++    _require_collective_contract,
++    _require_full_grid_residency,
++    _run_collective_preallocation_setup,
+ )
+ 
+ SUPPORTED_WORLD_SIZES = (2, 4, 8)
+ FP8_MAX = 448.0
++TWOSHOT_REQUIRED_SMS = 64
+ 
+ 
+ @lru_cache(maxsize=1)
+@@ -59,8 +67,12 @@ def quantize_per_row(x: torch.Tensor) -> tuple[torch.Tensor, torch.Tensor]:
+ class PCIeTwoShotSP:
+     """Two-shot fp8-transport reduce_scatter / all_gather runtime."""
+ 
+-    def __init__(
+-        self,
++    def __init__(self, *args, **kwargs) -> None:
++        raise RuntimeError("use PCIeTwoShotSP.from_exchange_group()")
++
++    @classmethod
++    def _from_prepared_factory(
++        cls,
+         *,
+         rank: int,
+         world_size: int,
+@@ -69,9 +81,11 @@ class PCIeTwoShotSP:
+         fptr: int,
+         owned_buffers: Sequence[_OwnedSharedBuffer],
+         ipc: CudaRTLibrary,
++        exchange_group: ProcessGroup,
+         max_rows: int,
+         row_elems: int,
+-    ) -> None:
++    ) -> "PCIeTwoShotSP":
++        self = object.__new__(cls)
+         self.rank = rank
+         self.world_size = world_size
+         self.device = device
+@@ -79,9 +93,15 @@ class PCIeTwoShotSP:
+         self._fptr = fptr
+         self._owned_buffers = list(owned_buffers)
+         self._ipc = ipc
++        self.exchange_group = exchange_group
+         self.max_rows = max_rows
+         self.row_elems = row_elems
+         self._closed = False
++        self._ipc_imports_closed = False
++        self._ipc_exports_freed = False
++        self._coordinated_close_complete = False
++        self._closed_ipc_import_indices: set[tuple[int, int]] = set()
++        return self
+ 
+     @classmethod
+     def from_exchange_group(
+@@ -95,64 +115,107 @@ class PCIeTwoShotSP:
+     ) -> "PCIeTwoShotSP":
+         rank = dist.get_rank(group=exchange_group)
+         world_size = dist.get_world_size(group=exchange_group)
+-        if world_size not in SUPPORTED_WORLD_SIZES:
+-            raise ValueError(f"unsupported world size {world_size}")
+-        if row_elems % 16 != 0:
+-            raise ValueError("row_elems must be a multiple of 16")
+-        if max_rows % world_size != 0:
+-            raise ValueError("max_rows must be divisible by world size")
+-
+-        device_obj = _normalize_device(device)
+-        if device_obj.type != "cuda":
+-            raise ValueError("PCIe twoshot requires a CUDA device")
+-
+-        ipc = CudaRTLibrary()
+-        ipc.cudaSetDevice(device_obj.index or 0)
+-        ext = ext_module or _load_extension()
+-
+-        # Per-slot staging: [world][pack_stride] Fp8Packs then
+-        # [world][scale_stride] fp32 scales, regions 256B-aligned.
+-        max_rows_per_rank = max_rows // world_size
+-        packs_per_row = row_elems // 16
+-        pack_stride = _align_up(max_rows_per_rank * packs_per_row, 16)
+-        payload_bytes = world_size * pack_stride * 16
+-        scale_offset = _align_up(payload_bytes, IPC_SLAB_ALIGNMENT)
+-        scale_stride = _align_up(max_rows_per_rank, 64)
+-        slot_bytes = _align_up(
+-            scale_offset + world_size * scale_stride * 4, IPC_SLAB_ALIGNMENT
++
++        def validate_factory_arguments():
++            device_obj = _normalize_device(device)
++            normalized_max_rows = int(max_rows)
++            normalized_row_elems = int(row_elems)
++            if world_size not in SUPPORTED_WORLD_SIZES:
++                raise ValueError(f"unsupported world size {world_size}")
++            if device_obj.type != "cuda":
++                raise ValueError("PCIe twoshot requires a CUDA device")
++            if normalized_max_rows <= 0:
++                raise ValueError("max_rows must be positive")
++            if normalized_row_elems <= 0 or normalized_row_elems % 16 != 0:
++                raise ValueError("row_elems must be a positive multiple of 16")
++            if normalized_max_rows % world_size != 0:
++                raise ValueError("max_rows must be divisible by world size")
++            return device_obj, normalized_max_rows, normalized_row_elems
++
++        device_obj, max_rows, row_elems = _run_collective_preallocation_setup(
++            owner="PCIe twoshot argument validation",
++            exchange_group=exchange_group,
++            setup=validate_factory_arguments,
+         )
+-        signal_bytes = _align_up(int(ext.meta_size()), IPC_SLAB_ALIGNMENT)
+-        slab_bytes = signal_bytes + 2 * slot_bytes
+ 
+-        local_ptr = ipc.cudaMalloc(slab_bytes)
+-        owned: list[_OwnedSharedBuffer] = []
+-        try:
+-            # Signals must start zeroed.
+-            ipc.cudaMemset(local_ptr, 0, signal_bytes)
+-            local_handle = ipc.cudaIpcGetMemHandleBytes(local_ptr)
+-            handles = _broadcast_gather_object(local_handle, exchange_group)
+-
+-            peer_ptrs: list[int] = []
+-            remote_ptrs: list[int] = []
+-            for idx, handle in enumerate(handles):
+-                if idx == rank:
+-                    peer_ptrs.append(local_ptr)
+-                else:
+-                    remote_ptr = ipc.cudaIpcOpenMemHandleBytes(handle)
+-                    peer_ptrs.append(remote_ptr)
+-                    remote_ptrs.append(remote_ptr)
+-            owned.append(
+-                _OwnedSharedBuffer(
+-                    local_ptr=local_ptr,
+-                    peer_ptrs=tuple(peer_ptrs),
+-                    remote_ptrs=tuple(remote_ptrs),
+-                )
++        _require_full_grid_residency(
++            owner="PCIe twoshot",
++            required_sms=TWOSHOT_REQUIRED_SMS,
++            device=device_obj,
++            exchange_group=exchange_group,
++        )
++
++        def prepare():
++            prepared_ipc = CudaRTLibrary()
++            prepared_ipc.cudaSetDevice(_cuda_device_index(device_obj))
++            prepared_ext = ext_module or _load_extension()
++
++            # Per-slot staging: [world][pack_stride] Fp8Packs then
++            # [world][scale_stride] fp32 scales, regions 256B-aligned.
++            max_rows_per_rank = max_rows // world_size
++            packs_per_row = row_elems // 16
++            pack_stride = _align_up(max_rows_per_rank * packs_per_row, 16)
++            payload_bytes = world_size * pack_stride * 16
++            scale_offset = _align_up(payload_bytes, IPC_SLAB_ALIGNMENT)
++            scale_stride = _align_up(max_rows_per_rank, 64)
++            slot_bytes = _align_up(
++                scale_offset + world_size * scale_stride * 4, IPC_SLAB_ALIGNMENT
+             )
++            signal_bytes = _align_up(int(prepared_ext.meta_size()), IPC_SLAB_ALIGNMENT)
++            slab_bytes = signal_bytes + 2 * slot_bytes
++            return (
++                prepared_ipc,
++                prepared_ext,
++                pack_stride,
++                scale_offset,
++                scale_stride,
++                signal_bytes,
++                slot_bytes,
++                slab_bytes,
++            )
++
++        (
++            ipc,
++            ext,
++            pack_stride,
++            scale_offset,
++            scale_stride,
++            signal_bytes,
++            slot_bytes,
++            slab_bytes,
++        ) = _run_collective_preallocation_setup(
++            owner="PCIe twoshot",
++            exchange_group=exchange_group,
++            setup=prepare,
++        )
++        _require_collective_contract(
++            owner="PCIe twoshot channel layout",
++            exchange_group=exchange_group,
++            contract=(
++                int(max_rows),
++                int(row_elems),
++                int(pack_stride),
++                int(scale_offset),
++                int(scale_stride),
++                int(signal_bytes),
++                int(slab_bytes),
++            ),
++        )
+ 
+-            signal_ptrs = [p for p in peer_ptrs]
+-            staging0 = [p + signal_bytes for p in peer_ptrs]
+-            staging1 = [p + signal_bytes + slot_bytes for p in peer_ptrs]
++        shared = PCIeOneshotAllReduce._allocate_shared_buffer(
++            exchange_group,
++            slab_bytes,
++            zero_fill=True,
++            ipc=ipc,
++        )
++        peer_ptrs = list(shared.peer_ptrs)
++        signal_ptrs = peer_ptrs
++        staging0 = [p + signal_bytes for p in peer_ptrs]
++        staging1 = [p + signal_bytes + slot_bytes for p in peer_ptrs]
+ 
++        fptr = 0
++        init_error: BaseException | None = None
++        try:
+             fptr = ext.init_twoshot(
+                 signal_ptrs,
+                 staging0,
+@@ -162,25 +225,35 @@ class PCIeTwoShotSP:
+                 scale_stride,
+                 rank,
+             )
+-            return cls(
+-                rank=rank,
+-                world_size=world_size,
+-                device=device_obj,
+-                ext_module=ext,
+-                fptr=fptr,
+-                owned_buffers=owned,
+-                ipc=ipc,
+-                max_rows=max_rows,
+-                row_elems=row_elems,
+-            )
+-        except Exception:
+-            for shared in owned:
+-                for ptr in shared.remote_ptrs:
+-                    with suppress(Exception):
+-                        ipc.cudaIpcCloseMemHandle(ptr)
+-            with suppress(Exception):
+-                ipc.cudaFree(local_ptr)
+-            raise
++        except Exception as exc:
++            init_error = exc
++
++        def abort_native_runtime() -> None:
++            nonlocal fptr
++            if fptr:
++                ext.dispose(fptr)
++                fptr = 0
++
++        _finish_collective_runtime_setup(
++            owner="PCIe twoshot",
++            exchange_group=exchange_group,
++            ipc=ipc,
++            shared=shared,
++            local_error=init_error,
++            local_cleanup=abort_native_runtime,
++        )
++        return cls._from_prepared_factory(
++            rank=rank,
++            world_size=world_size,
++            device=device_obj,
++            ext_module=ext,
++            fptr=fptr,
++            owned_buffers=[shared],
++            ipc=ipc,
++            exchange_group=exchange_group,
++            max_rows=max_rows,
++            row_elems=row_elems,
++        )
+ 
+     def _check(self, payload: torch.Tensor, scale: torch.Tensor, rows: int) -> None:
+         if self._closed:
+@@ -240,16 +313,123 @@ class PCIeTwoShotSP:
+         self._ext.all_gather_fp8(self._fptr, payload, scale, out, threads, block_limit)
+         return out
+ 
+-    def close(self) -> None:
+-        if self._closed:
++    def _closed_import_indices(self) -> set[tuple[int, int]]:
++        closed = getattr(self, "_closed_ipc_import_indices", None)
++        if closed is None:
++            closed = set()
++            self._closed_ipc_import_indices = closed
++        return closed
++
++    def _all_python_ipc_imports_closed(self, closed: set[tuple[int, int]]) -> bool:
++        return all(
++            (buffer_index, remote_index) in closed
++            for buffer_index, shared in enumerate(self._owned_buffers)
++            for remote_index, _ in enumerate(shared.remote_ptrs)
++        )
++
++    def _close_ipc_imports_strict(self) -> None:
++        if self._ipc_imports_closed:
+             return
+         self._closed = True
+-        with suppress(Exception):
+-            self._ext.dispose(self._fptr)
+-        for shared in self._owned_buffers:
+-            for ptr in shared.remote_ptrs:
+-                with suppress(Exception):
++        failures: list[tuple[str, Exception]] = []
++        if self._fptr:
++            try:
++                self._ext.dispose(self._fptr)
++            except Exception as exc:
++                failures.append(("native runtime", exc))
++            else:
++                self._fptr = 0
++
++        closed = self._closed_import_indices()
++        for buffer_index, shared in enumerate(self._owned_buffers):
++            for remote_index, ptr in enumerate(shared.remote_ptrs):
++                key = (buffer_index, remote_index)
++                if key in closed:
++                    continue
++                try:
++                    self._ipc.cudaIpcCloseMemHandle(ptr)
++                except Exception as exc:
++                    failures.append((f"CUDA IPC import {ptr}", exc))
++                else:
++                    closed.add(key)
++
++        if (
++            not failures
++            and not self._fptr
++            and self._all_python_ipc_imports_closed(closed)
++        ):
++            self._ipc_imports_closed = True
++        if failures:
++            _raise_local_cleanup_errors("PCIe twoshot", "IPC import close", failures)
++
++    def _close_ipc_imports_best_effort(self) -> None:
++        if self._ipc_imports_closed:
++            return
++        self._closed = True
++        native_imports_closed = not self._fptr
++        if self._fptr:
++            try:
++                self._ext.dispose(self._fptr)
++            except Exception:
++                pass
++            else:
++                self._fptr = 0
++                native_imports_closed = True
++
++        closed = self._closed_import_indices()
++        for buffer_index, shared in enumerate(self._owned_buffers):
++            for remote_index, ptr in enumerate(shared.remote_ptrs):
++                key = (buffer_index, remote_index)
++                if key in closed:
++                    continue
++                try:
+                     self._ipc.cudaIpcCloseMemHandle(ptr)
+-            with suppress(Exception):
++                except Exception:
++                    pass
++                else:
++                    closed.add(key)
++
++        if (
++            native_imports_closed
++            and not self._fptr
++            and self._all_python_ipc_imports_closed(closed)
++        ):
++            self._ipc_imports_closed = True
++
++    def _free_ipc_exports_strict(self) -> None:
++        if self._ipc_exports_freed:
++            return
++        self._close_ipc_imports_strict()
++        failures: list[tuple[str, Exception]] = []
++        remaining = []
++        for shared in self._owned_buffers:
++            try:
+                 self._ipc.cudaFree(shared.local_ptr)
+-        self._owned_buffers.clear()
++            except Exception as exc:
++                remaining.append(shared)
++                failures.append((f"CUDA IPC export {shared.local_ptr}", exc))
++        self._owned_buffers = remaining
++        if not remaining:
++            self._ipc_exports_freed = True
++        if failures:
++            _raise_local_cleanup_errors("PCIe twoshot", "IPC export free", failures)
++
++    def close(self) -> None:
++        if getattr(self, "_coordinated_close_complete", False):
++            return
++        _coordinated_close_channels(
++            (self,),
++            exchange_group=self.exchange_group,
++            device=self.device,
++        )
++
++    def __del__(
++        self,
++        _quarantine: dict[int, object] = _ABANDONED_PCIE_RUNTIME_QUARANTINE,
++    ) -> None:
++        # GC cannot prove queued CUDA work is complete.  Explicit close() is the
++        # only path allowed to synchronize, unmap imports, and free exports.
++        if getattr(self, "_coordinated_close_complete", False):
++            return
++        if getattr(self, "_fptr", 0) or getattr(self, "_owned_buffers", ()):
++            _quarantine[id(self)] = self
+diff --git a/sparkinfer/moe/_shared/kernels/dynamic.py b/sparkinfer/moe/_shared/kernels/dynamic.py
+index b7f6191d61b4dbb4ed8ff3dc277ec63bdf5556a2..745efdc0572de5da9c6e002f81bd53792165908d 100644
+--- a/sparkinfer/moe/_shared/kernels/dynamic.py
++++ b/sparkinfer/moe/_shared/kernels/dynamic.py
+@@ -822,7 +822,11 @@ class MoEDynamicKernelBackend:
+             source_tile_m=materialized_source_tile_m,
+             deterministic_output=bool(deterministic_output),
+             num_topk=self.num_topk,
+-            activation=self.activation,
++            # This helper is gated-only and is never launched unless the split
++            # materialized path is active.  Use a valid inert specialization for
++            # non-split activations (notably ReLU2) instead of rejecting them
++            # during otherwise valid monolithic-kernel construction.
++            activation=self.activation if self.w4a8_split_materialized else "silu",
+         )
+         self.materialized_phase2_kernel = W4A8MaterializedPhase2Kernel(
+             source_tile_m=materialized_source_tile_m,
+@@ -1065,12 +1069,8 @@ class MoEDynamicKernelBackend:
+         # MMA dispatch selector: FP6/FP8 byte-containers are indistinguishable
+         # from FP8 by dtype, so pass the explicit sub-format string ("e4m3"/
+         # "e2m3"/"e3m2"); the native FP4 path keeps passing the operand dtype.
+-        self._mma_fmt_a = (
+-            self.mxfp6_fmt_a if self.mxfp6_fmt_a is not None else None
+-        )
+-        self._mma_fmt_b = (
+-            self.mxfp6_fmt_b if self.mxfp6_fmt_b is not None else None
+-        )
++        self._mma_fmt_a = self.mxfp6_fmt_a if self.mxfp6_fmt_a is not None else None
++        self._mma_fmt_b = self.mxfp6_fmt_b if self.mxfp6_fmt_b is not None else None
+         self.cta_layout_mnk = cute.make_layout(self.cluster_shape_mnk)
+         self.num_m_tiles = self.tile_shape_mnk[0] // (16 * self.atom_shape[0])
+         self.num_n_tiles = self.tile_shape_mnk[1] // (8 * self.atom_shape[1])
+@@ -1405,9 +1405,7 @@ class MoEDynamicKernelBackend:
+             beta = cutlass.Float32(SITU_DEFAULT_BETA)
+             linear_beta = cutlass.Float32(SITU_DEFAULT_LINEAR_BETA)
+             situ_gate = (
+-                beta
+-                * cute.math.tanh(gate / beta, fastmath=self.fast_math)
+-                * sigmoid
++                beta * cute.math.tanh(gate / beta, fastmath=self.fast_math) * sigmoid
+             )
+             situ_up = linear_beta * cute.math.tanh(
+                 up / linear_beta,
+@@ -2636,9 +2634,7 @@ class MoEDynamicKernelBackend:
+             # for the expansion (cute.recast_tensor strips sB's swizzle), and
+             # ``storage`` must not be referenced inside warp-dispatch branches,
+             # so only these Int32 addresses may cross into them.
+-            sB_packed = cute.make_tensor(
+-                storage.sB.data_ptr(), b_packed_smem_staged
+-            )
++            sB_packed = cute.make_tensor(storage.sB.data_ptr(), b_packed_smem_staged)
+             sB_up_packed = cute.make_tensor(
+                 storage.sB_up.data_ptr(), b_packed_smem_staged
+             )
+@@ -4196,15 +4192,7 @@ class MoEDynamicKernelBackend:
+             # region; A bufs in sA past the FC2-intermediate bytes; FC1
+             # residual bufs in sC (dead until the epilogue rendezvous); FC2
+             # residual bufs alias the (FC1-only) A-buf region.
+-            if cutlass.const_expr(self.w4a8_repacked):
+-                w4a8_sa0 = (
+-                    ctrl_base_addr
+-                    + Int32(Storage._offsets["sA"])
+-                    + Int32(self.tile_shape_mnk[0] * self.tile_shape_mnk[2])
+-                )
+-                w4a8_res0 = ctrl_base_addr + Int32(Storage._offsets["sC"])
+-                w4a8_res2 = w4a8_sa0
+-            elif cutlass.const_expr(self.w4a8_small):
++            if cutlass.const_expr(self.w4a8_repacked or self.w4a8_small):
+                 w4a8_sa0 = (
+                     ctrl_base_addr
+                     + Int32(Storage._offsets["sA"])
+@@ -5912,23 +5900,17 @@ class MoEDynamicKernelBackend:
+                                 zero_total = Int32(128) * sf_blocks_per_row
+                                 zero_idx = Int32(tidx)
+                                 while zero_idx < zero_total:
+-                                    st_shared_u8(
+-                                        sfa_base_addr + zero_idx, Uint8(0)
+-                                    )
++                                    st_shared_u8(sfa_base_addr + zero_idx, Uint8(0))
+                                     zero_idx += Int32(
+-                                        self.num_mma_warps
+-                                        * self.num_threads_per_warp
++                                        self.num_mma_warps * self.num_threads_per_warp
+                                     )
+                                 self.epilog_sync_barrier.arrive_and_wait()
+                                 zero_total_sa = Int32(128) * packed_cols
+                                 zsa_idx = Int32(tidx)
+                                 while zsa_idx < zero_total_sa:
+-                                    st_shared_u8(
+-                                        sa_base_addr + zsa_idx, Uint8(0)
+-                                    )
++                                    st_shared_u8(sa_base_addr + zsa_idx, Uint8(0))
+                                     zsa_idx += Int32(
+-                                        self.num_mma_warps
+-                                        * self.num_threads_per_warp
++                                        self.num_mma_warps * self.num_threads_per_warp
+                                     )
+                                 self.epilog_sync_barrier.arrive_and_wait()
+                             quant_gs_value = gs_value
+@@ -6015,9 +5997,7 @@ class MoEDynamicKernelBackend:
+                                             ]
+                                         )
+                                         values[elem_idx] = value
+-                                        block_max = fmax_f32(
+-                                            block_max, fabs_f32(value)
+-                                        )
++                                        block_max = fmax_f32(block_max, fabs_f32(value))
+                                     containers, scale_byte = (
+                                         moe_mxfp6_quantize_input_block_containers(
+                                             values,
+@@ -6036,9 +6016,7 @@ class MoEDynamicKernelBackend:
+                                     _row_flat = row * Int32(self.tile_shape_mnk[2])
+                                     for elem_idx in cutlass.range_constexpr(32):
+                                         _flat = (
+-                                            _row_flat
+-                                            + block_start
+-                                            + Int32(elem_idx)
++                                            _row_flat + block_start + Int32(elem_idx)
+                                         )
+                                         st_shared_u8(
+                                             sa_base_addr + (_flat ^ _row_sw),
+@@ -6058,9 +6036,7 @@ class MoEDynamicKernelBackend:
+                                             ]
+                                         )
+                                         values[elem_idx] = value
+-                                        block_max = fmax_f32(
+-                                            block_max, fabs_f32(value)
+-                                        )
++                                        block_max = fmax_f32(block_max, fabs_f32(value))
+ 
+                                     packed64 = Uint64(0)
+                                     scale_byte = Uint8(0)
+diff --git a/sparkinfer/moe/_shared/kernels/micro.py b/sparkinfer/moe/_shared/kernels/micro.py
+index 37bdd339fd7cd616c02c58aa33fe26ac474df25b..8892e215d878f3a9c7800d395a693326d3887c20 100644
+--- a/sparkinfer/moe/_shared/kernels/micro.py
++++ b/sparkinfer/moe/_shared/kernels/micro.py
+@@ -106,9 +106,7 @@ def _fp6_micro_enabled() -> bool:
+     Keeps the validated dynamic FP6 fused path as the only FP6 backend until
+     the micro kernel is wired into dispatch and numerically proven.
+     """
+-    return os.environ.get(
+-        "SPARKINFER_ENABLE_FP6_MICRO", "0"
+-    ).strip().lower() not in (
++    return os.environ.get("SPARKINFER_ENABLE_FP6_MICRO", "0").strip().lower() not in (
+         "",
+         "0",
+         "false",
+@@ -562,7 +560,11 @@ class MoEMicroKernelBackend:
+         col: Int32,
+         n_cols: Int32,
+     ) -> Float32:
+-        addr = base_addr + ebase + Int64(kb16) * Int64(n_cols) + Int64(col)
++        # ModelOpt's E4M3 scale permutation is tiled in 64 output rows. Direct
++        # micro preparation retains the final padded tile so every permuted
++        # logical scale remains addressable.
++        packed_n_cols = (n_cols + Int32(63)) & ~Int32(63)
++        addr = base_addr + ebase + Int64(kb16) * Int64(packed_n_cols) + Int64(col)
+         word = ld_global_nc_u32(addr & ~Int64(3))
+         byte = (word >> Uint32((addr & Int64(3)) * Int64(8))) & Uint32(0xFF)
+         return cvt_w4a16_packed_e4m3_scale_to_f32(byte)
+@@ -712,11 +714,32 @@ class MoEMicroKernelBackend:
+                 rows_per_warp_div = 4
+             elif cfg.k_segments_aligned and cfg.k_segments == 12 and self.is_gated:
+                 rows_per_warp_div = 1
+-            num_fc1_chunks = min(num_fc1_chunks, n // (rows_per_warp_div * _BLOCK_SIZE))
++            num_fc1_chunks = min(
++                num_fc1_chunks,
++                max(1, n // (rows_per_warp_div * _BLOCK_SIZE)),
++            )
++            # The retile cap is a floor division, so it can choose a chunk
++            # count that no longer partitions a merely 16-aligned native
++            # ModelOpt intermediate (for example, n=144 caps 9 chunks at 4,
++            # yielding a truncated 36-value chunk). Walk down to the largest
++            # valid divisor so every FC1 chunk covers whole 16-value blocks.
++            # Aligned production shapes retain their existing geometry.
++            while num_fc1_chunks > 1 and (
++                n % num_fc1_chunks != 0 or (n // num_fc1_chunks) % _BLOCK_SIZE != 0
++            ):
++                num_fc1_chunks -= 1
+         if self.w4a16_mode and m > 1:
+             # Keep W4A16 multi-token FC1 chunks narrow enough to stay within
+-            # the 512-thread launch register limit.
+-            num_fc1_chunks = max(num_fc1_chunks, n // (_BLOCK_SIZE * 2))
++            # the 512-thread launch register limit. The chunk count must still
++            # divide n into whole 16-value blocks: floor(n/32) silently made
++            # i_chunk non-integral at shapes such as n=144 (four 36-value
++            # chunks), so FC1 wrote only 128 of 144 logical values.
++            num_fc1_chunks = max(
++                num_fc1_chunks,
++                (n + (_BLOCK_SIZE * 2) - 1) // (_BLOCK_SIZE * 2),
++            )
++            while n % num_fc1_chunks != 0 or (n // num_fc1_chunks) % _BLOCK_SIZE != 0:
++                num_fc1_chunks += 1
+         if self.a8_mx_mode:
+             # Per-32 self-ranging blocks: chunks must hold whole 32-blocks
+             # (the default policy picks i_chunk=16 at m<=2).
+@@ -752,9 +775,7 @@ class MoEMicroKernelBackend:
+             # Likewise FC2 can expose every output-row task directly once
+             # FC1 has completed in a prior launch.
+             grid_x = max(1, fc2_tasks)
+-        elif m == 1:
+-            grid_x = max(1, min(int(max_active_ctas), max(fc1_tasks, fc2_tasks)))
+-        elif m == 2:
++        elif m in (1, 2):
+             grid_x = max(1, min(int(max_active_ctas), max(fc1_tasks, fc2_tasks)))
+         elif num_fc1_chunks < 16:
+             grid_x = max(1, min(int(max_active_ctas), fc2_tasks))
+@@ -815,11 +836,18 @@ class MoEMicroKernelBackend:
+         k_row1 = k_row0 + Int32(1)
+ 
+         lane_byte_off = Int64(lane) * Int64(4)
+-        n_u32_per_expert = Int32(cfg.fc2_n_chunks * 128)
+         sf_cols = Int32(cfg.w2_sf_cols)
+         num_cb = sf_cols >> Int32(2)
+         lane_cb = lane >> Int32(3)
+         w_valid = Int32(1) if lane_cb < num_cb else Int32(0)
++        if cutlass.const_expr(self.w4a16_mode and cfg.n % 64 != 0):
++            # Native ModelOpt rows contain exactly n/8 packed u32 values.
++            # w2_sf_cols is padded to four scale columns, so its control-block
++            # count overstates the physical W2/packed-scale extent when n is a
++            # multiple of 16 but not 64 (for example, n=144). Keep the existing
++            # predicate byte-for-byte for the aligned production shapes, and
++            # gate odd-shape loads against the logical packed row instead.
++            w_valid = Int32(1) if lane < Int32(cfg.n // 8) else Int32(0)
+         lane_mode_c = (lane >> Int32(1)) & Int32(3)
+         bsf_byte_shift = lane_mode_c * Int32(8)
+         out_acc0 = Float32(0.0)
+@@ -857,10 +885,38 @@ class MoEMicroKernelBackend:
+             row_mode_32_1 = k_row1 & Int32(31)
+ 
+             kk_off = Int32(kk) * Int32(128)
+-            xh0 = Uint32(intermediate[kk_off + Int32(0 * 32) + lane])
+-            xh1 = Uint32(intermediate[kk_off + Int32(1 * 32) + lane])
+-            xh2 = Uint32(intermediate[kk_off + Int32(2 * 32) + lane])
+-            xh3 = Uint32(intermediate[kk_off + Int32(3 * 32) + lane])
++            if cutlass.const_expr(cfg.n < 256):
++                # The 128-u32 swizzle block pads narrow intermediates to 256
++                # logical values. FC1 writes only n/8 lanes in each 32-lane
++                # plane. Mask the remaining lanes before the dot: their
++                # weights are zero, but stale NaN scratch would make 0*NaN
++                # contaminate the warp reduction.
++                inter_valid = Int32(1) if lane < Int32(cfg.n // 8) else Int32(0)
++                xh0 = (
++                    Uint32(intermediate[kk_off + Int32(0 * 32) + lane])
++                    if inter_valid > Int32(0)
++                    else Uint32(0)
++                )
++                xh1 = (
++                    Uint32(intermediate[kk_off + Int32(1 * 32) + lane])
++                    if inter_valid > Int32(0)
++                    else Uint32(0)
++                )
++                xh2 = (
++                    Uint32(intermediate[kk_off + Int32(2 * 32) + lane])
++                    if inter_valid > Int32(0)
++                    else Uint32(0)
++                )
++                xh3 = (
++                    Uint32(intermediate[kk_off + Int32(3 * 32) + lane])
++                    if inter_valid > Int32(0)
++                    else Uint32(0)
++                )
++            else:
++                xh0 = Uint32(intermediate[kk_off + Int32(0 * 32) + lane])
++                xh1 = Uint32(intermediate[kk_off + Int32(1 * 32) + lane])
++                xh2 = Uint32(intermediate[kk_off + Int32(2 * 32) + lane])
++                xh3 = Uint32(intermediate[kk_off + Int32(3 * 32) + lane])
+ 
+             u_packed0 = (
+                 ld_global_nc_u32(
+@@ -1058,12 +1114,23 @@ class MoEMicroKernelBackend:
+                 kk_off = Int32(kk) * n_u32_per_expert + chunk_base
+                 cb_idx = Int32(nc) * Int32(4) + lane_cb
+                 w_valid = Int32(1) if cb_idx < num_cb else Int32(0)
+-                # If the last 256-wide chunk overhangs a non-256-aligned n
+-                # (e.g. n=384), lanes past num_cb index the uninitialized
+-                # intermediate tail. The weight there is already masked to 0,
+-                # but 0 * NaN = NaN, so mask the activation read too. Gated by
+-                # constexpr so 256-aligned shapes emit no extra runtime work.
+-                if cutlass.const_expr((cfg.w2_sf_cols >> 2) < cfg.fc2_n_chunks * 4):
++                if cutlass.const_expr(self.w4a16_mode and cfg.n % 64 != 0):
++                    packed_u32 = Int32(nc * 32) + lane
++                    w_valid = Int32(1) if packed_u32 < Int32(cfg.n // 8) else Int32(0)
++                # If the last 256-value chunk overhangs logical n, lanes past
++                # the exact native row read an unwritten intermediate tail.
++                # The padded scale grid can look full at widths such as n=496,
++                # so its control-block count is not a valid activation bound.
++                # The weight is zero there, but 0 * NaN still poisons the sum.
++                # Preserve the legacy predicate for non-W4A16 modes and emit
++                # no extra work for 256-aligned native ModelOpt shapes.
++                if cutlass.const_expr(
++                    (self.w4a16_mode and cfg.n % 256 != 0)
++                    or (
++                        (not self.w4a16_mode)
++                        and (cfg.w2_sf_cols >> 2) < cfg.fc2_n_chunks * 4
++                    )
++                ):
+                     xh0 = (
+                         Uint32(intermediate[kk_off + Int32(0 * 32) + lane])
+                         if w_valid > Int32(0)
+@@ -1246,7 +1313,6 @@ class MoEMicroKernelBackend:
+         k_row3 = k_row0 + Int32(3)
+ 
+         lane_byte_off = Int64(lane) * Int64(4)
+-        n_u32_per_expert = Int32(cfg.fc2_n_chunks * 128)
+         token_inter_base = t * Int32(cfg.inter_u32)
+         sf_cols = Int32(cfg.w2_sf_cols)
+         num_cb = sf_cols >> Int32(2)
+@@ -1471,6 +1537,8 @@ class MoEMicroKernelBackend:
+         num_cb = sf_cols >> Int32(2)
+         lane_cb = lane >> Int32(3)
+         w_valid = Int32(1) if lane_cb < num_cb else Int32(0)
++        if cutlass.const_expr(self.w4a16_mode and cfg.n % 64 != 0):
++            w_valid = Int32(1) if lane < Int32(cfg.n // 8) else Int32(0)
+         lane_mode_c = (lane >> Int32(1)) & Int32(3)
+         bsf_byte_shift = lane_mode_c * Int32(8)
+         out_acc0 = Float32(0.0)
+@@ -1508,10 +1576,36 @@ class MoEMicroKernelBackend:
+             ebase_sf_packed_e4m3 = Int64(eid) * Int64((cfg.n // 16) * cfg.k_dim)
+ 
+             kk_off = token_inter_base + Int32(kk) * Int32(128)
+-            xh0 = Uint32(intermediate[kk_off + Int32(0 * 32) + lane])
+-            xh1 = Uint32(intermediate[kk_off + Int32(1 * 32) + lane])
+-            xh2 = Uint32(intermediate[kk_off + Int32(2 * 32) + lane])
+-            xh3 = Uint32(intermediate[kk_off + Int32(3 * 32) + lane])
++            if cutlass.const_expr(cfg.n < 256):
++                # Match the m==1 path above: the packed 128-u32 swizzle has
++                # unwritten padding whenever the logical intermediate is
++                # narrower than 256 values.
++                inter_valid = Int32(1) if lane < Int32(cfg.n // 8) else Int32(0)
++                xh0 = (
++                    Uint32(intermediate[kk_off + Int32(0 * 32) + lane])
++                    if inter_valid > Int32(0)
++                    else Uint32(0)
++                )
++                xh1 = (
++                    Uint32(intermediate[kk_off + Int32(1 * 32) + lane])
++                    if inter_valid > Int32(0)
++                    else Uint32(0)
++                )
++                xh2 = (
++                    Uint32(intermediate[kk_off + Int32(2 * 32) + lane])
++                    if inter_valid > Int32(0)
++                    else Uint32(0)
++                )
++                xh3 = (
++                    Uint32(intermediate[kk_off + Int32(3 * 32) + lane])
++                    if inter_valid > Int32(0)
++                    else Uint32(0)
++                )
++            else:
++                xh0 = Uint32(intermediate[kk_off + Int32(0 * 32) + lane])
++                xh1 = Uint32(intermediate[kk_off + Int32(1 * 32) + lane])
++                xh2 = Uint32(intermediate[kk_off + Int32(2 * 32) + lane])
++                xh3 = Uint32(intermediate[kk_off + Int32(3 * 32) + lane])
+ 
+             u_packed0 = (
+                 ld_global_nc_u32(
+@@ -1726,9 +1820,20 @@ class MoEMicroKernelBackend:
+                 chunk_base = Int32(nc) * Int32(128)
+                 cb_idx = Int32(nc) * Int32(4) + lane_cb
+                 w_valid = Int32(1) if cb_idx < num_cb else Int32(0)
++                if cutlass.const_expr(self.w4a16_mode and cfg.n % 64 != 0):
++                    packed_u32 = Int32(nc * 32) + lane
++                    w_valid = Int32(1) if packed_u32 < Int32(cfg.n // 8) else Int32(0)
+                 if cutlass.const_expr(nc + 1 < cfg.fc2_n_chunks):
+                     next_cb_idx = Int32(nc + 1) * Int32(4) + lane_cb
+-                    if next_cb_idx < num_cb:
++                    next_w_valid = Int32(1) if next_cb_idx < num_cb else Int32(0)
++                    if cutlass.const_expr(self.w4a16_mode and cfg.n % 64 != 0):
++                        next_packed_u32 = Int32((nc + 1) * 32) + lane
++                        next_w_valid = (
++                            Int32(1)
++                            if next_packed_u32 < Int32(cfg.n // 8)
++                            else Int32(0)
++                        )
++                    if next_w_valid > Int32(0):
+                         next_chunk_base = Int32(nc + 1) * Int32(128)
+                         prefetch_global_l2(
+                             w2_base_addr
+@@ -1766,7 +1871,12 @@ class MoEMicroKernelBackend:
+                         cfg.w2_sf_rows * cfg.w2_sf_cols
+                     )
+                     next_cb_idx = lane_cb
+-                    if next_cb_idx < num_cb:
++                    next_w_valid = Int32(1) if next_cb_idx < num_cb else Int32(0)
++                    if cutlass.const_expr(self.w4a16_mode and cfg.n % 64 != 0):
++                        next_w_valid = (
++                            Int32(1) if lane < Int32(cfg.n // 8) else Int32(0)
++                        )
++                    if next_w_valid > Int32(0):
+                         prefetch_global_l2(
+                             w2_base_addr
+                             + next_ebase_w
+@@ -1831,9 +1941,15 @@ class MoEMicroKernelBackend:
+                                 w2s_base_addr + next_ebase_sf + next_bsf_off3
+                             )
+                 kk_off = token_inter_base + Int32(kk) * n_u32_per_expert + chunk_base
+-                # See _m1_fc2_rowpair_wide: mask the intermediate tail read for
+-                # non-256-aligned n (0 weight * NaN tail = NaN). constexpr-gated.
+-                if cutlass.const_expr((cfg.w2_sf_cols >> 2) < cfg.fc2_n_chunks * 4):
++                # See _m1_fc2_rowpair_wide: logical n, not the padded scale
++                # grid, determines whether the native intermediate tail is live.
++                if cutlass.const_expr(
++                    (self.w4a16_mode and cfg.n % 256 != 0)
++                    or (
++                        (not self.w4a16_mode)
++                        and (cfg.w2_sf_cols >> 2) < cfg.fc2_n_chunks * 4
++                    )
++                ):
+                     xh0 = (
+                         Uint32(intermediate[kk_off + Int32(0 * 32) + lane])
+                         if w_valid > Int32(0)
+@@ -2366,8 +2482,11 @@ class MoEMicroKernelBackend:
+             # ---- FC1 weight load + dot product ----
+             ebase_w = Int64(eid) * Int64(cfg.two_n) * Int64(cfg.k_half)
+             ebase_sf = Int64(eid) * Int64(cfg.w1_sf_rows * cfg.w1_sf_cols)
+-            ebase_sf_packed = Int64(eid) * Int64((cfg.k_dim // 32) * cfg.two_n)
+-            ebase_sf_packed_e4m3 = Int64(eid) * Int64((cfg.k_dim // 16) * cfg.two_n)
++            e8m0_w1_n_cols = _align_up(cfg.two_n, 64)
++            ebase_sf_packed = Int64(eid) * Int64((cfg.k_dim // 32) * e8m0_w1_n_cols)
++            ebase_sf_packed_e4m3 = Int64(eid) * Int64(
++                (cfg.k_dim // 16) * _align_up(cfg.two_n, 64)
++            )
+             thread_byte_off = Int64(lane) * Int64(cfg.k_half // 32)
+             xh_buf_base = Int32(0)
+             if cutlass.const_expr(cfg.k_segments == 2):
+@@ -2537,7 +2656,7 @@ class MoEMicroKernelBackend:
+ 
+                         if cutlass.const_expr(self.scale_format_e8m0_k32):
+                             kbb = (lane * Int32(cfg.k_segments)) >> Int32(1)
+-                            nc1 = Int32(cfg.two_n)
++                            nc1 = Int32(e8m0_w1_n_cols)
+                             u_k0 = self._ld_e8m0_scale(
+                                 w1s_base_addr,
+                                 ebase_sf_packed,
+@@ -2661,7 +2780,7 @@ class MoEMicroKernelBackend:
+ 
+                     if cutlass.const_expr(self.scale_format_e8m0_k32):
+                         kbbg = (lane * Int32(cfg.k_segments)) >> Int32(1)
+-                        nc1g = Int32(cfg.two_n)
++                        nc1g = Int32(e8m0_w1_n_cols)
+                         g_k0 = self._ld_e8m0_scale(
+                             w1s_base_addr,
+                             ebase_sf_packed,
+@@ -2978,7 +3097,7 @@ class MoEMicroKernelBackend:
+                         sf_u5 = Float32(0.0)
+                         if cutlass.const_expr(self.scale_format_e8m0_k32):
+                             kbb_u = lane_seg_base >> Int32(1)
+-                            nc_u = Int32(cfg.two_n)
++                            nc_u = Int32(e8m0_w1_n_cols)
+                             u_k0 = self._ld_e8m0_scale(
+                                 w1s_base_addr,
+                                 ebase_sf_packed,
+@@ -3118,7 +3237,7 @@ class MoEMicroKernelBackend:
+                     sf_g5 = Float32(0.0)
+                     if cutlass.const_expr(self.scale_format_e8m0_k32):
+                         kbb_g = lane_seg_base >> Int32(1)
+-                        nc_g = Int32(cfg.two_n)
++                        nc_g = Int32(e8m0_w1_n_cols)
+                         g_k0 = self._ld_e8m0_scale(
+                             w1s_base_addr,
+                             ebase_sf_packed,
+@@ -3356,7 +3475,7 @@ class MoEMicroKernelBackend:
+ 
+                         if cutlass.const_expr(self.scale_format_e8m0_k32):
+                             kbb_u = (lane * Int32(cfg.k_segments)) >> Int32(1)
+-                            nc_u = Int32(cfg.two_n)
++                            nc_u = Int32(e8m0_w1_n_cols)
+                             u_k0 = self._ld_e8m0_scale(
+                                 w1s_base_addr,
+                                 ebase_sf_packed,
+@@ -3538,7 +3657,7 @@ class MoEMicroKernelBackend:
+ 
+                     if cutlass.const_expr(self.scale_format_e8m0_k32):
+                         kbb_g = (lane * Int32(cfg.k_segments)) >> Int32(1)
+-                        nc_g = Int32(cfg.two_n)
++                        nc_g = Int32(e8m0_w1_n_cols)
+                         g_k0 = self._ld_e8m0_scale(
+                             w1s_base_addr,
+                             ebase_sf_packed,
+@@ -3833,7 +3952,7 @@ class MoEMicroKernelBackend:
+                                 ebase_sf_packed,
+                                 lane,
+                                 row_u,
+-                                Int32(cfg.two_n),
++                                Int32(e8m0_w1_n_cols),
+                                 Int32(cfg.k_dim // 32),
+                             )
+                             sf_u1 = sf_u0
+@@ -3869,7 +3988,7 @@ class MoEMicroKernelBackend:
+                             ebase_sf_packed,
+                             lane,
+                             row_g,
+-                            Int32(cfg.two_n),
++                            Int32(e8m0_w1_n_cols),
+                             Int32(cfg.k_dim // 32),
+                         )
+                         sf_g1 = sf_g0
+@@ -4363,7 +4482,7 @@ class MoEMicroKernelBackend:
+                                         ebase_sf_packed,
+                                         scale_col >> Int32(1),
+                                         row_g,
+-                                        Int32(cfg.two_n),
++                                        Int32(e8m0_w1_n_cols),
+                                         Int32(cfg.k_dim // 32),
+                                     )
+                                     if valid_seg > Int32(0)
+@@ -4420,7 +4539,7 @@ class MoEMicroKernelBackend:
+                                             ebase_sf_packed,
+                                             scale_col >> Int32(1),
+                                             row_u,
+-                                            Int32(cfg.two_n),
++                                            Int32(e8m0_w1_n_cols),
+                                             Int32(cfg.k_dim // 32),
+                                         )
+                                         if valid_seg > Int32(0)
+diff --git a/sparkinfer/moe/_shared/kernels/w4a16/host.py b/sparkinfer/moe/_shared/kernels/w4a16/host.py
+index b7970ade5661db0690106998fd241166220f312a..40c3eecd5e2804e427498778c9adb6bc41e555f6 100644
+--- a/sparkinfer/moe/_shared/kernels/w4a16/host.py
++++ b/sparkinfer/moe/_shared/kernels/w4a16/host.py
+@@ -219,6 +219,20 @@ def select_route_block_size_m(m: int, topk: int, num_experts: int) -> int:
+     return _W4A16_ALLOWED_ROUTED_SIZES[-1]
+ 
+ 
++def route_block_sizes_for_capacity(
++    max_tokens: int,
++    topk: int,
++    num_experts: int,
++) -> tuple[int, ...]:
++    """Conservative block-size set reachable within a token capacity."""
++    max_tokens = max(int(max_tokens), 1)
++    first = select_route_block_size_m(1, topk, num_experts)
++    last = select_route_block_size_m(max_tokens, topk, num_experts)
++    first_idx = _W4A16_ALLOWED_ROUTED_SIZES.index(first)
++    last_idx = _W4A16_ALLOWED_ROUTED_SIZES.index(last)
++    return _W4A16_ALLOWED_ROUTED_SIZES[first_idx : last_idx + 1]
++
++
+ def max_packed_route_slots(numel: int, block_size: int, num_experts: int) -> int:
+     max_packed_routes = int(numel) + int(num_experts) * (int(block_size) - 1)
+     if int(numel) < int(num_experts):
+@@ -240,6 +254,27 @@ def route_pack_token_capacity(tokens: int, topk: int) -> int:
+     return 1 << (max(int(tokens), 1) - 1).bit_length()
+ 
+ 
++def route_pack_capacity(
++    numel: int,
++    block_size: int,
++    num_experts: int,
++    *,
++    topk: int = 1,
++    bucket_tokens: bool = True,
++) -> tuple[int, int, int]:
++    """Return the canonical routed-row, packed-slot, and block capacities."""
++    numel_capacity = (
++        route_pack_numel_capacity(numel, topk=topk)
++        if bucket_tokens
++        else max(int(numel), 1)
++    )
++    packed_routes = max_packed_route_slots(
++        numel_capacity, int(block_size), int(num_experts)
++    )
++    route_blocks = (packed_routes + int(block_size) - 1) // int(block_size)
++    return max(numel_capacity, 1), max(packed_routes, 1), max(route_blocks, 1)
++
++
+ def max_w4a16_route_capacity(routed_rows: int, num_experts: int) -> tuple[int, int]:
+     route_slots = 0
+     route_blocks = 0
+@@ -424,6 +459,7 @@ __all__ = [
+     "plan_w4a16_buffers",
+     "reorder_w13_to_gate_up",
+     "route_pack_numel_capacity",
++    "route_pack_capacity",
+     "route_pack_token_capacity",
+     "select_route_block_size_m",
+     "unswizzle_block_scale",
+diff --git a/sparkinfer/moe/_shared/kernels/w4a16/kernel.py b/sparkinfer/moe/_shared/kernels/w4a16/kernel.py
+index fc4ac543722370258c5452cec10732bf50654dcc..bcd4cca463eb0070863ef74238ac7e82248ada79 100644
+--- a/sparkinfer/moe/_shared/kernels/w4a16/kernel.py
++++ b/sparkinfer/moe/_shared/kernels/w4a16/kernel.py
+@@ -6527,9 +6527,7 @@ class W4A16TopKSumKernel:
+                         v1 = fc2_flat[base + Int32(1)].to(cutlass.Float32)
+                         v2 = fc2_flat[base + Int32(2)].to(cutlass.Float32)
+                         v3 = fc2_flat[base + Int32(3)].to(cutlass.Float32)
+-                        h0, h1, h2, h3 = self._had128_quad(
+-                            v0, v1, v2, v3, lane
+-                        )
++                        h0, h1, h2, h3 = self._had128_quad(v0, v1, v2, v3, lane)
+                         if cutlass.const_expr(self.broadcast_svh):
+                             sbase = col0
+                         else:
+@@ -7054,6 +7052,7 @@ def compile_w4a16_fused_moe(
+     full_rotation: bool = False,
+     rotation_input_dtype: str | None = None,
+     broadcast_suh: bool = False,
++    _require_cached: bool = False,
+ ) -> W4A16FusedMoeCompileResult:
+     scale_format = _normalize_scale_format(scale_format)
+     intermediate_rotation = bool(intermediate_rotation)
+@@ -7433,6 +7432,13 @@ def compile_w4a16_fused_moe(
+             max_m_blocks=max_m_blocks,
+             blocks_per_sm=kernel.blocks_per_sm,
+         )
++    if _require_cached:
++        raise RuntimeError(
++            "W4A16 fused MoE launch is not resolved for CUDA graph capture "
++            f"(m={size_m}, moe_block_size={moe_block_size}, "
++            f"max_m_blocks={max_m_blocks}); run an eager warmup at this token "
++            "count before capturing"
++        )
+ 
+     if (not collect_activation_amax) and _small_m_direct_supported(
+         m=size_m,
+@@ -8545,9 +8551,7 @@ def _w4a16_fused_moe_launch_flat(
+             )
+         suh_gate_arg = suh_gate_table.reshape(-1)
+         suh_up_arg = suh_up_table.reshape(-1)
+-        broadcast_suh = (
+-            num_experts > 1 and suh_gate_arg.numel() == hidden_size
+-        )
++        broadcast_suh = num_experts > 1 and suh_gate_arg.numel() == hidden_size
+         if broadcast_suh != (suh_up_arg.numel() == hidden_size):
+             raise ValueError(
+                 "suh gate/up tables must both be per-expert or both broadcast"
+@@ -9737,6 +9741,23 @@ def _resolve_route_block_size_m(
+     return compiled
+ 
+ 
++def _w4a16_stream_is_capturing(
++    stream: cuda.CUstream,
++    *,
++    current_stream: cuda.CUstream,
++) -> bool:
++    """Observe capture on either Torch's current stream or an explicit stream."""
++    current_capturing = torch.cuda.is_current_stream_capturing()
++    if current_capturing or int(stream) == int(current_stream):
++        return current_capturing
++    result, status = cuda.cuStreamIsCapturing(stream)
++    if result != cuda.CUresult.CUDA_SUCCESS:
++        raise RuntimeError(
++            f"cuStreamIsCapturing failed for the selected W4A16 stream: {result}"
++        )
++    return int(status) != 0
++
++
+ def run_w4a16_moe(
+     a_input: torch.Tensor,
+     prepared,
+@@ -10005,7 +10026,8 @@ def run_w4a16_moe(
+     if block_size_m not in _ALLOWED_ROUTED_SIZES:
+         raise ValueError(f"unsupported W4A16 moe_block_size={block_size_m}")
+ 
+-    stream = current_cuda_stream() if stream is None else stream
++    current_stream = current_cuda_stream()
++    stream = current_stream if stream is None else stream
+     if (not collect_activation_amax) and _small_m_direct_supported(
+         m=m,
+         hidden_size=hidden_size,
+@@ -10274,6 +10296,10 @@ def run_w4a16_moe(
+             intermediate_rotation=intermediate_rotation_scales is not None,
+             full_rotation=full_rotation,
+             rotation_input_dtype=rotation_input_dtype,
++            _require_cached=_w4a16_stream_is_capturing(
++                stream,
++                current_stream=current_stream,
++            ),
+         )
+     else:
+         if int(fused_launch.size_m) < m:
+diff --git a/sparkinfer/moe/_shared/kernels/w4a16/prepare.py b/sparkinfer/moe/_shared/kernels/w4a16/prepare.py
+index 66cd8f634a6631487b8e3f550623f6d9d4bf223b..cc2fb2b96b41b493bda5ffdd84920cbf1fe86b47 100644
+--- a/sparkinfer/moe/_shared/kernels/w4a16/prepare.py
++++ b/sparkinfer/moe/_shared/kernels/w4a16/prepare.py
+@@ -669,6 +669,7 @@ def _permute_nvfp4_scales(
+     size_n: int,
+     a_dtype: torch.dtype,
+     row_rotation: int | None = None,
++    output_size_n: int | None = None,
+ ) -> tuple[torch.Tensor, torch.Tensor]:
+     combined_scale_factor = _nvfp4_compute_scale_factor(scales, a_dtype)
+     packed_scales: torch.Tensor | None = None
+@@ -684,6 +685,7 @@ def _permute_nvfp4_scales(
+             size_k=size_k,
+             size_n=size_n,
+             group_size=16,
++            output_size_n=output_size_n,
+         )
+         expert_packed = _process_nvfp4_packed_scales(
+             expert_scales,
+@@ -697,8 +699,9 @@ def _permute_nvfp4_scales(
+             )
+         packed_scales[expert].copy_(expert_packed)
+     if packed_scales is None:
++        packed_size_n = int(size_n) if output_size_n is None else int(output_size_n)
+         packed_scales = torch.empty(
+-            (0, size_k // _PACKED_TILE_SIZE, size_n // 2),
++            (0, size_k // _PACKED_TILE_SIZE, packed_size_n // 2),
+             dtype=torch.float8_e4m3fn,
+             device=scales.device,
+         )
+@@ -1098,6 +1101,24 @@ def prepare_w4a16_modelopt_native_weights(
+         size_n=hidden_size,
+         a_dtype=params_dtype,
+     )
++    micro_w13_scale = packed_w13_scale
++    micro_w13_global_scale = packed_w13_global_scale
++    if w13_rows % _PACKED_TILE_N_SIZE != 0:
++        # The direct micro reader uses the native 64-row scale permutation.
++        # Keep the final tile intact: truncating it after permutation discards
++        # logical rows whose permuted columns land above ``w13_rows``.
++        micro_scale_n = (
++            (w13_rows + _PACKED_TILE_N_SIZE - 1) // _PACKED_TILE_N_SIZE
++        ) * _PACKED_TILE_N_SIZE
++        micro_w13_scale, micro_w13_global_scale = _permute_nvfp4_scales(
++            w13_scale,
++            native_w13_global_scale,
++            size_k=hidden_size,
++            size_n=w13_rows,
++            a_dtype=params_dtype,
++            row_rotation=w13_row_rotation,
++            output_size_n=micro_scale_n,
++        )
+ 
+     return W4A16ModelOptWeights(
+         w13=w13_fp4,
+@@ -1113,9 +1134,9 @@ def prepare_w4a16_modelopt_native_weights(
+         is_gated=is_gated,
+         params_dtype=params_dtype,
+         source_format=source_format,
+-        micro_w13_scale=packed_w13_scale,
++        micro_w13_scale=micro_w13_scale,
+         micro_w13_global_scale=_process_nvfp4_micro_global_scale_from_packed(
+-            packed_w13_global_scale,
++            micro_w13_global_scale,
+             a_dtype=params_dtype,
+         ),
+         micro_w2_scale=packed_w2_scale,
+@@ -1162,9 +1183,12 @@ def prepare_w4a16_e8m0_native_weights(
+     w13_rows = shape.w13_rows
+     is_gated = shape.is_gated
+     allow_w2_k_tail = intermediate_size % 32 != 0
+-    padded_w13_scale_n = (
+-        _e8m0_logical_tail_scale_n(w13_rows) if allow_w2_k_tail else w13_rows
+-    )
++    # Packed E8M0 scale rows are permuted in 64-row blocks independently of
++    # whether W2 has a compact K tail.  Ungated 32-aligned intermediates such
++    # as I=224 therefore still need W13's 224 scale rows padded to 256; tying
++    # this padding to ``allow_w2_k_tail`` advertised the direct shape and then
++    # rejected it during preparation.
++    padded_w13_scale_n = _e8m0_logical_tail_scale_n(w13_rows)
+ 
+     w13_scale = _validate_e8m0_k32_scales(
+         w13_e8m0_scale,
+diff --git a/sparkinfer/moe/_shared/kernels/w4a16/route_pack.py b/sparkinfer/moe/_shared/kernels/w4a16/route_pack.py
+index 580078413cbe34599615d9904c7235f73146a4bf..c93236d85499cd383054d98842c3d286e4c9067d 100644
+--- a/sparkinfer/moe/_shared/kernels/w4a16/route_pack.py
++++ b/sparkinfer/moe/_shared/kernels/w4a16/route_pack.py
+@@ -6,10 +6,7 @@ import triton
+ import triton.language as tl
+ import torch
+ 
+-from sparkinfer.moe._shared.kernels.w4a16.host import (
+-    max_packed_route_slots,
+-    route_pack_numel_capacity,
+-)
++from sparkinfer.moe._shared.kernels.w4a16.host import route_pack_capacity
+ 
+ 
+ _COUNT_BLOCK_T = 256
+@@ -306,25 +303,28 @@ def pack_topk_routes_by_expert(
+ ) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor]:
+     numel = int(topk_ids.numel())
+     topk = int(topk_ids.shape[-1]) if topk_ids.ndim >= 2 else 1
+-    numel_capacity = route_pack_numel_capacity(numel, topk=topk)
+-    capacity_packed_routes = max_packed_route_slots(
+-        numel_capacity, int(block_size), int(num_experts)
+-    )
+-    capacity_route_blocks = (capacity_packed_routes + int(block_size) - 1) // int(
+-        block_size
++    numel_capacity, capacity_packed_routes, capacity_route_blocks = route_pack_capacity(
++        numel,
++        int(block_size),
++        int(num_experts),
++        topk=topk,
+     )
+     if packed_route_indices is not None and block_expert_ids is not None:
+         if (
+             int(packed_route_indices.numel()) < capacity_packed_routes
+             or int(block_expert_ids.numel()) < capacity_route_blocks
+         ):
+-            numel_capacity = numel
+-            capacity_packed_routes = max_packed_route_slots(
+-                numel, int(block_size), int(num_experts)
++            (
++                numel_capacity,
++                capacity_packed_routes,
++                capacity_route_blocks,
++            ) = route_pack_capacity(
++                numel,
++                int(block_size),
++                int(num_experts),
++                topk=topk,
++                bucket_tokens=False,
+             )
+-            capacity_route_blocks = (
+-                capacity_packed_routes + int(block_size) - 1
+-            ) // int(block_size)
+     max_packed_routes = capacity_packed_routes
+     max_route_blocks = capacity_route_blocks
+     max_packed_routes = max(max_packed_routes, 1)
+@@ -339,10 +339,7 @@ def pack_topk_routes_by_expert(
+     if (
+         provided_routes is not None
+         and provided_blocks is not None
+-        and (
+-            provided_routes < max_packed_routes
+-            or provided_blocks < max_route_blocks
+-        )
++        and (provided_routes < max_packed_routes or provided_blocks < max_route_blocks)
+     ):
+         raise ValueError(
+             "W4A16 route-packing workspace is too small: "
+diff --git a/sparkinfer/moe/ep_moe/_impl.py b/sparkinfer/moe/ep_moe/_impl.py
+index f1df49f4cbe9c9fb4a6adbd5b00c1f926e171da6..cd8e7ade4de404dc3a4eee6e17482f262f7a9bce 100644
+--- a/sparkinfer/moe/ep_moe/_impl.py
++++ b/sparkinfer/moe/ep_moe/_impl.py
+@@ -32,9 +32,9 @@ from sparkinfer.moe._shared.kernels.activations import (
+     moe_activation_w1_rows,
+ )
+ from sparkinfer.moe._shared.kernels.w4a16.host import (
+-    _W4A16_ALLOWED_ROUTED_SIZES,
+     max_packed_route_slots,
+     packed_gemm_scratch_elements,
++    route_block_sizes_for_capacity,
+     route_pack_token_capacity,
+ )
+ 
+@@ -379,7 +379,12 @@ def plan_ep_moe_scratch(caps: EPMoEScratchCaps) -> EPMoEScratchPlan:
+     route_blocks = 1
+     fc1_tmp = 1
+     fc2_tmp = 1
+-    for block_size in _W4A16_ALLOWED_ROUTED_SIZES:
++    block_sizes = route_block_sizes_for_capacity(
++        caps.max_tokens,
++        caps.num_topk,
++        caps.global_num_experts,
++    )
++    for block_size in block_sizes:
+         slots = max_packed_route_slots(
+             route_capacity_rows,
+             int(block_size),
+diff --git a/sparkinfer/moe/fused_moe/__init__.py b/sparkinfer/moe/fused_moe/__init__.py
+index f53f77b1515d2fcf362262c8259a1150981cb75f..18241439854217c30292dea98b233d3a41a99182 100644
+--- a/sparkinfer/moe/fused_moe/__init__.py
++++ b/sparkinfer/moe/fused_moe/__init__.py
+@@ -14,6 +14,8 @@ Runtime lifecycle:
+     ``plan(Caps)`` -> ``bind`` / ``bind_sparse`` / ``bind_route``
+     (allocation-free views) -> ``run`` / ``run_sparse`` / ``route``
+     (CUDA-graph capture safe)
++``required_nbytes(Caps)`` prices that scratch without compiling launches or
++retaining storage.
+ ``route_topk`` is a standalone one-shot top-k router; ``run_sparse`` fuses
+ gate -> top-k -> experts from router logits.
+ 
+@@ -52,6 +54,7 @@ META = OpMeta(
+         "Routing",
+         "WeightsPlan",
+         "plan",
++        "required_nbytes",
+         "plan_execution",
+         "plan_weights",
+         "prepare_weights",
+@@ -101,6 +104,7 @@ if TYPE_CHECKING:  # static analysis only; runtime resolution is lazy
+         clear_caches,
+         is_supported,
+         plan,
++        required_nbytes,
+         plan_execution,
+         plan_weights,
+         prepare_weights,
+diff --git a/sparkinfer/moe/fused_moe/_impl.py b/sparkinfer/moe/fused_moe/_impl.py
+index 185419719a9c7ae7bd9e59358c5b7f3dd172c976..1a79107cc133530754f02173f1b403216f0e806e 100644
+--- a/sparkinfer/moe/fused_moe/_impl.py
++++ b/sparkinfer/moe/fused_moe/_impl.py
+@@ -861,9 +861,7 @@ class TPMoEScratchPlan:
+     _prewarmed_fused_launches: tuple[tuple[int, object], ...] = field(
+         default=(), repr=False
+     )
+-    _prewarmed_topk_sum_launches: tuple[
+-        tuple[torch.dtype, bool, object], ...
+-    ] = field(
++    _prewarmed_topk_sum_launches: tuple[tuple[torch.dtype, bool, object], ...] = field(
+         default=(), repr=False
+     )
+ 
+@@ -2533,11 +2531,14 @@ def _plan_core_workspace(
+     )
+     if implementation == "w4a16":
+         from sparkinfer.moe._shared.kernels.w4a16.host import (
+-            _W4A16_ALLOWED_ROUTED_SIZES,
+             max_packed_route_slots,
+             packed_gemm_scratch_elements,
++            route_block_sizes_for_capacity,
++            select_route_block_size_m,
+         )
+         from sparkinfer.moe._shared.kernels.w4a16.kernel import (
++            _MAX_DIRECT_TOPK_ROUTE_M,
++            _TC_DECODE_MAX_M,
+             _small_m_direct_supported,
+         )
+ 
+@@ -2552,8 +2553,9 @@ def _plan_core_workspace(
+             if w4a16_weight_layout is not None
+             else _w4a16_weight_layout_for_source(source_format)
+         )
+-        route_E = int(route_num_experts or weight_E)
++        requested_route_E = int(route_num_experts or weight_E)
+         full_rotation = weight_layout == "trellis3_t256"
++        route_E = requested_route_E if full_rotation else int(weight_E)
+         if full_rotation:
+             if source_format != "exl3_trellis_mcg":
+                 raise ValueError(
+@@ -2574,10 +2576,31 @@ def _plan_core_workspace(
+         fc1_c_tmp_elements = 1
+         fc2_c_tmp_elements = 1
+         sms = max(1, int(get_num_sm(device)))
++        topk = max(int(num_topk), 1)
++        token_capacity = (routed_capacity + topk - 1) // topk
++        direct_route_slots_by_block: dict[int, int] = {}
++        if weight_layout == "packed":
++            direct_m_cap = _MAX_DIRECT_TOPK_ROUTE_M
++            if dtype == torch.bfloat16 and is_gated_moe_activation(activation):
++                direct_m_cap = _TC_DECODE_MAX_M
++            for direct_m in range(1, min(token_capacity, direct_m_cap) + 1):
++                direct_block_size = (
++                    int(w4a16_block_size_m)
++                    if w4a16_block_size_m is not None
++                    else select_route_block_size_m(direct_m, topk, route_E)
++                )
++                direct_route_slots_by_block[direct_block_size] = max(
++                    direct_route_slots_by_block.get(direct_block_size, 0),
++                    direct_m * topk * direct_block_size,
++                )
+         block_sizes = (
+             (int(w4a16_block_size_m),)
+             if w4a16_block_size_m is not None
+-            else _W4A16_ALLOWED_ROUTED_SIZES
++            else route_block_sizes_for_capacity(
++                max_tokens=token_capacity,
++                topk=topk,
++                num_experts=route_E,
++            )
+         )
+         for block_size in block_sizes:
+             route_slots = max_packed_route_slots(
+@@ -2585,6 +2608,10 @@ def _plan_core_workspace(
+                 int(block_size),
+                 route_E,
+             )
++            scratch_route_slots = max(
++                route_slots,
++                direct_route_slots_by_block.get(int(block_size), 0),
++            )
+             route_blocks = (route_slots + int(block_size) - 1) // int(block_size)
+             route_slots_capacity = max(route_slots_capacity, route_slots)
+             route_blocks_capacity = max(route_blocks_capacity, route_blocks)
+@@ -2592,7 +2619,7 @@ def _plan_core_workspace(
+                 fc1_c_tmp_elements,
+                 packed_gemm_scratch_elements(
+                     size_n=fc1_cols,
+-                    route_slots=route_slots,
++                    route_slots=scratch_route_slots,
+                     moe_block_size=int(block_size),
+                     sms=sms,
+                 ),
+@@ -2601,7 +2628,7 @@ def _plan_core_workspace(
+                 fc2_c_tmp_elements,
+                 packed_gemm_scratch_elements(
+                     size_n=int(k),
+-                    route_slots=route_slots,
++                    route_slots=scratch_route_slots,
+                     moe_block_size=int(block_size),
+                     sms=sms,
+                 ),
+@@ -6185,9 +6212,7 @@ def _plan_full_rotation_w4a16_launches(
+     if torch.cuda.is_current_stream_capturing():
+         raise RuntimeError("Trellis launch planning cannot run during capture")
+ 
+-    from sparkinfer.moe._shared.kernels.w4a16.host import (
+-        max_packed_route_slots,
+-    )
++    from sparkinfer.moe._shared.kernels.w4a16.host import route_pack_capacity
+     from sparkinfer.moe._shared.kernels.w4a16.kernel import (
+         _DEFAULT_MAX_SHARED_MEM,
+         compile_w4a16_fused_moe,
+@@ -6202,12 +6227,10 @@ def _plan_full_rotation_w4a16_launches(
+         )
+     block_size_m = int(core_plan.route_block_size_m)
+     weight_layout = _normalize_w4a16_weight_layout(
+-        caps.w4a16_weight_layout
+-        or _w4a16_weight_layout_for_source(caps.source_format)
++        caps.w4a16_weight_layout or _w4a16_weight_layout_for_source(caps.source_format)
+     )
+     scale_format = _normalize_w4a16_scale_format(
+-        caps.w4a16_scale_format
+-        or _w4a16_scale_format_for_source(caps.source_format)
++        caps.w4a16_scale_format or _w4a16_scale_format_for_source(caps.source_format)
+     )
+     if weight_layout != "trellis3_t256" or scale_format != "e4m3_k32":
+         raise RuntimeError(
+@@ -6216,14 +6239,13 @@ def _plan_full_rotation_w4a16_launches(
+             f"got weight_layout={weight_layout!r}, scale_format={scale_format!r}"
+         )
+     w13_layout = "trellis3_t256_proj"
+-    capacity_route_slots = max_packed_route_slots(
++    _, capacity_route_slots, capacity_m_blocks = route_pack_capacity(
+         capacity_tokens * core_plan.num_topk,
+         block_size_m,
+         core_plan.route_E,
++        topk=core_plan.num_topk,
++        bucket_tokens=False,
+     )
+-    capacity_m_blocks = (
+-        capacity_route_slots + block_size_m - 1
+-    ) // block_size_m
+     rotation_input_dtype = _w4a16_element_dtype(core_plan.dtype)
+ 
+     with torch.cuda.device(core_plan.device):
+@@ -6365,14 +6387,16 @@ def _plan_full_rotation_w4a16_launches(
+     return fused_launches, topk_sum_launches
+ 
+ 
+-def plan_tp_moe_scratch(caps: TPMoEScratchCaps) -> TPMoEScratchPlan:
+-    deterministic_output = caps.deterministic_output
++def _plan_tp_moe_arena_layout_from_caps(
++    caps: TPMoEScratchCaps,
++    *,
++    deterministic_output: bool | None = None,
++) -> TPMoEArenaLayout:
++    if not isinstance(caps, TPMoEScratchCaps):
++        raise TypeError("caps must be a TPMoEScratchCaps")
+     if deterministic_output is None:
+-        deterministic_output = _dynamic_deterministic_output_enabled(
+-            quant_mode=caps.quant_mode,
+-            device=torch.device(caps.device),
+-        )
+-    layout = plan_tp_moe_arena_layout(
++        deterministic_output = caps.deterministic_output
++    return plan_tp_moe_arena_layout(
+         max_tokens=caps.max_tokens,
+         num_topk=caps.num_topk,
+         device=caps.device,
+@@ -6389,6 +6413,19 @@ def plan_tp_moe_scratch(caps: TPMoEScratchCaps) -> TPMoEScratchPlan:
+         deterministic_output=deterministic_output,
+         w4a16_block_size_m=caps.w4a16_block_size_m,
+     )
++
++
++def tp_moe_required_nbytes(caps: TPMoEScratchCaps) -> int:
++    """Return the planned arena bytes without compiling launches or retaining storage."""
++    return _plan_tp_moe_arena_layout_from_caps(caps).total_nbytes
++
++
++def plan_tp_moe_scratch(caps: TPMoEScratchCaps) -> TPMoEScratchPlan:
++    deterministic_output = caps.deterministic_output
++    layout = _plan_tp_moe_arena_layout_from_caps(
++        caps,
++        deterministic_output=deterministic_output,
++    )
+     capacity_tokens = max(layout.core_token_counts or (int(caps.max_tokens),))
+     launch_plan = plan_tp_moe_execution(
+         num_tokens=capacity_tokens,
+@@ -6497,7 +6534,7 @@ def _prewarm_w4a16_planned_launches(
+     collect_activation_amax = bool(collect_activation_amax)
+ 
+     from sparkinfer.moe._shared.kernels.w4a16.host import (
+-        max_packed_route_slots,
++        route_pack_capacity,
+         select_route_block_size_m,
+     )
+     from sparkinfer.moe._shared.kernels.w4a16.kernel import (
+@@ -6543,12 +6580,13 @@ def _prewarm_w4a16_planned_launches(
+                 token_count, workspace.num_topk, workspace.route_E
+             )
+             routed_rows = int(token_count) * int(workspace.num_topk)
+-            route_slots = max_packed_route_slots(
++            _, _, max_m_blocks = route_pack_capacity(
+                 routed_rows,
+                 block_size_m,
+                 workspace.route_E,
++                topk=workspace.num_topk,
++                bucket_tokens=not full_rotation,
+             )
+-            max_m_blocks = (route_slots + block_size_m - 1) // block_size_m
+             t_shape = time.perf_counter() if _SPARKINFER_TIMING else 0.0
+             fused_key = (
+                 weight_layout,
+@@ -6610,9 +6648,9 @@ def _prewarm_w4a16_planned_launches(
+                                 broadcast_svh=broadcast_svh,
+                             )
+                             if not broadcast_svh:
+-                                topk_sum_launches[
+-                                    (token_count, ids_dtype, mapped)
+-                                ] = resolved_topk_sum
++                                topk_sum_launches[(token_count, ids_dtype, mapped)] = (
++                                    resolved_topk_sum
++                                )
+             else:
+                 topk_sum_launches[token_count] = compile_w4a16_topk_sum(
+                     m=token_count,
+diff --git a/sparkinfer/moe/fused_moe/api.py b/sparkinfer/moe/fused_moe/api.py
+index 5aa30de8a602601967ca64734264c62c393772a1..1c57ad6dbf48ca2571ace1bd4a88ae4155a48948 100644
+--- a/sparkinfer/moe/fused_moe/api.py
++++ b/sparkinfer/moe/fused_moe/api.py
+@@ -51,6 +51,9 @@ from ._impl import (
+ from ._impl import (
+     plan_tp_moe_scratch as plan,
+ )
++from ._impl import (
++    tp_moe_required_nbytes as required_nbytes,
++)
+ from ._impl import (
+     prepare_sparkinfer_fp4_moe_weights as prepare_weights,
+ )
+@@ -91,6 +94,7 @@ __all__ = [
+     "Routing",
+     "WeightsPlan",
+     "plan",
++    "required_nbytes",
+     "plan_execution",
+     "plan_weights",
+     "prepare_weights",
+diff --git a/tests/_lib/test_compile_cache.py b/tests/_lib/test_compile_cache.py
+index 2356cf379f3b159fc9d9da6d8d84ce237b0805f5..71ccf28ba2ec524a01df5330112300ebcdfff2dd 100644
+--- a/tests/_lib/test_compile_cache.py
++++ b/tests/_lib/test_compile_cache.py
+@@ -274,7 +274,7 @@ def test_uuid_unavailable_disables_disk_cache(monkeypatch):
+     assert not compiler._cute_compile_disk_cache_enabled_for_payload(payload)
+ 
+ 
+-def test_explicit_memory_cache_hit_skips_disk_payload(monkeypatch):
++def test_explicit_memory_cache_hit_skips_freeze_and_disk_payload(monkeypatch):
+     cute = pytest.importorskip("cutlass.cute")
+     compile_callable = object()
+     compiled = object()
+@@ -299,14 +299,55 @@ def test_explicit_memory_cache_hit_skips_disk_payload(monkeypatch):
+             AssertionError("memory hit rebuilt the disk payload")
+         ),
+     )
+-
+-    assert (
+-        compiler.compile(
+-            test_explicit_memory_cache_hit_skips_disk_payload,
+-            compile_spec=compile_spec,
++    runtime_control = importlib.import_module("sparkinfer._lib.runtime_control")
++
++    runtime_control.freeze_kernel_resolution("cached compile remains launchable")
++    try:
++        assert (
++            compiler.compile(
++                test_explicit_memory_cache_hit_skips_freeze_and_disk_payload,
++                compile_spec=compile_spec,
++            )
++            is compiled
+         )
+-        is compiled
++    finally:
++        runtime_control.unfreeze_kernel_resolution()
++
++
++def test_frozen_memory_miss_rejects_before_disk_cache_load(monkeypatch):
++    cute = pytest.importorskip("cutlass.cute")
++    runtime_control = importlib.import_module("sparkinfer._lib.runtime_control")
++    compile_spec = compiler.KernelCompileSpec.from_facts(
++        "test.freeze.disk_hit",
++        1,
++        ("rows", 8),
+     )
++    monkeypatch.setattr(cute, "compile", object())
++    monkeypatch.setattr(compiler, "_memory_cache_get", lambda _key: None)
++    monkeypatch.setattr(
++        compiler,
++        "_compile_disk_cache_payload",
++        lambda *_args, **_kwargs: (_ for _ in ()).throw(
++            AssertionError("frozen miss built a persistent-cache payload")
++        ),
++    )
++    monkeypatch.setattr(
++        compiler,
++        "_load_cute_compile_from_disk",
++        lambda _key: (_ for _ in ()).throw(
++            AssertionError("frozen miss loaded a persistent module")
++        ),
++    )
++
++    runtime_control.freeze_kernel_resolution("disk hits must not bypass freeze")
++    try:
++        with pytest.raises(runtime_control.KernelResolutionFrozenError):
++            compiler.compile(
++                test_frozen_memory_miss_rejects_before_disk_cache_load,
++                compile_spec=compile_spec,
++            )
++    finally:
++        runtime_control.unfreeze_kernel_resolution()
+ 
+ 
+ def test_v6_semantic_payload_matches_independent_validators(monkeypatch):
+diff --git a/tests/attention/test_compressed_mla.py b/tests/attention/test_compressed_mla.py
+index 68f76befd353716d4c69f02f0c82c9e3ea4e81b0..37b20d875d81c193b04973f3570b424a97a0d4ba 100644
+--- a/tests/attention/test_compressed_mla.py
++++ b/tests/attention/test_compressed_mla.py
+@@ -1,13 +1,28 @@
+ from __future__ import annotations
+ 
+ import math
++from collections.abc import Callable
+ 
+ import pytest
+ import torch
+ 
++from sparkinfer.attention._shared.mla.compressed_api import (
++    _validate_compressed_cache_layout,
++)
++from sparkinfer.attention._shared.mla.kernel import (
++    _cache_block_stride_bytes as _decode_cache_block_stride_bytes,
++)
++from sparkinfer.attention._shared.mla.prefill import (
++    _cache_block_stride_bytes as _prefill_cache_block_stride_bytes,
++)
++from sparkinfer.attention._shared.mla.prefill_mg import (
++    _cache_block_stride_bytes as _prefill_mg_cache_block_stride_bytes,
++)
+ from sparkinfer.attention._shared.mla.compressed_reference import (
++    COMPRESSED_MLA_BYTES_PER_TOKEN,
+     COMPRESSED_MLA_C128_PAGE_SIZE,
+     COMPRESSED_MLA_DSV4_PAGE_SIZE,
++    compressed_mla_page_nbytes,
+     compressed_sparse_mla_reference,
+     pack_compressed_mla_kv_cache_reference,
+ )
+@@ -28,6 +43,68 @@ _LOCAL_Q_HEADS = 32
+ _SM_SCALE = 1.0 / math.sqrt(_COMPRESSED_HEAD_DIM)
+ 
+ 
++@pytest.mark.parametrize("page_size", [16, 64, 256])
++def test_compressed_mla_layout_accepts_contiguous_and_padded_pages(
++    page_size: int,
++) -> None:
++    payload_nbytes = page_size * COMPRESSED_MLA_BYTES_PER_TOKEN
++    padded_nbytes = compressed_mla_page_nbytes(page_size)
++
++    _validate_compressed_cache_layout(
++        torch.empty((2, payload_nbytes), dtype=torch.uint8),
++        page_size=page_size,
++        name="cache",
++    )
++    _validate_compressed_cache_layout(
++        torch.empty((2, padded_nbytes), dtype=torch.uint8),
++        page_size=page_size,
++        name="cache",
++    )
++
++
++def test_compressed_mla_layout_rejects_short_page() -> None:
++    payload_nbytes = COMPRESSED_MLA_C128_PAGE_SIZE * COMPRESSED_MLA_BYTES_PER_TOKEN
++    with pytest.raises(ValueError, match="contiguous payload"):
++        _validate_compressed_cache_layout(
++            torch.empty((2, payload_nbytes - 1), dtype=torch.uint8),
++            page_size=COMPRESSED_MLA_C128_PAGE_SIZE,
++            name="cache",
++        )
++
++
++@pytest.mark.parametrize(
++    "stride_fn,kwargs",
++    [
++        (_decode_cache_block_stride_bytes, {"model_type": 0}),
++        (_prefill_cache_block_stride_bytes, {"model_type": 0}),
++        (_prefill_mg_cache_block_stride_bytes, {"is_glm": False}),
++    ],
++)
++@pytest.mark.parametrize("padded", [False, True])
++def test_compressed_mla_dispatch_uses_physical_page_stride(
++    stride_fn: Callable[..., int],
++    kwargs: dict[str, object],
++    padded: bool,
++) -> None:
++    payload_nbytes = COMPRESSED_MLA_DSV4_PAGE_SIZE * COMPRESSED_MLA_BYTES_PER_TOKEN
++    physical_nbytes = (
++        compressed_mla_page_nbytes(COMPRESSED_MLA_DSV4_PAGE_SIZE)
++        if padded
++        else payload_nbytes
++    )
++    storage = torch.empty(2 * physical_nbytes, dtype=torch.uint8)
++    cache = torch.as_strided(
++        storage,
++        size=(2, payload_nbytes),
++        stride=(physical_nbytes, 1),
++    )
++
++    assert (
++        stride_fn(cache, page_size=COMPRESSED_MLA_DSV4_PAGE_SIZE, **kwargs)
++        == physical_nbytes
++    )
++
++
+ def _make_split_merge_tensors(
+     *,
+     rows: int,
+diff --git a/tests/comm/test_pcie.py b/tests/comm/test_pcie.py
+index b1b045c788d9aabceec6cf74357b2ce643c25a04..a9ed9b6d61a5d6a447d08a5de886712fc5485f52 100644
+--- a/tests/comm/test_pcie.py
++++ b/tests/comm/test_pcie.py
+@@ -103,6 +103,7 @@ def _make_runtime(
+     if eager:
+         kwargs["eager_buffer_ptrs0"] = tuple(range(200, 200 + world_size))
+         kwargs["eager_buffer_ptrs1"] = tuple(range(300, 300 + world_size))
++        kwargs["eager_buffer_bytes"] = max_size
+     return PCIeOneshotAllReduce(
+         rank=rank,
+         world_size=world_size,
+diff --git a/tests/comm/test_pcie_collective_validation_gpu.py b/tests/comm/test_pcie_collective_validation_gpu.py
+new file mode 100644
+index 0000000000000000000000000000000000000000..c571299293f43b57ad6f351b71131e4add27a043
+--- /dev/null
++++ b/tests/comm/test_pcie_collective_validation_gpu.py
+@@ -0,0 +1,108 @@
++from __future__ import annotations
++
++import os
++import socket
++from datetime import timedelta
++
++import pytest
++import torch
++import torch.distributed as dist
++import torch.multiprocessing as mp
++
++from sparkinfer.comm.pcie.pcie_dcp_a2a import PCIeDCPA2A
++from sparkinfer.comm.pcie.pcie_oneshot import PCIeOneshotAllReduce
++from sparkinfer.comm.pcie.pcie_twoshot import PCIeTwoShotSP
++
++
++def _free_port() -> int:
++    with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as sock:
++        sock.bind(("127.0.0.1", 0))
++        return int(sock.getsockname()[1])
++
++
++def _expect_collective_rejection(operation) -> None:
++    with pytest.raises(RuntimeError, match="argument validation"):
++        operation()
++    # Prove every rank left the same failed setup round and can enter the next.
++    dist.barrier()
++
++
++def _worker(rank: int, world_size: int, port: int) -> None:
++    torch.cuda.set_device(rank)
++    device = torch.device("cuda", rank)
++    dist.init_process_group(
++        "nccl",
++        init_method=f"tcp://127.0.0.1:{port}",
++        rank=rank,
++        world_size=world_size,
++        timeout=timedelta(seconds=90),
++    )
++    group = dist.group.WORLD
++    try:
++        _expect_collective_rejection(
++            lambda: PCIeOneshotAllReduce.from_exchange_group(
++                exchange_group=group,
++                device=device,
++                eager_buffer_bytes=1 << 20,
++                max_size=(2 << 20) if rank == 0 else (1 << 20),
++                ext_module=object(),
++            )
++        )
++        _expect_collective_rejection(
++            lambda: PCIeDCPA2A.from_exchange_group(
++                exchange_group=group,
++                device=device,
++                max_batch_size=8,
++                total_heads=16,
++                head_dim=64,
++                query_head_dim=7 if rank == 0 else 64,
++                ext_module=object(),
++            )
++        )
++        _expect_collective_rejection(
++            lambda: PCIeDCPA2A.from_exchange_group(
++                exchange_group=group,
++                device=torch.device("cpu") if rank == 0 else device,
++                max_batch_size=8,
++                total_heads=16,
++                head_dim=64,
++                ext_module=object(),
++            )
++        )
++        _expect_collective_rejection(
++            lambda: PCIeTwoShotSP.from_exchange_group(
++                exchange_group=group,
++                device=device,
++                max_rows=8,
++                row_elems=17 if rank == 0 else 16,
++                ext_module=object(),
++            )
++        )
++        _expect_collective_rejection(
++            lambda: PCIeOneshotAllReduce(
++                rank=1 if rank == 0 else rank,
++                world_size=world_size,
++                device=device,
++                signal_ptrs=tuple(0 for _ in range(world_size)),
++                exchange_group=group,
++                ext_module=object(),
++            )
++        )
++    finally:
++        dist.destroy_process_group()
++
++
++def test_asymmetric_argument_failures_reject_all_ranks_before_ipc() -> None:
++    if os.getenv("SPARKINFER_PCIE_TEST_COLLECTIVE_VALIDATION") != "1":
++        pytest.skip("set the collective-validation GPU gate to run this test")
++    if not torch.cuda.is_available():
++        pytest.skip("CUDA is unavailable")
++    world_size = 2
++    if torch.cuda.device_count() < world_size:
++        pytest.skip("two CUDA devices are required")
++    mp.spawn(
++        _worker,
++        args=(world_size, _free_port()),
++        nprocs=world_size,
++        join=True,
++    )
+diff --git a/tests/comm/test_pcie_control_node_benchmark_contract.py b/tests/comm/test_pcie_control_node_benchmark_contract.py
+new file mode 100644
+index 0000000000000000000000000000000000000000..9c005afc3aa9fbdcdc3255c97216b838ff8ea609
+--- /dev/null
++++ b/tests/comm/test_pcie_control_node_benchmark_contract.py
+@@ -0,0 +1,133 @@
++from __future__ import annotations
++
++import ast
++import math
++import os
++import signal
++import subprocess
++import sys
++from contextlib import suppress
++from pathlib import Path
++from typing import Sequence
++
++import pytest
++
++
++_ROOT = Path(__file__).resolve().parents[2]
++
++
++def test_benchmark_prepares_distinct_stable_eager_and_graph_channels() -> None:
++    source = (
++        _ROOT / "benchmarks" / "benchmark_pcie_oneshot_control_node.py"
++    ).read_text(encoding="utf-8")
++
++    assert 'eager_channel_id = "eager:control-node-benchmark"' in source
++    assert 'graph_channel_id = "graph:control-node-benchmark"' in source
++    assert "pool.prepare_channels((eager_channel_id, graph_channel_id))" in source
++    assert "pool.for_stream(stream, channel_id=eager_channel_id)" in source
++    assert "pool.capture(stream, channel_id=graph_channel_id)" in source
++
++
++def _load_functions(relative_path: str, names: set[str]) -> dict[str, object]:
++    path = _ROOT / relative_path
++    tree = ast.parse(path.read_text(encoding="utf-8"), filename=str(path))
++    selected = [
++        node
++        for node in tree.body
++        if isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef))
++        and node.name in names
++    ]
++    assert {node.name for node in selected} == names
++    module = ast.Module(body=selected, type_ignores=[])
++    ast.fix_missing_locations(module)
++    namespace: dict[str, object] = {
++        "math": math,
++        "METRICS": ("mean_us", "p50_us", "p95_us"),
++        "os": os,
++        "Path": Path,
++        "Sequence": Sequence,
++        "signal": signal,
++        "subprocess": subprocess,
++        "suppress": suppress,
++    }
++    exec(compile(module, str(path), "exec"), namespace)
++    return namespace
++
++
++def test_distributed_critical_path_uses_aligned_iteration_maxima() -> None:
++    worker = _load_functions(
++        "benchmarks/benchmark_pcie_oneshot_control_node.py",
++        {"_summary", "_distributed_critical_path"},
++    )
++    per_rank = [
++        {
++            "eager": {"cold_us": 11.0, "samples_us": [10.0, 1.0, 10.0, 1.0]},
++            "graph": {"cold_us": 7.0, "samples_us": [6.0, 2.0, 6.0, 2.0]},
++        },
++        {
++            "eager": {"cold_us": 12.0, "samples_us": [1.0, 10.0, 1.0, 10.0]},
++            "graph": {"cold_us": 8.0, "samples_us": [2.0, 6.0, 2.0, 6.0]},
++        },
++    ]
++
++    result = worker["_distributed_critical_path"](per_rank)
++
++    # The old max(mean(rank)) aggregation reports 5.5us / 4us. The actual
++    # collective critical path changes rank each iteration and is 10us / 6us.
++    assert max(sum(row["eager"]["samples_us"]) / 4 for row in per_rank) == 5.5
++    assert result["eager"]["samples_us"] == [10.0, 10.0, 10.0, 10.0]
++    assert result["eager"]["mean_us"] == 10.0
++    assert result["eager"]["cold_us"] == 12.0
++    assert result["graph"]["samples_us"] == [6.0, 6.0, 6.0, 6.0]
++    assert result["graph"]["mean_us"] == 6.0
++    assert result["graph"]["cold_us"] == 8.0
++
++
++def test_controller_paired_deltas_use_distributed_critical_path() -> None:
++    controller = _load_functions(
++        "benchmarks/run_pcie_oneshot_control_node_ab.py",
++        {"_paired_deltas"},
++    )
++
++    def record(variant: str, eager: float, graph: float) -> dict[str, object]:
++        def mode(value: float) -> dict[str, float | list[float]]:
++            return {
++                "cold_us": value,
++                "mean_us": value,
++                "p50_us": value,
++                "p95_us": value,
++                "min_us": value,
++                "max_us": value,
++                "samples_us": [value],
++            }
++
++        return {
++            "identity": {"variant": variant},
++            "distributed_critical_path": {
++                "eager": mode(eager),
++                "graph": mode(graph),
++            },
++        }
++
++    deltas = controller["_paired_deltas"](
++        [
++            record("baseline", 10.0, 20.0),
++            record("candidate", 12.0, 18.0),
++        ]
++    )
++
++    assert deltas[0]["metrics"]["eager"]["mean_us"]["delta_us"] == 2.0
++    assert deltas[0]["metrics"]["graph"]["p95_us"]["delta_us"] == -2.0
++
++
++def test_controller_timeout_terminates_the_command_process_group() -> None:
++    controller = _load_functions(
++        "benchmarks/run_pcie_oneshot_control_node_ab.py",
++        {"_run"},
++    )
++
++    with pytest.raises(TimeoutError, match="process group was terminated"):
++        controller["_run"](
++            [sys.executable, "-c", "import time; time.sleep(30)"],
++            timeout=0.05,
++        )
+diff --git a/tests/comm/test_pcie_dcp_a2a.py b/tests/comm/test_pcie_dcp_a2a.py
+index 50088b56a6e1f5b80f2426b9acfaaf5bf2531420..ce38610abccef1fb40ae5cc5207e074c79a59cb2 100644
+--- a/tests/comm/test_pcie_dcp_a2a.py
++++ b/tests/comm/test_pcie_dcp_a2a.py
+@@ -187,9 +187,7 @@ def test_runtime_validates_and_dispatches_to_extension():
+ def test_runtime_accepts_head_major_input_and_output():
+     ext = _FakeExt()
+     runtime = _make_runtime(ext)
+-    input_storage = torch.arange(
+-        32 * 4 * 64, dtype=torch.bfloat16
+-    ).reshape(32, 4, 64)
++    input_storage = torch.arange(32 * 4 * 64, dtype=torch.bfloat16).reshape(32, 4, 64)
+     partial_output = input_storage.transpose(0, 1)[:2]
+     partial_lse = torch.zeros(2, 32, dtype=torch.float32)
+     output_storage = torch.empty(16, 2, 64, dtype=torch.bfloat16)
+@@ -226,6 +224,54 @@ def test_runtime_rejects_shape_dtype_and_capacity_mismatches():
+         runtime.all_gather_heads(torch.zeros(5, 16, 64, dtype=torch.bfloat16))
+ 
+ 
++def test_constructor_rejects_invalid_query_and_staging_capacity():
++    common = dict(
++        rank=0,
++        world_size=2,
++        device=torch.device("cpu"),
++        signal_ptrs=(100, 200),
++        staging0_ptrs=(300, 400),
++        staging1_ptrs=(500, 600),
++        max_batch_size=4,
++        total_heads=32,
++        head_dim=64,
++        lse_offset=4 * 32 * 64 * 2,
++        lse_capacity=4 * 32,
++        ext_module=_FakeExt(),
++    )
++    with pytest.raises(ValueError, match="query_head_dim"):
++        PCIeDCPA2A(
++            **common,
++            query_head_dim=0,
++            output_capacity_elems=4 * 32 * 64,
++        )
++    with pytest.raises(ValueError, match="output capacity"):
++        PCIeDCPA2A(
++            **common,
++            query_head_dim=32,
++            output_capacity_elems=4 * 32 * 32,
++        )
++
++
++def test_cuda_direct_runtime_requires_collective_factory():
++    with pytest.raises(ValueError, match="exchange_group is required"):
++        PCIeDCPA2A(
++            rank=0,
++            world_size=2,
++            device=torch.device("cuda:0"),
++            signal_ptrs=(100, 200),
++            staging0_ptrs=(300, 400),
++            staging1_ptrs=(500, 600),
++            max_batch_size=4,
++            total_heads=32,
++            head_dim=64,
++            output_capacity_elems=4 * 32 * 64,
++            lse_offset=4 * 32 * 64 * 2,
++            lse_capacity=4 * 32,
++            ext_module=_FakeExt(),
++        )
++
++
+ def test_pool_uses_distinct_channels_for_target_and_draft_captures(monkeypatch):
+     created = []
+     current_stream = [7]
+@@ -269,10 +315,363 @@ def test_pool_uses_distinct_channels_for_target_and_draft_captures(monkeypatch):
+         capturing[0] = False
+ 
+     assert target_channel is not draft_channel
+-    assert pool._channels[70] is target_channel
+-    assert pool._channels[80] is draft_channel
++    assert pool._channels == {}
++    assert target_channel in pool._all_channels
++    assert draft_channel in pool._all_channels
+     assert [entry[0] for entry in created] == [7, 8]
+ 
++    capturing[0] = True
++    current_stream[0] = 70
++    with pytest.raises(RuntimeError, match="no channel during CUDA graph capture"):
++        pool.for_stream()
++
++
++def test_pool_collectively_prepares_logical_channels_in_canonical_order(
++    monkeypatch,
++):
++    created = []
++    pool = PCIeDCPA2APool(
++        rank=0,
++        world_size=2,
++        device=torch.device("cpu"),
++        max_batch_size=4,
++        total_heads=32,
++        head_dim=64,
++        channel_factory=lambda stream_key: _make_runtime(),
++    )
++    pool._channel_factory = None
++    pool.exchange_group = object()
++    monkeypatch.setattr(
++        pool,
++        "_new_channel",
++        lambda stream_key: created.append(stream_key) or object(),
++    )
++    monkeypatch.setattr(
++        "sparkinfer.comm.pcie.pcie_dcp_a2a._broadcast_gather_object",
++        lambda local_state, group: [local_state, local_state],
++    )
++    monkeypatch.setattr(
++        "sparkinfer.comm.pcie.pcie_oneshot._broadcast_gather_object",
++        lambda local_status, group: [local_status, local_status],
++    )
++
++    pool.prepare_channels(("target", "draft"))
++    pool.prepare_channels(("draft", "target"))
++
++    assert list(pool._logical_channels) == ["draft", "target"]
++    assert created == [None, None]
++
++
++def test_pool_rejects_logical_channel_set_mismatch_before_allocation(monkeypatch):
++    pool = PCIeDCPA2APool(
++        rank=0,
++        world_size=2,
++        device=torch.device("cpu"),
++        max_batch_size=4,
++        total_heads=32,
++        head_dim=64,
++        channel_factory=lambda stream_key: _make_runtime(),
++    )
++    pool._channel_factory = None
++    pool.exchange_group = object()
++    monkeypatch.setattr(
++        pool,
++        "_new_channel",
++        lambda stream_key: pytest.fail("channel allocation must not start"),
++    )
++
++    def gather(local_state, group):
++        if not local_state or isinstance(local_state[0], str):
++            return [local_state, ()]
++        requested, existing = local_state
++        return [(("other",), existing), local_state]
++
++    monkeypatch.setattr(
++        "sparkinfer.comm.pcie.pcie_dcp_a2a._broadcast_gather_object", gather
++    )
++    monkeypatch.setattr(
++        "sparkinfer.comm.pcie.pcie_oneshot._broadcast_gather_object", gather
++    )
++
++    with pytest.raises(RuntimeError, match="differs across ranks"):
++        pool.prepare_channels(("target",))
++
++
++def test_pool_invalid_logical_id_is_rejected_collectively(monkeypatch):
++    pool = PCIeDCPA2APool(
++        rank=0,
++        world_size=2,
++        device=torch.device("cpu"),
++        max_batch_size=4,
++        total_heads=32,
++        head_dim=64,
++        channel_factory=lambda stream_key: _make_runtime(),
++    )
++    pool._channel_factory = None
++    pool.exchange_group = object()
++    monkeypatch.setattr(
++        pool,
++        "_new_channel",
++        lambda stream_key: pytest.fail("channel allocation must not start"),
++    )
++    monkeypatch.setattr(
++        "sparkinfer.comm.pcie.pcie_oneshot._broadcast_gather_object",
++        lambda local_status, group: [local_status, ()],
++    )
++
++    with pytest.raises(RuntimeError, match="must not be empty"):
++        pool.prepare_channels(("",))
++
++
++def test_pool_eager_channel_requires_id_and_rejects_duplicate_stream_owner(
++    monkeypatch,
++):
++    eager = _make_runtime()
++    pool = PCIeDCPA2APool(
++        rank=0,
++        world_size=2,
++        device=torch.device("cpu"),
++        max_batch_size=4,
++        total_heads=32,
++        head_dim=64,
++        channel_factory=lambda stream_key: eager,
++    )
++    pool._channel_factory = None
++    pool.exchange_group = object()
++    pool._logical_channels["eager:dcp"] = eager
++    monkeypatch.setattr(
++        "sparkinfer.comm.pcie.pcie_dcp_a2a._current_stream_key",
++        lambda device, stream=None: int(stream),
++    )
++
++    with pytest.raises(RuntimeError, match="explicit semantic channel_id"):
++        pool.for_stream(7)
++    assert pool.for_stream(7, channel_id="eager:dcp") is eager
++    with pytest.raises(RuntimeError, match="stream-affine"):
++        pool.for_stream(8, channel_id="eager:dcp")
++
++
++def test_pool_capture_requires_stable_semantic_id(monkeypatch):
++    pool = PCIeDCPA2APool(
++        rank=0,
++        world_size=2,
++        device=torch.device("cpu"),
++        max_batch_size=4,
++        total_heads=32,
++        head_dim=64,
++        channel_factory=lambda stream_key: _make_runtime(),
++    )
++    pool._channel_factory = None
++    pool.exchange_group = object()
++
++    monkeypatch.setattr(
++        pool,
++        "_new_channel",
++        lambda stream_key: pytest.fail("channel allocation must not start"),
++    )
++    monkeypatch.setattr(
++        "sparkinfer.comm.pcie.pcie_oneshot._broadcast_gather_object",
++        lambda local_status, group: [local_status, ()],
++    )
++
++    with (
++        pytest.raises(RuntimeError, match="stable semantic channel_id"),
++        pool.capture(7),
++    ):
++        pass
++
++
++def test_pool_capture_allows_opposite_order_from_agreed_catalog(monkeypatch):
++    target = _make_runtime()
++    draft = _make_runtime()
++    pool = PCIeDCPA2APool(
++        rank=0,
++        world_size=2,
++        device=torch.device("cpu"),
++        max_batch_size=4,
++        total_heads=32,
++        head_dim=64,
++        channel_factory=lambda stream_key: _make_runtime(),
++    )
++    pool._channel_factory = None
++    pool.exchange_group = object()
++    pool._logical_channels.update({"graph:draft": draft, "graph:target": target})
++    monkeypatch.setattr(
++        pool,
++        "_new_channel",
++        lambda stream_key: pytest.fail("channel allocation must not start"),
++    )
++    monkeypatch.setattr(
++        "sparkinfer.comm.pcie.pcie_dcp_a2a._current_stream_key",
++        lambda device, stream=None: int(stream),
++    )
++
++    def gather(local_state, group):
++        if local_state == ():
++            return [(), ()]
++        requested, catalog = local_state
++        assert requested == "graph:target"
++        return [local_state, ("graph:draft", catalog)]
++
++    monkeypatch.setattr(
++        "sparkinfer.comm.pcie.pcie_oneshot._broadcast_gather_object", gather
++    )
++
++    with pool.capture(7, channel_id="graph:target") as channel:
++        assert channel is target
++
++    assert pool._captured_channel_ids == {"graph:target"}
++
++
++def test_pool_capture_rejects_divergent_catalog_before_allocation(monkeypatch):
++    target = _make_runtime()
++    pool = PCIeDCPA2APool(
++        rank=0,
++        world_size=2,
++        device=torch.device("cpu"),
++        max_batch_size=4,
++        total_heads=32,
++        head_dim=64,
++        channel_factory=lambda stream_key: _make_runtime(),
++    )
++    pool._channel_factory = None
++    pool.exchange_group = object()
++    pool._logical_channels["graph:target"] = target
++    monkeypatch.setattr(
++        pool,
++        "_new_channel",
++        lambda stream_key: pytest.fail("channel allocation must not start"),
++    )
++
++    def gather(local_state, group):
++        if local_state == ():
++            return [(), ()]
++        return [local_state, ("graph:target", ())]
++
++    monkeypatch.setattr(
++        "sparkinfer.comm.pcie.pcie_oneshot._broadcast_gather_object", gather
++    )
++
++    with (
++        pytest.raises(RuntimeError, match="prepared channel catalog differs"),
++        pool.capture(7, channel_id="graph:target"),
++    ):
++        pass
++
++
++def test_pool_capture_rejects_differing_unprepared_ids(monkeypatch):
++    target = _make_runtime()
++    pool = PCIeDCPA2APool(
++        rank=0,
++        world_size=2,
++        device=torch.device("cpu"),
++        max_batch_size=4,
++        total_heads=32,
++        head_dim=64,
++        channel_factory=lambda stream_key: _make_runtime(),
++    )
++    pool._channel_factory = None
++    pool.exchange_group = object()
++    pool._logical_channels["graph:target"] = target
++    monkeypatch.setattr(
++        pool,
++        "_new_channel",
++        lambda stream_key: pytest.fail("channel allocation must not start"),
++    )
++
++    def gather(local_state, group):
++        if local_state == ():
++            return [(), ()]
++        _, catalog = local_state
++        return [local_state, ("graph:unknown", catalog)]
++
++    monkeypatch.setattr(
++        "sparkinfer.comm.pcie.pcie_oneshot._broadcast_gather_object", gather
++    )
++
++    with (
++        pytest.raises(RuntimeError, match="unprepared logical channels"),
++        pool.capture(7, channel_id="graph:target"),
++    ):
++        pass
++
++
++def test_pool_capture_preserves_same_id_convenience_allocation(monkeypatch):
++    created = []
++    channel = _make_runtime()
++    pool = PCIeDCPA2APool(
++        rank=0,
++        world_size=2,
++        device=torch.device("cpu"),
++        max_batch_size=4,
++        total_heads=32,
++        head_dim=64,
++        channel_factory=lambda stream_key: _make_runtime(),
++    )
++    pool._channel_factory = None
++    pool.exchange_group = object()
++    monkeypatch.setattr(
++        pool,
++        "_new_channel",
++        lambda stream_key: created.append(stream_key) or channel,
++    )
++    monkeypatch.setattr(
++        "sparkinfer.comm.pcie.pcie_dcp_a2a._current_stream_key",
++        lambda device, stream=None: int(stream),
++    )
++    monkeypatch.setattr(
++        "sparkinfer.comm.pcie.pcie_oneshot._broadcast_gather_object",
++        lambda local_state, group: [local_state, local_state],
++    )
++    monkeypatch.setattr(
++        "sparkinfer.comm.pcie.pcie_dcp_a2a._broadcast_gather_object",
++        lambda local_state, group: [local_state, local_state],
++    )
++
++    with pool.capture(7, channel_id="graph:target") as captured:
++        assert captured is channel
++
++    assert created == [None]
++    assert pool._logical_channels == {"graph:target": channel}
++
++
++def test_pool_capture_routes_eager_warmup_to_graph_channel(monkeypatch):
++    eager = _make_runtime()
++    target = _make_runtime()
++    pool = PCIeDCPA2APool(
++        rank=0,
++        world_size=2,
++        device=torch.device("cpu"),
++        max_batch_size=4,
++        total_heads=32,
++        head_dim=64,
++        channel_factory=lambda stream_key: _make_runtime(),
++    )
++    pool._channel_factory = None
++    pool.exchange_group = object()
++    pool._logical_channels.update({"eager:dcp": eager, "graph:target": target})
++    monkeypatch.setattr(
++        pool,
++        "_new_channel",
++        lambda stream_key: pytest.fail("channel allocation must not start"),
++    )
++    monkeypatch.setattr(
++        "sparkinfer.comm.pcie.pcie_dcp_a2a._current_stream_key",
++        lambda device, stream=None: 7 if stream is None else int(stream),
++    )
++    monkeypatch.setattr(
++        "sparkinfer.comm.pcie.pcie_oneshot._broadcast_gather_object",
++        lambda local_state, group: [local_state, local_state],
++    )
++
++    with pool.capture(7, channel_id="graph:target") as captured:
++        assert captured is target
++        assert pool.for_stream(7, channel_id="eager:dcp") is target
++        with pytest.raises(RuntimeError, match="stream-affine"):
++            pool.for_stream(8, channel_id="eager:dcp")
++
++    assert pool.for_stream(7, channel_id="eager:dcp") is eager
++
+ 
+ def test_pool_isolates_reused_capture_stream_keys(monkeypatch):
+     created = []
+@@ -317,8 +716,7 @@ def test_pool_isolates_reused_capture_stream_keys(monkeypatch):
+         capturing[0] = False
+ 
+     assert target_channel is not draft_channel
+-    assert pool._channels[7] is draft_channel
+-    assert pool._channels[70] is draft_channel
++    assert pool._channels == {}
+     assert target_channel in pool._all_channels
+     assert draft_channel in pool._all_channels
+     assert [entry[0] for entry in created] == [7, 7]
+@@ -328,6 +726,92 @@ def test_pool_isolates_reused_capture_stream_keys(monkeypatch):
+     assert draft_channel._ext.dispose_calls == [1234]
+ 
+ 
++def test_pool_restores_eager_mapping_after_capture(monkeypatch):
++    current_stream = [7]
++    capturing = [False]
++    pool = PCIeDCPA2APool(
++        rank=0,
++        world_size=2,
++        device=torch.device("cpu"),
++        max_batch_size=4,
++        total_heads=32,
++        head_dim=64,
++        channel_factory=lambda stream_key: _make_runtime(),
++    )
++    monkeypatch.setattr(
++        "sparkinfer.comm.pcie.pcie_dcp_a2a._current_stream_key",
++        lambda device, stream=None: (
++            current_stream[0] if stream is None else int(stream)
++        ),
++    )
++    monkeypatch.setattr(
++        "sparkinfer.comm.pcie.pcie_dcp_a2a._is_current_stream_capturing",
++        lambda device: capturing[0],
++    )
++
++    eager_channel = pool.for_stream()
++    with pool.capture(7) as graph_channel:
++        capturing[0] = True
++        current_stream[0] = 70
++        assert pool.for_stream() is graph_channel
++        capturing[0] = False
++
++    assert graph_channel is not eager_channel
++    assert pool._channels == {7: eager_channel}
++    assert graph_channel in pool._all_channels
++
++
++def test_pool_restores_nested_capture_mappings(monkeypatch):
++    current_stream = [7]
++    capturing = [False]
++    pool = PCIeDCPA2APool(
++        rank=0,
++        world_size=2,
++        device=torch.device("cpu"),
++        max_batch_size=4,
++        total_heads=32,
++        head_dim=64,
++        channel_factory=lambda stream_key: _make_runtime(),
++    )
++    monkeypatch.setattr(
++        "sparkinfer.comm.pcie.pcie_dcp_a2a._current_stream_key",
++        lambda device, stream=None: (
++            current_stream[0] if stream is None else int(stream)
++        ),
++    )
++    monkeypatch.setattr(
++        "sparkinfer.comm.pcie.pcie_dcp_a2a._is_current_stream_capturing",
++        lambda device: capturing[0],
++    )
++
++    eager_channel = pool.for_stream()
++    with pool.capture(7) as outer_channel:
++        assert pool._channels == {7: outer_channel}
++
++        current_stream[0] = 8
++        with pool.capture() as inner_channel:
++            capturing[0] = True
++            current_stream[0] = 80
++            assert pool.for_stream() is inner_channel
++            assert pool._channels == {
++                7: outer_channel,
++                8: inner_channel,
++                80: inner_channel,
++            }
++            capturing[0] = False
++
++        assert pool._channels == {7: outer_channel}
++        capturing[0] = True
++        current_stream[0] = 70
++        assert pool.for_stream() is outer_channel
++        capturing[0] = False
++
++    assert eager_channel is not outer_channel
++    assert outer_channel is not inner_channel
++    assert pool._channels == {7: eager_channel}
++    assert pool._capture_channel_stack == []
++
++
+ def test_pool_rolls_back_throwaway_capture_channels(monkeypatch):
+     created = []
+ 
+diff --git a/tests/comm/test_pcie_dcp_a2a_gpu.py b/tests/comm/test_pcie_dcp_a2a_gpu.py
+index 48cc0acf81f6e2fbc738e9fce3a4c2cf93399f9f..84fccdb90178c9307205f66f973141b0bcea7808 100644
+--- a/tests/comm/test_pcie_dcp_a2a_gpu.py
++++ b/tests/comm/test_pcie_dcp_a2a_gpu.py
+@@ -1,5 +1,6 @@
+ from __future__ import annotations
+ 
++import ctypes
+ import os
+ import socket
+ 
+@@ -8,9 +9,13 @@ import torch
+ import torch.distributed as dist
+ import torch.multiprocessing as mp
+ 
++import sparkinfer.comm.pcie.pcie_dcp_a2a as pcie_dcp_a2a
++from sparkinfer.comm.pcie.pcie_oneshot import PCIeOneshotAllReduce
+ from sparkinfer.comm.pcie.pcie_dcp_a2a import (
++    PCIeDCPA2A,
+     PCIeDCPA2APool,
+     _load_extension,
++    _staging_layout,
+     lse_reduce_scatter_reference,
+ )
+ 
+@@ -99,6 +104,34 @@ def _reference(
+     )
+ 
+ 
++def _local_staging_words(channel, stream: torch.cuda.Stream) -> tuple[int, int]:
++    assert channel._ipc is not None
++    assert len(channel._owned_buffers) == 1
++    layout = _staging_layout(
++        signal_bytes=int(channel._ext.meta_size()),
++        world_size=channel.world_size,
++        max_batch_size=channel.max_batch_size,
++        total_heads=channel.total_heads,
++        head_dim=channel.head_dim,
++        query_head_dim=channel.query_head_dim,
++    )
++    words = (ctypes.c_uint16(), ctypes.c_uint16())
++    local_ptr = channel._owned_buffers[0].local_ptr
++    for word, offset in zip(
++        words,
++        (layout.staging0_offset, layout.staging1_offset),
++        strict=True,
++    ):
++        channel._ipc.cudaMemcpyAsync(
++            ctypes.addressof(word),
++            local_ptr + offset,
++            ctypes.sizeof(word),
++            int(stream.cuda_stream),
++        )
++    stream.synchronize()
++    return words[0].value, words[1].value
++
++
+ def _check_eager(
+     pool: PCIeDCPA2APool,
+     rank: int,
+@@ -115,7 +148,7 @@ def _check_eager(
+                 dtype,
+                 device,
+             )
+-            gathered_q = pool.all_gather_heads(local_q)
++            gathered_q = pool.all_gather_heads(local_q, channel_id="eager:dcp")
+             expected_q = torch.cat(
+                 [
+                     _rank_query(
+@@ -133,7 +166,9 @@ def _check_eager(
+             torch.testing.assert_close(gathered_q, expected_q, rtol=0, atol=0)
+ 
+             partial_output, partial_lse = _rank_inputs(step, rank, batch, dtype, device)
+-            out = pool.lse_reduce_scatter(partial_output, partial_lse)
++            out = pool.lse_reduce_scatter(
++                partial_output, partial_lse, channel_id="eager:dcp"
++            )
+             torch.cuda.synchronize(device)
+             expected = _reference(
+                 step,
+@@ -166,6 +201,7 @@ def _check_eager(
+                 head_major_input,
+                 partial_lse,
+                 out=head_major_output,
++                channel_id="eager:dcp",
+             )
+             torch.cuda.synchronize(device)
+             assert actual is head_major_output
+@@ -173,6 +209,63 @@ def _check_eager(
+             torch.testing.assert_close(actual, expected, rtol=2e-2, atol=2e-2)
+ 
+ 
++def _check_eager_adjacency(
++    pool: PCIeDCPA2APool,
++    rank: int,
++    world_size: int,
++    device: torch.device,
++) -> None:
++    channel = pool.for_stream(channel_id="eager:dcp")
++    first_query = _rank_query(700, rank, world_size, MAX_BATCH, torch.bfloat16, device)
++    second_query = _rank_query(701, rank, world_size, MAX_BATCH, torch.bfloat16, device)
++    partial_output, partial_lse = _rank_inputs(702, rank, 1, torch.bfloat16, device)
++    first_gather = torch.empty(
++        MAX_BATCH,
++        TOTAL_HEADS,
++        QUERY_HEAD_DIM,
++        dtype=torch.bfloat16,
++        device=device,
++    )
++    second_gather = torch.empty_like(first_gather)
++    reduced = torch.empty(
++        1,
++        TOTAL_HEADS // world_size,
++        HEAD_DIM,
++        dtype=torch.bfloat16,
++        device=device,
++    )
++
++    # Issue large-grid AG -> small-grid RS -> large-grid AG without a host
++    # synchronization so adjacent eager executions exercise slot advancement.
++    channel.all_gather_heads(first_query, first_gather)
++    channel.lse_reduce_scatter(partial_output, partial_lse, reduced)
++    channel.all_gather_heads(second_query, second_gather)
++    torch.cuda.synchronize(device)
++
++    expected_first = torch.cat(
++        [
++            _rank_query(700, source, world_size, MAX_BATCH, torch.bfloat16, device)
++            for source in range(world_size)
++        ],
++        dim=1,
++    )
++    expected_second = torch.cat(
++        [
++            _rank_query(701, source, world_size, MAX_BATCH, torch.bfloat16, device)
++            for source in range(world_size)
++        ],
++        dim=1,
++    )
++    torch.testing.assert_close(first_gather, expected_first, rtol=0, atol=0)
++    torch.testing.assert_close(second_gather, expected_second, rtol=0, atol=0)
++    torch.testing.assert_close(
++        reduced,
++        _reference(702, rank, world_size, 1, torch.bfloat16, device),
++        rtol=2e-2,
++        atol=2e-2,
++    )
++
++
+ def _check_graph(
+     pool: PCIeDCPA2APool,
+     rank: int,
+@@ -180,7 +273,8 @@ def _check_graph(
+     device: torch.device,
+ ) -> None:
+     stream = torch.cuda.Stream(device=device)
+-    channel = pool.for_stream(stream)
++    pool.prepare_channels(("graph",))
++    channel = pool.for_stream(stream, channel_id="graph")
+     layers = 7
+     input_storages = [
+         torch.empty(
+@@ -244,7 +338,10 @@ def _check_graph(
+             channel.lse_reduce_scatter(inputs[layer], lses[layer], outputs[layer])
+     stream.synchronize()
+ 
+-    for replay in range(8):
++    replay_count = int(os.getenv("SPARKINFER_PCIE_DCP_GRAPH_REPLAYS", "8"))
++    if replay_count <= 0:
++        raise ValueError("SPARKINFER_PCIE_DCP_GRAPH_REPLAYS must be positive")
++    for replay in range(replay_count):
+         expected = []
+         expected_queries = []
+         for layer in range(layers):
+@@ -302,6 +399,165 @@ def _check_graph(
+         for out, reference in zip(gathered_queries, expected_queries, strict=True):
+             torch.testing.assert_close(out, reference, rtol=0, atol=0)
+ 
++    # One captured operation has odd capture-time parity. Adjacent A -> A
++    # replays must advance the device-owned slot at execution time.
++    odd_input = torch.empty(
++        1,
++        TOTAL_HEADS // world_size,
++        QUERY_HEAD_DIM,
++        dtype=torch.bfloat16,
++        device=device,
++    )
++    odd_output = torch.empty(
++        1,
++        TOTAL_HEADS,
++        QUERY_HEAD_DIM,
++        dtype=torch.bfloat16,
++        device=device,
++    )
++    with torch.cuda.stream(stream):
++        channel.all_gather_heads(odd_input, odd_output)
++    stream.synchronize()
++    dist.barrier()
++
++    odd_graph = torch.cuda.CUDAGraph()
++    with torch.cuda.graph(odd_graph, stream=stream):
++        channel.all_gather_heads(odd_input, odd_output)
++    stream.synchronize()
++
++    # Prime both slots after capture, then observe them read-only. A graph with
++    # a host-baked slot changes the same word on both replays; execution-owned
++    # parity changes alternate words.
++    with torch.cuda.stream(stream):
++        for value in (11.0, 12.0):
++            odd_input.fill_(value)
++            channel.all_gather_heads(odd_input, odd_output)
++    snapshots = [_local_staging_words(channel, stream)]
++    for value in (1.0, 2.0):
++        with torch.cuda.stream(stream):
++            odd_input.fill_(value)
++            odd_graph.replay()
++        snapshots.append(_local_staging_words(channel, stream))
++        torch.testing.assert_close(
++            odd_output, torch.full_like(odd_output, value), rtol=0, atol=0
++        )
++
++    changed_slots = [
++        {
++            slot
++            for slot, (before, after) in enumerate(
++                zip(snapshots[index], snapshots[index + 1], strict=True)
++            )
++            if before != after
++        }
++        for index in range(2)
++    ]
++    assert all(len(changed) == 1 for changed in changed_slots)
++    assert changed_slots[0] != changed_slots[1]
++
++
++def _check_semantic_capture_warmup(
++    pool: PCIeDCPA2APool,
++    rank: int,
++    world_size: int,
++    device: torch.device,
++) -> None:
++    """Match vLLM's eager DCP warmup inside a graph-owner scope."""
++    stream = torch.cuda.Stream(device=device)
++    local_query = _rank_query(
++        900,
++        rank,
++        world_size,
++        1,
++        torch.bfloat16,
++        device,
++    )
++    gathered = torch.empty(
++        1,
++        TOTAL_HEADS,
++        QUERY_HEAD_DIM,
++        dtype=torch.bfloat16,
++        device=device,
++    )
++    expected = torch.cat(
++        [
++            _rank_query(
++                900,
++                source,
++                world_size,
++                1,
++                torch.bfloat16,
++                device,
++            )
++            for source in range(world_size)
++        ],
++        dim=1,
++    )
++    pool.prepare_channels(("graph:warmup",))
++
++    graph = torch.cuda.CUDAGraph()
++    with (
++        torch.cuda.stream(stream),
++        pool.capture(stream, channel_id="graph:warmup") as graph_channel,
++    ):
++        warmup_channel = pool.for_stream(stream, channel_id="eager:dcp")
++        assert warmup_channel is graph_channel
++        warmup_channel.all_gather_heads(local_query, gathered)
++        stream.synchronize()
++        torch.testing.assert_close(gathered, expected, rtol=0, atol=0)
++
++        with torch.cuda.graph(graph, stream=stream):
++            graph_channel.all_gather_heads(local_query, gathered)
++
++    # The eager DCP channel was already bound to vLLM's default stream. Its
++    # original mapping must be usable again after the graph-owner scope exits.
++    eager_channel = pool.for_stream(channel_id="eager:dcp")
++    assert eager_channel is not graph_channel
++    with torch.cuda.stream(stream):
++        graph.replay()
++    stream.synchronize()
++    torch.testing.assert_close(gathered, expected, rtol=0, atol=0)
++
++
++def _check_teardown_retry(
++    pool: PCIeDCPA2APool,
++    rank: int,
++    device: torch.device,
++) -> None:
++    """Inject one local unmap failure and prove every rank retries coherently."""
++
++    assert pool._all_channels
++    channel = pool._all_channels[0]
++    assert channel._ipc is not None
++    original_close = channel._ipc.cudaIpcCloseMemHandle
++    injected = False
++
++    if rank == 0:
++
++        def fail_once(ptr):
++            nonlocal injected
++            if not injected:
++                injected = True
++                raise RuntimeError("injected DCP IPC unmap failure")
++            return original_close(ptr)
++
++        channel._ipc.cudaIpcCloseMemHandle = fail_once
++
++    failed = False
++    try:
++        pool.close()
++    except RuntimeError as exc:
++        failed = "IPC unmap" in str(exc)
++    verdict = torch.tensor(int(failed), device=device, dtype=torch.int32)
++    dist.all_reduce(verdict, op=dist.ReduceOp.MIN)
++    assert int(verdict.item()) == 1
++    assert not pool._closed
++
++    if rank == 0:
++        channel._ipc.cudaIpcCloseMemHandle = original_close
++    pool.close()
++    assert pool._closed
++
+ 
+ def _worker(rank: int, world_size: int, port: int) -> None:
+     torch.cuda.set_device(rank)
+@@ -319,18 +575,117 @@ def _worker(rank: int, world_size: int, port: int) -> None:
+         total_heads=TOTAL_HEADS,
+         head_dim=HEAD_DIM,
+         query_head_dim=QUERY_HEAD_DIM,
++        max_concurrent_channels=2,
+     )
++    closed = False
+     try:
++        pool.prepare_channels(("eager:dcp", "graph"))
+         _check_eager(pool, rank, world_size, device)
+         dist.barrier()
++        _check_eager_adjacency(pool, rank, world_size, device)
++        dist.barrier()
++        _check_semantic_capture_warmup(pool, rank, world_size, device)
++        dist.barrier()
+         _check_graph(pool, rank, world_size, device)
+         torch.cuda.synchronize(device)
++        if os.getenv("SPARKINFER_PCIE_DCP_TEST_TEARDOWN_RETRY", "0") == "1":
++            _check_teardown_retry(pool, rank, device)
++            closed = True
+     finally:
+-        pool.close()
++        if not closed:
++            pool.close()
++        dist.destroy_process_group()
++
++
++def _residency_rejection_worker(rank: int, world_size: int, port: int) -> None:
++    if rank != 0:
++        # Simulate one constrained/MIG-like rank in an otherwise full device
++        # group; every peer must reject before any IPC allocation.
++        os.environ.pop("SPARKINFER_PCIE_TEST_VISIBLE_SM_COUNT", None)
++    torch.cuda.set_device(rank)
++    device = torch.device("cuda", rank)
++    dist.init_process_group(
++        "nccl",
++        init_method=f"tcp://127.0.0.1:{port}",
++        rank=rank,
++        world_size=world_size,
++    )
++
++    original_cuda_rt = pcie_dcp_a2a.CudaRTLibrary
++
++    def unexpected_cuda_rt():
++        raise AssertionError("CUDA IPC allocation started before residency rejection")
++
++    pcie_dcp_a2a.CudaRTLibrary = unexpected_cuda_rt
++    try:
++        with pytest.raises(RuntimeError, match="requires at least 64 visible SMs"):
++            PCIeDCPA2A.from_process_group(
++                process_group=dist.group.WORLD,
++                device=device,
++                max_batch_size=MAX_BATCH,
++                total_heads=TOTAL_HEADS,
++                head_dim=HEAD_DIM,
++                query_head_dim=QUERY_HEAD_DIM,
++            )
++        dist.barrier()
++    finally:
++        pcie_dcp_a2a.CudaRTLibrary = original_cuda_rt
++        dist.destroy_process_group()
++
++
++def _preflight_rejection_worker(rank: int, world_size: int, port: int) -> None:
++    torch.cuda.set_device(rank)
++    device = torch.device("cuda", rank)
++    dist.init_process_group(
++        "nccl",
++        init_method=f"tcp://127.0.0.1:{port}",
++        rank=rank,
++        world_size=world_size,
++    )
++
++    original_cuda_rt = pcie_dcp_a2a.CudaRTLibrary
++    original_allocate = PCIeOneshotAllReduce._allocate_shared_buffer
++
++    class FakeExt:
++        @staticmethod
++        def meta_size():
++            return 256
++
++    def fail_cuda_rt():
++        raise RuntimeError("injected rank-zero pre-allocation failure")
++
++    def unexpected_allocate(*args, **kwargs):
++        raise AssertionError(
++            "CUDA IPC allocation started after a peer preflight failure"
++        )
++
++    if rank == 0:
++        pcie_dcp_a2a.CudaRTLibrary = fail_cuda_rt
++    PCIeOneshotAllReduce._allocate_shared_buffer = staticmethod(unexpected_allocate)
++    try:
++        with pytest.raises(RuntimeError, match="pre-allocation setup"):
++            PCIeDCPA2A.from_process_group(
++                process_group=dist.group.WORLD,
++                device=device,
++                max_batch_size=MAX_BATCH,
++                total_heads=TOTAL_HEADS,
++                head_dim=HEAD_DIM,
++                query_head_dim=QUERY_HEAD_DIM,
++                ext_module=FakeExt(),
++            )
++        dist.barrier()
++    finally:
++        pcie_dcp_a2a.CudaRTLibrary = original_cuda_rt
++        PCIeOneshotAllReduce._allocate_shared_buffer = original_allocate
+         dist.destroy_process_group()
+ 
+ 
+ def test_pcie_dcp_a2a_eager_and_cuda_graph_correctness():
++    if (
++        os.getenv("SPARKINFER_PCIE_DCP_TEST_EXPECT_RESIDENCY_REJECTION") == "1"
++        or os.getenv("SPARKINFER_PCIE_DCP_TEST_EXPECT_PREFLIGHT_REJECTION") == "1"
++    ):
++        pytest.skip("running the reduced-SM residency rejection gate")
+     if not torch.cuda.is_available():
+         pytest.skip("CUDA is unavailable")
+     world_size = int(os.getenv("SPARKINFER_PCIE_DCP_A2A_WORLD_SIZE", "2"))
+@@ -342,3 +697,48 @@ def test_pcie_dcp_a2a_eager_and_cuda_graph_correctness():
+         )
+     _load_extension()
+     mp.spawn(_worker, args=(world_size, _free_port()), nprocs=world_size, join=True)
++
++
++def test_pcie_dcp_a2a_rejects_reduced_sm_slice_before_ipc_allocation():
++    if os.getenv("SPARKINFER_PCIE_DCP_TEST_EXPECT_RESIDENCY_REJECTION") != "1":
++        pytest.skip("set the reduced-SM residency rejection gate to run this test")
++    visible_sms = int(os.getenv("SPARKINFER_PCIE_TEST_VISIBLE_SM_COUNT", "0") or "0")
++    assert 0 < visible_sms < pcie_dcp_a2a.DCP_A2A_REQUIRED_SMS, (
++        "set SPARKINFER_PCIE_TEST_VISIBLE_SM_COUNT below "
++        f"{pcie_dcp_a2a.DCP_A2A_REQUIRED_SMS} to exercise the residency gate"
++    )
++    if not torch.cuda.is_available():
++        pytest.skip("CUDA is unavailable")
++    world_size = int(os.getenv("SPARKINFER_PCIE_DCP_A2A_WORLD_SIZE", "2"))
++    if world_size not in (2, 4, 8):
++        pytest.skip("PCIe DCP A2A supports world sizes 2, 4, and 8")
++    if torch.cuda.device_count() < world_size:
++        pytest.skip(
++            f"need {world_size} CUDA devices, found {torch.cuda.device_count()}"
++        )
++    mp.spawn(
++        _residency_rejection_worker,
++        args=(world_size, _free_port()),
++        nprocs=world_size,
++        join=True,
++    )
++
++
++def test_pcie_dcp_a2a_coordinates_one_rank_preflight_failure_before_ipc():
++    if os.getenv("SPARKINFER_PCIE_DCP_TEST_EXPECT_PREFLIGHT_REJECTION") != "1":
++        pytest.skip("set the one-rank preflight rejection gate to run this test")
++    if not torch.cuda.is_available():
++        pytest.skip("CUDA is unavailable")
++    world_size = int(os.getenv("SPARKINFER_PCIE_DCP_A2A_WORLD_SIZE", "2"))
++    if world_size not in (2, 4, 8):
++        pytest.skip("PCIe DCP A2A supports world sizes 2, 4, and 8")
++    if torch.cuda.device_count() < world_size:
++        pytest.skip(
++            f"need {world_size} CUDA devices, found {torch.cuda.device_count()}"
++        )
++    mp.spawn(
++        _preflight_rejection_worker,
++        args=(world_size, _free_port()),
++        nprocs=world_size,
++        join=True,
++    )
+diff --git a/tests/comm/test_pcie_ipc_lifecycle.py b/tests/comm/test_pcie_ipc_lifecycle.py
+new file mode 100644
+index 0000000000000000000000000000000000000000..2bbd734ae95f708484c5f4466dde71571e0268eb
+--- /dev/null
++++ b/tests/comm/test_pcie_ipc_lifecycle.py
+@@ -0,0 +1,683 @@
++from __future__ import annotations
++
++import gc
++import weakref
++
++import pytest
++import torch
++
++from sparkinfer.comm.pcie.pcie_dcp_a2a import PCIeDCPA2A, PCIeDCPA2APool
++from sparkinfer.comm.pcie.pcie_oneshot import (
++    _ABANDONED_PCIE_RUNTIME_QUARANTINE,
++    PCIeOneshotAllReduce,
++    PCIeOneshotAllReducePool,
++)
++from sparkinfer.comm.pcie.pcie_twoshot import PCIeTwoShotSP
++
++
++class _FakeChannel:
++    def __init__(self, name: str, events: list[str]) -> None:
++        self.name = name
++        self.events = events
++
++    def _close_ipc_imports(self) -> None:
++        self.events.append(f"imports:{self.name}")
++
++    def _free_ipc_exports(self) -> None:
++        self.events.append(f"exports:{self.name}")
++
++
++def test_pool_explicit_close_coordinates_imports_before_exports(monkeypatch) -> None:
++    events = []
++    group = object()
++    channel_a = _FakeChannel("a", events)
++    channel_b = _FakeChannel("b", events)
++    pool = PCIeOneshotAllReducePool(
++        rank=0,
++        world_size=2,
++        device=torch.device("cuda:0"),
++        exchange_group=group,
++        channel_factory=lambda stream_key: channel_a,
++    )
++    pool._all_channels = [channel_a, channel_b]
++    pool._channels = {1: channel_a, 2: channel_b}
++    monkeypatch.setattr(
++        "sparkinfer.comm.pcie.pcie_oneshot.dist.barrier",
++        lambda *, group: events.append("barrier"),
++    )
++    monkeypatch.setattr(
++        "sparkinfer.comm.pcie.pcie_oneshot.torch.cuda.synchronize",
++        lambda device: events.append("synchronize"),
++    )
++    monkeypatch.setattr(
++        "sparkinfer.comm.pcie.pcie_oneshot._broadcast_gather_object",
++        lambda local_status, group: [local_status, ()],
++    )
++
++    pool.close()
++    pool.close()
++
++    assert events == [
++        "synchronize",
++        "barrier",
++        "imports:a",
++        "imports:b",
++        "barrier",
++        "exports:a",
++        "exports:b",
++        "barrier",
++    ]
++    assert pool._closed
++    assert pool._all_channels == []
++    assert pool._channels == {}
++
++
++def test_pool_destructor_is_nonblocking_and_does_not_touch_cuda_ownership(
++    monkeypatch,
++) -> None:
++    events = []
++    channel = _FakeChannel("a", events)
++    pool = PCIeOneshotAllReducePool(
++        rank=0,
++        world_size=2,
++        device=torch.device("cpu"),
++        exchange_group=object(),
++        channel_factory=lambda stream_key: pytest.fail("factory must not run"),
++    )
++    pool._all_channels = [channel]
++    pool._channels = {1: channel}
++    monkeypatch.setattr(
++        "sparkinfer.comm.pcie.pcie_oneshot.dist.barrier",
++        lambda *, group: events.append("barrier"),
++    )
++
++    pool.__del__()
++
++    assert events == []
++
++
++class _FakeExt:
++    def __init__(self, events: list[object], *, dispose_failures: int = 0) -> None:
++        self.events = events
++        self.dispose_failures = dispose_failures
++
++    def dispose(self, ptr: int) -> None:
++        self.events.append(("dispose", ptr))
++        if self.dispose_failures:
++            self.dispose_failures -= 1
++            raise RuntimeError("dispose failed")
++
++    def dispose_best_effort(self, ptr: int) -> None:
++        self.events.append(("dispose_best_effort", ptr))
++
++
++class _FakeIPC:
++    def __init__(
++        self,
++        events: list[object],
++        *,
++        close_failures: dict[int, int] | None = None,
++        free_failures: dict[int, int] | None = None,
++    ) -> None:
++        self.events = events
++        self.close_failures = dict(close_failures or {})
++        self.free_failures = dict(free_failures or {})
++
++    def cudaIpcCloseMemHandle(self, ptr: int) -> None:
++        self.events.append(("close", ptr))
++        if self.close_failures.get(ptr, 0):
++            self.close_failures[ptr] -= 1
++            raise RuntimeError(f"close {ptr} failed")
++
++    def cudaFree(self, ptr: int) -> None:
++        self.events.append(("free", ptr))
++        if self.free_failures.get(ptr, 0):
++            self.free_failures[ptr] -= 1
++            raise RuntimeError(f"free {ptr} failed")
++
++
++class _Shared:
++    def __init__(self, local_ptr: int, remote_ptrs: tuple[int, ...]) -> None:
++        self.local_ptr = local_ptr
++        self.remote_ptrs = remote_ptrs
++
++
++def _fake_twoshot(events: list[object]) -> PCIeTwoShotSP:
++    runtime = object.__new__(PCIeTwoShotSP)
++    runtime.rank = 0
++    runtime.world_size = 2
++    runtime.device = torch.device("cpu")
++    runtime.exchange_group = object()
++    runtime._ext = _FakeExt(events)
++    runtime._fptr = 123
++    runtime._owned_buffers = [_Shared(1000, (2000, 3000))]
++    runtime._ipc = _FakeIPC(events)
++    runtime.max_rows = 8
++    runtime.row_elems = 16
++    runtime._closed = False
++    runtime._ipc_imports_closed = False
++    runtime._ipc_exports_freed = False
++    return runtime
++
++
++def _fake_oneshot(events: list[object]) -> PCIeOneshotAllReduce:
++    runtime = object.__new__(PCIeOneshotAllReduce)
++    runtime.rank = 0
++    runtime.world_size = 2
++    runtime.device = torch.device("cpu")
++    runtime.exchange_group = None
++    runtime._ext = _FakeExt(events)
++    runtime._ptr = 123
++    runtime._owned_buffers = [_Shared(1000, (2000, 3000))]
++    runtime._ipc = _FakeIPC(events)
++    runtime._registered_input_ptrs = {10: (20,)}
++    runtime._closed = False
++    runtime._ipc_imports_closed = False
++    runtime._ipc_exports_freed = False
++    return runtime
++
++
++def _fake_dcp(events: list[object]) -> PCIeDCPA2A:
++    runtime = object.__new__(PCIeDCPA2A)
++    runtime.rank = 0
++    runtime.world_size = 2
++    runtime.device = torch.device("cpu")
++    runtime.exchange_group = None
++    runtime._ext = _FakeExt(events)
++    runtime._ptr = 123
++    runtime._owned_buffers = [_Shared(1000, (2000, 3000))]
++    runtime._ipc = _FakeIPC(events)
++    runtime._closed = False
++    runtime._ipc_imports_closed = False
++    runtime._ipc_exports_freed = False
++    runtime._coordinated_close_complete = False
++    runtime._closed_ipc_import_indices = set()
++    return runtime
++
++
++def test_dcp_explicit_close_retries_failed_unmap_before_export_free() -> None:
++    events: list[object] = []
++    runtime = _fake_dcp(events)
++    runtime._ipc = _FakeIPC(events, close_failures={2000: 1})
++
++    with pytest.raises(RuntimeError, match="failed during IPC unmap"):
++        runtime.close()
++
++    assert events == [
++        ("dispose", 123),
++        ("close", 2000),
++        ("close", 3000),
++    ]
++    assert runtime._ptr == 0
++    assert not runtime._ipc_imports_closed
++    assert not runtime._ipc_exports_freed
++
++    runtime.close()
++    assert events[-2:] == [("close", 2000), ("free", 1000)]
++    assert runtime._ipc_imports_closed
++    assert runtime._ipc_exports_freed
++
++
++def test_dcp_pool_failed_rollback_retains_transient_channel() -> None:
++    retained = _fake_dcp([])
++    transient_events: list[object] = []
++    transient = _fake_dcp(transient_events)
++    transient._ipc = _FakeIPC(transient_events, close_failures={2000: 1})
++    pool = PCIeDCPA2APool(
++        rank=0,
++        world_size=2,
++        device=torch.device("cpu"),
++        max_batch_size=4,
++        total_heads=32,
++        head_dim=64,
++        channel_factory=lambda stream_key: retained,
++    )
++    pool._all_channels = [retained, transient]
++    pool._channels = {1: retained, 2: transient}
++
++    with pytest.raises(RuntimeError, match="failed during IPC unmap"):
++        pool.rollback_channels((1, {1: retained}))
++
++    assert pool._all_channels == [retained, transient]
++    assert pool._channels == {1: retained, 2: transient}
++    assert ("free", 1000) not in transient_events
++
++
++def test_twoshot_explicit_close_coordinates_unmap_then_free(monkeypatch) -> None:
++    events: list[object] = []
++    runtime = _fake_twoshot(events)
++    runtime.device = torch.device("cuda:0")
++    monkeypatch.setattr(
++        "sparkinfer.comm.pcie.pcie_oneshot.dist.barrier",
++        lambda *, group: events.append("barrier"),
++    )
++    monkeypatch.setattr(
++        "sparkinfer.comm.pcie.pcie_oneshot.torch.cuda.synchronize",
++        lambda device: events.append("synchronize"),
++    )
++    monkeypatch.setattr(
++        "sparkinfer.comm.pcie.pcie_oneshot._broadcast_gather_object",
++        lambda local_status, group: [local_status, ()],
++    )
++
++    runtime.close()
++    runtime.close()
++
++    assert events == [
++        "synchronize",
++        "barrier",
++        ("dispose", 123),
++        ("close", 2000),
++        ("close", 3000),
++        "barrier",
++        ("free", 1000),
++        "barrier",
++    ]
++    assert runtime._fptr == 0
++    assert runtime._owned_buffers == []
++    assert runtime._ipc_imports_closed
++    assert runtime._ipc_exports_freed
++
++
++def test_twoshot_destructor_retains_imports_and_exports_without_cuda_calls(
++    monkeypatch,
++) -> None:
++    events: list[object] = []
++    runtime = _fake_twoshot(events)
++    monkeypatch.setattr(
++        "sparkinfer.comm.pcie.pcie_oneshot.dist.barrier",
++        lambda *, group: events.append("barrier"),
++    )
++
++    runtime.__del__()
++
++    assert events == []
++    assert runtime._fptr == 123
++    assert runtime._owned_buffers != []
++    assert not runtime._ipc_exports_freed
++
++
++@pytest.mark.parametrize("runtime_factory", (_fake_dcp, _fake_twoshot))
++def test_real_gc_quarantines_dcp_and_twoshot_ownership(runtime_factory) -> None:
++    events: list[object] = []
++    runtime = runtime_factory(events)
++    runtime_id = id(runtime)
++    runtime_ref = weakref.ref(runtime)
++
++    del runtime
++    gc.collect()
++
++    retained = _ABANDONED_PCIE_RUNTIME_QUARANTINE.pop(runtime_id)
++    assert runtime_ref() is retained
++    assert events == []
++    pointer_attr = "_ptr" if isinstance(retained, PCIeDCPA2A) else "_fptr"
++    assert getattr(retained, pointer_attr) == 123
++    assert retained._owned_buffers
++    assert not retained._ipc_exports_freed
++
++    # Production deliberately keeps this ownership until process teardown.
++    # The fake can be released after marking the coordinated path complete.
++    retained._coordinated_close_complete = True
++    del retained
++    gc.collect()
++    assert runtime_ref() is None
++
++
++@pytest.mark.parametrize("runtime_factory", (_fake_dcp, _fake_twoshot))
++def test_explicitly_closed_dcp_and_twoshot_are_not_quarantined(runtime_factory) -> None:
++    events: list[object] = []
++    runtime = runtime_factory(events)
++    runtime.exchange_group = None
++    runtime.close()
++    runtime_id = id(runtime)
++    runtime_ref = weakref.ref(runtime)
++
++    del runtime
++    gc.collect()
++
++    assert runtime_ref() is None
++    assert runtime_id not in _ABANDONED_PCIE_RUNTIME_QUARANTINE
++
++
++def test_real_gc_quarantines_dcp_pool_and_its_channel() -> None:
++    channel = _fake_dcp([])
++    pool = PCIeDCPA2APool(
++        rank=0,
++        world_size=2,
++        device=torch.device("cpu"),
++        max_batch_size=4,
++        total_heads=32,
++        head_dim=64,
++        channel_factory=lambda stream_key: pytest.fail("factory must not run"),
++    )
++    pool._all_channels = [channel]
++    pool._channels = {0: channel}
++    pool_id = id(pool)
++    pool_ref = weakref.ref(pool)
++
++    del pool
++    gc.collect()
++
++    retained = _ABANDONED_PCIE_RUNTIME_QUARANTINE.pop(pool_id)
++    assert pool_ref() is retained
++    assert retained._all_channels == [channel]
++    assert retained._channels
++
++    retained._closed = True
++    channel._coordinated_close_complete = True
++    del retained
++    del channel
++    gc.collect()
++    assert pool_ref() is None
++
++
++@pytest.mark.parametrize("runtime_factory", (_fake_oneshot, _fake_twoshot))
++def test_strict_close_reports_unmap_failure_retains_exports_and_retries_only_failure(
++    runtime_factory,
++) -> None:
++    events: list[object] = []
++    runtime = runtime_factory(events)
++    runtime.exchange_group = None
++    runtime._ipc = _FakeIPC(events, close_failures={2000: 1})
++
++    with pytest.raises(
++        RuntimeError,
++        match=r"coordinated PCIe close failed during IPC unmap.*not freed",
++    ):
++        runtime.close()
++
++    assert events == [
++        ("dispose", 123),
++        ("close", 2000),
++        ("close", 3000),
++    ]
++    pointer_attr = "_ptr" if isinstance(runtime, PCIeOneshotAllReduce) else "_fptr"
++    assert getattr(runtime, pointer_attr) == 0
++    assert runtime._closed
++    assert not runtime._ipc_imports_closed
++    assert not runtime._ipc_exports_freed
++    assert [shared.local_ptr for shared in runtime._owned_buffers] == [1000]
++
++    runtime.close()
++
++    assert events == [
++        ("dispose", 123),
++        ("close", 2000),
++        ("close", 3000),
++        ("close", 2000),
++        ("free", 1000),
++    ]
++    assert runtime._ipc_imports_closed
++    assert runtime._ipc_exports_freed
++    assert runtime._owned_buffers == []
++
++
++@pytest.mark.parametrize("runtime_factory", (_fake_oneshot, _fake_twoshot))
++def test_strict_close_reports_native_dispose_failure_without_losing_pointer(
++    runtime_factory,
++) -> None:
++    events: list[object] = []
++    runtime = runtime_factory(events)
++    runtime.exchange_group = None
++    runtime._ext = _FakeExt(events, dispose_failures=1)
++
++    with pytest.raises(RuntimeError, match="failed during IPC unmap"):
++        runtime.close()
++
++    pointer_attr = "_ptr" if isinstance(runtime, PCIeOneshotAllReduce) else "_fptr"
++    assert getattr(runtime, pointer_attr) == 123
++    assert events == [
++        ("dispose", 123),
++        ("close", 2000),
++        ("close", 3000),
++    ]
++    assert not runtime._ipc_imports_closed
++    assert not runtime._ipc_exports_freed
++
++    runtime.close()
++
++    assert getattr(runtime, pointer_attr) == 0
++    assert events == [
++        ("dispose", 123),
++        ("close", 2000),
++        ("close", 3000),
++        ("dispose", 123),
++        ("free", 1000),
++    ]
++    assert runtime._ipc_imports_closed
++    assert runtime._ipc_exports_freed
++
++
++@pytest.mark.parametrize("runtime_factory", (_fake_oneshot, _fake_twoshot))
++def test_strict_close_reports_free_failure_and_retains_only_failed_export(
++    runtime_factory,
++) -> None:
++    events: list[object] = []
++    runtime = runtime_factory(events)
++    runtime.exchange_group = None
++    runtime._owned_buffers.append(_Shared(4000, (5000,)))
++    runtime._ipc = _FakeIPC(events, free_failures={1000: 1})
++
++    with pytest.raises(RuntimeError, match="failed during IPC export free"):
++        runtime.close()
++
++    assert events == [
++        ("dispose", 123),
++        ("close", 2000),
++        ("close", 3000),
++        ("close", 5000),
++        ("free", 1000),
++        ("free", 4000),
++    ]
++    assert runtime._ipc_imports_closed
++    assert not runtime._ipc_exports_freed
++    assert [shared.local_ptr for shared in runtime._owned_buffers] == [1000]
++
++    runtime.close()
++
++    assert events[-1] == ("free", 1000)
++    assert runtime._ipc_exports_freed
++    assert runtime._owned_buffers == []
++
++
++def test_peer_unmap_failure_is_exchanged_before_any_local_export_free(
++    monkeypatch,
++) -> None:
++    events: list[object] = []
++    runtime = _fake_oneshot(events)
++    runtime.device = torch.device("cuda:0")
++    runtime.exchange_group = object()
++    peer_statuses = iter(
++        [
++            lambda local: [local, ("peer close failed",)],
++            lambda local: [local, ()],
++            lambda local: [local, ()],
++        ]
++    )
++
++    monkeypatch.setattr(
++        "sparkinfer.comm.pcie.pcie_oneshot.dist.barrier",
++        lambda *, group: events.append("barrier"),
++    )
++    monkeypatch.setattr(
++        "sparkinfer.comm.pcie.pcie_oneshot.torch.cuda.synchronize",
++        lambda device: events.append("synchronize"),
++    )
++    monkeypatch.setattr(
++        "sparkinfer.comm.pcie.pcie_oneshot._broadcast_gather_object",
++        lambda local_status, group: next(peer_statuses)(local_status),
++    )
++
++    with pytest.raises(RuntimeError, match="group rank 1: peer close failed"):
++        runtime.close()
++
++    assert ("free", 1000) not in events
++    assert runtime._ipc_imports_closed
++    assert not runtime._ipc_exports_freed
++
++    runtime.close()
++
++    assert events == [
++        "synchronize",
++        "barrier",
++        ("dispose", 123),
++        ("close", 2000),
++        ("close", 3000),
++        "synchronize",
++        "barrier",
++        "barrier",
++        ("free", 1000),
++        "barrier",
++    ]
++    assert runtime._ipc_exports_freed
++
++
++def test_status_exchange_failure_retains_local_exports(monkeypatch) -> None:
++    events: list[object] = []
++    runtime = _fake_oneshot(events)
++    runtime.exchange_group = object()
++
++    def fail_status_exchange(local_status, group):
++        raise RuntimeError("status exchange failed")
++
++    monkeypatch.setattr(
++        "sparkinfer.comm.pcie.pcie_oneshot.dist.barrier",
++        lambda *, group: events.append("barrier"),
++    )
++    monkeypatch.setattr(
++        "sparkinfer.comm.pcie.pcie_oneshot._broadcast_gather_object",
++        fail_status_exchange,
++    )
++
++    with pytest.raises(RuntimeError, match="failed to exchange peer IPC unmap"):
++        runtime.close()
++
++    assert events == [
++        "barrier",
++        ("dispose", 123),
++        ("close", 2000),
++        ("close", 3000),
++    ]
++    assert runtime._ipc_imports_closed
++    assert not runtime._ipc_exports_freed
++    assert runtime._owned_buffers
++
++
++@pytest.mark.parametrize("runtime_factory", (_fake_oneshot, _fake_twoshot))
++def test_rank_that_freed_locally_retries_until_peer_free_succeeds(
++    monkeypatch,
++    runtime_factory,
++) -> None:
++    events: list[object] = []
++    runtime = runtime_factory(events)
++    runtime.device = torch.device("cuda:0")
++    runtime.exchange_group = object()
++    peer_statuses = iter(
++        [
++            lambda local: [local, ()],
++            lambda local: [local, ("peer export free failed",)],
++            lambda local: [local, ()],
++            lambda local: [local, ()],
++        ]
++    )
++
++    monkeypatch.setattr(
++        "sparkinfer.comm.pcie.pcie_oneshot.dist.barrier",
++        lambda *, group: events.append("barrier"),
++    )
++    monkeypatch.setattr(
++        "sparkinfer.comm.pcie.pcie_oneshot.torch.cuda.synchronize",
++        lambda device: events.append("synchronize"),
++    )
++    monkeypatch.setattr(
++        "sparkinfer.comm.pcie.pcie_oneshot._broadcast_gather_object",
++        lambda local_status, group: next(peer_statuses)(local_status),
++    )
++
++    with pytest.raises(RuntimeError, match="group rank 1: peer export free failed"):
++        runtime.close()
++
++    assert runtime._ipc_exports_freed
++    assert not getattr(runtime, "_coordinated_close_complete", False)
++
++    runtime.close()
++    events_after_success = list(events)
++    runtime.close()
++
++    assert events == events_after_success
++    assert events == [
++        "synchronize",
++        "barrier",
++        ("dispose", 123),
++        ("close", 2000),
++        ("close", 3000),
++        "barrier",
++        ("free", 1000),
++        "synchronize",
++        "barrier",
++        "barrier",
++        "barrier",
++    ]
++    assert runtime._coordinated_close_complete
++
++
++@pytest.mark.parametrize("runtime_factory", (_fake_oneshot, _fake_twoshot))
++def test_gc_never_attempts_native_dispose_or_ipc_unmap(
++    runtime_factory,
++) -> None:
++    events: list[object] = []
++    runtime = runtime_factory(events)
++    runtime._ipc = _FakeIPC(events, close_failures={2000: 1})
++
++    runtime.__del__()
++
++    assert events == []
++    pointer_attr = "_ptr" if isinstance(runtime, PCIeOneshotAllReduce) else "_fptr"
++    assert getattr(runtime, pointer_attr) == 123
++    assert not runtime._ipc_imports_closed
++    assert not runtime._ipc_exports_freed
++    assert runtime._owned_buffers
++
++
++def test_gc_retention_preserves_explicit_close_retry_path() -> None:
++    events: list[object] = []
++    runtime = _fake_oneshot(events)
++
++    runtime.__del__()
++
++    assert events == []
++    assert runtime._ptr == 123
++    assert not runtime._ipc_imports_closed
++    runtime.close()
++    assert events == [
++        ("dispose", 123),
++        ("close", 2000),
++        ("close", 3000),
++        ("free", 1000),
++    ]
++    assert runtime._ipc_exports_freed
++
++
++def test_failed_rollback_keeps_transient_channel_owned_for_retry() -> None:
++    retained_events: list[object] = []
++    transient_events: list[object] = []
++    retained = _fake_oneshot(retained_events)
++    transient = _fake_oneshot(transient_events)
++    transient._ipc = _FakeIPC(transient_events, close_failures={2000: 1})
++    pool = PCIeOneshotAllReducePool(
++        rank=0,
++        world_size=2,
++        device=torch.device("cpu"),
++        channel_factory=lambda stream_key: retained,
++    )
++    pool._all_channels = [retained, transient]
++    pool._channels = {1: retained, 2: transient}
++    checkpoint = (1, {1: retained})
++
++    with pytest.raises(RuntimeError, match="failed during IPC unmap"):
++        pool.rollback_channels(checkpoint)
++
++    assert pool._all_channels == [retained, transient]
++    assert pool._channels == {1: retained, 2: transient}
++    assert not pool._closed
++    assert ("free", 1000) not in transient_events
+diff --git a/tests/comm/test_pcie_native_teardown.py b/tests/comm/test_pcie_native_teardown.py
+new file mode 100644
+index 0000000000000000000000000000000000000000..0e3451b7d92d8f85cf36f68d8d8f51eb0723122d
+--- /dev/null
++++ b/tests/comm/test_pcie_native_teardown.py
+@@ -0,0 +1,171 @@
++from __future__ import annotations
++
++import shutil
++import subprocess
++import textwrap
++from pathlib import Path
++
++import pytest
++
++
++ROOT = Path(__file__).resolve().parents[2]
++PCIE_ONESHOT = ROOT / "sparkinfer" / "comm" / "pcie" / "pcie_oneshot.cu"
++
++
++def test_oneshot_native_dispose_has_strict_and_best_effort_paths() -> None:
++    source = PCIE_ONESHOT.read_text(encoding="utf-8")
++
++    assert "IpcHandleRegistry<IPC_KEY, char*, cudaError_t, cudaSuccess>" in source
++    assert "IPCHandles ipc_handles_;" in source
++    assert "~PCIeAllreduce() noexcept = default;" in source
++    assert "cudaError_t close_ipc_handles_noexcept() noexcept" in source
++    assert "void close_ipc_handles_strict()" in source
++    assert "&dispose," in source
++    assert '"dispose_best_effort"' in source
++
++    dispose = source[source.index("static void dispose(fptr_t _fa)") :]
++    dispose = dispose[: dispose.index("static int64_t meta_size()")]
++    assert dispose.index("fa->close_ipc_handles_strict();") < dispose.index(
++        "delete fa;"
++    )
++    assert "static bool dispose_best_effort(fptr_t _fa) noexcept" in dispose
++
++
++def test_native_ipc_registry_destructor_survives_injected_close_failure(
++    tmp_path: Path,
++) -> None:
++    """Compile the production RAII helper and fail a close inside destruction.
++
++    Throwing for this injected status from an implicitly-noexcept destructor,
++    as the old PCIeAllreduce destructor did, would invoke the terminate handler
++    and make the subprocess exit 86.
++    """
++
++    compiler = shutil.which("c++") or shutil.which("clang++") or shutil.which("g++")
++    if compiler is None:
++        pytest.skip("no C++ compiler available for native teardown regression")
++
++    source = tmp_path / "ipc_registry_failure_injection.cpp"
++    binary = tmp_path / "ipc_registry_failure_injection"
++    source.write_text(
++        textwrap.dedent(
++            r"""
++            #include "sparkinfer/comm/pcie/ipc_handle_registry.h"
++
++            #include <cstdlib>
++            #include <exception>
++            #include <type_traits>
++
++            namespace {
++
++            constexpr int kSuccess = 0;
++            constexpr int kInjectedFailure = 7;
++            int close_calls = 0;
++            int failed_handle = 0;
++            int failures_remaining = 0;
++
++            int injected_close(int handle) noexcept {
++              ++close_calls;
++              if (handle == failed_handle && failures_remaining > 0) {
++                --failures_remaining;
++                return kInjectedFailure;
++              }
++              return kSuccess;
++            }
++
++            using Registry =
++                sparkinfer::pcie::IpcHandleRegistry<int, int, int, kSuccess>;
++
++            struct Owner {
++              Registry handles{&injected_close};
++              ~Owner() noexcept = default;
++            };
++
++            static_assert(std::is_nothrow_destructible_v<Registry>);
++            static_assert(std::is_nothrow_destructible_v<Owner>);
++
++            }  // namespace
++
++            int main() {
++              std::set_terminate([] { std::_Exit(86); });
++
++              failed_handle = 22;
++              failures_remaining = 1;
++              {
++                Owner owner;
++                owner.handles.emplace(1, 11);
++                owner.handles.emplace(2, 22);
++                owner.handles.emplace(3, 33);
++              }
++              if (close_calls != 3 || failures_remaining != 0) {
++                return 10;
++              }
++
++              close_calls = 0;
++              failures_remaining = 1;
++              {
++                Owner owner;
++                owner.handles.emplace(1, 11);
++                owner.handles.emplace(2, 22);
++                owner.handles.emplace(3, 33);
++                if (owner.handles.close_all_noexcept() != kInjectedFailure) {
++                  return 11;
++                }
++                if (close_calls != 3) {
++                  return 12;
++                }
++                if (owner.handles.close_all_noexcept() != kSuccess) {
++                  return 13;
++                }
++                if (close_calls != 4) {
++                  return 14;
++                }
++                if (owner.handles.close_all_noexcept() != kSuccess ||
++                    close_calls != 4) {
++                  return 15;
++                }
++              }
++              return close_calls == 4 ? 0 : 16;
++            }
++            """
++        ),
++        encoding="utf-8",
++    )
++
++    compile_result = subprocess.run(
++        [
++            compiler,
++            "-std=c++17",
++            "-Wall",
++            "-Wextra",
++            "-Werror",
++            "-I",
++            str(ROOT),
++            str(source),
++            "-o",
++            str(binary),
++        ],
++        check=False,
++        capture_output=True,
++        text=True,
++        timeout=30,
++    )
++    assert compile_result.returncode == 0, (
++        "native teardown regression failed to compile\n"
++        f"stdout:\n{compile_result.stdout}\n"
++        f"stderr:\n{compile_result.stderr}"
++    )
++
++    run_result = subprocess.run(
++        [str(binary)],
++        check=False,
++        capture_output=True,
++        text=True,
++        timeout=10,
++    )
++    assert run_result.returncode == 0, (
++        "injected native close failure terminated or violated idempotency\n"
++        f"returncode: {run_result.returncode}\n"
++        f"stdout:\n{run_result.stdout}\n"
++        f"stderr:\n{run_result.stderr}"
++    )
+diff --git a/tests/comm/test_pcie_oneshot.py b/tests/comm/test_pcie_oneshot.py
+index e065eafb2710fd6c79497a55d373738b247610f8..bbd20a30b7005142186018ad04f7c9a2d0d149f3 100644
+--- a/tests/comm/test_pcie_oneshot.py
++++ b/tests/comm/test_pcie_oneshot.py
+@@ -1,5 +1,8 @@
+ from __future__ import annotations
+ 
++import gc
++from types import SimpleNamespace
++
+ import pytest
+ import torch
+ 
+@@ -7,7 +10,16 @@ from sparkinfer.comm.pcie.pcie_oneshot import (
+     IPC_SLAB_ALIGNMENT,
+     PCIeOneshotAllReduce,
+     PCIeOneshotAllReducePool,
++    _abort_collective_ipc_setup,
++    _broadcast_gather_object,
+     _compute_crossover_size,
++    _finish_collective_runtime_setup,
++    _group_ranks,
++    _OwnedSharedBuffer,
++    _require_no_retained_ipc_setup,
++    _require_full_grid_residency,
++    _ABANDONED_PCIE_RUNTIME_QUARANTINE,
++    _RETAINED_FAILED_IPC_EXPORTS,
+     parse_pcie_oneshot_max_size,
+ )
+ 
+@@ -106,6 +118,7 @@ def _make_runtime(
+     if eager:
+         kwargs["eager_buffer_ptrs0"] = tuple(range(200, 200 + world_size))
+         kwargs["eager_buffer_ptrs1"] = tuple(range(300, 300 + world_size))
++        kwargs["eager_buffer_bytes"] = max_size
+     return PCIeOneshotAllReduce(
+         rank=rank,
+         world_size=world_size,
+@@ -127,6 +140,63 @@ def test_parse_pcie_oneshot_max_size_accepts_auto_and_suffixes():
+     assert parse_pcie_oneshot_max_size(4096) == 4096
+ 
+ 
++def test_full_grid_residency_accepts_device_with_enough_visible_sms(
++    monkeypatch,
++):
++    monkeypatch.setattr(
++        torch.cuda,
++        "get_device_properties",
++        lambda device: SimpleNamespace(multi_processor_count=84),
++    )
++
++    _require_full_grid_residency(
++        owner="test collective",
++        required_sms=64,
++        device=torch.device("cuda:0"),
++        exchange_group=None,
++    )
++
++
++def test_full_grid_residency_rejects_mig_like_capacity_collectively(
++    monkeypatch,
++):
++    monkeypatch.setattr(
++        torch.cuda,
++        "get_device_properties",
++        lambda device: SimpleNamespace(multi_processor_count=84),
++    )
++    monkeypatch.setenv("SPARKINFER_PCIE_TEST_VISIBLE_SM_COUNT", "32")
++    exchanged = []
++
++    def exchange(
++        local_error,
++        *,
++        exchange_group,
++        phase,
++        exports_retained_on_exchange_failure,
++    ):
++        assert not exports_retained_on_exchange_failure
++        exchanged.append((local_error, exchange_group, phase))
++        return ((f"RuntimeError: {local_error}",), ())
++
++    monkeypatch.setattr(
++        "sparkinfer.comm.pcie.pcie_oneshot._exchange_setup_failures", exchange
++    )
++
++    group = object()
++    with pytest.raises(RuntimeError, match="requires at least 64 visible SMs") as exc:
++        _require_full_grid_residency(
++            owner="test collective",
++            required_sms=64,
++            device=torch.device("cuda:0"),
++            exchange_group=group,
++        )
++
++    assert exchanged
++    assert exchanged[0][1:] == (group, "test collective resident-grid capability")
++    assert "exports were retained" not in str(exc.value)
++
++
+ def test_compute_crossover_size_runs_fine_sweep():
+     seen_sizes = []
+ 
+@@ -347,6 +417,76 @@ def test_should_allreduce_checks_device_dtype_size_alignment_and_contiguity():
+     )
+ 
+ 
++def test_eager_runtime_rejects_threshold_above_buffer_capacity():
++    with pytest.raises(ValueError, match="exceeds eager buffer capacity"):
++        PCIeOneshotAllReduce(
++            rank=0,
++            world_size=2,
++            device=torch.device("cpu"),
++            signal_ptrs=(100, 200),
++            eager_buffer_ptrs0=(300, 400),
++            eager_buffer_ptrs1=(500, 600),
++            eager_buffer_bytes=16,
++            max_size=32,
++            ext_module=_FakeExt(),
++        )
++
++
++def test_cuda_direct_runtime_requires_collective_factory():
++    with pytest.raises(ValueError, match="exchange_group is required"):
++        PCIeOneshotAllReduce(
++            rank=0,
++            world_size=2,
++            device=torch.device("cuda:0"),
++            signal_ptrs=(100, 200),
++            ext_module=_FakeExt(),
++        )
++
++
++@pytest.mark.parametrize(
++    "runtime_class", (PCIeOneshotAllReduce, PCIeOneshotAllReducePool)
++)
++def test_process_group_max_input_sets_threshold_and_capacity(
++    monkeypatch, runtime_class
++):
++    captured = {}
++
++    def fake_from_exchange_group(cls, **kwargs):
++        captured.update(kwargs)
++        return object()
++
++    monkeypatch.setattr(
++        runtime_class, "from_exchange_group", classmethod(fake_from_exchange_group)
++    )
++
++    runtime_class.from_process_group(
++        process_group=object(),
++        device=torch.device("cuda:0"),
++        max_input_bytes=1 << 20,
++    )
++
++    assert captured["eager_buffer_bytes"] == 1 << 20
++    assert captured["max_size"] == 1 << 20
++
++
++def test_autotune_never_benchmarks_past_eager_capacity(monkeypatch):
++    runtime = _make_runtime(eager=True, max_size=4096)
++    runtime.device = torch.device("cuda:0")
++    observed = {}
++
++    def fake_compute(benchmark, *, ceiling_bytes, fine_step_bytes):
++        observed["ceiling_bytes"] = ceiling_bytes
++        return ceiling_bytes, []
++
++    monkeypatch.setattr(
++        "sparkinfer.comm.pcie.pcie_oneshot._compute_crossover_size", fake_compute
++    )
++    monkeypatch.setattr(torch.cuda, "Stream", lambda *, device: object())
++
++    assert runtime.find_crossover_size(object(), ceiling_bytes=1 << 20) == 4096
++    assert observed["ceiling_bytes"] == 4096
++
++
+ def test_graph_buffer_api_exposes_explicit_registration_hooks():
+     runtime = _make_runtime()
+     ext = runtime._ext
+@@ -395,10 +535,14 @@ def test_allocate_shared_buffer_cleans_up_on_failed_peer_open(monkeypatch):
+     monkeypatch.setattr("torch.distributed.get_rank", lambda group=None: 0)
+     monkeypatch.setattr(
+         "sparkinfer.comm.pcie.pcie_oneshot._broadcast_gather_object",
+-        lambda local_object, group: [local_object, b"remote0", b"remote1"],
++        lambda local_object, group: (
++            [local_object, (), ()]
++            if isinstance(local_object, tuple)
++            else [local_object, b"remote0", b"remote1"]
++        ),
+     )
+ 
+-    with pytest.raises(RuntimeError, match="peer rank 2"):
++    with pytest.raises(RuntimeError, match="peer group rank 2"):
+         PCIeOneshotAllReduce._allocate_shared_buffer(
+             object(), 256, zero_fill=True, ipc=ipc
+         )
+@@ -407,74 +551,116 @@ def test_allocate_shared_buffer_cleans_up_on_failed_peer_open(monkeypatch):
+     assert ipc.freed == [1000]
+ 
+ 
+-def test_eager_channel_buffers_use_single_ipc_slab(monkeypatch):
++def test_failed_setup_export_free_is_retained_and_retryable(monkeypatch):
+     class FakeIPC:
+         def __init__(self):
+-            self.malloc_sizes = []
+-            self.memsets = []
+-            self.opened = []
++            self.free_attempts = 0
+ 
+         def cudaMalloc(self, size):
+-            self.malloc_sizes.append(size)
+             return 1000
+ 
+         def cudaMemset(self, ptr, value, size):
+-            self.memsets.append((ptr, value, size))
++            raise RuntimeError("injected setup failure")
++
++        def cudaIpcGetMemHandleBytes(self, ptr):
++            return b"local"
++
++        def cudaFree(self, ptr):
++            self.free_attempts += 1
++            if self.free_attempts == 1:
++                raise RuntimeError("transient free failure")
++
++    ipc = FakeIPC()
++    monkeypatch.setattr("torch.distributed.get_world_size", lambda group=None: 2)
++    monkeypatch.setattr("torch.distributed.get_rank", lambda group=None: 0)
++    monkeypatch.setattr(
++        "sparkinfer.comm.pcie.pcie_oneshot._broadcast_gather_object",
++        lambda local_object, group: [local_object, ()],
++    )
++
++    with pytest.raises(RuntimeError, match="exports were retained") as exc:
++        PCIeOneshotAllReduce._allocate_shared_buffer(
++            object(), 256, zero_fill=True, ipc=ipc
++        )
++
++    retained = exc.value.retryable_export
++    assert _RETAINED_FAILED_IPC_EXPORTS[retained.key] is retained
++    retained.retry()
++    assert ipc.free_attempts == 2
++    assert retained.local_ptr == 0
++    assert _RETAINED_FAILED_IPC_EXPORTS == {}
++
++
++def test_failed_peer_setup_export_free_is_retained_and_retryable(monkeypatch):
++    class FakeIPC:
++        def __init__(self):
++            self.closed = []
++            self.free_attempts = 0
++
++        def cudaMalloc(self, size):
++            return 1000
++
++        def cudaMemset(self, ptr, value, size):
++            pass
+ 
+         def cudaIpcGetMemHandleBytes(self, ptr):
+             return b"local"
+ 
+         def cudaIpcOpenMemHandleBytes(self, handle):
+-            ptr = {b"remote0": 2000, b"remote1": 3000}[handle]
+-            self.opened.append(ptr)
+-            return ptr
++            return 2000
+ 
+         def cudaIpcCloseMemHandle(self, ptr):
+-            raise AssertionError("success path should not close remote ptrs")
++            self.closed.append(ptr)
+ 
+         def cudaFree(self, ptr):
+-            raise AssertionError("success path should not free local ptr")
++            self.free_attempts += 1
++            if self.free_attempts == 1:
++                raise RuntimeError("transient free failure")
+ 
+     ipc = FakeIPC()
+-    exchange_group = object()
+-    signal_bytes = 300
+-    eager_bytes = 128
+-    eager0_offset = IPC_SLAB_ALIGNMENT * 2
+-    eager1_offset = eager0_offset + IPC_SLAB_ALIGNMENT
++    status_round = 0
++
++    def exchange(local_object, group):
++        nonlocal status_round
++        if not isinstance(local_object, tuple):
++            return [local_object, b"remote"]
++        status_round += 1
++        if status_round == 1:  # retained-setup gate
++            return [local_object, ()]
++        if status_round == 2:  # export preparation
++            return [local_object, ()]
++        if status_round == 3:  # import-open verdict
++            return [local_object, ("peer open failed",)]
++        if status_round == 4:  # rollback-unmap verdict
++            return [local_object, ()]
++        if status_round == 5:  # rollback-export-free verdict
++            return [local_object, ()]
++        if status_round == 6:  # retry export-free verdict
++            return [local_object, ()]
++        raise AssertionError(f"unexpected status round {status_round}")
+ 
+-    monkeypatch.setattr("torch.distributed.get_world_size", lambda group=None: 3)
++    monkeypatch.setattr("torch.distributed.get_world_size", lambda group=None: 2)
+     monkeypatch.setattr("torch.distributed.get_rank", lambda group=None: 0)
+     monkeypatch.setattr(
+-        "sparkinfer.comm.pcie.pcie_oneshot._broadcast_gather_object",
+-        lambda local_object, group: [local_object, b"remote0", b"remote1"],
++        "sparkinfer.comm.pcie.pcie_oneshot._broadcast_gather_object", exchange
+     )
+ 
+-    buffers = PCIeOneshotAllReduce._allocate_eager_channel_buffers(
+-        exchange_group,
+-        signal_bytes=signal_bytes,
+-        eager_buffer_bytes=eager_bytes,
+-        ipc=ipc,
+-    )
++    with pytest.raises(RuntimeError, match="exports were retained") as exc:
++        PCIeOneshotAllReduce._allocate_shared_buffer(
++            object(), 256, zero_fill=True, ipc=ipc
++        )
+ 
+-    assert ipc.malloc_sizes == [eager1_offset + eager_bytes]
+-    assert ipc.memsets == [(1000, 0, eager1_offset + eager_bytes)]
+-    assert ipc.opened == [2000, 3000]
+-    assert buffers.owned_buffer.local_ptr == 1000
+-    assert buffers.owned_buffer.remote_ptrs == (2000, 3000)
+-    assert buffers.signal_ptrs == (1000, 2000, 3000)
+-    assert buffers.eager0_ptrs == (
+-        1000 + eager0_offset,
+-        2000 + eager0_offset,
+-        3000 + eager0_offset,
+-    )
+-    assert buffers.eager1_ptrs == (
+-        1000 + eager1_offset,
+-        2000 + eager1_offset,
+-        3000 + eager1_offset,
+-    )
++    retained = exc.value.retryable_export
++    assert ipc.closed == [2000]
++    assert _RETAINED_FAILED_IPC_EXPORTS[retained.key] is retained
++    retained.retry()
++    assert ipc.free_attempts == 2
++    assert _RETAINED_FAILED_IPC_EXPORTS == {}
+ 
+ 
+-def test_eager_channel_buffers_cleanup_when_slab_zero_fails(monkeypatch):
++def test_peer_setup_and_unmap_failure_retains_export_and_closes_each_import_once(
++    monkeypatch,
++):
+     class FakeIPC:
+         def __init__(self):
+             self.closed = []
+@@ -484,7 +670,7 @@ def test_eager_channel_buffers_cleanup_when_slab_zero_fails(monkeypatch):
+             return 1000
+ 
+         def cudaMemset(self, ptr, value, size):
+-            raise RuntimeError("memset failed")
++            pass
+ 
+         def cudaIpcGetMemHandleBytes(self, ptr):
+             return b"local"
+@@ -499,128 +685,714 @@ def test_eager_channel_buffers_cleanup_when_slab_zero_fails(monkeypatch):
+             self.freed.append(ptr)
+ 
+     ipc = FakeIPC()
++    status_round = 0
++
++    def exchange(local_object, group):
++        nonlocal status_round
++        if not isinstance(local_object, tuple):
++            return [local_object, b"remote0", b"remote1"]
++        status_round += 1
++        if status_round == 1:  # retained-setup gate
++            return [local_object, (), ()]
++        if status_round == 2:  # export preparation
++            return [local_object, (), ()]
++        if status_round == 3:  # import-open verdict
++            return [local_object, ("peer open failed",), ()]
++        if status_round == 4:  # rollback-unmap verdict
++            return [local_object, ("peer unmap failed",), ()]
++        if status_round in (5, 6):  # retry unmap / retry export free
++            return [local_object, (), ()]
++        raise AssertionError(f"unexpected status round {status_round}")
+ 
+     monkeypatch.setattr("torch.distributed.get_world_size", lambda group=None: 3)
+     monkeypatch.setattr("torch.distributed.get_rank", lambda group=None: 0)
+     monkeypatch.setattr(
+-        "sparkinfer.comm.pcie.pcie_oneshot._broadcast_gather_object",
+-        lambda local_object, group: [local_object, b"remote0", b"remote1"],
++        "sparkinfer.comm.pcie.pcie_oneshot._broadcast_gather_object", exchange
+     )
+ 
+-    with pytest.raises(RuntimeError, match="memset failed"):
+-        PCIeOneshotAllReduce._allocate_eager_channel_buffers(
+-            object(),
+-            signal_bytes=300,
+-            eager_buffer_bytes=128,
+-            ipc=ipc,
++    with pytest.raises(RuntimeError, match=r"retained.*peer unmap failed") as exc:
++        PCIeOneshotAllReduce._allocate_shared_buffer(
++            object(), 256, zero_fill=True, ipc=ipc
+         )
+ 
+-    assert ipc.closed == []
++    assert ipc.closed == [2000, 3000]
++    assert ipc.freed == []
++    exc.value.retryable_setup.retry()
++    assert ipc.closed == [2000, 3000]
+     assert ipc.freed == [1000]
++    assert _RETAINED_FAILED_IPC_EXPORTS == {}
+ 
+ 
+-def test_register_graph_buffers_uses_exchange_group_broadcast(monkeypatch):
+-    remote_meta = {
+-        0: ([1, 2, 3], [0, 64]),
+-        1: ([9, 8, 7], [16, 80]),
+-    }
+-
+-    monkeypatch.setattr("torch.distributed.get_world_size", lambda group=None: 2)
+-    monkeypatch.setattr("torch.distributed.get_rank", lambda group=None: 0)
+-    monkeypatch.setattr(
+-        "torch.distributed.get_process_group_ranks", lambda group=None: [0, 1]
+-    )
+-    monkeypatch.setattr(
+-        "sparkinfer.comm.pcie.pcie_oneshot._object_broadcast_device",
+-        lambda group: "cpu",
+-    )
++def test_handle_exchange_failure_retains_export_until_collective_retry(monkeypatch):
++    class FakeIPC:
++        def __init__(self):
++            self.freed = []
+ 
+-    def fake_broadcast(object_list, src, group=None, device=None):
+-        object_list[0] = remote_meta[src]
++        def cudaMalloc(self, size):
++            return 1000
+ 
+-    monkeypatch.setattr("torch.distributed.broadcast_object_list", fake_broadcast)
++        def cudaMemset(self, ptr, value, size):
++            pass
+ 
+-    runtime = _make_runtime(exchange_group=object())
+-    ext = runtime._ext
+-    runtime.register_graph_buffers()
++        def cudaIpcGetMemHandleBytes(self, ptr):
++            return b"local"
+ 
+-    assert ext.register_graph_buffers_calls == [
+-        (12345, [[1, 2, 3], [9, 8, 7]], [[0, 64], [16, 80]])
+-    ]
++        def cudaFree(self, ptr):
++            self.freed.append(ptr)
+ 
++    ipc = FakeIPC()
++    status_round = 0
++    fail_handle_exchange = True
++
++    def exchange(local_object, group):
++        nonlocal status_round, fail_handle_exchange
++        if not isinstance(local_object, tuple):
++            if fail_handle_exchange:
++                fail_handle_exchange = False
++                raise RuntimeError("injected handle exchange failure")
++            return [local_object, b"remote"]
++        status_round += 1
++        return [local_object, ()]
+ 
+-def test_register_graph_buffers_noops_when_no_rank_registered_buffers(monkeypatch):
+     monkeypatch.setattr("torch.distributed.get_world_size", lambda group=None: 2)
+     monkeypatch.setattr("torch.distributed.get_rank", lambda group=None: 0)
+     monkeypatch.setattr(
+-        "torch.distributed.get_process_group_ranks", lambda group=None: [0, 1]
+-    )
+-    monkeypatch.setattr(
+-        "sparkinfer.comm.pcie.pcie_oneshot._object_broadcast_device",
+-        lambda group: "cpu",
+-    )
+-    monkeypatch.setattr(
+-        "torch.distributed.broadcast_object_list",
+-        lambda object_list, src, group=None, device=None: object_list.__setitem__(
+-            0, ([], [])
+-        ),
++        "sparkinfer.comm.pcie.pcie_oneshot._broadcast_gather_object", exchange
+     )
+ 
+-    runtime = _make_runtime(exchange_group=object())
+-    ext = runtime._ext
+-    ext.handle_bytes = []
+-    ext.offsets = []
++    with pytest.raises(RuntimeError, match="handle exchange failed") as exc:
++        PCIeOneshotAllReduce._allocate_shared_buffer(
++            object(), 256, zero_fill=True, ipc=ipc
++        )
+ 
+-    runtime.register_graph_buffers()
++    retained = exc.value.retryable_setup
++    assert retained.local_ptr == 1000
++    assert ipc.freed == []
++    retained.retry()
++    assert ipc.freed == [1000]
++    assert status_round == 4  # gate, export verdict, retry unmap, retry free
++    assert _RETAINED_FAILED_IPC_EXPORTS == {}
+ 
+-    assert ext.register_graph_buffers_calls == []
+ 
++def test_import_status_exchange_failure_retains_imports_for_retry(monkeypatch):
++    class FakeIPC:
++        def __init__(self):
++            self.closed = []
++            self.freed = []
+ 
+-def test_capture_registers_graph_buffers_after_context(monkeypatch):
+-    runtime = _make_runtime(exchange_group=object())
+-    calls = []
++        def cudaMalloc(self, size):
++            return 1000
+ 
+-    monkeypatch.setattr(
+-        runtime, "register_graph_buffers", lambda: calls.append("registered")
+-    )
++        def cudaMemset(self, ptr, value, size):
++            pass
+ 
+-    with runtime.capture():
+-        pass
++        def cudaIpcGetMemHandleBytes(self, ptr):
++            return b"local"
+ 
+-    assert calls == ["registered"]
++        def cudaIpcOpenMemHandleBytes(self, handle):
++            return 2000
+ 
++        def cudaIpcCloseMemHandle(self, ptr):
++            self.closed.append(ptr)
+ 
+-def test_eager_capture_skips_graph_buffer_registration(monkeypatch):
+-    runtime = _make_runtime(eager=True, exchange_group=object())
+-    calls = []
++        def cudaFree(self, ptr):
++            self.freed.append(ptr)
++
++    ipc = FakeIPC()
++    status_round = 0
++
++    def exchange(local_object, group):
++        nonlocal status_round
++        if not isinstance(local_object, tuple):
++            return [local_object, b"remote"]
++        status_round += 1
++        if status_round == 3:
++            raise RuntimeError("injected import verdict exchange failure")
++        return [local_object, ()]
+ 
++    monkeypatch.setattr("torch.distributed.get_world_size", lambda group=None: 2)
++    monkeypatch.setattr("torch.distributed.get_rank", lambda group=None: 0)
+     monkeypatch.setattr(
+-        runtime, "register_graph_buffers", lambda: calls.append("registered")
++        "sparkinfer.comm.pcie.pcie_oneshot._broadcast_gather_object", exchange
+     )
+ 
+-    with runtime.capture():
+-        pass
++    with pytest.raises(RuntimeError, match="import-open status") as exc:
++        PCIeOneshotAllReduce._allocate_shared_buffer(
++            object(), 256, zero_fill=True, ipc=ipc
++        )
+ 
+-    assert calls == []
++    retained = exc.value.retryable_setup
++    assert retained.remote_ptrs == [2000]
++    assert ipc.closed == []
++    retained.retry()
++    assert ipc.closed == [2000]
++    assert ipc.freed == [1000]
++    assert _RETAINED_FAILED_IPC_EXPORTS == {}
+ 
+ 
+-def test_pool_creates_distinct_channels_per_stream_key(monkeypatch):
+-    created = []
++def test_failed_native_cleanup_is_owned_and_retried_before_export_free(monkeypatch):
++    class FakeIPC:
++        def __init__(self):
++            self.closed = []
++            self.freed = []
+ 
+-    def make_channel(stream_key):
+-        runtime = _make_runtime(eager=True)
+-        created.append((stream_key, runtime))
+-        return runtime
++        def cudaIpcCloseMemHandle(self, ptr):
++            self.closed.append(ptr)
+ 
+-    pool = PCIeOneshotAllReducePool(
+-        rank=0,
+-        world_size=2,
+-        device=torch.device("cpu"),
+-        channel_factory=make_channel,
+-    )
++        def cudaFree(self, ptr):
++            self.freed.append(ptr)
+ 
+-    monkeypatch.setattr(
+-        "sparkinfer.comm.pcie.pcie_oneshot._current_stream_key",
++    ipc = FakeIPC()
++    cleanup_calls = 0
++
++    def cleanup():
++        nonlocal cleanup_calls
++        cleanup_calls += 1
++        if cleanup_calls == 1:
++            raise RuntimeError("transient native dispose failure")
++
++    monkeypatch.setattr(
++        "sparkinfer.comm.pcie.pcie_oneshot._broadcast_gather_object",
++        lambda local_status, group: [local_status, ()],
++    )
++
++    with pytest.raises(RuntimeError, match="rollback native cleanup") as exc:
++        _abort_collective_ipc_setup(
++            owner="test runtime",
++            setup_phase="native initialization",
++            setup_statuses=(("peer init failed",), ()),
++            exchange_group=object(),
++            ipc=ipc,
++            local_ptr=1000,
++            remote_ptrs=(2000,),
++            local_error=RuntimeError("peer init failed"),
++            local_cleanup=cleanup,
++        )
++
++    retained = exc.value.retryable_setup
++    assert cleanup_calls == 1
++    assert retained.state == "native"
++    assert ipc.closed == []
++    assert ipc.freed == []
++    retained.retry()
++    assert cleanup_calls == 2
++    assert ipc.closed == [2000]
++    assert ipc.freed == [1000]
++    assert _RETAINED_FAILED_IPC_EXPORTS == {}
++
++
++def test_peer_native_cleanup_failure_blocks_every_rank_from_unmapping(monkeypatch):
++    class FakeIPC:
++        def __init__(self):
++            self.closed = []
++            self.freed = []
++
++        def cudaIpcCloseMemHandle(self, ptr):
++            self.closed.append(ptr)
++
++        def cudaFree(self, ptr):
++            self.freed.append(ptr)
++
++    ipc = FakeIPC()
++    cleanup_calls = 0
++    status_round = 0
++
++    def cleanup():
++        nonlocal cleanup_calls
++        cleanup_calls += 1
++
++    def exchange(local_status, group):
++        nonlocal status_round
++        status_round += 1
++        if status_round == 1:
++            return [local_status, ("peer native dispose failed",)]
++        return [local_status, ()]
++
++    monkeypatch.setattr(
++        "sparkinfer.comm.pcie.pcie_oneshot._broadcast_gather_object", exchange
++    )
++
++    with pytest.raises(RuntimeError, match="rollback native cleanup") as exc:
++        _abort_collective_ipc_setup(
++            owner="test runtime",
++            setup_phase="native initialization",
++            setup_statuses=(("peer init failed",), ()),
++            exchange_group=object(),
++            ipc=ipc,
++            local_ptr=1000,
++            remote_ptrs=(2000,),
++            local_error=RuntimeError("peer init failed"),
++            local_cleanup=cleanup,
++        )
++
++    retained = exc.value.retryable_setup
++    assert retained.state == "native"
++    assert retained.local_cleanup is None
++    assert cleanup_calls == 1
++    assert ipc.closed == []
++    assert ipc.freed == []
++
++    retained.retry()
++    assert cleanup_calls == 1
++    assert ipc.closed == [2000]
++    assert ipc.freed == [1000]
++    assert _RETAINED_FAILED_IPC_EXPORTS == {}
++
++
++def test_native_cleanup_verdict_exchange_failure_retains_imports(monkeypatch):
++    events = []
++
++    class FakeIPC:
++        def cudaIpcCloseMemHandle(self, ptr):
++            events.append(("close", ptr))
++
++        def cudaFree(self, ptr):
++            events.append(("free", ptr))
++
++    ipc = FakeIPC()
++    status_round = 0
++
++    def exchange(local_status, group):
++        nonlocal status_round
++        status_round += 1
++        if status_round == 1:
++            raise RuntimeError("injected native cleanup verdict exchange failure")
++        return [local_status, ()]
++
++    monkeypatch.setattr(
++        "sparkinfer.comm.pcie.pcie_oneshot._broadcast_gather_object", exchange
++    )
++
++    with pytest.raises(RuntimeError, match="cleanup status exchange") as exc:
++        _abort_collective_ipc_setup(
++            owner="test runtime",
++            setup_phase="native initialization",
++            setup_statuses=(("peer init failed",), ()),
++            exchange_group=object(),
++            ipc=ipc,
++            local_ptr=1000,
++            remote_ptrs=(2000,),
++            local_error=RuntimeError("peer init failed"),
++            local_cleanup=lambda: events.append(("dispose", 3000)),
++        )
++
++    retained = exc.value.retryable_setup
++    assert retained.state == "native"
++    assert retained.local_cleanup is None
++    assert events == [("dispose", 3000)]
++
++    retained.retry()
++    assert events == [("dispose", 3000), ("close", 2000), ("free", 1000)]
++    assert _RETAINED_FAILED_IPC_EXPORTS == {}
++
++
++def test_initial_native_verdict_exchange_retains_complete_setup_until_retry(
++    monkeypatch,
++):
++    events = []
++
++    class FakeIPC:
++        def cudaIpcCloseMemHandle(self, ptr):
++            events.append(("close", ptr))
++
++        def cudaFree(self, ptr):
++            events.append(("free", ptr))
++
++    ipc = FakeIPC()
++    group = object()
++    status_round = 0
++
++    def exchange(local_status, exchange_group):
++        nonlocal status_round
++        assert exchange_group is group
++        status_round += 1
++        if status_round == 1:
++            raise RuntimeError("injected first native verdict exchange failure")
++        return [local_status, ()]
++
++    monkeypatch.setattr(
++        "sparkinfer.comm.pcie.pcie_oneshot._broadcast_gather_object", exchange
++    )
++
++    with pytest.raises(RuntimeError, match="must be coordinated by every rank") as exc:
++        _finish_collective_runtime_setup(
++            owner="PCIe twoshot proof",
++            exchange_group=group,
++            ipc=ipc,
++            shared=_OwnedSharedBuffer(
++                local_ptr=1000,
++                peer_ptrs=(1000, 2000),
++                remote_ptrs=(2000,),
++            ),
++            local_error=None,
++            local_cleanup=lambda: events.append(("dispose", 3000)),
++        )
++
++    retained = exc.value.retryable_setup
++    assert retained.local_ptr == 1000
++    assert retained.remote_ptrs == [2000]
++    assert retained.local_cleanup is not None
++    assert events == []
++    assert _RETAINED_FAILED_IPC_EXPORTS[retained.key] is retained
++
++    # The retained generation gate rejects another setup on this process group
++    # before CUDA allocation.  A caller may only retry after arranging the same
++    # retry call on every rank that participated in the failed exchange.
++    with pytest.raises(RuntimeError, match="retained CUDA IPC setup gate"):
++        _require_no_retained_ipc_setup(group)
++    assert events == []
++
++    retained.retry()
++    assert events == [("dispose", 3000), ("close", 2000), ("free", 1000)]
++    assert _RETAINED_FAILED_IPC_EXPORTS == {}
++
++
++def test_free_status_exchange_failure_keeps_coordination_ticket_without_double_free(
++    monkeypatch,
++):
++    class FakeIPC:
++        def __init__(self):
++            self.freed = []
++
++        def cudaFree(self, ptr):
++            self.freed.append(ptr)
++
++    ipc = FakeIPC()
++    status_round = 0
++
++    def exchange(local_status, group):
++        nonlocal status_round
++        status_round += 1
++        if status_round == 2:
++            raise RuntimeError("injected free verdict exchange failure")
++        return [local_status, ()]
++
++    monkeypatch.setattr(
++        "sparkinfer.comm.pcie.pcie_oneshot._broadcast_gather_object", exchange
++    )
++
++    with pytest.raises(RuntimeError, match="free status exchange") as exc:
++        _abort_collective_ipc_setup(
++            owner="test runtime",
++            setup_phase="native initialization",
++            setup_statuses=(("peer init failed",), ()),
++            exchange_group=object(),
++            ipc=ipc,
++            local_ptr=1000,
++            remote_ptrs=(),
++            local_error=RuntimeError("peer init failed"),
++        )
++
++    retained = exc.value.retryable_setup
++    assert retained.local_ptr == 0
++    assert ipc.freed == [1000]
++    retained.retry()
++    assert ipc.freed == [1000]
++    assert _RETAINED_FAILED_IPC_EXPORTS == {}
++
++
++def test_retained_generation_blocks_second_setup_before_cuda_allocation(monkeypatch):
++    class FakeIPC:
++        def __init__(self):
++            self.malloc_calls = 0
++
++        def cudaMalloc(self, size):
++            self.malloc_calls += 1
++            raise RuntimeError("injected no-local-export allocation failure")
++
++    ipc = FakeIPC()
++    group = object()
++    status_round = 0
++
++    def exchange(local_status, exchange_group):
++        nonlocal status_round
++        status_round += 1
++        if status_round == 2:
++            raise RuntimeError("injected preparation verdict exchange failure")
++        return [local_status, ()]
++
++    monkeypatch.setattr(
++        "sparkinfer.comm.pcie.pcie_oneshot._broadcast_gather_object", exchange
++    )
++
++    with pytest.raises(RuntimeError, match="preparation status") as exc:
++        PCIeOneshotAllReduce._allocate_shared_buffer(
++            group, 256, zero_fill=True, ipc=ipc
++        )
++    retained = exc.value.retryable_setup
++    first_key = retained.key
++    assert retained.local_ptr == 0
++    assert ipc.malloc_calls == 1
++
++    with pytest.raises(RuntimeError, match="retained CUDA IPC setup gate"):
++        PCIeOneshotAllReduce._allocate_shared_buffer(
++            group, 256, zero_fill=True, ipc=ipc
++        )
++    assert ipc.malloc_calls == 1
++    assert tuple(_RETAINED_FAILED_IPC_EXPORTS) == (first_key,)
++
++    retained.retry()
++    assert _RETAINED_FAILED_IPC_EXPORTS == {}
++
++
++def test_eager_channel_buffers_use_single_ipc_slab(monkeypatch):
++    class FakeIPC:
++        def __init__(self):
++            self.malloc_sizes = []
++            self.memsets = []
++            self.opened = []
++
++        def cudaMalloc(self, size):
++            self.malloc_sizes.append(size)
++            return 1000
++
++        def cudaMemset(self, ptr, value, size):
++            self.memsets.append((ptr, value, size))
++
++        def cudaIpcGetMemHandleBytes(self, ptr):
++            return b"local"
++
++        def cudaIpcOpenMemHandleBytes(self, handle):
++            ptr = {b"remote0": 2000, b"remote1": 3000}[handle]
++            self.opened.append(ptr)
++            return ptr
++
++        def cudaIpcCloseMemHandle(self, ptr):
++            raise AssertionError("success path should not close remote ptrs")
++
++        def cudaFree(self, ptr):
++            raise AssertionError("success path should not free local ptr")
++
++    ipc = FakeIPC()
++    exchange_group = object()
++    signal_bytes = 300
++    eager_bytes = 128
++    eager0_offset = IPC_SLAB_ALIGNMENT * 2
++    eager1_offset = eager0_offset + IPC_SLAB_ALIGNMENT
++
++    monkeypatch.setattr("torch.distributed.get_world_size", lambda group=None: 3)
++    monkeypatch.setattr("torch.distributed.get_rank", lambda group=None: 0)
++    monkeypatch.setattr(
++        "sparkinfer.comm.pcie.pcie_oneshot._broadcast_gather_object",
++        lambda local_object, group: (
++            [local_object, (), ()]
++            if isinstance(local_object, tuple)
++            else [local_object, b"remote0", b"remote1"]
++        ),
++    )
++
++    buffers = PCIeOneshotAllReduce._allocate_eager_channel_buffers(
++        exchange_group,
++        signal_bytes=signal_bytes,
++        eager_buffer_bytes=eager_bytes,
++        ipc=ipc,
++    )
++
++    assert ipc.malloc_sizes == [eager1_offset + eager_bytes]
++    assert ipc.memsets == [(1000, 0, eager1_offset + eager_bytes)]
++    assert ipc.opened == [2000, 3000]
++    assert buffers.owned_buffer.local_ptr == 1000
++    assert buffers.owned_buffer.remote_ptrs == (2000, 3000)
++    assert buffers.signal_ptrs == (1000, 2000, 3000)
++    assert buffers.eager0_ptrs == (
++        1000 + eager0_offset,
++        2000 + eager0_offset,
++        3000 + eager0_offset,
++    )
++    assert buffers.eager1_ptrs == (
++        1000 + eager1_offset,
++        2000 + eager1_offset,
++        3000 + eager1_offset,
++    )
++
++
++def test_eager_channel_buffers_cleanup_when_slab_zero_fails(monkeypatch):
++    class FakeIPC:
++        def __init__(self):
++            self.closed = []
++            self.freed = []
++
++        def cudaMalloc(self, size):
++            return 1000
++
++        def cudaMemset(self, ptr, value, size):
++            raise RuntimeError("memset failed")
++
++        def cudaIpcGetMemHandleBytes(self, ptr):
++            return b"local"
++
++        def cudaIpcOpenMemHandleBytes(self, handle):
++            return {b"remote0": 2000, b"remote1": 3000}[handle]
++
++        def cudaIpcCloseMemHandle(self, ptr):
++            self.closed.append(ptr)
++
++        def cudaFree(self, ptr):
++            self.freed.append(ptr)
++
++    ipc = FakeIPC()
++
++    monkeypatch.setattr("torch.distributed.get_world_size", lambda group=None: 3)
++    monkeypatch.setattr("torch.distributed.get_rank", lambda group=None: 0)
++    monkeypatch.setattr(
++        "sparkinfer.comm.pcie.pcie_oneshot._broadcast_gather_object",
++        lambda local_object, group: (
++            [local_object, (), ()]
++            if isinstance(local_object, tuple)
++            else [local_object, b"remote0", b"remote1"]
++        ),
++    )
++
++    with pytest.raises(RuntimeError, match="memset failed"):
++        PCIeOneshotAllReduce._allocate_eager_channel_buffers(
++            object(),
++            signal_bytes=300,
++            eager_buffer_bytes=128,
++            ipc=ipc,
++        )
++
++    assert ipc.closed == []
++    assert ipc.freed == [1000]
++
++
++def test_register_graph_buffers_uses_exchange_group_broadcast(monkeypatch):
++    remote_meta = {
++        0: ([1, 2, 3], [0, 64]),
++        1: ([9, 8, 7], [16, 80]),
++    }
++
++    monkeypatch.setattr("torch.distributed.get_world_size", lambda group=None: 2)
++    monkeypatch.setattr("torch.distributed.get_rank", lambda group=None: 0)
++    monkeypatch.setattr(
++        "torch.distributed.get_process_group_ranks", lambda group=None: [0, 1]
++    )
++    monkeypatch.setattr(
++        "sparkinfer.comm.pcie.pcie_oneshot._object_broadcast_device",
++        lambda group: "cpu",
++    )
++
++    def fake_broadcast(object_list, src, group=None, device=None):
++        object_list[0] = remote_meta[src]
++
++    monkeypatch.setattr("torch.distributed.broadcast_object_list", fake_broadcast)
++
++    runtime = _make_runtime()
++    runtime.exchange_group = object()
++    ext = runtime._ext
++    runtime.register_graph_buffers()
++
++    assert ext.register_graph_buffers_calls == [
++        (12345, [[1, 2, 3], [9, 8, 7]], [[0, 64], [16, 80]])
++    ]
++
++
++def test_nonmonotonic_process_group_order_is_preserved_for_handle_slots(
++    monkeypatch,
++):
++    group = object()
++    sources: list[int] = []
++    nonmonotonic_ranks = [7, 2, 9]
++    monkeypatch.setattr("torch.distributed.get_world_size", lambda group=None: 3)
++    monkeypatch.setattr("torch.distributed.get_rank", lambda group=None: 1)
++    monkeypatch.setattr(
++        "torch.distributed.get_process_group_ranks",
++        lambda group=None: list(nonmonotonic_ranks),
++    )
++    monkeypatch.setattr(
++        "sparkinfer.comm.pcie.pcie_oneshot._object_broadcast_device",
++        lambda group: "cpu",
++    )
++
++    def fake_broadcast(object_list, src, group=None, device=None):
++        sources.append(src)
++        object_list[0] = f"from-{src}"
++
++    monkeypatch.setattr("torch.distributed.broadcast_object_list", fake_broadcast)
++
++    assert _group_ranks(group) == nonmonotonic_ranks
++    assert _broadcast_gather_object("local", group) == [
++        "from-7",
++        "from-2",
++        "from-9",
++    ]
++    assert sources == nonmonotonic_ranks
++
++
++def test_register_graph_buffers_noops_when_no_rank_registered_buffers(monkeypatch):
++    monkeypatch.setattr("torch.distributed.get_world_size", lambda group=None: 2)
++    monkeypatch.setattr("torch.distributed.get_rank", lambda group=None: 0)
++    monkeypatch.setattr(
++        "torch.distributed.get_process_group_ranks", lambda group=None: [0, 1]
++    )
++    monkeypatch.setattr(
++        "sparkinfer.comm.pcie.pcie_oneshot._object_broadcast_device",
++        lambda group: "cpu",
++    )
++    monkeypatch.setattr(
++        "torch.distributed.broadcast_object_list",
++        lambda object_list, src, group=None, device=None: object_list.__setitem__(
++            0, ([], [])
++        ),
++    )
++
++    runtime = _make_runtime()
++    runtime.exchange_group = object()
++    ext = runtime._ext
++    ext.handle_bytes = []
++    ext.offsets = []
++
++    runtime.register_graph_buffers()
++
++    assert ext.register_graph_buffers_calls == []
++
++
++def test_capture_registers_graph_buffers_after_context(monkeypatch):
++    runtime = _make_runtime()
++    runtime.exchange_group = object()
++    calls = []
++
++    monkeypatch.setattr(
++        runtime, "register_graph_buffers", lambda: calls.append("registered")
++    )
++
++    with runtime.capture():
++        pass
++
++    assert calls == ["registered"]
++
++
++def test_eager_capture_skips_graph_buffer_registration(monkeypatch):
++    runtime = _make_runtime(eager=True)
++    runtime.exchange_group = object()
++    calls = []
++
++    monkeypatch.setattr(
++        runtime, "register_graph_buffers", lambda: calls.append("registered")
++    )
++
++    with runtime.capture():
++        pass
++
++    assert calls == []
++
++
++def test_pool_creates_distinct_channels_per_stream_key(monkeypatch):
++    created = []
++
++    def make_channel(stream_key):
++        runtime = _make_runtime(eager=True)
++        created.append((stream_key, runtime))
++        return runtime
++
++    pool = PCIeOneshotAllReducePool(
++        rank=0,
++        world_size=2,
++        device=torch.device("cpu"),
++        channel_factory=make_channel,
++    )
++
++    monkeypatch.setattr(
++        "sparkinfer.comm.pcie.pcie_oneshot._current_stream_key",
+         lambda device, stream=None: 7 if stream is None else int(stream),
+     )
+ 
+@@ -633,6 +1405,337 @@ def test_pool_creates_distinct_channels_per_stream_key(monkeypatch):
+     assert [entry[0] for entry in created] == [7, 8]
+ 
+ 
++def test_collective_logical_channel_preparation_is_canonical(monkeypatch):
++    created = []
++    pool = PCIeOneshotAllReducePool(
++        rank=0,
++        world_size=2,
++        device=torch.device("cpu"),
++        channel_factory=lambda stream_key: _make_runtime(eager=True),
++    )
++    pool._channel_factory = None
++    pool.exchange_group = object()
++    monkeypatch.setattr(
++        pool,
++        "_new_channel",
++        lambda stream_key: created.append(stream_key) or object(),
++    )
++    monkeypatch.setattr(
++        "sparkinfer.comm.pcie.pcie_oneshot._broadcast_gather_object",
++        lambda local_state, group: [local_state, local_state],
++    )
++
++    pool.prepare_channels(("draft", "target"))
++    pool.prepare_channels(("target", "draft"))
++
++    assert list(pool._logical_channels) == ["draft", "target"]
++    assert created == [None, None]
++
++
++def test_collective_logical_channel_mismatch_rejects_before_allocation(monkeypatch):
++    pool = PCIeOneshotAllReducePool(
++        rank=0,
++        world_size=2,
++        device=torch.device("cpu"),
++        channel_factory=lambda stream_key: _make_runtime(eager=True),
++    )
++    pool._channel_factory = None
++    pool.exchange_group = object()
++    monkeypatch.setattr(
++        pool,
++        "_new_channel",
++        lambda stream_key: pytest.fail("channel allocation must not start"),
++    )
++
++    def gather(local_state, group):
++        if not local_state or isinstance(local_state[0], str):
++            return [local_state, ()]
++        _requested, existing = local_state
++        return [local_state, (("other",), existing)]
++
++    monkeypatch.setattr(
++        "sparkinfer.comm.pcie.pcie_oneshot._broadcast_gather_object", gather
++    )
++
++    with pytest.raises(RuntimeError, match="differs across ranks"):
++        pool.prepare_channels(("target",))
++
++
++def test_invalid_logical_channel_id_is_rejected_collectively_before_allocation(
++    monkeypatch,
++):
++    pool = PCIeOneshotAllReducePool(
++        rank=0,
++        world_size=2,
++        device=torch.device("cpu"),
++        channel_factory=lambda stream_key: _make_runtime(eager=True),
++    )
++    pool._channel_factory = None
++    pool.exchange_group = object()
++    monkeypatch.setattr(
++        pool,
++        "_new_channel",
++        lambda stream_key: pytest.fail("channel allocation must not start"),
++    )
++    monkeypatch.setattr(
++        "sparkinfer.comm.pcie.pcie_oneshot._broadcast_gather_object",
++        lambda local_status, group: [local_status, ()],
++    )
++
++    with pytest.raises(RuntimeError, match="must not be empty"):
++        pool.prepare_channels(("  ",))
++
++
++def test_empty_logical_channel_set_still_enters_collective_contract(monkeypatch):
++    pool = PCIeOneshotAllReducePool(
++        rank=0,
++        world_size=2,
++        device=torch.device("cpu"),
++        channel_factory=lambda stream_key: _make_runtime(eager=True),
++    )
++    pool._channel_factory = None
++    pool.exchange_group = object()
++
++    def gather(local_state, group):
++        if not local_state or isinstance(local_state[0], str):
++            return [local_state, ()]
++        _, existing = local_state
++        return [local_state, (("peer-channel",), existing)]
++
++    monkeypatch.setattr(
++        "sparkinfer.comm.pcie.pcie_oneshot._broadcast_gather_object", gather
++    )
++
++    with pytest.raises(RuntimeError, match="differs across ranks"):
++        pool.prepare_channels(())
++
++
++def test_collective_capture_requires_stable_semantic_id(monkeypatch):
++    pool = PCIeOneshotAllReducePool(
++        rank=0,
++        world_size=2,
++        device=torch.device("cpu"),
++        channel_factory=lambda stream_key: _make_runtime(eager=True),
++    )
++    pool._channel_factory = None
++    pool.exchange_group = object()
++
++    monkeypatch.setattr(
++        pool,
++        "_new_channel",
++        lambda stream_key: pytest.fail("channel allocation must not start"),
++    )
++    monkeypatch.setattr(
++        "sparkinfer.comm.pcie.pcie_oneshot._broadcast_gather_object",
++        lambda local_status, group: [local_status, ()],
++    )
++
++    with (
++        pytest.raises(RuntimeError, match="stable semantic channel_id"),
++        pool.capture(7),
++    ):
++        pass
++
++
++def test_collective_capture_allows_opposite_order_from_agreed_catalog(monkeypatch):
++    target = _make_runtime(eager=True)
++    draft = _make_runtime(eager=True)
++    pool = PCIeOneshotAllReducePool(
++        rank=0,
++        world_size=2,
++        device=torch.device("cpu"),
++        channel_factory=lambda stream_key: _make_runtime(eager=True),
++    )
++    pool._channel_factory = None
++    pool.exchange_group = object()
++    pool._logical_channels.update({"graph:draft": draft, "graph:target": target})
++    monkeypatch.setattr(
++        pool,
++        "_new_channel",
++        lambda stream_key: pytest.fail("channel allocation must not start"),
++    )
++    monkeypatch.setattr(
++        "sparkinfer.comm.pcie.pcie_oneshot._current_stream_key",
++        lambda device, stream=None: int(stream),
++    )
++
++    def gather(local_state, group):
++        if local_state == ():
++            return [(), ()]
++        requested, catalog = local_state
++        assert requested == "graph:target"
++        return [local_state, ("graph:draft", catalog)]
++
++    monkeypatch.setattr(
++        "sparkinfer.comm.pcie.pcie_oneshot._broadcast_gather_object", gather
++    )
++
++    with pool.capture(7, channel_id="graph:target") as channel:
++        assert channel is target
++
++    assert pool._captured_channel_ids == {"graph:target"}
++
++
++def test_collective_capture_rejects_divergent_catalog_before_allocation(monkeypatch):
++    target = _make_runtime(eager=True)
++    pool = PCIeOneshotAllReducePool(
++        rank=0,
++        world_size=2,
++        device=torch.device("cpu"),
++        channel_factory=lambda stream_key: _make_runtime(eager=True),
++    )
++    pool._channel_factory = None
++    pool.exchange_group = object()
++    pool._logical_channels["graph:target"] = target
++    monkeypatch.setattr(
++        pool,
++        "_new_channel",
++        lambda stream_key: pytest.fail("channel allocation must not start"),
++    )
++
++    def gather(local_state, group):
++        if local_state == ():
++            return [(), ()]
++        return [local_state, ("graph:target", ())]
++
++    monkeypatch.setattr(
++        "sparkinfer.comm.pcie.pcie_oneshot._broadcast_gather_object", gather
++    )
++
++    with (
++        pytest.raises(RuntimeError, match="prepared channel catalog differs"),
++        pool.capture(7, channel_id="graph:target"),
++    ):
++        pass
++
++
++def test_collective_capture_rejects_differing_unprepared_ids(monkeypatch):
++    target = _make_runtime(eager=True)
++    pool = PCIeOneshotAllReducePool(
++        rank=0,
++        world_size=2,
++        device=torch.device("cpu"),
++        channel_factory=lambda stream_key: _make_runtime(eager=True),
++    )
++    pool._channel_factory = None
++    pool.exchange_group = object()
++    pool._logical_channels["graph:target"] = target
++    monkeypatch.setattr(
++        pool,
++        "_new_channel",
++        lambda stream_key: pytest.fail("channel allocation must not start"),
++    )
++
++    def gather(local_state, group):
++        if local_state == ():
++            return [(), ()]
++        _, catalog = local_state
++        return [local_state, ("graph:unknown", catalog)]
++
++    monkeypatch.setattr(
++        "sparkinfer.comm.pcie.pcie_oneshot._broadcast_gather_object", gather
++    )
++
++    with (
++        pytest.raises(RuntimeError, match="unprepared logical channels"),
++        pool.capture(7, channel_id="graph:target"),
++    ):
++        pass
++
++
++def test_collective_capture_preserves_same_id_convenience_allocation(monkeypatch):
++    created = []
++    channel = _make_runtime(eager=True)
++    pool = PCIeOneshotAllReducePool(
++        rank=0,
++        world_size=2,
++        device=torch.device("cpu"),
++        channel_factory=lambda stream_key: _make_runtime(eager=True),
++    )
++    pool._channel_factory = None
++    pool.exchange_group = object()
++    monkeypatch.setattr(
++        pool,
++        "_new_channel",
++        lambda stream_key: created.append(stream_key) or channel,
++    )
++    monkeypatch.setattr(
++        "sparkinfer.comm.pcie.pcie_oneshot._current_stream_key",
++        lambda device, stream=None: int(stream),
++    )
++    monkeypatch.setattr(
++        "sparkinfer.comm.pcie.pcie_oneshot._broadcast_gather_object",
++        lambda local_state, group: [local_state, local_state],
++    )
++
++    with pool.capture(7, channel_id="graph:target") as captured:
++        assert captured is channel
++
++    assert created == [None]
++    assert pool._logical_channels == {"graph:target": channel}
++
++
++def test_collective_capture_routes_eager_warmup_to_graph_channel(monkeypatch):
++    eager = _make_runtime(eager=True)
++    target = _make_runtime(eager=True)
++    pool = PCIeOneshotAllReducePool(
++        rank=0,
++        world_size=2,
++        device=torch.device("cpu"),
++        channel_factory=lambda stream_key: _make_runtime(eager=True),
++    )
++    pool._channel_factory = None
++    pool.exchange_group = object()
++    pool._logical_channels.update({"eager:model": eager, "graph:target": target})
++    monkeypatch.setattr(
++        pool,
++        "_new_channel",
++        lambda stream_key: pytest.fail("channel allocation must not start"),
++    )
++    monkeypatch.setattr(
++        "sparkinfer.comm.pcie.pcie_oneshot._current_stream_key",
++        lambda device, stream=None: 7 if stream is None else int(stream),
++    )
++    monkeypatch.setattr(
++        "sparkinfer.comm.pcie.pcie_oneshot._broadcast_gather_object",
++        lambda local_state, group: [local_state, local_state],
++    )
++
++    with pool.capture(7, channel_id="graph:target") as captured:
++        assert captured is target
++        assert pool.for_stream(7, channel_id="eager:model") is target
++        with pytest.raises(RuntimeError, match="stream-affine"):
++            pool.for_stream(8, channel_id="eager:model")
++
++    assert pool.for_stream(7, channel_id="eager:model") is eager
++
++
++def test_collective_eager_channel_requires_id_and_rejects_duplicate_stream_owner(
++    monkeypatch,
++):
++    eager = _make_runtime(eager=True)
++    pool = PCIeOneshotAllReducePool(
++        rank=0,
++        world_size=2,
++        device=torch.device("cpu"),
++        channel_factory=lambda stream_key: eager,
++    )
++    pool._channel_factory = None
++    pool.exchange_group = object()
++    pool._logical_channels["eager:model"] = eager
++    monkeypatch.setattr(
++        "sparkinfer.comm.pcie.pcie_oneshot._current_stream_key",
++        lambda device, stream=None: int(stream),
++    )
++
++    with pytest.raises(RuntimeError, match="explicit semantic channel_id"):
++        pool.for_stream(7)
++
++    assert pool.for_stream(7, channel_id="eager:model") is eager
++    with pytest.raises(RuntimeError, match="stream-affine"):
++        pool.for_stream(8, channel_id="eager:model")
++
++
+ def test_pool_reuses_single_channel_across_stream_keys(monkeypatch):
+     created = []
+ 
+@@ -726,11 +1829,60 @@ def test_nested_capture_reuses_its_outer_channel(monkeypatch):
+         capturing[0] = False
+ 
+     assert target_channel is not draft_channel
+-    assert pool._channels[70] is target_channel
+-    assert pool._channels[80] is draft_channel
++    assert pool._channels == {}
++    assert target_channel in pool._all_channels
++    assert draft_channel in pool._all_channels
+     assert [entry[0] for entry in created] == [7, 8]
+ 
+ 
++def test_pool_restores_nested_capture_mappings_in_lifo_order(monkeypatch):
++    current_stream = [7]
++    capturing = [False]
++    pool = PCIeOneshotAllReducePool(
++        rank=0,
++        world_size=2,
++        device=torch.device("cpu"),
++        channel_factory=lambda stream_key: _make_runtime(eager=True),
++    )
++    monkeypatch.setattr(
++        "sparkinfer.comm.pcie.pcie_oneshot._current_stream_key",
++        lambda device, stream=None: (
++            current_stream[0] if stream is None else int(stream)
++        ),
++    )
++    monkeypatch.setattr(
++        "sparkinfer.comm.pcie.pcie_oneshot._is_current_stream_capturing",
++        lambda device: capturing[0],
++    )
++
++    eager_channel = pool.for_stream()
++    with pool.capture(7) as outer_channel:
++        assert pool._channels == {7: outer_channel}
++
++        current_stream[0] = 8
++        with pool.capture() as inner_channel:
++            capturing[0] = True
++            current_stream[0] = 80
++            assert pool.for_stream() is inner_channel
++            assert pool._channels == {
++                7: outer_channel,
++                8: inner_channel,
++                80: inner_channel,
++            }
++            capturing[0] = False
++
++        assert pool._channels == {7: outer_channel}
++        capturing[0] = True
++        current_stream[0] = 70
++        assert pool.for_stream() is outer_channel
++        capturing[0] = False
++
++    assert eager_channel is not outer_channel
++    assert outer_channel is not inner_channel
++    assert pool._channels == {7: eager_channel}
++    assert pool._capture_channel_stack == []
++
++
+ def test_reused_capture_stream_keys_get_distinct_channels(monkeypatch):
+     created = []
+     current_stream = [7]
+@@ -773,8 +1925,7 @@ def test_reused_capture_stream_keys_get_distinct_channels(monkeypatch):
+         capturing[0] = False
+ 
+     assert target_channel is not draft_channel
+-    assert pool._channels[7] is draft_channel
+-    assert pool._channels[70] is draft_channel
++    assert pool._channels == {}
+     assert target_channel in pool._all_channels
+     assert draft_channel in pool._all_channels
+     assert [entry[0] for entry in created] == [7, 7]
+@@ -859,13 +2010,12 @@ def test_pool_coordinates_ipc_teardown_across_ranks(monkeypatch):
+     assert pool._channels == {3: retained}
+ 
+ 
+-def test_channel_teardown_completes_when_ipc_cleanup_raises():
++def test_channel_destructor_retains_all_cuda_ownership_without_side_effects():
+     events = []
+ 
+     class FailingExt:
+-        def dispose(self, ptr):
+-            events.append(("dispose", ptr))
+-            raise RuntimeError("dispose failed")
++        def dispose_best_effort(self, ptr):
++            events.append(("dispose_best_effort", ptr))
+ 
+     class FailingIPC:
+         def cudaIpcCloseMemHandle(self, ptr):
+@@ -873,8 +2023,7 @@ def test_channel_teardown_completes_when_ipc_cleanup_raises():
+             raise RuntimeError("close failed")
+ 
+         def cudaFree(self, ptr):
+-            events.append(("free", ptr))
+-            raise RuntimeError("free failed")
++            raise AssertionError("GC must not free exported IPC allocations")
+ 
+     class SharedBuffer:
+         def __init__(self, local_ptr, remote_ptrs):
+@@ -885,6 +2034,8 @@ def test_channel_teardown_completes_when_ipc_cleanup_raises():
+     channel._closed = False
+     channel._ipc_imports_closed = False
+     channel._ipc_exports_freed = False
++    channel.exchange_group = None
++    channel.device = torch.device("cpu")
+     channel._ptr = 123
+     channel._ext = FailingExt()
+     channel._ipc = FailingIPC()
+@@ -893,24 +2044,47 @@ def test_channel_teardown_completes_when_ipc_cleanup_raises():
+         SharedBuffer(4000, (5000,)),
+     ]
+     channel._registered_input_ptrs = {1: (2,)}
++    channel._coordinated_close_complete = False
+ 
+-    channel.close()
+-    channel.close()
++    channel.__del__()
+ 
+-    assert events == [
+-        ("dispose", 123),
+-        ("close", 2000),
+-        ("close", 3000),
+-        ("close", 5000),
+-        ("free", 1000),
+-        ("free", 4000),
+-    ]
+-    assert channel._ptr == 0
+-    assert channel._closed
+-    assert channel._ipc_imports_closed
+-    assert channel._ipc_exports_freed
+-    assert channel._owned_buffers == []
+-    assert channel._registered_input_ptrs == {}
++    assert events == []
++    assert channel._ptr == 123
++    assert not channel._closed
++    assert not channel._ipc_imports_closed
++    assert not channel._ipc_exports_freed
++    assert [shared.local_ptr for shared in channel._owned_buffers] == [1000, 4000]
++    assert channel._registered_input_ptrs == {1: (2,)}
++    assert _ABANDONED_PCIE_RUNTIME_QUARANTINE.pop(id(channel)) is channel
++
++
++def test_channel_gc_quarantines_rank_data_tensor_and_native_pointer():
++    events = []
++
++    class RankData:
++        def __del__(self):
++            events.append("rank_data_freed")
++
++    channel = object.__new__(PCIeOneshotAllReduce)
++    channel._ptr = 123
++    channel._owned_buffers = []
++    channel._coordinated_close_complete = False
++    channel.rank_data = RankData()
++    channel_id = id(channel)
++
++    del channel
++    gc.collect()
++
++    retained = _ABANDONED_PCIE_RUNTIME_QUARANTINE.pop(channel_id)
++    assert retained._ptr == 123
++    assert events == []
++
++    # The production quarantine is process-lifetime. Tests may release this
++    # fake only after proving the owned allocation survived object GC.
++    retained._coordinated_close_complete = True
++    del retained
++    gc.collect()
++    assert events == ["rank_data_freed"]
+ 
+ 
+ def test_pool_rejects_channel_rollback_during_capture():
+diff --git a/tests/comm/test_pcie_oneshot_fused_rmsnorm_gpu.py b/tests/comm/test_pcie_oneshot_fused_rmsnorm_gpu.py
+index 34f9e5e04ec74eda3d9886abe64ad10721374359..fae489373fb4acd468a1fc1ef4f6edf5bbbc03d9 100644
+--- a/tests/comm/test_pcie_oneshot_fused_rmsnorm_gpu.py
++++ b/tests/comm/test_pcie_oneshot_fused_rmsnorm_gpu.py
+@@ -1,7 +1,10 @@
+ from __future__ import annotations
+ 
++import ctypes
+ import os
+ import socket
++import time
++from datetime import timedelta
+ 
+ import pytest
+ import torch
+@@ -19,6 +22,9 @@ pytestmark = pytest.mark.skipif(
+         "RMSNorm GPU tests"
+     ),
+ )
++TEST_TIMEOUT_SECONDS = float(
++    os.getenv("SPARKINFER_PCIE_ONESHOT_RMS_TIMEOUT_SECONDS", "300")
++)
+ 
+ 
+ def _free_port() -> int:
+@@ -71,7 +77,33 @@ def _assert_close(
+         torch.testing.assert_close(actual, expected, rtol=2e-2, atol=2e-2)
+ 
+ 
+-def _cuda_graph_kernel_count(graph: torch.cuda.CUDAGraph) -> int:
++def _local_eager_words(
++    channel, stream: torch.cuda.Stream, *, offset: int = 0
++) -> tuple[int, int]:
++    assert channel._ipc is not None
++    assert channel._eager_ptrs is not None
++    words = (ctypes.c_uint64(), ctypes.c_uint64())
++    for word, slot_ptrs in zip(words, channel._eager_ptrs, strict=True):
++        channel._ipc.cudaMemcpyAsync(
++            ctypes.addressof(word),
++            slot_ptrs[channel.rank] + offset,
++            ctypes.sizeof(word),
++            int(stream.cuda_stream),
++        )
++    stream.synchronize()
++    return words[0].value, words[1].value
++
++
++def _dim3_tuple(value) -> tuple[int, int, int]:
++    return int(value.x), int(value.y), int(value.z)
++
++
++def _cuda_graph_kernel_chain(
++    graph: torch.cuda.CUDAGraph,
++) -> tuple[
++    tuple[tuple[int, int, int], tuple[int, int, int]],
++    tuple[tuple[int, int, int], tuple[int, int, int]],
++]:
+     graph_handle = graph.raw_cuda_graph()
+     result, _, num_nodes = cudart.cudaGraphGetNodes(graph_handle)
+     assert result == cudart.cudaError_t.cudaSuccess
+@@ -82,12 +114,62 @@ def _cuda_graph_kernel_count(graph: torch.cuda.CUDAGraph) -> int:
+     assert result == cudart.cudaError_t.cudaSuccess
+     assert returned_nodes == num_nodes
+     kernel_type = cudart.cudaGraphNodeType.cudaGraphNodeTypeKernel
+-    kernel_count = 0
++    kernel_nodes = []
+     for node in nodes[:num_nodes]:
+         result, node_type = cudart.cudaGraphNodeGetType(node)
+         assert result == cudart.cudaError_t.cudaSuccess
+-        kernel_count += node_type == kernel_type
+-    return kernel_count
++        if node_type == kernel_type:
++            kernel_nodes.append(node)
++    assert len(kernel_nodes) == 2, (
++        "staged fused capture must contain one slot-control node followed by "
++        f"one worker node, found {len(kernel_nodes)} kernel nodes"
++    )
++
++    edge_query = cudart.cudaGraphGetEdges(graph_handle)
++    assert edge_query[0] == cudart.cudaError_t.cudaSuccess
++    num_edges = int(edge_query[-1])
++    edges = cudart.cudaGraphGetEdges(graph_handle, num_edges)
++    result, from_nodes, to_nodes, returned_edges = (
++        edges[0],
++        edges[1],
++        edges[2],
++        edges[-1],
++    )
++    assert result == cudart.cudaError_t.cudaSuccess
++    assert returned_edges == num_edges
++    kernel_edges = []
++    for source, destination in zip(
++        from_nodes[:num_edges],
++        to_nodes[:num_edges],
++        strict=True,
++    ):
++        result, source_type = cudart.cudaGraphNodeGetType(source)
++        assert result == cudart.cudaError_t.cudaSuccess
++        result, destination_type = cudart.cudaGraphNodeGetType(destination)
++        assert result == cudart.cudaError_t.cudaSuccess
++        if source_type == kernel_type and destination_type == kernel_type:
++            kernel_edges.append((source, destination))
++    assert len(kernel_edges) == 1, (
++        "staged fused capture must directly order its control node before its "
++        f"worker node, found {len(kernel_edges)} kernel-to-kernel edges"
++    )
++
++    def geometry(node) -> tuple[tuple[int, int, int], tuple[int, int, int]]:
++        result, params = cudart.cudaGraphKernelNodeGetParams(node)
++        if result != cudart.cudaError_t.cudaSuccess and hasattr(
++            cudart, "cudaGraphNodeGetParams"
++        ):
++            fallback_result, node_params = cudart.cudaGraphNodeGetParams(node)
++            assert fallback_result == cudart.cudaError_t.cudaSuccess
++            result, params = fallback_result, node_params.kernel
++        assert result == cudart.cudaError_t.cudaSuccess
++        return _dim3_tuple(params.gridDim), _dim3_tuple(params.blockDim)
++
++    control, worker = map(geometry, kernel_edges[0])
++    assert control == ((1, 1, 1), (1, 1, 1))
++    assert worker[0][0] > 1
++    assert worker[1][0] >= 64
++    return control, worker
+ 
+ 
+ def _run_eager(
+@@ -129,6 +211,7 @@ def _run_eager(
+                 residual,
+                 weight,
+                 epsilon,
++                channel_id="eager:fused-rmsnorm",
+             )
+             torch.cuda.synchronize(device)
+             _assert_close(out, expected_out, dtype)
+@@ -152,10 +235,11 @@ def _run_graph(
+         rank,
+     )
+     out = torch.empty_like(inp)
+-    pool.for_stream()
+-
+     graph = torch.cuda.CUDAGraph(keep_graph=True)
+-    with pool.capture(), torch.cuda.graph(graph):
++    with (
++        pool.capture(channel_id="graph:fused-rmsnorm") as channel,
++        torch.cuda.graph(graph),
++    ):
+         pool.all_reduce_fused_add_rms_norm(
+             inp,
+             residual,
+@@ -163,8 +247,19 @@ def _run_graph(
+             epsilon,
+             out=out,
+             residual_out=residual,
++            channel_id="graph:fused-rmsnorm",
+         )
+-    assert _cuda_graph_kernel_count(graph) == 1
++    # Staged capture is now control + worker, in that order. The registered
++    # path still launches only its worker, but public graph capture deliberately
++    # requires stable eager staging buffers and therefore exercises this
++    # two-node contract.
++    _cuda_graph_kernel_chain(graph)
++    stream = torch.cuda.current_stream(device)
++    offset = 0
++    if os.getenv("SPARKINFER_PCIE_ONESHOT_PUSH", "0") not in ("", "0"):
++        remote_source = (rank + 1) % dist.get_world_size()
++        offset = remote_source * inp.numel() * inp.element_size()
++    snapshots = [_local_eager_words(channel, stream, offset=offset)]
+ 
+     for iteration in range(3):
+         next_inp, next_residual, _ = _make_inputs(
+@@ -187,6 +282,23 @@ def _run_graph(
+         torch.cuda.synchronize(device)
+         _assert_close(out, expected_out, dtype)
+         _assert_close(residual, expected_residual, dtype)
++        snapshots.append(_local_eager_words(channel, stream, offset=offset))
++
++    changed_slots = [
++        {
++            slot
++            for slot, (before, after) in enumerate(
++                zip(snapshots[index], snapshots[index + 1], strict=True)
++            )
++            if before != after
++        }
++        for index in range(3)
++    ]
++    assert all(len(changed) == 1 for changed in changed_slots)
++    assert all(
++        changed_slots[index] != changed_slots[index + 1]
++        for index in range(len(changed_slots) - 1)
++    )
+ 
+ 
+ def _worker(rank: int, world_size: int, port: int) -> None:
+@@ -197,14 +309,18 @@ def _worker(rank: int, world_size: int, port: int) -> None:
+         init_method=f"tcp://127.0.0.1:{port}",
+         rank=rank,
+         world_size=world_size,
++        timeout=timedelta(seconds=TEST_TIMEOUT_SECONDS),
+     )
+     pool = PCIeOneshotAllReducePool.from_process_group(
+         process_group=dist.group.WORLD,
+         device=device,
+         max_input_bytes=128 * 1024,
+         max_size=128 * 1024,
++        max_concurrent_channels=2,
+     )
+     try:
++        pool.prepare_channels(("eager:fused-rmsnorm", "graph:fused-rmsnorm"))
++        pool.for_stream(channel_id="eager:fused-rmsnorm")
+         _run_eager(pool, device, rank)
+         dist.barrier()
+         _run_graph(pool, device, rank)
+@@ -224,4 +340,27 @@ def test_pcie_oneshot_fused_add_rms_norm_eager_and_graph() -> None:
+         pytest.skip(
+             f"need {world_size} CUDA devices, found {torch.cuda.device_count()}"
+         )
+-    mp.spawn(_worker, args=(world_size, _free_port()), nprocs=world_size, join=True)
++    context = mp.spawn(
++        _worker,
++        args=(world_size, _free_port()),
++        nprocs=world_size,
++        join=False,
++    )
++    deadline = time.monotonic() + TEST_TIMEOUT_SECONDS
++    while time.monotonic() < deadline:
++        remaining = deadline - time.monotonic()
++        if context.join(timeout=min(1.0, remaining), grace_period=5):
++            return
++    for process in context.processes:
++        if process.is_alive():
++            process.terminate()
++    for process in context.processes:
++        process.join(timeout=5)
++    for process in context.processes:
++        if process.is_alive():
++            process.kill()
++        process.join()
++    pytest.fail(
++        "PCIe oneshot fused RMSNorm test exceeded "
++        f"{TEST_TIMEOUT_SECONDS:.0f}s; probable collective deadlock"
++    )
+diff --git a/tests/comm/test_pcie_oneshot_opposite_order_gpu.py b/tests/comm/test_pcie_oneshot_opposite_order_gpu.py
+new file mode 100644
+index 0000000000000000000000000000000000000000..99559e07f3d07e6a4fcb7aa486590f9f409d0536
+--- /dev/null
++++ b/tests/comm/test_pcie_oneshot_opposite_order_gpu.py
+@@ -0,0 +1,295 @@
++from __future__ import annotations
++
++import os
++import socket
++import time
++from datetime import timedelta
++
++import pytest
++import torch
++import torch.distributed as dist
++import torch.multiprocessing as mp
++
++from sparkinfer.comm.pcie.pcie_oneshot import PCIeOneshotAllReducePool
++
++
++pytestmark = pytest.mark.skipif(
++    os.getenv("SPARKINFER_RUN_PCIE_ONESHOT_OPPOSITE_ORDER") != "1",
++    reason=(
++        "set SPARKINFER_RUN_PCIE_ONESHOT_OPPOSITE_ORDER=1 to run the "
++        "four-rank opposite-order PCIe oneshot GPU test"
++    ),
++)
++
++WORLD_SIZE = 4
++EAGER_ITERS = int(os.getenv("SPARKINFER_PCIE_OPPOSITE_EAGER_ITERS", "64"))
++GRAPH_REPLAYS = int(os.getenv("SPARKINFER_PCIE_OPPOSITE_GRAPH_REPLAYS", "64"))
++TEST_TIMEOUT_SECONDS = float(
++    os.getenv("SPARKINFER_PCIE_OPPOSITE_TIMEOUT_SECONDS", "180")
++)
++NUMEL = int(os.getenv("SPARKINFER_PCIE_OPPOSITE_NUMEL", "32768"))
++
++
++def _free_port() -> int:
++    with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as sock:
++        sock.bind(("127.0.0.1", 0))
++        return int(sock.getsockname()[1])
++
++
++def _expected(base: float, world_size: int, device: torch.device) -> torch.Tensor:
++    rank_sum = world_size * (world_size - 1) // 2
++    return torch.tensor(
++        world_size * base + rank_sum,
++        dtype=torch.float32,
++        device=device,
++    )
++
++
++def _assert_reduced(
++    out: torch.Tensor,
++    base: float,
++    world_size: int,
++    device: torch.device,
++) -> None:
++    torch.testing.assert_close(
++        out,
++        _expected(base, world_size, device).expand_as(out),
++        rtol=0,
++        atol=0,
++    )
++
++
++def _rank_order(rank: int) -> tuple[str, str]:
++    # Every rank executes the same ordered sequence within each channel. Only
++    # the cross-channel enqueue order differs, which is valid because each
++    # stream owns a distinct signal/staging pair.
++    return ("a", "b") if rank % 2 == 0 else ("b", "a")
++
++
++def _run_eager_opposite_order(
++    pool: PCIeOneshotAllReducePool,
++    device: torch.device,
++    rank: int,
++    world_size: int,
++) -> None:
++    stream_a = torch.cuda.Stream(device=device)
++    stream_b = torch.cuda.Stream(device=device)
++
++    # Each rank supplies the same logical set in opposite local order. The pool
++    # must canonicalize allocation by id rather than pairing local stream keys.
++    logical_ids = ("eager:a", "eager:b")
++    if rank % 2:
++        logical_ids = tuple(reversed(logical_ids))
++    pool.prepare_channels(logical_ids)
++    channel_a = pool.for_stream(stream_a, channel_id="eager:a")
++    channel_b = pool.for_stream(stream_b, channel_id="eager:b")
++    dist.barrier()
++    assert channel_a is not channel_b
++    assert channel_a._signal_ptrs != channel_b._signal_ptrs
++
++    inputs = {
++        "a": torch.empty(NUMEL, device=device, dtype=torch.float32),
++        "b": torch.empty(NUMEL, device=device, dtype=torch.float32),
++    }
++    outputs = {name: torch.empty_like(inp) for name, inp in inputs.items()}
++    streams = {"a": stream_a, "b": stream_b}
++    channels = {"a": channel_a, "b": channel_b}
++
++    for iteration in range(EAGER_ITERS):
++        bases = {
++            "a": float(4 * (iteration % 32)),
++            "b": float(1024 + 8 * (iteration % 32)),
++        }
++        for name in _rank_order(rank):
++            with torch.cuda.stream(streams[name]):
++                inputs[name].fill_(bases[name] + rank)
++                channels[name].all_reduce(inputs[name], out=outputs[name])
++
++        # Both valid channel collectives are now enqueued on every rank. A
++        # device-wide wait makes a deadlock visible to the parent timeout.
++        torch.cuda.synchronize(device)
++        for name in ("a", "b"):
++            _assert_reduced(outputs[name], bases[name], world_size, device)
++
++
++def _capture_channel(
++    pool: PCIeOneshotAllReducePool,
++    stream: torch.cuda.Stream,
++    inp: torch.Tensor,
++    out: torch.Tensor,
++    channel_id: str,
++) -> tuple[object, torch.cuda.CUDAGraph]:
++    graph = torch.cuda.CUDAGraph()
++    with (
++        pool.capture(stream, channel_id=channel_id) as channel,
++        torch.cuda.graph(graph, stream=stream),
++    ):
++        channel.all_reduce(inp, out=out)
++    return channel, graph
++
++
++def _run_capture_warmup_scope(
++    pool: PCIeOneshotAllReducePool,
++    device: torch.device,
++    rank: int,
++    world_size: int,
++) -> None:
++    """Match vLLM's eager warmup inside its semantic graph-owner scope."""
++    stream = torch.cuda.Stream(device=device)
++    inp = torch.full(
++        (NUMEL,),
++        float(4096 + rank),
++        dtype=torch.float32,
++        device=device,
++    )
++    out = torch.empty_like(inp)
++    pool.prepare_channels(("eager:warmup", "graph:warmup"))
++
++    graph = torch.cuda.CUDAGraph()
++    with (
++        torch.cuda.stream(stream),
++        pool.capture(stream, channel_id="graph:warmup") as graph_channel,
++    ):
++        # CUDA capture has not begun. The active semantic scope must still
++        # override the call site's static eager id on this same owner stream.
++        warmup_channel = pool.for_stream(stream, channel_id="eager:warmup")
++        assert warmup_channel is graph_channel
++        warmup_channel.all_reduce(inp, out=out)
++        stream.synchronize()
++        _assert_reduced(out, 4096.0, world_size, device)
++
++        with torch.cuda.graph(graph, stream=stream):
++            graph_channel.all_reduce(inp, out=out)
++
++    # Leaving the semantic scope restores normal eager routing even though
++    # the graph-owned channel remains alive for replay on the same stream.
++    eager_channel = pool.for_stream(stream, channel_id="eager:warmup")
++    assert eager_channel is not graph_channel
++    with torch.cuda.stream(stream):
++        inp.fill_(8192.0 + rank)
++        graph.replay()
++    stream.synchronize()
++    _assert_reduced(out, 8192.0, world_size, device)
++
++
++def _run_graph_opposite_order(
++    pool: PCIeOneshotAllReducePool,
++    device: torch.device,
++    rank: int,
++    world_size: int,
++) -> None:
++    stream_a = torch.cuda.Stream(device=device)
++    stream_b = torch.cuda.Stream(device=device)
++    inputs = {
++        "a": torch.empty(NUMEL, device=device, dtype=torch.float32),
++        "b": torch.empty(NUMEL, device=device, dtype=torch.float32),
++    }
++    outputs = {name: torch.empty_like(inp) for name, inp in inputs.items()}
++
++    logical_ids = ("graph:a", "graph:b")
++    if rank % 2:
++        logical_ids = tuple(reversed(logical_ids))
++    pool.prepare_channels(logical_ids)
++    captured = {}
++    for name in _rank_order(rank):
++        captured[name] = _capture_channel(
++            pool,
++            {"a": stream_a, "b": stream_b}[name],
++            inputs[name],
++            outputs[name],
++            f"graph:{name}",
++        )
++        {"a": stream_a, "b": stream_b}[name].synchronize()
++    dist.barrier()
++    channel_a, graph_a = captured["a"]
++    channel_b, graph_b = captured["b"]
++    assert channel_a is not channel_b
++    assert channel_a._signal_ptrs != channel_b._signal_ptrs
++
++    streams = {"a": stream_a, "b": stream_b}
++    graphs = {"a": graph_a, "b": graph_b}
++    for iteration in range(GRAPH_REPLAYS):
++        bases = {
++            "a": float(256 + 4 * (iteration % 32)),
++            "b": float(2048 + 8 * (iteration % 32)),
++        }
++        for name in _rank_order(rank):
++            with torch.cuda.stream(streams[name]):
++                inputs[name].fill_(bases[name] + rank)
++                graphs[name].replay()
++
++        torch.cuda.synchronize(device)
++        for name in ("a", "b"):
++            _assert_reduced(outputs[name], bases[name], world_size, device)
++
++
++def _worker(rank: int, world_size: int, port: int) -> None:
++    torch.cuda.set_device(rank)
++    device = torch.device(f"cuda:{rank}")
++    dist.init_process_group(
++        "nccl",
++        init_method=f"tcp://127.0.0.1:{port}",
++        rank=rank,
++        world_size=world_size,
++        timeout=timedelta(seconds=TEST_TIMEOUT_SECONDS),
++    )
++    pool = PCIeOneshotAllReducePool.from_process_group(
++        process_group=dist.group.WORLD,
++        device=device,
++        max_input_bytes=NUMEL * torch.float32.itemsize,
++        max_size=NUMEL * torch.float32.itemsize,
++        # Two independent streams intentionally enqueue peer-waiting grids at
++        # once; gate residency for the complete overlap, not one grid.
++        max_concurrent_channels=2,
++    )
++    try:
++        _run_capture_warmup_scope(pool, device, rank, world_size)
++        dist.barrier()
++        _run_eager_opposite_order(pool, device, rank, world_size)
++        dist.barrier()
++        _run_graph_opposite_order(pool, device, rank, world_size)
++        torch.cuda.synchronize(device)
++        dist.barrier()
++    finally:
++        try:
++            pool.close()
++        finally:
++            dist.destroy_process_group()
++
++
++def _spawn_with_timeout(port: int) -> None:
++    context = mp.spawn(
++        _worker,
++        args=(WORLD_SIZE, port),
++        nprocs=WORLD_SIZE,
++        join=False,
++    )
++    deadline = time.monotonic() + TEST_TIMEOUT_SECONDS
++    while time.monotonic() < deadline:
++        remaining = deadline - time.monotonic()
++        if context.join(timeout=min(1.0, remaining), grace_period=5):
++            return
++
++    for process in context.processes:
++        if process.is_alive():
++            process.terminate()
++    for process in context.processes:
++        process.join(timeout=5)
++    for process in context.processes:
++        if process.is_alive():
++            process.kill()
++        process.join()
++    pytest.fail(
++        "four-rank opposite-order eager/graph PCIe oneshot test exceeded "
++        f"{TEST_TIMEOUT_SECONDS:.0f}s; probable collective deadlock"
++    )
++
++
++def test_pcie_oneshot_four_rank_opposite_channel_order() -> None:
++    if not torch.cuda.is_available():
++        pytest.skip("CUDA is not available")
++    if torch.cuda.device_count() < WORLD_SIZE:
++        pytest.skip(
++            f"need {WORLD_SIZE} CUDA devices, found {torch.cuda.device_count()}"
++        )
++    _spawn_with_timeout(_free_port())
+diff --git a/tests/comm/test_pcie_oneshot_torture.py b/tests/comm/test_pcie_oneshot_torture.py
+index a5ab20a8d2678bfe7990dd32c6e1fad89811eb42..3269e14295aeacfba4d877df241ffdbc0806409f 100644
+--- a/tests/comm/test_pcie_oneshot_torture.py
++++ b/tests/comm/test_pcie_oneshot_torture.py
+@@ -1,5 +1,6 @@
+ from __future__ import annotations
+ 
++import ctypes
+ import os
+ import socket
+ 
+@@ -16,9 +17,15 @@ pytestmark = pytest.mark.skipif(
+     reason="set SPARKINFER_RUN_PCIE_ONESHOT_TORTURE=1 to run PCIe oneshot CUDA torture tests",
+ )
+ 
+-TORTURE_EAGER_ITERS = int(os.getenv("SPARKINFER_PCIE_ONESHOT_TORTURE_EAGER_ITERS", "256"))
+-TORTURE_GRAPH_REPLAYS = int(os.getenv("SPARKINFER_PCIE_ONESHOT_TORTURE_GRAPH_REPLAYS", "256"))
+-TORTURE_MULTISTREAM_ITERS = int(os.getenv("SPARKINFER_PCIE_ONESHOT_TORTURE_MULTISTREAM_ITERS", "256"))
++TORTURE_EAGER_ITERS = int(
++    os.getenv("SPARKINFER_PCIE_ONESHOT_TORTURE_EAGER_ITERS", "256")
++)
++TORTURE_GRAPH_REPLAYS = int(
++    os.getenv("SPARKINFER_PCIE_ONESHOT_TORTURE_GRAPH_REPLAYS", "256")
++)
++TORTURE_MULTISTREAM_ITERS = int(
++    os.getenv("SPARKINFER_PCIE_ONESHOT_TORTURE_MULTISTREAM_ITERS", "256")
++)
+ 
+ 
+ def _free_port() -> int:
+@@ -36,7 +43,26 @@ def _rank_sum(world_size: int) -> int:
+     return world_size * (world_size - 1) // 2
+ 
+ 
+-def _run_eager(pool: PCIeOneshotAllReducePool, device: torch.device, rank: int, world_size: int) -> None:
++def _local_eager_words(
++    channel, stream: torch.cuda.Stream, *, offset: int = 0
++) -> tuple[int, int]:
++    assert channel._ipc is not None
++    assert channel._eager_ptrs is not None
++    words = (ctypes.c_uint64(), ctypes.c_uint64())
++    for word, slot_ptrs in zip(words, channel._eager_ptrs, strict=True):
++        channel._ipc.cudaMemcpyAsync(
++            ctypes.addressof(word),
++            slot_ptrs[channel.rank] + offset,
++            ctypes.sizeof(word),
++            int(stream.cuda_stream),
++        )
++    stream.synchronize()
++    return words[0].value, words[1].value
++
++
++def _run_eager(
++    pool: PCIeOneshotAllReducePool, device: torch.device, rank: int, world_size: int
++) -> None:
+     dtypes = (torch.float16, torch.bfloat16, torch.float32)
+     numels = (8, 256, 4096, 32768)
+     rank_sum = _rank_sum(world_size)
+@@ -48,7 +74,7 @@ def _run_eager(pool: PCIeOneshotAllReducePool, device: torch.device, rank: int,
+             for iteration in range(TORTURE_EAGER_ITERS):
+                 base = float((iteration % 64) * 3)
+                 inp.fill_(base + rank)
+-                pool.all_reduce(inp, out=out)
++                pool.all_reduce(inp, out=out, channel_id="eager:default")
+                 torch.cuda.synchronize(device)
+                 _assert_constant(out, world_size * base + rank_sum)
+ 
+@@ -60,7 +86,6 @@ def _run_graph_scratch_reuse(
+     world_size: int,
+ ) -> None:
+     stream = torch.cuda.Stream(device=device)
+-    channel = pool.for_stream(stream)
+     rank_sum = _rank_sum(world_size)
+     layers = 17
+     numel = 4096
+@@ -77,20 +102,57 @@ def _run_graph_scratch_reuse(
+     torch.cuda.synchronize(device)
+ 
+     graph = torch.cuda.CUDAGraph()
+-    with pool.capture(stream), torch.cuda.graph(graph, stream=stream):
++    with (
++        pool.capture(stream, channel_id="graph:torture") as channel,
++        torch.cuda.graph(graph, stream=stream),
++    ):
+         for layer in range(layers):
+             scratch.copy_(sources[layer])
+             channel.all_reduce(scratch, out=outs[layer])
+     stream.synchronize()
+ 
+     for iteration in range(TORTURE_GRAPH_REPLAYS):
+-        fill_sources(iteration)
+-        graph.replay()
++        with torch.cuda.stream(stream):
++            fill_sources(iteration)
++            graph.replay()
+         stream.synchronize()
+         for layer, out in enumerate(outs):
+             base = float((iteration % 32) * 5 + layer)
+             _assert_constant(out, world_size * base + rank_sum)
+ 
++    # A graph with an odd number of collectives must swap which slot receives
++    # the final layer on every replay. Both slots are overwritten by this
++    # 17-layer graph, so merely counting changed slots cannot identify the
++    # selected parity: the final two layer markers must exchange positions.
++    snapshots = [_local_eager_words(channel, stream)]
++    expected_words = [
++        tuple(int(source.view(torch.uint64)[0].item()) for source in sources[-2:])
++    ]
++    for iteration in (101, 102):
++        with torch.cuda.stream(stream):
++            fill_sources(iteration)
++            graph.replay()
++        stream.synchronize()
++        snapshots.append(_local_eager_words(channel, stream))
++        expected_words.append(
++            tuple(int(source.view(torch.uint64)[0].item()) for source in sources[-2:])
++        )
++        for layer, out in enumerate(outs):
++            base = float((iteration % 32) * 5 + layer)
++            _assert_constant(out, world_size * base + rank_sum)
++
++    final_slots = []
++    for snapshot, expected in zip(snapshots, expected_words, strict=True):
++        assert set(snapshot) == set(expected), (
++            f"staging slots {snapshot} do not contain the final layer markers "
++            f"{expected}"
++        )
++        final_slots.append(snapshot.index(expected[-1]))
++    assert all(
++        final_slots[index] != final_slots[index + 1]
++        for index in range(len(final_slots) - 1)
++    ), f"odd-collective graph did not alternate final staging slots: {final_slots}"
++
+ 
+ def _run_multistream(
+     pool: PCIeOneshotAllReducePool,
+@@ -100,8 +162,8 @@ def _run_multistream(
+ ) -> None:
+     stream_a = torch.cuda.Stream(device=device)
+     stream_b = torch.cuda.Stream(device=device)
+-    pool.for_stream(stream_a)
+-    pool.for_stream(stream_b)
++    pool.for_stream(stream_a, channel_id="eager:a")
++    pool.for_stream(stream_b, channel_id="eager:b")
+     rank_sum = _rank_sum(world_size)
+ 
+     inp_a = torch.empty(2048, device=device, dtype=torch.float16)
+@@ -114,10 +176,10 @@ def _run_multistream(
+         base_b = float(100 + (iteration % 64) * 2)
+         with torch.cuda.stream(stream_a):
+             inp_a.fill_(base_a + rank)
+-            pool.all_reduce(inp_a, out=out_a)
++            pool.all_reduce(inp_a, out=out_a, channel_id="eager:a")
+         with torch.cuda.stream(stream_b):
+             inp_b.fill_(base_b + rank)
+-            pool.all_reduce(inp_b, out=out_b)
++            pool.all_reduce(inp_b, out=out_b, channel_id="eager:b")
+         stream_a.synchronize()
+         stream_b.synchronize()
+         _assert_constant(out_a, world_size * base_a + rank_sum)
+@@ -137,8 +199,10 @@ def _worker(rank: int, world_size: int, port: int) -> None:
+         process_group=dist.group.WORLD,
+         device=device,
+         max_input_bytes=1 << 20,
++        max_concurrent_channels=2,
+     )
+     try:
++        pool.prepare_channels(("eager:default", "eager:a", "eager:b", "graph:torture"))
+         _run_eager(pool, device, rank, world_size)
+         dist.barrier()
+         _run_graph_scratch_reuse(pool, device, rank, world_size)
+diff --git a/tests/comm/test_pcie_preallocation_setup.py b/tests/comm/test_pcie_preallocation_setup.py
+new file mode 100644
+index 0000000000000000000000000000000000000000..a6c02d91522d73289942ed46d7c55ff933834af3
+--- /dev/null
++++ b/tests/comm/test_pcie_preallocation_setup.py
+@@ -0,0 +1,486 @@
++from __future__ import annotations
++
++import pytest
++import torch
++
++import sparkinfer.comm.pcie.pcie_dcp_a2a as dcp
++import sparkinfer.comm.pcie.pcie_oneshot as oneshot
++import sparkinfer.comm.pcie.pcie_twoshot as twoshot
++
++
++def _mock_collective_failure(monkeypatch) -> None:
++    def exchange(
++        local_error,
++        *,
++        exchange_group,
++        phase,
++        exports_retained_on_exchange_failure=True,
++    ):
++        assert not exports_retained_on_exchange_failure
++        if local_error is None:
++            return ((), ())
++        return ((f"RuntimeError: {local_error}",), ())
++
++    monkeypatch.setattr(oneshot, "_exchange_setup_failures", exchange)
++
++
++def _fail_cuda_runtime():
++    raise RuntimeError("injected one-rank CUDA runtime load failure")
++
++
++def test_oneshot_factory_coordinates_preallocation_failure_before_ipc(
++    monkeypatch,
++) -> None:
++    _mock_collective_failure(monkeypatch)
++    monkeypatch.setattr(oneshot.dist, "get_rank", lambda group=None: 0)
++    monkeypatch.setattr(oneshot.dist, "get_world_size", lambda group=None: 2)
++    monkeypatch.setattr(oneshot, "_require_full_grid_residency", lambda **kwargs: None)
++    monkeypatch.setattr(oneshot, "CudaRTLibrary", _fail_cuda_runtime)
++    monkeypatch.setattr(
++        oneshot.PCIeOneshotAllReduce,
++        "_allocate_eager_channel_buffers",
++        lambda *args, **kwargs: pytest.fail("IPC allocation must not start"),
++    )
++
++    with pytest.raises(RuntimeError, match="pre-allocation setup") as exc:
++        oneshot.PCIeOneshotAllReduce.from_exchange_group(
++            exchange_group=object(),
++            device=torch.device("cuda:0"),
++        )
++
++    assert "exports were retained" not in str(exc.value)
++
++
++def test_dcp_factory_coordinates_preallocation_failure_before_ipc(monkeypatch) -> None:
++    _mock_collective_failure(monkeypatch)
++    monkeypatch.setattr(dcp.dist, "get_rank", lambda group=None: 0)
++    monkeypatch.setattr(dcp.dist, "get_world_size", lambda group=None: 2)
++    monkeypatch.setattr(dcp, "_require_full_grid_residency", lambda **kwargs: None)
++    monkeypatch.setattr(dcp, "CudaRTLibrary", _fail_cuda_runtime)
++    monkeypatch.setattr(
++        oneshot.PCIeOneshotAllReduce,
++        "_allocate_shared_buffer",
++        lambda *args, **kwargs: pytest.fail("IPC allocation must not start"),
++    )
++
++    with pytest.raises(RuntimeError, match="pre-allocation setup") as exc:
++        dcp.PCIeDCPA2A.from_exchange_group(
++            exchange_group=object(),
++            device=torch.device("cuda:0"),
++            max_batch_size=8,
++            total_heads=16,
++            head_dim=64,
++        )
++
++    assert "exports were retained" not in str(exc.value)
++
++
++def test_twoshot_factory_coordinates_preallocation_failure_before_ipc(
++    monkeypatch,
++) -> None:
++    _mock_collective_failure(monkeypatch)
++    monkeypatch.setattr(twoshot.dist, "get_rank", lambda group=None: 0)
++    monkeypatch.setattr(twoshot.dist, "get_world_size", lambda group=None: 2)
++    monkeypatch.setattr(twoshot, "_require_full_grid_residency", lambda **kwargs: None)
++    monkeypatch.setattr(twoshot, "CudaRTLibrary", _fail_cuda_runtime)
++    monkeypatch.setattr(
++        oneshot.PCIeOneshotAllReduce,
++        "_allocate_shared_buffer",
++        lambda *args, **kwargs: pytest.fail("IPC allocation must not start"),
++    )
++
++    with pytest.raises(RuntimeError, match="pre-allocation setup") as exc:
++        twoshot.PCIeTwoShotSP.from_exchange_group(
++            exchange_group=object(),
++            device=torch.device("cuda:0"),
++            max_rows=8,
++            row_elems=16,
++        )
++
++    assert "exports were retained" not in str(exc.value)
++
++
++@pytest.mark.parametrize("module_name", ("oneshot", "dcp"))
++def test_direct_constructor_coordinates_argument_failure_before_residency(
++    monkeypatch,
++    module_name: str,
++) -> None:
++    _mock_collective_failure(monkeypatch)
++    if module_name == "oneshot":
++        monkeypatch.setattr(
++            oneshot,
++            "_require_full_grid_residency",
++            lambda **kwargs: pytest.fail("residency gate must not start"),
++        )
++
++        def constructor():
++            return oneshot.PCIeOneshotAllReduce(
++                rank=0,
++                world_size=2,
++                device=torch.device("cuda:0"),
++                signal_ptrs=(100,),
++                exchange_group=object(),
++                ext_module=object(),
++            )
++    else:
++        monkeypatch.setattr(
++            dcp,
++            "_require_full_grid_residency",
++            lambda **kwargs: pytest.fail("residency gate must not start"),
++        )
++
++        def constructor():
++            return dcp.PCIeDCPA2A(
++                rank=0,
++                world_size=2,
++                device=torch.device("cuda:0"),
++                signal_ptrs=(100,),
++                staging0_ptrs=(200, 300),
++                staging1_ptrs=(400, 500),
++                max_batch_size=8,
++                total_heads=16,
++                head_dim=64,
++                output_capacity_elems=8 * 16 * 64,
++                lse_offset=8 * 16 * 64 * 2,
++                lse_capacity=8 * 16,
++                exchange_group=object(),
++                ext_module=object(),
++            )
++
++    with pytest.raises(RuntimeError, match="argument validation"):
++        constructor()
++
++
++@pytest.mark.parametrize(
++    ("module", "class_name"),
++    (
++        (oneshot, "PCIeOneshotAllReduce"),
++        (dcp, "PCIeDCPA2A"),
++    ),
++)
++def test_exported_direct_constructor_contains_capability_and_setup_coordination(
++    module,
++    class_name: str,
++) -> None:
++    import inspect
++
++    source = inspect.getsource(getattr(module, class_name).__init__)
++    assert "_require_full_grid_residency(" in source
++    assert "_run_collective_preallocation_setup(" in source
++    assert "_finish_collective_unowned_runtime_setup(" in source
++    assert "_factory_managed_setup" not in source
++
++
++def test_twoshot_direct_construction_cannot_bypass_factory_gates() -> None:
++    with pytest.raises(RuntimeError, match="from_exchange_group"):
++        twoshot.PCIeTwoShotSP()
++
++
++def test_pool_overlap_residency_scales_with_declared_concurrency(monkeypatch) -> None:
++    events: list[tuple[str, object]] = []
++
++    class FakeIPC:
++        def cudaSetDevice(self, device):
++            events.append(("device", device))
++
++    class FakeOneshotExt:
++        @staticmethod
++        def meta_size():
++            return 256
++
++    monkeypatch.setattr(oneshot.dist, "get_rank", lambda group=None: 0)
++    monkeypatch.setattr(oneshot.dist, "get_world_size", lambda group=None: 2)
++    monkeypatch.setattr(
++        oneshot,
++        "_run_collective_preallocation_setup",
++        lambda **kwargs: kwargs["setup"](),
++    )
++    monkeypatch.setattr(
++        oneshot,
++        "_require_full_grid_residency",
++        lambda **kwargs: events.append(("oneshot_sms", kwargs["required_sms"])),
++    )
++    monkeypatch.setattr(
++        oneshot,
++        "_require_collective_contract",
++        lambda **kwargs: events.append(("oneshot_contract", kwargs["contract"])),
++    )
++
++    oneshot_pool = oneshot.PCIeOneshotAllReducePool(
++        rank=0,
++        world_size=2,
++        device=torch.device("cuda:0"),
++        exchange_group=object(),
++        ipc=FakeIPC(),
++        ext_module=FakeOneshotExt(),
++        max_concurrent_channels=3,
++    )
++    oneshot_pool._closed = True
++
++    monkeypatch.setattr(dcp.dist, "get_rank", lambda group=None: 0)
++    monkeypatch.setattr(dcp.dist, "get_world_size", lambda group=None: 2)
++    monkeypatch.setattr(
++        dcp,
++        "_run_collective_preallocation_setup",
++        lambda **kwargs: kwargs["setup"](),
++    )
++    monkeypatch.setattr(
++        dcp,
++        "_require_collective_contract",
++        lambda **kwargs: events.append(("dcp_contract", kwargs["contract"])),
++    )
++    monkeypatch.setattr(
++        dcp,
++        "_require_full_grid_residency",
++        lambda **kwargs: events.append(("dcp_sms", kwargs["required_sms"])),
++    )
++
++    dcp_pool = dcp.PCIeDCPA2APool(
++        rank=0,
++        world_size=2,
++        device=torch.device("cuda:0"),
++        max_batch_size=8,
++        total_heads=16,
++        head_dim=64,
++        exchange_group=object(),
++        max_concurrent_channels=2,
++    )
++    dcp_pool._closed = True
++
++    assert ("oneshot_sms", oneshot.ONESHOT_REQUIRED_SMS * 3) in events
++    oneshot_contract = next(
++        contract for name, contract in events if name == "oneshot_contract"
++    )
++    assert oneshot_contract[-2] == 3
++    assert ("dcp_contract", 2) in events
++    assert ("dcp_sms", dcp.DCP_A2A_REQUIRED_SMS * 2) in events
++
++
++@pytest.mark.parametrize("module_name", ("oneshot", "dcp"))
++def test_pool_rejects_nonpositive_overlap_before_allocation(
++    monkeypatch, module_name: str
++) -> None:
++    if module_name == "oneshot":
++        with pytest.raises(ValueError, match="max_concurrent_channels"):
++            oneshot.PCIeOneshotAllReducePool(
++                rank=0,
++                world_size=2,
++                device=torch.device("cpu"),
++                max_concurrent_channels=0,
++                channel_factory=lambda stream_key: object(),
++            )
++    else:
++        with pytest.raises(ValueError, match="max_concurrent_channels"):
++            dcp.PCIeDCPA2APool(
++                rank=0,
++                world_size=2,
++                device=torch.device("cpu"),
++                max_batch_size=8,
++                total_heads=16,
++                head_dim=64,
++                max_concurrent_channels=0,
++                channel_factory=lambda stream_key: object(),
++            )
++
++
++def test_oneshot_overlap_contract_mismatch_fails_before_channel_allocation(
++    monkeypatch,
++) -> None:
++    class FakeIPC:
++        def cudaSetDevice(self, device):
++            pass
++
++    class FakeExt:
++        @staticmethod
++        def meta_size():
++            return 256
++
++    monkeypatch.setattr(oneshot.dist, "get_rank", lambda group=None: 0)
++    monkeypatch.setattr(oneshot.dist, "get_world_size", lambda group=None: 2)
++    monkeypatch.setattr(
++        oneshot,
++        "_run_collective_preallocation_setup",
++        lambda **kwargs: kwargs["setup"](),
++    )
++    monkeypatch.setattr(oneshot, "_require_full_grid_residency", lambda **kwargs: None)
++    monkeypatch.setattr(
++        oneshot,
++        "_broadcast_gather_object",
++        lambda contract, group: [contract, (*contract[:-2], 2, contract[-1])],
++    )
++    monkeypatch.setattr(
++        oneshot.PCIeOneshotAllReduce,
++        "_allocate_eager_channel_buffers",
++        lambda *args, **kwargs: pytest.fail("channel allocation must not start"),
++    )
++
++    with pytest.raises(RuntimeError, match="contract differs across ranks"):
++        oneshot.PCIeOneshotAllReducePool(
++            rank=0,
++            world_size=2,
++            device=torch.device("cuda:0"),
++            exchange_group=object(),
++            ipc=FakeIPC(),
++            ext_module=FakeExt(),
++            max_concurrent_channels=3,
++        )
++
++
++def test_dcp_overlap_contract_mismatch_fails_before_channel_allocation(
++    monkeypatch,
++) -> None:
++    monkeypatch.setattr(dcp.dist, "get_rank", lambda group=None: 0)
++    monkeypatch.setattr(dcp.dist, "get_world_size", lambda group=None: 2)
++    monkeypatch.setattr(
++        dcp,
++        "_run_collective_preallocation_setup",
++        lambda **kwargs: kwargs["setup"](),
++    )
++    monkeypatch.setattr(
++        oneshot,
++        "_broadcast_gather_object",
++        lambda contract, group: [contract, 1],
++    )
++    monkeypatch.setattr(
++        dcp,
++        "_require_full_grid_residency",
++        lambda **kwargs: pytest.fail("residency/allocation must not start"),
++    )
++
++    with pytest.raises(RuntimeError, match="contract differs across ranks"):
++        dcp.PCIeDCPA2APool(
++            rank=0,
++            world_size=2,
++            device=torch.device("cuda:0"),
++            max_batch_size=8,
++            total_heads=16,
++            head_dim=64,
++            exchange_group=object(),
++            max_concurrent_channels=2,
++        )
++
++
++def test_oneshot_direct_cuda_constructor_executes_all_collective_gates(
++    monkeypatch,
++) -> None:
++    events = []
++
++    class FakeTensor:
++        pass
++
++    class FakeExt:
++        def init_custom_ar(self, signal_ptrs, rank_data, rank):
++            events.append("native-init")
++            return 123
++
++    class FakeIPC:
++        def cudaSetDevice(self, device):
++            events.append(("set-device", device))
++
++    monkeypatch.setattr(
++        oneshot,
++        "_require_full_grid_residency",
++        lambda **kwargs: events.append("residency"),
++    )
++    monkeypatch.setattr(
++        oneshot,
++        "_run_collective_preallocation_setup",
++        lambda **kwargs: (events.append("preflight"), kwargs["setup"]())[1],
++    )
++    monkeypatch.setattr(
++        oneshot,
++        "_require_collective_contract",
++        lambda **kwargs: events.append("contract"),
++    )
++    monkeypatch.setattr(
++        oneshot,
++        "_finish_collective_unowned_runtime_setup",
++        lambda **kwargs: events.append("native-verdict"),
++    )
++    monkeypatch.setattr(oneshot.torch, "empty", lambda *args, **kwargs: FakeTensor())
++    monkeypatch.setattr(oneshot.dist, "get_rank", lambda group=None: 0)
++    monkeypatch.setattr(oneshot.dist, "get_world_size", lambda group=None: 2)
++
++    runtime = oneshot.PCIeOneshotAllReduce(
++        rank=0,
++        world_size=2,
++        device=torch.device("cuda:0"),
++        signal_ptrs=(100, 200),
++        exchange_group=object(),
++        ipc=FakeIPC(),
++        ext_module=FakeExt(),
++    )
++
++    assert runtime._ptr == 123
++    assert events == [
++        "preflight",
++        "residency",
++        "preflight",
++        ("set-device", 0),
++        "contract",
++        "native-init",
++        "native-verdict",
++    ]
++    runtime._coordinated_close_complete = True
++
++
++def test_dcp_direct_cuda_constructor_executes_all_collective_gates(
++    monkeypatch,
++) -> None:
++    events = []
++
++    class FakeExt:
++        def init_dcp_a2a(self, *args):
++            events.append("native-init")
++            return 456
++
++    monkeypatch.setattr(
++        dcp,
++        "_require_full_grid_residency",
++        lambda **kwargs: events.append("residency"),
++    )
++    monkeypatch.setattr(
++        dcp,
++        "_run_collective_preallocation_setup",
++        lambda **kwargs: (events.append("preflight"), kwargs["setup"]())[1],
++    )
++    monkeypatch.setattr(
++        dcp,
++        "_require_collective_contract",
++        lambda **kwargs: events.append("contract"),
++    )
++    monkeypatch.setattr(
++        dcp,
++        "_finish_collective_unowned_runtime_setup",
++        lambda **kwargs: events.append("native-verdict"),
++    )
++    monkeypatch.setattr(dcp.dist, "get_rank", lambda group=None: 0)
++    monkeypatch.setattr(dcp.dist, "get_world_size", lambda group=None: 2)
++
++    runtime = dcp.PCIeDCPA2A(
++        rank=0,
++        world_size=2,
++        device=torch.device("cuda:0"),
++        signal_ptrs=(100, 200),
++        staging0_ptrs=(300, 400),
++        staging1_ptrs=(500, 600),
++        max_batch_size=8,
++        total_heads=16,
++        head_dim=64,
++        output_capacity_elems=8 * 16 * 64,
++        lse_offset=8 * 16 * 64 * 2,
++        lse_capacity=8 * 16,
++        exchange_group=object(),
++        ext_module=FakeExt(),
++    )
++
++    assert runtime._ptr == 456
++    assert events == [
++        "preflight",
++        "residency",
++        "preflight",
++        "contract",
++        "native-init",
++        "native-verdict",
++    ]
++    runtime._coordinated_close_complete = True
+diff --git a/tests/comm/test_pcie_staging_control.py b/tests/comm/test_pcie_staging_control.py
+new file mode 100644
+index 0000000000000000000000000000000000000000..b761f71515d460065b9e5d48f1d2a9192d56b18f
+--- /dev/null
++++ b/tests/comm/test_pcie_staging_control.py
+@@ -0,0 +1,291 @@
++from __future__ import annotations
++
++from pathlib import Path
++
++import pytest
++
++
++ROOT = Path(__file__).resolve().parents[2]
++PCIE = ROOT / "sparkinfer" / "comm" / "pcie"
++UINT32_MASK = (1 << 32) - 1
++
++
++def _advance(generation: int) -> tuple[int, int]:
++    """Model the device control kernel's unsigned generation update."""
++    return generation & 1, (generation + 1) & UINT32_MASK
++
++
++def _section(source: str, start: str, end: str) -> str:
++    return source[source.index(start) : source.index(end, source.index(start))]
++
++
++def test_slot_control_alternates_across_replays_and_wraps() -> None:
++    generation = 0
++    slots = []
++    for _ in range(7):
++        slot, generation = _advance(generation)
++        slots.append(slot)
++
++    assert slots == [0, 1, 0, 1, 0, 1, 0]
++    assert _advance(UINT32_MASK) == (1, 0)
++    assert _advance(0) == (0, 1)
++
++
++def test_same_stream_capture_replay_handles_variable_worker_grids() -> None:
++    generation = 0
++    replay_slots = []
++    worker_slots = []
++
++    for worker_blocks in (1, 64, 3, 36, 8):
++        slot, generation = _advance(generation)
++        replay_slots.append(slot)
++        worker_slots.append([slot] * worker_blocks)
++
++    assert replay_slots == [0, 1, 0, 1, 0]
++    assert all(len(set(cta_slots)) == 1 for cta_slots in worker_slots)
++
++
++def test_multistream_separate_channels_match_across_rank_interleavings() -> None:
++    schedules = {
++        0: ("decode", "prefill", "decode", "prefill"),
++        1: ("prefill", "decode", "prefill", "decode"),
++    }
++    rank_observations = {}
++
++    for rank, schedule in schedules.items():
++        generations = {"decode": 0, "prefill": 0}
++        observed = {"decode": [], "prefill": []}
++        for channel in schedule:
++            slot, generations[channel] = _advance(generations[channel])
++            observed[channel].append(slot)
++        rank_observations[rank] = observed
++
++    assert rank_observations[0] == rank_observations[1]
++    assert rank_observations[0] == {
++        "decode": [0, 1],
++        "prefill": [0, 1],
++    }
++
++
++@pytest.mark.parametrize("source_name", ("pcie_oneshot.cu", "pcie_twoshot.cu"))
++def test_worker_slot_selection_has_no_grid_rendezvous(source_name: str) -> None:
++    source = (PCIE / source_name).read_text(encoding="utf-8")
++
++    assert "active_staging_slot" in source
++    assert "advance_staging_slot_kernel" in source
++    assert "staging_arrive" not in source
++    assert "cudaLaunchCooperativeKernel" not in source
++    assert "launch_cooperative" not in source
++
++    selector_name = (
++        "DINLINE void select_rank_data"
++        if source_name == "pcie_oneshot.cu"
++        else "DINLINE void select_rank_ptrs"
++    )
++    selector = _section(source, selector_name, "template <")
++    assert "active_staging_slot" in selector
++    assert "atomicAdd" not in selector
++    assert "while (" not in selector
++
++
++def test_fused_rms_residency_is_runtime_derived_and_capture_cached() -> None:
++    source = (PCIE / "pcie_oneshot.cu").read_text(encoding="utf-8")
++
++    assert "cudaOccupancyMaxActiveBlocksPerMultiprocessor" in source
++    assert "cudaDevAttrMultiProcessorCount" in source
++    assert "fused_resident_capacity_" in source
++    assert "cap_fused_ctas_per_row" in source
++    assert "SPARKINFER_PCIE_TEST_RESIDENT_GRID_CAPACITY" in source
++    assert "kMaxBlocks <= SM count" not in source
++
++    # Model the native clamp for reduced/MIG-like capacities. A capacity below
++    # the requested multi-CTA grid must select the barrier-free single-CTA path.
++    def cap(requested: int, rows: int, resident: int) -> int:
++        return max(1, min(requested, max(1, resident // rows)))
++
++    assert cap(3, 1, 1) == 1
++    assert cap(3, 1, 2) == 2
++    assert cap(3, 2, 2) == 1
++    assert cap(3, 2, 8) == 3
++
++
++@pytest.mark.parametrize(
++    ("source_name", "python_name", "constant_name", "required_sms"),
++    (
++        ("pcie_oneshot.cu", "pcie_oneshot.py", "ONESHOT_REQUIRED_SMS", 36),
++        ("pcie_twoshot.cu", "pcie_twoshot.py", "TWOSHOT_REQUIRED_SMS", 64),
++        ("pcie_dcp_a2a.cu", "pcie_dcp_a2a.py", "DCP_A2A_REQUIRED_SMS", 64),
++    ),
++)
++def test_peer_waiting_grid_is_fully_resident_or_rejected_before_ipc(
++    source_name: str,
++    python_name: str,
++    constant_name: str,
++    required_sms: int,
++) -> None:
++    source = (PCIE / source_name).read_text(encoding="utf-8")
++    wrapper = (PCIE / python_name).read_text(encoding="utf-8")
++
++    assert f"constexpr int kMaxBlocks = {required_sms};" in source
++    assert source.count("__global__ void __launch_bounds__(512, 1)") == 2
++    assert f"{constant_name} = {required_sms}" in wrapper
++    assert "_require_full_grid_residency(" in wrapper
++
++    # All peer-waiting worker launches use no dynamic shared memory. Combined
++    # with launch_bounds(..., 1), one CTA is resident per visible SM; requiring
++    # kMaxBlocks SMs makes every possible worker CTA simultaneously resident.
++    worker_launches = [
++        line
++        for line in source.splitlines()
++        if "<<<blocks, threads, 0, stream>>>" in line
++    ]
++    assert worker_launches
++    assert all(", 0, stream>>>" in line for line in worker_launches)
++
++
++def test_oneshot_control_is_staged_only_and_precedes_each_worker() -> None:
++    source = (PCIE / "pcie_oneshot.cu").read_text(encoding="utf-8")
++    control_launch = "advance_staging_slot_kernel<<<1, 1, 0, stream>>>(self_sg_);"
++    assert source.count(control_launch) == 2
++
++    regular = _section(
++        source,
++        "void allreduce(cudaStream_t stream",
++        "void allreduce_fused_add_rms_norm",
++    )
++    assert f"if (stage_input) {{\n      {control_launch}" in regular
++    assert regular.index(control_launch) < regular.index("#define KL(ngpus)")
++
++    fused = _section(
++        source,
++        "void allreduce_fused_add_rms_norm",
++        "~PCIeAllreduce",
++    )
++    assert f"if (use_eager_staging) {{\n      {control_launch}" in fused
++    assert fused.index(control_launch) < fused.index("#define KL(ngpus, SINGLE, MODE)")
++
++    # Registered one-shot and fused registered paths retain their original
++    # direct buffer route; only the double-buffered staged route advances.
++    assert "if (stage_input)" in regular
++    assert "pcie_allreduce_kernel<T, ngpus, true>" in regular
++    assert "pcie_allreduce_kernel<T, ngpus, false>" in regular
++    assert "if (mode == kModeStagePush)" in fused
++    assert "KL(ngpus, SINGLE, kModeStagePush)" in fused
++    assert "KL(ngpus, SINGLE, kModeStagePull)" in fused
++    assert "kModeRegistered" in fused
++
++
++def test_twoshot_control_precedes_reduce_scatter_and_all_gather_workers() -> None:
++    source = (PCIE / "pcie_twoshot.cu").read_text(encoding="utf-8")
++    control_launch = "advance_staging_slot_kernel<<<1, 1, 0, stream>>>(self_sg_);"
++    assert source.count(control_launch) == 2
++
++    reduce_scatter = _section(source, "void reduce_scatter(", "void all_gather(")
++    assert reduce_scatter.index(control_launch) < reduce_scatter.index(
++        "rs_fp8_kernel<ngpus><<<blocks, threads, 0, stream>>>"
++    )
++
++    all_gather = _section(source, "void all_gather(", "\n};")
++    assert all_gather.index(control_launch) < all_gather.index(
++        "ag_fp8_kernel<ngpus><<<blocks, threads, 0, stream>>>"
++    )
++
++
++def test_twoshot_validates_launch_geometry_before_grid_division() -> None:
++    source = (PCIE / "pcie_twoshot.cu").read_text(encoding="utf-8")
++    validator = _section(source, "void check_launch_config(", "void reduce_scatter(")
++
++    assert "threads < world_size_" in validator
++    assert "threads > 1024" in validator
++    assert "threads % 32 != 0" in validator
++    assert "block_limit <= 0" in validator
++    assert "block_limit > kMaxBlocks" in validator
++
++    reduce_scatter = _section(source, "void reduce_scatter(", "void all_gather(")
++    all_gather = _section(source, "void all_gather(", "\n};")
++    for operation in (reduce_scatter, all_gather):
++        assert operation.index("check_launch_config(threads, block_limit);") < (
++            operation.index("(shard_packs + threads - 1) / threads")
++        )
++
++
++def test_dcp_control_selects_one_slot_per_operation_before_workers() -> None:
++    source = (PCIE / "pcie_dcp_a2a.cu").read_text(encoding="utf-8")
++    control_launch = "advance_staging_slot_kernel<<<1, 1, 0, stream>>>(self_signal_);"
++    assert source.count(control_launch) == 2
++
++    selector = _section(source, "DINLINE void select_staging", "// pre_sync")
++    assert "active_staging_slot" in selector
++    assert "self_counter[blockIdx.x]" not in selector
++    assert "atomicAdd" not in selector
++    assert "while (" not in selector
++
++    reduce_scatter = _section(
++        source, "void run(cudaStream_t stream", "void all_gather_heads("
++    )
++    gather = _section(source, "void all_gather_heads(", "\n};")
++    assert reduce_scatter.index(control_launch) < reduce_scatter.index(
++        "#define LAUNCH(world)"
++    )
++    assert gather.index(control_launch) < gather.index("#define LAUNCH(world)")
++    assert "SPARKINFER_PCIE_DCP_TEST_POST_BARRIER_DELAY_CYCLES" in source
++    assert "test_post_barrier_delay(rank, delayed_rank, delay_cycles);" in source
++
++
++@pytest.mark.parametrize(
++    "source_name", ("pcie_oneshot.cu", "pcie_twoshot.cu", "pcie_dcp_a2a.cu")
++)
++def test_control_kernel_is_graph_replay_dynamic(source_name: str) -> None:
++    source = (PCIE / source_name).read_text(encoding="utf-8")
++    control = _section(
++        source,
++        "__global__ void advance_staging_slot_kernel",
++        "template <",
++    )
++
++    # The generation update runs in a CUDA kernel—not on the host—so capture
++    # records it as a graph node and every replay advances the channel slot.
++    assert "staging_generation" in control
++    assert "active_staging_slot = generation & FlagType{1}" in control
++    assert "staging_generation = generation + FlagType{1}" in control
++
++
++@pytest.mark.parametrize(
++    ("source_name", "expected_checks"),
++    (("pcie_oneshot.cu", 4), ("pcie_twoshot.cu", 4)),
++)
++def test_control_and_worker_launches_have_immediate_error_checks(
++    source_name: str, expected_checks: int
++) -> None:
++    source = (PCIE / source_name).read_text(encoding="utf-8")
++    assert source.count("CHECK_CUDA_SUCCESS(cudaGetLastError());") >= expected_checks
++
++    control_launch = "advance_staging_slot_kernel<<<1, 1, 0, stream>>>(self_sg_);"
++    for suffix in source.split(control_launch)[1:]:
++        assert suffix.lstrip().startswith("CHECK_CUDA_SUCCESS(cudaGetLastError());")
++
++
++def test_control_node_graph_topology_contract() -> None:
++    # This is a node-topology contract, not a performance claim. Public-head
++    # A/B results compare net algorithms; only the staged plain one-shot 64 KiB
++    # path is covered by the dedicated timing harness.
++    control_nodes = {
++        "oneshot_registered": 0,
++        "oneshot_staged_pull": 1,
++        "fused_registered": 0,
++        "fused_staged_pull": 1,
++        "fused_staged_push": 1,
++        "twoshot_reduce_scatter": 1,
++        "twoshot_all_gather": 1,
++        "dcp_lse_reduce_scatter": 1,
++        "dcp_all_gather_heads": 1,
++    }
++    total_nodes = {name: 1 + extra for name, extra in control_nodes.items()}
++
++    assert total_nodes["oneshot_registered"] == 1
++    assert total_nodes["fused_registered"] == 1
++    assert {
++        total_nodes[name]
++        for name in total_nodes
++        if name not in {"oneshot_registered", "fused_registered"}
++    } == {2}
+diff --git a/tests/comm/test_pcie_twoshot.py b/tests/comm/test_pcie_twoshot.py
+index 0862089c5bf687b5753a849891ff2c5d94f210b4..d9ab1548f137470abce4a83b377a42452375ba43 100644
+--- a/tests/comm/test_pcie_twoshot.py
++++ b/tests/comm/test_pcie_twoshot.py
+@@ -6,12 +6,19 @@ Run with torchrun on 2, 4 or 8 GPUs:
+         --nproc-per-node=8 tests/distributed/test_pcie_twoshot.py
+ """
+ 
++import ctypes
+ import os
+ import time
+ 
++import pytest
+ import torch
+ import torch.distributed as dist
+ 
++from sparkinfer.comm.pcie.pcie_oneshot import (
++    PCIeOneshotAllReduce,
++    _OwnedSharedBuffer,
++    _RETAINED_FAILED_IPC_EXPORTS,
++)
+ from sparkinfer.comm.pcie.pcie_twoshot import (
+     PCIeTwoShotSP,
+     quantize_per_row,
+@@ -21,6 +28,159 @@ ROWS = 4096
+ ROW_ELEMS = 6144
+ 
+ 
++def test_factory_retains_twoshot_native_and_ipc_ownership_when_verdict_fails(
++    monkeypatch,
++) -> None:
++    events: list[tuple[str, int]] = []
++
++    class FakeIPC:
++        def cudaIpcCloseMemHandle(self, ptr):
++            events.append(("close", ptr))
++
++        def cudaFree(self, ptr):
++            events.append(("free", ptr))
++
++    class FakeExt:
++        @staticmethod
++        def init_twoshot(*args):
++            return 3000
++
++        @staticmethod
++        def dispose(ptr):
++            events.append(("dispose", ptr))
++
++    ipc = FakeIPC()
++    ext = FakeExt()
++    group = object()
++    shared = _OwnedSharedBuffer(
++        local_ptr=1000,
++        peer_ptrs=(1000, 2000),
++        remote_ptrs=(2000,),
++    )
++    preallocation_round = 0
++
++    def fake_preallocation(*, owner, exchange_group, setup):
++        nonlocal preallocation_round
++        assert exchange_group is group
++        preallocation_round += 1
++        if preallocation_round == 1:
++            return torch.device("cuda:0"), 8, 16
++        assert preallocation_round == 2
++        return ipc, ext, 1, 256, 64, 256, 512, 1280
++
++    verdict_round = 0
++
++    def exchange(local_status, exchange_group):
++        nonlocal verdict_round
++        assert exchange_group is group
++        verdict_round += 1
++        if verdict_round == 1:
++            raise RuntimeError("injected twoshot native verdict exchange failure")
++        return [local_status, ()]
++
++    monkeypatch.setattr(dist, "get_rank", lambda group=None: 0)
++    monkeypatch.setattr(dist, "get_world_size", lambda group=None: 2)
++    monkeypatch.setattr(
++        "sparkinfer.comm.pcie.pcie_twoshot._run_collective_preallocation_setup",
++        fake_preallocation,
++    )
++    monkeypatch.setattr(
++        "sparkinfer.comm.pcie.pcie_twoshot._require_full_grid_residency",
++        lambda **kwargs: None,
++    )
++    monkeypatch.setattr(
++        "sparkinfer.comm.pcie.pcie_twoshot._require_collective_contract",
++        lambda **kwargs: None,
++    )
++    monkeypatch.setattr(
++        PCIeOneshotAllReduce,
++        "_allocate_shared_buffer",
++        classmethod(lambda cls, *args, **kwargs: shared),
++    )
++    monkeypatch.setattr(
++        "sparkinfer.comm.pcie.pcie_oneshot._broadcast_gather_object",
++        exchange,
++    )
++
++    with pytest.raises(RuntimeError, match="must be coordinated by every rank") as exc:
++        PCIeTwoShotSP.from_exchange_group(
++            exchange_group=group,
++            device="cuda:0",
++            max_rows=8,
++            row_elems=16,
++            ext_module=ext,
++        )
++
++    retained = exc.value.retryable_setup
++    assert retained.local_ptr == 1000
++    assert retained.remote_ptrs == [2000]
++    assert retained.local_cleanup is not None
++    assert events == []
++    assert _RETAINED_FAILED_IPC_EXPORTS[retained.key] is retained
++
++    retained.retry()
++    assert events == [("dispose", 3000), ("close", 2000), ("free", 1000)]
++    assert _RETAINED_FAILED_IPC_EXPORTS == {}
++
++
++def _align_up(value: int, alignment: int) -> int:
++    return (value + alignment - 1) // alignment * alignment
++
++
++def _local_staging_words(
++    pool: PCIeTwoShotSP, stream: torch.cuda.Stream
++) -> tuple[int, int]:
++    assert len(pool._owned_buffers) == 1
++    max_rows_per_rank = pool.max_rows // pool.world_size
++    pack_stride = _align_up(max_rows_per_rank * (pool.row_elems // 16), 16)
++    payload_bytes = pool.world_size * pack_stride * 16
++    scale_offset = _align_up(payload_bytes, 256)
++    scale_stride = _align_up(max_rows_per_rank, 64)
++    slot_bytes = _align_up(
++        scale_offset + pool.world_size * scale_stride * 4,
++        256,
++    )
++    signal_bytes = _align_up(int(pool._ext.meta_size()), 256)
++    remote_source = (pool.rank + 1) % pool.world_size
++    source_offset = remote_source * pack_stride * 16
++    words = (ctypes.c_uint64(), ctypes.c_uint64())
++    local_ptr = pool._owned_buffers[0].local_ptr
++    for word, offset in zip(
++        words,
++        (
++            signal_bytes + source_offset,
++            signal_bytes + slot_bytes + source_offset,
++        ),
++        strict=True,
++    ):
++        pool._ipc.cudaMemcpyAsync(
++            ctypes.addressof(word),
++            local_ptr + offset,
++            ctypes.sizeof(word),
++            int(stream.cuda_stream),
++        )
++    stream.synchronize()
++    return words[0].value, words[1].value
++
++
++def _assert_alternating_slots(snapshots: list[tuple[int, int]]) -> None:
++    changed_slots = [
++        {
++            slot
++            for slot, (before, after) in enumerate(
++                zip(snapshots[index], snapshots[index + 1], strict=True)
++            )
++            if before != after
++        }
++        for index in range(len(snapshots) - 1)
++    ]
++    assert all(len(changed) == 1 for changed in changed_slots)
++    assert all(
++        changed_slots[index] != changed_slots[index + 1]
++        for index in range(len(changed_slots) - 1)
++    )
++
++
+ def _partial(seed: int, rows: int, device: torch.device) -> torch.Tensor:
+     gen = torch.Generator(device="cpu").manual_seed(seed)
+     x = torch.randn(rows, ROW_ELEMS, generator=gen, dtype=torch.float32)
+@@ -127,6 +287,56 @@ def _check_graph_capture(pool: PCIeTwoShotSP, rank: int, world: int) -> None:
+         )
+         assert torch.equal(ag_out, ag_ref)
+ 
++    # Capture a single collective so adjacent replays must alternate the
++    # device-selected staging slot. The two-op graph above has even parity.
++    odd_graph = torch.cuda.CUDAGraph()
++    with torch.cuda.graph(odd_graph):
++        pool.all_gather_fp8(ag_q, ag_s, ag_out)
++
++    for value in (11, 12):
++        ag_q.fill_(float(value + rank))
++        ag_s.fill_(1.0)
++        pool.all_gather_fp8(ag_q, ag_s, ag_out)
++    torch.cuda.synchronize()
++    snapshots = [_local_staging_words(pool, torch.cuda.current_stream(device))]
++
++    for value in (1, 2):
++        ag_q.fill_(float(value + rank))
++        ag_s.fill_(1.0)
++        dist.barrier()
++        odd_graph.replay()
++        torch.cuda.synchronize()
++        snapshots.append(_local_staging_words(pool, torch.cuda.current_stream(device)))
++        for source_rank in range(world):
++            lo = source_rank * rows_per_rank
++            hi = lo + rows_per_rank
++            assert torch.all(ag_out[lo:hi] == float(value + source_rank))
++
++    _assert_alternating_slots(snapshots)
++
++    rs_graph = torch.cuda.CUDAGraph()
++    with torch.cuda.graph(rs_graph):
++        pool.reduce_scatter_fp8(q_in, s_in, rs_out)
++
++    for value in (21, 22):
++        q_in.fill_(float(value + rank))
++        s_in.fill_(1.0)
++        pool.reduce_scatter_fp8(q_in, s_in, rs_out)
++    torch.cuda.synchronize()
++    snapshots = [_local_staging_words(pool, torch.cuda.current_stream(device))]
++
++    rank_sum = world * (world - 1) // 2
++    for value in (3, 4):
++        q_in.fill_(float(value + rank))
++        s_in.fill_(1.0)
++        dist.barrier()
++        rs_graph.replay()
++        torch.cuda.synchronize()
++        snapshots.append(_local_staging_words(pool, torch.cuda.current_stream(device)))
++        assert torch.all(rs_out == float(world * value + rank_sum))
++
++    _assert_alternating_slots(snapshots)
++
+ 
+ def _bench(pool: PCIeTwoShotSP, rank: int, world: int) -> None:
+     device = pool.device
+diff --git a/tests/moe/test_ep_moe_api.py b/tests/moe/test_ep_moe_api.py
+index fbf791ecc7e5543c2e252aa5b8162fc478e5a05a..94d3a95fc85d7952d7824ef728fc06affcdec69d 100644
+--- a/tests/moe/test_ep_moe_api.py
++++ b/tests/moe/test_ep_moe_api.py
+@@ -5,9 +5,17 @@ import torch
+ 
+ import sparkinfer.moe.ep_moe._impl as ep_moe
+ from sparkinfer._lib.intrinsics import swizzle_block_scale
+-from sparkinfer.moe.ep_moe._impl import EPMoEScratchCaps, plan_ep_moe_scratch, prepare_ep_expert_map, sparkinfer_ep_moe_fp4
++from sparkinfer.moe.ep_moe._impl import (
++    EPMoEScratchCaps,
++    plan_ep_moe_scratch,
++    prepare_ep_expert_map,
++    sparkinfer_ep_moe_fp4,
++)
+ from sparkinfer.moe.fused_moe._impl import plan_sparkinfer_fp4_moe_weights
+-from sparkinfer.moe._shared.kernels.w4a16.host import max_w4a16_route_capacity
++from sparkinfer.moe._shared.kernels.w4a16.host import (
++    max_packed_route_slots,
++    route_block_sizes_for_capacity,
++)
+ from tests._reference.helpers import prepare_tp_moe_fp4_experts, run_tp_moe_fp4
+ 
+ 
+@@ -116,7 +124,14 @@ def test_ep_scratch_reserves_route_pack_power_of_two_capacity(
+     )
+ 
+     layout = {spec.name: spec for spec in plan._layout}
+-    expected_slots, expected_blocks = max_w4a16_route_capacity(4 * 2, 10)
++    block_sizes = route_block_sizes_for_capacity(3, 2, 10)
++    expected_slots = max(
++        max_packed_route_slots(4 * 2, block_size, 10) for block_size in block_sizes
++    )
++    expected_blocks = max(
++        (max_packed_route_slots(4 * 2, block_size, 10) + block_size - 1) // block_size
++        for block_size in block_sizes
++    )
+     assert layout["packed_route_indices"].elements == expected_slots
+     assert layout["block_expert_ids"].elements == expected_blocks
+     assert layout["intermediate_cache2"].elements == 3 * 2 * 128
+@@ -154,14 +169,18 @@ def _make_modelopt_weights(
+         device="cuda",
+     )
+     w13_scale = swizzle_block_scale(
+-        (torch.rand(experts, 2 * intermediate_size, hidden_size // 16, device="cuda")
+-         * 0.25
+-         + 0.03125).to(torch.float8_e4m3fn)
++        (
++            torch.rand(experts, 2 * intermediate_size, hidden_size // 16, device="cuda")
++            * 0.25
++            + 0.03125
++        ).to(torch.float8_e4m3fn)
+     )
+     w2_scale = swizzle_block_scale(
+-        (torch.rand(experts, hidden_size, intermediate_size // 16, device="cuda")
+-         * 0.25
+-         + 0.03125).to(torch.float8_e4m3fn)
++        (
++            torch.rand(experts, hidden_size, intermediate_size // 16, device="cuda")
++            * 0.25
++            + 0.03125
++        ).to(torch.float8_e4m3fn)
+     )
+     w13_alpha = (torch.rand(experts, device="cuda") * 0.1 + 0.05).float()
+     w2_alpha = (torch.rand(experts, device="cuda") * 0.1 + 0.05).float()
+@@ -318,9 +337,11 @@ def test_ep_binding_replays_with_changed_routes_under_cuda_graph() -> None:
+     global_ids = torch.tensor([0, 2])
+     experts = _prepare_experts(a, weights, global_ids)
+     expert_map = torch.tensor([0, -1, 1, -1], dtype=torch.int32, device="cuda")
+-    topk_ids = torch.tensor([[1, 3]], dtype=torch.int32, device="cuda").expand(
+-        m, -1
+-    ).contiguous()
++    topk_ids = (
++        torch.tensor([[1, 3]], dtype=torch.int32, device="cuda")
++        .expand(m, -1)
++        .contiguous()
++    )
+     topk_weights = torch.full((m, topk), 0.5, dtype=torch.float32, device="cuda")
+     nonlocal_output, binding = _run_ep_rank(
+         a=a,
+diff --git a/tests/moe/test_fused_moe_planning.py b/tests/moe/test_fused_moe_planning.py
+new file mode 100644
+index 0000000000000000000000000000000000000000..fe38b5d10c4476d0a1e828a0cfd36129110e1850
+--- /dev/null
++++ b/tests/moe/test_fused_moe_planning.py
+@@ -0,0 +1,171 @@
++from __future__ import annotations
++
++import pytest
++import torch
++
++from sparkinfer.moe import fused_moe
++import sparkinfer.moe.fused_moe._impl as fused_moe_impl
++
++
++def _weight_plan() -> fused_moe.WeightsPlan:
++    return fused_moe.plan_weights(
++        quant_modes="w4a16",
++        source_format="modelopt_nvfp4",
++        activation="silu",
++        params_dtype=torch.bfloat16,
++        num_experts=160,
++        hidden_size=6144,
++        intermediate_size=512,
++        w13_layout="w13",
++    )
++
++
++def _caps(*, block_size_m: int | None) -> fused_moe.Caps:
++    return fused_moe.Caps(
++        max_tokens=64,
++        num_topk=8,
++        route_num_experts=160,
++        device="cpu",
++        weight_plan=_weight_plan(),
++        quant_mode="w4a16",
++        w4a16_block_size_m=block_size_m,
++    )
++
++
++def _trellis_caps() -> fused_moe.Caps:
++    weight_plan = fused_moe.plan_weights(
++        quant_modes="w4a16",
++        source_format="exl3_trellis_mcg",
++        activation="silu",
++        params_dtype=torch.bfloat16,
++        num_experts=160,
++        hidden_size=6144,
++        intermediate_size=512,
++        w13_layout="w13",
++        trellis_bits=3,
++        trellis_tile_config=(64, 256, 64, 256),
++    )
++    return fused_moe.Caps(
++        max_tokens=3072,
++        num_topk=8,
++        route_num_experts=160,
++        device="cpu",
++        weight_plan=weight_plan,
++        quant_mode="w4a16",
++        w4a16_block_size_m=64,
++    )
++
++
++def _small_packed_caps() -> fused_moe.Caps:
++    weight_plan = fused_moe.plan_weights(
++        quant_modes="w4a16",
++        source_format="compressed_tensors",
++        activation="silu",
++        params_dtype=torch.bfloat16,
++        num_experts=16,
++        hidden_size=128,
++        intermediate_size=128,
++        w13_layout="w13",
++    )
++    return fused_moe.Caps(
++        max_tokens=4,
++        num_topk=8,
++        route_num_experts=16,
++        device="cpu",
++        weight_plan=weight_plan,
++        quant_mode="w4a16",
++    )
++
++
++def _subset_router_caps() -> fused_moe.Caps:
++    weight_plan = fused_moe.plan_weights(
++        quant_modes="w4a16",
++        source_format="compressed_tensors",
++        activation="silu",
++        params_dtype=torch.bfloat16,
++        num_experts=160,
++        hidden_size=128,
++        intermediate_size=128,
++        w13_layout="w13",
++    )
++    return fused_moe.Caps(
++        max_tokens=8,
++        num_topk=8,
++        route_num_experts=16,
++        device="cpu",
++        weight_plan=weight_plan,
++        quant_mode="w4a16",
++    )
++
++
++def test_required_nbytes_avoids_launch_prewarm(
++    monkeypatch: pytest.MonkeyPatch,
++) -> None:
++    monkeypatch.setattr(fused_moe_impl, "get_num_sm", lambda _device: 188)
++
++    def fail_launch_prewarm(**_kwargs) -> None:
++        raise AssertionError("launch prewarm called")
++
++    monkeypatch.setattr(
++        fused_moe_impl,
++        "_plan_full_rotation_w4a16_launches",
++        fail_launch_prewarm,
++    )
++    caps = _trellis_caps()
++
++    required = fused_moe.required_nbytes(caps)
++
++    assert required > 1024 * 1024 * 1024
++    assert "required_nbytes" in fused_moe.META.entry_points
++    with pytest.raises(TypeError, match="TPMoEScratchCaps"):
++        fused_moe.required_nbytes(object())
++
++
++def test_required_nbytes_matches_scratch_plan(
++    monkeypatch: pytest.MonkeyPatch,
++) -> None:
++    monkeypatch.setattr(fused_moe_impl, "get_num_sm", lambda _device: 188)
++    caps = _caps(block_size_m=8)
++
++    plan = fused_moe.plan(caps)
++
++    assert fused_moe.required_nbytes(caps) == plan.scratch_specs()[0].shape[0]
++
++
++def test_small_packed_plan_covers_direct_topk_scratch(
++    monkeypatch: pytest.MonkeyPatch,
++) -> None:
++    monkeypatch.setattr(fused_moe_impl, "get_num_sm", lambda _device: 188)
++
++    plan = fused_moe.plan(_small_packed_caps())
++    specs = {spec.name: spec for spec in plan._core_workspace_plan.tensor_specs}
++
++    assert specs["fc1_c_tmp"].shape == (131072,)
++    assert specs["fc2_c_tmp"].shape == (65536,)
++
++
++def test_non_trellis_core_sizes_routes_for_weight_experts(
++    monkeypatch: pytest.MonkeyPatch,
++) -> None:
++    monkeypatch.setattr(fused_moe_impl, "get_num_sm", lambda _device: 188)
++
++    plan = fused_moe.plan(_subset_router_caps())
++    specs = {spec.name: spec for spec in plan._core_workspace_plan.tensor_specs}
++
++    assert plan._core_workspace_plan.route_E == 160
++    assert specs["packed_route_indices"].shape == (512,)
++    assert specs["block_expert_ids"].shape == (64,)
++    assert specs["expert_offsets"].shape == (161,)
++
++
++def test_unpinned_small_capacity_matches_reachable_block_8(
++    monkeypatch: pytest.MonkeyPatch,
++) -> None:
++    monkeypatch.setattr(fused_moe_impl, "get_num_sm", lambda _device: 188)
++
++    automatic = fused_moe.required_nbytes(_caps(block_size_m=None))
++    exact = fused_moe.required_nbytes(_caps(block_size_m=8))
++    oversized = fused_moe.required_nbytes(_caps(block_size_m=64))
++
++    assert automatic == exact
++    assert oversized - automatic > 64 * 1024 * 1024
+diff --git a/tests/moe/test_w4a16_e2e.py b/tests/moe/test_w4a16_e2e.py
+index b24b785624c3b69cff5cb5337cca09fc18af0db6..f59c2cd8052fe1e6a48e40a68629ab3abff70741 100644
+--- a/tests/moe/test_w4a16_e2e.py
++++ b/tests/moe/test_w4a16_e2e.py
+@@ -19,10 +19,15 @@ from sparkinfer.moe._shared.kernels.reference import (
+     moe_reference_w4a16_f32,
+     moe_reference_w4a16_fp4_e8m0_k32,
+ )
+-from sparkinfer.moe._shared.kernels.w4a16.host import max_packed_route_slots, select_route_block_size_m
++from sparkinfer.moe._shared.kernels.w4a16.host import (
++    max_packed_route_slots,
++    route_pack_capacity,
++    select_route_block_size_m,
++)
+ from sparkinfer.moe._shared.kernels.w4a16.kernel import (
+     _DEFAULT_MAX_SHARED_MEM,
+     MoEMicroKernelW4A16SmallMDirect,
++    _w4a16_stream_is_capturing,
+     _small_m_direct_supported,
+     compile_w4a16_fused_moe,
+     compile_w4a16_topk_sum,
+@@ -35,10 +40,221 @@ from sparkinfer.moe._shared.kernels.w4a16.prepare import (
+     prepare_w4a16_modelopt_nvfp4_weights as prepare_w4a16_weights,
+     prepare_w4a16_packed_weights,
+ )
+-from tests._reference.helpers import prepare_tp_moe_fp4_experts, run_tp_moe_fp4
++from tests._reference.helpers import (
++    make_tp_moe_fp4_binding,
++    prepare_tp_moe_fp4_experts,
++    run_tp_moe_fp4,
++)
+ from tests._reference.w4a16_reference import compare_to_reference, moe_reference_w4a16
+ 
+ 
++def test_w4a16_fused_compile_rejects_unresolved_capture_launch(
++    monkeypatch: pytest.MonkeyPatch,
++) -> None:
++    from sparkinfer.moe._shared.kernels.w4a16 import kernel as w4a16_kernel
++
++    monkeypatch.setattr(w4a16_kernel, "_FUSED_CACHE", {})
++    monkeypatch.setattr(w4a16_kernel.torch.cuda, "is_available", lambda: False)
++
++    with pytest.raises(
++        RuntimeError,
++        match="W4A16 fused MoE launch is not resolved for CUDA graph capture",
++    ):
++        compile_w4a16_fused_moe(
++            size_m=16,
++            hidden_size=128,
++            intermediate_size=128,
++            num_experts=8,
++            top_k=2,
++            activation="silu",
++            apply_router_weight_on_input=False,
++            zero_fc2_output=False,
++            moe_block_size=8,
++            max_m_blocks=16,
++            sms=188,
++            max_shared_mem=_DEFAULT_MAX_SHARED_MEM,
++            _require_cached=True,
++        )
++
++
++def test_w4a16_capture_guard_checks_selected_stream(
++    monkeypatch: pytest.MonkeyPatch,
++) -> None:
++    from sparkinfer.moe._shared.kernels.w4a16 import kernel as w4a16_kernel
++
++    selected_stream = 22
++    queried: list[object] = []
++    monkeypatch.setattr(
++        w4a16_kernel.torch.cuda,
++        "is_current_stream_capturing",
++        lambda: False,
++    )
++    monkeypatch.setattr(
++        w4a16_kernel.cuda,
++        "cuStreamIsCapturing",
++        lambda stream: (
++            queried.append(stream) or w4a16_kernel.cuda.CUresult.CUDA_SUCCESS,
++            1,
++        ),
++    )
++
++    assert _w4a16_stream_is_capturing(selected_stream, current_stream=11)
++    assert queried == [selected_stream]
++
++
++def test_w4a16_capture_guard_preserves_current_stream_capture(
++    monkeypatch: pytest.MonkeyPatch,
++) -> None:
++    from sparkinfer.moe._shared.kernels.w4a16 import kernel as w4a16_kernel
++
++    monkeypatch.setattr(
++        w4a16_kernel.torch.cuda,
++        "is_current_stream_capturing",
++        lambda: True,
++    )
++    monkeypatch.setattr(
++        w4a16_kernel.cuda,
++        "cuStreamIsCapturing",
++        lambda _stream: (_ for _ in ()).throw(
++            AssertionError("current-stream capture queried the selected stream")
++        ),
++    )
++
++    assert _w4a16_stream_is_capturing(22, current_stream=11)
++
++
++@pytest.mark.parametrize(
++    ("tokens", "bucket_tokens"),
++    (
++        (1, 1),
++        (8, 8),
++        (9, 16),
++        (3072, 4096),
++        (4096, 4096),
++        (4097, 8192),
++    ),
++)
++def test_generic_w4a16_planner_runtime_key_agrees_at_bucket_boundaries(
++    tokens: int,
++    bucket_tokens: int,
++) -> None:
++    topk = 8
++    block_size = 64
++    num_experts = 160
++    routed_capacity, packed_routes, max_m_blocks = route_pack_capacity(
++        tokens * topk,
++        block_size,
++        num_experts,
++        topk=topk,
++    )
++    expected_routes = bucket_tokens * topk
++    expected_packed = max_packed_route_slots(
++        expected_routes,
++        block_size,
++        num_experts,
++    )
++
++    assert routed_capacity == expected_routes
++    assert packed_routes == expected_packed
++    assert max_m_blocks == (expected_packed + block_size - 1) // block_size
++    if tokens == 3072:
++        assert max_m_blocks == 670
++
++
++def test_trellis_w4a16_planner_runtime_key_preserves_exact_capacity() -> None:
++    topk = 8
++    block_size = 64
++    num_experts = 160
++    routed_capacity, packed_routes, max_m_blocks = route_pack_capacity(
++        3072 * topk,
++        block_size,
++        num_experts,
++        topk=topk,
++        bucket_tokens=False,
++    )
++
++    assert routed_capacity == 3072 * topk
++    assert packed_routes == max_packed_route_slots(
++        3072 * topk,
++        block_size,
++        num_experts,
++    )
++    assert max_m_blocks == 542
++
++
++def test_trellis_w4a16_capture_prewarm_uses_exact_runtime_key(
++    monkeypatch: pytest.MonkeyPatch,
++) -> None:
++    from contextlib import nullcontext
++    from types import SimpleNamespace
++
++    from sparkinfer.moe.fused_moe import _impl as tp_moe_impl
++    from sparkinfer.moe._shared.kernels.w4a16 import kernel as w4a16_kernel
++
++    workspace = SimpleNamespace(
++        device=torch.device("cuda"),
++        dtype=torch.bfloat16,
++        full_rotation=True,
++        route_block_size_m=64,
++        num_topk=8,
++        route_E=160,
++        weight_E=160,
++        k=6144,
++        n=2048,
++        activation="silu",
++        trellis_bits=3,
++        trellis_tile_config=None,
++    )
++    fused_calls: list[dict[str, object]] = []
++    resolved_fused = object()
++    monkeypatch.setattr(tp_moe_impl.torch.cuda, "device", lambda _device: nullcontext())
++    monkeypatch.setattr(
++        tp_moe_impl.torch.cuda,
++        "is_current_stream_capturing",
++        lambda: True,
++    )
++    monkeypatch.setattr(
++        tp_moe_impl.torch.cuda,
++        "get_device_properties",
++        lambda _device: SimpleNamespace(
++            multi_processor_count=188,
++            shared_memory_per_block_optin=_DEFAULT_MAX_SHARED_MEM,
++        ),
++    )
++    monkeypatch.setattr(w4a16_kernel, "_rot_scales_dummy", lambda _device: None)
++    monkeypatch.setattr(
++        w4a16_kernel,
++        "compile_w4a16_fused_moe",
++        lambda **kwargs: fused_calls.append(kwargs) or resolved_fused,
++    )
++    monkeypatch.setattr(
++        w4a16_kernel,
++        "compile_w4a16_topk_sum",
++        lambda **_kwargs: object(),
++    )
++
++    tp_moe_impl._prewarm_w4a16_planned_launches(
++        workspace,
++        token_counts=(3072,),
++        apply_router_weight_on_input=False,
++        swiglu_limit=None,
++        swiglu_alpha=1.0,
++        swiglu_beta=1.0,
++        scale_format="e4m3_k32",
++        weight_layout="trellis3_t256",
++        w13_layout="trellis3_t256_proj",
++        collect_activation_amax=False,
++    )
++
++    assert len(fused_calls) == 2
++    assert {call["size_m"] for call in fused_calls} == {3072}
++    assert {call["max_m_blocks"] for call in fused_calls} == {542}
++    assert (
++        workspace.planned_fused_moe_launches[("trellis3_t256", "e4m3_k32", 3072, False)]
++        is resolved_fused
++    )
++
++
+ def _positive_fp8(shape: tuple[int, ...]) -> torch.Tensor:
+     return (torch.rand(shape, device="cuda") * 0.25 + 0.03125).to(torch.float8_e4m3fn)
+ 
+@@ -57,7 +273,7 @@ def _pattern_e8m0(shape: tuple[int, ...], *, offset: int = 0) -> torch.Tensor:
+     numel = 1
+     for dim in shape:
+         numel *= int(dim)
+-    storage = ((torch.arange(numel, device="cuda", dtype=torch.int64) + offset) % 4 + 119)
++    storage = (torch.arange(numel, device="cuda", dtype=torch.int64) + offset) % 4 + 119
+     return storage.to(torch.uint8).reshape(shape).view(e8m0_dtype)
+ 
+ 
+@@ -84,9 +300,7 @@ def _quantize_dense_moe_weight_storage(
+             torch.float8_e4m3fn
+         )
+         scale = scale.to(torch.float32)
+-        output_scale = 1.0 / (scale * (1.0 / global_scale[group_idx])).clamp(
+-            min=1e-30
+-        )
++        output_scale = 1.0 / (scale * (1.0 / global_scale[group_idx])).clamp(min=1e-30)
+         clipped = torch.clamp(
+             sliced * output_scale,
+             -FLOAT4_E2M1_MAX,
+@@ -106,7 +320,9 @@ def _make_weights(
+     hidden_size: int,
+     intermediate_size: int,
+     activation: str,
+-) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor, torch.Tensor, torch.Tensor, torch.Tensor]:
++) -> tuple[
++    torch.Tensor, torch.Tensor, torch.Tensor, torch.Tensor, torch.Tensor, torch.Tensor
++]:
+     is_gated = activation in {"silu", "situ"}
+     w13_rows = intermediate_size * (2 if is_gated else 1)
+     w13 = torch.randint(
+@@ -129,8 +345,12 @@ def _make_weights(
+     w2_blockscale = swizzle_block_scale(
+         _positive_fp8((experts, hidden_size, intermediate_size // 16))
+     )
+-    w13_global_scale = (torch.rand(experts, device="cuda") * 0.1 + 0.05).to(torch.float32)
+-    w2_global_scale = (torch.rand(experts, device="cuda") * 0.1 + 0.05).to(torch.float32)
++    w13_global_scale = (torch.rand(experts, device="cuda") * 0.1 + 0.05).to(
++        torch.float32
++    )
++    w2_global_scale = (torch.rand(experts, device="cuda") * 0.1 + 0.05).to(
++        torch.float32
++    )
+     return w13, w13_blockscale, w13_global_scale, w2, w2_blockscale, w2_global_scale
+ 
+ 
+@@ -260,6 +480,57 @@ def test_w4a16_packed_weights_do_not_route_to_small_m_direct(
+     )
+ 
+ 
++@pytest.mark.parametrize(
++    "intermediate_size",
++    [16, 144, 352, 464, 480, 496, 512],
++)
++@pytest.mark.parametrize("activation", ["relu2", "silu"])
++@pytest.mark.parametrize("m", [1, 3])
++def test_w4a16_modelopt_direct_keeps_non64_intermediate_contract(
++    m: int,
++    activation: str,
++    intermediate_size: int,
++) -> None:
++    """Native ModelOpt decode supports every 16-aligned intermediate shape."""
++    assert _small_m_direct_supported(
++        m=m,
++        hidden_size=128,
++        intermediate_size=intermediate_size,
++        num_experts=1,
++        topk=1,
++        activation=activation,
++        apply_router_weight_on_input=False,
++        swiglu_limit=None,
++        swiglu_alpha=None,
++        swiglu_beta=None,
++        element_dtype="bf16",
++        weight_layout="modelopt",
++        w13_layout="w13",
++        scale_format="e4m3_k16",
++    )
++    kernel = MoEMicroKernelW4A16SmallMDirect(
++        activation=activation,
++        fast_math=True,
++        share_input_across_experts=True,
++        share_expert_scales=True,
++        single_token=m == 1,
++    )
++    kernel.configure(
++        m=m,
++        k=128,
++        n=intermediate_size,
++        num_topk=1,
++        weight_E=1,
++        max_active_ctas=1,
++    )
++    assert kernel._cfg is not None
++    assert kernel._cfg.n % kernel._cfg.fc1_chunks == 0
++    assert kernel._cfg.i_chunk % 16 == 0
++    assert kernel._cfg.inter_blocks * 16 == kernel._cfg.i_chunk
++    if m > 1:
++        assert kernel._cfg.i_chunk <= 32
++
++
+ @pytest.mark.skipif(not torch.cuda.is_available(), reason="requires CUDA")
+ @pytest.mark.parametrize("activation", ["relu2", "silu"])
+ def test_w4a16_fp4_e8m0_k32_kernel_matches_raw_e8m0_oracle(
+@@ -368,6 +639,7 @@ def test_w4a16_fp4_e8m0_k32_kernel_matches_raw_e8m0_oracle(
+ 
+ 
+ @pytest.mark.skipif(not torch.cuda.is_available(), reason="requires CUDA")
++@pytest.mark.parametrize("intermediate_size", [128, 224])
+ @pytest.mark.parametrize("w13_layout", ["w13", "w31"])
+ # 0.5 is small enough to actually engage the SwiGLU clamp at these scales.
+ @pytest.mark.parametrize("swiglu_limit", [None, 0.5])
+@@ -378,6 +650,7 @@ def test_w4a16_e8m0_native_micro_matches_raw_e8m0_oracle(
+     m: int,
+     swiglu_limit: float | None,
+     w13_layout: str,
++    intermediate_size: int,
+ ) -> None:
+     """Small-M micro decode path with native MXFP4 (E8M0 K/32) scales."""
+     if swiglu_limit is not None and activation != "silu":
+@@ -390,14 +663,10 @@ def test_w4a16_e8m0_native_micro_matches_raw_e8m0_oracle(
+             share_expert_scales=True,
+             single_token=True,
+         )
+-        e4m3 = MoEMicroKernelW4A16SmallMDirect(
+-            scale_format="e4m3_k16", **common
+-        )
+-        e8m0 = MoEMicroKernelW4A16SmallMDirect(
+-            scale_format="e8m0_k32", **common
+-        )
++        e4m3 = MoEMicroKernelW4A16SmallMDirect(scale_format="e4m3_k16", **common)
++        e8m0 = MoEMicroKernelW4A16SmallMDirect(scale_format="e8m0_k32", **common)
+         assert e4m3.__cache_key__ != e8m0.__cache_key__
+-    experts, hidden_size, intermediate_size = 4, 128, 128
++    experts, hidden_size = 4, 128
+     rows = intermediate_size * (2 if activation == "silu" else 1)
+     topk = 2
+     torch.manual_seed(20260601 + (1000 if activation == "silu" else 0) + m)
+@@ -445,6 +714,16 @@ def test_w4a16_e8m0_native_micro_matches_raw_e8m0_oracle(
+         params_dtype=torch.bfloat16,
+         w13_layout=w13_layout,
+     )
++    expected_w13_scale_rows = ((rows + 63) // 64) * 64
++    assert tuple(prepared.w13_scale.shape) == (
++        experts,
++        hidden_size // 32,
++        expected_w13_scale_rows,
++    )
++    assert prepared.micro_w13_scale is not None
++    assert int(prepared.micro_w13_scale.numel()) == (
++        experts * (hidden_size // 32) * expected_w13_scale_rows
++    )
+     buffers = make_w4a16_buffers(
+         prepared, m=m, topk=topk, dtype=torch.bfloat16, device=torch.device("cuda")
+     )
+@@ -455,9 +734,7 @@ def test_w4a16_e8m0_native_micro_matches_raw_e8m0_oracle(
+         2 * m * fc2_n_chunks * 128 * topk, dtype=torch.bfloat16, device="cuda"
+     )
+     x = torch.randn(m, hidden_size, dtype=torch.bfloat16, device="cuda")
+-    topk_ids = torch.randint(
+-        0, experts, (m, topk), dtype=torch.int32, device="cuda"
+-    )
++    topk_ids = torch.randint(0, experts, (m, topk), dtype=torch.int32, device="cuda")
+     topk_weights = torch.rand(m, topk, dtype=torch.float32, device="cuda")
+ 
+     def launch() -> torch.Tensor:
+@@ -751,20 +1028,15 @@ def test_w4a16_beats_nvfp4_against_true_fp32_oracle_for_odd_shapes(
+     for batch_size, seq_len, topk, ids_dtype, input_scale in cases:
+         m = batch_size * seq_len
+         torch.manual_seed(
+-            20260525
+-            + m * 31
+-            + topk
+-            + (1000 if activation == "silu" else 0)
++            20260525 + m * 31 + topk + (1000 if activation == "silu" else 0)
+         )
+         rows = intermediate_size * (2 if activation == "silu" else 1)
+-        w13_dense = (
+-            torch.randn(experts, rows, hidden_size, device="cuda")
+-            * (0.18 if activation == "silu" else 0.08)
+-        )
+-        w2_dense = (
+-            torch.randn(experts, hidden_size, intermediate_size, device="cuda")
+-            * (0.18 if activation == "silu" else 0.08)
++        w13_dense = torch.randn(experts, rows, hidden_size, device="cuda") * (
++            0.18 if activation == "silu" else 0.08
+         )
++        w2_dense = torch.randn(
++            experts, hidden_size, intermediate_size, device="cuda"
++        ) * (0.18 if activation == "silu" else 0.08)
+         w13_global_scale = torch.ones(experts, dtype=torch.float32, device="cuda")
+         w2_global_scale = torch.ones(experts, dtype=torch.float32, device="cuda")
+         w13, w13_blockscale = _quantize_dense_moe_weight_storage(
+@@ -878,6 +1150,310 @@ def test_w4a16_beats_nvfp4_against_true_fp32_oracle_for_odd_shapes(
+         )
+ 
+ 
++@pytest.mark.skipif(not torch.cuda.is_available(), reason="requires CUDA")
++@pytest.mark.parametrize("activation", ["relu2", "silu"])
++@pytest.mark.parametrize("m", [1, 3])
++@pytest.mark.parametrize(
++    "intermediate_size",
++    [32, 128, 144, 224, 352, 464, 480, 496, 512],
++)
++def test_w4a16_modelopt_direct_replay_ignores_stale_swizzle_tail(
++    activation: str,
++    m: int,
++    intermediate_size: int,
++    monkeypatch: pytest.MonkeyPatch,
++) -> None:
++    import sparkinfer.moe._shared.kernels.w4a16.kernel as w4a16_kernel
++
++    experts, hidden_size = 8, 128
++    topk = 2
++    monkeypatch.setenv("SPARKINFER_W4A16_SMALL_M_DIRECT", "1")
++    torch.manual_seed(
++        20260730 + (1000 if activation == "silu" else 0) + m + intermediate_size
++    )
++    real_direct_launch = w4a16_kernel._w4a16_small_m_direct_launch_flat
++    direct_launches: list[tuple[int, int]] = []
++
++    def spy_direct_launch(*args, **kwargs) -> None:
++        direct_launches.append((int(kwargs["m"]), int(kwargs["intermediate_size"])))
++        real_direct_launch(*args, **kwargs)
++
++    monkeypatch.setattr(
++        w4a16_kernel,
++        "_w4a16_small_m_direct_launch_flat",
++        spy_direct_launch,
++    )
++    rows = intermediate_size * (2 if activation == "silu" else 1)
++    w13_dense = torch.randn(experts, rows, hidden_size, device="cuda") * 0.12
++    w2_dense = (
++        torch.randn(experts, hidden_size, intermediate_size, device="cuda") * 0.12
++    )
++    w13_global_scale = torch.ones(experts, dtype=torch.float32, device="cuda")
++    w2_global_scale = torch.ones(experts, dtype=torch.float32, device="cuda")
++    w13, w13_blockscale = _quantize_dense_moe_weight_storage(
++        w13_dense,
++        w13_global_scale,
++    )
++    w2, w2_blockscale = _quantize_dense_moe_weight_storage(
++        w2_dense,
++        w2_global_scale,
++    )
++    x = (torch.randn(m, hidden_size, device="cuda") * 0.5).to(torch.bfloat16)
++    topk_ids = torch.randint(
++        0,
++        experts,
++        (m, topk),
++        device="cuda",
++        dtype=torch.int32,
++    )
++    topk_weights = torch.softmax(torch.randn(m, topk, device="cuda"), dim=-1)
++    a_gscale = torch.ones(experts, dtype=torch.float32, device="cuda")
++    w4a16_experts = prepare_tp_moe_fp4_experts(
++        a=x,
++        a1_gscale=a_gscale,
++        w1_fp4=w13,
++        w1_blockscale=w13_blockscale,
++        w1_alphas=w13_global_scale,
++        a2_gscale=a_gscale,
++        w2_fp4=w2,
++        w2_blockscale=w2_blockscale,
++        w2_alphas=w2_global_scale,
++        activation=activation,
++        quant_mode="w4a16",
++    )
++    prepared_w4a16 = w4a16_experts.representation_for("w4a16")
++    assert prepared_w4a16.weight_layout == "modelopt"
++    micro_w13_scale = prepared_w4a16.micro_w13_scale
++    assert micro_w13_scale is not None
++    expected_micro_w13_rows = ((rows + 63) // 64) * 64
++    assert int(micro_w13_scale.numel()) == (
++        experts * (hidden_size // 16) * expected_micro_w13_rows
++    )
++    assert _small_m_direct_supported(
++        m=m,
++        hidden_size=hidden_size,
++        intermediate_size=intermediate_size,
++        num_experts=experts,
++        topk=topk,
++        activation=activation,
++        apply_router_weight_on_input=False,
++        swiglu_limit=None,
++        swiglu_alpha=None,
++        swiglu_beta=None,
++        element_dtype="bf16",
++        weight_layout=prepared_w4a16.weight_layout,
++        w13_layout="w13",
++        scale_format="e4m3_k16",
++    )
++    binding = make_tp_moe_fp4_binding(
++        a=x,
++        experts=w4a16_experts,
++        topk_weights=topk_weights,
++        topk_ids=topk_ids,
++        output=torch.empty(
++            (m, hidden_size),
++            dtype=x.dtype,
++            device=x.device,
++        ),
++        quant_mode="w4a16",
++    )
++    expected = moe_reference_w4a16_f32(
++        x,
++        w13,
++        w13_blockscale,
++        w13_global_scale,
++        w2,
++        w2_blockscale,
++        w2_global_scale,
++        topk_ids,
++        topk_weights,
++        experts,
++        hidden_size,
++        intermediate_size,
++        activation=activation,
++    )
++
++    first = binding.run().clone()
++    torch.cuda.synchronize()
++    first_metrics = compare_to_reference(first, expected)
++    assert bool(torch.isfinite(first).all().item())
++    assert first_metrics.cos > 0.999, first_metrics
++
++    # The arena legitimately preserves the padded half of each 128-u32
++    # swizzle block. Poison it all, then prove FC1 rewrites every logical lane
++    # and FC2 ignores every inactive lane on the same-binding replay.
++    binding.intermediate_cache2.fill_(float("nan"))
++    replay = binding.run().clone()
++    torch.cuda.synchronize()
++    replay_metrics = compare_to_reference(replay, expected)
++    assert bool(torch.isfinite(replay).all().item())
++    assert replay_metrics.cos > 0.999, replay_metrics
++    torch.testing.assert_close(replay, first, atol=0.0, rtol=0.0)
++
++    # Capture the same direct path once, then repeatedly replay it after
++    # poisoning the arena tail. Graph replay does not re-enter the Python spy,
++    # so three launches prove two eager calls plus one captured custom-op node.
++    graph = torch.cuda.CUDAGraph()
++    torch.cuda.synchronize()
++    with torch.cuda.graph(graph):
++        graph_output = binding.run()
++    for _ in range(16):
++        binding.intermediate_cache2.fill_(float("nan"))
++        graph.replay()
++    torch.cuda.synchronize()
++    graph_metrics = compare_to_reference(graph_output, expected)
++    assert bool(torch.isfinite(graph_output).all().item())
++    assert graph_metrics.cos > 0.999, graph_metrics
++    torch.testing.assert_close(graph_output, first, atol=0.0, rtol=0.0)
++    assert direct_launches == [(m, intermediate_size)] * 3
++
++
++@pytest.mark.skipif(not torch.cuda.is_available(), reason="requires CUDA")
++@pytest.mark.parametrize(
++    "intermediate_size",
++    [144, 352, 464, 480, 496, 512],
++)
++@pytest.mark.parametrize("activation", ["relu2", "silu"])
++@pytest.mark.parametrize("m", [1, 3])
++def test_w4a16_modelopt_direct_non64_intermediate_is_bounds_safe(
++    m: int,
++    activation: str,
++    intermediate_size: int,
++    monkeypatch: pytest.MonkeyPatch,
++) -> None:
++    """Exercise the exact native row tail under CUDA memcheck.
++
++    I=144 exercises the narrow one-chunk kernel: it has 18 logical packed-u32
++    values per W2 row while the ModelOpt scale grid pads its control geometry
++    to 24. I=352 exercises a partial scale/control tail in the wide kernel.
++    I=496 is the boundary case where that padded control grid looks completely
++    full even though the final two activation lanes are unwritten. Selecting
++    the only expert makes an unmasked W2 tail load cross the tensor allocation
++    instead of merely reading the next expert. Run this test under
++    compute-sanitizer with ``PYTORCH_NO_CUDA_MEMORY_CACHING=1`` to audit
++    m==1/m>=2 and ungated/gated direct-FC2 implementations.
++    """
++    import sparkinfer.moe._shared.kernels.w4a16.kernel as w4a16_kernel
++
++    experts, hidden_size, topk = 1, 128, 1
++    monkeypatch.setenv("SPARKINFER_W4A16_SMALL_M_DIRECT", "1")
++    real_direct_launch = w4a16_kernel._w4a16_small_m_direct_launch_flat
++    direct_launches: list[tuple[int, int]] = []
++
++    def spy_direct_launch(*args, **kwargs) -> None:
++        direct_launches.append((int(kwargs["m"]), int(kwargs["intermediate_size"])))
++        real_direct_launch(*args, **kwargs)
++
++    monkeypatch.setattr(
++        w4a16_kernel,
++        "_w4a16_small_m_direct_launch_flat",
++        spy_direct_launch,
++    )
++    torch.manual_seed(
++        20260731 + m + intermediate_size + (1000 if activation == "silu" else 0)
++    )
++
++    rows = intermediate_size * (2 if activation == "silu" else 1)
++    w13_dense = (
++        torch.randn(
++            experts,
++            rows,
++            hidden_size,
++            device="cuda",
++        )
++        * 0.12
++    )
++    w2_dense = (
++        torch.randn(
++            experts,
++            hidden_size,
++            intermediate_size,
++            device="cuda",
++        )
++        * 0.12
++    )
++    w13_global_scale = torch.ones(experts, dtype=torch.float32, device="cuda")
++    w2_global_scale = torch.ones(experts, dtype=torch.float32, device="cuda")
++    w13, w13_blockscale = _quantize_dense_moe_weight_storage(
++        w13_dense,
++        w13_global_scale,
++    )
++    w2, w2_blockscale = _quantize_dense_moe_weight_storage(
++        w2_dense,
++        w2_global_scale,
++    )
++    x = (torch.randn(m, hidden_size, device="cuda") * 0.5).to(torch.bfloat16)
++    topk_ids = torch.zeros((m, topk), device="cuda", dtype=torch.int32)
++    topk_weights = torch.ones((m, topk), device="cuda", dtype=torch.float32)
++    a_gscale = torch.ones(experts, dtype=torch.float32, device="cuda")
++
++    experts_w4a16 = prepare_tp_moe_fp4_experts(
++        a=x,
++        a1_gscale=a_gscale,
++        w1_fp4=w13,
++        w1_blockscale=w13_blockscale,
++        w1_alphas=w13_global_scale,
++        a2_gscale=a_gscale,
++        w2_fp4=w2,
++        w2_blockscale=w2_blockscale,
++        w2_alphas=w2_global_scale,
++        activation=activation,
++        quant_mode="w4a16",
++    )
++    prepared = experts_w4a16.representation_for("w4a16")
++    assert prepared.weight_layout == "modelopt"
++    assert _small_m_direct_supported(
++        m=m,
++        hidden_size=hidden_size,
++        intermediate_size=intermediate_size,
++        num_experts=experts,
++        topk=topk,
++        activation=activation,
++        apply_router_weight_on_input=False,
++        swiglu_limit=None,
++        swiglu_alpha=None,
++        swiglu_beta=None,
++        element_dtype="bf16",
++        weight_layout=prepared.weight_layout,
++        w13_layout="w13",
++        scale_format="e4m3_k16",
++    )
++
++    binding = make_tp_moe_fp4_binding(
++        a=x,
++        experts=experts_w4a16,
++        topk_weights=topk_weights,
++        topk_ids=topk_ids,
++        quant_mode="w4a16",
++    )
++    expected = moe_reference_w4a16_f32(
++        x,
++        w13,
++        w13_blockscale,
++        w13_global_scale,
++        w2,
++        w2_blockscale,
++        w2_global_scale,
++        topk_ids,
++        topk_weights,
++        experts,
++        hidden_size,
++        intermediate_size,
++        activation=activation,
++    )
++
++    first = binding.run().clone()
++    binding.intermediate_cache2.fill_(float("nan"))
++    replay = binding.run().clone()
++    torch.cuda.synchronize()
++    for actual in (first, replay):
++        metrics = compare_to_reference(actual, expected)
++        assert bool(torch.isfinite(actual).all().item())
++        assert metrics.cos > 0.999, metrics
++    assert direct_launches == [(m, intermediate_size), (m, intermediate_size)]
++    torch.testing.assert_close(first, replay, rtol=0, atol=0)
++
++
+ @pytest.mark.skipif(not torch.cuda.is_available(), reason="requires CUDA")
+ @pytest.mark.parametrize("m", [1, 2, 3, 4, 5, 6, 7, 8])
+ def test_w4a16_tc_decode_fused_sum_matches_oracle(
+@@ -1473,7 +2049,11 @@ def test_w4a16_modelopt_nvfp4_explicit_w13_layout_matches_oracle(
+             [w13_blockscale[:, half:], w13_blockscale[:, :half]], dim=1
+         ).contiguous()
+ 
+-    prepare = prepare_w4a16_modelopt_native_weights if prepare_native else prepare_w4a16_weights
++    prepare = (
++        prepare_w4a16_modelopt_native_weights
++        if prepare_native
++        else prepare_w4a16_weights
++    )
+     kwargs = {"source_format": "modelopt_nvfp4"} if prepare_native else {}
+     prepared = prepare(
+         source_w13,
+@@ -1538,9 +2118,7 @@ def test_tp_moe_w4a16_modelopt_nvfp4_uses_normal_nvfp4_scale_contract(
+         activation=activation,
+     )
+     w13, w13_blockscale, w13_global_scale, w2, w2_blockscale, w2_global_scale = weights
+-    w13_input_scale = (torch.rand(experts, device="cuda") * 2.0 + 1.5).to(
+-        torch.float32
+-    )
++    w13_input_scale = (torch.rand(experts, device="cuda") * 2.0 + 1.5).to(torch.float32)
+     w2_input_scale = (torch.rand(experts, device="cuda") * 2.0 + 1.5).to(torch.float32)
+     a1_gscale = (1.0 / w13_input_scale).contiguous()
+     a2_gscale = (1.0 / w2_input_scale).contiguous()
+@@ -1584,8 +2162,9 @@ def test_tp_moe_w4a16_modelopt_nvfp4_uses_normal_nvfp4_scale_contract(
+ 
+ 
+ @pytest.mark.skipif(not torch.cuda.is_available(), reason="requires CUDA")
+-def test_tp_moe_w4a16_prepared_reuse_path_is_deterministic_under_odd_shape_stress(
+-) -> None:
++def test_tp_moe_w4a16_prepared_reuse_path_is_deterministic_under_odd_shape_stress() -> (
++    None
++):
+     torch.manual_seed(20260526)
+     experts, hidden_size, intermediate_size = 8, 128, 128
+     activation = "silu"
+@@ -1596,9 +2175,7 @@ def test_tp_moe_w4a16_prepared_reuse_path_is_deterministic_under_odd_shape_stres
+         activation=activation,
+     )
+     reference_weights = tuple(t.clone() for t in weights)
+-    w13, w13_blockscale, w13_global_scale, w2, w2_blockscale, w2_global_scale = (
+-        weights
+-    )
++    w13, w13_blockscale, w13_global_scale, w2, w2_blockscale, w2_global_scale = weights
+     a_gscale = torch.ones(experts, dtype=torch.float32, device="cuda")
+     weight_plan = plan_sparkinfer_fp4_moe_weights(
+         quant_modes="w4a16",
+@@ -1710,7 +2287,9 @@ def test_w4a16_moe_matches_oracle_with_expert_map(
+     expert_map = torch.full((global_experts,), -1, dtype=torch.int32, device="cuda")
+     expert_map[::2] = torch.arange(local_experts, dtype=torch.int32, device="cuda")
+ 
+-    valid_global_ids = torch.arange(0, global_experts, 2, dtype=torch.int32, device="cuda")
++    valid_global_ids = torch.arange(
++        0, global_experts, 2, dtype=torch.int32, device="cuda"
++    )
+     x = (torch.randn(m, hidden_size, device="cuda") * 0.25).to(torch.bfloat16)
+     topk_ids = valid_global_ids[
+         torch.randint(0, local_experts, (m, topk), device="cuda")
+@@ -1752,9 +2331,7 @@ def test_w4a16_moe_swiglu_limit_matches_oracle_under_cuda_graph() -> None:
+         activation=activation,
+     )
+     w13, w13_blockscale, _, w2, w2_blockscale, w2_global_scale = weights
+-    w13_global_scale = torch.full(
+-        (experts,), 8.0, dtype=torch.float32, device="cuda"
+-    )
++    w13_global_scale = torch.full((experts,), 8.0, dtype=torch.float32, device="cuda")
+     weights = (
+         w13,
+         w13_blockscale,
+@@ -1842,9 +2419,9 @@ def test_w4a16_preplanned_capacity_launch_accepts_smaller_live_m() -> None:
+     experts, hidden_size, intermediate_size = 8, 128, 128
+     topk, live_m, capacity_m = 2, 24, 32
+     activation = "relu2"
+-    assert select_route_block_size_m(live_m, topk, experts) != select_route_block_size_m(
+-        capacity_m, topk, experts
+-    )
++    assert select_route_block_size_m(
++        live_m, topk, experts
++    ) != select_route_block_size_m(capacity_m, topk, experts)
+     weights = _make_weights(
+         experts=experts,
+         hidden_size=hidden_size,
+@@ -1852,7 +2429,9 @@ def test_w4a16_preplanned_capacity_launch_accepts_smaller_live_m() -> None:
+         activation=activation,
+     )
+     x = (torch.randn(live_m, hidden_size, device="cuda") * 0.25).to(torch.bfloat16)
+-    topk_ids = torch.randint(0, experts, (live_m, topk), device="cuda", dtype=torch.int32)
++    topk_ids = torch.randint(
++        0, experts, (live_m, topk), device="cuda", dtype=torch.int32
++    )
+     topk_weights = torch.softmax(torch.randn(live_m, topk, device="cuda"), dim=-1)
+     prepared = prepare_w4a16_weights(
+         *weights,
+diff --git a/tests/moe/test_w4a16_route_pack.py b/tests/moe/test_w4a16_route_pack.py
+index 529c37c4f21b369e550f6b8100be47fb4efc8878..27f0451539b1337a667ccfba0902e184de31c452 100644
+--- a/tests/moe/test_w4a16_route_pack.py
++++ b/tests/moe/test_w4a16_route_pack.py
+@@ -6,6 +6,44 @@ import pytest
+ import torch
+ 
+ from sparkinfer.moe._shared.kernels.w4a16.kernel import pack_topk_routes_by_expert
++from sparkinfer.moe._shared.kernels.w4a16.host import (
++    route_block_sizes_for_capacity,
++    select_route_block_size_m,
++)
++
++
++@pytest.mark.parametrize(
++    ("max_tokens", "topk", "num_experts"),
++    [
++        (1, 8, 160),
++        (64, 8, 160),
++        (144, 8, 160),
++        (1024, 8, 256),
++        (32, 64, 8),
++    ],
++)
++def test_capacity_block_sizes_cover_every_live_selection(
++    max_tokens: int,
++    topk: int,
++    num_experts: int,
++) -> None:
++    planned = route_block_sizes_for_capacity(max_tokens, topk, num_experts)
++    selected = {
++        select_route_block_size_m(m, topk, num_experts)
++        for m in range(1, max_tokens + 1)
++    }
++
++    assert selected.issubset(planned)
++    assert planned[0] == select_route_block_size_m(1, topk, num_experts)
++    assert planned[-1] == select_route_block_size_m(
++        max_tokens,
++        topk,
++        num_experts,
++    )
++
++
++def test_small_capacity_needs_only_block_8() -> None:
++    assert route_block_sizes_for_capacity(64, 8, 160) == (8,)
+ 
+ 
+ def _expected_route_pack(
+@@ -79,14 +117,19 @@ def test_pack_topk_routes_by_expert_groups_and_pads_routes(
+         device="cuda",
+     )
+ 
+-    local_packed_routes, local_block_experts, local_packed_route_count = pack_topk_routes_by_expert(
+-        topk_ids,
+-        block_size,
+-        num_experts,
+-    )
+-    expected_ids, expected_valid, expected_packed_route_count, expected_block_experts = (
+-        _expected_route_pack(topk_ids, block_size, num_experts)
++    local_packed_routes, local_block_experts, local_packed_route_count = (
++        pack_topk_routes_by_expert(
++            topk_ids,
++            block_size,
++            num_experts,
++        )
+     )
++    (
++        expected_ids,
++        expected_valid,
++        expected_packed_route_count,
++        expected_block_experts,
++    ) = _expected_route_pack(topk_ids, block_size, num_experts)
+ 
+     sentinel = int(topk_ids.numel())
+     valid = int(expected_packed_route_count.item())
+@@ -99,12 +142,18 @@ def test_pack_topk_routes_by_expert_groups_and_pads_routes(
+     host_route_payload = host_packed_routes[host_packed_routes < sentinel]
+     assert host_route_payload.numel() == int(expected_valid.sum().item())
+     for expert in range(num_experts):
+-        actual = host_route_payload[expected_ids[host_route_payload] == expert].sort().values
+-        expected = torch.nonzero(expected_valid & (expected_ids == expert), as_tuple=False)
++        actual = (
++            host_route_payload[expected_ids[host_route_payload] == expert].sort().values
++        )
++        expected = torch.nonzero(
++            expected_valid & (expected_ids == expert), as_tuple=False
++        )
+         expected = expected.flatten().sort().values
+         assert torch.equal(actual, expected), expert
+ 
+-    host_block_experts = local_block_experts[:valid_blocks].detach().cpu().to(torch.int64)
++    host_block_experts = (
++        local_block_experts[:valid_blocks].detach().cpu().to(torch.int64)
++    )
+     for block, expert in enumerate(host_block_experts.tolist()):
+         block_routes = host_packed_routes[block * block_size : (block + 1) * block_size]
+         payload = block_routes[block_routes < sentinel]
+@@ -131,9 +180,12 @@ def test_pack_topk_routes_by_expert_handles_large_prefill_plan_shape() -> None:
+             num_experts,
+         )
+     )
+-    expected_ids, expected_valid, expected_packed_route_count, expected_block_experts = (
+-        _expected_route_pack(topk_ids, block_size, num_experts)
+-    )
++    (
++        expected_ids,
++        expected_valid,
++        expected_packed_route_count,
++        expected_block_experts,
++    ) = _expected_route_pack(topk_ids, block_size, num_experts)
+ 
+     sentinel = int(topk_ids.numel())
+     valid = int(expected_packed_route_count.item())
+@@ -146,8 +198,12 @@ def test_pack_topk_routes_by_expert_handles_large_prefill_plan_shape() -> None:
+     host_route_payload = host_packed_routes[host_packed_routes < sentinel]
+     assert host_route_payload.numel() == int(expected_valid.sum().item())
+     for expert in range(num_experts):
+-        actual = host_route_payload[expected_ids[host_route_payload] == expert].sort().values
+-        expected = torch.nonzero(expected_valid & (expected_ids == expert), as_tuple=False)
++        actual = (
++            host_route_payload[expected_ids[host_route_payload] == expert].sort().values
++        )
++        expected = torch.nonzero(
++            expected_valid & (expected_ids == expert), as_tuple=False
++        )
+         expected = expected.flatten().sort().values
+         assert torch.equal(actual, expected), expert
+ 
+@@ -173,15 +229,20 @@ def test_pack_topk_routes_by_expert_applies_expert_map(
+     expert_map = torch.full((global_experts,), -1, dtype=torch.int32, device="cuda")
+     expert_map[::2] = torch.arange(local_experts, dtype=torch.int32, device="cuda")
+ 
+-    local_packed_routes, local_block_experts, local_packed_route_count = pack_topk_routes_by_expert(
+-        topk_ids,
+-        block_size,
+-        global_experts,
+-        expert_map=expert_map,
+-    )
+-    expected_ids, expected_valid, expected_packed_route_count, expected_block_experts = (
+-        _expected_route_pack(topk_ids, block_size, global_experts, expert_map)
++    local_packed_routes, local_block_experts, local_packed_route_count = (
++        pack_topk_routes_by_expert(
++            topk_ids,
++            block_size,
++            global_experts,
++            expert_map=expert_map,
++        )
+     )
++    (
++        expected_ids,
++        expected_valid,
++        expected_packed_route_count,
++        expected_block_experts,
++    ) = _expected_route_pack(topk_ids, block_size, global_experts, expert_map)
+ 
+     sentinel = int(topk_ids.numel())
+     valid = int(expected_packed_route_count.item())
+@@ -194,7 +255,11 @@ def test_pack_topk_routes_by_expert_applies_expert_map(
+     host_route_payload = host_packed_routes[host_packed_routes < sentinel]
+     assert host_route_payload.numel() == int(expected_valid.sum().item())
+     for local_expert in range(local_experts):
+-        actual = host_route_payload[expected_ids[host_route_payload] == local_expert].sort().values
++        actual = (
++            host_route_payload[expected_ids[host_route_payload] == local_expert]
++            .sort()
++            .values
++        )
+         expected = torch.nonzero(
+             expected_valid & (expected_ids == local_expert),
+             as_tuple=False,
+@@ -213,14 +278,19 @@ def test_pack_topk_routes_by_expert_ignores_invalid_ids() -> None:
+     block_size = 4
+     num_experts = 8
+ 
+-    local_packed_routes, local_block_experts, local_packed_route_count = pack_topk_routes_by_expert(
+-        topk_ids,
+-        block_size,
+-        num_experts,
+-    )
+-    expected_ids, expected_valid, expected_packed_route_count, expected_block_experts = (
+-        _expected_route_pack(topk_ids, block_size, num_experts)
++    local_packed_routes, local_block_experts, local_packed_route_count = (
++        pack_topk_routes_by_expert(
++            topk_ids,
++            block_size,
++            num_experts,
++        )
+     )
++    (
++        expected_ids,
++        expected_valid,
++        expected_packed_route_count,
++        expected_block_experts,
++    ) = _expected_route_pack(topk_ids, block_size, num_experts)
+ 
+     sentinel = int(topk_ids.numel())
+     valid = int(expected_packed_route_count.item())
+@@ -230,4 +300,6 @@ def test_pack_topk_routes_by_expert_ignores_invalid_ids() -> None:
+     payload = local_packed_routes[:valid].detach().cpu().to(torch.int64)
+     payload = payload[payload < sentinel]
+     assert payload.numel() == int(expected_valid.sum().item())
+-    assert torch.equal(payload[expected_ids[payload] == 4].sort().values, torch.tensor([2, 5]))
++    assert torch.equal(
++        payload[expected_ids[payload] == 4].sort().values, torch.tensor([2, 5])
++    )

--- a/patches/releases/gilded-gnosis-v20-r17/sparkinfer/integration.patch
+++ b/patches/releases/gilded-gnosis-v20-r17/sparkinfer/integration.patch
@@ -2002,6 +2002,19 @@ index 0000000000000000000000000000000000000000..42e9a4c7d7e79c7f448caa793dd59238
 +
 +if __name__ == "__main__":
 +    main()
+diff --git a/pyproject.toml b/pyproject.toml
+index ddf85f611aec805c627b376093ab23e8875048bb..6ee2c0abd43cd2bacfff67078f2b4c11c6f53574 100644
+--- a/pyproject.toml
++++ b/pyproject.toml
+@@ -39,7 +39,7 @@ where = ["."]
+ include = ["sparkinfer*"]
+ 
+ [tool.setuptools.package-data]
+-"sparkinfer.comm.pcie" = ["*.cu"]
++"sparkinfer.comm.pcie" = ["*.cu", "*.h"]
+ 
+ [tool.ruff.lint]
+ select = ["E", "F", "B", "SIM"]
 diff --git a/sparkinfer/_lib/compiler.py b/sparkinfer/_lib/compiler.py
 index 3357d377d044a3450d87f2e384aa831c7a3b8256..9bba8af21c6a6cc27e164aadee9a1d1f3275292b 100644
 --- a/sparkinfer/_lib/compiler.py
@@ -15661,3 +15674,53 @@ index 529c37c4f21b369e550f6b8100be47fb4efc8878..27f0451539b1337a667ccfba0902e184
 +    assert torch.equal(
 +        payload[expected_ids[payload] == 4].sort().values, torch.tensor([2, 5])
 +    )
+diff --git a/tests/test_packaging.py b/tests/test_packaging.py
+index ce1cb089ec80b18a487a9fbfc4eb0b9880617df8..3671d431e483d8ffbffcfb896178aa48db942f2f 100644
+--- a/tests/test_packaging.py
++++ b/tests/test_packaging.py
+@@ -1,5 +1,6 @@
+ from __future__ import annotations
+ 
++import re
+ from pathlib import Path
+ 
+ try:
+@@ -10,6 +11,8 @@ except ModuleNotFoundError:  # Python 3.10
+ 
+ ROOT = Path(__file__).parents[1]
+ PCIE_PACKAGE = "sparkinfer.comm.pcie"
++PCIE_SOURCE_DIR = ROOT / "sparkinfer" / "comm" / "pcie"
++PCIE_PACKAGE_PATTERNS = {"*.cu", "*.h"}
+ RUNTIME_CUDA_SOURCES = {
+     "pcie_dcp_a2a.cu",
+     "pcie_dcp_topk.cu",
+@@ -17,13 +20,27 @@ RUNTIME_CUDA_SOURCES = {
+     "pcie_oneshot.cu",
+     "pcie_twoshot.cu",
+ }
++LOCAL_INCLUDE_RE = re.compile(r'^\s*#include\s+"([^"]+)"', re.MULTILINE)
+ 
+ 
+ def test_runtime_cuda_sources_are_in_package_data() -> None:
+     config = tomllib.loads((ROOT / "pyproject.toml").read_text())
+     package_data = config["tool"]["setuptools"]["package-data"]
+ 
+-    assert package_data[PCIE_PACKAGE] == ["*.cu"]
++    assert set(package_data[PCIE_PACKAGE]) == PCIE_PACKAGE_PATTERNS
+     assert {
+-        path.name for path in (ROOT / "sparkinfer" / "comm" / "pcie").glob("*.cu")
++        path.name for path in PCIE_SOURCE_DIR.glob("*.cu")
+     } == RUNTIME_CUDA_SOURCES
++
++
++def test_runtime_cuda_local_includes_are_packaged() -> None:
++    config = tomllib.loads((ROOT / "pyproject.toml").read_text())
++    package_patterns = config["tool"]["setuptools"]["package-data"][PCIE_PACKAGE]
++
++    for source in PCIE_SOURCE_DIR.glob("*.cu"):
++        for include in LOCAL_INCLUDE_RE.findall(source.read_text(encoding="utf-8")):
++            dependency = source.parent / include
++            assert dependency.is_file(), f"{source.name} includes missing {include}"
++            assert any(dependency.match(pattern) for pattern in package_patterns), (
++                f"{source.name} includes {include}, but {include} is not package data"
++            )

--- a/patches/releases/gilded-gnosis-v20-r17/vllm/integration.lock.json
+++ b/patches/releases/gilded-gnosis-v20-r17/vllm/integration.lock.json
@@ -1,0 +1,75 @@
+{
+  "base": {
+    "commit": "30038602b71395f481ef4a6edfe4fcf8551d9c15",
+    "ref": "refs/heads/dev/gilded-gnosis",
+    "repository": "https://github.com/local-inference-lab/vllm.git"
+  },
+  "manifest": {
+    "sha256": "963a7c61400ba1259c86e6590001cce616f1e8a321ef36d69501a2bc88e8c2d9"
+  },
+  "name": "gilded-gnosis-v20",
+  "pull_requests": [
+    {
+      "disposition": "merged",
+      "head": "99bf3f13f13012b72d6d67e49572d686b45b2833",
+      "number": 145,
+      "ref": "refs/pull/145/head",
+      "title": "GLM-5.2 calibrated NVFP4 MLA KV outer scales"
+    },
+    {
+      "disposition": "merged",
+      "head": "fbc022664df3ad39a3acb1b6404d1b17683ada4c",
+      "number": 212,
+      "ref": "refs/pull/212/head",
+      "title": "Preserve compressed MLA page stride"
+    },
+    {
+      "disposition": "merged",
+      "head": "5f144274d6e092237f4f4f437b7e9d3aaa427157",
+      "number": 213,
+      "ref": "refs/pull/213/head",
+      "title": "Skip pre-KV V2 attention during FlashInfer autotune"
+    },
+    {
+      "disposition": "merged",
+      "head": "e63a190ee1b48d051ccebce485de343dbe2b3505",
+      "number": 214,
+      "ref": "refs/pull/214/head",
+      "title": "Add DeepSeek-V4-Flash-0731 DSpark profile"
+    },
+    {
+      "disposition": "merged",
+      "head": "69a9076645c78b4cfd301ae841f91cf8550112ce",
+      "number": 217,
+      "ref": "refs/pull/217/head",
+      "title": "Use shared regions for native CPU KV offload"
+    },
+    {
+      "disposition": "merged",
+      "head": "3b89c7a113f92522aa07cc3271422c04e458d771",
+      "number": 218,
+      "ref": "refs/pull/218/head",
+      "title": "Align native SWA/MTP retention and shared-prefix tails"
+    },
+    {
+      "disposition": "merged",
+      "head": "52201611719edf67f18bc0cbec17802880a4afb7",
+      "number": 216,
+      "ref": "refs/pull/216/head",
+      "title": "Isolate semantic PCIe graph channels"
+    },
+    {
+      "disposition": "merged",
+      "head": "6206ac40fbd75be0ed18817bde64a63b6b838d2f",
+      "number": 222,
+      "ref": "refs/pull/222/head",
+      "title": "Shape-aware mixed EXL3 decode and bounded serial prefill"
+    }
+  ],
+  "result": {
+    "patch": "integration.patch",
+    "patch_sha256": "1ee5fd4ea5c059dc344d0b6860bfa0af6422b2193c3db75c4d5cad1c05953b82",
+    "tree": "db293280d021d32db0552f3f6e4b95abbd9c69a1"
+  },
+  "schema_version": 1
+}

--- a/patches/releases/gilded-gnosis-v20-r17/vllm/integration.patch
+++ b/patches/releases/gilded-gnosis-v20-r17/vllm/integration.patch
@@ -1,0 +1,5055 @@
+diff --git a/kv-scales/README.md b/kv-scales/README.md
+new file mode 100644
+index 0000000000000000000000000000000000000000..36b37d5aa188027675ec9eaa447e9597b3921e4c
+--- /dev/null
++++ b/kv-scales/README.md
+@@ -0,0 +1,49 @@
++# GLM-5.2 NVFP4 MLA KV outer scales
++
++Per-layer calibration for the `nvfp4_ds_mla` KV cache writer
++(`VLLM_NVFP4_MLA_SCALES_FILE`, format `nvfp4_ds_mla_outer_scale_v1`).
++
++GLM-5.2's post-RMSNorm 512-dim `kv_c` latent spans a ~240x amplitude range
++across layers. With the default outer scale of 1.0, shallow layers quantize
++with E4M3 block scales at or below the subnormal floor, and shallow-layer KV
++error is strongly amplified downstream. `s_l = max_abs(kv_c_normed) / (6*448)`
++re-centers every layer so its largest block scale lands at the top of the
++E4M3 range.
++
++## Files
++
++- `glm52-nvfp4-nf3-hybrid_mla_outer_scales_v1.json` — calibrated on
++  `madeby561/GLM-5.2-MXFP8-NVFP4-NF3-Hybrid` (K64R16), Salesforce/wikitext
++  (wikitext-2-raw-v1, test), 2048-token context, TP4; per-layer envelope with
++  an independent community capture of the same base model for shallow-layer
++  headroom. `max_abs` per layer is included for auditability.
++
++## Usage
++
++```bash
++VLLM_NVFP4_MLA_SCALES_FILE=/path/to/glm52-nvfp4-nf3-hybrid_mla_outer_scales_v1.json \
++  ./serve-glm52.sh   # nvfp4_ds_mla + B12X_MLA_SPARSE only; inert otherwise
++```
++
++## Results (teacher-forced prefill KLD vs BF16 reference, 5 fresh boots each)
++
++| KV config | mean +/- sd | max ctx (4x96GB) |
++|---|---|---|
++| fp8_ds_mla | 0.1263 +/- 0.0030 | 373k |
++| nvfp4_ds_mla + scales, bf16 rope | 0.1345 +/- 0.0035 | 550k |
++| nvfp4_ds_mla + scales, fp8 rope (`KV_FP8_ROPE=1`) | 0.1356 +/- 0.0054 | 600k+ |
++| nvfp4_ds_mla, no scales, bf16 rope | 0.158 | 550k |
++| nvfp4_ds_mla, no scales, fp8 rope | 0.168 | 600k+ |
++
++Protocol: local-inference-lab/rtx6kpro `benchmarks/glm52-kld-evaluation.md`
++(festr2 2026-07-08 reference logits, one fixed 2048-token window, 2047
++positions, full 154,880 vocab, `KL(ref || candidate)`).
++
++## Cache invalidation (required)
++
++CuTeDSL folds the outer-scale multiply out of the kernel when `latent_scale`
++traces at exactly 1.0. b12x builds without the identity/dynamic compile-spec
++fact (see lukealonso/b12x PR "mla: split latent_scale identity/dynamic
++compile-cache entries") replay stale identity cubins from persistent compile
++caches, silently dropping the restore. Clear mounted b12x compile caches once
++when enabling scales on such builds.
+diff --git a/kv-scales/glm52-nvfp4-nf3-hybrid_mla_outer_scales_v1.json b/kv-scales/glm52-nvfp4-nf3-hybrid_mla_outer_scales_v1.json
+new file mode 100644
+index 0000000000000000000000000000000000000000..7ae9d9351c4e8de79f6387b5f64a5fa9618bf155
+--- /dev/null
++++ b/kv-scales/glm52-nvfp4-nf3-hybrid_mla_outer_scales_v1.json
+@@ -0,0 +1,178 @@
++{
++ "format": "nvfp4_ds_mla_outer_scale_v1",
++ "num_layers": 78,
++ "latent_dim": 512,
++ "denominator": 2688.0,
++ "formula": "s_l = max_abs(kv_c_normed) / (6 * 448)",
++ "model": "madeby561/GLM-5.2-MXFP8-NVFP4-NF3-Hybrid (local K64R16 build; own capture)",
++ "dataset": {
++  "name": "Salesforce/wikitext",
++  "config": "wikitext-2-raw-v1",
++  "split": "test",
++  "context_length": 2048,
++  "windows": 1,
++  "note": "the canonical festr2-0708 census window"
++ },
++ "created_utc": "2026-07-20T16:40:43.312260+00:00",
++ "hook": "mla.py kv_a_layernorm output (bind-mount capture patch), per-TP-rank agreement checked",
++ "max_abs": [
++  0.04833984375,
++  0.021728515625,
++  0.03662109375,
++  0.1005859375,
++  0.023681640625,
++  0.03515625,
++  0.046875,
++  0.033203125,
++  0.259765625,
++  0.1474609375,
++  0.7734375,
++  1.0,
++  1.1171875,
++  0.150390625,
++  0.76171875,
++  0.392578125,
++  0.25390625,
++  0.455078125,
++  0.80859375,
++  0.80078125,
++  0.96875,
++  0.78515625,
++  0.58203125,
++  0.330078125,
++  0.89453125,
++  0.73046875,
++  1.0390625,
++  1.578125,
++  1.0078125,
++  0.92578125,
++  1.25,
++  1.5859375,
++  1.234375,
++  1.9140625,
++  1.9453125,
++  1.7578125,
++  1.7890625,
++  2.546875,
++  2.296875,
++  2.4375,
++  1.921875,
++  2.171875,
++  2.875,
++  2.546875,
++  2.765625,
++  3.234375,
++  2.5625,
++  3.390625,
++  2.40625,
++  2.546875,
++  3.09375,
++  2.90625,
++  3.671875,
++  2.46875,
++  2.609375,
++  2.359375,
++  3.078125,
++  3.171875,
++  2.578125,
++  2.359375,
++  3.890625,
++  2.953125,
++  4.09375,
++  4.09375,
++  5.0625,
++  5.1875,
++  2.984375,
++  2.875,
++  2.984375,
++  3.296875,
++  3.828125,
++  2.859375,
++  3.59375,
++  3.734375,
++  4.25,
++  4.1875,
++  4.84375,
++  3.75
++ ],
++ "scales": [
++  1.7983572823660715e-05,
++  8.083525158110119e-06,
++  1.3623918805803572e-05,
++  3.742036365327381e-05,
++  8.810134161086309e-06,
++  1.3078962053571428e-05,
++  1.743861607142857e-05,
++  1.2352353050595238e-05,
++  9.663899739583333e-05,
++  5.485897972470238e-05,
++  0.00028773716517857144,
++  0.0003720238095238095,
++  0.00041562034970238094,
++  5.5948893229166664e-05,
++  0.0002833775111607143,
++  0.00014604840959821428,
++  9.445917038690477e-05,
++  0.00016929989769345238,
++  0.00030081612723214287,
++  0.0002979096912202381,
++  0.0003603980654761905,
++  0.00029209681919642856,
++  0.00021652948288690475,
++  0.0001227969215029762,
++  0.00033278692336309525,
++  0.00027175176711309525,
++  0.0003865559895833333,
++  0.0005871000744047619,
++  0.0003749302455357143,
++  0.0003444126674107143,
++  0.0004650297619047619,
++  0.0005900065104166666,
++  0.0004592168898809524,
++  0.0007120768229166666,
++  0.0007237025669642857,
++  0.0006539481026785714,
++  0.0006655738467261905,
++  0.0009474981398809524,
++  0.0008544921875,
++  0.0009068080357142857,
++  0.0007149832589285714,
++  0.0008079892113095238,
++  0.0010695684523809525,
++  0.0009474981398809524,
++  0.0010288783482142857,
++  0.0012032645089285715,
++  0.0009533110119047619,
++  0.0012613932291666667,
++  0.0008951822916666666,
++  0.0009474981398809524,
++  0.0011509486607142857,
++  0.0010811941964285715,
++  0.001366024925595238,
++  0.0009184337797619048,
++  0.0009707496279761905,
++  0.0008777436755952381,
++  0.0011451357886904762,
++  0.0011800130208333333,
++  0.0009591238839285714,
++  0.0008777436755952381,
++  0.0014474051339285715,
++  0.0010986328125,
++  0.0015229724702380952,
++  0.0015229724702380952,
++  0.0018833705357142857,
++  0.001929873511904762,
++  0.001110258556547619,
++  0.0010695684523809525,
++  0.001110258556547619,
++  0.0012265159970238095,
++  0.0014241536458333333,
++  0.0010637555803571428,
++  0.0013369605654761905,
++  0.0013892764136904762,
++  0.0015811011904761905,
++  0.0015578497023809525,
++  0.0018019903273809525,
++  0.0013950892857142857
++ ]
++}
+\ No newline at end of file
+diff --git a/serve-ds4-flash.sh b/serve-ds4-flash.sh
+index f9a640bed07f8e82381274cc027f6723c9ed57d5..ee0da27992a6ca220b6576c482c3970a966f65bc 100755
+--- a/serve-ds4-flash.sh
++++ b/serve-ds4-flash.sh
+@@ -40,9 +40,10 @@ case "${mode}" in
+   off|mtp0|standard-mtp0) mode=mtp0 ;;
+   mtp2|standard-mtp2) mode=mtp2 ;;
+   mtp3|standard-mtp3) mode=mtp3 ;;
++  dspark-off|dspark-mtp0) mode=dspark-mtp0 ;;
+   dspark) ;;
+   *)
+-    echo "MODE must be mtp0, mtp2, mtp3, or dspark; got '${mode}'" >&2
++    echo "MODE must be mtp0, mtp2, mtp3, dspark-mtp0, or dspark; got '${mode}'" >&2
+     exit 2
+     ;;
+ esac
+@@ -59,13 +60,13 @@ case "${backend}" in
+ esac
+ 
+ standard_model=${STANDARD_MODEL:-deepseek-ai/DeepSeek-V4-Flash}
+-dspark_model=${DSPARK_MODEL:-deepseek-ai/DeepSeek-V4-Flash-DSpark}
++dspark_model=${DSPARK_MODEL:-deepseek-ai/DeepSeek-V4-Flash-0731}
+ standard_model_revision=${STANDARD_MODEL_REVISION:-60d8d70770c6776ff598c94bb586a859a38244f1}
+-dspark_model_revision=${DSPARK_MODEL_REVISION:-62af8fffb2f7030cac4de2f0169f5b8d1101b646}
+-if [[ "${mode}" == "dspark" ]]; then
++dspark_model_revision=${DSPARK_MODEL_REVISION:-9e165c30e2704aec5d9d593cce3eebd58bbef1cb}
++if [[ "${mode}" == "dspark" || "${mode}" == "dspark-mtp0" ]]; then
+   model=${MODEL_PATH:-${MODEL:-${dspark_model}}}
+   spec_model=${SPEC_MODEL_PATH:-${model}}
+-  served_model_name=${SERVED_MODEL_NAME:-DeepSeek-V4-Flash-DSpark}
++  served_model_name=${SERVED_MODEL_NAME:-DeepSeek-V4-Flash-0731}
+   default_model_revision=${dspark_model_revision}
+ else
+   model=${MODEL_PATH:-${MODEL:-${standard_model}}}
+@@ -88,13 +89,19 @@ fi
+ host=${HOST:-0.0.0.0}
+ port=${PORT:-8000}
+ tp_size=${TP_SIZE:-${TP:-2}}
+-dcp_size=${DCP_SIZE:-1}
+-max_num_seqs=${MAX_NUM_SEQS:-64}
+-max_model_len=${MAX_MODEL_LEN:-262144}
++dcp_size=${DCP_SIZE:-${DCP:-1}}
++if [[ "${mode}" == "dspark" || "${mode}" == "dspark-mtp0" ]]; then
++  max_num_seqs=${MAX_NUM_SEQS:-16}
++  max_model_len=${MAX_MODEL_LEN:-131072}
++else
++  max_num_seqs=${MAX_NUM_SEQS:-64}
++  max_model_len=${MAX_MODEL_LEN:-262144}
++fi
+ max_num_batched_tokens=${MAX_NUM_BATCHED_TOKENS:-8192}
+ gpu_memory_utilization=${GPU_MEMORY_UTILIZATION:-}
+ block_size=${BLOCK_SIZE:-256}
+ load_format=${LOAD_FORMAT:-instanttensor}
++kv_offloading_size=${KV_OFFLOADING_SIZE:-}
+ prefix_cache=$(bool_value PREFIX_CACHE "${PREFIX_CACHE:-1}")
+ enable_flashinfer_autotune=$(bool_value ENABLE_FLASHINFER_AUTOTUNE "${ENABLE_FLASHINFER_AUTOTUNE:-1}")
+ draft_sample_method=${DRAFT_SAMPLE_METHOD:-probabilistic}
+@@ -105,6 +112,11 @@ require_positive_int DCP_SIZE "${dcp_size}"
+ require_positive_int MAX_NUM_SEQS "${max_num_seqs}"
+ require_positive_int MAX_NUM_BATCHED_TOKENS "${max_num_batched_tokens}"
+ require_positive_int BLOCK_SIZE "${block_size}"
++if [[ -n "${kv_offloading_size}" \
++  && ! "${kv_offloading_size}" =~ ^([0-9]+([.][0-9]*)?|[.][0-9]+)$ ]]; then
++  echo "KV_OFFLOADING_SIZE must be a non-negative GiB value; got '${kv_offloading_size}'" >&2
++  exit 2
++fi
+ if [[ "${mode}" == "dspark" && "${dcp_size}" != "1" ]]; then
+   echo "DSpark non-causal attention currently requires DCP_SIZE=1" >&2
+   exit 2
+@@ -246,6 +258,7 @@ esac
+ spec_args=()
+ spec_tokens=0
+ graph_multiplier=4
++dspark_depth_mode=disabled
+ if [[ "${mode}" == "mtp2" || "${mode}" == "mtp3" ]]; then
+   if [[ "${mode}" == "mtp2" ]]; then spec_tokens=2; else spec_tokens=3; fi
+   mtp_moe_json=
+@@ -259,7 +272,7 @@ if [[ "${mode}" == "mtp2" || "${mode}" == "mtp3" ]]; then
+   spec_args=(--speculative-config "${spec_json}")
+   graph_multiplier=8
+ elif [[ "${mode}" == "dspark" ]]; then
+-  spec_tokens=${DSPARK_TOKENS:-5}
++  spec_tokens=${DSPARK_TOKENS:-${NUM_SPECULATIVE_TOKENS:-7}}
+   require_positive_int DSPARK_TOKENS "${spec_tokens}"
+   # Target verification schedules at most one sampled token plus K drafts per
+   # request. Capturing beyond that physical row count only consumes graph
+@@ -280,7 +293,25 @@ elif [[ "${mode}" == "dspark" ]]; then
+     draft_attention_json=$(printf \
+       ',"draft_attention_backend":"%s"' "${draft_attention_backend}")
+   fi
+-  dspark_capacity=$(bool_value DSPARK_CAPACITY "${DSPARK_CAPACITY:-0}")
++  dspark_depth_mode=${DSPARK_DEPTH_MODE:-fixed}
++  case "${dspark_depth_mode}" in
++    fixed)
++      default_dspark_capacity=0
++      default_dynamic_depth=0
++      default_activation_batch_size=0
++      ;;
++    dynamic)
++      default_dspark_capacity=1
++      default_dynamic_depth=1
++      default_activation_batch_size=1
++      ;;
++    *)
++      echo "DSPARK_DEPTH_MODE must be fixed or dynamic" >&2
++      exit 2
++      ;;
++  esac
++  dspark_capacity=$(bool_value DSPARK_CAPACITY \
++    "${DSPARK_CAPACITY:-${default_dspark_capacity}}")
+   capacity_json=
+   if [[ "${dspark_capacity}" == "1" ]]; then
+     capacity_mode=${DSPARK_CAPACITY_VERIFICATION_MODE:-}
+@@ -319,11 +350,14 @@ elif [[ "${mode}" == "dspark" ]]; then
+     "${rejection_sample_method}" "${draft_attention_json}" "${capacity_json}")
+   spec_args=(--speculative-config "${spec_json}")
+   export VLLM_DSPARK_FP8_DRAFT_HEAD=$(bool_value DSPARK_FP8_DRAFT_HEAD "${DSPARK_FP8_DRAFT_HEAD:-0}")
+-  export VLLM_DSPARK_DYNAMIC_DRAFT_DEPTH=$(bool_value DSPARK_DYNAMIC_DRAFT_DEPTH "${DSPARK_DYNAMIC_DRAFT_DEPTH:-0}")
++  dynamic_depth=${DSPARK_DYNAMIC_DRAFT_DEPTH:-${VLLM_DSPARK_DYNAMIC_DRAFT_DEPTH:-${default_dynamic_depth}}}
++  export VLLM_DSPARK_DYNAMIC_DRAFT_DEPTH=$(bool_value \
++    DSPARK_DYNAMIC_DRAFT_DEPTH "${dynamic_depth}")
+   export VLLM_DSPARK_DYNAMIC_DRAFT_DEPTH_WINDOW=${DSPARK_DYNAMIC_DRAFT_DEPTH_WINDOW:-8}
+   require_positive_int DSPARK_DYNAMIC_DRAFT_DEPTH_WINDOW \
+     "${VLLM_DSPARK_DYNAMIC_DRAFT_DEPTH_WINDOW}"
+-  export VLLM_DSPARK_CAPACITY_ACTIVATION_BATCH_SIZE=${DSPARK_CAPACITY_ACTIVATION_BATCH_SIZE:-0}
++  activation_batch_size=${DSPARK_CAPACITY_ACTIVATION_BATCH_SIZE:-${VLLM_DSPARK_CAPACITY_ACTIVATION_BATCH_SIZE:-${default_activation_batch_size}}}
++  export VLLM_DSPARK_CAPACITY_ACTIVATION_BATCH_SIZE=${activation_batch_size}
+   require_nonnegative_int DSPARK_CAPACITY_ACTIVATION_BATCH_SIZE \
+     "${VLLM_DSPARK_CAPACITY_ACTIVATION_BATCH_SIZE}"
+   export VLLM_DSPARK_CAPACITY_LOG_INTERVAL=${DSPARK_CAPACITY_LOG_INTERVAL:-0}
+@@ -358,8 +392,10 @@ if [[ "${sp_async_tp}" == "1" ]]; then
+ fi
+ 
+ if [[ -z "${gpu_memory_utilization}" ]]; then
+-  # The v10 profiler includes attention and FULL-graph allocations. These
+-  # defaults preserve the 262k serving limit used by v9 after that accounting.
++  # The 0731 DSpark draft head is larger than the historical MTP head. Its
++  # B12X TP2 profile needs 0.975 to retain the default 131k serving limit after
++  # attention and FULL-graph allocations are accounted for. At 0.97 the r15
++  # stack exposed 7.11 GiB of KV storage while this profile needs 7.37 GiB.
+   if [[ "${mode}" == "dspark" ]]; then
+     if [[ "${backend}" == "lucifer-default" ]]; then
+       # The default DeepGEMM MoE path retains more model/runtime memory than
+@@ -377,7 +413,7 @@ if [[ -z "${gpu_memory_utilization}" ]]; then
+     elif [[ "${backend}" == lucifer-* ]]; then
+       gpu_memory_utilization=0.9465
+     else
+-      gpu_memory_utilization=0.95
++      gpu_memory_utilization=0.975
+     fi
+   elif [[ "${backend}" == lucifer-* \
+     && ( "${mode}" == "mtp2" || "${mode}" == "mtp3" ) ]]; then
+@@ -398,6 +434,26 @@ if [[ "${enable_flashinfer_autotune}" == "0" ]]; then
+   autotune_args=(--no-enable-flashinfer-autotune)
+ fi
+ 
++offloading_args=()
++if [[ -n "${kv_offloading_size}" \
++  && ! "${kv_offloading_size}" =~ ^0*([.]0*)?$ ]]; then
++  # This is the total host-cache capacity across all TP ranks, matching the
++  # vLLM CLI contract. LMCache remains a separate deployment mode. Native KV
++  # offload pins/registers GPU cache allocations, so PyTorch's remappable VMM
++  # segments must be disabled while preserving any other allocator settings.
++  allocator_config=${PYTORCH_CUDA_ALLOC_CONF:-}
++  if [[ -z "${allocator_config}" ]]; then
++    allocator_config=expandable_segments:False
++  elif [[ "${allocator_config}" =~ (^|,)expandable_segments:True(,|$) ]]; then
++    allocator_config=${allocator_config//expandable_segments:True/expandable_segments:False}
++  fi
++  export PYTORCH_CUDA_ALLOC_CONF=${allocator_config}
++  offloading_args=(
++    --kv-offloading-size "${kv_offloading_size}"
++    --kv-offloading-backend native
++  )
++fi
++
+ capture_args=()
+ capture_sizes=${CUDAGRAPH_CAPTURE_SIZES:-default}
+ if [[ "${capture_sizes}" == "auto" ]]; then
+@@ -465,6 +521,7 @@ command=(
+   "${autotune_args[@]}"
+   "${prefix_args[@]}"
+   "${capture_args[@]}"
++  "${offloading_args[@]}"
+   "${spec_args[@]}"
+   "${backend_args[@]}"
+   "${allreduce_args[@]}"
+@@ -478,10 +535,12 @@ if [[ -n "${EXTRA_VLLM_ARGS:-}" ]]; then
+ fi
+ command+=("$@")
+ 
+-printf 'DS4 launch: mode=%s backend=%s allreduce=%s b12x_dma=%s indexer=%s tp=%s dcp=%s max_seqs=%s graph=%s load_format=%s instanttensor_backend=%s model=%s\n' \
+-  "${mode}" "${backend}" "${allreduce_mode}" "${b12x_pcie_dma}" \
++printf 'DS4 launch: mode=%s depth=%s backend=%s allreduce=%s b12x_dma=%s indexer=%s tp=%s dcp=%s max_seqs=%s graph=%s load_format=%s instanttensor_backend=%s allocator=%s model=%s\n' \
++  "${mode}" "${dspark_depth_mode}" \
++  "${backend}" "${allreduce_mode}" "${b12x_pcie_dma}" \
+   "${indexer_backend}" "${tp_size}" "${dcp_size}" "${max_num_seqs}" \
+-  "${graph_cap}" "${load_format}" "${INSTANTTENSOR_BACKEND}" "${model}" >&2
++  "${graph_cap}" "${load_format}" "${INSTANTTENSOR_BACKEND}" \
++  "${PYTORCH_CUDA_ALLOC_CONF:-<unset>}" "${model}" >&2
+ printf 'Command:' >&2
+ printf ' %q' "${command[@]}" >&2
+ printf '\n' >&2
+diff --git a/serve-glm52.sh b/serve-glm52.sh
+index 68f7501b3d618dea5c4ae93047b281cd56efd85d..8933ad62d752aabbc9f2e6a80bc3b17945afef41 100755
+--- a/serve-glm52.sh
++++ b/serve-glm52.sh
+@@ -107,6 +107,8 @@ MOE_BACKEND="${MOE_BACKEND:-b12x}"
+ MOE_SPEC_BACKEND="${MOE_SPEC_BACKEND:-b12x}"
+ ATTENTION_BACKEND="${ATTENTION_BACKEND:-B12X_MLA_SPARSE}"
+ KV_CACHE_DTYPE="${KV_CACHE_DTYPE:-fp8}"
++# Calibrated per-layer outer scales for nvfp4_ds_mla KV (empty = disabled).
++export VLLM_NVFP4_MLA_SCALES_FILE="${VLLM_NVFP4_MLA_SCALES_FILE:-}"
+ GLM51_PROFILE="${GLM51_PROFILE:-0}"
+ GLM52_CAUSAL_CASCADE="${GLM52_CAUSAL_CASCADE:-0}"
+ GLM52_DSPARK="${GLM52_DSPARK:-0}"
+diff --git a/tests/distributed/test_b12x_fused_all_reduce.py b/tests/distributed/test_b12x_fused_all_reduce.py
+index a789e2a6aca8a7c59feb75c7876c2dacf427dce8..2457d3c4cade325d2e7ce584efba6086e12b05ca 100644
+--- a/tests/distributed/test_b12x_fused_all_reduce.py
++++ b/tests/distributed/test_b12x_fused_all_reduce.py
+@@ -1,6 +1,7 @@
+ # SPDX-License-Identifier: Apache-2.0
+ # SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+ 
++from types import SimpleNamespace
+ from unittest.mock import MagicMock
+ 
+ import pytest
+@@ -25,6 +26,7 @@ from vllm.config import (
+     set_current_vllm_config,
+ )
+ from vllm.distributed import tensor_model_parallel_all_reduce
++from vllm.distributed.device_communicators import custom_all_reduce
+ from vllm.distributed.device_communicators.custom_all_reduce import (
+     CustomAllreduce,
+     _b12x_pcie_dma_min_bytes,
+@@ -106,7 +108,66 @@ def test_b12x_fused_allreduce_uses_independent_cutoff() -> None:
+         out=inp,
+         residual_out=residual,
+         stream=None,
++        channel_id="vllm:eager:allreduce",
+     )
++    runtime.for_stream.assert_called_with(
++        None,
++        channel_id="vllm:eager:allreduce",
++    )
++
++
++def test_b12x_eager_allreduce_forwards_stable_semantic_channel() -> None:
++    custom_allreduce, runtime = make_b12x_custom_allreduce(
++        allreduce_max_size=64,
++        fused_max_size=64,
++    )
++    inp = torch.randn(2, 4)
++    expected = torch.empty_like(inp)
++    runtime.all_reduce.return_value = expected
++
++    actual = custom_allreduce.all_reduce(inp)
++
++    assert actual is expected
++    runtime.all_reduce.assert_called_once_with(
++        inp,
++        out=None,
++        stream=None,
++        channel_id="vllm:eager:allreduce",
++    )
++
++
++def test_b12x_eager_owner_fails_closed_on_second_stream_bind() -> None:
++    custom_allreduce, runtime = make_b12x_custom_allreduce(
++        allreduce_max_size=64,
++        fused_max_size=64,
++    )
++    first_stream = object()
++    second_stream = object()
++    custom_allreduce._pcie_runtime_stream = MagicMock(  # type: ignore[method-assign]
++        side_effect=(first_stream, second_stream)
++    )
++    bound_stream = None
++
++    def for_stream(stream, *, channel_id):
++        nonlocal bound_stream
++        assert channel_id == "vllm:eager:allreduce"
++        if bound_stream is None:
++            bound_stream = stream
++        elif stream is not bound_stream:
++            raise RuntimeError("stream-affine logical owner rebound")
++        channel = MagicMock()
++        channel.should_allreduce.return_value = True
++        return channel
++
++    runtime.for_stream.side_effect = for_stream
++    inp = torch.randn(2, 4)
++
++    assert custom_allreduce.should_custom_ar(inp)
++    with pytest.raises(RuntimeError, match="stream-affine"):
++        custom_allreduce.should_custom_ar(inp)
++    assert [
++        call.kwargs["channel_id"] for call in runtime.for_stream.call_args_list
++    ] == ["vllm:eager:allreduce", "vllm:eager:allreduce"]
+ 
+ 
+ def test_b12x_fused_allreduce_falls_back_above_its_cutoff() -> None:
+@@ -142,6 +203,121 @@ def test_b12x_oneshot_defaults_to_stream_isolation(
+     assert not envs.environment_variables["VLLM_PCIE_ONESHOT_SINGLE_CHANNEL"]()
+ 
+ 
++def test_b12x_pool_prepares_single_stable_eager_owner(
++    monkeypatch: pytest.MonkeyPatch,
++) -> None:
++    captured = {}
++    runtime = MagicMock()
++
++    class FakePool:
++        @classmethod
++        def from_exchange_group(cls, **kwargs):
++            captured.update(kwargs)
++            return runtime
++
++    def fake_all_gather(gather_list, tensor, *, group):
++        for index, slot in enumerate(gather_list):
++            slot.fill_(index)
++
++    fake_config = SimpleNamespace(
++        model_config=SimpleNamespace(get_hidden_size=lambda: 4),
++        scheduler_config=SimpleNamespace(max_num_batched_tokens=8),
++    )
++    monkeypatch.setattr(custom_all_reduce, "custom_ar", True)
++    monkeypatch.setattr(custom_all_reduce.dist, "get_backend", lambda group: "gloo")
++    monkeypatch.setattr(
++        custom_all_reduce,
++        "in_the_same_node_as",
++        lambda group, source_rank=0: [True, True],
++    )
++    monkeypatch.setattr(custom_all_reduce.dist, "get_rank", lambda group=None: 0)
++    monkeypatch.setattr(custom_all_reduce.dist, "get_world_size", lambda group=None: 2)
++    monkeypatch.setattr(custom_all_reduce.dist, "all_gather", fake_all_gather)
++    monkeypatch.setattr(
++        custom_all_reduce.dist, "all_reduce", lambda *args, **kwargs: None
++    )
++    monkeypatch.setattr(
++        custom_all_reduce,
++        "_b12x_pcie_allreduce_requested",
++        lambda: True,
++    )
++    monkeypatch.setattr(custom_all_reduce, "_can_p2p", lambda *args: True)
++    monkeypatch.setattr(
++        custom_all_reduce,
++        "_is_cross_numa_topology",
++        lambda ids: False,
++    )
++    monkeypatch.setattr(
++        custom_all_reduce,
++        "_load_b12x_pcie_oneshot_pool",
++        lambda: FakePool,
++    )
++    monkeypatch.setattr(
++        custom_all_reduce,
++        "_b12x_pcie_dma_min_bytes",
++        lambda: None,
++    )
++    monkeypatch.setattr(
++        custom_all_reduce.current_platform,
++        "get_device_capability",
++        lambda: None,
++    )
++    monkeypatch.setattr(
++        custom_all_reduce.current_platform,
++        "visible_device_id_to_physical_device_id",
++        lambda index: index,
++    )
++    monkeypatch.setattr(
++        custom_all_reduce.current_platform,
++        "is_cuda_alike",
++        lambda: True,
++    )
++    monkeypatch.setattr(
++        custom_all_reduce.current_platform,
++        "is_fully_connected",
++        lambda ids: False,
++        raising=False,
++    )
++    monkeypatch.setattr(
++        custom_all_reduce.current_platform,
++        "is_cuda",
++        lambda: True,
++    )
++    monkeypatch.setattr(
++        custom_all_reduce.current_platform,
++        "is_rocm",
++        lambda: False,
++    )
++    monkeypatch.setattr(
++        "vllm.config.get_current_vllm_config",
++        lambda: fake_config,
++    )
++    monkeypatch.setattr(
++        custom_all_reduce.envs,
++        "VLLM_PCIE_ONESHOT_SINGLE_CHANNEL",
++        False,
++        raising=False,
++    )
++    monkeypatch.setattr(
++        custom_all_reduce.envs,
++        "VLLM_ALLOW_CUSTOM_ALLREDUCE_PCIE",
++        False,
++        raising=False,
++    )
++
++    built = CustomAllreduce(
++        object(),  # type: ignore[arg-type]
++        torch.device("cuda:0"),
++        nccl_group=object(),  # type: ignore[arg-type]
++    )
++
++    assert not built.disabled
++    assert captured["single_channel"] is False
++    assert captured["max_concurrent_channels"] == 2
++    runtime.prepare_channels.assert_called_once_with(("vllm:eager:allreduce",))
++    runtime.for_stream.assert_called_once_with(channel_id="vllm:eager:allreduce")
++
++
+ def test_b12x_channel_checkpoint_delegates_to_runtime() -> None:
+     custom_allreduce, runtime = make_b12x_custom_allreduce(
+         allreduce_max_size=64,
+@@ -157,6 +333,40 @@ def test_b12x_channel_checkpoint_delegates_to_runtime() -> None:
+     runtime.rollback_channels.assert_called_once_with(checkpoint)
+ 
+ 
++def test_b12x_capture_forwards_semantic_channel_id() -> None:
++    custom_allreduce, runtime = make_b12x_custom_allreduce(
++        allreduce_max_size=64,
++        fused_max_size=64,
++    )
++    stream = object()
++
++    with custom_allreduce.capture(  # type: ignore[arg-type]
++        stream,
++        channel_id="vllm:target:profile",
++    ):
++        pass
++
++    runtime.capture.assert_called_once_with(
++        stream=stream,
++        channel_id="vllm:target:profile",
++    )
++
++
++def test_b12x_capture_rejects_missing_semantic_channel_id() -> None:
++    custom_allreduce, runtime = make_b12x_custom_allreduce(
++        allreduce_max_size=64,
++        fused_max_size=64,
++    )
++
++    with (
++        pytest.raises(RuntimeError, match="semantic channel_id"),
++        custom_allreduce.capture(),
++    ):
++        pass
++
++    runtime.capture.assert_not_called()
++
++
+ def test_b12x_oneshot_buffer_tracks_dispatch_limits(
+     monkeypatch: pytest.MonkeyPatch,
+ ) -> None:
+@@ -357,7 +567,10 @@ def _run_b12x_fused_allreduce_gpu(rank: int, port: int) -> None:
+     )
+     inp.copy_(original_inp)
+     residual.copy_(original_residual)
+-    with graph_capture(device=device) as capture_context:
++    with graph_capture(
++        device=device,
++        channel_id="vllm:test:b12x-fused",
++    ) as capture_context:
+         graph = torch.cuda.CUDAGraph()
+         with torch.cuda.graph(graph, stream=capture_context.stream):
+             torch.ops.vllm.b12x_fused_allreduce_add_rms_norm.default(
+diff --git a/tests/distributed/test_custom_allreduce_lifecycle.py b/tests/distributed/test_custom_allreduce_lifecycle.py
+new file mode 100644
+index 0000000000000000000000000000000000000000..c5806ccbddeb65c3af7ec2ab38a6dac2d8b79980
+--- /dev/null
++++ b/tests/distributed/test_custom_allreduce_lifecycle.py
+@@ -0,0 +1,144 @@
++# SPDX-License-Identifier: Apache-2.0
++# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
++
++import gc
++import weakref
++from unittest.mock import MagicMock
++
++import pytest
++import torch
++
++from vllm.distributed.device_communicators.cuda_communicator import CudaCommunicator
++from vllm.distributed.device_communicators.custom_all_reduce import CustomAllreduce
++from vllm.distributed.parallel_state import GroupCoordinator
++
++
++def make_b12x_custom_allreduce() -> tuple[CustomAllreduce, MagicMock]:
++    runtime = MagicMock()
++    custom_allreduce = object.__new__(CustomAllreduce)
++    custom_allreduce.disabled = False
++    custom_allreduce._pcie_runtime = runtime
++    custom_allreduce._pcie_dma = None
++    custom_allreduce._ptr = 0
++    return custom_allreduce, runtime
++
++
++def test_b12x_destructor_skips_collective_close_without_retention() -> None:
++    custom_allreduce, runtime = make_b12x_custom_allreduce()
++    dma = MagicMock()
++    custom_allreduce._pcie_dma = dma
++    custom_allreduce_ref = weakref.ref(custom_allreduce)
++
++    del custom_allreduce
++    gc.collect()
++
++    dma.close.assert_not_called()
++    runtime.close.assert_not_called()
++    assert custom_allreduce_ref() is None
++
++
++def test_b12x_explicit_close_remains_coordinated() -> None:
++    custom_allreduce, runtime = make_b12x_custom_allreduce()
++    dma = MagicMock()
++    custom_allreduce._pcie_dma = dma
++    close_order = []
++    runtime.close.side_effect = lambda: close_order.append("runtime")
++    dma.close.side_effect = lambda: close_order.append("dma")
++
++    custom_allreduce.close()
++
++    assert close_order == ["runtime", "dma"]
++    dma.close.assert_called_once_with()
++    runtime.close.assert_called_once_with()
++    assert custom_allreduce._pcie_dma is None
++    assert custom_allreduce._pcie_runtime is None
++
++
++def test_b12x_close_retains_owners_when_runtime_close_fails() -> None:
++    custom_allreduce, runtime = make_b12x_custom_allreduce()
++    dma = MagicMock()
++    runtime.close.side_effect = RuntimeError("close failed")
++    custom_allreduce._pcie_dma = dma
++
++    with pytest.raises(RuntimeError, match="close failed"):
++        custom_allreduce.close()
++
++    assert custom_allreduce._pcie_runtime is runtime
++    assert custom_allreduce._pcie_dma is dma
++    dma.close.assert_not_called()
++
++
++def test_cuda_communicator_closes_custom_allreduce_before_nccl() -> None:
++    communicator = object.__new__(CudaCommunicator)
++    communicator.ca_comm = MagicMock()
++    communicator.pynccl_comm = MagicMock()
++    communicator.aiter_ar_comm = None
++    communicator.fi_ar_comm = None
++    communicator.all2all_manager = None
++    close_order = []
++    communicator.ca_comm.close.side_effect = lambda: close_order.append("custom")
++    communicator.pynccl_comm.destroy.side_effect = lambda: close_order.append("nccl")
++
++    communicator.destroy()
++
++    assert close_order == ["custom", "nccl"]
++    assert communicator.ca_comm is None
++    assert communicator.pynccl_comm is None
++
++
++def test_cuda_communicator_retains_owners_when_custom_close_fails() -> None:
++    communicator = object.__new__(CudaCommunicator)
++    custom_allreduce = MagicMock()
++    custom_allreduce.close.side_effect = RuntimeError("close failed")
++    communicator.ca_comm = custom_allreduce
++    communicator.pynccl_comm = MagicMock()
++    communicator.aiter_ar_comm = None
++    communicator.fi_ar_comm = None
++    communicator.all2all_manager = None
++
++    with pytest.raises(RuntimeError, match="close failed"):
++        communicator.destroy()
++
++    assert communicator.ca_comm is custom_allreduce
++    communicator.pynccl_comm.destroy.assert_not_called()
++
++
++def test_group_destroy_keeps_process_groups_live_for_communicator(
++    monkeypatch: pytest.MonkeyPatch,
++) -> None:
++    coordinator = object.__new__(GroupCoordinator)
++    coordinator.device_group = object()
++    coordinator.cpu_group = object()
++    coordinator.device_communicator = MagicMock()
++    coordinator.mq_broadcaster = None
++    device_group = coordinator.device_group
++    destroy_order = []
++    coordinator.device_communicator.destroy.side_effect = lambda: destroy_order.append(
++        "communicator"
++    )
++    monkeypatch.setattr(
++        torch.distributed,
++        "destroy_process_group",
++        lambda group: destroy_order.append(
++            "device" if group is device_group else "cpu"
++        ),
++    )
++
++    coordinator.destroy()
++
++    assert destroy_order == ["communicator", "device", "cpu"]
++
++
++def test_group_destroy_retains_process_groups_when_communicator_close_fails() -> None:
++    coordinator = object.__new__(GroupCoordinator)
++    coordinator.device_group = object()
++    coordinator.cpu_group = object()
++    coordinator.device_communicator = MagicMock()
++    coordinator.device_communicator.destroy.side_effect = RuntimeError("close failed")
++    coordinator.mq_broadcaster = None
++
++    with pytest.raises(RuntimeError, match="close failed"):
++        coordinator.destroy()
++
++    assert hasattr(coordinator, "device_group")
++    assert hasattr(coordinator, "cpu_group")
+diff --git a/tests/distributed/test_dcp_a2a.py b/tests/distributed/test_dcp_a2a.py
+index 85ec4d74deb3f64de8c5523f3b81061dea8ae7f1..c0a3ae9f4be6fa70f54b8fe57d322826ff8c2135 100644
+--- a/tests/distributed/test_dcp_a2a.py
++++ b/tests/distributed/test_dcp_a2a.py
+@@ -10,7 +10,7 @@ Tests cover:
+ 
+ import importlib.util
+ import math
+-from contextlib import contextmanager
++from contextlib import contextmanager, nullcontext
+ from typing import Any
+ 
+ import multiprocess as mp
+@@ -552,8 +552,11 @@ def test_b12x_pool_uses_independent_stream_channels(
+             captured.update(kwargs)
+             return cls()
+ 
+-        def for_stream(self):
+-            captured["warmed"] = True
++        def prepare_channels(self, channel_ids):
++            captured["prepared"] = tuple(channel_ids)
++
++        def for_stream(self, *, channel_id):
++            captured["warmed"] = channel_id
+ 
+     group = _FakeCPGroup(2, object())  # type: ignore[arg-type]
+     monkeypatch.setattr(dcp_alltoall, "_B12X_DCP_A2A_POOLS", {})
+@@ -577,25 +580,27 @@ def test_b12x_pool_uses_independent_stream_channels(
+ 
+     assert pool is not None
+     assert captured["single_channel"] is False
+-    assert captured["warmed"] is True
++    assert captured["max_concurrent_channels"] == 2
++    assert captured["prepared"] == ("vllm:eager:dcp",)
++    assert captured["warmed"] == "vllm:eager:dcp"
+ 
+ 
+ def test_b12x_dcp_capture_selects_only_current_group_pools(monkeypatch):
+     from vllm.v1.attention.ops import dcp_alltoall
+ 
+-    events = []
++    events: list[Any] = []
+ 
+     class _FakePool:
+         def __init__(self, name):
+             self.name = name
+ 
+         @contextmanager
+-        def capture(self, *, stream):
+-            events.append(("enter", self.name, stream))
++        def capture(self, *, stream, channel_id):
++            events.append(("enter", self.name, stream, channel_id))
+             try:
+                 yield
+             finally:
+-                events.append(("exit", self.name, stream))
++                events.append(("exit", self.name, stream, channel_id))
+ 
+     device_group = object()
+     group = _FakeCPGroup(2, device_group)  # type: ignore[arg-type]
+@@ -607,24 +612,47 @@ def test_b12x_dcp_capture_selects_only_current_group_pools(monkeypatch):
+     }
+     monkeypatch.setattr(dcp_alltoall, "_B12X_DCP_A2A_POOLS", pools)
+ 
+-    with dcp_alltoall.capture_b12x_dcp_a2a(group, stream):  # type: ignore[arg-type]
+-        events.append(("body", None, stream))
++    with dcp_alltoall.capture_b12x_dcp_a2a(  # type: ignore[arg-type]
++        group,
++        stream,
++        channel_id="vllm:target:profile",
++    ):
++        events.append(("body", None, stream, "vllm:target:profile"))
+ 
+     assert events == [
+-        ("enter", "output", stream),
+-        ("enter", "query", stream),
+-        ("body", None, stream),
+-        ("exit", "query", stream),
+-        ("exit", "output", stream),
++        ("enter", "output", stream, "vllm:target:profile"),
++        ("enter", "query", stream, "vllm:target:profile"),
++        ("body", None, stream, "vllm:target:profile"),
++        ("exit", "query", stream, "vllm:target:profile"),
++        ("exit", "output", stream, "vllm:target:profile"),
+     ]
+ 
+ 
++def test_b12x_dcp_capture_rejects_missing_semantic_id(monkeypatch):
++    from vllm.v1.attention.ops import dcp_alltoall
++
++    device_group = object()
++    group = _FakeCPGroup(2, device_group)  # type: ignore[arg-type]
++    key = (id(device_group), 0, 64, 512, 576, 64)
++    monkeypatch.setattr(
++        dcp_alltoall,
++        "_B12X_DCP_A2A_POOLS",
++        {key: object()},
++    )
++
++    with (
++        pytest.raises(RuntimeError, match="semantic channel_id"),
++        dcp_alltoall.capture_b12x_dcp_a2a(group),
++    ):
++        pass
++
++
+ def test_b12x_dcp_channel_rollback_restores_existing_and_closes_new_pools(
+     monkeypatch,
+ ):
+     from vllm.v1.attention.ops import dcp_alltoall
+ 
+-    events = []
++    events: list[Any] = []
+ 
+     class _FakePool:
+         def __init__(self, name):
+@@ -667,7 +695,7 @@ def test_profile_channel_checkpoint_rolls_back_all_b12x_transports(monkeypatch):
+     from vllm.distributed import parallel_state
+     from vllm.v1.attention.ops import dcp_alltoall
+ 
+-    events = []
++    events: list[Any] = []
+ 
+     class _FakeCommunicator:
+         def checkpoint_pcie_channels(self):
+@@ -691,10 +719,15 @@ def test_profile_channel_checkpoint_rolls_back_all_b12x_transports(monkeypatch):
+     monkeypatch.setattr(parallel_state, "_TP", tp_group)
+     monkeypatch.setattr(parallel_state, "_PP", pp_group)
+     monkeypatch.setattr(parallel_state, "_DCP", dcp_group)
++
++    def checkpoint_dcp(group):
++        events.append("checkpoint-dcp")
++        return "dcp-checkpoint"
++
+     monkeypatch.setattr(
+         dcp_alltoall,
+         "checkpoint_b12x_dcp_a2a_channels",
+-        lambda group: events.append("checkpoint-dcp") or "dcp-checkpoint",
++        checkpoint_dcp,
+     )
+     monkeypatch.setattr(
+         dcp_alltoall,
+@@ -717,25 +750,38 @@ def test_global_graph_capture_enters_b12x_dcp_pool(monkeypatch):
+     from vllm.distributed import parallel_state
+     from vllm.v1.attention.ops import dcp_alltoall
+ 
+-    events = []
++    events: list[Any] = []
+ 
+     class _FakeGroup:
+         world_size = 2
+ 
++        def __init__(self, name):
++            self.name = name
++
+         @contextmanager
+         def graph_capture(self, context):
+-            yield context
++            events.append(("enter-group", self.name, context.channel_id))
++            try:
++                yield context
++            finally:
++                events.append(("exit-group", self.name, context.channel_id))
+ 
+-    tp_group = _FakeGroup()
+-    pp_group = _FakeGroup()
+-    dcp_group = _FakeGroup()
++    tp_group = _FakeGroup("tp")
++    pp_group = _FakeGroup("pp")
++    dcp_group = _FakeGroup("dcp")
+     stream = object()
+-    context = parallel_state.GraphCaptureContext(stream)  # type: ignore[arg-type]
++    context = parallel_state.GraphCaptureContext(  # type: ignore[arg-type]
++        stream,
++        channel_id="vllm:target:profile",
++    )
+ 
+     @contextmanager
+-    def fake_b12x_capture(group, selected_stream):
+-        events.append((group, selected_stream))
+-        yield
++    def fake_b12x_capture(group, selected_stream, *, channel_id):
++        events.append(("enter-b12x", group, selected_stream, channel_id))
++        try:
++            yield
++        finally:
++            events.append(("exit-b12x", group, selected_stream, channel_id))
+ 
+     monkeypatch.setattr(parallel_state, "_DCP", dcp_group)
+     monkeypatch.setattr(parallel_state, "get_tp_group", lambda: tp_group)
+@@ -746,7 +792,75 @@ def test_global_graph_capture_enters_b12x_dcp_pool(monkeypatch):
+     with parallel_state.graph_capture(torch.device("cpu"), context) as actual:
+         assert actual is context
+ 
+-    assert events == [(dcp_group, stream)]
++    assert events == [
++        ("enter-group", "tp", "vllm:target:profile"),
++        ("enter-group", "pp", "vllm:target:profile"),
++        ("enter-group", "dcp", "vllm:target:profile"),
++        (
++            "enter-b12x",
++            dcp_group,
++            stream,
++            "vllm:target:profile",
++        ),
++        (
++            "exit-b12x",
++            dcp_group,
++            stream,
++            "vllm:target:profile",
++        ),
++        ("exit-group", "dcp", "vllm:target:profile"),
++        ("exit-group", "pp", "vllm:target:profile"),
++        ("exit-group", "tp", "vllm:target:profile"),
++    ]
++
++
++def test_group_capture_forwards_semantic_id_to_custom_allreduce(monkeypatch):
++    from vllm._aiter_ops import rocm_aiter_ops
++    from vllm.distributed import parallel_state
++    from vllm.distributed.device_communicators.cuda_communicator import (
++        CudaCommunicator,
++    )
++
++    events: list[Any] = []
++
++    class FakeCustomAllreduce:
++        @contextmanager
++        def capture(self, *, stream, channel_id):
++            events.append(("enter", stream, channel_id))
++            try:
++                yield
++            finally:
++                events.append(("exit", stream, channel_id))
++
++    communicator = object.__new__(CudaCommunicator)
++    communicator.ca_comm = FakeCustomAllreduce()
++    group = object.__new__(parallel_state.GroupCoordinator)
++    group.device_communicator = communicator
++    stream = object()
++    context = parallel_state.GraphCaptureContext(  # type: ignore[arg-type]
++        stream,
++        channel_id="vllm:draft:decode:production",
++    )
++
++    monkeypatch.setattr(rocm_aiter_ops, "is_enabled", lambda: False)
++    monkeypatch.setattr(
++        parallel_state.torch.cuda,
++        "current_stream",
++        lambda: stream,
++    )
++    monkeypatch.setattr(
++        parallel_state.torch.cuda,
++        "stream",
++        lambda selected: nullcontext(),
++    )
++
++    with parallel_state.GroupCoordinator.graph_capture(group, context) as actual:
++        assert actual is context
++
++    assert events == [
++        ("enter", stream, "vllm:draft:decode:production"),
++        ("exit", stream, "vllm:draft:decode:production"),
++    ]
+ 
+ 
+ @pytest.mark.skipif(torch.accelerator.device_count() < 1, reason="CUDA is required.")
+@@ -760,8 +874,15 @@ def test_b12x_lse_reduce_honors_token_cap(monkeypatch: pytest.MonkeyPatch):
+ 
+     class _FakePool:
+         def lse_reduce_scatter(
+-            self, partial, lse, out=None, *, is_lse_base_on_e
++            self,
++            partial,
++            lse,
++            out=None,
++            *,
++            is_lse_base_on_e,
++            channel_id,
+         ):
++            created["channel_id"] = channel_id
+             return sentinel
+ 
+     def fake_get_pool(
+@@ -787,6 +908,7 @@ def test_b12x_lse_reduce_honors_token_cap(monkeypatch: pytest.MonkeyPatch):
+     # Batch within the cap uses B12X, with the staging pool capped too.
+     assert result is sentinel
+     assert created["max_batch_size"] == 4
++    assert created["channel_id"] == "vllm:eager:dcp"
+ 
+     out_large = torch.zeros(8, 16, 64, dtype=torch.bfloat16, device="cuda")
+     lse_large = torch.zeros(8, 16, dtype=torch.float32, device="cuda")
+@@ -813,7 +935,8 @@ def test_b12x_query_gather_honors_token_cap(monkeypatch: pytest.MonkeyPatch):
+     sentinel = torch.zeros(1)
+ 
+     class _FakePool:
+-        def all_gather_heads(self, local_input):
++        def all_gather_heads(self, local_input, *, channel_id):
++            created["channel_id"] = channel_id
+             return sentinel
+ 
+     def fake_get_pool(
+@@ -834,6 +957,7 @@ def test_b12x_query_gather_honors_token_cap(monkeypatch: pytest.MonkeyPatch):
+     )
+     assert result is sentinel
+     assert created["max_batch_size"] == 4
++    assert created["channel_id"] == "vllm:eager:dcp"
+ 
+     large = torch.zeros(8, 8, 64, dtype=torch.bfloat16, device="cuda")
+     result = dcp_alltoall._try_b12x_dcp_all_gather_heads(
+@@ -856,9 +980,20 @@ def test_b12x_lse_reduce_preserves_supported_layouts(monkeypatch: pytest.MonkeyP
+ 
+     class _FakePool:
+         def lse_reduce_scatter(
+-            self, partial, lse, out=None, *, is_lse_base_on_e
++            self,
++            partial,
++            lse,
++            out=None,
++            *,
++            is_lse_base_on_e,
++            channel_id,
+         ):
+-            received.update(partial=partial, lse=lse, out=out)
++            received.update(
++                partial=partial,
++                lse=lse,
++                out=out,
++                channel_id=channel_id,
++            )
+             return sentinel
+ 
+     monkeypatch.setattr(
+@@ -889,10 +1024,9 @@ def test_b12x_lse_reduce_preserves_supported_layouts(monkeypatch: pytest.MonkeyP
+     assert received["partial"].is_contiguous()
+     assert received["lse"].is_contiguous()
+     assert received["out"].movedim(0, 1).is_contiguous()
++    assert received["channel_id"] == "vllm:eager:dcp"
+ 
+-    head_major_storage = torch.zeros(
+-        16, 8, 64, dtype=torch.bfloat16, device="cuda"
+-    )
++    head_major_storage = torch.zeros(16, 8, 64, dtype=torch.bfloat16, device="cuda")
+     head_major = head_major_storage.transpose(0, 1)[:4]
+     result = dcp_alltoall._try_b12x_dcp_lse_reduce(
+         head_major,
+@@ -1267,7 +1401,15 @@ def _distributed_b12x_a2a_worker(env: dict[str, str]) -> None:
+         dcp_alltoall._dcp_a2a_send_recv_buffers = fail_packed_nccl
+         group.all_gather = fail_query_nccl  # type: ignore[attr-defined]
+         graph = torch.cuda.CUDAGraph()
+-        with torch.cuda.graph(graph):
++        capture_stream = torch.cuda.Stream(device=f"cuda:{local_rank}")
++        with (
++            dcp_alltoall.capture_b12x_dcp_a2a(
++                group,  # type: ignore[arg-type]
++                capture_stream,
++                channel_id="test:dcp:graph",
++            ),
++            torch.cuda.graph(graph, stream=capture_stream),
++        ):
+             graph_query = dcp_alltoall.dcp_b12x_all_gather_heads(
+                 static_query,
+                 group,  # type: ignore[arg-type]
+diff --git a/tests/entrypoints/test_ds4_flash_launcher.py b/tests/entrypoints/test_ds4_flash_launcher.py
+new file mode 100644
+index 0000000000000000000000000000000000000000..f19d90d42db5a6b85198567987690c3df4e230a5
+--- /dev/null
++++ b/tests/entrypoints/test_ds4_flash_launcher.py
+@@ -0,0 +1,134 @@
++# SPDX-License-Identifier: Apache-2.0
++# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
++
++import os
++import subprocess
++from pathlib import Path
++
++_REPO_ROOT = Path(__file__).parents[2]
++_LAUNCHER = _REPO_ROOT / "serve-ds4-flash.sh"
++
++
++def _dry_run(tmp_path: Path, **overrides: str) -> str:
++    env = {
++        "PATH": os.environ["PATH"],
++        "HOME": str(tmp_path),
++        "XDG_CACHE_HOME": str(tmp_path / "cache"),
++        "DRY_RUN": "1",
++        **overrides,
++    }
++    result = subprocess.run(
++        ["bash", str(_LAUNCHER)],
++        env=env,
++        check=True,
++        capture_output=True,
++        text=True,
++    )
++    return result.stderr
++
++
++def test_ds4_launcher_defaults_to_0731_fixed_k7(tmp_path: Path) -> None:
++    output = _dry_run(tmp_path)
++
++    assert "mode=dspark depth=fixed" in output
++    assert "model=deepseek-ai/DeepSeek-V4-Flash-0731" in output
++    assert "9e165c30e2704aec5d9d593cce3eebd58bbef1cb" in output
++    assert 'num_speculative_tokens\\":7' in output
++    assert "max_seqs=16 graph=128" in output
++    assert "--max-model-len 131072" in output
++    assert "--gpu-memory-utilization 0.975" in output
++
++
++def test_ds4_launcher_dynamic_depth_enables_capacity_mode(tmp_path: Path) -> None:
++    output = _dry_run(tmp_path, DSPARK_DEPTH_MODE="dynamic")
++
++    assert "mode=dspark depth=dynamic" in output
++    assert 'dspark_capacity_verification_mode\\":\\"varlen' in output
++    assert 'dspark_sps_curve\\":\\"auto' in output
++
++
++def test_ds4_launcher_accepts_cluster_style_aliases(tmp_path: Path) -> None:
++    output = _dry_run(
++        tmp_path,
++        DCP="1",
++        NUM_SPECULATIVE_TOKENS="5",
++    )
++
++    assert "dcp=1" in output
++    assert 'num_speculative_tokens\\":5' in output
++
++
++def test_ds4_launcher_standard_mtp_uses_standard_checkpoint(tmp_path: Path) -> None:
++    output = _dry_run(tmp_path, MODE="mtp2")
++
++    assert "mode=mtp2 depth=disabled" in output
++    assert "model=deepseek-ai/DeepSeek-V4-Flash" in output
++    assert "DeepSeek-V4-Flash-0731" not in output
++    assert 'method\\":\\"mtp' in output
++    assert 'num_speculative_tokens\\":2' in output
++
++
++def test_ds4_launcher_can_disable_dspark_on_0731(tmp_path: Path) -> None:
++    output = _dry_run(tmp_path, MODE="dspark-mtp0")
++
++    assert "mode=dspark-mtp0 depth=disabled" in output
++    assert "model=deepseek-ai/DeepSeek-V4-Flash-0731" in output
++    assert "--speculative-config" not in output
++
++
++def test_ds4_launcher_enables_native_kv_offload(tmp_path: Path) -> None:
++    output = _dry_run(tmp_path, KV_OFFLOADING_SIZE="5.5")
++
++    assert "--kv-offloading-size 5.5" in output
++    assert "--kv-offloading-backend native" in output
++    assert "allocator=expandable_segments:False" in output
++
++
++def test_ds4_launcher_native_offload_preserves_other_allocator_settings(
++    tmp_path: Path,
++) -> None:
++    output = _dry_run(
++        tmp_path,
++        KV_OFFLOADING_SIZE="5.5",
++        PYTORCH_CUDA_ALLOC_CONF=(
++            "max_split_size_mb:256,expandable_segments:True"
++        ),
++    )
++
++    assert (
++        "allocator=max_split_size_mb:256,expandable_segments:False" in output
++    )
++
++
++def test_ds4_launcher_without_offload_keeps_expandable_segments(
++    tmp_path: Path,
++) -> None:
++    output = _dry_run(tmp_path)
++
++    assert "allocator=expandable_segments:True" in output
++
++
++def test_ds4_launcher_zero_kv_offload_stays_disabled(tmp_path: Path) -> None:
++    output = _dry_run(tmp_path, KV_OFFLOADING_SIZE="0.0")
++
++    assert "--kv-offloading-size" not in output
++
++
++def test_ds4_launcher_rejects_invalid_kv_offload_size(tmp_path: Path) -> None:
++    env = {
++        "PATH": os.environ["PATH"],
++        "HOME": str(tmp_path),
++        "XDG_CACHE_HOME": str(tmp_path / "cache"),
++        "DRY_RUN": "1",
++        "KV_OFFLOADING_SIZE": "five",
++    }
++    result = subprocess.run(
++        ["bash", str(_LAUNCHER)],
++        env=env,
++        check=False,
++        capture_output=True,
++        text=True,
++    )
++
++    assert result.returncode == 2
++    assert "KV_OFFLOADING_SIZE must be a non-negative GiB value" in result.stderr
+diff --git a/tests/model_executor/test_flashinfer_autotune_cache.py b/tests/model_executor/test_flashinfer_autotune_cache.py
+index 65b8e8f55d2da000353a80317babdf02885096ac..dc0bf6a13e9b9ca71a332efe8d73e7f39e16ff9e 100644
+--- a/tests/model_executor/test_flashinfer_autotune_cache.py
++++ b/tests/model_executor/test_flashinfer_autotune_cache.py
+@@ -128,6 +128,53 @@ def _patch_flashinfer_autotune_deps(monkeypatch):
+     return calls
+ 
+ 
++def test_flashinfer_autotune_dummy_run_skips_pre_kv_v2_attention() -> None:
++    runner = SimpleNamespace(
++        scheduler_config=SimpleNamespace(max_num_batched_tokens=8192),
++        vllm_config=SimpleNamespace(use_v2_model_runner=True),
++    )
++
++    kwargs = kernel_warmup._flashinfer_autotune_dummy_run_kwargs(runner)
++
++    assert kwargs == {
++        "num_tokens": 8192,
++        "skip_eplb": True,
++        "is_profile": True,
++        "skip_attn": True,
++    }
++
++
++def test_flashinfer_autotune_dummy_run_keeps_attention_after_kv_init() -> None:
++    runner = SimpleNamespace(
++        scheduler_config=SimpleNamespace(max_num_batched_tokens=8192),
++        vllm_config=SimpleNamespace(use_v2_model_runner=True),
++        block_tables=object(),
++    )
++
++    kwargs = kernel_warmup._flashinfer_autotune_dummy_run_kwargs(runner)
++
++    assert kwargs == {
++        "num_tokens": 8192,
++        "skip_eplb": True,
++        "is_profile": True,
++    }
++
++
++def test_flashinfer_autotune_dummy_run_keeps_v1_signature() -> None:
++    runner = SimpleNamespace(
++        scheduler_config=SimpleNamespace(max_num_batched_tokens=8192),
++        vllm_config=SimpleNamespace(use_v2_model_runner=False),
++    )
++
++    kwargs = kernel_warmup._flashinfer_autotune_dummy_run_kwargs(runner)
++
++    assert kwargs == {
++        "num_tokens": 8192,
++        "skip_eplb": True,
++        "is_profile": True,
++    }
++
++
+ def test_b12x_dcp_warmup_finds_generic_mla_attention(monkeypatch) -> None:
+     from vllm.distributed import parallel_state
+     from vllm.model_executor.layers.attention.mla_attention import MLAAttention
+diff --git a/tests/models/deepseek_v4/test_b12x_cache_page_view.py b/tests/models/deepseek_v4/test_b12x_cache_page_view.py
+new file mode 100644
+index 0000000000000000000000000000000000000000..eca0977b9baa22fe09d8b1692fd48ae86aede596
+--- /dev/null
++++ b/tests/models/deepseek_v4/test_b12x_cache_page_view.py
+@@ -0,0 +1,71 @@
++# SPDX-License-Identifier: Apache-2.0
++# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
++
++import pytest
++import torch
++
++from vllm.models.deepseek_v4.nvidia.b12x import _b12x_cache_page_view
++
++
++_PAGE_SIZE = 64
++_PAYLOAD_BYTES = _PAGE_SIZE * 584
++_PADDED_PAGE_BYTES = 37_440
++
++
++def test_b12x_cache_page_view_accepts_contiguous_payload_pages() -> None:
++    cache = torch.empty((3, _PAGE_SIZE, 584), dtype=torch.uint8)
++
++    view = _b12x_cache_page_view(cache, _PAGE_SIZE, "cache")
++
++    assert view.shape == (3, _PAYLOAD_BYTES)
++    assert view.stride() == (_PAYLOAD_BYTES, 1)
++
++
++def test_b12x_cache_page_view_preserves_padded_physical_stride() -> None:
++    storage = torch.empty(3 * _PADDED_PAGE_BYTES, dtype=torch.uint8)
++    cache = torch.as_strided(
++        storage,
++        size=(3, _PAGE_SIZE, 584),
++        stride=(_PADDED_PAGE_BYTES, 584, 1),
++    )
++
++    view = _b12x_cache_page_view(cache, _PAGE_SIZE, "cache")
++
++    assert view.shape == (3, _PAYLOAD_BYTES)
++    assert view.stride() == (_PADDED_PAGE_BYTES, 1)
++
++
++def test_b12x_cache_page_view_rejects_short_physical_stride() -> None:
++    storage = torch.empty(2 * _PAYLOAD_BYTES, dtype=torch.uint8)
++    cache = torch.as_strided(
++        storage,
++        size=(2, _PAGE_SIZE, 584),
++        stride=(_PAYLOAD_BYTES - 1, 584, 1),
++    )
++
++    with pytest.raises(RuntimeError, match=r"page stride .* is smaller"):
++        _b12x_cache_page_view(cache, _PAGE_SIZE, "cache")
++
++
++def test_b12x_cache_page_view_rejects_overlapping_2d_pages() -> None:
++    storage = torch.empty(2 * _PAYLOAD_BYTES, dtype=torch.uint8)
++    cache = torch.as_strided(
++        storage,
++        size=(2, _PAYLOAD_BYTES),
++        stride=(_PAYLOAD_BYTES - 1, 1),
++    )
++
++    with pytest.raises(RuntimeError, match=r"page stride .* is smaller"):
++        _b12x_cache_page_view(cache, _PAGE_SIZE, "cache")
++
++
++def test_b12x_cache_page_view_rejects_gapped_page_payload() -> None:
++    storage = torch.empty(2 * _PAYLOAD_BYTES + _PAGE_SIZE, dtype=torch.uint8)
++    cache = torch.as_strided(
++        storage,
++        size=(2, _PAGE_SIZE, 584),
++        stride=(_PAYLOAD_BYTES, 585, 1),
++    )
++
++    with pytest.raises(RuntimeError, match=r"page payload must be contiguous"):
++        _b12x_cache_page_view(cache, _PAGE_SIZE, "cache")
+diff --git a/tests/quantization/test_exl3.py b/tests/quantization/test_exl3.py
+index 5f6c72d43d1b9a7c46e3a13d813fe7cea56e0d76..1763ffedc4c547433b1942fc2a0abfa3d9b0357f 100644
+--- a/tests/quantization/test_exl3.py
++++ b/tests/quantization/test_exl3.py
+@@ -313,6 +313,7 @@ def test_mixed_rank_sliced_weights_are_partitioned_by_declared_bitrate(monkeypat
+         local_num_experts=experts,
+         exl3_hidden_size=hidden,
+         exl3_intermediate_size_per_partition=intermediate,
++        exl3_params_dtype=torch.float16,
+         exl3_layer_bitrates=bitrates,
+         activation=MoEActivation.SILU,
+         layer_name="model.layers.3.mlp.experts",
+@@ -324,6 +325,8 @@ def test_mixed_rank_sliced_weights_are_partitioned_by_declared_bitrate(monkeypat
+             name = f"{prefix}_{suffix}"
+             backing = slabs.get(name)
+             setattr(layer, name, parameter(shards, backing=backing))
++    marker = torch.tensor(0xCBAC1FED - (1 << 32), dtype=torch.int32)
++    layer.w13_mcg.exl3_tensors[(0, "w1")] = marker
+ 
+     class FakeMixedApi:
+         def __init__(self):
+@@ -346,8 +349,23 @@ def test_mixed_rank_sliced_weights_are_partitioned_by_declared_bitrate(monkeypat
+         def combine_trellis_rotations(tier0, tier1):
+             return tier0, tier1
+ 
++    class FakeFusedApi:
++        def __init__(self):
++            self.plans = []
++            self.prepared = []
++
++        def plan_weights(self, **kwargs):
++            self.plans.append(kwargs)
++            return SimpleNamespace(**kwargs)
++
++        def prepare_weights(self, **kwargs):
++            self.prepared.append(kwargs)
++            return SimpleNamespace(plan=kwargs["plan"])
++
+     api = FakeMixedApi()
++    fused_api = FakeFusedApi()
+     monkeypatch.setattr(exl3_module, "_load_sparkinfer_mixed_trellis", lambda: api)
++    monkeypatch.setattr(exl3_module, "_load_sparkinfer_fused_moe", lambda: fused_api)
+     method = object.__new__(Exl3MoEMethod)
+     method._rank_sliced_backing = lambda _layer, name: slabs[name]
+ 
+@@ -376,6 +394,23 @@ def test_mixed_rank_sliced_weights_are_partitioned_by_declared_bitrate(monkeypat
+     ]
+     assert layer.exl3_mixed_trellis["tier_ids"] == ((0, 2), (1, 3))
+     assert layer.exl3_mixed_trellis["tier_bits"] == (3, 4)
++    assert [entry["trellis_bits"] for entry in fused_api.plans] == [3, 4]
++    assert [entry["trellis_tile_config"] for entry in fused_api.plans] == [
++        (64, 128, 64, 128),
++        (64, 128, 64, 128),
++    ]
++    assert all(entry["trellis_mcg"] is marker for entry in fused_api.prepared)
++    assert len(layer.exl3_mixed_trellis["serial_tiers"]) == 2
++    rotations = layer.exl3_mixed_trellis["rotations"]
++    for mixed_entry, serial_entry in zip(api.prepared, fused_api.prepared, strict=True):
++        assert (
++            mixed_entry["gate_suh"].untyped_storage().data_ptr()
++            == rotations.gate_suh.untyped_storage().data_ptr()
++        )
++        assert (
++            serial_entry["gate_suh"].untyped_storage().data_ptr()
++            == rotations.gate_suh.untyped_storage().data_ptr()
++        )
+     assert layer.w13_trellis.exl3_tensors == {}
+     assert layer.w2_trellis.exl3_tensors == {}
+     assert layer.w13_suh.exl3_backing is None
+@@ -390,6 +425,105 @@ def test_mixed_trellis_buffer_accounting_ignores_metadata() -> None:
+     assert exl3_module._unique_tensor_storage_bytes(first, second) == 8
+ 
+ 
++def test_mixed_trellis_dispatches_decode_and_serial_prefill(monkeypatch):
++    class FakeMixedApi:
++        calls = 0
++
++        def run_mixed_trellis(self, x, *args):
++            self.calls += 1
++            return torch.ones_like(x)
++
++    class FakeFusedApi:
++        def __init__(self):
++            self.bindings = []
++
++        def bind(self, plan, **kwargs):
++            del plan
++            self.bindings.append(kwargs)
++            return kwargs
++
++        @staticmethod
++        def run(*, binding):
++            output = binding["output"]
++            if output is not None:
++                output.fill_(1)
++                return output
++            return torch.full_like(binding["a"], 2, dtype=torch.float32)
++
++    class FakePlan:
++        @staticmethod
++        def scratch_specs():
++            return [SimpleNamespace(shape=(16,), dtype=torch.uint8)]
++
++    mixed_api = FakeMixedApi()
++    fused_api = FakeFusedApi()
++    runtime = {
++        "mixed_api": mixed_api,
++        "fused_api": fused_api,
++        "decode": {"launch": object(), "buffers": object()},
++        "prefill_plans": (FakePlan(), FakePlan()),
++        "prefill_arena": torch.empty(16, dtype=torch.uint8),
++        "prefill_accum": torch.empty((8, 4), dtype=torch.float32),
++        "max_decode_m": 8,
++        "max_batched_tokens": 16,
++        "prefill_capacity": 8,
++    }
++    tiers = (
++        {"weights": object(), "route_expert_map": torch.tensor([0, -1])},
++        {"weights": object(), "route_expert_map": torch.tensor([-1, 0])},
++    )
++    layer = SimpleNamespace(
++        exl3_mixed_trellis={
++            "tiers": (object(), object()),
++            "serial_tiers": tiers,
++            "global_to_combined": object(),
++            "descriptor_map": object(),
++            "rotations": object(),
++        }
++    )
++    method = object.__new__(Exl3MoEMethod)
++    monkeypatch.setattr(
++        method, "_mixed_rank_sliced_runtime", lambda layer, x, ids: runtime
++    )
++    weights = torch.ones((16, 2), dtype=torch.float32)
++    ids = torch.zeros((16, 2), dtype=torch.int64)
++
++    decode = method._apply_mixed_rank_sliced(
++        layer, torch.zeros((4, 4)), weights[:4], ids[:4]
++    )
++    prefill = method._apply_mixed_rank_sliced(layer, torch.zeros((16, 4)), weights, ids)
++
++    torch.testing.assert_close(decode, torch.ones_like(decode))
++    torch.testing.assert_close(prefill, torch.full_like(prefill, 3))
++    assert mixed_api.calls == 1
++    assert len(fused_api.bindings) == 4
++    assert [binding["a"].shape[0] for binding in fused_api.bindings] == [8] * 4
++    assert all(
++        torch.equal(binding["topk_weights"], weights[:8])
++        for binding in fused_api.bindings[:2]
++    )
++    assert all(
++        torch.equal(binding["topk_weights"], weights[8:])
++        for binding in fused_api.bindings[2:]
++    )
++    assert all(
++        torch.equal(binding["topk_ids"], ids[:8]) for binding in fused_api.bindings[:2]
++    )
++    assert all(
++        torch.equal(binding["topk_ids"], ids[8:]) for binding in fused_api.bindings[2:]
++    )
++    assert (
++        fused_api.bindings[0]["output"].data_ptr()
++        == runtime["prefill_accum"].data_ptr()
++    )
++    assert fused_api.bindings[1]["output"] is None
++    assert (
++        fused_api.bindings[2]["output"].data_ptr()
++        == runtime["prefill_accum"].data_ptr()
++    )
++    assert fused_api.bindings[3]["output"] is None
++
++
+ @pytest.mark.parametrize(
+     ("hidden", "intermediate", "expected"),
+     [
+diff --git a/tests/quantization/test_exl3_prefill_plan.py b/tests/quantization/test_exl3_prefill_plan.py
+index c55be20ee366173ca5bc5d96d3fb6090b8dd11b4..295e595ab2b8ad7cd0bfa7df77bc579334bc2247 100644
+--- a/tests/quantization/test_exl3_prefill_plan.py
++++ b/tests/quantization/test_exl3_prefill_plan.py
+@@ -7,7 +7,8 @@ The planned Trellis API and the ExLlamaV3 extension are mocked; these tests
+ prove backend policy only:
+ 
+ * decode window m in [min, max] binds the decode plan;
+-* max < m <= capacity binds the prefill plan (block_size_m=64 by default);
++* max < m <= scheduler capacity binds capacity-bounded prefill slices;
++* the opt-in prefill capacity defaults to the scheduler capacity;
+ * m < min stays on the parity path with chunk-capped staging buffers;
+ * VLLM_EXL3_PREFILL_TRELLIS=0 restores the single-plan parity behavior
+   with full-capacity staging;
+@@ -50,6 +51,7 @@ class _FakeFusedMoeApi:
+     def __init__(self):
+         self.planned = []
+         self.bound = []
++        self.routed = []
+ 
+     def Caps(self, **kwargs):
+         return kwargs
+@@ -59,13 +61,62 @@ class _FakeFusedMoeApi:
+         self.planned.append(caps)
+         return plan
+ 
+-    def bind(self, plan, *, scratch, a, experts, topk_weights, topk_ids):
+-        del scratch, experts, topk_weights, topk_ids
++    def bind(
++        self,
++        plan,
++        *,
++        scratch,
++        a,
++        experts,
++        topk_weights,
++        topk_ids,
++        route_expert_map=None,
++        output_expert_map=None,
++        output=None,
++    ):
++        del scratch, experts
+         self.bound.append((plan, int(a.shape[0])))
+-        return SimpleNamespace(plan=plan, m=int(a.shape[0]))
++        self.routed.append((topk_weights.clone(), topk_ids.clone()))
++        return SimpleNamespace(
++            plan=plan,
++            a=a,
++            route_expert_map=route_expert_map,
++            output_expert_map=output_expert_map,
++            output=output,
++        )
+ 
+     def run(self, *, binding):
+-        return torch.zeros((binding.m, HIDDEN), dtype=torch.float32)
++        if binding.route_expert_map is not None:
++            tier_output = binding.a.to(torch.float32).mul(0.5)
++            if binding.output is not None:
++                binding.output.copy_(tier_output)
++                return binding.output
++            return tier_output
++        return binding.a.to(torch.float32)
++
++
++class _FakeMixedTrellisApi:
++    def __init__(self):
++        self.compiled = []
++        self.routed = []
++
++    def max_packed_route_slots(self, routed_rows, block_size, experts):
++        del block_size, experts
++        return routed_rows
++
++    def compile_mixed_trellis(self, **kwargs):
++        launch = SimpleNamespace(**kwargs)
++        self.compiled.append(launch)
++        return launch
++
++    def make_mixed_trellis_buffers(self, launch, **kwargs):
++        del kwargs
++        return SimpleNamespace(scratch=torch.empty(launch.size_m, dtype=torch.uint8))
++
++    def run_mixed_trellis(self, *args):
++        x, topk_weights, topk_ids = args[0], args[3], args[4]
++        self.routed.append((topk_weights.clone(), topk_ids.clone()))
++        return x.to(torch.float32)
+ 
+ 
+ class _FakeExt:
+@@ -96,6 +147,32 @@ def _make_layer():
+     )
+ 
+ 
++def _make_mixed_layer():
++    layer = _make_layer()
++    layer.exl3_mixed_bitrate = True
++    layer.exl3_mixed_trellis = {
++        "tiers": (object(), object()),
++        "tier_ids": ((0, 1, 2, 3), (4, 5, 6, 7)),
++        "tier_bits": (3, 4),
++        "global_to_combined": object(),
++        "descriptor_map": object(),
++        "rotations": object(),
++        "tile_config": (64, 128, 64, 128),
++        "serial_tile_config": (64, 128, 64, 128),
++        "serial_tiers": (
++            {
++                "weights": SimpleNamespace(plan=object()),
++                "route_expert_map": torch.tensor([0, 1, 2, 3, -1, -1, -1, -1]),
++            },
++            {
++                "weights": SimpleNamespace(plan=object()),
++                "route_expert_map": torch.tensor([-1, -1, -1, -1, 0, 1, 2, 3]),
++            },
++        ),
++    }
++    return layer
++
++
+ def _make_method():
+     method = object.__new__(Exl3MoEMethod)
+     method.quant_config = SimpleNamespace(
+@@ -112,6 +189,7 @@ class _Harness:
+         self._saved_capturing = None
+         self.api = _FakeFusedMoeApi()
+         self.ext = _FakeExt()
++        self.mixed_api = _FakeMixedTrellisApi()
+ 
+     def __enter__(self):
+         for name, value in self._env.items():
+@@ -122,30 +200,41 @@ class _Harness:
+                 os.environ[name] = value
+         self._saved_loaders = (
+             exl3_module._load_sparkinfer_fused_moe,
++            exl3_module._load_sparkinfer_mixed_trellis,
+             exl3_module._load_exl3_ext,
+         )
+         exl3_module._load_sparkinfer_fused_moe = lambda: self.api
++        exl3_module._load_sparkinfer_mixed_trellis = lambda: self.mixed_api
+         exl3_module._load_exl3_ext = lambda: self.ext
+         self._saved_capturing = torch.cuda.is_current_stream_capturing
+         torch.cuda.is_current_stream_capturing = lambda: False
+         self._saved_current_device = torch.cuda.current_device
+         torch.cuda.current_device = lambda: 0
++        self._saved_device_properties = torch.cuda.get_device_properties
++        torch.cuda.get_device_properties = lambda device: SimpleNamespace(
++            multi_processor_count=1,
++            shared_memory_per_block_optin=1,
++        )
+         exl3_module._RANK_SLICED_RUNTIMES.clear()
++        exl3_module._MIXED_TRELLIS_RUNTIMES.clear()
+         return self
+ 
+     def __exit__(self, *exc):
+         (
+             exl3_module._load_sparkinfer_fused_moe,
++            exl3_module._load_sparkinfer_mixed_trellis,
+             exl3_module._load_exl3_ext,
+         ) = self._saved_loaders
+         torch.cuda.is_current_stream_capturing = self._saved_capturing
+         torch.cuda.current_device = self._saved_current_device
++        torch.cuda.get_device_properties = self._saved_device_properties
+         for name, value in self._saved_env.items():
+             if value is None:
+                 os.environ.pop(name, None)
+             else:
+                 os.environ[name] = value
+         exl3_module._RANK_SLICED_RUNTIMES.clear()
++        exl3_module._MIXED_TRELLIS_RUNTIMES.clear()
+         return False
+ 
+     def planned_caps(self):
+@@ -159,24 +248,24 @@ def _apply(method, layer, m):
+     return method._apply_rank_sliced(layer, x, weights, ids)
+ 
+ 
+-def test_dual_plan_construction_and_dispatch():
+-    with _Harness() as h:
++def test_opt_in_prefill_capacity_slices_dispatch():
++    with _Harness(env={"VLLM_EXL3_PREFILL_CAPACITY": "128"}) as h:
+         method = _make_method()
+         layer = _make_layer()
+ 
+         out = _apply(method, layer, 16)
+         assert out.dtype == torch.bfloat16 and out.shape == (16, HIDDEN)
+-        # Two plans: decode (32, block 8) then prefill (capacity, block 64).
++        # Two plans: decode (32, block 8), then bounded prefill (block 64).
+         assert [
+             (caps["max_tokens"], caps["w4a16_block_size_m"])
+             for caps in h.planned_caps()
+-        ] == [(32, 8), (MAX_BATCHED, 64)]
++        ] == [(32, 8), (128, 64)]
+         assert all(caps["route_num_experts"] == 0 for caps in h.planned_caps())
+         assert h.api.bound[-1][0].caps["max_tokens"] == 32
+ 
+         _apply(method, layer, 200)
+-        assert h.api.bound[-1][0].caps["max_tokens"] == MAX_BATCHED
+-        assert h.api.bound[-1][1] == 200
++        assert all(bound[0].caps["max_tokens"] == 128 for bound in h.api.bound[-2:])
++        assert [bound[1] for bound in h.api.bound[-2:]] == [128, 72]
+         assert not h.ext.moe_calls
+ 
+         _apply(method, layer, 2)
+@@ -188,6 +277,7 @@ def test_dual_plan_construction_and_dispatch():
+         assert runtime["parity_rows"] == 128
+         assert runtime["xh"].shape[0] == 128
+         assert runtime["token_sorted"].numel() == 128 * TOPK
++        assert runtime["prefill_capacity"] == 128
+ 
+         # Batches above the scheduler contract must fail before allocating a
+         # replacement runtime or a larger Trellis arena during serving.
+@@ -204,6 +294,73 @@ def test_dual_plan_construction_and_dispatch():
+         assert len(h.planned_caps()) == plan_count
+ 
+ 
++@pytest.mark.parametrize(
++    ("rows", "expected_slice_rows"),
++    ((127, [127]), (128, [128]), (129, [128, 1])),
++)
++def test_prefill_capacity_boundaries_preserve_rows_and_routing(
++    rows, expected_slice_rows
++):
++    with _Harness(env={"VLLM_EXL3_PREFILL_CAPACITY": "128"}) as h:
++        method = _make_method()
++        layer = _make_layer()
++        x = torch.arange(rows, dtype=torch.bfloat16).unsqueeze(1).expand(-1, HIDDEN)
++        weights = torch.arange(rows * TOPK, dtype=torch.float32).reshape(rows, TOPK)
++        ids = torch.arange(rows * TOPK, dtype=torch.int64).reshape(rows, TOPK)
++        ids = ids.remainder(EXPERTS)
++
++        out = method._apply_rank_sliced(layer, x, weights, ids)
++
++        assert [bound[1] for bound in h.api.bound] == expected_slice_rows
++        assert torch.equal(out, x)
++        assert torch.equal(torch.cat([route[0] for route in h.api.routed]), weights)
++        assert torch.equal(torch.cat([route[1] for route in h.api.routed]), ids)
++        assert all(bound[0] is h.api.bound[0][0] for bound in h.api.bound)
++
++
++def test_default_prefill_capacity_keeps_single_dispatch():
++    with _Harness() as h:
++        out = _apply(_make_method(), _make_layer(), 200)
++
++        assert h.planned_caps()[-1]["max_tokens"] == MAX_BATCHED
++        assert [bound[1] for bound in h.api.bound] == [200]
++        assert out.shape == (200, HIDDEN)
++
++
++def test_mixed_prefill_capacity_slices_rows_and_routing():
++    with _Harness(env={"VLLM_EXL3_PREFILL_CAPACITY": "128"}) as h:
++        method = _make_method()
++        layer = _make_mixed_layer()
++        rows = 200
++        x = torch.arange(rows, dtype=torch.bfloat16).unsqueeze(1).expand(-1, HIDDEN)
++        weights = torch.arange(rows * TOPK, dtype=torch.float32).reshape(rows, TOPK)
++        ids = torch.arange(rows * TOPK, dtype=torch.int64).reshape(rows, TOPK)
++        ids = ids.remainder(EXPERTS)
++
++        out = method._apply_rank_sliced(layer, x, weights, ids)
++
++        assert [launch.size_m for launch in h.mixed_api.compiled] == [32]
++        assert [caps["max_tokens"] for caps in h.planned_caps()] == [128, 128]
++        assert [bound[1] for bound in h.api.bound] == [128, 128, 72, 72]
++        assert torch.equal(out, x)
++        assert torch.equal(
++            torch.cat([route[0] for route in h.api.routed[::2]]), weights
++        )
++        assert torch.equal(torch.cat([route[1] for route in h.api.routed[::2]]), ids)
++        assert all(
++            torch.equal(left[0], right[0]) and torch.equal(left[1], right[1])
++            for left, right in zip(h.api.routed[::2], h.api.routed[1::2], strict=True)
++        )
++
++
++def test_prefill_capacity_cannot_exceed_scheduler_bound():
++    env = {"VLLM_EXL3_PREFILL_CAPACITY": str(MAX_BATCHED + 1)}
++    with _Harness(env=env) as h:
++        with pytest.raises(ValueError, match="cannot exceed max_num_batched_tokens"):
++            _apply(_make_method(), _make_layer(), 16)
++        assert not h.planned_caps()
++
++
+ def test_prefill_trellis_disabled_restores_parity():
+     with _Harness(env={"VLLM_EXL3_PREFILL_TRELLIS": "0"}) as h:
+         method = _make_method()
+@@ -221,16 +378,19 @@ def test_prefill_trellis_disabled_restores_parity():
+         runtime = next(iter(exl3_module._RANK_SLICED_RUNTIMES.values()))
+         assert runtime["prefill_plan"] is None
+         assert runtime["parity_rows"] == MAX_BATCHED
+-        assert runtime["xh"].shape[0] == MAX_BATCHED
+ 
+ 
+ def test_prefill_block_m_env_override():
+-    with _Harness(env={"VLLM_EXL3_PREFILL_BLOCK_M": "48"}) as h:
++    env = {
++        "VLLM_EXL3_PREFILL_BLOCK_M": "48",
++        "VLLM_EXL3_PREFILL_CAPACITY": "128",
++    }
++    with _Harness(env=env) as h:
+         method = _make_method()
+         layer = _make_layer()
+         _apply(method, layer, 40)
+         assert h.planned_caps()[-1]["w4a16_block_size_m"] == 48
+-        assert h.api.bound[-1][0].caps["max_tokens"] == MAX_BATCHED
++        assert h.api.bound[-1][0].caps["max_tokens"] == 128
+ 
+ 
+ def test_parity_window_capacity_is_validated_before_planning():
+@@ -259,7 +419,11 @@ def test_disabled_prefill_plan_keeps_full_parity_capacity():
+ 
+ 
+ def test_explicit_parity_path_guarded_against_capture():
+-    with _Harness(env={"VLLM_EXL3_TRELLIS_MIN_M": "4"}) as h:
++    env = {
++        "VLLM_EXL3_TRELLIS_MIN_M": "4",
++        "VLLM_EXL3_PREFILL_CAPACITY": "128",
++    }
++    with _Harness(env=env) as h:
+         method = _make_method()
+         layer = _make_layer()
+         # Plan eagerly, then flip into "capturing" state.
+@@ -268,18 +432,14 @@ def test_explicit_parity_path_guarded_against_capture():
+         # Both trellis plans stay capture-safe.
+         _apply(method, layer, 16)
+         _apply(method, layer, 200)
+-        assert h.api.bound[-1][1] == 200
++        assert [bound[1] for bound in h.api.bound[-2:]] == [128, 72]
+         # The eager parity path must refuse to be recorded.
+-        try:
++        with pytest.raises(RuntimeError, match="capture"):
+             _apply(method, layer, 2)
+-        except RuntimeError as err:
+-            assert "capture" in str(err)
+-        else:
+-            raise AssertionError("parity path must raise during capture")
+ 
+ 
+ if __name__ == "__main__":
+-    test_dual_plan_construction_and_dispatch()
++    test_opt_in_prefill_capacity_slices_dispatch()
+     test_prefill_trellis_disabled_restores_parity()
+     test_prefill_block_m_env_override()
+     test_explicit_parity_path_guarded_against_capture()
+diff --git a/tests/v1/cudagraph/test_breakable_cudagraph.py b/tests/v1/cudagraph/test_breakable_cudagraph.py
+index 72a9a11d3cb81cf388b7a42fc7ba7af68ae9a288..aedc99a1787da628151a439d96f7d175cce94649 100644
+--- a/tests/v1/cudagraph/test_breakable_cudagraph.py
++++ b/tests/v1/cudagraph/test_breakable_cudagraph.py
+@@ -99,6 +99,7 @@ def test_memory_profile_reuses_production_pool_and_destroys_graphs(monkeypatch):
+         def capture(self, *args, **kwargs):
+             assert self.pool is production_pool
+             assert wrapper.graph_pool is production_pool
++            assert kwargs["channel_id"] == "vllm:target:profile"
+             lazy_wrapper = FakeWrapper()
+             lazy_wrapper.graph_pool = self.pool
+             lazy_wrappers.append(lazy_wrapper)
+@@ -112,8 +113,9 @@ def test_memory_profile_reuses_production_pool_and_destroys_graphs(monkeypatch):
+         def get_cudagraph_managers(self):
+             return []
+ 
+-        def capture(self):
++        def capture(self, *, capture_phase):
+             assert workspace_module._workspace_lane.get() == 1
++            assert capture_phase == "profile"
+             events.append("spec_capture")
+ 
+     manager = FakeManager()
+@@ -235,6 +237,7 @@ def test_production_capture_releases_pool_anchor_on_failure(monkeypatch):
+ 
+         @staticmethod
+         def capture(*args, **kwargs):
++            assert kwargs["channel_id"] == "vllm:target:production"
+             events.append("capture")
+             raise RuntimeError("capture failed")
+ 
+@@ -269,6 +272,60 @@ def test_production_capture_releases_pool_anchor_on_failure(monkeypatch):
+     assert events == ["capture", "anchor_reset"]
+ 
+ 
++def test_production_capture_assigns_target_and_draft_phase_ids(monkeypatch):
++    from vllm.v1.worker.gpu import model_runner as model_runner_module
++
++    events = []
++
++    class FakeManager:
++        @staticmethod
++        def needs_capture():
++            return True
++
++        @staticmethod
++        def capture(*args, **kwargs):
++            events.append(("target", kwargs["channel_id"]))
++
++    class FakeSpeculator:
++        @staticmethod
++        def capture(*, capture_phase):
++            events.append(("draft", capture_phase))
++
++    runner = model_runner_module.GPUModelRunner.__new__(
++        model_runner_module.GPUModelRunner
++    )
++    runner.cudagraph_manager = FakeManager()
++    runner._cudagraph_pool_anchor = None
++    runner.lora_config = None
++    runner.model = object()
++    runner.model_state = object()
++    runner.input_buffers = object()
++    runner.intermediate_tensors = object()
++    runner.block_tables = object()
++    runner.attn_groups = object()
++    runner.kv_cache_config = object()
++    runner.use_aux_hidden_state_outputs = False
++    runner.speculator = FakeSpeculator()
++    runner.maybe_setup_dummy_loras = lambda _: nullcontext()
++    runner._zero_cudagraph_capture_kv_blocks = lambda: None
++
++    monkeypatch.setattr(model_runner_module.gc, "collect", lambda: None)
++    monkeypatch.setattr(torch.accelerator, "empty_cache", lambda: None)
++    monkeypatch.setattr(
++        torch.accelerator,
++        "get_memory_info",
++        lambda: (1000, 0),
++    )
++    monkeypatch.setattr(model_runner_module, "lock_workspace", lambda: None)
++
++    runner.capture_model()
++
++    assert events == [
++        ("target", "vllm:target:production"),
++        ("draft", "production"),
++    ]
++
++
+ def test_skipped_production_capture_releases_pool_anchor():
+     from vllm.v1.worker.gpu import model_runner as model_runner_module
+ 
+@@ -372,13 +429,21 @@ def test_piecewise_capture_builds_fresh_metadata_for_both_passes():
+         patch(
+             "vllm.v1.worker.gpu.cudagraph_utils.graph_capture",
+             return_value=nullcontext(),
+-        ),
++        ) as graph_capture_mock,
+         patch(
+             "vllm.v1.worker.gpu.cudagraph_utils.is_global_first_rank",
+             return_value=False,
+         ),
+     ):
+-        manager.capture(create_forward_fn)
++        manager.capture(
++            create_forward_fn,
++            channel_id="vllm:target:profile",
++        )
++
++    graph_capture_mock.assert_called_once_with(
++        device=torch.device("cpu"),
++        channel_id="vllm:target:profile",
++    )
+ 
+     assert [warmup for warmup, _ in create_calls] == [True, False]
+     assert [mode for _, mode, _ in forward_calls] == [
+diff --git a/tests/v1/kv_connector/unit/offloading_connector/test_scheduler.py b/tests/v1/kv_connector/unit/offloading_connector/test_scheduler.py
+index c783957de6717a633d46e78f210735fc6dfacd45..90800361815b1cc1ac541011b411e4d0206fe97f 100644
+--- a/tests/v1/kv_connector/unit/offloading_connector/test_scheduler.py
++++ b/tests/v1/kv_connector/unit/offloading_connector/test_scheduler.py
+@@ -1783,6 +1783,288 @@ def test_swa_alignment_skip(request_runner, async_scheduling: bool):
+     )
+ 
+ 
++@pytest.mark.parametrize("async_scheduling", [True, False])
++def test_swa_alignment_skip_eagle(request_runner, async_scheduling: bool):
++    """EAGLE/MTP SWA groups store their per-segment tail run shifted one
++    block past the segment boundary.
++
++    _lookup requires sliding_window_size_in_chunks + 1 consecutive stored
++    blocks for eagle groups (the "+1 peek" block, dropped after matching).
++    Mirroring SlidingWindowManager.reachable_block_mask (shift=1), the store
++    path retains a run of tail + 1 blocks ending one block PAST each segment
++    boundary, so the post-drop hit lands exactly on the boundary.
++
++    Setup:
++      - Group 0: full attention, block_size=16
++      - Group 1: SWA + eagle, block_size=4, sliding_window=8
++
++    alignment_chunk_count = 16 / 4 = 4, tail = 2, need = 3 (incl. peek).
++    Reachable block positions: {2, 3, 4} and {6, 7, 8} (shifted by one).
++
++    With a 36-token prompt (2 full full-attn blocks, 9 SWA blocks):
++      - Group 0 stores: blocks 0, 1
++      - Group 1 stores: blocks 2, 3, 4, 6, 7, 8
++
++    A replay then hits exactly 32 tokens (the second segment boundary): the
++    eagle lookup matches the run [6, 7, 8], drops peek block 8, and the
++    load fetches window blocks [6, 7].
++    """
++    full_attn_block_size = 16
++    swa_block_size = 4
++    sliding_window = 8
++    num_gpu_blocks = 200
++
++    kv_cache_groups = [
++        KVCacheGroupSpec(
++            ["layer0"],
++            FullAttentionSpec(
++                block_size=full_attn_block_size,
++                num_kv_heads=1,
++                head_size=1,
++                dtype=torch.float32,
++            ),
++        ),
++        KVCacheGroupSpec(
++            ["layer1"],
++            SlidingWindowSpec(
++                block_size=swa_block_size,
++                num_kv_heads=1,
++                head_size=1,
++                dtype=torch.float32,
++                sliding_window=sliding_window,
++            ),
++            is_eagle_group=True,
++        ),
++    ]
++
++    runner = request_runner(
++        block_size=swa_block_size,
++        num_gpu_blocks=num_gpu_blocks,
++        async_scheduling=async_scheduling,
++        kv_cache_groups=kv_cache_groups,
++    )
++
++    kv_group_configs = runner.connector_scheduler.config.kv_group_configs
++    assert kv_group_configs[1].is_eagle_group
++    assert kv_group_configs[1].alignment_chunk_count == 4
++    assert kv_group_configs[1].sliding_window_size_in_chunks == 2
++    # No sparse retention -> no per-request replay tail.
++    assert runner.connector_scheduler.config.replay_alignment_tokens is None
++
++    # Track stored keys so lookups reflect the actual store-side filtering.
++    stored_keys: set = set()
++
++    def _prepare_store(keys, req_context):
++        keys = list(keys)
++        stored_keys.update(keys)
++        return generate_store_output(keys)
++
++    runner.manager.prepare_store.side_effect = _prepare_store
++    runner.manager.lookup.side_effect = lambda key, req_context: (
++        LookupResult.HIT if key in stored_keys else LookupResult.MISS
++    )
++
++    num_tokens = 36
++    runner.new_request(token_ids=[0] * num_tokens)
++    runner.run(decoded_tokens=[0])
++    runner.run(
++        decoded_tokens=[EOS_TOKEN_ID],
++        expected_stored=(
++            (0, 0),
++            (0, 1),
++            (1, 2),
++            (1, 3),
++            (1, 4),
++            (1, 6),
++            (1, 7),
++            (1, 8),
++        ),
++    )
++
++    # Replay the same prompt; the eagle group must hit exactly at the
++    # 32-token segment boundary via the shifted run [6, 7, 8].
++    runner.scheduler.reset_prefix_cache()
++    # Avoid re-storing the (unloaded) peek block during the replay.
++    runner.manager.prepare_store.side_effect = lambda keys, req_context: (
++        generate_store_output([])
++    )
++    runner.new_request(token_ids=[0] * num_tokens)
++    runner.run(
++        decoded_tokens=[EOS_TOKEN_ID],
++        expected_loaded=(
++            (0, 0),
++            (0, 1),
++            (1, 6),
++            (1, 7),
++        ),
++    )
++
++
++@pytest.mark.parametrize("async_scheduling", [True, False])
++def test_swa_alignment_retention_interval(
++    request_runner, monkeypatch, async_scheduling: bool
++):
++    """VLLM_PREFIX_CACHE_RETENTION_INTERVAL sets the sparsity segment size,
++    and a per-request replay-boundary tail keeps exact replays servable.
++
++    Mirrors SlidingWindowManager.reachable_block_mask: with sparse retention
++    the local GPU cache keeps SWA tails once per retention interval (not at
++    every full-attention block boundary), plus one tail run at the latest
++    full-attention-aligned boundary of the prompt (the "replay boundary") so
++    a replay of the same prompt does not fall back a whole retention segment.
++
++    Setup:
++      - retention interval = 32 tokens
++      - Group 0: full attention, block_size=16
++      - Group 1: SWA, block_size=4, sliding_window=8
++
++    alignment_chunk_count = 32 / 4 = 8 (retention-based, not 16 / 4 = 4).
++
++    With a 56-token prompt (3 full full-attn blocks, 14 SWA blocks):
++      - segment tails: blocks {6, 7} (the second segment is incomplete:
++        blocks 14, 15 never fill)
++      - replay boundary: (56 - 1) // 16 * 16 = 48 -> tail run {10, 11}
++      - Group 1 stores: blocks 6, 7, 10, 11
++
++    A replay of the prompt hits 48 tokens via the replay tail {10, 11};
++    without it, the hit would fall back to 32 (the only segment boundary).
++    """
++    monkeypatch.setenv("VLLM_PREFIX_CACHE_RETENTION_INTERVAL", "32")
++
++    full_attn_block_size = 16
++    swa_block_size = 4
++    sliding_window = 8
++    num_gpu_blocks = 200
++
++    kv_cache_groups = [
++        KVCacheGroupSpec(
++            ["layer0"],
++            FullAttentionSpec(
++                block_size=full_attn_block_size,
++                num_kv_heads=1,
++                head_size=1,
++                dtype=torch.float32,
++            ),
++        ),
++        KVCacheGroupSpec(
++            ["layer1"],
++            SlidingWindowSpec(
++                block_size=swa_block_size,
++                num_kv_heads=1,
++                head_size=1,
++                dtype=torch.float32,
++                sliding_window=sliding_window,
++            ),
++        ),
++    ]
++
++    runner = request_runner(
++        block_size=swa_block_size,
++        num_gpu_blocks=num_gpu_blocks,
++        async_scheduling=async_scheduling,
++        kv_cache_groups=kv_cache_groups,
++    )
++
++    config = runner.connector_scheduler.config
++    # Segment granularity comes from the retention interval.
++    assert config.kv_group_configs[1].alignment_chunk_count == 8
++    assert config.kv_group_configs[1].sliding_window_size_in_chunks == 2
++    # Replay tails align to the full-attention block size.
++    assert config.replay_alignment_tokens == full_attn_block_size
++
++    # Track stored keys so lookups reflect the actual store-side filtering.
++    stored_keys: set = set()
++
++    def _prepare_store(keys, req_context):
++        keys = list(keys)
++        stored_keys.update(keys)
++        return generate_store_output(keys)
++
++    runner.manager.prepare_store.side_effect = _prepare_store
++    runner.manager.lookup.side_effect = lambda key, req_context: (
++        LookupResult.HIT if key in stored_keys else LookupResult.MISS
++    )
++
++    num_tokens = 56
++    runner.new_request(token_ids=[0] * num_tokens)
++    runner.run(decoded_tokens=[0])
++    runner.run(
++        decoded_tokens=[EOS_TOKEN_ID],
++        expected_stored=(
++            (0, 0),
++            (0, 1),
++            (0, 2),
++            (1, 6),
++            (1, 7),
++            (1, 10),
++            (1, 11),
++        ),
++    )
++
++    # Replay the same prompt; the hit must reach the 48-token replay
++    # boundary served by the replay tail run {10, 11}.
++    runner.scheduler.reset_prefix_cache()
++    runner.manager.prepare_store.side_effect = lambda keys, req_context: (
++        generate_store_output([])
++    )
++    runner.new_request(token_ids=[0] * num_tokens)
++    runner.run(
++        decoded_tokens=[EOS_TOKEN_ID],
++        expected_loaded=(
++            (0, 0),
++            (0, 1),
++            (0, 2),
++            (1, 10),
++            (1, 11),
++        ),
++    )
++
++
++def test_swa_alignment_retains_shared_prefix_boundary(request_runner, monkeypatch):
++    """Native offload retains the same sparse shared-prefix tail as APC."""
++    monkeypatch.setenv("VLLM_PREFIX_CACHE_RETENTION_INTERVAL", "64")
++
++    kv_cache_groups = [
++        KVCacheGroupSpec(
++            ["layer0"],
++            FullAttentionSpec(
++                block_size=16,
++                num_kv_heads=1,
++                head_size=1,
++                dtype=torch.float32,
++            ),
++        ),
++        KVCacheGroupSpec(
++            ["layer1"],
++            SlidingWindowSpec(
++                block_size=4,
++                num_kv_heads=1,
++                head_size=1,
++                dtype=torch.float32,
++                sliding_window=8,
++            ),
++        ),
++    ]
++    runner = request_runner(
++        block_size=4,
++        num_gpu_blocks=200,
++        async_scheduling=False,
++        kv_cache_groups=kv_cache_groups,
++    )
++
++    runner.new_request(token_ids=[0] * 56)
++    request = runner.scheduler.requests[str(runner.req_id)]
++    request.shared_prefix_boundary = 32
++
++    group_config = runner.connector_scheduler.config.kv_group_configs[1]
++    assert runner.connector_scheduler._reachable_tail_end_chunks(
++        group_config, request, shift=0
++    ) == (
++        12,  # Latest replay boundary: floor((56 - 1) / 16) * 16 / 4.
++        8,  # Shared-prefix junction: 32 / 4.
++    )
++
++
+ @pytest.mark.parametrize("async_scheduling", [True, False])
+ def test_stale_sliding_window_block_after_prepare_store_failure(
+     request_runner, async_scheduling: bool
+diff --git a/tests/v1/kv_offload/test_factory.py b/tests/v1/kv_offload/test_factory.py
+index 98191db57b735fba639f7e809ac85a47645c2482..663debbfdedaee38b23fc4bc4f39dbe0bc3b25eb 100644
+--- a/tests/v1/kv_offload/test_factory.py
++++ b/tests/v1/kv_offload/test_factory.py
+@@ -328,7 +328,8 @@ def test_create_cpu_offloading_spec_end_to_end():
+ 
+ @pytest.mark.parametrize("packed", [False, True])
+ def test_cpu_spec_sizing_preserves_tensor_layout(packed: bool):
+-    cpu_bytes_to_use = 1920
++    alignment = SharedOffloadRegion.BLOCK_SIZE_ALIGNMENT
++    cpu_bytes_to_use = alignment * 3
+     config = _make_layout_vllm_config(
+         cpu_bytes_to_use=cpu_bytes_to_use,
+         extra_config={"block_size": 32},
+@@ -340,8 +341,83 @@ def test_cpu_spec_sizing_preserves_tensor_layout(packed: bool):
+ 
+     assert isinstance(spec, CPUOffloadingSpec)
+     assert spec.cpu_page_size_per_worker == 32
+-    assert spec.kv_bytes_per_chunk == 192
+-    assert spec.num_blocks == cpu_bytes_to_use // 192
++    assert spec.kv_bytes_per_chunk == alignment
++    assert spec.num_blocks == 3
++
++
++def test_cpu_spec_create_worker_uses_shared_region_on_cuda(monkeypatch):
++    import vllm.v1.kv_offload.cpu.spec as cpu_spec_module
++
++    alignment = SharedOffloadRegion.BLOCK_SIZE_ALIGNMENT
++    config = _make_layout_vllm_config(
++        cpu_bytes_to_use=alignment * 2,
++        tensor_parallel_size=4,
++    )
++    spec = _create_spec(config, _make_sizing_kv_cache_config(packed=False))
++    assert isinstance(spec, CPUOffloadingSpec)
++
++    region = MagicMock()
++    region_ctor = MagicMock(return_value=region)
++    worker_ctor = MagicMock(return_value=MagicMock())
++    monkeypatch.setattr(cpu_spec_module.current_platform, "is_cuda_alike", lambda: True)
++    monkeypatch.setattr(cpu_spec_module, "SharedOffloadRegion", region_ctor)
++    monkeypatch.setattr(cpu_spec_module, "CPUOffloadingWorker", worker_ctor)
++    monkeypatch.setattr(
++        cpu_spec_module.torch.accelerator, "current_device_index", lambda: 5
++    )
++
++    kv_caches = MagicMock()
++    spec.create_worker(kv_caches)
++
++    region_ctor.assert_called_once_with(
++        engine_id=spec.config.engine_id,
++        num_blocks=spec.num_blocks,
++        rank=1,
++        kv_bytes_per_block=spec.kv_bytes_per_chunk,
++        cpu_page_size=spec.cpu_page_size_per_worker,
++    )
++    worker_ctor.assert_called_once_with(
++        kv_caches=kv_caches,
++        blocks_per_chunk=spec.blocks_per_chunk,
++        num_cpu_blocks=spec.num_blocks,
++        mmap_region=region,
++    )
++
++
++@pytest.mark.parametrize("num_blocks", [0, 2])
++def test_cpu_spec_create_worker_keeps_tensor_path_without_cuda_or_blocks(
++    monkeypatch, num_blocks: int
++):
++    import vllm.v1.kv_offload.cpu.spec as cpu_spec_module
++
++    alignment = SharedOffloadRegion.BLOCK_SIZE_ALIGNMENT
++    config = _make_layout_vllm_config(cpu_bytes_to_use=alignment * 2)
++    kv_cache_config = _make_sizing_kv_cache_config(packed=False)
++    if num_blocks == 0:
++        kv_cache_config.num_blocks = 0
++    spec = _create_spec(config, kv_cache_config)
++    assert isinstance(spec, CPUOffloadingSpec)
++
++    region_ctor = MagicMock()
++    worker_ctor = MagicMock(return_value=MagicMock())
++    monkeypatch.setattr(
++        cpu_spec_module.current_platform,
++        "is_cuda_alike",
++        lambda: num_blocks == 0,
++    )
++    monkeypatch.setattr(cpu_spec_module, "SharedOffloadRegion", region_ctor)
++    monkeypatch.setattr(cpu_spec_module, "CPUOffloadingWorker", worker_ctor)
++
++    kv_caches = MagicMock()
++    spec.create_worker(kv_caches)
++
++    region_ctor.assert_not_called()
++    worker_ctor.assert_called_once_with(
++        kv_caches=kv_caches,
++        blocks_per_chunk=spec.blocks_per_chunk,
++        num_cpu_blocks=spec.num_blocks,
++        mmap_region=None,
++    )
+ 
+ 
+ def test_cpu_spec_rejects_partially_packed_tensor_layout():
+diff --git a/tests/v1/spec_decode/test_dflash_cudagraph_lifetime.py b/tests/v1/spec_decode/test_dflash_cudagraph_lifetime.py
+index 11fb1b66e85b09cf4f5cb74ee88a19c87dbd6a3a..89e5e79d0af63f12f19b69c50f0cdadaab030815 100644
+--- a/tests/v1/spec_decode/test_dflash_cudagraph_lifetime.py
++++ b/tests/v1/spec_decode/test_dflash_cudagraph_lifetime.py
+@@ -63,3 +63,34 @@ def test_dflash_does_not_retain_eager_backbone_output(monkeypatch):
+     )
+ 
+     assert speculator._captured_backbone_outputs == []
++
++
++def test_dflash_capture_uses_phase_specific_draft_channel_ids():
++    events = []
++
++    class FakeManager:
++        def capture(self, *args, **kwargs):
++            events.append(kwargs["channel_id"])
++
++    speculator = SimpleNamespace(
++        _speculator_name="DFlash",
++        sample_indices=torch.zeros(1),
++        sample_pos=torch.zeros(1),
++        sample_idx_mapping=torch.zeros(1),
++        query_cudagraph_manager=FakeManager(),
++        _generate_draft=object(),
++        input_buffers=object(),
++        block_tables=object(),
++        attn_groups=object(),
++        kv_cache_config=object(),
++        max_model_len=1,
++        _group_causal=True,
++    )
++
++    DFlashSpeculator.capture(speculator, capture_phase="profile")
++    DFlashSpeculator.capture(speculator, capture_phase="production")
++
++    assert events == [
++        "vllm:draft:dflash:profile",
++        "vllm:draft:dflash:production",
++    ]
+diff --git a/tests/v1/worker/test_gpu_autoregressive_speculator.py b/tests/v1/worker/test_gpu_autoregressive_speculator.py
+index 89dc32ee4c68d96afc57d5e2c380657364a9f4fe..53772397b56d3dd810ac4ce4f02f23079c75d45d 100644
+--- a/tests/v1/worker/test_gpu_autoregressive_speculator.py
++++ b/tests/v1/worker/test_gpu_autoregressive_speculator.py
+@@ -166,3 +166,42 @@ def test_ar_probabilistic_draft_uses_shared_sampler(monkeypatch):
+ 
+     assert captured["positions"] is positions
+     assert captured["active_rows"] is speculator.active_num_reqs
++
++
++def test_autoregressive_capture_ids_are_deterministic_and_phase_separated():
++    def capture_channel_ids() -> list[str]:
++        events = []
++
++        class FakeManager:
++            use_breakable_cg = False
++
++            def capture(self, *args, **kwargs):
++                events.append(kwargs["channel_id"])
++
++        speculator = object.__new__(_TestSpeculator)
++        speculator.last_token_indices = torch.zeros(1)
++        speculator.prefill_cudagraph_manager = FakeManager()
++        speculator.decode_cudagraph_manager = FakeManager()
++        speculator.model = object()
++        speculator._prefill = object()
++        speculator._generate_draft = object()
++        speculator.model_state = object()
++        speculator.target_input_buffers = object()
++        speculator.input_buffers = object()
++        speculator.block_tables = object()
++        speculator.target_attn_groups = object()
++        speculator.attn_groups = object()
++        speculator.kv_cache_config = object()
++        speculator.num_speculative_steps = 3
++
++        speculator.capture(capture_phase="profile")
++        speculator.capture(capture_phase="production")
++        return events
++
++    expected = [
++        "vllm:draft:prefill:profile",
++        "vllm:draft:decode:profile",
++        "vllm:draft:prefill:production",
++        "vllm:draft:decode:production",
++    ]
++    assert capture_channel_ids() == capture_channel_ids() == expected
+diff --git a/tests/v1/worker/test_gpu_model_runner.py b/tests/v1/worker/test_gpu_model_runner.py
+index 254432312cb3209f44a504e389a67ef8a382f46d..e341d2cbe7b469d6a1e120364a7a987891c5bc54 100644
+--- a/tests/v1/worker/test_gpu_model_runner.py
++++ b/tests/v1/worker/test_gpu_model_runner.py
+@@ -1,6 +1,7 @@
+ # SPDX-License-Identifier: Apache-2.0
+ # SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+ 
++from contextlib import contextmanager, nullcontext
+ from types import SimpleNamespace
+ from unittest.mock import Mock
+ 
+@@ -12,6 +13,7 @@ import vllm.v1.worker.gpu_model_runner as gpu_model_runner_module
+ from vllm.config import (
+     AttentionConfig,
+     CacheConfig,
++    CUDAGraphMode,
+     ModelConfig,
+     ParallelConfig,
+     SchedulerConfig,
+@@ -1779,3 +1781,367 @@ def test_mamba_cache_raises_when_max_num_seqs_exceeds_blocks():
+ 
+         with pytest.raises(ValueError, match="max_num_seqs"):
+             runner.initialize_kv_cache(kv_cache_config)
++
++
++def test_v1_capture_separates_target_and_draft_semantic_channels(monkeypatch):
++    runner = GPUModelRunner.__new__(GPUModelRunner)
++    runner.compilation_config = SimpleNamespace(cudagraph_mode=CUDAGraphMode.PIECEWISE)
++    runner.speculative_config = SimpleNamespace(
++        enforce_eager=False,
++        use_eagle=lambda: False,
++        uses_draft_model=lambda: True,
++        uses_extract_hidden_states=lambda: False,
++    )
++    runner.cudagraph_dispatcher = SimpleNamespace(
++        get_capture_descs=lambda: [
++            (CUDAGraphMode.FULL, []),
++            (CUDAGraphMode.PIECEWISE, [object()]),
++        ]
++    )
++    runner.encoder_cudagraph_manager = None
++    runner.device = torch.device("cpu")
++    runner._maybe_init_encoder_cudagraph_manager = lambda: None
++    runner._freeze_gc = nullcontext
++
++    active_channel: list[str] = []
++    channel_entries: list[str] = []
++    captures: list[tuple[str, bool]] = []
++
++    @contextmanager
++    def fake_graph_capture(*, device, channel_id, **kwargs):
++        assert device == runner.device
++        active_channel.append(channel_id)
++        channel_entries.append(channel_id)
++        try:
++            yield SimpleNamespace(channel_id=channel_id)
++        finally:
++            assert active_channel.pop() == channel_id
++
++    def fake_capture_cudagraphs(*, run_drafter, **kwargs):
++        assert len(active_channel) == 1
++        captures.append((active_channel[0], run_drafter))
++
++    runner._capture_cudagraphs = fake_capture_cudagraphs
++    runner.encoder_cudagraph_manager = SimpleNamespace(
++        capture=lambda **_: captures.append((active_channel[0], True))
++    )
++    memory_info = iter(((1000, 0), (900, 0)))
++    monkeypatch.setattr(gpu_model_runner_module, "graph_capture", fake_graph_capture)
++    monkeypatch.setattr(
++        gpu_model_runner_module,
++        "set_cudagraph_capturing_enabled",
++        lambda _: None,
++    )
++    monkeypatch.setattr(gpu_model_runner_module, "lock_workspace", lambda: None)
++    monkeypatch.setattr(
++        gpu_model_runner_module,
++        "current_platform",
++        SimpleNamespace(graph_pool_handle=object),
++    )
++    monkeypatch.setattr(
++        torch.accelerator,
++        "synchronize",
++        lambda: None,
++    )
++    monkeypatch.setattr(torch.accelerator, "empty_cache", lambda: None)
++    monkeypatch.setattr(
++        torch.accelerator,
++        "get_memory_info",
++        lambda: next(memory_info),
++    )
++
++    assert runner.capture_model() == 100
++    assert captures == [
++        ("vllm:target:production", False),
++        ("vllm:draft:production", True),
++        ("vllm:encoder:production", True),
++    ]
++    assert channel_entries == [
++        "vllm:target:production",
++        "vllm:draft:production",
++        "vllm:encoder:production",
++    ]
++
++
++def test_v1_full_capture_without_speculation_is_target_only(monkeypatch):
++    runner = GPUModelRunner.__new__(GPUModelRunner)
++    runner.compilation_config = SimpleNamespace(cudagraph_mode=CUDAGraphMode.FULL)
++    runner.speculative_config = None
++    runner.cudagraph_dispatcher = SimpleNamespace(
++        get_capture_descs=lambda: [(CUDAGraphMode.FULL, [object()])]
++    )
++    runner.encoder_cudagraph_manager = None
++    runner.device = torch.device("cpu")
++    runner._maybe_init_encoder_cudagraph_manager = lambda: None
++    runner._freeze_gc = nullcontext
++
++    channels: list[str] = []
++    captures: list[bool] = []
++
++    @contextmanager
++    def fake_graph_capture(*, channel_id, **kwargs):
++        channels.append(channel_id)
++        yield SimpleNamespace(channel_id=channel_id)
++
++    runner._capture_cudagraphs = lambda *, run_drafter, **_: captures.append(
++        run_drafter
++    )
++    memory_info = iter(((1000, 0), (900, 0)))
++    monkeypatch.setattr(gpu_model_runner_module, "graph_capture", fake_graph_capture)
++    monkeypatch.setattr(
++        gpu_model_runner_module,
++        "set_cudagraph_capturing_enabled",
++        lambda _: None,
++    )
++    monkeypatch.setattr(gpu_model_runner_module, "lock_workspace", lambda: None)
++    monkeypatch.setattr(
++        torch.accelerator,
++        "synchronize",
++        lambda: None,
++    )
++    monkeypatch.setattr(torch.accelerator, "empty_cache", lambda: None)
++    monkeypatch.setattr(
++        torch.accelerator,
++        "get_memory_info",
++        lambda: next(memory_info),
++    )
++
++    assert runner.capture_model() == 100
++    assert channels == ["vllm:target:production"]
++    assert captures == [True]
++
++
++def test_v1_profile_rolls_back_distinct_target_and_draft_channels(monkeypatch):
++    runner = GPUModelRunner.__new__(GPUModelRunner)
++    runner.vllm_config = object()
++    runner.device = torch.device("cpu")
++    runner.speculative_config = SimpleNamespace(
++        enforce_eager=False,
++        use_eagle=lambda: False,
++        uses_draft_model=lambda: True,
++        uses_extract_hidden_states=lambda: False,
++    )
++    desc = SimpleNamespace(num_tokens=32)
++    runner.cudagraph_dispatcher = SimpleNamespace(
++        get_capture_descs=lambda: [
++            (CUDAGraphMode.FULL, []),
++            (CUDAGraphMode.PIECEWISE, [desc]),
++        ],
++        cudagraph_keys={},
++        keys_initialized=True,
++    )
++    runner.max_model_len = 4096
++    runner.max_num_tokens = 256
++    runner.lora_config = None
++    runner._freeze_gc = nullcontext
++    runner._init_minimal_kv_cache_for_profiling = lambda: None
++    runner._create_encoder_cudagraph_manager = lambda: None
++    runner.maybe_remove_all_loras = lambda _: None
++
++    events: list[object] = []
++    active_channel: list[str] = []
++
++    @contextmanager
++    def fake_graph_capture(*, device, channel_id, **kwargs):
++        assert device == runner.device
++        active_channel.append(channel_id)
++        events.append(("enter", channel_id))
++        try:
++            yield SimpleNamespace(channel_id=channel_id)
++        finally:
++            assert active_channel.pop() == channel_id
++            events.append(("exit", channel_id))
++
++    def fake_warmup_and_capture(*args, run_drafter, **kwargs):
++        assert len(active_channel) == 1
++        events.append(("capture", active_channel[0], run_drafter))
++
++    runner._warmup_and_capture = fake_warmup_and_capture
++    runner._cleanup_profiling_kv_cache = lambda: events.extend(
++        ("cleanup-sync", "cleanup")
++    )
++
++    checkpoint = ((lambda _: None, "checkpoint"),)
++
++    def checkpoint_graph_channels():
++        events.append("checkpoint")
++        return checkpoint
++
++    monkeypatch.setattr(
++        gpu_model_runner_module,
++        "checkpoint_b12x_graph_channels",
++        checkpoint_graph_channels,
++    )
++    monkeypatch.setattr(
++        gpu_model_runner_module,
++        "rollback_b12x_graph_channels",
++        lambda value: events.append(("rollback", value)),
++    )
++    monkeypatch.setattr(gpu_model_runner_module, "graph_capture", fake_graph_capture)
++    monkeypatch.setattr(
++        gpu_model_runner_module,
++        "set_current_vllm_config",
++        lambda _: nullcontext(),
++    )
++    monkeypatch.setattr(
++        gpu_model_runner_module,
++        "current_platform",
++        SimpleNamespace(
++            graph_pool_handle=object,
++            is_rocm=lambda: False,
++        ),
++    )
++    monkeypatch.setattr(
++        gpu_model_runner_module,
++        "set_cudagraph_capturing_enabled",
++        lambda enabled: events.append(("capture-enabled", enabled)),
++    )
++    monkeypatch.setattr(
++        gpu_model_runner_module.CUDAGraphWrapper,
++        "_all_instances",
++        [],
++    )
++    monkeypatch.setattr(
++        gpu_model_runner_module.BreakableCUDAGraphWrapper,
++        "_all_instances",
++        [],
++    )
++    monkeypatch.setattr(
++        gpu_model_runner_module.CUDAGraphWrapper,
++        "clear_all_graphs",
++        lambda: events.append("clear-target"),
++    )
++    monkeypatch.setattr(
++        gpu_model_runner_module.BreakableCUDAGraphWrapper,
++        "clear_all_graphs",
++        lambda: events.append("clear-breakable"),
++    )
++    memory_info = iter(((1000, 0), (900, 0), (900, 0), (800, 0)))
++    monkeypatch.setattr(
++        torch.accelerator,
++        "synchronize",
++        lambda: events.append("sync"),
++    )
++    monkeypatch.setattr(torch.accelerator, "empty_cache", lambda: None)
++    monkeypatch.setattr(
++        torch.accelerator,
++        "get_memory_info",
++        lambda: next(memory_info),
++    )
++
++    assert runner.profile_cudagraph_memory() == 200
++    assert ("capture", "vllm:target:profile", False) in events
++    assert ("capture", "vllm:draft:profile", True) in events
++    assert events.index("clear-target") < events.index("cleanup")
++    assert events.index("cleanup-sync") < events.index("cleanup")
++    assert events.index("cleanup") < events.index(("rollback", checkpoint))
++    assert events[-1] == ("rollback", checkpoint)
++
++
++@pytest.mark.parametrize("cleanup_fails", [False, True])
++def test_v1_profile_restores_state_when_capture_or_cleanup_fails(
++    monkeypatch,
++    cleanup_fails,
++):
++    runner = GPUModelRunner.__new__(GPUModelRunner)
++    runner.vllm_config = object()
++    runner.device = torch.device("cpu")
++    runner.speculative_config = None
++    desc = SimpleNamespace(num_tokens=32)
++    runner.cudagraph_dispatcher = SimpleNamespace(
++        get_capture_descs=lambda: [(CUDAGraphMode.FULL, [desc])],
++        cudagraph_keys={},
++        keys_initialized=True,
++    )
++    runner.max_model_len = 4096
++    runner.max_num_tokens = 256
++    runner.lora_config = None
++    runner._freeze_gc = nullcontext
++    runner._init_minimal_kv_cache_for_profiling = lambda: None
++    runner._create_encoder_cudagraph_manager = lambda: None
++    runner.maybe_remove_all_loras = lambda _: None
++
++    events: list[object] = []
++
++    @contextmanager
++    def fake_graph_capture(**kwargs):
++        yield SimpleNamespace(channel_id=kwargs["channel_id"])
++
++    def fail_capture(*args, **kwargs):
++        events.append("capture-failed")
++        raise RuntimeError("expected capture failure")
++
++    runner._warmup_and_capture = fail_capture
++    runner._cleanup_profiling_kv_cache = lambda: events.extend(
++        ("cleanup-sync", "cleanup")
++    )
++    checkpoint = ((lambda _: None, "checkpoint"),)
++
++    monkeypatch.setattr(
++        gpu_model_runner_module,
++        "checkpoint_b12x_graph_channels",
++        lambda: checkpoint,
++    )
++    monkeypatch.setattr(
++        gpu_model_runner_module,
++        "rollback_b12x_graph_channels",
++        lambda value: events.append(("rollback", value)),
++    )
++    monkeypatch.setattr(gpu_model_runner_module, "graph_capture", fake_graph_capture)
++    monkeypatch.setattr(
++        gpu_model_runner_module,
++        "set_current_vllm_config",
++        lambda _: nullcontext(),
++    )
++    monkeypatch.setattr(
++        gpu_model_runner_module,
++        "current_platform",
++        SimpleNamespace(graph_pool_handle=object, is_rocm=lambda: False),
++    )
++    monkeypatch.setattr(
++        gpu_model_runner_module,
++        "set_cudagraph_capturing_enabled",
++        lambda enabled: events.append(("capture-enabled", enabled)),
++    )
++    original_pool = object()
++    wrapper = SimpleNamespace(graph_pool=original_pool)
++    monkeypatch.setattr(
++        gpu_model_runner_module.CUDAGraphWrapper,
++        "_all_instances",
++        [wrapper],
++    )
++    monkeypatch.setattr(
++        gpu_model_runner_module.BreakableCUDAGraphWrapper,
++        "_all_instances",
++        [],
++    )
++
++    def clear_target_graphs():
++        events.append("clear-target")
++        if cleanup_fails:
++            raise RuntimeError("expected cleanup failure")
++
++    monkeypatch.setattr(
++        gpu_model_runner_module.CUDAGraphWrapper,
++        "clear_all_graphs",
++        clear_target_graphs,
++    )
++    monkeypatch.setattr(
++        gpu_model_runner_module.BreakableCUDAGraphWrapper,
++        "clear_all_graphs",
++        lambda: events.append("clear-breakable"),
++    )
++    monkeypatch.setattr(torch.accelerator, "synchronize", lambda: None)
++    monkeypatch.setattr(torch.accelerator, "empty_cache", lambda: None)
++    monkeypatch.setattr(torch.accelerator, "get_memory_info", lambda: (1000, 0))
++
++    expected_error = "expected cleanup failure" if cleanup_fails else "capture failure"
++    with pytest.raises(RuntimeError, match=expected_error):
++        runner.profile_cudagraph_memory()
++
++    assert wrapper.graph_pool is original_pool
++    if not cleanup_fails:
++        assert events.index("clear-target") < events.index("cleanup")
++        assert events.index("cleanup-sync") < events.index("cleanup")
++        assert events.index("cleanup") < events.index(("rollback", checkpoint))
++    assert events[-1] == ("rollback", checkpoint)
+diff --git a/vllm/distributed/device_communicators/cuda_communicator.py b/vllm/distributed/device_communicators/cuda_communicator.py
+index 82fa3723ed1030b01c303412ca594d8ed915e7ec..febdd95c4978af7c3b967eefc6d382b62b0d62a2 100644
+--- a/vllm/distributed/device_communicators/cuda_communicator.py
++++ b/vllm/distributed/device_communicators/cuda_communicator.py
+@@ -662,11 +662,14 @@ class CudaCommunicator(DeviceCommunicatorBase):
+             raise ValueError("No PyNCCL communicator found")
+ 
+     def destroy(self):
++        if self.ca_comm is not None:
++            # SparkInfer close is coordinated across ranks and must run before
++            # its NCCL exchange group is destroyed.
++            self.ca_comm.close()
++            self.ca_comm = None
+         if self.pynccl_comm is not None:
+             self.pynccl_comm.destroy()
+             self.pynccl_comm = None
+-        if self.ca_comm is not None:
+-            self.ca_comm = None
+         if self.aiter_ar_comm is not None:
+             self.aiter_ar_comm.close()
+             self.aiter_ar_comm = None
+diff --git a/vllm/distributed/device_communicators/custom_all_reduce.py b/vllm/distributed/device_communicators/custom_all_reduce.py
+index 1b4b4f0cfcc229ca7bd522298059ed32b1afab0e..9a252b34e60d9b72588cbb85c128207aadf36b90 100644
+--- a/vllm/distributed/device_communicators/custom_all_reduce.py
++++ b/vllm/distributed/device_communicators/custom_all_reduce.py
+@@ -31,6 +31,12 @@ except Exception:
+ 
+ logger = init_logger(__name__)
+ 
++# The eager scheduler has one stable all-reduce stream owner.  Never derive
++# this identity from a process-local CUDA stream handle; SparkInfer deliberately
++# fails closed if the same logical owner is rebound to a second eager stream.
++_B12X_PCIE_EAGER_CHANNEL_ID = "vllm:eager:allreduce"
++_B12X_PCIE_MAX_CONCURRENT_CHANNELS = 2
++
+ 
+ def _get_pcie_allreduce_backend() -> str:
+     backend = envs.VLLM_PCIE_ALLREDUCE_BACKEND.lower()
+@@ -488,8 +494,15 @@ class CustomAllreduce:
+                     eager_buffer_bytes=pcie_oneshot_buffer_size,
+                     max_size=pcie_oneshot_buffer_size,
+                     single_channel=pcie_single_channel,
++                    max_concurrent_channels=_B12X_PCIE_MAX_CONCURRENT_CHANNELS,
++                )
++                if not pcie_single_channel:
++                    pcie_runtime.prepare_channels((_B12X_PCIE_EAGER_CHANNEL_ID,))
++                pcie_runtime.for_stream(
++                    channel_id=(
++                        None if pcie_single_channel else _B12X_PCIE_EAGER_CHANNEL_ID
++                    )
+                 )
+-                pcie_runtime.for_stream()
+             except Exception as exc:
+                 pcie_init_error = exc
+ 
+@@ -655,12 +668,26 @@ class CustomAllreduce:
+         ops.register_buffer(self._ptr, self.buffer_ptrs)
+ 
+     @contextmanager
+-    def capture(self, stream: torch.cuda.Stream | None = None):
++    def capture(
++        self,
++        stream: torch.cuda.Stream | None = None,
++        *,
++        channel_id: str | None = None,
++    ):
+         """Bind communicator resources to the enclosing CUDA graph capture.
+ 
+         Legacy custom all-reduce registers graph buffers on exit. SparkInfer
+         PCIe channels are instead created on the graph's owning stream and
+         remain valid for the graph lifetime.
++
++        Args:
++            stream: CUDA stream owned by the enclosing graph capture.
++            channel_id: Stable identity shared by every rank for this graph
++                owner. Required when the SparkInfer PCIe runtime is active.
++
++        Raises:
++            RuntimeError: If the PCIe runtime is active and ``channel_id`` is
++                ``None``.
+         """
+         old_pcie_capture_stream = self._pcie_capture_stream
+         try:
+@@ -668,8 +695,16 @@ class CustomAllreduce:
+             if self._pcie_runtime is None:
+                 yield
+             else:
++                if channel_id is None:
++                    raise RuntimeError(
++                        "distributed PCIe graph capture requires an explicit "
++                        "semantic channel_id"
++                    )
+                 self._pcie_capture_stream = stream
+-                with self._pcie_runtime.capture(stream=stream):
++                with self._pcie_runtime.capture(
++                    stream=stream,
++                    channel_id=channel_id,
++                ):
+                     yield
+         finally:
+             self._pcie_capture_stream = old_pcie_capture_stream
+@@ -727,7 +762,8 @@ class CustomAllreduce:
+     def register_graph_buffers(self):
+         if self._pcie_runtime is not None:
+             self._pcie_runtime.for_stream(
+-                self._pcie_runtime_stream()
++                self._pcie_runtime_stream(),
++                channel_id=_B12X_PCIE_EAGER_CHANNEL_ID,
+             ).register_graph_buffers()
+             return
+         handle, offset = ops.get_graph_buffer_ipc_meta(self._ptr)
+@@ -757,7 +793,8 @@ class CustomAllreduce:
+                 self._pcie_allreduce_max_size is not None
+                 and inp_size <= self._pcie_allreduce_max_size
+                 and self._pcie_runtime.for_stream(
+-                    self._pcie_runtime_stream()
++                    self._pcie_runtime_stream(),
++                    channel_id=_B12X_PCIE_EAGER_CHANNEL_ID,
+                 ).should_allreduce(inp)
+             )
+             if (
+@@ -836,7 +873,10 @@ class CustomAllreduce:
+                     self._pcie_runtime_stream() is not None,
+                 )
+             return self._pcie_runtime.all_reduce(
+-                inp, out=out, stream=self._pcie_runtime_stream()
++                inp,
++                out=out,
++                stream=self._pcie_runtime_stream(),
++                channel_id=_B12X_PCIE_EAGER_CHANNEL_ID,
+             )
+         if out is None:
+             out = torch.empty_like(inp)
+@@ -878,7 +918,8 @@ class CustomAllreduce:
+             return False
+         assert self._pcie_runtime is not None
+         if not self._pcie_runtime.for_stream(
+-            self._pcie_runtime_stream()
++            self._pcie_runtime_stream(),
++            channel_id=_B12X_PCIE_EAGER_CHANNEL_ID,
+         ).should_allreduce(inp):
+             return False
+         if (
+@@ -905,6 +946,7 @@ class CustomAllreduce:
+             out=inp,
+             residual_out=residual,
+             stream=self._pcie_runtime_stream(),
++            channel_id=_B12X_PCIE_EAGER_CHANNEL_ID,
+         )
+         return True
+ 
+@@ -932,12 +974,12 @@ class CustomAllreduce:
+             return self.all_reduce(input, registered=False)
+ 
+     def close(self):
+-        if self._pcie_dma is not None:
+-            self._pcie_dma.close()
+-            self._pcie_dma = None
+         if self._pcie_runtime is not None:
+             self._pcie_runtime.close()
+             self._pcie_runtime = None
++        if self._pcie_dma is not None:
++            self._pcie_dma.close()
++            self._pcie_dma = None
+         if not self.disabled and self._ptr:
+             if ops is not None:
+                 ops.dispose(self._ptr)
+@@ -945,7 +987,16 @@ class CustomAllreduce:
+             self.free_shared_buffer(self.meta_ptrs, rank=self.rank)
+             self.free_shared_buffer(self.buffer_ptrs, rank=self.rank)
+ 
+-    def __del__(self):
++    def __del__(self) -> None:
++        # A finalizer cannot collectively close SparkInfer after another rank
++        # has exited or vLLM has destroyed the process group. The backend owns
++        # abnormal resource finalization; explicit close() is coordinated by
++        # CudaCommunicator.destroy() while both process groups are still live.
++        if (
++            getattr(self, "_pcie_runtime", None) is not None
++            or getattr(self, "_pcie_dma", None) is not None
++        ):
++            return
+         self.close()
+ 
+     @staticmethod
+diff --git a/vllm/distributed/kv_transfer/kv_connector/v1/offloading/scheduler.py b/vllm/distributed/kv_transfer/kv_connector/v1/offloading/scheduler.py
+index 0d15ec22fdf9fd5cb41245495b073b0b6388f9d2..dfc5cc6a2a952056e33371fb2bc4def61c424f75 100644
+--- a/vllm/distributed/kv_transfer/kv_connector/v1/offloading/scheduler.py
++++ b/vllm/distributed/kv_transfer/kv_connector/v1/offloading/scheduler.py
+@@ -6,6 +6,7 @@ from dataclasses import dataclass, field
+ from itertools import chain, islice
+ from typing import Any, NamedTuple
+ 
++import vllm.envs as envs
+ from vllm.config import VllmConfig
+ from vllm.distributed.kv_events import KVCacheEvent
+ from vllm.distributed.kv_transfer.kv_connector.utils import yield_req_data
+@@ -84,10 +85,11 @@ class GroupOffloadConfig(NamedTuple):
+     kv_event_group_spec: OffloadingEventGroupSpec
+     # None below means full attention
+     sliding_window_size_in_chunks: int | None
+-    # Number of this group's offloaded chunks per full-attention alignment
+-    # segment. Used to skip storing SWA chunks that can never serve a load
+-    # hit (e.g. DeepSeek V4 where SWA groups have much smaller block sizes
+-    # than the MLA full-attention group).
++    # Number of this group's offloaded chunks per sparsity segment (the
++    # full-attention alignment size, or VLLM_PREFIX_CACHE_RETENTION_INTERVAL
++    # when sparse retention is configured). Used to skip storing SWA chunks
++    # that can never serve a load hit (e.g. DeepSeek V4 where SWA groups have
++    # much smaller block sizes than the MLA full-attention group).
+     # None for full-attention groups or when the optimization doesn't apply.
+     alignment_chunk_count: int | None = None
+     # True for EAGLE/MTP draft-model attention groups. The trailing chunk
+@@ -136,6 +138,11 @@ class SchedulerOffloadConfig(NamedTuple):
+     blocks_per_chunk: int
+     num_workers: int
+     offload_prompt_only: bool
++    # Token alignment of the per-request "replay boundary" tail (see
++    # OffloadingConnectorScheduler._replay_tail_end_chunk). Set to the
++    # full-attention alignment size when sparse retention
++    # (VLLM_PREFIX_CACHE_RETENTION_INTERVAL) is enabled, else None.
++    replay_alignment_tokens: int | None = None
+ 
+     @classmethod
+     def from_spec(
+@@ -164,16 +171,34 @@ class SchedulerOffloadConfig(NamedTuple):
+         if len(full_attn_tokens_per_chunk) == 1:
+             alignment_tokens = full_attn_tokens_per_chunk.pop()
+ 
++        # Mirror SlidingWindowManager.reachable_block_mask's segment-size
++        # choice: with sparse retention (VLLM_PREFIX_CACHE_RETENTION_INTERVAL)
++        # the local GPU prefix cache keeps SWA tails once per retention
++        # segment rather than at every full-attention block boundary. Use the
++        # same granularity so stored tails sit exactly where lookups converge.
++        # An interval of 0 (latest-boundary-only retention) disables the
++        # store-side skip entirely (conservative: store all chunks).
++        retention_interval = envs.VLLM_PREFIX_CACHE_RETENTION_INTERVAL
++        segment_tokens: int | None = (
++            alignment_tokens
++            if retention_interval is None
++            else (None if retention_interval == 0 else retention_interval)
++        )
++
+         def _alignment_chunk_count(
+             tokens_per_chunk: int,
+             sliding_window_size_in_chunks: int | None,
++            is_eagle_group: bool,
+         ) -> int | None:
+-            if alignment_tokens is None or sliding_window_size_in_chunks is None:
++            if segment_tokens is None or sliding_window_size_in_chunks is None:
+                 return None
+-            if alignment_tokens <= tokens_per_chunk:
++            if segment_tokens <= tokens_per_chunk:
+                 return None
+-            per_segment = alignment_tokens // tokens_per_chunk
+-            if sliding_window_size_in_chunks >= per_segment:
++            per_segment = segment_tokens // tokens_per_chunk
++            # Contiguous chunks a hit needs at a segment boundary, including
++            # the "+1 peek" chunk for EAGLE/MTP groups (see _lookup).
++            need = sliding_window_size_in_chunks + (1 if is_eagle_group else 0)
++            if need >= per_segment:
+                 return None
+             return per_segment
+ 
+@@ -216,7 +241,9 @@ class SchedulerOffloadConfig(NamedTuple):
+                         )
+                     ),
+                     alignment_chunk_count=_alignment_chunk_count(
+-                        tokens_per_block * spec.blocks_per_chunk, sw
++                        tokens_per_block * spec.blocks_per_chunk,
++                        sw,
++                        idx in eagle_groups,
+                     ),
+                     kv_event_group_spec=get_offloading_event_group_spec(
+                         kv_cache_config.kv_cache_groups[idx]
+@@ -227,6 +254,9 @@ class SchedulerOffloadConfig(NamedTuple):
+             ),
+             blocks_per_chunk=spec.blocks_per_chunk,
+             offload_prompt_only=spec.offload_prompt_only,
++            replay_alignment_tokens=(
++                alignment_tokens if retention_interval is not None else None
++            ),
+         )
+ 
+ 
+@@ -413,6 +443,20 @@ class OffloadingConnectorScheduler:
+             spec, kv_cache_config
+         )
+ 
++        # Tokens that must remain past a replay boundary for it to be
++        # servable: the last prompt token is always recomputed (hence the
++        # default of 1), and each EAGLE/MTP group must be able to match one
++        # complete chunk past the boundary (its "+1 peek", dropped after
++        # verification in _lookup).
++        self._replay_reserve_tokens: int = max(
++            (
++                group_config.tokens_per_chunk
++                for group_config in self.config.kv_group_configs
++                if group_config.is_eagle_group
++            ),
++            default=1,
++        )
++
+         self._req_status: dict[ReqId, RequestOffloadState] = {}
+         self._current_batch_load_jobs: dict[int, TransferJob] = {}
+         self._current_batch_jobs_to_flush: set[int] = set()
+@@ -943,6 +987,37 @@ class OffloadingConnectorScheduler:
+                         ):
+                             group_state.block_ids[j] = 0
+ 
++    def _reachable_tail_end_chunks(
++        self, group_config: GroupOffloadConfig, req: Request, shift: int
++    ) -> tuple[int, ...]:
++        """End chunk indices (exclusive) of serviceable boundary tails.
++
++        Mirrors the replay-boundary handling of
++        SlidingWindowManager.reachable_block_mask: with sparse retention,
++        segment tails exist only once per retention interval. Retain tails at
++        the request replay boundary and at a detected shared-prefix junction.
++        Clamp each boundary to the latest point that every group can service,
++        including a complete EAGLE/MTP peek chunk.
++        """
++        alignment_tokens = self.config.replay_alignment_tokens
++        if alignment_tokens is None:
++            return ()
++
++        latest_serviceable = req.num_prompt_tokens - self._replay_reserve_tokens
++        boundaries = [latest_serviceable]
++        if req.shared_prefix_boundary:
++            boundaries.append(min(req.shared_prefix_boundary, latest_serviceable))
++
++        ends: list[int] = []
++        for boundary in boundaries:
++            aligned = boundary // alignment_tokens * alignment_tokens
++            if aligned <= 0 or aligned % group_config.tokens_per_chunk != 0:
++                continue
++            end = aligned // group_config.tokens_per_chunk + shift
++            if end not in ends:
++                ends.append(end)
++        return tuple(ends)
++
+     def _build_store_jobs(
+         self,
+         scheduler_output: SchedulerOutput,
+@@ -995,22 +1070,45 @@ class OffloadingConnectorScheduler:
+ 
+                 alignment_chunk_count = group_config.alignment_chunk_count
+                 tail = group_config.sliding_window_size_in_chunks
++                # Chunks reachable by _sliding_window_lookup, mirroring
++                # SlidingWindowManager.reachable_block_mask: a hit needs
++                # `need` contiguous chunks ending at a segment boundary. For
++                # EAGLE/MTP groups the run includes the "+1 peek" chunk and
++                # is shifted one chunk past the boundary, so that after
++                # _lookup drops the peek the hit lands exactly on it.
++                need = shift = 0
++                reachable_end_chunks: tuple[int, ...] = ()
++                if alignment_chunk_count is not None:
++                    assert tail is not None
++                    shift = 1 if group_config.is_eagle_group else 0
++                    need = tail + shift
++                    reachable_end_chunks = self._reachable_tail_end_chunks(
++                        group_config, req, shift
++                    )
+ 
+                 for key_idx, (offload_key, block_id) in enumerate(
+                     zip(offload_keys, offload_block_ids)
+                 ):
+                     if block_id == 0:
+                         continue
+-                    # Skip SWA chunks that can never serve a load hit:
+-                    # within each full-attention alignment segment, only the
+-                    # trailing `tail` chunks are reachable by
++                    # Skip SWA chunks that can never serve a load hit: only
++                    # the trailing `need` chunks of each alignment segment
++                    # (plus the replay-boundary tail) are reachable by
+                     # _sliding_window_lookup. For DeepSeek V4 with 100K
+                     # tokens this reduces SWA stores by ~78%.
+                     if alignment_chunk_count is not None:
+-                        assert tail is not None
+                         abs_chunk_idx = start_chunk_idx + key_idx
+-                        pos_in_segment = abs_chunk_idx % alignment_chunk_count
+-                        if pos_in_segment < alignment_chunk_count - tail:
++                        reachable = (
++                            abs_chunk_idx >= shift
++                            and (abs_chunk_idx - shift) % alignment_chunk_count
++                            >= alignment_chunk_count - need
++                        )
++                        if not reachable:
++                            reachable = any(
++                                end - need <= abs_chunk_idx < end
++                                for end in reachable_end_chunks
++                            )
++                        if not reachable:
+                             continue
+                     new_offload_keys.append(offload_key)
+ 
+diff --git a/vllm/distributed/parallel_state.py b/vllm/distributed/parallel_state.py
+index 0364580062f895a5e726137c0624caa76a30ec96..fc86a31038e022b7fd38de56d4d12a87cdaf9208 100644
+--- a/vllm/distributed/parallel_state.py
++++ b/vllm/distributed/parallel_state.py
+@@ -65,6 +65,7 @@ if TYPE_CHECKING:
+ @dataclass
+ class GraphCaptureContext:
+     stream: torch.cuda.Stream
++    channel_id: str | None = None
+ 
+ 
+ TensorMetadata = namedtuple("TensorMetadata", ["device", "dtype", "size"])
+@@ -620,7 +621,10 @@ class GroupCoordinator:
+             )
+             ca_comm = self.device_communicator.ca_comm
+             if ca_comm is not None:
+-                maybe_ca_context = ca_comm.capture(stream=stream)  # type: ignore
++                maybe_ca_context = ca_comm.capture(  # type: ignore
++                    stream=stream,
++                    channel_id=graph_capture_context.channel_id,
++                )
+ 
+             from vllm._aiter_ops import rocm_aiter_ops
+ 
+@@ -1261,14 +1265,14 @@ class GroupCoordinator:
+         return self.device_communicator.recv(size, dtype, src)
+ 
+     def destroy(self):
++        if self.device_communicator is not None:
++            self.device_communicator.destroy()
+         if hasattr(self, "device_group"):
+             torch.distributed.destroy_process_group(self.device_group)
+             del self.device_group
+         if hasattr(self, "cpu_group"):
+             torch.distributed.destroy_process_group(self.cpu_group)
+             del self.cpu_group
+-        if self.device_communicator is not None:
+-            self.device_communicator.destroy()
+         if self.mq_broadcaster is not None:
+             self.mq_broadcaster = None
+ 
+@@ -1643,14 +1647,15 @@ def get_pcp_group() -> GroupCoordinator:
+ def graph_capture(
+     device: torch.device,
+     graph_capture_context: GraphCaptureContext | None = None,
++    channel_id: str | None = None,
+ ):
+     """
+     `graph_capture` is a context manager which should surround the code that
+     is capturing the CUDA graph. Its main purpose is to ensure that some
+     operations will be run after the graph is captured, before the graph
+     is replayed. It returns a `GraphCaptureContext` object which contains the
+-    necessary data for the graph capture. Currently, it only contains the
+-    stream that the graph capture is running on. This stream is set to the
++    necessary data for the graph capture: its stream and an optional semantic
++    channel identity for distributed capture resources. The stream is set to the
+     current CUDA stream when the context manager is entered and reset to the
+     default stream when the context manager is exited. This is to ensure that
+     the graph capture is running on a separate stream from the default stream,
+@@ -1659,22 +1664,47 @@ def graph_capture(
+ 
+     A caller may pass an explicit ``graph_capture_context`` to control the
+     stream used (e.g. to capture on the default stream).
++
++    Args:
++        device: Device that owns a newly created capture stream.
++        graph_capture_context: Existing capture context to reuse.
++        channel_id: Stable distributed identity for this graph owner.
++
++    Raises:
++        ValueError: If ``channel_id`` conflicts with the identity stored on
++            ``graph_capture_context``.
+     """
+-    context = graph_capture_context or GraphCaptureContext(
+-        torch.cuda.Stream(device=device)
+-    )
++    if graph_capture_context is None:
++        context = GraphCaptureContext(
++            torch.cuda.Stream(device=device),
++            channel_id=channel_id,
++        )
++    else:
++        context = graph_capture_context
++        if channel_id is not None:
++            if context.channel_id is not None and context.channel_id != channel_id:
++                raise ValueError(
++                    "graph capture channel_id conflicts with GraphCaptureContext"
++                )
++            if context.channel_id is None:
++                context = GraphCaptureContext(context.stream, channel_id=channel_id)
+     maybe_dcp_capture = (
+         get_dcp_group().graph_capture(context)
+         if _DCP is not None and get_dcp_group().world_size > 1
+         else nullcontext()
+     )
++    maybe_b12x_dcp_capture: contextlib.AbstractContextManager[Any]
+     if _DCP is not None and get_dcp_group().world_size > 1:
+         # Import locally to avoid making distributed initialization depend on
+         # attention modules. The helper is a no-op until DCP warmup creates a
+         # SparkInfer pool for this process group.
+         from vllm.v1.attention.ops.dcp_alltoall import capture_b12x_dcp_a2a
+ 
+-        maybe_b12x_dcp_capture = capture_b12x_dcp_a2a(get_dcp_group(), context.stream)
++        maybe_b12x_dcp_capture = capture_b12x_dcp_a2a(
++            get_dcp_group(),
++            context.stream,
++            channel_id=context.channel_id,
++        )
+     else:
+         maybe_b12x_dcp_capture = nullcontext()
+     with (
+diff --git a/vllm/envs.py b/vllm/envs.py
+index 3167a840af0635f4222e3a7467397c1502ccf084..871690e34892e0a114c8f1232cb4d181526f811d 100755
+--- a/vllm/envs.py
++++ b/vllm/envs.py
+@@ -2287,12 +2287,12 @@ environment_variables: dict[str, Callable[[], Any]] = {
+     "VLLM_EXL3_TRELLIS_MAX_M": lambda: os.getenv("VLLM_EXL3_TRELLIS_MAX_M"),
+     "VLLM_EXL3_TRELLIS_BLOCK_M": lambda: os.getenv("VLLM_EXL3_TRELLIS_BLOCK_M"),
+     "VLLM_EXL3_PREFILL_CHUNK": lambda: os.getenv("VLLM_EXL3_PREFILL_CHUNK"),
++    "VLLM_EXL3_PREFILL_CAPACITY": lambda: os.getenv("VLLM_EXL3_PREFILL_CAPACITY"),
+     "VLLM_EXL3_PREFILL_TRELLIS": lambda: os.getenv("VLLM_EXL3_PREFILL_TRELLIS"),
+     "VLLM_EXL3_PREFILL_BLOCK_M": lambda: os.getenv("VLLM_EXL3_PREFILL_BLOCK_M"),
+     # Prebuilt exllamav3 extension location and torch-ABI compatibility shim.
+     "VLLM_EXL3_EXT_PATH": lambda: os.getenv("VLLM_EXL3_EXT_PATH"),
+     "VLLM_EXL3_ABI_SHIM": lambda: os.getenv("VLLM_EXL3_ABI_SHIM"),
+-
+ }
+ 
+ 
+diff --git a/vllm/model_executor/layers/quantization/exl3.py b/vllm/model_executor/layers/quantization/exl3.py
+index a625a000728d4d812eca4a32710bb7f553cb6060..65c6ac2226a11231f4382240de751bbb748e9160 100644
+--- a/vllm/model_executor/layers/quantization/exl3.py
++++ b/vllm/model_executor/layers/quantization/exl3.py
+@@ -264,6 +264,15 @@ def _unique_tensor_storage_bytes(*buffers: Any) -> int:
+     return total
+ 
+ 
++def _scratch_view(backing: torch.Tensor, spec: Any) -> torch.Tensor:
++    """Return a typed plan-scratch view over a shared byte arena."""
++
++    nbytes = int(spec.dtype.itemsize)
++    for dim in spec.shape:
++        nbytes *= int(dim)
++    return backing.narrow(0, 0, nbytes).view(spec.dtype).view(tuple(spec.shape))
++
++
+ def _positive_env_int(name: str, default: int) -> int:
+     # An env var that is present but blank means "unset". Compose and Kubernetes
+     # both render an unset variable as the empty string, so int("") would abort
+@@ -284,6 +293,21 @@ def _positive_env_int(name: str, default: int) -> int:
+     return value
+ 
+ 
++def _resolve_prefill_capacity(max_batched_tokens: int) -> int:
++    """Resolve the optional EXL3 arena bound within the scheduler contract."""
++
++    prefill_capacity = _positive_env_int(
++        "VLLM_EXL3_PREFILL_CAPACITY", max_batched_tokens
++    )
++    if prefill_capacity > max_batched_tokens:
++        raise ValueError(
++            "VLLM_EXL3_PREFILL_CAPACITY cannot exceed "
++            "max_num_batched_tokens: "
++            f"capacity={prefill_capacity}, max={max_batched_tokens}"
++        )
++    return prefill_capacity
++
++
+ @torch.library.custom_op(
+     "vllm::exl3_gemm",
+     mutates_args=(),
+@@ -1570,7 +1594,8 @@ class Exl3MoEMethod(FusedMoEMethodBase):
+         return (128, 128, 128, 128)
+ 
+     def _prepare_mixed_rank_sliced_weights(self, layer: RoutedExperts) -> None:
+-        api = _load_sparkinfer_mixed_trellis()
++        mixed_api = _load_sparkinfer_mixed_trellis()
++        fused_api = _load_sparkinfer_fused_moe()
+         num_experts = int(layer.local_num_experts)
+         hidden_size = int(layer.exl3_hidden_size)
+         intermediate_size = int(layer.exl3_intermediate_size_per_partition)
+@@ -1609,9 +1634,36 @@ class Exl3MoEMethod(FusedMoEMethodBase):
+         down_suh = self._rank_sliced_backing(layer, "w2_suh")
+         down_svh = self._rank_sliced_backing(layer, "w2_svh")
+         device = gate_suh.device
+-        tile_config = self._mixed_trellis_tile_config(hidden_size, intermediate_size)
++        mixed_tile_config = self._mixed_trellis_tile_config(
++            hidden_size, intermediate_size
++        )
++        serial_tile_config = self._trellis_tile_config(hidden_size, intermediate_size)
++        marker = layer.w13_mcg.exl3_tensors[(0, "w1")]
++        tier_order = tuple(
++            expert_id for expert_ids in tiers.values() for expert_id in expert_ids
++        )
++        tier_index = torch.tensor(tier_order, dtype=torch.long, device=device)
++        combined_gate_suh = gate_suh.index_select(0, tier_index).contiguous()
++        combined_up_suh = up_suh.index_select(0, tier_index).contiguous()
++        combined_intermediate_rotations = torch.cat(
++            (
++                gate_svh.index_select(0, tier_index),
++                up_svh.index_select(0, tier_index),
++                down_suh.index_select(0, tier_index),
++            ),
++            dim=1,
++        ).contiguous()
++        combined_down_svh = down_svh.index_select(0, tier_index).contiguous()
++        combined_rotations = SimpleNamespace(
++            intermediate=combined_intermediate_rotations,
++            gate_suh=combined_gate_suh,
++            up_suh=combined_up_suh,
++            down_svh=combined_down_svh,
++        )
+         prepared_tiers = []
++        serial_tiers = []
+         tier_ids = []
++        tier_offset = 0
+         for bits, expert_ids in tiers.items():
+             expected_last = 16 * bits
+             w13 = torch.stack(
+@@ -1651,27 +1703,21 @@ class Exl3MoEMethod(FusedMoEMethodBase):
+                 )
+ 
+             index = torch.tensor(expert_ids, dtype=torch.long, device=device)
+-            tier_gate_suh = gate_suh.index_select(0, index).contiguous()
+-            tier_up_suh = up_suh.index_select(0, index).contiguous()
+-            intermediate_rotations = torch.cat(
+-                (
+-                    gate_svh.index_select(0, index),
+-                    up_svh.index_select(0, index),
+-                    down_suh.index_select(0, index),
+-                ),
+-                dim=1,
+-            ).contiguous()
+-            tier_down_svh = down_svh.index_select(0, index).contiguous()
++            tier_slice = slice(tier_offset, tier_offset + len(expert_ids))
++            tier_gate_suh = combined_gate_suh[tier_slice]
++            tier_up_suh = combined_up_suh[tier_slice]
++            intermediate_rotations = combined_intermediate_rotations[tier_slice]
++            tier_down_svh = combined_down_svh[tier_slice]
+             prepared_tiers.append(
+-                api.prepare_weights(
++                mixed_api.prepare_weights(
+                     w13=w13,
+                     w2=w2,
+                     hidden_size=hidden_size,
+                     intermediate_size=intermediate_size,
+                     num_experts=len(expert_ids),
+                     activation=layer.activation.value,
+-                    fc1_tile_n=tile_config[1],
+-                    fc2_tile_n=tile_config[3],
++                    fc1_tile_n=mixed_tile_config[1],
++                    fc2_tile_n=mixed_tile_config[3],
+                     params_dtype=torch.float16,
+                     w13_layout="trellis3_t256_proj",
+                     trellis_bits=bits,
+@@ -1680,25 +1726,64 @@ class Exl3MoEMethod(FusedMoEMethodBase):
+                     up_suh=tier_up_suh,
+                     intermediate_rotations=intermediate_rotations,
+                     down_svh=tier_down_svh,
+-                    tile_config=tile_config,
++                    tile_config=mixed_tile_config,
+                     workspace=w13.view(torch.int32).reshape(-1)[:1],
+                 )
+             )
++            serial_weight_plan = fused_api.plan_weights(
++                quant_modes="w4a16",
++                source_format="exl3_trellis_mcg",
++                activation=layer.activation.value,
++                params_dtype=layer.exl3_params_dtype,
++                num_experts=len(expert_ids),
++                hidden_size=hidden_size,
++                intermediate_size=intermediate_size,
++                w13_layout="w13",
++                trellis_bits=bits,
++                trellis_tile_config=serial_tile_config,
++            )
++            serial_weights = fused_api.prepare_weights(
++                plan=serial_weight_plan,
++                params_dtype=layer.exl3_params_dtype,
++                w1_fp4=w13,
++                w2_fp4=w2,
++                gate_suh=tier_gate_suh,
++                up_suh=tier_up_suh,
++                intermediate_rotations=intermediate_rotations,
++                down_svh=tier_down_svh,
++                trellis_mcg=marker,
++            )
++            route_expert_map = torch.full(
++                (num_experts,), -1, dtype=torch.int32, device=device
++            )
++            route_expert_map[index] = torch.arange(
++                len(expert_ids), dtype=torch.int32, device=device
++            )
++            serial_tiers.append(
++                {
++                    "bits": bits,
++                    "weights": serial_weights,
++                    "route_expert_map": route_expert_map,
++                }
++            )
+             tier_ids.append(expert_ids)
++            tier_offset += len(expert_ids)
+ 
+-        global_to_combined, descriptor_map = api.build_tiered_maps(
++        global_to_combined, descriptor_map = mixed_api.build_tiered_maps(
+             tier_ids[0], tier_ids[1], device=device
+         )
+         layer.exl3_mixed_trellis = {
+             "tiers": tuple(prepared_tiers),
++            "serial_tiers": tuple(serial_tiers),
+             "tier_ids": tuple(tier_ids),
+             "tier_bits": tuple(tiers),
+             "global_to_combined": global_to_combined,
+             "descriptor_map": descriptor_map,
+-            "rotations": api.combine_trellis_rotations(*prepared_tiers),
+-            "tile_config": tile_config,
++            "rotations": combined_rotations,
++            "tile_config": mixed_tile_config,
++            "serial_tile_config": serial_tile_config,
+         }
+-        layer.exl3_trellis_tile_config = tile_config
++        layer.exl3_trellis_tile_config = serial_tile_config
+ 
+         # The prepared tier objects own compact, tier-ordered copies. Release
+         # per-expert source tensors and the original rotation slabs now rather
+@@ -1834,6 +1919,8 @@ class Exl3MoEMethod(FusedMoEMethodBase):
+         mixed = layer.exl3_mixed_trellis
+         max_decode_m = _positive_env_int("VLLM_EXL3_TRELLIS_MAX_M", 32)
+         max_batched_tokens = int(layer.exl3_max_num_batched_tokens)
++        prefill_capacity = _resolve_prefill_capacity(max_batched_tokens)
++        prefill_block_m = _positive_env_int("VLLM_EXL3_PREFILL_BLOCK_M", 64)
+         if max_decode_m > max_batched_tokens:
+             max_decode_m = max_batched_tokens
+         topk = int(topk_ids.shape[1])
+@@ -1852,7 +1939,10 @@ class Exl3MoEMethod(FusedMoEMethodBase):
+             topk,
+             max_decode_m,
+             max_batched_tokens,
++            prefill_capacity,
+             mixed["tile_config"],
++            mixed["serial_tile_config"],
++            prefill_block_m,
+         )
+         runtime = _MIXED_TRELLIS_RUNTIMES.get(key)
+         if runtime is not None:
+@@ -1868,18 +1958,19 @@ class Exl3MoEMethod(FusedMoEMethodBase):
+                 f"{topk_ids.dtype}"
+             )
+ 
+-        api = _load_sparkinfer_mixed_trellis()
++        mixed_api = _load_sparkinfer_mixed_trellis()
++        fused_api = _load_sparkinfer_fused_moe()
+         device = x.device
+         props = torch.cuda.get_device_properties(device)
+         total_experts = sum(experts for _, experts in tier_signature)
+ 
+-        def make_state(capacity: int) -> dict[str, Any]:
+-            route_slots = api.max_packed_route_slots(
++        def make_decode_state(capacity: int) -> dict[str, Any]:
++            route_slots = mixed_api.max_packed_route_slots(
+                 capacity * topk,
+                 _MIXED_TRELLIS_ROUTE_BLOCK_SIZE,
+                 total_experts,
+             )
+-            launch = api.compile_mixed_trellis(
++            launch = mixed_api.compile_mixed_trellis(
+                 size_m=capacity,
+                 hidden_size=int(layer.exl3_hidden_size),
+                 intermediate_size=int(layer.exl3_intermediate_size_per_partition),
+@@ -1900,37 +1991,72 @@ class Exl3MoEMethod(FusedMoEMethodBase):
+             return {
+                 "capacity": capacity,
+                 "launch": launch,
+-                "buffers": api.make_mixed_trellis_buffers(
++                "buffers": mixed_api.make_mixed_trellis_buffers(
+                     launch,
+                     device=device,
+                     sms=int(props.multi_processor_count),
+                 ),
+             }
+ 
+-        decode = make_state(max_decode_m)
+-        prefill = (
+-            make_state(max_batched_tokens)
+-            if max_batched_tokens > max_decode_m
+-            else decode
+-        )
++        decode = make_decode_state(max_decode_m)
++        prefill_plans = []
++        prefill_arena = None
++        prefill_accum = None
++        if max_batched_tokens > max_decode_m:
++            if os.environ.get("VLLM_EXL3_PREFILL_TRELLIS", "1") != "1":
++                raise ValueError("mixed-K EXL3 requires VLLM_EXL3_PREFILL_TRELLIS=1")
++            scratch_bytes = 0
++            for tier in mixed["serial_tiers"]:
++                caps = fused_api.Caps(
++                    max_tokens=prefill_capacity,
++                    num_topk=topk,
++                    route_num_experts=total_experts,
++                    device=device,
++                    weight_plan=tier["weights"].plan,
++                    quant_mode="w4a16",
++                    w4a16_block_size_m=prefill_block_m,
++                )
++                plan = fused_api.plan(caps)
++                prefill_plans.append(plan)
++                spec = plan.scratch_specs()[0]
++                size = int(spec.dtype.itemsize)
++                for dim in spec.shape:
++                    size *= int(dim)
++                scratch_bytes = max(scratch_bytes, size)
++            prefill_arena = torch.empty(scratch_bytes, dtype=torch.uint8, device=device)
++            prefill_accum = torch.empty(
++                (prefill_capacity, int(layer.exl3_hidden_size)),
++                dtype=torch.float32,
++                device=device,
++            )
+         runtime = {
+-            "api": api,
++            "mixed_api": mixed_api,
++            "fused_api": fused_api,
+             "decode": decode,
+-            "prefill": prefill,
++            "prefill_plans": tuple(prefill_plans),
++            "prefill_arena": prefill_arena,
++            "prefill_accum": prefill_accum,
+             "max_decode_m": max_decode_m,
+             "max_batched_tokens": max_batched_tokens,
++            "prefill_capacity": prefill_capacity,
+         }
+         _MIXED_TRELLIS_RUNTIMES[key] = runtime
+-        buffer_bytes = _unique_tensor_storage_bytes(
+-            decode["buffers"], prefill["buffers"]
++        decode_bytes = _unique_tensor_storage_bytes(decode["buffers"])
++        prefill_bytes = sum(
++            tensor.numel() * tensor.element_size()
++            for tensor in (prefill_arena, prefill_accum)
++            if tensor is not None
+         )
+         logger.info_once(
+-            "EXL3 mixed Trellis runtime planned: tiers=%s decode_capacity=%d "
+-            "prefill_capacity=%d buffers=%.1f MiB",
++            "EXL3 mixed Trellis runtime planned: tiers=%s one-grid decode=%d "
++            "serial prefill=%d/%d block_m=%d buffers=%.1f+%.1f MiB",
+             tier_signature,
+             max_decode_m,
++            prefill_capacity,
+             max_batched_tokens,
+-            buffer_bytes / (1 << 20),
++            prefill_block_m,
++            decode_bytes / (1 << 20),
++            prefill_bytes / (1 << 20),
+         )
+         return runtime
+ 
+@@ -1948,23 +2074,75 @@ class Exl3MoEMethod(FusedMoEMethodBase):
+                 "mixed-bitrate EXL3 batch exceeds planned capacity: "
+                 f"m={m}, capacity={runtime['max_batched_tokens']}"
+             )
+-        state = (
+-            runtime["decode"] if m <= runtime["max_decode_m"] else runtime["prefill"]
+-        )
+         mixed = layer.exl3_mixed_trellis
+-        output = runtime["api"].run_mixed_trellis(
+-            x,
+-            mixed["tiers"][0],
+-            mixed["tiers"][1],
+-            topk_weights,
+-            topk_ids,
+-            mixed["global_to_combined"],
+-            mixed["descriptor_map"],
+-            mixed["rotations"],
+-            state["launch"],
+-            state["buffers"],
+-        )
+-        return output.to(x.dtype)
++        # The cooperative mixed-K grid wins at small M, but its SM120 path is
++        # currently limited to route block 8.  Homogeneous tier plans support
++        # block 64 and are substantially faster for prefill, so keep the
++        # one-grid launch for decode and dispatch large M through the two
++        # serial tiers until the mixed kernel gains an efficient large block.
++        if m <= runtime["max_decode_m"]:
++            state = runtime["decode"]
++            output = runtime["mixed_api"].run_mixed_trellis(
++                x,
++                mixed["tiers"][0],
++                mixed["tiers"][1],
++                topk_weights,
++                topk_ids,
++                mixed["global_to_combined"],
++                mixed["descriptor_map"],
++                mixed["rotations"],
++                state["launch"],
++                state["buffers"],
++            )
++            return output.to(x.dtype)
++
++        if runtime["prefill_arena"] is None or runtime["prefill_accum"] is None:
++            raise RuntimeError("mixed-K EXL3 serial prefill plan is unavailable")
++        prefill_capacity = int(runtime["prefill_capacity"])
++
++        def run_serial_slice(
++            slice_x: torch.Tensor,
++            slice_weights: torch.Tensor,
++            slice_ids: torch.Tensor,
++        ) -> torch.Tensor:
++            slice_m = int(slice_x.shape[0])
++            accum = runtime["prefill_accum"][:slice_m]
++            first = True
++            for plan, tier in zip(
++                runtime["prefill_plans"], mixed["serial_tiers"], strict=True
++            ):
++                binding = runtime["fused_api"].bind(
++                    plan,
++                    scratch=_scratch_view(
++                        runtime["prefill_arena"], plan.scratch_specs()[0]
++                    ),
++                    a=slice_x,
++                    experts=tier["weights"],
++                    topk_weights=slice_weights,
++                    topk_ids=slice_ids,
++                    route_expert_map=tier["route_expert_map"],
++                    output_expert_map=tier["route_expert_map"],
++                    output=accum if first else None,
++                )
++                tier_output = runtime["fused_api"].run(binding=binding)
++                if not first:
++                    accum.add_(tier_output)
++                first = False
++            return accum.to(slice_x.dtype)
++
++        if m <= prefill_capacity:
++            return run_serial_slice(x, topk_weights, topk_ids)
++
++        output = torch.empty_like(x)
++        for start in range(0, m, prefill_capacity):
++            stop = min(start + prefill_capacity, m)
++            slice_output = run_serial_slice(
++                x[start:stop],
++                topk_weights[start:stop],
++                topk_ids[start:stop],
++            )
++            output[start:stop].copy_(slice_output)
++        return output
+ 
+     def _rank_sliced_runtime(
+         self,
+@@ -1996,12 +2174,11 @@ class Exl3MoEMethod(FusedMoEMethodBase):
+             raise ValueError(
+                 "VLLM_EXL3_TRELLIS_MIN_M cannot exceed VLLM_EXL3_TRELLIS_MAX_M"
+             )
+-        # Batch-INVARIANT capacity. Including x.shape[0] here made the runtime
+-        # cache key depend on the live batch, so any m above the planned capacity
+-        # produced a cache MISS -- silently planning a fresh ~1 GiB arena mid-serve
+-        # and making the capacity guard in _apply_rank_sliced unreachable. The
+-        # planned capacity is a property of the layer, not of one forward pass.
++        # Both capacities are batch-invariant runtime properties. The scheduler
++        # bound remains fail-closed while a smaller opt-in Trellis capacity is
++        # handled by slicing at dispatch.
+         max_batched_tokens = int(layer.exl3_max_num_batched_tokens)
++        prefill_capacity = _resolve_prefill_capacity(max_batched_tokens)
+         prefill_plan_enabled = prefill_trellis and max_batched_tokens > max_trellis_m
+         parity_rows = (
+             min(chunk, max_batched_tokens)
+@@ -2036,6 +2213,7 @@ class Exl3MoEMethod(FusedMoEMethodBase):
+             prefill_trellis,
+             prefill_block_m,
+             layer.exl3_trellis_tile_config,
++            prefill_capacity,
+         )
+         runtime = _RANK_SLICED_RUNTIMES.get(key)
+         if runtime is not None:
+@@ -2079,7 +2257,7 @@ class Exl3MoEMethod(FusedMoEMethodBase):
+         prefill_scratch = None
+         if prefill_plan_enabled:
+             prefill_plan, prefill_scratch = _plan_with_scratch(
+-                max_batched_tokens, prefill_block_m
++                prefill_capacity, prefill_block_m
+             )
+ 
+         ext = _load_exl3_ext()
+@@ -2110,6 +2288,7 @@ class Exl3MoEMethod(FusedMoEMethodBase):
+             "min_trellis_m": min_trellis_m,
+             "max_trellis_m": max_trellis_m,
+             "max_batched_tokens": max_batched_tokens,
++            "prefill_capacity": prefill_capacity,
+             "parity_rows": parity_rows,
+             "topk": topk,
+             "chunk": chunk,
+@@ -2182,12 +2361,13 @@ class Exl3MoEMethod(FusedMoEMethodBase):
+         )
+         logger.info_once(
+             "EXL3 rank-sliced runtime planned: Trellis m=%d..%d block_m=%d, "
+-            "prefill %s capacity=%d chunk=%d topk=%d",
++            "prefill %s scheduler_capacity=%d chunk=%d topk=%d",
+             min_trellis_m,
+             max_trellis_m,
+             block_m,
+             (
+-                f"trellis block_m={prefill_block_m} arena={prefill_arena_mib:.1f}MiB"
++                f"trellis block_m={prefill_block_m} "
++                f"capacity={prefill_capacity} arena={prefill_arena_mib:.1f}MiB"
+                 if prefill_plan is not None
+                 else "parity"
+             ),
+@@ -2231,16 +2411,33 @@ class Exl3MoEMethod(FusedMoEMethodBase):
+                     "EXL3 batch exceeds its planned capacity: "
+                     f"m={m}, capacity={runtime['max_batched_tokens']}"
+                 )
+-            binding = runtime["api"].bind(
+-                runtime["prefill_plan"],
+-                scratch=runtime["prefill_scratch"],
+-                a=x,
+-                experts=layer.exl3_trellis_weights,
+-                topk_weights=topk_weights,
+-                topk_ids=topk_ids,
+-            )
+-            output = runtime["api"].run(binding=binding)
+-            return output.to(x.dtype)
++            prefill_capacity = int(runtime["prefill_capacity"])
++            if m <= prefill_capacity:
++                binding = runtime["api"].bind(
++                    runtime["prefill_plan"],
++                    scratch=runtime["prefill_scratch"],
++                    a=x,
++                    experts=layer.exl3_trellis_weights,
++                    topk_weights=topk_weights,
++                    topk_ids=topk_ids,
++                )
++                output = runtime["api"].run(binding=binding)
++                return output.to(x.dtype)
++
++            output = torch.empty_like(x)
++            for start in range(0, m, prefill_capacity):
++                stop = min(start + prefill_capacity, m)
++                binding = runtime["api"].bind(
++                    runtime["prefill_plan"],
++                    scratch=runtime["prefill_scratch"],
++                    a=x[start:stop],
++                    experts=layer.exl3_trellis_weights,
++                    topk_weights=topk_weights[start:stop],
++                    topk_ids=topk_ids[start:stop],
++                )
++                slice_output = runtime["api"].run(binding=binding)
++                output[start:stop].copy_(slice_output)
++            return output
+ 
+         if torch.cuda.is_current_stream_capturing():
+             raise RuntimeError(
+diff --git a/vllm/model_executor/warmup/kernel_warmup.py b/vllm/model_executor/warmup/kernel_warmup.py
+index 36a17fa8aa263009adc60acc5bf8ca172fa49645..95408d971f86597a245000d3337c47ff79bbd489 100644
+--- a/vllm/model_executor/warmup/kernel_warmup.py
++++ b/vllm/model_executor/warmup/kernel_warmup.py
+@@ -442,6 +442,28 @@ def _flashinfer_autotune_skip_ops(runner: "GPUModelRunner") -> set[str] | None:
+     return None
+ 
+ 
++def _flashinfer_autotune_dummy_run_kwargs(
++    runner: "GPUModelRunner",
++) -> dict[str, object]:
++    kwargs = dict(
++        num_tokens=runner.scheduler_config.max_num_batched_tokens,
++        skip_eplb=True,
++        is_profile=True,
++    )
++
++    # V2 initializes attention backends and block tables only after the initial
++    # memory profile.  Kernel autotuning runs during that profile, so execute
++    # the model kernels without attention until those tables exist.  Attention
++    # backends have their own warmup after KV-cache initialization.
++    if (
++        getattr(runner.vllm_config, "use_v2_model_runner", False)
++        and not hasattr(runner, "block_tables")
++    ):
++        kwargs["skip_attn"] = True
++
++    return kwargs
++
++
+ def flashinfer_autotune(runner: "GPUModelRunner") -> None:
+     """
+     Autotune FlashInfer operations.
+@@ -475,11 +497,7 @@ def flashinfer_autotune(runner: "GPUModelRunner") -> None:
+ 
+     if not use_persistent_cache:
+         with torch.inference_mode(), fi_utils.autotune(**autotune_kwargs):
+-            runner._dummy_run(
+-                num_tokens=runner.scheduler_config.max_num_batched_tokens,
+-                skip_eplb=True,
+-                is_profile=True,
+-            )
++            runner._dummy_run(**_flashinfer_autotune_dummy_run_kwargs(runner))
+         get_world_group().barrier()
+         return
+ 
+@@ -494,11 +512,7 @@ def flashinfer_autotune(runner: "GPUModelRunner") -> None:
+     # When autotuning with number of tokens m, flashinfer will autotune
+     # operations for all number of tokens up to m, so we only need to
+     # run with the max number of tokens.
+-    dummy_run_kwargs = dict(
+-        num_tokens=runner.scheduler_config.max_num_batched_tokens,
+-        skip_eplb=True,
+-        is_profile=True,
+-    )
++    dummy_run_kwargs = _flashinfer_autotune_dummy_run_kwargs(runner)
+ 
+     with torch.inference_mode():
+         if is_leader:
+diff --git a/vllm/models/deepseek_v4/nvidia/b12x.py b/vllm/models/deepseek_v4/nvidia/b12x.py
+index 9b26bd1ab599a7bbd45f285b6d55300b30f04a6c..ff76638829cc4d81de16dbf83f46e3187d15f95e 100644
+--- a/vllm/models/deepseek_v4/nvidia/b12x.py
++++ b/vllm/models/deepseek_v4/nvidia/b12x.py
+@@ -44,7 +44,6 @@ if TYPE_CHECKING:
+ _DSV4_HEAD_DIM = 512
+ _DSV4_V_HEAD_DIM = 512
+ _DSV4_CACHE_BYTES_PER_TOKEN = 584
+-_DSV4_CACHE_PAD_ALIGNMENT_BYTES = 576
+ _DECODE_SPLIT_TILE = 64
+ _C128A_TOPK_ALIGNMENT = 128
+ _VALIDATE_DCP_INDICES_ENV = "VLLM_DSV4_DCP_VALIDATE_INDICES"
+@@ -55,11 +54,20 @@ def _cdiv(x: int, y: int) -> int:
+ 
+ 
+ def _dsv4_b12x_page_nbytes(page_size: int) -> int:
+-    payload_nbytes = int(page_size) * _DSV4_CACHE_BYTES_PER_TOKEN
+-    return (
+-        _cdiv(payload_nbytes, _DSV4_CACHE_PAD_ALIGNMENT_BYTES)
+-        * _DSV4_CACHE_PAD_ALIGNMENT_BYTES
+-    )
++    """Return the logical DSV4 payload bytes in one cache page.
++
++    vLLM may place padding between physical pages, but the padding is not part
++    of the compressed-MLA payload.  Keeping it out of the exported view also
++    supports standalone contiguous allocations, whose physical page stride is
++    exactly ``page_size * 584`` bytes.
++
++    Args:
++        page_size: Number of tokens stored in one cache page.
++
++    Returns:
++        The logical compressed-MLA payload size in bytes.
++    """
++    return int(page_size) * _DSV4_CACHE_BYTES_PER_TOKEN
+ 
+ 
+ def _b12x_cache_page_view(
+@@ -67,7 +75,25 @@ def _b12x_cache_page_view(
+     page_size: int,
+     name: str,
+ ) -> torch.Tensor:
+-    """Return a uint8 ``[pages, padded_page_bytes]`` view for b12x kernels."""
++    """Return a uint8 ``[pages, payload_bytes]`` view for SparkInfer kernels.
++
++    Preserve the physical page stride so both padded packed allocations and
++    contiguous per-layer allocations follow the same runtime contract.
++
++    Args:
++        cache: Source paged cache tensor.
++        page_size: Number of tokens stored in one cache page.
++        name: Cache name used in validation errors.
++
++    Returns:
++        A logical byte view that preserves the source physical page stride.
++
++    Raises:
++        ValueError: If ``page_size`` is not positive.
++        RuntimeError: If the cache is not paged, a page cannot contain the
++            logical payload, pages overlap, or the payload within a page is
++            not contiguous.
++    """
+     page_nbytes = _dsv4_b12x_page_nbytes(page_size)
+     if page_nbytes <= 0:
+         raise ValueError(f"{name} page_size must be positive, got {page_size}")
+@@ -77,11 +103,19 @@ def _b12x_cache_page_view(
+         if int(byte_cache.shape[1]) < page_nbytes:
+             raise RuntimeError(
+                 f"{name} page width {int(byte_cache.shape[1])} is smaller than "
+-                f"DSV4 padded page width {page_nbytes}"
++                f"DSV4 payload width {page_nbytes}"
+             )
+-        if not byte_cache.is_contiguous():
+-            raise RuntimeError(f"{name} page cache must be contiguous")
+-        return byte_cache
++        if int(byte_cache.stride(1)) != 1:
++            raise RuntimeError(
++                f"{name} page payload must be contiguous, got stride "
++                f"{tuple(byte_cache.stride())}"
++            )
++        if int(byte_cache.stride(0)) < page_nbytes:
++            raise RuntimeError(
++                f"{name} page stride {int(byte_cache.stride(0))} is smaller than "
++                f"DSV4 page payload {page_nbytes}"
++            )
++        return byte_cache[:, :page_nbytes]
+ 
+     if byte_cache.ndim < 2:
+         raise RuntimeError(
+@@ -93,13 +127,22 @@ def _b12x_cache_page_view(
+     if page_stride_nbytes < page_nbytes:
+         raise RuntimeError(
+             f"{name} page stride {page_stride_nbytes} is smaller than DSV4 page "
+-            f"width {page_nbytes}"
++            f"payload {page_nbytes}"
+         )
+ 
++    expected_stride = 1
++    for dim in range(byte_cache.ndim - 1, 0, -1):
++        if int(byte_cache.stride(dim)) != expected_stride:
++            raise RuntimeError(
++                f"{name} page payload must be contiguous, got stride "
++                f"{tuple(byte_cache.stride())}"
++            )
++        expected_stride *= int(byte_cache.shape[dim])
++
+     # Packed DS4 KV cache views have a storage offset for this layer and a
+-    # larger per-block stride for the whole packed block. Expose only this
+-    # layer's page payload while preserving stride(0), so B12X can use the
+-    # packed block stride without materializing/copying.
++    # larger per-block stride for the whole packed block. Expose only the
++    # logical payload while preserving stride(0), so SparkInfer can use the
++    # physical block stride without materializing/copying.
+     page_view = torch.as_strided(
+         byte_cache,
+         size=(pages, page_nbytes),
+diff --git a/vllm/v1/attention/ops/dcp_alltoall.py b/vllm/v1/attention/ops/dcp_alltoall.py
+index e908a7262d1a85aedec4d4e73f1879b59f13ebb6..da0dce93e14e08d49d6caadcc93f8babcd923316 100644
+--- a/vllm/v1/attention/ops/dcp_alltoall.py
++++ b/vllm/v1/attention/ops/dcp_alltoall.py
+@@ -41,6 +41,10 @@ logger = init_logger(__name__)
+ 
+ _B12X_DCP_A2A_POOLS: dict[tuple[int, int, int, int, int, int], Any] = {}
+ _B12X_DCP_A2A_DISABLED: set[tuple[int, int, int, int, int, int]] = set()
++# DCP likewise has one stable eager scheduler owner.  Graph target/draft/encoder
++# identities are supplied separately by their GraphCaptureContext.
++_B12X_DCP_EAGER_CHANNEL_ID = "vllm:eager:dcp"
++_B12X_DCP_MAX_CONCURRENT_CHANNELS = 2
+ _DCP_A2A_GRAPH_BUFFERS: dict[
+     tuple[tuple[int, ...], torch.device, torch.dtype],
+     tuple[torch.Tensor, torch.Tensor],
+@@ -53,9 +57,7 @@ def _is_supported_bhd_layout(tensor: torch.Tensor) -> bool:
+         return False
+     batch, heads, head_dim = (int(value) for value in tensor.shape)
+     stride_batch, stride_head, _ = (int(value) for value in tensor.stride())
+-    packed_token_major = (
+-        stride_batch == heads * head_dim and stride_head == head_dim
+-    )
++    packed_token_major = stride_batch == heads * head_dim and stride_head == head_dim
+     capacity_strided_head_major = (
+         stride_batch == head_dim and stride_head >= batch * head_dim
+     )
+@@ -130,8 +132,10 @@ def _get_b12x_dcp_a2a_pool(
+             head_dim=head_dim,
+             query_head_dim=query_head_dim,
+             single_channel=False,
++            max_concurrent_channels=_B12X_DCP_MAX_CONCURRENT_CHANNELS,
+         )
+-        pool.for_stream()
++        pool.prepare_channels((_B12X_DCP_EAGER_CHANNEL_ID,))
++        pool.for_stream(channel_id=_B12X_DCP_EAGER_CHANNEL_ID)
+     except Exception as exc:
+         init_error = exc
+ 
+@@ -171,6 +175,8 @@ def _get_b12x_dcp_a2a_pool(
+ def capture_b12x_dcp_a2a(
+     cp_group: GroupCoordinator,
+     stream: torch.cuda.Stream | None = None,
++    *,
++    channel_id: str | None = None,
+ ):
+     """Bind registered SparkInfer DCP pools to the graph's owning stream.
+ 
+@@ -180,6 +186,7 @@ def capture_b12x_dcp_a2a(
+     Args:
+         cp_group: DCP group whose registered pools should enter capture.
+         stream: CUDA stream owned by the enclosing graph capture.
++        channel_id: Stable identity shared by every rank for this graph owner.
+     """
+     group_id = id(cp_group.device_group)
+     matching_pools = sorted(
+@@ -190,9 +197,14 @@ def capture_b12x_dcp_a2a(
+         ),
+         key=lambda item: item[0][1:],
+     )
++    if matching_pools and channel_id is None:
++        raise RuntimeError(
++            "distributed PCIe DCP graph capture requires an explicit semantic "
++            "channel_id"
++        )
+     with ExitStack() as stack:
+         for _, pool in matching_pools:
+-            stack.enter_context(pool.capture(stream=stream))
++            stack.enter_context(pool.capture(stream=stream, channel_id=channel_id))
+         yield
+ 
+ 
+@@ -313,6 +325,7 @@ def _try_b12x_dcp_lse_reduce(
+         cp_attn_lse,
+         out=reduced,
+         is_lse_base_on_e=is_lse_base_on_e,
++        channel_id=_B12X_DCP_EAGER_CHANNEL_ID,
+     )
+ 
+ 
+@@ -363,7 +376,10 @@ def _try_b12x_dcp_all_gather_heads(
+     )
+     if pool is None:
+         return None
+-    return pool.all_gather_heads(local_input)
++    return pool.all_gather_heads(
++        local_input,
++        channel_id=_B12X_DCP_EAGER_CHANNEL_ID,
++    )
+ 
+ 
+ def dcp_b12x_all_gather_heads(
+diff --git a/vllm/v1/kv_offload/cpu/spec.py b/vllm/v1/kv_offload/cpu/spec.py
+index f6d1c29aff930bf485354a45478040261fa68205..f48a550c3af8f872bcda421621f2f355f91f08a8 100644
+--- a/vllm/v1/kv_offload/cpu/spec.py
++++ b/vllm/v1/kv_offload/cpu/spec.py
+@@ -2,6 +2,7 @@
+ # SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+ from typing import Any
+ 
++import torch
+ from typing_extensions import override
+ 
+ from vllm.platforms import current_platform
+@@ -20,10 +21,11 @@ from vllm.v1.kv_offload.config import OffloadingConfig
+ from vllm.v1.kv_offload.cpu.common import CPUOffloadingMetrics
+ from vllm.v1.kv_offload.cpu.gpu_worker import CPUOffloadingWorker
+ from vllm.v1.kv_offload.cpu.manager import CPUOffloadingManager
++from vllm.v1.kv_offload.cpu.shared_offload_region import SharedOffloadRegion
+ 
+ 
+ class CPUOffloadingSpec(OffloadingSpec):
+-    BLOCK_SIZE_ALIGNMENT = 1
++    BLOCK_SIZE_ALIGNMENT = SharedOffloadRegion.BLOCK_SIZE_ALIGNMENT
+ 
+     @classmethod
+     def build_metric_definitions(
+@@ -133,10 +135,22 @@ class CPUOffloadingSpec(OffloadingSpec):
+         return self._manager
+ 
+     def create_worker(self, kv_caches: CanonicalKVCaches) -> CPUOffloadingWorker:
++        mmap_region: SharedOffloadRegion | None = None
++        if current_platform.is_cuda_alike() and self.num_blocks > 0:
++            world_size = self.config.parallel.world_size
++            rank = torch.accelerator.current_device_index() % world_size
++            mmap_region = SharedOffloadRegion(
++                engine_id=self.config.engine_id,
++                num_blocks=self.num_blocks,
++                rank=rank,
++                kv_bytes_per_block=self.kv_bytes_per_chunk,
++                cpu_page_size=self.cpu_page_size_per_worker,
++            )
+         return CPUOffloadingWorker(
+             kv_caches=kv_caches,
+             blocks_per_chunk=self.blocks_per_chunk,
+             num_cpu_blocks=self.num_blocks,
++            mmap_region=mmap_region,
+         )
+ 
+     @override
+diff --git a/vllm/v1/worker/gpu/cudagraph_utils.py b/vllm/v1/worker/gpu/cudagraph_utils.py
+index 7b2991bf6c4d13a0ddb21dfdec9c77ea4e018467..1f4cc19e3b4fbf70c26a88f6a9ff5aed7f1d6bfa 100644
+--- a/vllm/v1/worker/gpu/cudagraph_utils.py
++++ b/vllm/v1/worker/gpu/cudagraph_utils.py
+@@ -446,6 +446,8 @@ class CudaGraphManager:
+     def capture(
+         self,
+         create_forward_fn: CreateForwardFn,
++        *,
++        channel_id: str,
+         progress_bar_desc: str = "Capturing CUDA graphs",
+     ) -> None:
+         """Capture CUDA graphs.
+@@ -456,12 +458,16 @@ class CudaGraphManager:
+                 it is invoked once with warmup=True and again with warmup=False
+                 because attention backends may mutate or lazily initialize
+                 metadata during warmup.
++            channel_id: Stable distributed identity for this graph owner.
+         """
+         # Keep event handles created by descriptor warmups alive together with
+         # the graph artifacts captured below. Some multi-stream custom ops run
+         # on joined auxiliary streams where CUDA's per-current-stream capture
+         # query is false even though later graph nodes retain those handles.
+-        with graph_capture(device=self.device), vllm_cudagraph_capture_scope():
++        with (
++            graph_capture(device=self.device, channel_id=channel_id),
++            vllm_cudagraph_capture_scope(),
++        ):
+             # Capture in order: PIECEWISE first, then FULL. PIECEWISE has larger
+             # activations so FULL activations should fit in already allocated
+             # buffers in the graph pool.
+@@ -638,6 +644,8 @@ class ModelCudaGraphManager(CudaGraphManager):
+         has_lora: bool = False,
+         use_aux_hidden_state_outputs: bool = False,
+         lora_capture_hook: Callable[[int, int, int], None] | None = None,
++        *,
++        channel_id: str,
+         progress_bar_desc: str = "Capturing CUDA graphs",
+     ) -> None:
+         """Capture CUDA graphs for model forward pass."""
+@@ -752,7 +760,11 @@ class ModelCudaGraphManager(CudaGraphManager):
+ 
+             return forward_fn
+ 
+-        super().capture(create_forward_fn, progress_bar_desc)
++        super().capture(
++            create_forward_fn,
++            channel_id=channel_id,
++            progress_bar_desc=progress_bar_desc,
++        )
+ 
+     def clear(self) -> None:
+         super().clear()
+diff --git a/vllm/v1/worker/gpu/model_runner.py b/vllm/v1/worker/gpu/model_runner.py
+index 596b1c2b5be77a318371ca2ccf0bf30c514a5a87..1ba33888a05b3b1d2bede735ea3ea326cb21b60a 100644
+--- a/vllm/v1/worker/gpu/model_runner.py
++++ b/vllm/v1/worker/gpu/model_runner.py
+@@ -967,11 +967,12 @@ class GPUModelRunner(LoRAModelRunnerMixin):
+                     has_lora=self.lora_config is not None,
+                     use_aux_hidden_state_outputs=self.use_aux_hidden_state_outputs,
+                     lora_capture_hook=create_lora_capture_hook(self.lora_config, self),
++                    channel_id="vllm:target:profile",
+                     progress_bar_desc="Profiling CUDA graph memory",
+                 )
+                 if self.speculator is not None:
+                     with use_workspace_lane(1):
+-                        self.speculator.capture()
++                        self.speculator.capture(capture_phase="profile")
+                 self._zero_cudagraph_capture_kv_blocks()
+             end_free_gpu_memory = torch.accelerator.get_memory_info()[0]
+             gross_cuda_graph_size = max(start_free_gpu_memory - end_free_gpu_memory, 0)
+@@ -1050,10 +1051,11 @@ class GPUModelRunner(LoRAModelRunnerMixin):
+                     has_lora=self.lora_config is not None,
+                     use_aux_hidden_state_outputs=self.use_aux_hidden_state_outputs,
+                     lora_capture_hook=create_lora_capture_hook(self.lora_config, self),
++                    channel_id="vllm:target:production",
+                 )
+                 if self.speculator is not None:
+                     with use_workspace_lane(1):
+-                        self.speculator.capture()
++                        self.speculator.capture(capture_phase="production")
+                 self._zero_cudagraph_capture_kv_blocks()
+         finally:
+             self._release_cudagraph_pool_anchor()
+diff --git a/vllm/v1/worker/gpu/spec_decode/autoregressive/cudagraph_utils.py b/vllm/v1/worker/gpu/spec_decode/autoregressive/cudagraph_utils.py
+index 19919043c831574b73c8617615a352e885c648f8..c625d91aee8496d3f518361fff2d234ecdf8329a 100644
+--- a/vllm/v1/worker/gpu/spec_decode/autoregressive/cudagraph_utils.py
++++ b/vllm/v1/worker/gpu/spec_decode/autoregressive/cudagraph_utils.py
+@@ -35,6 +35,8 @@ class SpeculatorCudaGraphManager(CudaGraphManager):
+         block_tables: BlockTables,
+         attn_groups: list[list[AttentionGroup]],
+         kv_cache_config: KVCacheConfig,
++        *,
++        channel_id: str,
+         progress_bar_desc: str = "Capturing CUDA graphs",
+     ) -> None:
+         def create_forward_fn(
+@@ -71,4 +73,8 @@ class SpeculatorCudaGraphManager(CudaGraphManager):
+                 cg_mode,
+             )
+ 
+-        super().capture(create_forward_fn, progress_bar_desc)
++        super().capture(
++            create_forward_fn,
++            channel_id=channel_id,
++            progress_bar_desc=progress_bar_desc,
++        )
+diff --git a/vllm/v1/worker/gpu/spec_decode/autoregressive/speculator.py b/vllm/v1/worker/gpu/spec_decode/autoregressive/speculator.py
+index 9633feaa0103d51d638621b9a90a089e9f9d1d12..d9ab74a28fb9bd1d0f288829f35a5446c5185255 100644
+--- a/vllm/v1/worker/gpu/spec_decode/autoregressive/speculator.py
++++ b/vllm/v1/worker/gpu/spec_decode/autoregressive/speculator.py
+@@ -21,7 +21,10 @@ from vllm.v1.worker.gpu.input_batch import InputBatch, InputBuffers
+ from vllm.v1.worker.gpu.spec_decode.autoregressive.cudagraph_utils import (
+     SpeculatorCudaGraphManager,
+ )
+-from vllm.v1.worker.gpu.spec_decode.speculator import DraftModelSpeculator
++from vllm.v1.worker.gpu.spec_decode.speculator import (
++    CUDAGraphCapturePhase,
++    DraftModelSpeculator,
++)
+ 
+ logger = init_logger(__name__)
+ 
+@@ -87,7 +90,7 @@ class AutoRegressiveSpeculator(DraftModelSpeculator):
+             decode_query_len=1,
+         )
+ 
+-    def capture(self) -> None:
++    def capture(self, *, capture_phase: CUDAGraphCapturePhase) -> None:
+         logger.info("Capturing model for speculator...")
+         # Reset indices to zeros to prevent stale values from prior
+         # dummy runs to cause out-of-bounds indexing during capture.
+@@ -111,6 +114,7 @@ class AutoRegressiveSpeculator(DraftModelSpeculator):
+             self.block_tables,
+             self.target_attn_groups,
+             self.kv_cache_config,
++            channel_id=f"vllm:draft:prefill:{capture_phase}",
+             progress_bar_desc="Capturing prefill CUDA graphs",
+         )
+ 
+@@ -128,6 +132,7 @@ class AutoRegressiveSpeculator(DraftModelSpeculator):
+             self.block_tables,
+             self.attn_groups,
+             self.kv_cache_config,
++            channel_id=f"vllm:draft:decode:{capture_phase}",
+             progress_bar_desc="Capturing decode CUDA graphs",
+         )
+ 
+diff --git a/vllm/v1/worker/gpu/spec_decode/dflash/cudagraph.py b/vllm/v1/worker/gpu/spec_decode/dflash/cudagraph.py
+index 5b36fee76eb227cd735648b9e31ac97ff1aabbec..fb0f0f2b6014f5ac3810ea4394bbf27255485d6b 100644
+--- a/vllm/v1/worker/gpu/spec_decode/dflash/cudagraph.py
++++ b/vllm/v1/worker/gpu/spec_decode/dflash/cudagraph.py
+@@ -72,6 +72,8 @@ class DFlashCudaGraphManager(CudaGraphManager):
+         kv_cache_config: KVCacheConfig,
+         max_model_len: int,
+         causal: bool | Mapping[int, bool],
++        *,
++        channel_id: str,
+         progress_bar_desc: str = "Capturing CUDA graphs",
+     ) -> None:
+         def create_forward_fn(
+@@ -108,4 +110,8 @@ class DFlashCudaGraphManager(CudaGraphManager):
+                 num_query_per_req=desc.uniform_token_count,
+             )
+ 
+-        super().capture(create_forward_fn, progress_bar_desc)
++        super().capture(
++            create_forward_fn,
++            channel_id=channel_id,
++            progress_bar_desc=progress_bar_desc,
++        )
+diff --git a/vllm/v1/worker/gpu/spec_decode/dflash/speculator.py b/vllm/v1/worker/gpu/spec_decode/dflash/speculator.py
+index 4859d74bcb150019a010b3173e885d3e135ef8b4..8af47efab18f3e263373e91740dcf536bc2b1815 100644
+--- a/vllm/v1/worker/gpu/spec_decode/dflash/speculator.py
++++ b/vllm/v1/worker/gpu/spec_decode/dflash/speculator.py
+@@ -35,7 +35,10 @@ from vllm.v1.worker.gpu.spec_decode.dflash.utils import (
+     load_dflash_model,
+     maybe_load_mask_embedding,
+ )
+-from vllm.v1.worker.gpu.spec_decode.speculator import DraftModelSpeculator
++from vllm.v1.worker.gpu.spec_decode.speculator import (
++    CUDAGraphCapturePhase,
++    DraftModelSpeculator,
++)
+ from vllm.v1.worker.gpu.spec_decode.utils import get_parallel_drafting_token_id
+ from vllm.v1.worker.utils import AttentionGroup
+ 
+@@ -184,7 +187,7 @@ class DFlashSpeculator(DraftModelSpeculator):
+             decode_query_len=self.num_query_per_req,
+         )
+ 
+-    def capture(self) -> None:
++    def capture(self, *, capture_phase: CUDAGraphCapturePhase) -> None:
+         logger.info("Capturing model for %s speculator...", self._speculator_name)
+         # Reset sampling indices to prevent stale values from prior dummy runs
+         # from being baked into the captured graph. Mapping rows stay inert.
+@@ -200,6 +203,7 @@ class DFlashSpeculator(DraftModelSpeculator):
+             self.kv_cache_config,
+             self.max_model_len,
+             causal=self._group_causal,
++            channel_id=f"vllm:draft:dflash:{capture_phase}",
+             progress_bar_desc=f"Capturing {self._speculator_name.lower()} CUDA graphs",
+         )
+ 
+diff --git a/vllm/v1/worker/gpu/spec_decode/speculator.py b/vllm/v1/worker/gpu/spec_decode/speculator.py
+index 0784f580ac0106849ec5f56aa6750d3784979695..a59cd1270bdd030f2beed072d5f1f4b726d6d916 100644
+--- a/vllm/v1/worker/gpu/spec_decode/speculator.py
++++ b/vllm/v1/worker/gpu/spec_decode/speculator.py
+@@ -2,7 +2,7 @@
+ # SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+ from abc import ABC, abstractmethod
+ from collections.abc import Mapping
+-from typing import TYPE_CHECKING, Any
++from typing import TYPE_CHECKING, Any, Literal
+ 
+ import torch
+ import torch.nn as nn
+@@ -32,6 +32,8 @@ if TYPE_CHECKING:
+ 
+ logger = init_logger(__name__)
+ 
++CUDAGraphCapturePhase = Literal["profile", "production"]
++
+ 
+ class BaseSpeculator(ABC):
+     # Draft-token capacity surface, implemented by speculators with a
+@@ -51,7 +53,7 @@ class BaseSpeculator(ABC):
+         pass
+ 
+     @abstractmethod
+-    def capture(self) -> None:
++    def capture(self, *, capture_phase: CUDAGraphCapturePhase) -> None:
+         pass
+ 
+     def get_cudagraph_managers(self) -> tuple["CudaGraphManager", ...]:
+diff --git a/vllm/v1/worker/gpu_model_runner.py b/vllm/v1/worker/gpu_model_runner.py
+index 5a066f77c195d6daf9c35820b29dc9f3646833ef..7d1216710fd4a4e7e6ac5c13b17934d04aa273ab 100644
+--- a/vllm/v1/worker/gpu_model_runner.py
++++ b/vllm/v1/worker/gpu_model_runner.py
+@@ -44,12 +44,14 @@ from vllm.distributed.kv_transfer import get_kv_transfer_group, has_kv_transfer_
+ from vllm.distributed.kv_transfer.kv_connector.utils import copy_kv_blocks
+ from vllm.distributed.parallel_state import (
+     GraphCaptureContext,
++    checkpoint_b12x_graph_channels,
+     get_dcp_group,
+     get_pp_group,
+     get_tp_group,
+     graph_capture,
+     is_global_first_rank,
+     prepare_communication_buffer_for_model,
++    rollback_b12x_graph_channels,
+ )
+ from vllm.forward_context import (
+     BatchDescriptor,
+@@ -4643,11 +4645,7 @@ class GPUModelRunner(
+             )
+             # Whether the drafter runs a GPU model forward (and thus carries
+             # TP/EP/DP collectives), independent of padded-batch timing.
+-            drafter_runs_model_forward = (
+-                spec_config.use_eagle()
+-                or spec_config.uses_draft_model()
+-                or spec_config.uses_extract_hidden_states()
+-            )
++            drafter_runs_model_forward = self._drafter_runs_model_forward()
+             use_gpu_toks = (
+                 drafter_runs_model_forward
+                 and not spec_config.disable_padded_drafter_batch
+@@ -5845,6 +5843,7 @@ class GPUModelRunner(
+         profile_seq_lens: int | None = None,
+         include_mm_inputs: bool = True,
+         single_request_prefill: bool = False,
++        run_drafter: bool = True,
+     ) -> tuple[torch.Tensor, torch.Tensor]:
+         """
+         Run a dummy forward pass to warm up/profile run or capture the
+@@ -5878,6 +5877,7 @@ class GPUModelRunner(
+             single_request_prefill: If True, create one prefill request with
+                 `num_tokens` tokens. This covers text-only single-request
+                 prefill kernels without keying warmup on a live prompt length.
++            run_drafter: Whether to execute the draft-model portion of the run.
+         """
+         mm_config = self.vllm_config.model_config.multimodal_config
+         if mm_config and mm_config.mm_encoder_only:
+@@ -6177,11 +6177,7 @@ class GPUModelRunner(
+             else:
+                 hidden_states = outputs
+ 
+-            if self.speculative_config and (
+-                self.speculative_config.use_eagle()
+-                or self.speculative_config.uses_draft_model()
+-                or self.speculative_config.uses_extract_hidden_states()
+-            ):
++            if run_drafter and self._drafter_runs_model_forward():
+                 assert isinstance(
+                     self.drafter,
+                     EagleProposer
+@@ -6672,7 +6668,7 @@ class GPUModelRunner(
+ 
+         saved_num_cudagraph_captured = compilation_counter.num_cudagraph_captured
+ 
+-        capture_descs = self.cudagraph_dispatcher.get_capture_descs()
++        capture_descs = list(self.cudagraph_dispatcher.get_capture_descs())
+         # Use a temporary manager for memory profiling. The persistent manager
+         # is initialized later so it does not keep profiling-only graph state.
+         encoder_cudagraph_manager = self._create_encoder_cudagraph_manager()
+@@ -6715,81 +6711,117 @@ class GPUModelRunner(
+             original_pools[id(instance)] = instance.graph_pool
+             instance.graph_pool = profiling_pool
+ 
+-        shared_memory_estimate = {}
+-        per_graph_estimate = {}
++        shared_memory_estimate: dict[CUDAGraphMode, int] = {}
++        per_graph_estimate: dict[CUDAGraphMode, int] = {}
+         encoder_memory_estimate = 0
+ 
+-        # On ROCm, capture these throwaway profiling graphs on vLLM's dedicated
+-        # compute stream instead of the fresh side stream graph_capture()
+-        # allocates by default. torch's allocator pools free blocks per stream,
+-        # so a side-stream forward strands a persistent aiter scratch buffer in
+-        # a separate pool, shifting the physical placement of the real KV cache
+-        # allocated afterward and slowing bandwidth-bound decode ~20%. The
+-        # graphs are discarded, so a side stream is unnecessary here.
+-        # Use current_stream(), not torch.cuda.current_stream(): before vLLM
+-        # initializes its dedicated stream, torch returns the per-thread default
+-        # stream (cuda_stream=0), which cannot be used for cudagraph capture.
+-        # cap_ctx=None keeps the side-stream path on CUDA.
+-        cap_ctx = (
+-            GraphCaptureContext(current_stream())
+-            if current_platform.is_rocm()
+-            else None
+-        )
+-
+         # Cleanup-only guard: CUDA graph capture errors should still propagate
+         # because encoder graph capture is opt-in.
++        graph_channel_checkpoints: tuple[tuple[Callable[[Any], None], Any], ...] = ()
+         try:
++            graph_channel_checkpoints = checkpoint_b12x_graph_channels()
+             set_cudagraph_capturing_enabled(True)
+-            with (
+-                self._freeze_gc(),
+-                graph_capture(device=self.device, graph_capture_context=cap_ctx),
+-            ):
+-                torch.accelerator.synchronize()
+-                torch.accelerator.empty_cache()
+-
+-                for mode, descs in capture_descs:
+-                    profile_descs = descs[:2]
+-                    mem_samples: list[int] = []
+-
+-                    for i, desc in enumerate(profile_descs):
+-                        mem_before = torch.accelerator.get_memory_info()[0]
+-                        self._warmup_and_capture(
+-                            desc,
+-                            cudagraph_runtime_mode=mode,
+-                            profile_seq_lens=(
+-                                min(
+-                                    self.max_model_len,
+-                                    self.max_num_tokens // desc.num_tokens,
+-                                )
+-                                if mode == CUDAGraphMode.FULL and i == 0
+-                                else None
+-                            ),
++            with self._freeze_gc():
++                for component, channel_id in (
++                    ("target", "vllm:target:profile"),
++                    ("draft", "vllm:draft:profile"),
++                ):
++                    component_descs = [
++                        (mode, descs)
++                        for mode, descs in capture_descs
++                        if descs
++                        and (
++                            component == "target"
++                            or self._captures_independent_drafter_graphs(mode)
+                         )
+-                        torch.accelerator.synchronize()
+-                        free_after = torch.accelerator.get_memory_info()[0]
+-                        mem_samples.append(mem_before - free_after)
++                    ]
++                    if not component_descs:
++                        continue
+ 
+-                    first_capture = mem_samples[0]
+-                    # Use at least 1 MiB per graph for driver overhead
+-                    per_graph = max(
+-                        mem_samples[1] if len(mem_samples) > 1 else 0, 1 << 20
++                    # ROCm profiles on vLLM's dedicated compute stream to avoid
++                    # stranding allocator pages in a disposable side stream.
++                    cap_ctx = (
++                        GraphCaptureContext(current_stream(), channel_id=channel_id)
++                        if current_platform.is_rocm()
++                        else None
+                     )
++                    with graph_capture(
++                        device=self.device,
++                        graph_capture_context=cap_ctx,
++                        channel_id=channel_id,
++                    ):
++                        torch.accelerator.synchronize()
++                        torch.accelerator.empty_cache()
+ 
+-                    shared_memory_estimate[mode] = first_capture
+-                    per_graph_estimate[mode] = per_graph * (len(descs) - 1)
++                        for mode, descs in component_descs:
++                            profile_descs = descs[:2]
++                            mem_samples: list[int] = []
++                            captures_drafter = (
++                                self._captures_independent_drafter_graphs(mode)
++                            )
+ 
+-                    logger.debug(
+-                        "Estimated %s CUDA graph memory: "
+-                        "%.2f MiB first-capture + (%d-1) × %.2f MiB per-graph",
+-                        mode.name,
+-                        first_capture / (1 << 20),
+-                        len(descs),
+-                        per_graph / (1 << 20),
+-                    )
++                            for i, desc in enumerate(profile_descs):
++                                mem_before = torch.accelerator.get_memory_info()[0]
++                                self._warmup_and_capture(
++                                    desc,
++                                    cudagraph_runtime_mode=mode,
++                                    profile_seq_lens=(
++                                        min(
++                                            self.max_model_len,
++                                            self.max_num_tokens // desc.num_tokens,
++                                        )
++                                        if mode == CUDAGraphMode.FULL and i == 0
++                                        else None
++                                    ),
++                                    run_drafter=(
++                                        component == "draft" or not captures_drafter
++                                    ),
++                                )
++                                torch.accelerator.synchronize()
++                                free_after = torch.accelerator.get_memory_info()[0]
++                                mem_samples.append(max(mem_before - free_after, 0))
++
++                            first_capture = mem_samples[0]
++                            # Use at least 1 MiB per graph for driver overhead.
++                            per_graph = max(
++                                mem_samples[1] if len(mem_samples) > 1 else 0,
++                                1 << 20,
++                            )
++
++                            shared_memory_estimate[mode] = (
++                                shared_memory_estimate.get(mode, 0) + first_capture
++                            )
++                            per_graph_estimate[mode] = per_graph_estimate.get(
++                                mode, 0
++                            ) + per_graph * (len(descs) - 1)
++
++                            logger.debug(
++                                "Estimated %s %s CUDA graph memory: "
++                                "%.2f MiB first-capture + (%d-1) x %.2f MiB "
++                                "per-graph",
++                                component,
++                                mode.name,
++                                first_capture / (1 << 20),
++                                len(descs),
++                                per_graph / (1 << 20),
++                            )
+ 
+                 if encoder_cudagraph_manager is not None:
++                    channel_id = "vllm:encoder:profile"
++                    cap_ctx = (
++                        GraphCaptureContext(current_stream(), channel_id=channel_id)
++                        if current_platform.is_rocm()
++                        else None
++                    )
+                     mem_before = torch.accelerator.get_memory_info()[0]
+-                    encoder_cudagraph_manager.capture(graph_pool=encoder_profiling_pool)
++                    with graph_capture(
++                        device=self.device,
++                        graph_capture_context=cap_ctx,
++                        channel_id=channel_id,
++                    ):
++                        encoder_cudagraph_manager.capture(
++                            graph_pool=encoder_profiling_pool
++                        )
+                     torch.accelerator.synchronize()
+                     free_after = torch.accelerator.get_memory_info()[0]
+                     encoder_memory_estimate = max(mem_before - free_after, 0)
+@@ -6800,23 +6832,26 @@ class GPUModelRunner(
+                         encoder_graphs,
+                     )
+         finally:
+-            set_cudagraph_capturing_enabled(False)
+-            CUDAGraphWrapper.clear_all_graphs()
+-            BreakableCUDAGraphWrapper.clear_all_graphs()
+-            if encoder_cudagraph_manager is not None:
+-                encoder_cudagraph_manager.clear()
+-            all_wrappers = list(CUDAGraphWrapper._all_instances) + list(
+-                BreakableCUDAGraphWrapper._all_instances
+-            )
+-            for instance in all_wrappers:
+-                if id(instance) in original_pools:
+-                    instance.graph_pool = original_pools[id(instance)]
+-            for key_set in self.cudagraph_dispatcher.cudagraph_keys.values():
+-                key_set.clear()
+-            self.cudagraph_dispatcher.keys_initialized = False
+-            self.maybe_remove_all_loras(self.lora_config)
+-            self._cleanup_profiling_kv_cache()
+-            compilation_counter.num_cudagraph_captured = saved_num_cudagraph_captured
++            try:
++                try:
++                    set_cudagraph_capturing_enabled(False)
++                    CUDAGraphWrapper.clear_all_graphs()
++                    BreakableCUDAGraphWrapper.clear_all_graphs()
++                    if encoder_cudagraph_manager is not None:
++                        encoder_cudagraph_manager.clear()
++                finally:
++                    for instance in all_wrappers:
++                        instance.graph_pool = original_pools[id(instance)]
++                for key_set in self.cudagraph_dispatcher.cudagraph_keys.values():
++                    key_set.clear()
++                self.cudagraph_dispatcher.keys_initialized = False
++                self.maybe_remove_all_loras(self.lora_config)
++                self._cleanup_profiling_kv_cache()
++                compilation_counter.num_cudagraph_captured = (
++                    saved_num_cudagraph_captured
++                )
++            finally:
++                rollback_b12x_graph_channels(graph_channel_checkpoints)
+ 
+         # FULL and PIECEWISE graphs share the global pool at runtime and are
+         # never replayed concurrently, so the pool overlays their memory.
+@@ -6853,36 +6888,58 @@ class GPUModelRunner(
+         # Trigger CUDA graph capture for specific shapes.
+         # Capture the large shapes first so that the smaller shapes
+         # can reuse the memory pool allocated for the large shapes.
++        capture_descs = list(self.cudagraph_dispatcher.get_capture_descs())
+         set_cudagraph_capturing_enabled(True)
+-        with self._freeze_gc(), graph_capture(device=self.device):
+-            torch.accelerator.synchronize()
+-            torch.accelerator.empty_cache()
+-            start_free_gpu_memory = torch.accelerator.get_memory_info()[0]
+-
+-            for (
+-                runtime_mode,
+-                batch_descs,
+-            ) in self.cudagraph_dispatcher.get_capture_descs():
+-                self._capture_cudagraphs(
+-                    batch_descriptors=batch_descs,
+-                    cudagraph_runtime_mode=runtime_mode,
+-                )
++        try:
++            with self._freeze_gc():
+                 torch.accelerator.synchronize()
++                torch.accelerator.empty_cache()
++                start_free_gpu_memory = torch.accelerator.get_memory_info()[0]
+ 
+-            # Capture encoder CUDA graphs if enabled
+-            if self.encoder_cudagraph_manager is not None:
+-                encoder_graph_pool = current_platform.graph_pool_handle()
+-                self.encoder_cudagraph_manager.capture(graph_pool=encoder_graph_pool)
++                for component, channel_id in (
++                    ("target", "vllm:target:production"),
++                    ("draft", "vllm:draft:production"),
++                ):
++                    component_descs = [
++                        (mode, descs)
++                        for mode, descs in capture_descs
++                        if descs
++                        and (
++                            component == "target"
++                            or self._captures_independent_drafter_graphs(mode)
++                        )
++                    ]
++                    if not component_descs:
++                        continue
++                    with graph_capture(device=self.device, channel_id=channel_id):
++                        for runtime_mode, batch_descs in component_descs:
++                            captures_drafter = (
++                                self._captures_independent_drafter_graphs(runtime_mode)
++                            )
++                            self._capture_cudagraphs(
++                                batch_descriptors=batch_descs,
++                                cudagraph_runtime_mode=runtime_mode,
++                                run_drafter=(
++                                    component == "draft" or not captures_drafter
++                                ),
++                            )
++                            torch.accelerator.synchronize()
+ 
+-            torch.accelerator.synchronize()
+-            end_free_gpu_memory = torch.accelerator.get_memory_info()[0]
++                if self.encoder_cudagraph_manager is not None:
++                    encoder_graph_pool = current_platform.graph_pool_handle()
++                    with graph_capture(
++                        device=self.device,
++                        channel_id="vllm:encoder:production",
++                    ):
++                        self.encoder_cudagraph_manager.capture(
++                            graph_pool=encoder_graph_pool
++                        )
+ 
+-        # Disable cudagraph capturing globally, so any unexpected cudagraph
+-        # capturing will be detected and raise an error after here.
+-        # Note: We don't put it into graph_capture context manager because
+-        # we may do lazy capturing in future that still allows capturing
+-        # after here.
+-        set_cudagraph_capturing_enabled(False)
++                torch.accelerator.synchronize()
++                end_free_gpu_memory = torch.accelerator.get_memory_info()[0]
++        finally:
++            # Leave capture mode disabled even when one graph owner fails.
++            set_cudagraph_capturing_enabled(False)
+ 
+         torch.accelerator.synchronize()
+         torch.accelerator.empty_cache()
+@@ -6902,6 +6959,35 @@ class GPUModelRunner(
+         )
+         return cuda_graph_size
+ 
++    def _captures_independent_drafter_graphs(
++        self,
++        cudagraph_runtime_mode: CUDAGraphMode,
++    ) -> bool:
++        """Return whether PIECEWISE capture needs a separate drafter pass.
++
++        Args:
++            cudagraph_runtime_mode: CUDA graph mode being captured.
++
++        Returns:
++            Whether the mode owns independently replayable drafter graphs.
++        """
++        spec_config = self.speculative_config
++        return (
++            cudagraph_runtime_mode == CUDAGraphMode.PIECEWISE
++            and spec_config is not None
++            and not spec_config.enforce_eager
++            and self._drafter_runs_model_forward()
++        )
++
++    def _drafter_runs_model_forward(self) -> bool:
++        """Return whether the configured drafter executes a model forward."""
++        spec_config = self.speculative_config
++        return spec_config is not None and (
++            spec_config.use_eagle()
++            or spec_config.uses_draft_model()
++            or spec_config.uses_extract_hidden_states()
++        )
++
+     def _warmup_and_capture(
+         self,
+         desc: BatchDescriptor,
+@@ -6909,6 +6995,7 @@ class GPUModelRunner(
+         profile_seq_lens: int | None = None,
+         allow_microbatching: bool = False,
+         num_warmups: int | None = None,
++        run_drafter: bool = True,
+     ):
+         if num_warmups is None:
+             num_warmups = self.compilation_config.cudagraph_num_of_warmups
+@@ -6924,6 +7011,7 @@ class GPUModelRunner(
+                 remove_lora=False,
+                 num_active_loras=desc.num_active_loras,
+                 profile_seq_lens=profile_seq_lens,
++                run_drafter=run_drafter,
+             )
+         self._dummy_run(
+             desc.num_tokens,
+@@ -6935,12 +7023,15 @@ class GPUModelRunner(
+             num_active_loras=desc.num_active_loras,
+             is_graph_capturing=True,
+             profile_seq_lens=profile_seq_lens,
++            run_drafter=run_drafter,
+         )
+ 
+     def _capture_cudagraphs(
+         self,
+         batch_descriptors: list[BatchDescriptor],
+         cudagraph_runtime_mode: CUDAGraphMode,
++        *,
++        run_drafter: bool = True,
+     ):
+         assert (
+             cudagraph_runtime_mode != CUDAGraphMode.NONE
+@@ -6983,6 +7074,7 @@ class GPUModelRunner(
+                 batch_desc,
+                 cudagraph_runtime_mode=cudagraph_runtime_mode,
+                 allow_microbatching=allow_microbatching,
++                run_drafter=run_drafter,
+             )
+             torch.accelerator.synchronize()
+         self.maybe_remove_all_loras(self.lora_config)

--- a/tests/test-gilded-gnosis-release-composition.sh
+++ b/tests/test-gilded-gnosis-release-composition.sh
@@ -302,4 +302,33 @@ grep -Fxq 'lmcache_version=0.5.2+glm52dcp.4' <<<"${output_r16}"
 grep -Fxq 'xgrammar_ref=v0.2.5' <<<"${output_r16}"
 grep -Fxq 'xgrammar_transformers5_compat=1' <<<"${output_r16}"
 
+output_r17="$(
+  cd "${repo_root}"
+  PRINT_RELEASE_CONFIG=1 VLLM_RELEASE_COMPOSITION=reproduce-r17 \
+    ./build-gilded-gnosis-v20-final-cu132.sh
+)"
+
+grep -Fxq 'composition=reproduce-r17' <<<"${output_r17}"
+grep -Fxq \
+  'image=voipmonitor/vllm:gilded-gnosis-v20-vllmdb29328-sicfde478-fi801d57a-cu132-20260801-r17' \
+  <<<"${output_r17}"
+grep -Fxq \
+  'version=0.11.2.dev280+gilded.gnosis.v20.vllmdb29328.sicfde478.fi801d57a.cu132.20260801.r17' \
+  <<<"${output_r17}"
+grep -Fxq \
+  'vllm_tree=db293280d021d32db0552f3f6e4b95abbd9c69a1' \
+  <<<"${output_r17}"
+grep -Fxq \
+  'sparkinfer_tree=cfde4787facf7e32248beb8011a1aa0048b4c33c' \
+  <<<"${output_r17}"
+grep -Fxq \
+  'lmcache_tree=a5aa59cc8edca462a3f4c198d17fd2b9c1a7ffaa' \
+  <<<"${output_r17}"
+grep -Fxq \
+  'lmcache_patch=releases/gilded-gnosis-v20-r17/lmcache/integration.patch' \
+  <<<"${output_r17}"
+grep -Fxq 'lmcache_version=0.5.2+glm52dcp.4' <<<"${output_r17}"
+grep -Fxq 'xgrammar_ref=v0.2.5' <<<"${output_r17}"
+grep -Fxq 'xgrammar_transformers5_compat=1' <<<"${output_r17}"
+
 echo 'Gilded Gnosis release composition: PASS'

--- a/tests/test-gilded-gnosis-release-composition.sh
+++ b/tests/test-gilded-gnosis-release-composition.sh
@@ -322,10 +322,10 @@ grep -Fxq \
   'sparkinfer_tree=cfde4787facf7e32248beb8011a1aa0048b4c33c' \
   <<<"${output_r17}"
 grep -Fxq \
-  'launcher_ref=16482e1d3195f9880dc888da47b73ea28499575b' \
+  'launcher_ref=ec0279f1c2ccf06656df21d65c7a18984c45fcd8' \
   <<<"${output_r17}"
 grep -Fxq \
-  'launcher_commit=16482e1d3195f9880dc888da47b73ea28499575b' \
+  'launcher_commit=ec0279f1c2ccf06656df21d65c7a18984c45fcd8' \
   <<<"${output_r17}"
 grep -Fxq \
   'lmcache_tree=a5aa59cc8edca462a3f4c198d17fd2b9c1a7ffaa' \

--- a/tests/test-gilded-gnosis-release-composition.sh
+++ b/tests/test-gilded-gnosis-release-composition.sh
@@ -310,16 +310,16 @@ output_r17="$(
 
 grep -Fxq 'composition=reproduce-r17' <<<"${output_r17}"
 grep -Fxq \
-  'image=voipmonitor/vllm:gilded-gnosis-v20-vllmdb29328-sicfde478-fi801d57a-cu132-20260801-r17' \
+  'image=voipmonitor/vllm:gilded-gnosis-v20-vllmdb29328-sib2bff71-fi801d57a-cu132-20260801-r17' \
   <<<"${output_r17}"
 grep -Fxq \
-  'version=0.11.2.dev280+gilded.gnosis.v20.vllmdb29328.sicfde478.fi801d57a.cu132.20260801.r17' \
+  'version=0.11.2.dev280+gilded.gnosis.v20.vllmdb29328.sib2bff71.fi801d57a.cu132.20260801.r17' \
   <<<"${output_r17}"
 grep -Fxq \
   'vllm_tree=db293280d021d32db0552f3f6e4b95abbd9c69a1' \
   <<<"${output_r17}"
 grep -Fxq \
-  'sparkinfer_tree=cfde4787facf7e32248beb8011a1aa0048b4c33c' \
+  'sparkinfer_tree=b2bff719ba1be0a5d30cb39cba795f0812db0f3d' \
   <<<"${output_r17}"
 grep -Fxq \
   'launcher_ref=ec0279f1c2ccf06656df21d65c7a18984c45fcd8' \

--- a/tests/test-gilded-gnosis-release-composition.sh
+++ b/tests/test-gilded-gnosis-release-composition.sh
@@ -322,6 +322,12 @@ grep -Fxq \
   'sparkinfer_tree=cfde4787facf7e32248beb8011a1aa0048b4c33c' \
   <<<"${output_r17}"
 grep -Fxq \
+  'launcher_ref=16482e1d3195f9880dc888da47b73ea28499575b' \
+  <<<"${output_r17}"
+grep -Fxq \
+  'launcher_commit=16482e1d3195f9880dc888da47b73ea28499575b' \
+  <<<"${output_r17}"
+grep -Fxq \
   'lmcache_tree=a5aa59cc8edca462a3f4c198d17fd2b9c1a7ffaa' \
   <<<"${output_r17}"
 grep -Fxq \

--- a/tests/test-glm52-pcie-calibration-helper.sh
+++ b/tests/test-glm52-pcie-calibration-helper.sh
@@ -190,4 +190,18 @@ unexported_preload_output="$(
 )"
 assert_contains "${unexported_preload_output}" "${calibrator}"
 
+unexported_other_output="$(
+  run_runtime_env_preload unexported /tmp/unexported-preload.so
+)"
+assert_contains \
+  "${unexported_other_output}" \
+  "${calibrator}:/tmp/unexported-preload.so"
+
+space_separated_output="$(
+  run_runtime_env_preload set "/tmp/first-preload.so /tmp/second-preload.so"
+)"
+assert_contains \
+  "${space_separated_output}" \
+  "${calibrator}:/tmp/first-preload.so /tmp/second-preload.so"
+
 echo "GLM-5.2 PCIe calibration helper: PASS"

--- a/tests/test-glm52-pcie-calibration-helper.sh
+++ b/tests/test-glm52-pcie-calibration-helper.sh
@@ -146,17 +146,36 @@ if run_helper DCP_CKV_GATHER_MAX_TOKENS=not-a-number >/dev/null; then
 fi
 
 runtime_env_script="${repo_root}/launchers/glm52-pcie-runtime-env.sh"
-preload_output="$(
+run_runtime_env_preload() {
+  local preload_state="$1"
+  local initial_preload="${2:-}"
+
   RUNTIME_ENV_SCRIPT="${runtime_env_script}" \
-  TEST_NCCL_PATH="${calibrator}" \
-  bash -c '
+    TEST_NCCL_PATH="${calibrator}" \
+    bash -c '
+    case "$1" in
+      unset) unset LD_PRELOAD ;;
+      empty) export LD_PRELOAD= ;;
+      set) export LD_PRELOAD="$2" ;;
+      *) exit 64 ;;
+    esac
+    set -u
     source "${RUNTIME_ENV_SCRIPT}"
     export NCCL_LOCAL_INFERENCE_PATH="${TEST_NCCL_PATH}"
-    export LD_PRELOAD=/tmp/existing-preload.so
     configure_glm52_pcie_runtime_env 1 0
     configure_glm52_pcie_runtime_env 1 0
     printf "%s\n" "${LD_PRELOAD}"
-  '
+  ' _ "${preload_state}" "${initial_preload}"
+}
+
+unset_preload_output="$(run_runtime_env_preload unset)"
+assert_contains "${unset_preload_output}" "${calibrator}"
+
+empty_preload_output="$(run_runtime_env_preload empty)"
+assert_contains "${empty_preload_output}" "${calibrator}"
+
+preload_output="$(
+  run_runtime_env_preload set /tmp/existing-preload.so
 )"
 assert_contains "${preload_output}" "${calibrator}:/tmp/existing-preload.so"
 

--- a/tests/test-glm52-pcie-calibration-helper.sh
+++ b/tests/test-glm52-pcie-calibration-helper.sh
@@ -157,7 +157,9 @@ run_runtime_env_preload() {
       unset) unset LD_PRELOAD ;;
       empty) export LD_PRELOAD= ;;
       set) export LD_PRELOAD="$2" ;;
-      unexported) LD_PRELOAD="$2" ;;
+      unexported)
+        unset LD_PRELOAD
+        LD_PRELOAD="$2" ;;
       *) exit 64 ;;
     esac
     set -u

--- a/tests/test-glm52-pcie-calibration-helper.sh
+++ b/tests/test-glm52-pcie-calibration-helper.sh
@@ -157,6 +157,7 @@ run_runtime_env_preload() {
       unset) unset LD_PRELOAD ;;
       empty) export LD_PRELOAD= ;;
       set) export LD_PRELOAD="$2" ;;
+      unexported) LD_PRELOAD="$2" ;;
       *) exit 64 ;;
     esac
     set -u
@@ -164,6 +165,11 @@ run_runtime_env_preload() {
     export NCCL_LOCAL_INFERENCE_PATH="${TEST_NCCL_PATH}"
     configure_glm52_pcie_runtime_env 1 0
     configure_glm52_pcie_runtime_env 1 0
+    [[ "$(declare -p LD_PRELOAD)" == "declare -x "* ]] || {
+      printf "LD_PRELOAD was not exported: %s\n" \
+        "$(declare -p LD_PRELOAD)" >&2
+      exit 65
+    }
     printf "%s\n" "${LD_PRELOAD}"
   ' _ "${preload_state}" "${initial_preload}"
 }
@@ -178,5 +184,10 @@ preload_output="$(
   run_runtime_env_preload set /tmp/existing-preload.so
 )"
 assert_contains "${preload_output}" "${calibrator}:/tmp/existing-preload.so"
+
+unexported_preload_output="$(
+  run_runtime_env_preload unexported "${calibrator}"
+)"
+assert_contains "${unexported_preload_output}" "${calibrator}"
 
 echo "GLM-5.2 PCIe calibration helper: PASS"

--- a/tests/test-release-manifest-fail-fast.sh
+++ b/tests/test-release-manifest-fail-fast.sh
@@ -27,17 +27,33 @@ fi
 
 bash -n "${build_script}"
 
-launcher_ref="$(sed -n 's/^export LAUNCHER_REF="${LAUNCHER_REF:-\([^}]*\)}"$/\1/p' \
-  "${build_script}")"
-launcher_commit="$(sed -n 's/^export LAUNCHER_COMMIT="${LAUNCHER_COMMIT:-\([^}]*\)}"$/\1/p' \
-  "${build_script}")"
-[[ "${launcher_ref}" =~ ^[0-9a-f]{40}$ ]] || {
-  echo "default LAUNCHER_REF is not an immutable commit" >&2
+mapfile -t launcher_refs < <(
+  sed -n 's/^  export LAUNCHER_REF="${LAUNCHER_REF:-\([^}]*\)}"$/\1/p' \
+    "${build_script}"
+)
+mapfile -t launcher_commits < <(
+  sed -n 's/^  export LAUNCHER_COMMIT="${LAUNCHER_COMMIT:-\([^}]*\)}"$/\1/p' \
+    "${build_script}"
+)
+
+[[ "${#launcher_refs[@]}" -gt 0 ]] || {
+  echo "no default LAUNCHER_REF values found" >&2
   exit 1
 }
-[[ "${launcher_ref}" == "${launcher_commit}" ]] || {
-  echo "default LAUNCHER_REF and LAUNCHER_COMMIT differ" >&2
+[[ "${#launcher_refs[@]}" -eq "${#launcher_commits[@]}" ]] || {
+  echo "default LAUNCHER_REF and LAUNCHER_COMMIT counts differ" >&2
   exit 1
 }
+
+for index in "${!launcher_refs[@]}"; do
+  [[ "${launcher_refs[index]}" =~ ^[0-9a-f]{40}$ ]] || {
+    echo "default LAUNCHER_REF is not an immutable commit" >&2
+    exit 1
+  }
+  [[ "${launcher_refs[index]}" == "${launcher_commits[index]}" ]] || {
+    echo "default LAUNCHER_REF and LAUNCHER_COMMIT differ" >&2
+    exit 1
+  }
+done
 
 echo "release manifest fail-fast contract: PASS"


### PR DESCRIPTION
## Purpose

Publish the audited Gilded Gnosis r17 composition and make every release input reproducible from public branches and immutable commits.

The release combines the current GG base with the explicitly pinned vLLM, SparkInfer, FlashInfer, and LMCache changes recorded in the checked-in lock manifests. No source checkout or mutable branch is consumed during the build.

## Primary r17 fix

The first r17 candidate silently fell back from SparkInfer PCIe all-reduce to PyNCCL because the SparkInfer wheel contained `pcie_oneshot.cu` but omitted its local runtime-JIT header `ipc_handle_registry.h`. Runtime compilation then failed with a missing-header error.

SparkInfer #105 now packages local `*.h` files and has a wheel-level regression test. This release also validates local quoted includes during composition, so a future incomplete wheel fails during the build rather than degrading at runtime.

## Composition

- vLLM base: `30038602b71395f481ef4a6edfe4fcf8551d9c15`
- composed vLLM tree: `db293280d021d32db0552f3f6e4b95abbd9c69a1`
- SparkInfer base: `b0976b7fd46b5d34357a5f615822b86792676feb`
- composed SparkInfer tree: `b2bff719ba1be0a5d30cb39cba795f0812db0f3d`
- FlashInfer: `801d57a`
- CUDA: 13.2
- LMCache base: `9cebd405`
- composed LMCache tree: `a5aa59cc`

The exact PR heads are recorded in `patches/releases/gilded-gnosis-v20-r17/*/integration.lock.json`.

## Validation

Build-time gates passed:

- release composition and fail-fast manifest tests;
- 6 compose tests;
- 219 LMCache tests, 131 skipped;
- SparkInfer wheel local-header validation;
- runtime import and launcher-contract checks;
- XGrammar 0.2.5, InstantTensor 0.1.9, CUDA, and NCCL checks.

E2E on 4x RTX PRO 6000 Blackwell, `willfalco/GLM-5.2-EXL3-TR3-3.25bpw`, TP4/DCP4/MTP0:

- custom SparkInfer PCIe group selected; no missing-header fallback;
- logical KV capacity: 855,808 tokens;
- settled prefill at 3K / 32K / 128K: 3,761 / 3,670 / 3,306 tok/s;
- matched the fixed A/B reference (3,799 / 3,677 / 3,302 tok/s) within noise;
- response sanity returned exactly `OK`.

The Discord report around vLLM #219 is already represented by #222: shape-aware one-grid K3/K4 decode and serial FP32-accumulating prefill are retained, with bounded-prefill capacity added. The r17 slowdown was the independent wheel-packaging fallback fixed above.

## Published image

`voipmonitor/vllm:gilded-gnosis-v20-vllmdb29328-sib2bff71-fi801d57a-cu132-20260801-r17`

Digest: `sha256:d1008eb2bce2947110010fcf52b715b49d54ed3bf62a6b1e0a0b698774157727`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added the Gilded Gnosis v20 r17 release composition with updated vLLM, SparkInfer, LMCache, launcher, and XGrammar configurations.
  * Improved PCIe communication, CUDA graph replay, KV-cache offloading, memory management, and model execution for supported workloads.
  * Added GLM-5.2 calibration and optional scale-file configuration support.

* **Bug Fixes**
  * Improved handling of partial storage failures, memory pressure, remote errors, runtime cleanup, and compatible filesystem formats.
  * Added validation to detect incomplete CUDA package dependencies during image builds.

* **Tests**
  * Expanded coverage for release composition, runtime environment configuration, manifests, communication, caching, and GPU execution.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

Release wiki: https://github.com/local-inference-lab/rtx6kpro/blob/master/models/glm5.2_v20.md

Canonical merge checklist: https://github.com/local-inference-lab/rtx6kpro/issues/33