### PR TITLE
build(gg): publish reproducible DS4 r24 release

### DIFF
--- a/Dockerfile.vllm-b12x-cu132
+++ b/Dockerfile.vllm-b12x-cu132
@@ -1351,6 +1351,7 @@ ARG DEEPGEMM_REF
 ARG DEEPGEMM_COMMIT
 ARG TRITON_KERNELS_REF
 ARG TRITON_KERNELS_COMMIT
+ARG INSTANTTENSOR_REPO
 ARG INSTANTTENSOR_REF
 ARG INSTANTTENSOR_COMMIT
 ARG LAUNCHER_REF
@@ -1427,6 +1428,7 @@ LABEL org.opencontainers.image.description="Clean CUDA 13.2.1 vLLM+SparkInfer im
       local-inference.deepgemm.commit="${DEEPGEMM_COMMIT}" \
       local-inference.triton_kernels.branch="${TRITON_KERNELS_REF}" \
       local-inference.triton_kernels.commit="${TRITON_KERNELS_COMMIT}" \
+      local-inference.instanttensor.repo="${INSTANTTENSOR_REPO}" \
       local-inference.instanttensor.branch="${INSTANTTENSOR_REF}" \
       local-inference.instanttensor.commit="${INSTANTTENSOR_COMMIT}" \
       local-inference.exllamav3.repo="${EXLLAMAV3_REPO}" \

--- a/README.md
+++ b/README.md
@@ -313,6 +313,29 @@ no encodes, an identical EXL3 cache manifest, and reached `/health` in 113.94
 seconds. MTP0 CC1 decode was 53.23/53.08 tok/s; uncached prefill was 3,635.67
 tok/s at 8k and 3,512.62 tok/s at 64k.
 
+The r24 DS4 release hardens compressed MLA workspace sizing, InstantTensor
+host registration, native KV-offload shared-region lifetime, replay/IPC graph
+state, and the MHC compile boundary. It also includes capacity-bounded LMCache
+storage. Reproduce the exact source trees with:
+
+```bash
+VLLM_RELEASE_COMPOSITION=reproduce-r24 \
+  ./build-gilded-gnosis-v20-final-cu132.sh
+```
+
+Published r24 image:
+
+```text
+voipmonitor/vllm:gilded-gnosis-v20-vllmf5981f1-si2b9bf2a-fi801d57a-cu132-20260803-r24
+```
+
+The DS4 deployment recipe is
+`examples/docker-compose-ds4-v20-r24.yml`. Native KV offload is disabled by
+default. When enabled, its shared host region is unlinked after every worker
+has mapped it, so it is reclaimed automatically when the final worker exits.
+LMCache's disk-capacity fix is included, but LMCache remains experimental for
+DS4 because long-context output correctness is not yet closed.
+
 The current unified image installs
 `/usr/local/bin/serve-fathomless-firmament.sh`, which dispatches to the GLM or
 DS4 helper through `MODEL_FAMILY`. Start either model with a minimal

--- a/README.md
+++ b/README.md
@@ -327,6 +327,7 @@ Published r24 image:
 
 ```text
 voipmonitor/vllm:gilded-gnosis-v20-vllmf5981f1-si2b9bf2a-fi801d57a-cu132-20260803-r24
+manifest: sha256:64b94299abdd3bcf5bb5050ca91b378f9ee4e0b0eff4748375b95352371d7cb2
 ```
 
 The DS4 deployment recipe is

--- a/build-gilded-gnosis-v20-final-cu132.sh
+++ b/build-gilded-gnosis-v20-final-cu132.sh
@@ -101,8 +101,18 @@ if [[ "${composition_mode}" == "clean" ]]; then
     --output-dir "${lmcache_composition_dir}" >/dev/null
   configure_lmcache_composition "${lmcache_composition_dir}" 1
 
-  export IMAGE="${IMAGE:-voipmonitor/vllm:gilded-gnosis-v20-vllm${VLLM_INTEGRATION_TREE:0:7}-si${SPARKINFER_INTEGRATION_TREE:0:7}-fi801d57a-cu132-${release_date}-r21}"
-  export VLLM_BUILD_VERSION="${VLLM_BUILD_VERSION:-0.11.2.dev280+gilded.gnosis.v20.vllm${VLLM_INTEGRATION_TREE:0:7}.si${SPARKINFER_INTEGRATION_TREE:0:7}.fi801d57a.cu132.${release_date}.r21}"
+  export IMAGE="${IMAGE:-voipmonitor/vllm:gilded-gnosis-v20-vllm${VLLM_INTEGRATION_TREE:0:7}-si${SPARKINFER_INTEGRATION_TREE:0:7}-fi801d57a-cu132-${release_date}-r24}"
+  export VLLM_BUILD_VERSION="${VLLM_BUILD_VERSION:-0.11.2.dev280+gilded.gnosis.v20.vllm${VLLM_INTEGRATION_TREE:0:7}.si${SPARKINFER_INTEGRATION_TREE:0:7}.fi801d57a.cu132.${release_date}.r24}"
+elif [[ "${composition_mode}" == "reproduce-r24" ]]; then
+  configure_vllm_composition \
+    "patches/releases/gilded-gnosis-v20-r24/vllm" 0
+  configure_sparkinfer_composition \
+    "patches/releases/gilded-gnosis-v20-r24/sparkinfer" 0
+  configure_lmcache_composition \
+    "patches/releases/gilded-gnosis-v20-r24/lmcache" 0
+
+  export IMAGE="${IMAGE:-voipmonitor/vllm:gilded-gnosis-v20-vllmf5981f1-si2b9bf2a-fi801d57a-cu132-20260803-r24}"
+  export VLLM_BUILD_VERSION="${VLLM_BUILD_VERSION:-0.11.2.dev280+gilded.gnosis.v20.vllmf5981f1.si2b9bf2a.fi801d57a.cu132.20260803.r24}"
 elif [[ "${composition_mode}" == "reproduce-r20" ]]; then
   configure_vllm_composition \
     "patches/releases/gilded-gnosis-v20-r20/vllm" 0
@@ -303,7 +313,7 @@ export VLLM_PATCH_URL=
 export SPARKINFER_VERSION="${SPARKINFER_VERSION:-1.0.1}"
 
 export LAUNCHER_REPO="${LAUNCHER_REPO:-https://github.com/local-inference-lab/blackwell-llm-docker.git}"
-if [[ "${composition_mode}" == "clean" || "${composition_mode}" == "reproduce-r20" ]]; then
+if [[ "${composition_mode}" == "clean" || "${composition_mode}" == "reproduce-r24" || "${composition_mode}" == "reproduce-r20" ]]; then
   export LAUNCHER_REF="${LAUNCHER_REF:-76b1cf0350709910208e61285adc955e34655136}"
   export LAUNCHER_COMMIT="${LAUNCHER_COMMIT:-76b1cf0350709910208e61285adc955e34655136}"
 elif [[ "${composition_mode}" == "reproduce-r19" || "${composition_mode}" == "reproduce-r18" ]]; then
@@ -328,7 +338,7 @@ export TRITON_KERNELS_REF=
 export TRITON_KERNELS_COMMIT=
 
 export XGRAMMAR_REPO="${XGRAMMAR_REPO:-https://github.com/mlc-ai/xgrammar.git}"
-if [[ "${composition_mode}" == "clean" || "${composition_mode}" == "reproduce-r8" || "${composition_mode}" == "reproduce-r9" || "${composition_mode}" == "reproduce-r11" || "${composition_mode}" == "reproduce-r12" || "${composition_mode}" == "reproduce-r13" || "${composition_mode}" == "reproduce-r14" || "${composition_mode}" == "reproduce-r15" || "${composition_mode}" == "reproduce-r16" || "${composition_mode}" == "reproduce-r17" || "${composition_mode}" == "reproduce-r18" || "${composition_mode}" == "reproduce-r19" || "${composition_mode}" == "reproduce-r20" ]]; then
+if [[ "${composition_mode}" == "clean" || "${composition_mode}" == "reproduce-r8" || "${composition_mode}" == "reproduce-r9" || "${composition_mode}" == "reproduce-r11" || "${composition_mode}" == "reproduce-r12" || "${composition_mode}" == "reproduce-r13" || "${composition_mode}" == "reproduce-r14" || "${composition_mode}" == "reproduce-r15" || "${composition_mode}" == "reproduce-r16" || "${composition_mode}" == "reproduce-r17" || "${composition_mode}" == "reproduce-r18" || "${composition_mode}" == "reproduce-r19" || "${composition_mode}" == "reproduce-r20" || "${composition_mode}" == "reproduce-r24" ]]; then
   export XGRAMMAR_REF="${XGRAMMAR_REF:-v0.2.5}"
   export XGRAMMAR_COMMIT="${XGRAMMAR_COMMIT:-2ea71da4ccb997a06928c9fb69b99f330da56697}"
   export XGRAMMAR_VERSION="${XGRAMMAR_VERSION:-0.2.5}"
@@ -342,7 +352,7 @@ else
   export XGRAMMAR_TRANSFORMERS5_COMPAT="${XGRAMMAR_TRANSFORMERS5_COMPAT:-0}"
 fi
 
-if [[ "${composition_mode}" == "clean" ]]; then
+if [[ "${composition_mode}" == "clean" || "${composition_mode}" == "reproduce-r24" ]]; then
   export INSTANTTENSOR_REPO="${INSTANTTENSOR_REPO:-https://github.com/voipmonitor/InstantTensor.git}"
   export INSTANTTENSOR_REF="${INSTANTTENSOR_REF:-25b3f268ea95b76bd03c825a1681872c9b615428}"
   export INSTANTTENSOR_COMMIT="${INSTANTTENSOR_COMMIT:-25b3f268ea95b76bd03c825a1681872c9b615428}"
@@ -351,7 +361,7 @@ else
   export INSTANTTENSOR_REF="${INSTANTTENSOR_REF:-85e7c5f5539d9c006ee0c26bc1b5233c65251b6b}"
   export INSTANTTENSOR_COMMIT="${INSTANTTENSOR_COMMIT:-85e7c5f5539d9c006ee0c26bc1b5233c65251b6b}"
 fi
-if [[ "${composition_mode}" == "clean" || "${composition_mode}" == "reproduce-r11" || "${composition_mode}" == "reproduce-r12" || "${composition_mode}" == "reproduce-r13" || "${composition_mode}" == "reproduce-r14" || "${composition_mode}" == "reproduce-r15" || "${composition_mode}" == "reproduce-r16" || "${composition_mode}" == "reproduce-r17" || "${composition_mode}" == "reproduce-r18" || "${composition_mode}" == "reproduce-r19" || "${composition_mode}" == "reproduce-r20" ]]; then
+if [[ "${composition_mode}" == "clean" || "${composition_mode}" == "reproduce-r11" || "${composition_mode}" == "reproduce-r12" || "${composition_mode}" == "reproduce-r13" || "${composition_mode}" == "reproduce-r14" || "${composition_mode}" == "reproduce-r15" || "${composition_mode}" == "reproduce-r16" || "${composition_mode}" == "reproduce-r17" || "${composition_mode}" == "reproduce-r18" || "${composition_mode}" == "reproduce-r19" || "${composition_mode}" == "reproduce-r20" || "${composition_mode}" == "reproduce-r24" ]]; then
   export LMCACHE_BUILD_VERSION="${LMCACHE_BUILD_VERSION:-0.5.2+glm52dcp.4}"
 elif [[ "${composition_mode}" == "reproduce-r6" ]]; then
   export LMCACHE_REPO="${LMCACHE_REPO:-https://github.com/LMCache/LMCache.git}"
@@ -437,7 +447,7 @@ jq -e --arg value "${LMCACHE_PATCH_SHA256}" '."local-inference.lmcache.patch_sha
 jq -e --arg value "${LMCACHE_BUILD_VERSION}" '."local-inference.lmcache.version" == $value' <<<"${labels}" >/dev/null
 jq -e --arg value "${INSTANTTENSOR_REPO}" '."local-inference.instanttensor.repo" == $value' <<<"${labels}" >/dev/null
 jq -e --arg value "${INSTANTTENSOR_COMMIT}" '."local-inference.instanttensor.commit" == $value' <<<"${labels}" >/dev/null
-if [[ "${composition_mode}" == "clean" || "${composition_mode}" == "reproduce-r11" || "${composition_mode}" == "reproduce-r12" || "${composition_mode}" == "reproduce-r13" || "${composition_mode}" == "reproduce-r14" || "${composition_mode}" == "reproduce-r15" || "${composition_mode}" == "reproduce-r16" || "${composition_mode}" == "reproduce-r17" || "${composition_mode}" == "reproduce-r18" || "${composition_mode}" == "reproduce-r19" || "${composition_mode}" == "reproduce-r20" ]]; then
+if [[ "${composition_mode}" == "clean" || "${composition_mode}" == "reproduce-r11" || "${composition_mode}" == "reproduce-r12" || "${composition_mode}" == "reproduce-r13" || "${composition_mode}" == "reproduce-r14" || "${composition_mode}" == "reproduce-r15" || "${composition_mode}" == "reproduce-r16" || "${composition_mode}" == "reproduce-r17" || "${composition_mode}" == "reproduce-r18" || "${composition_mode}" == "reproduce-r19" || "${composition_mode}" == "reproduce-r20" || "${composition_mode}" == "reproduce-r24" ]]; then
   jq -e --arg value "${LMCACHE_INTEGRATION_TREE}" '."local-inference.lmcache.integration.tree" == $value' <<<"${labels}" >/dev/null
   jq -e --arg value "${LMCACHE_INTEGRATION_PRS}" '."local-inference.lmcache.integration.prs" == $value' <<<"${labels}" >/dev/null
   jq -e --arg value "${LMCACHE_INTEGRATION_LOCK_SHA256}" '."local-inference.lmcache.integration.lock_sha256" == $value' <<<"${labels}" >/dev/null

--- a/build-gilded-gnosis-v20-final-cu132.sh
+++ b/build-gilded-gnosis-v20-final-cu132.sh
@@ -101,8 +101,8 @@ if [[ "${composition_mode}" == "clean" ]]; then
     --output-dir "${lmcache_composition_dir}" >/dev/null
   configure_lmcache_composition "${lmcache_composition_dir}" 1
 
-  export IMAGE="${IMAGE:-voipmonitor/vllm:gilded-gnosis-v20-vllm${VLLM_INTEGRATION_TREE:0:7}-si${SPARKINFER_INTEGRATION_TREE:0:7}-fi801d57a-cu132-${release_date}-r20}"
-  export VLLM_BUILD_VERSION="${VLLM_BUILD_VERSION:-0.11.2.dev280+gilded.gnosis.v20.vllm${VLLM_INTEGRATION_TREE:0:7}.si${SPARKINFER_INTEGRATION_TREE:0:7}.fi801d57a.cu132.${release_date}.r20}"
+  export IMAGE="${IMAGE:-voipmonitor/vllm:gilded-gnosis-v20-vllm${VLLM_INTEGRATION_TREE:0:7}-si${SPARKINFER_INTEGRATION_TREE:0:7}-fi801d57a-cu132-${release_date}-r21}"
+  export VLLM_BUILD_VERSION="${VLLM_BUILD_VERSION:-0.11.2.dev280+gilded.gnosis.v20.vllm${VLLM_INTEGRATION_TREE:0:7}.si${SPARKINFER_INTEGRATION_TREE:0:7}.fi801d57a.cu132.${release_date}.r21}"
 elif [[ "${composition_mode}" == "reproduce-r20" ]]; then
   configure_vllm_composition \
     "patches/releases/gilded-gnosis-v20-r20/vllm" 0
@@ -342,9 +342,15 @@ else
   export XGRAMMAR_TRANSFORMERS5_COMPAT="${XGRAMMAR_TRANSFORMERS5_COMPAT:-0}"
 fi
 
-export INSTANTTENSOR_REPO="${INSTANTTENSOR_REPO:-https://github.com/scitix/InstantTensor.git}"
-export INSTANTTENSOR_REF="${INSTANTTENSOR_REF:-85e7c5f5539d9c006ee0c26bc1b5233c65251b6b}"
-export INSTANTTENSOR_COMMIT="${INSTANTTENSOR_COMMIT:-85e7c5f5539d9c006ee0c26bc1b5233c65251b6b}"
+if [[ "${composition_mode}" == "clean" ]]; then
+  export INSTANTTENSOR_REPO="${INSTANTTENSOR_REPO:-https://github.com/voipmonitor/InstantTensor.git}"
+  export INSTANTTENSOR_REF="${INSTANTTENSOR_REF:-25b3f268ea95b76bd03c825a1681872c9b615428}"
+  export INSTANTTENSOR_COMMIT="${INSTANTTENSOR_COMMIT:-25b3f268ea95b76bd03c825a1681872c9b615428}"
+else
+  export INSTANTTENSOR_REPO="${INSTANTTENSOR_REPO:-https://github.com/scitix/InstantTensor.git}"
+  export INSTANTTENSOR_REF="${INSTANTTENSOR_REF:-85e7c5f5539d9c006ee0c26bc1b5233c65251b6b}"
+  export INSTANTTENSOR_COMMIT="${INSTANTTENSOR_COMMIT:-85e7c5f5539d9c006ee0c26bc1b5233c65251b6b}"
+fi
 if [[ "${composition_mode}" == "clean" || "${composition_mode}" == "reproduce-r11" || "${composition_mode}" == "reproduce-r12" || "${composition_mode}" == "reproduce-r13" || "${composition_mode}" == "reproduce-r14" || "${composition_mode}" == "reproduce-r15" || "${composition_mode}" == "reproduce-r16" || "${composition_mode}" == "reproduce-r17" || "${composition_mode}" == "reproduce-r18" || "${composition_mode}" == "reproduce-r19" || "${composition_mode}" == "reproduce-r20" ]]; then
   export LMCACHE_BUILD_VERSION="${LMCACHE_BUILD_VERSION:-0.5.2+glm52dcp.4}"
 elif [[ "${composition_mode}" == "reproduce-r6" ]]; then
@@ -364,7 +370,7 @@ else
 fi
 
 if [[ "${PRINT_RELEASE_CONFIG:-0}" == 1 ]]; then
-  printf 'composition=%s\nimage=%s\nversion=%s\nvllm_tree=%s\nsparkinfer_tree=%s\nlauncher_repo=%s\nlauncher_ref=%s\nlauncher_commit=%s\nlmcache_tree=%s\nlmcache_repo=%s\nlmcache_ref=%s\nlmcache_commit=%s\nlmcache_patch=%s\nlmcache_version=%s\nxgrammar_repo=%s\nxgrammar_ref=%s\nxgrammar_commit=%s\nxgrammar_version=%s\nxgrammar_transformers5_compat=%s\n' \
+  printf 'composition=%s\nimage=%s\nversion=%s\nvllm_tree=%s\nsparkinfer_tree=%s\nlauncher_repo=%s\nlauncher_ref=%s\nlauncher_commit=%s\nlmcache_tree=%s\nlmcache_repo=%s\nlmcache_ref=%s\nlmcache_commit=%s\nlmcache_patch=%s\nlmcache_version=%s\nxgrammar_repo=%s\nxgrammar_ref=%s\nxgrammar_commit=%s\nxgrammar_version=%s\nxgrammar_transformers5_compat=%s\ninstanttensor_repo=%s\ninstanttensor_ref=%s\ninstanttensor_commit=%s\n' \
     "${composition_mode}" "${IMAGE}" "${VLLM_BUILD_VERSION}" \
     "${VLLM_INTEGRATION_TREE:-}" "${SPARKINFER_INTEGRATION_TREE:-}" \
     "${LAUNCHER_REPO}" "${LAUNCHER_REF}" "${LAUNCHER_COMMIT}" \
@@ -372,7 +378,8 @@ if [[ "${PRINT_RELEASE_CONFIG:-0}" == 1 ]]; then
     "${LMCACHE_REPO}" "${LMCACHE_REF}" "${LMCACHE_COMMIT}" \
     "${LMCACHE_PATCH_FILE}" "${LMCACHE_BUILD_VERSION}" \
     "${XGRAMMAR_REPO}" "${XGRAMMAR_REF}" "${XGRAMMAR_COMMIT}" \
-    "${XGRAMMAR_VERSION}" "${XGRAMMAR_TRANSFORMERS5_COMPAT}"
+    "${XGRAMMAR_VERSION}" "${XGRAMMAR_TRANSFORMERS5_COMPAT}" \
+    "${INSTANTTENSOR_REPO}" "${INSTANTTENSOR_REF}" "${INSTANTTENSOR_COMMIT}"
   exit 0
 fi
 export HUMMING_KERNELS_SPEC="${HUMMING_KERNELS_SPEC:-humming-kernels[cu13]==0.1.10}"
@@ -428,6 +435,8 @@ jq -e --arg value "${EXLLAMAV3_COMMIT}" '."local-inference.exllamav3.commit" == 
 jq -e --arg value "${LMCACHE_COMMIT}" '."local-inference.lmcache.commit" == $value' <<<"${labels}" >/dev/null
 jq -e --arg value "${LMCACHE_PATCH_SHA256}" '."local-inference.lmcache.patch_sha256" == $value' <<<"${labels}" >/dev/null
 jq -e --arg value "${LMCACHE_BUILD_VERSION}" '."local-inference.lmcache.version" == $value' <<<"${labels}" >/dev/null
+jq -e --arg value "${INSTANTTENSOR_REPO}" '."local-inference.instanttensor.repo" == $value' <<<"${labels}" >/dev/null
+jq -e --arg value "${INSTANTTENSOR_COMMIT}" '."local-inference.instanttensor.commit" == $value' <<<"${labels}" >/dev/null
 if [[ "${composition_mode}" == "clean" || "${composition_mode}" == "reproduce-r11" || "${composition_mode}" == "reproduce-r12" || "${composition_mode}" == "reproduce-r13" || "${composition_mode}" == "reproduce-r14" || "${composition_mode}" == "reproduce-r15" || "${composition_mode}" == "reproduce-r16" || "${composition_mode}" == "reproduce-r17" || "${composition_mode}" == "reproduce-r18" || "${composition_mode}" == "reproduce-r19" || "${composition_mode}" == "reproduce-r20" ]]; then
   jq -e --arg value "${LMCACHE_INTEGRATION_TREE}" '."local-inference.lmcache.integration.tree" == $value' <<<"${labels}" >/dev/null
   jq -e --arg value "${LMCACHE_INTEGRATION_PRS}" '."local-inference.lmcache.integration.prs" == $value' <<<"${labels}" >/dev/null

--- a/examples/docker-compose-ds4-v20-r24.yml
+++ b/examples/docker-compose-ds4-v20-r24.yml
@@ -1,0 +1,55 @@
+# DeepSeek-V4-Flash-0731 DSpark release profile.
+#
+# Default: TP2/DCP1, SparkInfer W4A8, fixed K5. K7 remains opt-in because
+# long-context output-quality reports are still unresolved.
+#
+# Native KV offload is opt-in with KV_OFFLOADING_SIZE=<total GiB>. Because this
+# compose file uses host IPC, /dev/shm must have that capacity plus normal
+# runtime headroom. r24 unlinks the backing pathname after every worker maps
+# it, so normal or abrupt process exit releases the mapping automatically.
+#
+# TP4 Lucifer CUTLASS example:
+#   GPUS=0,1,2,3 TP_SIZE=4 BACKEND=lucifer-cutlass docker compose \
+#     -f examples/docker-compose-ds4-v20-r24.yml up -d
+services:
+  ds4:
+    image: ${IMAGE:-voipmonitor/vllm:gilded-gnosis-v20-vllmf5981f1-si2b9bf2a-fi801d57a-cu132-20260803-r24}
+    container_name: ${NAME:-ds4-0731-r24}
+    entrypoint: ["/usr/local/bin/serve-ds4-flash.sh"]
+    network_mode: host
+    ipc: host
+    privileged: true
+    init: true
+    shm_size: 32gb
+    gpus: all
+    restart: unless-stopped
+    ulimits:
+      memlock:
+        soft: -1
+        hard: -1
+      nofile:
+        soft: 1048576
+        hard: 1048576
+      stack: 67108864
+    environment:
+      CUDA_VISIBLE_DEVICES: ${GPUS:-0,1}
+      PORT: ${PORT:-8000}
+      MODE: ${MODE:-dspark}
+      BACKEND: ${BACKEND:-b12x-a8}
+      TP_SIZE: ${TP_SIZE:-2}
+      DCP_SIZE: ${DCP_SIZE:-1}
+      DSPARK_DEPTH_MODE: ${DSPARK_DEPTH_MODE:-fixed}
+      DSPARK_TOKENS: ${DSPARK_TOKENS:-5}
+      MAX_NUM_SEQS: ${MAX_NUM_SEQS:-16}
+      MAX_MODEL_LEN: ${MAX_MODEL_LEN:-131072}
+      MAX_NUM_BATCHED_TOKENS: ${MAX_NUM_BATCHED_TOKENS:-8192}
+      GPU_MEMORY_UTILIZATION: ${GPU_MEMORY_UTILIZATION:-0.975}
+      LOAD_FORMAT: ${LOAD_FORMAT:-instanttensor}
+      INSTANTTENSOR_BACKEND: ${INSTANTTENSOR_BACKEND:-BUFFERED}
+      # Total native host KV capacity across all TP ranks; 0 disables it.
+      KV_OFFLOADING_SIZE: ${KV_OFFLOADING_SIZE:-0}
+    volumes:
+      - ${HF_CACHE:-/root/.cache/huggingface}:/root/.cache/huggingface
+      - ${MODEL_ROOT:-/root/models}:/root/models:ro
+      - ${JIT_CACHE:-./cache/ds4-v20-r24}:/cache
+      - ${CONTAINER_TMP:-./cache/ds4-v20-r24/tmp}:/container-tmp

--- a/manifests/vllm/gilded-gnosis-v20.json
+++ b/manifests/vllm/gilded-gnosis-v20.json
@@ -10,9 +10,9 @@
       "title": "GLM-5.2 calibrated NVFP4 MLA KV outer scales"
     },
     {
-      "number": 212,
-      "head": "fbc022664df3ad39a3acb1b6404d1b17683ada4c",
-      "title": "Preserve compressed MLA page stride"
+      "number": 229,
+      "head": "672aec40dc664de014bd1e92d9a2885d7658c37f",
+      "title": "Harden compressed MLA cache and workspace contracts"
     },
     {
       "number": 213,
@@ -26,7 +26,7 @@
     },
     {
       "number": 217,
-      "head": "69a9076645c78b4cfd301ae841f91cf8550112ce",
+      "head": "222512b9fe02b30e917188baa89e4b11ddde8cc6",
       "title": "Use shared regions for native CPU KV offload"
     },
     {

--- a/manifests/vllm/gilded-gnosis-v20.json
+++ b/manifests/vllm/gilded-gnosis-v20.json
@@ -26,8 +26,8 @@
     },
     {
       "number": 217,
-      "head": "222512b9fe02b30e917188baa89e4b11ddde8cc6",
-      "title": "Use shared regions for native CPU KV offload"
+      "head": "c7ac22d5bfe923803cc923f2293085faac7d1dd0",
+      "title": "Harden shared regions for native CPU KV offload"
     },
     {
       "number": 218,
@@ -43,6 +43,11 @@
       "number": 228,
       "head": "1702ed2d28342d84551539f8d7e2de637f7ca04e",
       "title": "Consolidate r20 EXL3 prefill and online K6 cache"
+    },
+    {
+      "number": 230,
+      "head": "9401f9d8916f3bdf34123d2d493a918b748c8132",
+      "title": "Keep broadcast MHC pre behind the compile boundary"
     }
   ]
 }

--- a/patches/releases/gilded-gnosis-v20-r24/lmcache/integration.lock.json
+++ b/patches/releases/gilded-gnosis-v20-r24/lmcache/integration.lock.json
@@ -1,63 +1,96 @@
 {
-  "schema_version": 1,
+  "base": {
+    "commit": "9cebd405d0caf4bebe01d694b5a8bf4e3e354314",
+    "ref": "refs/heads/release/v0.5.2-glm52-dcp-base",
+    "repository": "https://github.com/local-inference-lab/LMCache.git"
+  },
+  "manifest": {
+    "sha256": "7cce6c13a12987da499b1adb3e52c25447604aecfa2ec5d90d0dbbb6f76d570c"
+  },
   "name": "gilded-gnosis-v20-lmcache",
-  "repository": "https://github.com/local-inference-lab/LMCache.git",
-  "base_ref": "refs/heads/release/v0.5.2-glm52-dcp-base",
   "pull_requests": [
     {
-      "number": 7,
+      "disposition": "merged",
       "head": "7b7583aef55e98ba05a6c199e71601d78552e794",
+      "number": 7,
+      "ref": "refs/pull/7/head",
       "title": "Return bounded LMCache MP RPC handler errors"
     },
     {
-      "number": 8,
+      "disposition": "merged",
       "head": "31c4175d2134518e5b43fe8f4a7d072df6043a13",
+      "number": 8,
+      "ref": "refs/pull/8/head",
       "title": "Recover failed MP retrieves by recomputing invalid blocks"
     },
     {
-      "number": 9,
+      "disposition": "merged",
       "head": "c3b73de74d855f6263deea8b6c6c4dde87e6e5b9",
+      "number": 9,
+      "ref": "refs/pull/9/head",
       "title": "Restore the largest exact L1 prefix after allocation failure"
     },
     {
-      "number": 10,
+      "disposition": "merged",
       "head": "59186798bb5859b7add7bcac81dff9f2fd4037ab",
+      "number": 10,
+      "ref": "refs/pull/10/head",
       "title": "Protect native lookup keys from concurrent deletion"
     },
     {
-      "number": 11,
+      "disposition": "merged",
       "head": "2cee5a2c1ef7e80028e94b1bc4bfbfc02e2c2a8d",
+      "number": 11,
+      "ref": "refs/pull/11/head",
       "title": "Log bounded prefetch failure key samples"
     },
     {
-      "number": 12,
+      "disposition": "merged",
       "head": "baf1345106ebe568a116a35fdcee36bfec73da57",
+      "number": 12,
+      "ref": "refs/pull/12/head",
       "title": "Return native per-key store results"
     },
     {
-      "number": 13,
+      "disposition": "merged",
       "head": "d4dce69bf90362953cf9ac9a86cccc186b3219dc",
+      "number": 13,
+      "ref": "refs/pull/13/head",
       "title": "Enforce native filesystem O_DIRECT alignment"
     },
     {
-      "number": 14,
+      "disposition": "merged",
       "head": "502b3c60f2e61625d6e32a31d0d725eedc620792",
+      "number": 14,
+      "ref": "refs/pull/14/head",
       "title": "Support current and legacy native filesystem object-group keys"
     },
     {
-      "number": 15,
+      "disposition": "merged",
       "head": "7729a9c75f2c29f14a27ea1e84ee6970950197ce",
+      "number": 15,
+      "ref": "refs/pull/15/head",
       "title": "Make native stores durable and capacity-bounded"
     },
     {
-      "number": 16,
+      "disposition": "merged",
       "head": "e6c2708fe8ae8a96d3c66e83bf4b548c734fbb13",
+      "number": 16,
+      "ref": "refs/pull/16/head",
       "title": "Restore native filesystem capacity accounting after restart"
     },
     {
-      "number": 17,
+      "disposition": "merged",
       "head": "f9639e2094f70955a1145bfd7219b6fdd39ee143",
+      "number": 17,
+      "ref": "refs/pull/17/head",
       "title": "Add bounded L1 writeback to durable storage"
     }
-  ]
+  ],
+  "result": {
+    "patch": "integration.patch",
+    "patch_sha256": "e9f5369ee134cbc697e77d9fd9d77219aceea5fabf2fe90e3b74542bbeb200ca",
+    "tree": "9a05c8818bae48d15b79c7e876418bb813c08cd0"
+  },
+  "schema_version": 1
 }

--- a/patches/releases/gilded-gnosis-v20-r24/lmcache/integration.patch
+++ b/patches/releases/gilded-gnosis-v20-r24/lmcache/integration.patch
@@ -1,0 +1,4262 @@
+diff --git a/csrc/storage_backends/connector_base.h b/csrc/storage_backends/connector_base.h
+index c2cd35a174a1225c467d1479ea347b0d6e5ebd0e..0df7677cef0d0172a7cb60f7c9f3599cb189b555 100644
+--- a/csrc/storage_backends/connector_base.h
++++ b/csrc/storage_backends/connector_base.h
+@@ -111,6 +111,9 @@ class ConnectorBase : public IStorageConnector {
+     auto [batch_future_id, batch_state, num_tiles, tile_size] =
+         prepare_batch_operation(num_items, Op::BATCH_TILE_SET);
+ 
++    // pre-allocate per-key results so partial store failures are visible
++    batch_state->per_key_results.assign(num_items, 0);
++
+     // fan out work to threads
+     for (size_t tile_idx = 0; tile_idx < num_tiles; ++tile_idx) {
+       auto tile_req = create_tile_request(
+@@ -326,10 +329,30 @@ class ConnectorBase : public IStorageConnector {
+       }
+     }
+   }
++  // Records a per-key result for every key in the tile (continuing past
++  // failures instead of aborting the tile), then rethrows so batch-level
++  // ok=false semantics are preserved for consumers that ignore per-key
++  // results.
+   virtual void do_batch_set(ConnectionType& conn, const Request& req) {
++    bool any_failed = false;
++    std::string first_error;
+     for (size_t i = 0; i < req.keys.size(); ++i) {
+-      do_single_set(conn, req.keys[i], req.buf_ptrs[i], req.buf_lens[i],
+-                    req.batch_chunk_num_bytes);
++      try {
++        do_single_set(conn, req.keys[i], req.buf_ptrs[i], req.buf_lens[i],
++                      req.batch_chunk_num_bytes);
++        req.batch->per_key_results[req.start_idx + i] = 1;
++      } catch (const std::exception& e) {
++        req.batch->per_key_results[req.start_idx + i] = 0;
++        if (!any_failed) {
++          any_failed = true;
++          first_error = e.what();
++        }
++        fprintf(stderr, "[LMCache SET] key %s failed: %s\n",
++                req.keys[i].c_str(), e.what());
++      }
++    }
++    if (any_failed) {
++      throw std::runtime_error("batch set partially failed: " + first_error);
+     }
+   }
+   virtual void do_batch_exists(ConnectionType& conn, const Request& req) {
+@@ -612,9 +635,10 @@ class ConnectorBase : public IStorageConnector {
+         std::lock_guard<std::mutex> lk(req.batch->err_mu);
+         batch_comp.error = req.batch->first_error;
+       }
+-      // for batch exists and batch get, move per-key results
++      // move per-key results for every op that records them
+       if (req.batch->batch_op == Op::BATCH_TILE_EXISTS ||
+           req.batch->batch_op == Op::BATCH_TILE_GET ||
++          req.batch->batch_op == Op::BATCH_TILE_SET ||
+           req.batch->batch_op == Op::BATCH_TILE_DELETE) {
+         batch_comp.result_bytes = std::move(req.batch->per_key_results);
+       }
+diff --git a/csrc/storage_backends/fs/connector.cpp b/csrc/storage_backends/fs/connector.cpp
+index e54d98f54f5428afad363cf1c5f5f380cdd8fffb..727ed016f10ae0b0c6e863c4234439dbaac0e7f8 100644
+--- a/csrc/storage_backends/fs/connector.cpp
++++ b/csrc/storage_backends/fs/connector.cpp
+@@ -2,10 +2,22 @@
+ 
+ #include "connector.h"
+ #include <cerrno>
++#include <cstdint>
+ #include <cstdio>
+ #include <stdexcept>
+ #include <string>
+ 
++namespace {
++// O_DIRECT requires the buffer ADDRESS to be block-aligned as well as the
++// length; a misaligned address fails the read/write with EINVAL. Buffers
++// come from Python and carry no alignment guarantee, so fall back to
++// buffered I/O whenever either constraint is unmet.
++bool odirect_eligible(const void* buf, size_t len, size_t disk_block_size) {
++  return disk_block_size > 0 && len % disk_block_size == 0 &&
++         reinterpret_cast<uintptr_t>(buf) % disk_block_size == 0;
++}
++}  // namespace
++
+ namespace lmcache {
+ namespace connector {
+ 
+@@ -27,22 +39,23 @@ std::string FSConnector::replace_all(const std::string& str,
+ 
+ std::string FSConnector::key_to_filename(const std::string& key) {
+   // Input key format (from _object_key_to_string):
+-  //   Unsalted: <model_name>@<kv_rank_hex>@<chunk_hash_hex>
+-  //   Salted  : <model_name>@<kv_rank_hex>@<chunk_hash_hex>@<cache_salt>
++  //   Legacy unsalted: <model_name>@<kv_rank_hex>@<chunk_hash_hex>
++  //   Legacy salted  : <model_name>@<kv_rank_hex>@<chunk_hash_hex>@<cache_salt>
++  //   Current unsalted:
++  //     <model_name>@<kv_rank_hex>@<object_group_id_hex>@<chunk_hash_hex>
++  //   Current salted appends @<cache_salt> to the current unsalted shape.
+   //
+   // Output filename (matching fs_l2_adapter.py._object_key_to_filename):
+   //   Unsalted: <model_name_safe>@0x<kv_rank_hex>@<chunk_hash_hex>.data
+   //   Salted  :
+   //   <model_name_safe>@0x<kv_rank_hex>@<chunk_hash_hex>@<cache_salt>.data
+   //
+-  // The unsalted 3-field shape is bit-identical to the pre-cache_salt
+-  // format, so existing cache directories remain valid.
+-  //
+-  // NOTE: both model_name and cache_salt are forbidden from containing
+-  // '@' (invariant enforced on the Python side), so splitting on '@'
+-  // is unambiguous — no marker, no rsplit.
++  // Four fields are intentionally not interpreted: that shape can mean a
++  // legacy salted key or a current unsalted key, and both map correctly by
++  // preserving every field after kv_rank verbatim.
+ 
+-  // Split on '@' — must yield 3 (unsalted) or 4 (salted) fields.
++  // Split on '@'. Current ObjectKey serialization has four or five fields;
++  // three-field legacy keys remain readable for cache compatibility.
+   std::vector<std::string> parts;
+   size_t start = 0;
+   for (size_t pos = 0; pos <= key.size(); ++pos) {
+@@ -51,34 +64,28 @@ std::string FSConnector::key_to_filename(const std::string& key) {
+       start = pos + 1;
+     }
+   }
+-  if (parts.size() != 3 && parts.size() != 4) {
++  if (parts.size() < 3 || parts.size() > 5) {
+     throw std::runtime_error(
+-        "FSConnector: malformed key (expected 3 or 4 '@'-separated fields): " +
++        "FSConnector: malformed key (expected 3 to 5 '@'-separated fields): " +
+         key);
+   }
+ 
+   const std::string& model_name = parts[0];
+   const std::string& kv_rank_hex = parts[1];
+-  const std::string& chunk_hash = parts[2];
+-  const std::string cache_salt = parts.size() == 4 ? parts[3] : std::string();
+ 
+   // Replace '/' with '-SEP-' for filesystem safety
+   std::string safe_model = replace_all(model_name, "/", PATH_SLASH_REPLACEMENT);
+ 
+-  // Emit filename. Salt is appended at the tail so the unsalted shape
+-  // matches what older builds wrote to disk.
++  // Emit the model and normalized rank, preserving all remaining fields.
+   std::string result;
+-  result.reserve(safe_model.size() + kv_rank_hex.size() + chunk_hash.size() +
+-                 cache_salt.size() + 32);
++  result.reserve(key.size() + 16);
+   result += safe_model;
+   result += KEY_SEP;
+   result += "0x";
+   result += kv_rank_hex;
+-  result += KEY_SEP;
+-  result += chunk_hash;
+-  if (!cache_salt.empty()) {
++  for (size_t i = 2; i < parts.size(); ++i) {
+     result += KEY_SEP;
+-    result += cache_salt;
++    result += parts[i];
+   }
+   result += FILE_EXT;
+   return result;
+@@ -174,8 +181,11 @@ void FSConnector::do_single_get(WorkerFSConn& conn, const std::string& key,
+   int flags = O_RDONLY;
+   bool do_odirect = conn.use_odirect;
+   if (do_odirect) {
+-    bool aligned = conn.disk_block_size > 0 && len % conn.disk_block_size == 0;
+-    if (aligned) {
++    const bool split_aligned = conn.disk_block_size > 0 &&
++                               (conn.read_ahead_size == 0 ||
++                                len <= conn.read_ahead_size ||
++                                conn.read_ahead_size % conn.disk_block_size == 0);
++    if (odirect_eligible(buf, len, conn.disk_block_size) && split_aligned) {
+ #ifdef O_DIRECT
+       flags |= O_DIRECT;
+ #endif
+@@ -243,8 +253,7 @@ void FSConnector::do_single_set(WorkerFSConn& conn, const std::string& key,
+   int flags = O_CREAT | O_WRONLY | O_TRUNC;
+   bool do_odirect = conn.use_odirect;
+   if (do_odirect) {
+-    bool aligned = conn.disk_block_size > 0 && len % conn.disk_block_size == 0;
+-    if (aligned) {
++    if (odirect_eligible(buf, len, conn.disk_block_size)) {
+ #ifdef O_DIRECT
+       flags |= O_DIRECT;
+ #endif
+diff --git a/csrc/storage_backends/fs/connector.h b/csrc/storage_backends/fs/connector.h
+index 03b7b9cc5e0a2cac7ab9e39404d80c760b4e9018..7b9010947c18de36684317ed7c2628c3d2be0161 100644
+--- a/csrc/storage_backends/fs/connector.h
++++ b/csrc/storage_backends/fs/connector.h
+@@ -21,7 +21,9 @@ static constexpr const char* FILE_EXT = ".data";
+ static constexpr const char* TMP_EXT = ".tmp";
+ 
+ // Per-worker connection state for the FS connector.
+-// Each worker maintains its own I/O buffer for O_DIRECT.
++// O_DIRECT engages per request only when both the transfer length and the
++// caller's buffer address are multiples of the disk block size; anything
++// else falls back to buffered I/O.
+ struct WorkerFSConn {
+   std::filesystem::path base_path;
+   std::filesystem::path tmp_dir;  // empty if not configured
+@@ -52,17 +54,20 @@ class FSConnector : public ConnectorBase<WorkerFSConn> {
+   // Build the filesystem-safe filename from a serialized key string.
+   //
+   // Input key (from NativeConnectorL2Adapter._object_key_to_string):
+-  //   Unsalted: "{model}@{kv_rank:08x}@{hash.hex()}"
+-  //   Salted  : "{model}@{kv_rank:08x}@{hash.hex()}@{cache_salt}"
++  //   Current unsalted:
++  //     "{model}@{kv_rank:08x}@{object_group:x}@{hash.hex()}"
++  //   Current salted appends "@{cache_salt}". Legacy three/four-field keys
++  //   without object_group_id remain supported.
+   //
+   // Output filename (matching fs_l2_adapter.py._object_key_to_filename):
+-  //   Unsalted: "{safe_model}@{kv_rank:#010x}@{hash.hex()}.data"
+-  //   Salted  : "{safe_model}@{kv_rank:#010x}@{hash.hex()}@{cache_salt}.data"
++  //   Current unsalted:
++  //     "{safe_model}@{kv_rank:#010x}@{object_group:x}@{hash.hex()}.data"
++  //   Current salted appends "@{cache_salt}" before ".data".
+   //
+   // Differences from the input: '/' in model becomes '-SEP-', kv_rank
+-  // gains a '0x' prefix, and '.data' is appended. Both model_name and
+-  // cache_salt are forbidden from containing '@' (enforced on the
+-  // Python side), so the parse is unambiguous.
++  // gains a '0x' prefix, and '.data' is appended. All fields after kv_rank
++  // are preserved because four fields can represent either a legacy salted
++  // key or a current unsalted key.
+   static std::string key_to_filename(const std::string& key);
+ 
+   static std::string replace_all(const std::string& str,
+diff --git a/csrc/storage_backends/mooncake/connector.cpp b/csrc/storage_backends/mooncake/connector.cpp
+index 685fa4165b188b517a5c0de50753e5ae2e596d6f..0d5109e0dbb5595476806071d62c6dedd6f2bf98 100644
+--- a/csrc/storage_backends/mooncake/connector.cpp
++++ b/csrc/storage_backends/mooncake/connector.cpp
+@@ -173,12 +173,23 @@ void MooncakeConnector::do_batch_set(WorkerMooncakeConn& conn,
+       conn.client->batch_put_from(req.keys, req.buf_ptrs, req.buf_lens);
+   ensure_batch_result_size(results, req.keys.size(), "batch_put_from");
+ 
++  // Record per-key results before failing the tile so partial store
++  // failures stay visible to consumers that honor them.
++  size_t first_failed = results.size();
+   for (size_t i = 0; i < results.size(); ++i) {
+-    if (results[i] != 0) {
+-      throw std::runtime_error("Mooncake batch_put_from failed for key: " +
+-                               req.keys[i]);
++    if (results[i] == 0) {
++      req.batch->per_key_results[req.start_idx + i] = 1;
++    } else {
++      req.batch->per_key_results[req.start_idx + i] = 0;
++      if (first_failed == results.size()) {
++        first_failed = i;
++      }
+     }
+   }
++  if (first_failed != results.size()) {
++    throw std::runtime_error("Mooncake batch_put_from failed for key: " +
++                             req.keys[first_failed]);
++  }
+ }
+ 
+ void MooncakeConnector::do_batch_exists(WorkerMooncakeConn& conn,
+diff --git a/lmcache/integration/vllm/lmcache_mp_connector.py b/lmcache/integration/vllm/lmcache_mp_connector.py
+index d268070c3c0daa534a616c88312f8da7b5c665de..21af3747ede9f78c608841a692acc9c25e0bbc29 100644
+--- a/lmcache/integration/vllm/lmcache_mp_connector.py
++++ b/lmcache/integration/vllm/lmcache_mp_connector.py
+@@ -464,6 +464,42 @@ class LMCacheMPRequestMetadata:
+             "number of LMCache hit tokens. "
+         )
+         if end_token_idx > start_token_idx:
++            # allocated_block_ids must cover [start_token_idx, end_token_idx)
++            # in every engine group. slice_block_ids_per_group() validates
++            # chunk alignment only; its plain Python slice truncates
++            # silently, so a tracker primed with LMCache hit counts on a
++            # scheduling pass whose allocation never materialised would emit
++            # a retrieve op with too few block ids. The MP server fails
++            # closed on the short list, wasting a doomed round-trip and
++            # relying on the failure being surfaced at all. Suppress the op
++            # instead so the request recomputes cleanly. Never clamp
++            # end_token_idx: a clamped retrieve completes a load vLLM does
++            # not expect and re-creates the desync downstream.
++            # One allocated id of group g covers group_tokens_per_block[g]
++            # global token positions (KV-spec block_size, DCP-scaled), the
++            # same arithmetic GetStoreMetadata uses to bound its
++            # allocated_tokens.
++            for group_idx, tokens_per_block in enumerate(group_tokens_per_block):
++                allocated = len(tracker.allocated_block_ids.get(group_idx, []))
++                if allocated * tokens_per_block < end_token_idx:
++                    logger.warning(
++                        "LMCache retrieve suppressed for request_id=%s: "
++                        "engine group %d has %d allocated block(s) x %d "
++                        "tokens/block = %d tokens < end_token_idx=%d "
++                        "(start_token_idx=%d, vllm_hit_tokens=%d, "
++                        "lmcache_hit_tokens=%d) -- tracker/allocation "
++                        "desync; falling back to recompute.",
++                        tracker.request_id,
++                        group_idx,
++                        allocated,
++                        tokens_per_block,
++                        allocated * tokens_per_block,
++                        end_token_idx,
++                        start_token_idx,
++                        tracker.num_vllm_hit_tokens,
++                        tracker.num_lmcache_hit_tokens,
++                    )
++                    return None
+             block_ids = slice_block_ids_per_group(
+                 tracker.allocated_block_ids,
+                 group_tokens_per_block,
+diff --git a/lmcache/integration/vllm/vllm_multi_process_adapter.py b/lmcache/integration/vllm/vllm_multi_process_adapter.py
+index d74fe3af02cbefc7755c8446434a36034c681ef3..dd5aa0e6033292eaad06dd8f0b7961d58cf6b2f1 100644
+--- a/lmcache/integration/vllm/vllm_multi_process_adapter.py
++++ b/lmcache/integration/vllm/vllm_multi_process_adapter.py
+@@ -1173,8 +1173,11 @@ class LMCacheMPWorkerAdapter:
+         self.store_events: dict[str, list[_IpcEvent]] = {}
+         self.retrieve_events: dict[str, _IpcEvent] = {}
+ 
+-        # Block IDs that failed due to retrieve timeout
++        # Block IDs of failed retrieves (timeout, server-reported failure,
++        # or raising future), consumed by get_block_ids_with_load_errors().
+         self.error_block_ids: set[int] = set()
++        # Total failed retrieves on this worker, for log-based diagnostics.
++        self.retrieve_failure_count: int = 0
+ 
+         # Retrieve request ids dropped by the unhealthy early-return of
+         # submit_retrieve_request. get_finished must still report each id
+@@ -1657,6 +1660,9 @@ class LMCacheMPWorkerAdapter:
+             - The second set contains the finished retrieve request ids,
+                 including retrieves dropped at submit time while unhealthy
+                 (reported exactly once; blocks already in error_block_ids).
++                A failed retrieve (server result False or a raising future)
++                is reported finished with its block ids recorded in
++                error_block_ids so the scheduler recomputes them.
+ 
+         Notes:
+             When enabling async scheduling in vLLM, the same request ID may appear
+@@ -1701,19 +1707,45 @@ class LMCacheMPWorkerAdapter:
+ 
+         finished_stores = self._poll_store_futures()
+         finished_retrieves = set()
+-        for request_id, (r_future, _) in self.retrieve_futures.items():
++        for request_id, (r_future, r_block_ids) in self.retrieve_futures.items():
+             if not r_future.query():
+                 continue
+ 
+-            r_result = r_future.result()
++            try:
++                r_result = r_future.result()
++            except Exception as exc:
++                # A raising future must not propagate out of get_finished
++                # (that would kill the engine step); contain it as a failed
++                # retrieve on the standard failure path.
++                logger.error(
++                    "LMCache retrieve future raised for request_id=%s: %r "
++                    "-- treating as failed retrieve.",
++                    request_id,
++                    exc,
++                )
++                r_result = False
+             finished_retrieves.add(request_id)
+ 
+             if not r_result:
++                # Surface the failure to the scheduler. Reporting the
++                # request finished without recording the failed span would
++                # ACK the load as successful: the request then decodes over
++                # never-written GPU blocks and the phantom blocks enter the
++                # shared prefix cache. error_block_ids feeds
++                # get_block_ids_with_load_errors() ->
++                # kv_connector_output.invalid_block_ids -> scheduler
++                # recompute. The MP server collapses per-key results into
++                # one bool, so marking the op's whole span is
++                # conservative-correct for partial failures too.
++                self.error_block_ids.update(r_block_ids)
++                self.retrieve_failure_count += 1
+                 logger.error(
+-                    "Something went wrong when processing the "
+-                    "retrieve request for request_id=%s, result=%s",
++                    "LMCache retrieve failed for request_id=%s: %d block(s) "
++                    "marked invalid for scheduler recompute "
++                    "(total retrieve failures this worker: %d)",
+                     request_id,
+-                    r_result,
++                    len(r_block_ids),
++                    self.retrieve_failure_count,
+                 )
+ 
+         # Store futures and events are removed together by _poll_store_futures.
+@@ -1758,8 +1790,8 @@ class LMCacheMPWorkerAdapter:
+ 
+     def get_block_ids_with_load_errors(self) -> set[int]:
+         """
+-        Returns the block IDs that failed due to retrieve timeout,
+-        then clears the internal set.
++        Returns the block IDs of failed retrieves (timeout, server-reported
++        failure, or raising future), then clears the internal set.
+         """
+         errors = self.error_block_ids.copy()
+         self.error_block_ids.clear()
+diff --git a/lmcache/v1/distributed/config.py b/lmcache/v1/distributed/config.py
+index de36535a57df7ceb8ca8bbb97276c4733e568270..ac11158668fdbfd00f36512cc08a90b7f42860b4 100644
+--- a/lmcache/v1/distributed/config.py
++++ b/lmcache/v1/distributed/config.py
+@@ -226,6 +226,21 @@ class EvictionConfig:
+     extra_logging_interval: float = field(default=10.0)
+     """ Seconds between L1 memory usage log lines when extra logging is enabled. """
+ 
++    write_back_on_evict: bool = field(default=False)
++    """ Flush evicted L1 objects to L2 synchronously and delete them from L1
++    only once every key in the batch is durable; without this, eviction
++    discards the objects. Requires an L2 adapter with store_objects_sync(). """
++
++    periodic_flush_interval: float = field(default=0.0)
++    """ Seconds between periodic L1-to-L2 backup flush scans while below the
++    eviction watermark (0 disables). Backup keeps the L1 copy; only L2 gains
++    a copy, so a restart or session expiry no longer costs a cold prefill. """
++
++    emergency_evict_for_prefetch: bool = field(default=False)
++    """ Allow the prefetch controller to synchronously evict LRU L1 keys to
++    make room for large L2-to-L1 restores. Effective only together with
++    write_back_on_evict, so victims are persisted before deletion. """
++
+ 
+ @dataclass
+ class StorageManagerConfig:
+@@ -296,6 +311,12 @@ def validate_storage_manager_config(config: StorageManagerConfig) -> None:
+         ValueError: If mutually exclusive L1 tiers are both configured, or
+             hybrid L1 is paired with incompatible L2 adapters.
+     """
++    eviction = config.eviction_config
++    if eviction.periodic_flush_interval < 0:
++        raise ValueError("periodic_flush_interval must be >= 0")
++    if eviction.emergency_evict_for_prefetch and not eviction.write_back_on_evict:
++        raise ValueError("emergency_evict_for_prefetch requires write_back_on_evict")
++
+     if (
+         config.l1_manager_config.gds_l1_config is not None
+         and config.l1_manager_config.memory_config.devdax_path
+@@ -471,6 +492,28 @@ def add_storage_manager_args(
+         help="The fraction of memory to evict when triggered (0.0 to 1.0). "
+         "Default is 0.2.",
+     )
++    eviction_group.add_argument(
++        "--write-back-on-evict",
++        action="store_true",
++        help="Flush evicted L1 objects to L2 synchronously and delete them "
++        "from L1 only once every key in the batch is durable. Requires an "
++        "L2 adapter with a synchronous store path.",
++    )
++    eviction_group.add_argument(
++        "--periodic-flush-interval",
++        type=float,
++        default=0.0,
++        help="Seconds between periodic L1-to-L2 backup flush scans while "
++        "below the eviction watermark (0 disables). The backup keeps the "
++        "L1 copy; only L2 gains a copy.",
++    )
++    eviction_group.add_argument(
++        "--emergency-evict-for-prefetch",
++        action="store_true",
++        help="Allow the prefetch controller to synchronously evict LRU L1 "
++        "keys to make room for large L2-to-L1 restores. Effective only "
++        "together with --write-back-on-evict.",
++    )
+ 
+     # L2 Policies
+     # Import here to break circular dependency:
+@@ -596,6 +639,11 @@ def parse_args_to_config(
+         eviction_ratio=args.eviction_ratio,
+         extra_logging_enabled=getattr(args, "enable_extra_logging", False),
+         extra_logging_interval=getattr(args, "extra_logging_interval", 10.0),
++        write_back_on_evict=getattr(args, "write_back_on_evict", False),
++        periodic_flush_interval=getattr(args, "periodic_flush_interval", 0.0),
++        emergency_evict_for_prefetch=getattr(
++            args, "emergency_evict_for_prefetch", False
++        ),
+     )
+ 
+     l2_adapter_config = parse_args_to_l2_adapters_config(args)
+diff --git a/lmcache/v1/distributed/l1_manager.py b/lmcache/v1/distributed/l1_manager.py
+index 44cf55f615f2bf491bdf72784ac152a7ee422457..4a2be000b86a576759cb3d5579acbc45181b14e7 100644
+--- a/lmcache/v1/distributed/l1_manager.py
++++ b/lmcache/v1/distributed/l1_manager.py
+@@ -5,6 +5,7 @@ Managing objects and memory for L1 cache
+ 
+ # Standard
+ from dataclasses import dataclass
++from itertools import chain, islice
+ from typing import Literal
+ import threading
+ 
+@@ -462,6 +463,11 @@ class L1Manager:
+         Errors:
+             KEY_NOT_WRITABLE: The key exists but is not writable.
+             OUT_OF_MEMORY: Not enough memory to allocate for the object.
++
++        Note:
++            When the full batch does not fit, the longest prefix of the
++            to-be-allocated keys that fits is allocated and the remaining
++            keys report OUT_OF_MEMORY.
+         """
+         need_to_allocate: list[tuple[ObjectKey, bool]] = []
+         ret: dict[ObjectKey, L1OperationResult] = {}
+@@ -499,6 +505,26 @@ class L1Manager:
+             layout_desc, len(need_to_allocate)
+         )
+ 
++        # A full-batch allocation failure would fail every key even when
++        # most of the batch fits, collapsing large L2->L1 restores to zero
++        # prefix hits and forcing full re-prefills upstream. Fall back to
++        # allocating the longest prefix that fits; callers already handle
++        # per-key OOM (prefetch trims to the contiguous prefix, the store
++        # path skips failed keys).
++        if err != L1Error.SUCCESS and len(need_to_allocate) > 1:
++            if allocated_objs:
++                self._memory_manager.free(allocated_objs)
++                allocated_objs = []
++            err, allocated_objs = self._allocate_largest_prefix(
++                layout_desc, len(need_to_allocate)
++            )
++            if err == L1Error.SUCCESS:
++                logger.warning(
++                    "Partial L1 allocation: %d/%d objects (prefix) allocated",
++                    len(allocated_objs),
++                    len(need_to_allocate),
++                )
++
+         if err != L1Error.SUCCESS:
+             for key, _ in need_to_allocate:
+                 ret[key] = (L1Error.OUT_OF_MEMORY, None)
+@@ -508,6 +534,10 @@ class L1Manager:
+                 self._memory_manager.free(allocated_objs)
+ 
+         else:
++            # Mark any unallocated tail as OOM so every requested key keeps
++            # an explicit per-key result.
++            for key, _ in need_to_allocate[len(allocated_objs) :]:
++                ret[key] = (L1Error.OUT_OF_MEMORY, None)
+             for (key, is_temp), mem_obj in zip(
+                 need_to_allocate, allocated_objs, strict=False
+             ):
+@@ -531,6 +561,41 @@ class L1Manager:
+         )
+         return ret
+ 
++    def _allocate_largest_prefix(
++        self, layout_desc: MemoryLayoutDesc, want: int
++    ) -> tuple[L1Error, list[MemoryObj]]:
++        """Allocate the largest prefix below an already-failed full batch.
++
++        L1 allocators have an all-or-nothing batch contract. While holding the
++        L1 manager lock, allocation feasibility is therefore monotonic: if a
++        batch of size ``n`` fits, every smaller batch also fits. Binary search
++        finds the maximum without relying on byte estimates that can be wrong
++        for alignment or fragmented free lists. Successful probes are freed
++        before the final allocation.
++
++        This recovery path runs only after the ``want`` allocation failed, so
++        normal reservations still perform exactly one allocation.
++        """
++        low = 1
++        high = want - 1
++        largest = 0
++
++        while low <= high:
++            candidate = (low + high) // 2
++            err, objects = self._memory_manager.allocate(layout_desc, candidate)
++            if err == L1Error.SUCCESS:
++                largest = candidate
++                self._memory_manager.free(objects)
++                low = candidate + 1
++            else:
++                if objects:
++                    self._memory_manager.free(objects)
++                high = candidate - 1
++
++        if largest == 0:
++            return L1Error.OUT_OF_MEMORY, []
++        return self._memory_manager.allocate(layout_desc, largest)
++
+     @l1_mgr_synchronized
+     def finish_write(
+         self,
+@@ -793,6 +858,59 @@ class L1Manager:
+             locked_count,
+         )
+ 
++    @l1_mgr_synchronized
++    def get_evictable_keys(
++        self,
++        limit: int,
++        cursor: int = 0,
++        scan_limit: int | None = None,
++    ) -> tuple[list[ObjectKey], int]:
++        """Return a bounded, rotating batch of evictable keys.
++
++        ``cursor`` is an insertion-order offset returned by the previous call.
++        The scan wraps once and inspects at most ``scan_limit`` entries, so a
++        periodic backup cannot materialize the complete L1 keyspace while the
++        manager lock is held. Concurrent insertions or removals may shift the
++        offset, but every returned key is revalidated by ``reserve_read``.
++
++        Args:
++            limit: Maximum number of keys to return.
++            cursor: Insertion-order offset at which to resume scanning.
++            scan_limit: Maximum entries to inspect. Defaults to four batches.
++
++        Returns:
++            A pair of the eligible keys and the cursor for the next call.
++        """
++        if limit <= 0 or not self._objects:
++            return [], 0
++
++        object_count = len(self._objects)
++        start = cursor % object_count
++        max_scan = min(
++            object_count,
++            max(limit, scan_limit if scan_limit is not None else limit * 4),
++        )
++        ordered_keys = chain(
++            islice(self._objects, start, None),
++            islice(self._objects, 0, start),
++        )
++        keys: list[ObjectKey] = []
++        scanned = 0
++        for key in ordered_keys:
++            scanned += 1
++            if self.is_key_evictable(key):
++                keys.append(key)
++                if len(keys) >= limit:
++                    break
++            if scanned >= max_scan:
++                break
++        return keys, (start + scanned) % object_count
++
++    @l1_mgr_synchronized
++    def num_objects(self) -> int:
++        """Return the number of objects currently tracked in L1."""
++        return len(self._objects)
++
+     def is_key_evictable(self, key: ObjectKey) -> bool:
+         """Check if a key is eligible for eviction (not locked).
+ 
+diff --git a/lmcache/v1/distributed/l2_adapters/base.py b/lmcache/v1/distributed/l2_adapters/base.py
+index 1838553e285ce0f2c7a0b3d9a3180b6ad57ed499..dcc71deaa4c5097911fc810a6e80e80225baa384 100644
+--- a/lmcache/v1/distributed/l2_adapters/base.py
++++ b/lmcache/v1/distributed/l2_adapters/base.py
+@@ -135,6 +135,7 @@ class L2AdapterInterface(ABC):
+         # every adapter exposes the same shape via ``get_usage()``.
+         self._max_capacity_bytes: int = max_capacity_bytes
+         self._total_bytes_used: int = 0
++        self._reserved_store_bytes: int = 0
+         self._bytes_by_cache_salt: dict[str, int] = {}
+         self._usage_lock = threading.Lock()
+ 
+@@ -354,13 +355,8 @@ class L2AdapterInterface(ABC):
+         """Register a listener to receive L2 adapter events."""
+         self._listeners.append(listener)
+ 
+-    def _notify_keys_stored(self, keys: list[ObjectKey], sizes: list[int]) -> None:
+-        """Update byte accounting and notify listeners that ``keys`` were
+-        stored. ``sizes[i]`` is the byte size of ``keys[i]``.
+-
+-        Accounting is held under ``_usage_lock``; listener callbacks fire
+-        outside the lock so a slow listener cannot stall further notifies.
+-        """
++    def _account_keys_stored(self, keys: list[ObjectKey], sizes: list[int]) -> None:
++        """Apply stored-key byte accounting without invoking listeners."""
+         # Aggregate per-salt deltas before touching
+         # ``_bytes_by_cache_salt`` — one dict read/write per unique
+         # salt instead of one per key. This matters when the registry is
+@@ -377,9 +373,90 @@ class L2AdapterInterface(ABC):
+                 self._bytes_by_cache_salt[salt] = (
+                     self._bytes_by_cache_salt.get(salt, 0) + d
+                 )
++
++    def _try_reserve_store_bytes(self, size: int) -> bool:
++        """Reserve capacity before an asynchronous L2 store is submitted.
++
++        The reservation covers transient backend storage as well as the final
++        object. This keeps a burst of in-flight writes from exceeding a hard
++        adapter capacity before completion accounting becomes visible.
++        """
++        if size < 0:
++            raise ValueError("store reservation size must be non-negative")
++        with self._usage_lock:
++            projected = self._total_bytes_used + self._reserved_store_bytes + size
++            if self._max_capacity_bytes > 0 and projected > self._max_capacity_bytes:
++                return False
++            self._reserved_store_bytes += size
++            return True
++
++    def _settle_store_reservation(
++        self,
++        reserved_bytes: int,
++        keys: list[ObjectKey],
++        sizes: list[int],
++    ) -> None:
++        """Atomically release a store reservation and account durable keys."""
++        if reserved_bytes < 0:
++            raise ValueError("reserved_bytes must be non-negative")
++
++        delta: dict[str, int] = {}
++        total_delta = 0
++        for key, size in zip(keys, sizes, strict=True):
++            delta[key.cache_salt] = delta.get(key.cache_salt, 0) + size
++            total_delta += size
++
++        with self._usage_lock:
++            if reserved_bytes > self._reserved_store_bytes:
++                raise RuntimeError(
++                    "store reservation accounting underflow: "
++                    f"settling {reserved_bytes} bytes with only "
++                    f"{self._reserved_store_bytes} reserved"
++                )
++            self._reserved_store_bytes -= reserved_bytes
++            self._total_bytes_used += total_delta
++            for salt, d in delta.items():
++                self._bytes_by_cache_salt[salt] = (
++                    self._bytes_by_cache_salt.get(salt, 0) + d
++                )
++
++    def _release_store_reservation(self, reserved_bytes: int) -> None:
++        """Release capacity for a store that will not produce a completion."""
++        if reserved_bytes < 0:
++            raise ValueError("reserved_bytes must be non-negative")
++        with self._usage_lock:
++            if reserved_bytes > self._reserved_store_bytes:
++                raise RuntimeError(
++                    "store reservation accounting underflow: "
++                    f"releasing {reserved_bytes} bytes with only "
++                    f"{self._reserved_store_bytes} reserved"
++                )
++            self._reserved_store_bytes -= reserved_bytes
++
++    def get_reserved_store_bytes(self) -> int:
++        """Return bytes reserved by submitted stores awaiting completion."""
++        with self._usage_lock:
++            return self._reserved_store_bytes
++
++    def _notify_keys_stored_listeners(
++        self,
++        keys: list[ObjectKey],
++        sizes: list[int],
++    ) -> None:
++        """Notify stored-key observers after accounting is committed."""
+         for listener in self._listeners:
+             listener.on_l2_keys_stored(keys, sizes)
+ 
++    def _notify_keys_stored(self, keys: list[ObjectKey], sizes: list[int]) -> None:
++        """Update byte accounting and notify listeners that ``keys`` were
++        stored. ``sizes[i]`` is the byte size of ``keys[i]``.
++
++        Accounting is held under ``_usage_lock``; listener callbacks fire
++        outside the lock so a slow listener cannot stall further notifies.
++        """
++        self._account_keys_stored(keys, sizes)
++        self._notify_keys_stored_listeners(keys, sizes)
++
+     def _notify_keys_accessed(self, keys: list[ObjectKey]) -> None:
+         # ``_notify_keys_accessed`` carries no byte impact — only LRU
+         # bookkeeping cares about it, so no accounting is needed here.
+diff --git a/lmcache/v1/distributed/l2_adapters/fs_native_l2_adapter.py b/lmcache/v1/distributed/l2_adapters/fs_native_l2_adapter.py
+index 2d703499d20c5aa1c0ecc8e1f0667f2bf857c6a2..dacdead73b3eb1a34bec530fe14c535759607b2a 100644
+--- a/lmcache/v1/distributed/l2_adapters/fs_native_l2_adapter.py
++++ b/lmcache/v1/distributed/l2_adapters/fs_native_l2_adapter.py
+@@ -10,9 +10,11 @@ Backed by the native C++ filesystem connector wrapped with
+ from __future__ import annotations
+ 
+ # Standard
++from pathlib import Path
+ from typing import TYPE_CHECKING, Optional
+ 
+ if TYPE_CHECKING:
++    from lmcache.v1.distributed.api import ObjectKey
+     from lmcache.v1.distributed.internal_api import (
+         L1MemoryDesc,
+     )
+@@ -158,7 +160,7 @@ def _create_fs_native_l2_adapter(
+         config.use_odirect,
+         config.read_ahead_size,
+     )
+-    return NativeConnectorL2Adapter(
++    adapter = NativeConnectorL2Adapter(
+         native_client,
+         max_capacity_gb=config.max_capacity_gb,
+         type_name="FSNativeL2Adapter",
+@@ -169,6 +171,53 @@ def _create_fs_native_l2_adapter(
+             "read_ahead_size": config.read_ahead_size,
+         },
+     )
++    try:
++        keys, sizes = _scan_existing_fs_native_files(config.base_path)
++        adapter.prime_existing_keys(keys, sizes)
++    except Exception:
++        adapter.close()
++        raise
++    return adapter
++
++
++def _scan_existing_fs_native_files(
++    base_path: str,
++) -> tuple[list["ObjectKey"], list[int]]:
++    """Recover durable keys and sizes, ordered from oldest to newest."""
++    # First Party
++    from lmcache.v1.distributed.l2_adapters.fs_l2_adapter import (
++        _filename_to_object_key,
++    )
++
++    root = Path(base_path)
++    if not root.is_dir():
++        return [], []
++
++    entries: list[tuple[int, str, ObjectKey, int]] = []
++    for path in root.glob("*.data"):
++        try:
++            if not path.is_file():
++                continue
++            key = _filename_to_object_key(path.name)
++            if key is None:
++                logger.warning("Ignoring unrecognized cache file: %s", path)
++                continue
++            stat = path.stat()
++            if stat.st_size <= 0:
++                logger.warning("Ignoring empty cache file: %s", path)
++                continue
++            entries.append((stat.st_mtime_ns, path.name, key, stat.st_size))
++        except OSError as exc:
++            # Silently omitting a durable object would under-report usage and
++            # seed an incomplete eviction index. Fail adapter construction so
++            # the operator can repair the directory or retry the startup scan.
++            raise RuntimeError(f"Could not inspect cache file {path}: {exc}") from exc
++
++    entries.sort(key=lambda entry: (entry[0], entry[1]))
++    return (
++        [entry[2] for entry in entries],
++        [entry[3] for entry in entries],
++    )
+ 
+ 
+ register_l2_adapter_type("fs_native", FSNativeL2AdapterConfig)
+diff --git a/lmcache/v1/distributed/l2_adapters/native_connector_l2_adapter.py b/lmcache/v1/distributed/l2_adapters/native_connector_l2_adapter.py
+index c10d3802dfbdba50b6a49e4d764ebf10a567a0df..97518b74a161dd995548a7894eb0e13a3fed0df2 100644
+--- a/lmcache/v1/distributed/l2_adapters/native_connector_l2_adapter.py
++++ b/lmcache/v1/distributed/l2_adapters/native_connector_l2_adapter.py
+@@ -30,7 +30,7 @@ import threading
+ from lmcache.logging import init_logger
+ from lmcache.native_storage_ops import Bitmap
+ from lmcache.v1.distributed.api import MemoryLayoutDesc, ObjectKey
+-from lmcache.v1.distributed.internal_api import L2StoreResult
++from lmcache.v1.distributed.internal_api import L2AdapterListener, L2StoreResult
+ from lmcache.v1.distributed.l2_adapters.base import (
+     L2AdapterInterface,
+     L2TaskId,
+@@ -98,6 +98,7 @@ class NativeConnectorL2Adapter(L2AdapterInterface):
+ 
+     # Operation type tags for the pending-ops map
+     _OP_STORE = "store"
++    _OP_SYNC_STORE = "sync_store"
+     _OP_LOOKUP = "lookup"
+     _OP_LOAD = "load"
+     _OP_DELETE = "delete"
+@@ -144,15 +145,30 @@ class NativeConnectorL2Adapter(L2AdapterInterface):
+         # Pending delete events for synchronous delete() calls
+         self._pending_delete_events: dict[L2TaskId, threading.Event] = {}
+ 
++        # Synchronous stores use private completions so StoreController cannot
++        # consume another thread's result from _completed_stores.
++        self._pending_sync_store_events: dict[
++            L2TaskId, tuple[threading.Event, dict[str, Any]]
++        ] = {}
++
+         # Per-key size tracking. ``_key_sizes`` lets us look up byte sizes
+         # at delete time (the native completion only carries booleans, not
+         # sizes) so we can pass them to ``_notify_keys_deleted``. Aggregate
+         # and per-user totals live in the base class — see ``get_usage``.
+         self._key_sizes: dict[ObjectKey, int] = {}
+-        # Pending store sizes: native future_id -> (keys, per_key_sizes).
++        # Pending store sizes:
++        #   native future_id -> (keys, per_key_sizes, reserved_bytes).
+         # Bridges the async store submit → demux completion gap so the
+         # demux thread can fire ``_notify_keys_stored(keys, sizes)``.
+-        self._pending_store_sizes: dict[int, tuple[list[ObjectKey], list[int]]] = {}
++        self._pending_store_sizes: dict[
++            int, tuple[list[ObjectKey], list[int], int]
++        ] = {}
++
++        # A filesystem factory may prime durable objects before the eviction
++        # listener exists. Keep one temporary startup snapshot for that first
++        # listener; _key_sizes remains the sole long-lived key index.
++        self._startup_primed = False
++        self._startup_replay: tuple[list[ObjectKey], list[int]] | None = None
+ 
+         # Task ID counter
+         self._next_task_id: L2TaskId = 0
+@@ -194,20 +210,39 @@ class NativeConnectorL2Adapter(L2AdapterInterface):
+         key_strings = [_object_key_to_string(k) for k in keys]
+         memviews = [_obj_to_memoryview(obj) for obj in objects]
+         per_key_sizes = [obj.get_size() for obj in objects]
++        reserved_bytes = sum(per_key_sizes)
+ 
+         # Register pending op BEFORE submit to avoid race
+         # with demux thread. The native submit is
+         # non-blocking so holding the lock is brief.
+         with self._lock:
+             task_id = self._get_next_task_id()
+-            future_id = int(self._client.submit_batch_set(key_strings, memviews))
++            if not self._try_reserve_store_bytes(reserved_bytes):
++                self._completed_stores[task_id] = L2StoreResult(False, 0)
++                self._store_efd.notify()
++                logger.warning(
++                    "Rejected native L2 store of %d bytes: capacity would "
++                    "exceed %d bytes",
++                    reserved_bytes,
++                    self._max_capacity_bytes,
++                )
++                return task_id
++            try:
++                future_id = int(self._client.submit_batch_set(key_strings, memviews))
++            except Exception:
++                self._release_store_reservation(reserved_bytes)
++                raise
+             self._pending_ops[future_id] = (
+                 self._OP_STORE,
+                 task_id,
+                 len(keys),
+                 None,
+             )
+-            self._pending_store_sizes[future_id] = (list(keys), per_key_sizes)
++            self._pending_store_sizes[future_id] = (
++                list(keys),
++                per_key_sizes,
++                reserved_bytes,
++            )
+ 
+         return task_id
+ 
+@@ -219,6 +254,83 @@ class NativeConnectorL2Adapter(L2AdapterInterface):
+             self._completed_stores = {}
+         return completed
+ 
++    def store_objects_sync(
++        self,
++        keys: list[ObjectKey],
++        objects: list[MemoryObj],
++        timeout: float | None = None,
++    ) -> tuple[bool, int, int]:
++        """Persist objects and wait for their native backend completion.
++
++        Returns ``(success, persisted_count, bytes_written)``. ``success`` is
++        true only when every key persisted, while the other fields account
++        for successful keys in a partially failed batch.
++        """
++        if len(keys) != len(objects):
++            raise ValueError("keys and objects length mismatch")
++        if not keys:
++            return True, 0, 0
++        if timeout is not None and timeout <= 0:
++            raise ValueError("timeout must be positive")
++
++        key_strings = [_object_key_to_string(key) for key in keys]
++        memviews = [_obj_to_memoryview(obj) for obj in objects]
++        per_key_sizes = [obj.get_size() for obj in objects]
++        reserved_bytes = sum(per_key_sizes)
++        done_event = threading.Event()
++        result: dict[str, Any] = {
++            "ok": False,
++            "persisted_count": 0,
++            "bytes_written": 0,
++        }
++
++        with self._lock:
++            task_id = self._get_next_task_id()
++            if not self._try_reserve_store_bytes(reserved_bytes):
++                logger.warning(
++                    "Rejected synchronous native L2 store of %d bytes: "
++                    "capacity would exceed %d bytes",
++                    reserved_bytes,
++                    self._max_capacity_bytes,
++                )
++                return False, 0, 0
++            try:
++                future_id = int(self._client.submit_batch_set(key_strings, memviews))
++            except Exception:
++                self._release_store_reservation(reserved_bytes)
++                raise
++            self._pending_ops[future_id] = (
++                self._OP_SYNC_STORE,
++                task_id,
++                len(keys),
++                None,
++            )
++            self._pending_store_sizes[future_id] = (
++                list(keys),
++                per_key_sizes,
++                reserved_bytes,
++            )
++            self._pending_sync_store_events[task_id] = (done_event, result)
++
++        wait_timeout = (
++            timeout if timeout is not None else max(30.0, min(300.0, len(keys) * 5.0))
++        )
++        if not done_event.wait(timeout=wait_timeout):
++            with self._lock:
++                self._pending_sync_store_events.pop(task_id, None)
++            logger.warning(
++                "store_objects_sync() timed out after %.1fs for %d keys",
++                wait_timeout,
++                len(keys),
++            )
++            return False, 0, 0
++
++        return (
++            bool(result["ok"]),
++            int(result["persisted_count"]),
++            int(result["bytes_written"]),
++        )
++
+     # ---------------------------------------------------------------
+     # Lookup and Lock Interface
+     # ---------------------------------------------------------------
+@@ -297,22 +409,46 @@ class NativeConnectorL2Adapter(L2AdapterInterface):
+         tracking stays in sync.
+ 
+         No-op if the connector does not expose ``submit_batch_delete``
+-        or if the key list is empty.
++        or if the key list is empty. Keys currently lookup-locked by an
++        in-flight prefetch are skipped: the load task would race the
++        unlink and fail with a phantom not_found.
+         """
+         if not keys or not self._has_delete:
+             return
+ 
+-        key_strings = [_object_key_to_string(k) for k in keys]
+         done_event = threading.Event()
+ 
+         with self._lock:
++            # A key becomes lookup-locked only when the native EXISTS
++            # completion is demultiplexed. Protect pending lookup keys as
++            # well, otherwise eviction can delete a key between lookup
++            # submission and lock acquisition. Filtering and delete submit
++            # stay in one critical section so a new lookup cannot enter that
++            # same gap.
++            protected_keys = set(self._locked_keys)
++            for op_type, _task_id, _num_keys, op_keys in self._pending_ops.values():
++                if op_type == self._OP_LOOKUP and op_keys is not None:
++                    protected_keys.update(op_keys)
++
++            delete_keys = [key for key in keys if key not in protected_keys]
++            skipped_count = len(keys) - len(delete_keys)
++            if skipped_count:
++                logger.info(
++                    "delete(): skipping %d lookup-pending or locked keys; %d remain",
++                    skipped_count,
++                    len(delete_keys),
++                )
++            if not delete_keys:
++                return
++
++            key_strings = [_object_key_to_string(k) for k in delete_keys]
+             task_id = self._get_next_task_id()
+             future_id = int(self._client.submit_batch_delete(key_strings))
+             self._pending_ops[future_id] = (
+                 self._OP_DELETE,
+                 task_id,
+-                len(keys),
+-                list(keys),
++                len(delete_keys),
++                delete_keys,
+             )
+             self._pending_delete_events[task_id] = done_event
+ 
+@@ -328,7 +464,7 @@ class NativeConnectorL2Adapter(L2AdapterInterface):
+                         break
+             logger.warning(
+                 "delete() timed out after 30s for %d keys",
+-                len(keys),
++                len(delete_keys),
+             )
+             return
+ 
+@@ -345,6 +481,52 @@ class NativeConnectorL2Adapter(L2AdapterInterface):
+     # Status Interface
+     # ---------------------------------------------------------------
+ 
++    def prime_existing_keys(
++        self,
++        keys: list[ObjectKey],
++        sizes: list[int],
++    ) -> None:
++        """Account durable objects discovered before adapter registration."""
++        if len(keys) != len(sizes):
++            raise ValueError("keys and sizes length mismatch")
++
++        unique: dict[ObjectKey, int] = {}
++        for key, size in zip(keys, sizes, strict=True):
++            if size <= 0:
++                raise ValueError("existing object sizes must be positive")
++            unique.setdefault(key, int(size))
++
++        primed_keys = list(unique)
++        primed_sizes = list(unique.values())
++        with self._lock:
++            if self._startup_primed:
++                raise RuntimeError("existing keys were already primed")
++            if self._listeners:
++                raise RuntimeError("existing keys must be primed before listeners")
++            self._startup_primed = True
++            self._key_sizes.update(unique)
++            self._startup_replay = (primed_keys, primed_sizes)
++
++        # No listener is registered during factory construction. This uses
++        # the common accounting implementation without retaining a second
++        # byte-accounting path in this adapter.
++        if primed_keys:
++            self._notify_keys_stored(primed_keys, primed_sizes)
++            logger.info(
++                "Startup scan primed %.2f GB in %d existing objects",
++                sum(primed_sizes) / 1e9,
++                len(primed_keys),
++            )
++
++    def register_listener(self, listener: L2AdapterListener) -> None:
++        """Register a listener and replay the one-time startup snapshot."""
++        with self._lock:
++            replay = self._startup_replay
++            self._startup_replay = None
++        if replay is not None and replay[0]:
++            listener.on_l2_keys_stored(*replay)
++        super().register_listener(listener)
++
+     def report_status(self) -> dict[str, Any]:
+         """Return a status dict for this native-connector L2 adapter.
+ 
+@@ -360,6 +542,7 @@ class NativeConnectorL2Adapter(L2AdapterInterface):
+         status: dict[str, Any] = {
+             "is_healthy": (self._demux_thread.is_alive() and not self._stop.is_set()),
+             "type": self._type_name,
++            "reserved_store_bytes": self.get_reserved_store_bytes(),
+         }
+         status.update(self._extra_status)
+         return status
+@@ -372,6 +555,22 @@ class NativeConnectorL2Adapter(L2AdapterInterface):
+         self._stop.set()
+         self._demux_thread.join(timeout=5)
+ 
++        with self._lock:
++            sync_events = [
++                event for event, _result in self._pending_sync_store_events.values()
++            ]
++            self._pending_sync_store_events.clear()
++            abandoned_reservations = sum(
++                reserved_bytes
++                for _keys, _sizes, reserved_bytes in self._pending_store_sizes.values()
++            )
++            self._pending_store_sizes.clear()
++            self._pending_ops.clear()
++        if abandoned_reservations:
++            self._release_store_reservation(abandoned_reservations)
++        for event in sync_events:
++            event.set()
++
+         self._client.close()
+ 
+         self._store_efd.close()
+@@ -420,11 +619,13 @@ class NativeConnectorL2Adapter(L2AdapterInterface):
+             keys_accessed: list[ObjectKey] = []
+             keys_deleted: list[ObjectKey] = []
+             sizes_deleted: list[int] = []
++            settled_store_reservations = 0
+             # Events for synchronous ``delete()`` callers. We set these
+             # AFTER firing ``_notify_keys_deleted`` below so that when
+             # the caller unblocks and calls ``get_usage()``, the base
+             # class's byte counters already reflect the deletion.
+             delete_done_events: list[threading.Event] = []
++            sync_store_done_events: list[threading.Event] = []
+ 
+             with self._lock:
+                 for (
+@@ -449,12 +650,31 @@ class NativeConnectorL2Adapter(L2AdapterInterface):
+                         lookup_keys,
+                     ) = entry
+ 
+-                    if op_type == self._OP_STORE:
++                    if op_type in (self._OP_STORE, self._OP_SYNC_STORE):
+                         store_info = self._pending_store_sizes.pop(fid, None)
+                         task_bytes = 0
+-                        if ok and store_info is not None:
+-                            store_keys, sizes = store_info
+-                            for key, size in zip(store_keys, sizes, strict=True):
++                        persisted_count = 0
++                        completion_ok = False
++                        if store_info is not None:
++                            store_keys, sizes, reserved_bytes = store_info
++                            settled_store_reservations += reserved_bytes
++                            if result_bools is None:
++                                stored_flags = [bool(ok)] * len(store_keys)
++                            else:
++                                stored_flags = [bool(value) for value in result_bools]
++                                if len(stored_flags) < len(store_keys):
++                                    stored_flags.extend(
++                                        [False] * (len(store_keys) - len(stored_flags))
++                                    )
++                                elif len(stored_flags) > len(store_keys):
++                                    stored_flags = stored_flags[: len(store_keys)]
++                            completion_ok = bool(ok) and all(stored_flags)
++                            for key, size, stored in zip(
++                                store_keys, sizes, stored_flags, strict=True
++                            ):
++                                if not stored:
++                                    continue
++                                persisted_count += 1
+                                 # First-store wins for byte accounting:
+                                 # a re-store of an existing key adds 0
+                                 # bytes (the backend already holds it).
+@@ -470,8 +690,21 @@ class NativeConnectorL2Adapter(L2AdapterInterface):
+                                 else:
+                                     keys_stored.append(key)
+                                     sizes_stored.append(0)
+-                        self._completed_stores[task_id] = L2StoreResult(ok, task_bytes)
+-                        self._store_efd.notify()
++                        if op_type == self._OP_STORE:
++                            self._completed_stores[task_id] = L2StoreResult(
++                                completion_ok, task_bytes
++                            )
++                            self._store_efd.notify()
++                        else:
++                            sync_entry = self._pending_sync_store_events.pop(
++                                task_id, None
++                            )
++                            if sync_entry is not None:
++                                sync_event, sync_result = sync_entry
++                                sync_result["ok"] = completion_ok
++                                sync_result["persisted_count"] = persisted_count
++                                sync_result["bytes_written"] = task_bytes
++                                sync_store_done_events.append(sync_event)
+ 
+                     elif op_type == self._OP_LOOKUP:
+                         bitmap = Bitmap(num_keys)
+@@ -519,10 +752,22 @@ class NativeConnectorL2Adapter(L2AdapterInterface):
+                         if evt is not None:
+                             delete_done_events.append(evt)
+ 
+-            # Fire listener notifications outside the lock so a slow
+-            # listener cannot stall further demux iterations.
++            # Release in-flight reservations and commit durable-byte
++            # accounting in one critical section before waking callers.
++            if settled_store_reservations or keys_stored:
++                self._settle_store_reservation(
++                    settled_store_reservations,
++                    keys_stored,
++                    sizes_stored,
++                )
++            for evt in sync_store_done_events:
++                evt.set()
++
++            # Observer callbacks remain outside the lock and after synchronous
++            # durability completion. A slow observer must not defeat a caller's
++            # store timeout after persistence and accounting have committed.
+             if keys_stored:
+-                self._notify_keys_stored(keys_stored, sizes_stored)
++                self._notify_keys_stored_listeners(keys_stored, sizes_stored)
+             if keys_accessed:
+                 self._notify_keys_accessed(keys_accessed)
+             if keys_deleted:
+diff --git a/lmcache/v1/distributed/storage_controllers/eviction_controller.py b/lmcache/v1/distributed/storage_controllers/eviction_controller.py
+index 8624207de385ab334a102852b6d1b7c19d3182b0..899d8bf2166c2451fde6605dc839fa912e0e22f5 100644
+--- a/lmcache/v1/distributed/storage_controllers/eviction_controller.py
++++ b/lmcache/v1/distributed/storage_controllers/eviction_controller.py
+@@ -6,7 +6,10 @@ from __future__ import annotations
+ # Standard
+ from abc import abstractmethod
+ from collections import Counter
++from enum import Enum, auto
+ from typing import TYPE_CHECKING
++import inspect
++import math
+ import threading
+ import time
+ 
+@@ -16,6 +19,7 @@ from lmcache.v1.distributed.api import ObjectKey
+ from lmcache.v1.distributed.config import EvictionConfig
+ from lmcache.v1.distributed.eviction import L1EvictionPolicy, L2EvictionPolicy
+ from lmcache.v1.distributed.eviction_policy import CreateEvictionPolicy
++from lmcache.v1.distributed.error import L1Error
+ from lmcache.v1.distributed.internal_api import (
+     EvictionAction,
+     EvictionDestination,
+@@ -33,6 +37,12 @@ if TYPE_CHECKING:
+ logger = init_logger(__name__)
+ 
+ 
++class _SyncFlushResult(Enum):
++    SUCCESS = auto()
++    FAILURE = auto()
++    DEADLINE_EXHAUSTED = auto()
++
++
+ class EvictionController(StorageControllerInterface):
+     """
+     Abstract base class for eviction controllers.
+@@ -92,12 +102,33 @@ class L1EvictionController(EvictionController):
+     Uses an L1EvictionPolicy bridge to keep the eviction policy up-to-date
+     with L1 manager events, and periodically triggers eviction based on
+     L1 memory usage.
++
++    With ``EvictionConfig.write_back_on_evict`` enabled and L2 adapters
++    injected via ``set_l2_adapters``, eviction actions target
++    ``EvictionDestination.L2_CACHE``: readable objects are synchronously
++    persisted to L2 in bounded batches and deleted from L1 only once every
++    key in the batch is durable. Repeated flush failures open a circuit
++    breaker that pauses write-back instead of retrying every second.
++
++    ``EvictionConfig.periodic_flush_interval`` additionally enables a
++    below-watermark backup flush that copies evictable L1 keys to L2
++    without deleting them from L1.
+     """
+ 
++    # Bounded batches keep each blocking sync-store call short.
++    _SYNC_FLUSH_BATCH_SIZE = 128
++    # Keys per periodic backup flush cycle.
++    _BACKUP_FLUSH_BATCH_SIZE = 128
++    # A prefetch request must not stall the controller indefinitely on L2.
++    _EMERGENCY_FLUSH_TIMEOUT_SECONDS = 1.0
++    # Periodic backup runs under the flush lock and must remain stoppable.
++    _PERIODIC_FLUSH_TIMEOUT_SECONDS = 5.0
++
+     def __init__(
+         self,
+         l1_manager: L1Manager,
+         eviction_config: EvictionConfig,
++        l2_adapters: dict[int, L2AdapterInterface] | None = None,
+     ):
+         super().__init__()
+         self._eviction_config = eviction_config
+@@ -108,13 +139,101 @@ class L1EvictionController(EvictionController):
+         self._event_bus = get_event_bus()
+         self._last_extra_log = time.monotonic()
+ 
++        self._write_back_enabled = bool(eviction_config.write_back_on_evict)
++        self._l2_adapters: dict[int, L2AdapterInterface] = {}
++        self._l2_adapter_supports_timeout: dict[int, bool] = {}
++        self._l2_adapters_lock = threading.Lock()
++        # Serializes all synchronous L2 flushes and adapter-set replacement.
++        # StorageManager can therefore remove an adapter only after any L1
++        # writeback currently using it has finished.
++        self._flush_lock = threading.Lock()
++        # Sync-flush circuit breaker: a dead L2 must not cause a
++        # multi-thousand-key synchronous retry and warning storm every
++        # second.
++        self._sync_flush_failures: int = 0
++        self._sync_flush_backoff_until: float = 0.0
++        self._last_backup_flush = time.monotonic()
++        self._backup_flush_cursor: int = 0
++        # Serializes emergency evictions from concurrent callers.
++        self._emergency_evict_lock = threading.Lock()
++        if self._write_back_enabled:
++            # Writeback must fail closed. Register the L2 destination even
++            # before a compatible adapter exists so policy never falls back
++            # to DISCARD when persistence is unavailable.
++            self._eviction_policy.register_eviction_destination(
++                EvictionDestination.L2_CACHE
++            )
++        if l2_adapters:
++            self.set_l2_adapters(l2_adapters)
++
++    def set_l2_adapters(self, l2_adapters: dict[int, L2AdapterInterface]) -> None:
++        """Late-inject L2 adapters after StorageManager creates them.
++
++        Only adapters with an explicit synchronous durability contract are
++        eligible. The L2 eviction destination itself is registered at
++        construction so enabled writeback always fails closed.
++        """
++        compatible: dict[int, L2AdapterInterface] = {}
++        supports_timeout: dict[int, bool] = {}
++        for adapter_id, adapter in l2_adapters.items():
++            sync_store = getattr(adapter, "store_objects_sync", None)
++            if not callable(sync_store):
++                continue
++            compatible[adapter_id] = adapter
++            try:
++                supports_timeout[adapter_id] = (
++                    "timeout" in inspect.signature(sync_store).parameters
++                )
++            except (TypeError, ValueError):
++                supports_timeout[adapter_id] = False
++        ignored = sorted(set(l2_adapters) - set(compatible))
++        if ignored:
++            logger.warning(
++                "L1 writeback ignored adapters without store_objects_sync: %s",
++                ignored,
++            )
++        with self._flush_lock:
++            with self._l2_adapters_lock:
++                self._l2_adapters = compatible
++                self._l2_adapter_supports_timeout = supports_timeout
++
++    def has_l2_flush_adapter(self) -> bool:
++        """Return whether a synchronous durability backend is available."""
++        return bool(self._snapshot_l2_adapters())
++
++    def _snapshot_l2_adapters(self) -> list[tuple[int, L2AdapterInterface]]:
++        with self._l2_adapters_lock:
++            return list(self._l2_adapters.items())
++
++    def _snapshot_l2_flush_adapters(
++        self,
++    ) -> list[tuple[int, L2AdapterInterface, bool]]:
++        with self._l2_adapters_lock:
++            return [
++                (
++                    adapter_id,
++                    adapter,
++                    self._l2_adapter_supports_timeout.get(adapter_id, False),
++                )
++                for adapter_id, adapter in self._l2_adapters.items()
++            ]
++
+     def report_status(self) -> dict:
++        adapters = self._snapshot_l2_adapters()
+         return {
+             "is_healthy": self._thread.is_alive(),
+             "thread_alive": self._thread.is_alive(),
+             "eviction_policy": self._eviction_config.eviction_policy,
+             "trigger_watermark": self._eviction_config.trigger_watermark,
+             "eviction_ratio": self._eviction_config.eviction_ratio,
++            "write_back_enabled": self._write_back_enabled,
++            "l2_flush_enabled": bool(adapters),
++            "l2_flush_adapter_ids": [adapter_id for adapter_id, _ in adapters],
++            "periodic_flush_interval": (self._eviction_config.periodic_flush_interval),
++            "sync_flush_failures": self._sync_flush_failures,
++            "sync_flush_backoff_seconds": max(
++                0.0, self._sync_flush_backoff_until - time.monotonic()
++            ),
+         }
+ 
+     def _publish_skipped(self, usage: float, watermark: float) -> None:
+@@ -160,6 +279,7 @@ class L1EvictionController(EvictionController):
+     def eviction_loop(self):
+         watermark = self._eviction_config.trigger_watermark
+         eviction_ratio = self._eviction_config.eviction_ratio
++        backup_interval = self._eviction_config.periodic_flush_interval
+ 
+         while not self._stop_flag.is_set():
+             time.sleep(1)
+@@ -168,6 +288,13 @@ class L1EvictionController(EvictionController):
+                 self._maybe_log_memory_usage(used_bytes, total_bytes)
+             usage = 0 if total_bytes == 0 else used_bytes / total_bytes
+             if usage < watermark:
++                if (
++                    backup_interval > 0
++                    and self._snapshot_l2_adapters()
++                    and time.monotonic() - self._last_backup_flush >= backup_interval
++                ):
++                    self._last_backup_flush = time.monotonic()
++                    self._backup_to_l2_no_delete(self._BACKUP_FLUSH_BATCH_SIZE)
+                 logger.debug(
+                     "L1 memory usage %.2f below watermark %.2f; skipping eviction.",
+                     usage,
+@@ -176,6 +303,13 @@ class L1EvictionController(EvictionController):
+                 self._publish_skipped(usage, watermark)
+                 continue
+ 
++            if (
++                self._write_back_enabled
++                and time.monotonic() < self._sync_flush_backoff_until
++            ):
++                self._publish_skipped(usage, watermark)
++                continue
++
+             logger.info(
+                 "L1 memory usage %.2f above watermark %.2f; triggering eviction.",
+                 usage,
+@@ -190,13 +324,340 @@ class L1EvictionController(EvictionController):
+             self._publish_triggered(usage, watermark)
+ 
+     def execute_eviction_action(self, action: EvictionAction):
+-        if action.destination == EvictionDestination.DISCARD:
++        if action.destination == EvictionDestination.L2_CACHE:
++            self._flush_to_l2_then_delete(action.keys)
++        elif action.destination == EvictionDestination.DISCARD:
+             self._l1_manager.delete(action.keys)
+         else:
+             logger.error("Unsupported eviction destination: %s", action.destination)
+             logger.error("Treating it as DISCARD.")
+             self._l1_manager.delete(action.keys)
+ 
++    def emergency_evict_bytes(self, target_free_bytes: int, requester: str = "") -> int:
++        """Synchronously evict LRU L1 keys until at least
++        ``target_free_bytes`` bytes are free.
++
++        Victims take the normal eviction path, so with write-back enabled
++        they are flushed to L2 before deletion. Intended for the prefetch
++        controller when a large L2-to-L1 restore cannot reserve L1 buffers.
++
++        Args:
++            target_free_bytes: The free-space goal in bytes.
++            requester: Optional label for logging.
++
++        Returns:
++            The free byte count after eviction.
++        """
++        deadline = time.monotonic() + self._EMERGENCY_FLUSH_TIMEOUT_SECONDS
++        if not self._emergency_evict_lock.acquire(
++            timeout=self._EMERGENCY_FLUSH_TIMEOUT_SECONDS
++        ):
++            used, total = self._l1_manager.get_memory_usage()
++            return max(0, total - used)
++        try:
++            used, total = self._l1_manager.get_memory_usage()
++            free = max(0, total - used)
++            if free >= target_free_bytes:
++                return free
++            deficit = target_free_bytes - free
++            num_objects = self._l1_manager.num_objects()
++            if num_objects <= 0:
++                return free
++            if self._write_back_enabled and (
++                time.monotonic() < self._sync_flush_backoff_until
++                or not self.has_l2_flush_adapter()
++            ):
++                return free
++            per_key = max(1, used // num_objects)
++            need_keys = math.ceil(deficit / per_key)
++            need_keys += max(1, math.ceil(need_keys / 8))
++            tracked = num_objects
++            get_tracked = getattr(self._eviction_policy, "get_num_tracked_keys", None)
++            if callable(get_tracked):
++                tracked = max(1, int(get_tracked()))
++            ratio = min(1.0, need_keys / max(tracked, 1))
++            start = time.monotonic()
++            actions = self._eviction_policy.get_eviction_actions(
++                ratio,
++                key_eligible_filter=self._l1_manager.is_key_evictable,
++            )
++            evicted_keys = 0
++            for action in actions:
++                evicted_keys += len(action.keys)
++                if action.destination == EvictionDestination.L2_CACHE:
++                    self._flush_to_l2_then_delete(action.keys, deadline=deadline)
++                else:
++                    self.execute_eviction_action(action)
++                if time.monotonic() >= deadline:
++                    break
++            used_after, total_after = self._l1_manager.get_memory_usage()
++            free_after = max(0, total_after - used_after)
++            logger.info(
++                "Emergency L1 eviction%s: wanted %.0f MB free, evicted %d "
++                "keys in %.0f ms; free %.0f MB -> %.0f MB",
++                (" for " + requester) if requester else "",
++                target_free_bytes / 1e6,
++                evicted_keys,
++                (time.monotonic() - start) * 1000.0,
++                free / 1e6,
++                free_after / 1e6,
++            )
++            return free_after
++        finally:
++            self._emergency_evict_lock.release()
++
++    def _flush_to_l2_then_delete(
++        self,
++        keys: list[ObjectKey],
++        deadline: float | None = None,
++    ) -> None:
++        """Persist bounded batches to L2 and delete only fully durable
++        batches from L1.
++
++        The native adapter reports a store successful only when every key
++        persisted, so this method conservatively retains the whole readable
++        batch on any partial failure. Repeated failures open the circuit
++        breaker with exponential backoff.
++        """
++        if deadline is None:
++            self._flush_lock.acquire()
++        else:
++            remaining = deadline - time.monotonic()
++            if remaining <= 0 or not self._flush_lock.acquire(timeout=remaining):
++                return
++        try:
++            if not keys:
++                return
++            if time.monotonic() < self._sync_flush_backoff_until:
++                return
++
++            all_ok = True
++            deadline_exhausted = False
++            for start in range(0, len(keys), self._SYNC_FLUSH_BATCH_SIZE):
++                if deadline is not None and time.monotonic() >= deadline:
++                    deadline_exhausted = True
++                    break
++                batch = keys[start : start + self._SYNC_FLUSH_BATCH_SIZE]
++                result = self._flush_one_l2_batch_then_delete(batch, deadline=deadline)
++                if result == _SyncFlushResult.DEADLINE_EXHAUSTED:
++                    deadline_exhausted = True
++                    break
++                if result == _SyncFlushResult.FAILURE:
++                    all_ok = False
++                    break
++
++            if deadline_exhausted:
++                logger.debug(
++                    "L1-to-L2 emergency flush exhausted its time budget; "
++                    "remaining L1 keys preserved"
++                )
++            elif all_ok:
++                self._sync_flush_failures = 0
++                self._sync_flush_backoff_until = 0.0
++            else:
++                self._sync_flush_failures += 1
++                delay = min(60.0, float(2 ** min(self._sync_flush_failures, 6)))
++                self._sync_flush_backoff_until = time.monotonic() + delay
++                logger.warning(
++                    "L1-to-L2 flush circuit breaker: failure=%d, retry in %.0fs; "
++                    "remaining L1 keys preserved",
++                    self._sync_flush_failures,
++                    delay,
++                )
++        finally:
++            self._flush_lock.release()
++
++    def _flush_one_l2_batch_then_delete(
++        self,
++        keys: list[ObjectKey],
++        deadline: float | None = None,
++    ) -> _SyncFlushResult:
++        """Flush one batch to L2; delete from L1 only when fully durable.
++
++        Returns:
++            SUCCESS when every readable key was persisted (or none were
++            readable), FAILURE for an actual persistence failure, and
++            DEADLINE_EXHAUSTED when an emergency flush consumed its budget.
++        """
++        if not keys:
++            return _SyncFlushResult.SUCCESS
++
++        read_result = self._l1_manager.reserve_read(keys)
++        readable_keys: list[ObjectKey] = []
++        readable_objs = []
++        for key in keys:
++            entry = read_result.get(key)
++            if (
++                entry is not None
++                and entry[0] == L1Error.SUCCESS
++                and entry[1] is not None
++            ):
++                readable_keys.append(key)
++                readable_objs.append(entry[1])
++
++        flushed = not readable_keys
++        deadline_exhausted = False
++        if readable_keys:
++            try:
++                for (
++                    idx,
++                    adapter,
++                    supports_timeout,
++                ) in self._snapshot_l2_flush_adapters():
++                    sync_store = adapter.store_objects_sync
++                    try:
++                        if deadline is None:
++                            result = sync_store(readable_keys, readable_objs)
++                        else:
++                            remaining = deadline - time.monotonic()
++                            if remaining <= 0:
++                                deadline_exhausted = True
++                                break
++                            if not supports_timeout:
++                                logger.warning(
++                                    "Emergency L1 writeback skipped adapter %d: "
++                                    "store_objects_sync has no timeout contract",
++                                    idx,
++                                )
++                                continue
++                            result = sync_store(
++                                readable_keys,
++                                readable_objs,
++                                timeout=remaining,
++                            )
++                        ok, persisted_count, bytes_written = result
++                    except Exception:
++                        if deadline is not None and time.monotonic() >= deadline:
++                            deadline_exhausted = True
++                            break
++                        logger.exception(
++                            "L1-to-L2 flush: sync store failed on adapter %d", idx
++                        )
++                        continue
++                    if not ok and deadline is not None and time.monotonic() >= deadline:
++                        deadline_exhausted = True
++                        break
++                    # Never delete unless every readable key is durable.
++                    if ok and persisted_count == len(readable_keys):
++                        flushed = True
++                        logger.info(
++                            "L1-to-L2 flush: sync persisted %d/%d keys "
++                            "(%d bytes) via adapter %d",
++                            persisted_count,
++                            len(readable_keys),
++                            bytes_written,
++                            idx,
++                        )
++                        break
++                    logger.warning(
++                        "L1-to-L2 flush: adapter %d partial/failed persist "
++                        "(%d/%d keys, %d bytes)",
++                        idx,
++                        persisted_count,
++                        len(readable_keys),
++                        bytes_written,
++                    )
++            finally:
++                self._l1_manager.finish_read(readable_keys)
++
++        # Only keys we read and then fully persisted may be deleted. A key
++        # that failed reserve_read can have become locked after candidate
++        # selection and must never be treated as absent.
++        keys_to_delete = list(readable_keys) if flushed else []
++        if not flushed and readable_keys:
++            logger.warning(
++                "L1-to-L2 flush: preserving %d readable keys after failed persist",
++                len(readable_keys),
++            )
++
++        if keys_to_delete:
++            result = self._l1_manager.delete(keys_to_delete)
++            not_deleted = [k for k, err in result.items() if err != L1Error.SUCCESS]
++            if not_deleted:
++                logger.debug(
++                    "L1-to-L2 flush: %d keys not deleted, likely still locked",
++                    len(not_deleted),
++                )
++        if deadline_exhausted:
++            return _SyncFlushResult.DEADLINE_EXHAUSTED
++        if flushed:
++            return _SyncFlushResult.SUCCESS
++        return _SyncFlushResult.FAILURE
++
++    def _backup_to_l2_no_delete(self, batch_limit: int) -> None:
++        """Flush evictable L1 keys to L2 without deleting them from L1.
++
++        A backup, not an eviction: keys remain in L1 for fast access while
++        L2 gains a copy, so losing L1 (session expiry, restart) no longer
++        costs a cold prefill. A rotating cursor spreads repeated scans over
++        the whole L1 keyspace instead of hammering the first ``batch_limit``
++        insertion-ordered keys forever. Adapters skip keys they already
++        hold, so the flush is idempotent.
++        """
++        with self._flush_lock:
++            self._backup_to_l2_no_delete_locked(batch_limit)
++
++    def _backup_to_l2_no_delete_locked(self, batch_limit: int) -> None:
++        """Implementation of periodic backup under ``_flush_lock``."""
++        batch, self._backup_flush_cursor = self._l1_manager.get_evictable_keys(
++            limit=batch_limit,
++            cursor=self._backup_flush_cursor,
++        )
++        if not batch:
++            return
++
++        read_result = self._l1_manager.reserve_read(batch)
++        readable_keys: list[ObjectKey] = []
++        readable_objs = []
++        for key in batch:
++            entry = read_result.get(key)
++            if (
++                entry is not None
++                and entry[0] == L1Error.SUCCESS
++                and entry[1] is not None
++            ):
++                readable_keys.append(key)
++                readable_objs.append(entry[1])
++
++        if not readable_keys:
++            return
++
++        persisted_keys = 0
++        persisted_bytes = 0
++        try:
++            for idx, adapter, supports_timeout in self._snapshot_l2_flush_adapters():
++                if not supports_timeout:
++                    logger.warning(
++                        "Periodic L2 backup skipped adapter %d: "
++                        "store_objects_sync has no timeout contract",
++                        idx,
++                    )
++                    continue
++                sync_store = adapter.store_objects_sync
++                try:
++                    ok, persisted, written = sync_store(
++                        readable_keys,
++                        readable_objs,
++                        timeout=self._PERIODIC_FLUSH_TIMEOUT_SECONDS,
++                    )
++                    if ok and persisted == len(readable_keys):
++                        persisted_keys = persisted
++                        persisted_bytes = written
++                        break
++                except Exception:
++                    logger.exception("Periodic L2 backup: sync store failed on %d", idx)
++        finally:
++            self._l1_manager.finish_read(readable_keys)
++
++        if persisted_bytes > 0:
++            logger.info(
++                "Periodic L2 backup: persisted %d keys (%d new bytes, "
++                "%d evictable in L1, none deleted)",
++                persisted_keys,
++                persisted_bytes,
++                len(batch),
++            )
++
+ 
+ class L2AdapterEvictionState:
+     """Per-adapter eviction state: its own policy, listener, and config."""
+diff --git a/lmcache/v1/distributed/storage_controllers/prefetch_controller.py b/lmcache/v1/distributed/storage_controllers/prefetch_controller.py
+index 2138a33aa01ce95d7926bd4f6bcda79ae7d1955a..46239e518abaee70412223ec76eaa89f934a4bbe 100644
+--- a/lmcache/v1/distributed/storage_controllers/prefetch_controller.py
++++ b/lmcache/v1/distributed/storage_controllers/prefetch_controller.py
+@@ -55,6 +55,9 @@ from lmcache.v1.platform import (
+ 
+ if TYPE_CHECKING:
+     # First Party
++    from lmcache.v1.distributed.storage_controllers.eviction_controller import (
++        L1EvictionController,
++    )
+     from lmcache.v1.memory_management import MemoryObj
+ 
+ logger = init_logger(__name__)
+@@ -121,6 +124,17 @@ def trim_load_plan_with_mask(
+     return trimmed_plan
+ 
+ 
++def _layout_nbytes(layout_desc: MemoryLayoutDesc) -> int:
++    """Return the byte size of one object with the given layout."""
++    total = 0
++    for shape, dtype in zip(layout_desc.shapes, layout_desc.dtypes, strict=True):
++        numel = 1
++        for dim in shape:
++            numel *= int(dim)
++        total += numel * dtype.itemsize
++    return total
++
++
+ # Poll timeout in milliseconds for the prefetch loop
+ PREFETCH_LOOP_POLL_TIMEOUT_MS = 500
+ 
+@@ -227,6 +241,11 @@ class PrefetchController(StorageControllerInterface):
+         self._policy = policy
+         self._max_in_flight = max_in_flight
+ 
++        # Optional L1 eviction controller for emergency make-room before
++        # large restores; injected by StorageManager when
++        # EvictionConfig.emergency_evict_for_prefetch is enabled.
++        self._l1_eviction_controller: "L1EvictionController | None" = None
++
+         # Adapters that are being drained and will be removed after all
+         # the in-flight operations are done.
+         self._draining: dict[int, threading.Event] = {}
+@@ -847,6 +866,25 @@ class PrefetchController(StorageControllerInterface):
+     # =========================================================================
+     # Load phase
+     # =========================================================================
++    def _select_l1_retentions(
++        self,
++        request_id: int,
++        keys: list[ObjectKey],
++    ) -> list[bool]:
++        """Return one retention decision per key, degrading safely on a
++        malformed policy result."""
++        retentions = self._policy.select_l1_retentions(keys)
++        if len(retentions) != len(keys):
++            logger.error(
++                "Prefetch request %d: policy returned %d retentions for "
++                "%d keys; defaulting to temporary entries",
++                request_id,
++                len(retentions),
++                len(keys),
++            )
++            return [False] * len(keys)
++        return retentions
++
+     def _transition_to_load_phase(self, request: InFlightPrefetchRequest) -> None:
+         """Compute load plan, reserve L1 buffers, and submit load tasks."""
+         request.phase = PrefetchPhase.PLAN_AND_LOAD
+@@ -899,15 +937,23 @@ class PrefetchController(StorageControllerInterface):
+         if request.mode is PrefetchMode.WARM:
+             retentions = [True] * len(keys_to_reserve)
+         else:
+-            retentions = self._policy.select_l1_retentions(
++            retentions = self._select_l1_retentions(
++                request.request_id,
+                 keys_to_reserve,
+             )
++            # Non-WARM only: a WARM warm-up must never trigger emergency
++            # eviction of other sessions' chunks.
++            self._make_room_for_restore(request, keys_to_reserve)
+         write_results = l1_mgr.reserve_write(
+             keys=keys_to_reserve,
+             is_temporary=[not r for r in retentions],
+             layout_desc=request.layout_desc,
+             mode="new",
+         )
++        if request.mode is not PrefetchMode.WARM:
++            write_results = self._retry_oom_reservations(
++                request, keys_to_reserve, retentions, write_results
++            )
+ 
+         # Step 4: filter to successfully reserved keys
+         reserved_key_set: set[ObjectKey] = set()
+@@ -1038,6 +1084,123 @@ class PrefetchController(StorageControllerInterface):
+             len(reserved_key_set),
+         )
+ 
++    def set_l1_eviction_controller(
++        self,
++        controller: "L1EvictionController | None",
++    ) -> None:
++        """Enable emergency L1 eviction for large restores.
++
++        With a controller injected, a non-WARM restore that would not fit
++        in free L1 space synchronously evicts LRU keys (write-back first)
++        before reserving, and retries OOM reservations once. Pass ``None``
++        after the last synchronous L2 adapter is removed to disable this path.
++        """
++        self._l1_eviction_controller = controller
++
++    # Never let a single restore claim more than this fraction of L1: a
++    # huge context must not wipe every hot chunk of the running sessions.
++    _EMERGENCY_EVICT_MAX_L1_FRACTION = 0.6
++    # Headroom per object for alignment and allocator bookkeeping.
++    _PER_OBJECT_HEADROOM_BYTES = 8192
++
++    def _make_room_for_restore(
++        self,
++        request: InFlightPrefetchRequest,
++        keys_to_reserve: list[ObjectKey],
++    ) -> None:
++        """Pre-evict LRU L1 chunks so the upcoming reserve_write for this
++        restore can succeed. No-op unless an eviction controller was
++        injected via ``set_l1_eviction_controller``."""
++        evictor = self._l1_eviction_controller
++        if evictor is None or not keys_to_reserve:
++            return
++        per_obj = _layout_nbytes(request.layout_desc)
++        if per_obj <= 0:
++            return
++        used, total = self._l1_manager.get_memory_usage()
++        need = (per_obj + self._PER_OBJECT_HEADROOM_BYTES) * len(keys_to_reserve)
++        need = min(need, int(total * self._EMERGENCY_EVICT_MAX_L1_FRACTION))
++        free = max(0, total - used)
++        if free >= need:
++            return
++        try:
++            evictor.emergency_evict_bytes(
++                need, requester=f"prefetch_request={request.request_id}"
++            )
++        except Exception:
++            logger.exception(
++                "Emergency eviction failed for prefetch request %d",
++                request.request_id,
++            )
++
++    def _retry_oom_reservations(
++        self,
++        request: InFlightPrefetchRequest,
++        keys_to_reserve: list[ObjectKey],
++        retentions: list[bool],
++        write_results: dict[ObjectKey, tuple[L1Error, "MemoryObj | None"]],
++    ) -> dict[ObjectKey, tuple[L1Error, "MemoryObj | None"]]:
++        """One retry round for keys whose reservation failed with
++        OUT_OF_MEMORY: evict the missing amount, reserve just those keys
++        again, and merge the results. No-op unless an eviction controller
++        was injected."""
++        evictor = self._l1_eviction_controller
++        if evictor is None:
++            return write_results
++        oom_keys: list[ObjectKey] = []
++        retention_by_key = dict(zip(keys_to_reserve, retentions, strict=True))
++        for key in keys_to_reserve:
++            entry = write_results.get(key)
++            if entry is None:
++                oom_keys.append(key)
++                continue
++            err, mem_obj = entry
++            if err == L1Error.OUT_OF_MEMORY or (
++                err == L1Error.SUCCESS and mem_obj is None
++            ):
++                oom_keys.append(key)
++        if not oom_keys:
++            return write_results
++        per_obj = _layout_nbytes(request.layout_desc)
++        if per_obj <= 0:
++            return write_results
++        _, total = self._l1_manager.get_memory_usage()
++        need = (per_obj + self._PER_OBJECT_HEADROOM_BYTES) * len(oom_keys)
++        need = min(need, int(total * self._EMERGENCY_EVICT_MAX_L1_FRACTION))
++        try:
++            evictor.emergency_evict_bytes(
++                need, requester=f"prefetch_request={request.request_id}/retry"
++            )
++        except Exception:
++            logger.exception(
++                "Emergency eviction retry failed for prefetch request %d",
++                request.request_id,
++            )
++            return write_results
++        retry_results = self._l1_manager.reserve_write(
++            keys=oom_keys,
++            is_temporary=[not retention_by_key[k] for k in oom_keys],
++            layout_desc=request.layout_desc,
++            mode="new",
++        )
++        recovered = sum(
++            1
++            for k in oom_keys
++            if retry_results.get(k)
++            and retry_results[k][0] == L1Error.SUCCESS
++            and retry_results[k][1] is not None
++        )
++        if recovered:
++            logger.info(
++                "Retry recovered %d/%d OOM reservations for prefetch request %d",
++                recovered,
++                len(oom_keys),
++                request.request_id,
++            )
++        merged = dict(write_results)
++        merged.update(retry_results)
++        return merged
++
+     def _update_lookup_results(
+         self, request_id: PrefetchRequestId, prefix_hit_count: int
+     ) -> None:
+@@ -1181,6 +1344,17 @@ class PrefetchController(StorageControllerInterface):
+         # added once the serde PR lands and adapters can distinguish
+         # deserialization errors from missing objects.
+         if failed_keys:
++            # These keys were reported present by the L2 lookup but the load
++            # returned no data. Sample a few so the on-disk state can be
++            # inspected post hoc.
++            logger.warning(
++                "Prefetch request %d: %d/%d plan keys failed to load from "
++                "L2 (lookup hit, load empty); sample: %s",
++                request.request_id,
++                len(failed_keys),
++                len(request.write_reserved_keys),
++                [str(k)[:160] for k in failed_keys[:3]],
++            )
+             self._event_bus.publish(
+                 Event(
+                     event_type=EventType.L2_PREFETCH_FAILED,
+diff --git a/lmcache/v1/distributed/storage_manager.py b/lmcache/v1/distributed/storage_manager.py
+index 3054e2441c5c7d98d817ca7a1f9ac30b4a7e92d7..a7da312a475264ddd1c829ad73937fc103cbf1a8 100644
+--- a/lmcache/v1/distributed/storage_manager.py
++++ b/lmcache/v1/distributed/storage_manager.py
+@@ -66,6 +66,7 @@ logger = init_logger(__name__)
+ 
+ class StorageManager:
+     def __init__(self, config: StorageManagerConfig):
++        self._eviction_config = config.eviction_config
+         self._l1_manager = L1Manager(config.l1_manager_config)
+         self._event_bus = get_event_bus()
+ 
+@@ -154,6 +155,31 @@ class StorageManager:
+         )
+         self._prefetch_controller.start()
+ 
++        # Opt-in L1 write-back tier: wire L2 adapters into the L1 eviction
++        # controller so evicted or periodically backed-up chunks are flushed
++        # to L2, and optionally let the prefetch controller trigger
++        # emergency eviction to make room for large restores.
++        eviction_config = config.eviction_config
++        wants_l1_write_back = (
++            eviction_config.write_back_on_evict
++            or eviction_config.periodic_flush_interval > 0
++        )
++        if wants_l1_write_back:
++            self._sync_l1_writeback_adapters()
++            if not self._eviction_controller.has_l2_flush_adapter():
++                logger.warning(
++                    "write_back_on_evict / periodic_flush_interval is set but "
++                    "no L2 adapter exposes store_objects_sync"
++                )
++        if (
++            eviction_config.emergency_evict_for_prefetch
++            and not self._eviction_controller.has_l2_flush_adapter()
++        ):
++            logger.warning(
++                "emergency_evict_for_prefetch has no synchronous L2 "
++                "adapter; inactive until one is added"
++            )
++
+         # L2 usage gauge — one observation per adapter, tagged by
+         # ``l2_name``.  Parallel to L1Manager's ``l1_memory_usage_bytes``.
+         register_gauge(
+@@ -904,6 +930,7 @@ class StorageManager:
+             with self._adapters_lock:
+                 self._l2_adapters[adapter_id] = adapter
+                 self._adapter_descriptors[adapter_id] = descriptor
++            self._sync_l1_writeback_adapters()
+             self._store_controller.add_adapter(adapter_id, adapter, descriptor)
+             self._prefetch_controller.add_adapter(adapter_id, adapter, descriptor)
+             if self._should_enable_l2_eviction(adapter, config.eviction_config):
+@@ -956,6 +983,9 @@ class StorageManager:
+             with self._adapters_lock:
+                 adapter = self._l2_adapters.pop(adapter_id)
+                 self._adapter_descriptors.pop(adapter_id, None)
++            # Waits for any synchronous L1 flush using the removed adapter
++            # before adapter.close() releases its native resources.
++            self._sync_l1_writeback_adapters()
+             adapter.close()
+             logger.info("Deleted L2 adapter %d", adapter_id)
+ 
+@@ -1121,6 +1151,21 @@ class StorageManager:
+             return False
+         return True
+ 
++    def _sync_l1_writeback_adapters(self) -> None:
++        """Publish the current adapter set to the optional L1 writeback tier."""
++        config = self._eviction_config
++        if not (config.write_back_on_evict or config.periodic_flush_interval > 0):
++            return
++        with self._adapters_lock:
++            adapters = dict(self._l2_adapters)
++        self._eviction_controller.set_l2_adapters(adapters)
++        if config.emergency_evict_for_prefetch:
++            self._prefetch_controller.set_l1_eviction_controller(
++                self._eviction_controller
++                if self._eviction_controller.has_l2_flush_adapter()
++                else None
++            )
++
+     def _unwrap_reconfigurable_l2_adapter(
+         self,
+         adapter: L2AdapterInterface,
+diff --git a/lmcache/v1/multiprocess/futures.py b/lmcache/v1/multiprocess/futures.py
+index beadae5505e4062d95b3e5f083d8e72b6bdf06d1..ab5195eec56aa3fcd9b52550aac52dc6133680b4 100644
+--- a/lmcache/v1/multiprocess/futures.py
++++ b/lmcache/v1/multiprocess/futures.py
+@@ -14,6 +14,7 @@ class MessagingFuture(Generic[T]):
+     def __init__(self):
+         self.is_done_ = threading.Event()
+         self.result_ = None
++        self.exception_: BaseException | None = None
+ 
+     def query(self) -> bool:
+         """
+@@ -54,6 +55,8 @@ class MessagingFuture(Generic[T]):
+         flag = self.wait(timeout)
+         if not flag:
+             raise LMCacheTimeoutError("Future result not available within timeout")
++        if self.exception_ is not None:
++            raise self.exception_
+         return self.result_
+ 
+     def set_result(self, result: T) -> None:
+@@ -68,6 +71,13 @@ class MessagingFuture(Generic[T]):
+         self.result_ = result
+         self.is_done_.set()
+ 
++    def set_exception(self, exception: BaseException) -> None:
++        """Complete the future with an exception from the messaging system."""
++        if not isinstance(exception, BaseException):
++            raise TypeError("exception must derive from BaseException")
++        self.exception_ = exception
++        self.is_done_.set()
++
+     def to_cuda_future(
+         self,
+         device: Any | None = None,
+diff --git a/lmcache/v1/multiprocess/mq.py b/lmcache/v1/multiprocess/mq.py
+index 271ff93b2a933f6c0f70f95a95d6f2249e7636c1..a5d0d0cf7322a523a9a8b89a0c5af2e2466109b1 100644
+--- a/lmcache/v1/multiprocess/mq.py
++++ b/lmcache/v1/multiprocess/mq.py
+@@ -40,6 +40,26 @@ T = TypeVar("T")
+ # Internal type used for the client-server communication
+ RequestUID = int
+ 
++_ERROR_RESPONSE_MARKER = b"LMCACHE_RPC_ERROR_V1"
++_MAX_REMOTE_ERROR_MESSAGE_BYTES = 4096
++
++
++class RemoteHandlerError(RuntimeError):
++    """A request handler failed in the remote LMCache process."""
++
++    def __init__(
++        self, request_type: RequestType, error_type: str, message: str
++    ) -> None:
++        self.request_type = request_type
++        self.error_type = error_type
++        self.remote_message = message
++        super().__init__(f"{request_type.name} handler failed: {error_type}: {message}")
++
++
++class _RemoteErrorPayload(msgspec.Struct, frozen=True):
++    error_type: str
++    message: str
++
+ 
+ # Helper functions
+ def encode_request_uid(uid: RequestUID) -> bytes:
+@@ -346,7 +366,28 @@ class MessageQueueClient:
+ 
+         if request_uid in self.pending_futures:
+             future = self.pending_futures.pop(request_uid)
+-            if b_response:
++            if b_response and b_response[0] == _ERROR_RESPONSE_MARKER:
++                if len(b_response) != 2:
++                    future.set_exception(
++                        RuntimeError("Malformed LMCache RPC error response")
++                    )
++                    return
++                try:
++                    error = msgspec_decode(b_response[1], cls=_RemoteErrorPayload)
++                except Exception:
++                    future.set_exception(
++                        RuntimeError("Failed to decode LMCache RPC error response")
++                    )
++                    logger.exception("Failed to decode RPC error response")
++                    return
++                future.set_exception(
++                    RemoteHandlerError(
++                        request_type=request_type,
++                        error_type=error.error_type,
++                        message=error.message,
++                    )
++                )
++            elif b_response:
+                 response = msgspec_decode(b_response[0], cls=response_cls)
+                 future.set_result(response)
+             else:
+@@ -516,6 +557,24 @@ class MessageQueueServer:
+         # Thread pools assigned via add_normal_thread_pool / add_affinity_thread_pool
+         self.extra_pools: list[ThreadPoolExecutor | AffinityThreadPool] = []
+ 
++    def _queue_error_response(
++        self, prefix_frames: list[bytes], exception: BaseException
++    ) -> None:
++        """Return a bounded error response without touching ZMQ off-thread."""
++        message = str(exception).encode("utf-8")[:_MAX_REMOTE_ERROR_MESSAGE_BYTES]
++        payload = _RemoteErrorPayload(
++            error_type=type(exception).__name__,
++            message=message.decode("utf-8", errors="replace"),
++        )
++        self.output_queue.put(
++            prefix_frames
++            + [
++                _ERROR_RESPONSE_MARKER,
++                msgspec_encode(payload, cls=_RemoteErrorPayload),
++            ]
++        )
++        self._output_efd.notify()
++
+     def _call_sync_handler(
+         self,
+         handler_entry: SyncRequestHandler[Any],
+@@ -571,8 +630,9 @@ class MessageQueueServer:
+                 self.output_queue.put(frames_to_send)
+                 self._output_efd.notify()
+ 
+-            except Exception:
++            except Exception as exc:
+                 logger.exception("Error in blocking handler")
++                self._queue_error_response(prefix_frames, exc)
+ 
+         future.add_done_callback(_notify_response)
+ 
+@@ -619,13 +679,23 @@ class MessageQueueServer:
+                             payloads=payloads,
+                             prefix_frames=[identity, b_request_uid, b_request_type],
+                         )
+-                    except Exception:
++                    except Exception as exc:
+                         logger.exception("Error handling request %s", request_type)
++                        self._queue_error_response(
++                            [identity, b_request_uid, b_request_type], exc
++                        )
+                 else:
+                     logger.error(
+                         "No handler registered for request type %s", request_type
+                     )
+                     logger.error("Available handlers: %s", list(self.handlers.keys()))
++                    self._queue_error_response(
++                        [identity, b_request_uid, b_request_type],
++                        RuntimeError(
++                            "No handler registered for request type "
++                            f"{request_type.name}"
++                        ),
++                    )
+ 
+             # Send the responses
+             if outbound_state and outbound_state & zmq.POLLIN:
+diff --git a/tests/v1/distributed/test_fs_native_startup_scan.py b/tests/v1/distributed/test_fs_native_startup_scan.py
+new file mode 100644
+index 0000000000000000000000000000000000000000..796c27e183c9ff0bc923b4d5fbe7e7dfdb6957bc
+--- /dev/null
++++ b/tests/v1/distributed/test_fs_native_startup_scan.py
+@@ -0,0 +1,78 @@
++# SPDX-License-Identifier: Apache-2.0
++"""Restart accounting for the native filesystem L2 adapter."""
++
++# Standard
++import os
++
++# Third Party
++import pytest
++
++# First Party
++from lmcache.v1.distributed.api import ObjectKey
++from lmcache.v1.distributed.l2_adapters.fs_l2_adapter import (
++    _object_key_to_filename,
++)
++from lmcache.v1.distributed.l2_adapters.fs_native_l2_adapter import (
++    _scan_existing_fs_native_files,
++)
++
++
++def _key(chunk_id: int) -> ObjectKey:
++    return ObjectKey(
++        chunk_hash=ObjectKey.IntHash2Bytes(chunk_id),
++        model_name="test-model",
++        kv_rank=0,
++    )
++
++
++def _write(root, key: ObjectKey, size: int, mtime_ns: int) -> None:
++    path = root / _object_key_to_filename(key)
++    path.write_bytes(b"x" * size)
++    os.utime(path, ns=(mtime_ns, mtime_ns))
++
++
++def test_scan_returns_oldest_to_newest_keys_and_sizes(tmp_path):
++    newer = _key(2)
++    older = _key(1)
++    _write(tmp_path, newer, 200, 2_000_000_000)
++    _write(tmp_path, older, 100, 1_000_000_000)
++
++    keys, sizes = _scan_existing_fs_native_files(str(tmp_path))
++
++    assert keys == [older, newer]
++    assert sizes == [100, 200]
++
++
++def test_scan_skips_foreign_empty_and_temporary_files(tmp_path):
++    valid = _key(1)
++    _write(tmp_path, valid, 100, 1_000_000_000)
++    (tmp_path / "not-a-cache-file.data").write_bytes(b"x")
++    (tmp_path / _object_key_to_filename(_key(2))).write_bytes(b"")
++    (tmp_path / "pending.tmp").write_bytes(b"x")
++
++    keys, sizes = _scan_existing_fs_native_files(str(tmp_path))
++
++    assert keys == [valid]
++    assert sizes == [100]
++
++
++def test_scan_missing_directory_returns_empty(tmp_path):
++    assert _scan_existing_fs_native_files(str(tmp_path / "missing")) == ([], [])
++
++
++def test_scan_fails_closed_when_existing_file_cannot_be_inspected(
++    tmp_path, monkeypatch
++):
++    path = tmp_path / "broken.data"
++    path.write_bytes(b"x")
++    original_stat = type(path).stat
++
++    def fail_data_stat(self, *args, **kwargs):
++        if self == path:
++            raise OSError("injected stat failure")
++        return original_stat(self, *args, **kwargs)
++
++    monkeypatch.setattr(type(path), "stat", fail_data_stat)
++
++    with pytest.raises(RuntimeError, match="Could not inspect cache file"):
++        _scan_existing_fs_native_files(str(tmp_path))
+diff --git a/tests/v1/distributed/test_l1_manager.py b/tests/v1/distributed/test_l1_manager.py
+index fea845f903879a84856058ac107589a4b21e0fc7..5b0fb89bc77f4b274f8a27bc48c876aa3c7b54bb 100644
+--- a/tests/v1/distributed/test_l1_manager.py
++++ b/tests/v1/distributed/test_l1_manager.py
+@@ -132,18 +132,6 @@ def basic_layout():
+     )
+ 
+ 
+-@pytest.fixture
+-def large_layout():
+-    """Create a large MemoryLayoutDesc that will exhaust small memory.
+-
+-    Each allocation is 8MB (2M elements * 4 bytes).
+-    """
+-    return MemoryLayoutDesc(
+-        shapes=[torch.Size([2048, 1024])],  # 2M elements * 4 bytes = 8MB
+-        dtypes=[torch.float32],
+-    )
+-
+-
+ def make_object_key(chunk_hash: int, model_name: str = "test_model", kv_rank: int = 0):
+     """Helper to create ObjectKey instances."""
+     hash_bytes = ObjectKey.IntHash2Bytes(chunk_hash)
+@@ -879,14 +867,23 @@ class TestReserveWrite:
+ 
+         manager.close()
+ 
+-    def test_reserve_write_out_of_memory(self, small_l1_config, large_layout):
+-        """Test that reserve_write returns OUT_OF_MEMORY when allocation fails."""
++    def test_reserve_write_out_of_memory(self, small_l1_config):
++        """Test that reserve_write returns OUT_OF_MEMORY when allocation fails.
++
++        Uses an object larger than the whole pool; a batch that partially
++        fits allocates the longest prefix instead (see
++        tests/v1/distributed/test_l1_manager_partial_alloc.py).
++        """
+         manager = L1Manager(small_l1_config)
+         keys = [make_object_key(i) for i in range(10)]
+         is_temporary = [False] * 10
+ 
+-        # Request more memory than available (8MB * 10 = 80MB > 64MB)
+-        result = manager.reserve_write(keys, is_temporary, large_layout)
++        # A single object (128MB) exceeds the 64MB pool.
++        oversized_layout = MemoryLayoutDesc(
++            shapes=[torch.Size([2048 * 16, 1024])],
++            dtypes=[torch.float32],
++        )
++        result = manager.reserve_write(keys, is_temporary, oversized_layout)
+ 
+         # All keys should return OUT_OF_MEMORY
+         for key in keys:
+diff --git a/tests/v1/distributed/test_l1_manager_partial_alloc.py b/tests/v1/distributed/test_l1_manager_partial_alloc.py
+new file mode 100644
+index 0000000000000000000000000000000000000000..30ddc3fba0ce10c957ad6375874fac7df9cc8585
+--- /dev/null
++++ b/tests/v1/distributed/test_l1_manager_partial_alloc.py
+@@ -0,0 +1,151 @@
++# SPDX-License-Identifier: Apache-2.0
++"""Partial-prefix allocation behavior of ``L1Manager.reserve_write``.
++
++A batch whose full allocation does not fit must not fail every key
++(all-or-nothing would collapse large L2->L1 restores to zero prefix hits):
++the longest prefix that fits is allocated and only the tail reports
++OUT_OF_MEMORY. Uses the CPU shared-memory allocator, no GPU required.
++"""
++
++# Standard
++from collections.abc import Iterator
++from types import SimpleNamespace
++
++# Third Party
++import pytest
++import torch
++
++# First Party
++from lmcache.v1.distributed.api import MemoryLayoutDesc, ObjectKey
++from lmcache.v1.distributed.config import (
++    L1ManagerConfig,
++    L1MemoryManagerConfig,
++)
++from lmcache.v1.distributed.error import L1Error
++from lmcache.v1.distributed.l1_manager import L1Manager
++
++POOL_BYTES = 64 * 1024 * 1024
++
++# 8MB per object: ten of them cannot fit in the 64MB pool, most can.
++OBJECT_LAYOUT = MemoryLayoutDesc(
++    shapes=[torch.Size([2048, 1024])],
++    dtypes=[torch.float32],
++)
++
++# A single 128MB object exceeds the whole pool.
++OVERSIZED_LAYOUT = MemoryLayoutDesc(
++    shapes=[torch.Size([2048 * 16, 1024])],
++    dtypes=[torch.float32],
++)
++
++
++@pytest.fixture
++def manager() -> Iterator[L1Manager]:
++    config = L1ManagerConfig(
++        memory_config=L1MemoryManagerConfig(
++            size_in_bytes=POOL_BYTES,
++            use_lazy=False,
++            init_size_in_bytes=POOL_BYTES,
++            align_bytes=0x1000,
++        ),
++        write_ttl_seconds=600,
++        read_ttl_seconds=300,
++    )
++    manager = L1Manager(config)
++    yield manager
++    manager.close()
++
++
++def _make_keys(count: int) -> list[ObjectKey]:
++    return [
++        ObjectKey(
++            chunk_hash=ObjectKey.IntHash2Bytes(i),
++            model_name="test_model",
++            kv_rank=0,
++        )
++        for i in range(count)
++    ]
++
++
++def test_reserve_write_allocates_longest_prefix_on_oom(manager: L1Manager) -> None:
++    """When the full batch does not fit, a non-empty prefix succeeds and
++    only the tail reports OUT_OF_MEMORY; every requested key keeps an
++    explicit per-key result."""
++    keys = _make_keys(10)
++    result = manager.reserve_write(keys, [False] * 10, OBJECT_LAYOUT)
++
++    assert set(result) == set(keys)
++    statuses = [result[key][0] for key in keys]
++    num_success = statuses.count(L1Error.SUCCESS)
++    assert 0 < num_success < 10
++
++    # The successful keys form a prefix in request order.
++    assert statuses == [L1Error.SUCCESS] * num_success + [L1Error.OUT_OF_MEMORY] * (
++        10 - num_success
++    )
++    for key in keys[:num_success]:
++        assert result[key][1] is not None
++    for key in keys[num_success:]:
++        assert result[key][1] is None
++
++
++def test_partial_prefix_is_committable(manager: L1Manager) -> None:
++    """The allocated prefix stays usable: finish_write succeeds for it."""
++    keys = _make_keys(10)
++    result = manager.reserve_write(keys, [False] * 10, OBJECT_LAYOUT)
++    successful = [key for key in keys if result[key][0] == L1Error.SUCCESS]
++    assert successful
++
++    finish_result = manager.finish_write(successful)
++    for key in successful:
++        assert finish_result[key] == L1Error.SUCCESS
++
++
++def test_reserve_write_all_oom_when_nothing_fits(manager: L1Manager) -> None:
++    """An object larger than the pool still fails every key."""
++    keys = _make_keys(3)
++    result = manager.reserve_write(keys, [False] * 3, OVERSIZED_LAYOUT)
++
++    for key in keys:
++        assert result[key][0] == L1Error.OUT_OF_MEMORY
++        assert result[key][1] is None
++
++
++def test_single_key_batch_keeps_all_or_nothing(manager: L1Manager) -> None:
++    """A one-key batch has no prefix to fall back to; it simply fails."""
++    keys = _make_keys(1)
++    result = manager.reserve_write(keys, [False], OVERSIZED_LAYOUT)
++
++    assert result[keys[0]] == (L1Error.OUT_OF_MEMORY, None)
++
++
++def test_largest_prefix_search_does_not_stop_at_a_smaller_fit() -> None:
++    """The OOM fallback finds the maximum, rather than accepting a midpoint."""
++
++    class BoundedMemoryManager:
++        def __init__(self, capacity: int) -> None:
++            self.capacity = capacity
++            self.allocate_counts: list[int] = []
++
++        def allocate(self, _layout: MemoryLayoutDesc, count: int):
++            self.allocate_counts.append(count)
++            if count > self.capacity:
++                return L1Error.OUT_OF_MEMORY, []
++            return L1Error.SUCCESS, [object() for _ in range(count)]
++
++        def free(self, _objects: list[object]) -> L1Error:
++            return L1Error.SUCCESS
++
++    memory_manager = BoundedMemoryManager(capacity=7)
++    manager = SimpleNamespace(_memory_manager=memory_manager)
++
++    err, objects = L1Manager._allocate_largest_prefix(
++        manager,
++        OBJECT_LAYOUT,
++        10,  # type: ignore[arg-type]
++    )
++
++    assert err == L1Error.SUCCESS
++    assert len(objects) == 7
++    assert memory_manager.allocate_counts[-1] == 7
++    assert 8 in memory_manager.allocate_counts
+diff --git a/tests/v1/distributed/test_l1_write_back_eviction.py b/tests/v1/distributed/test_l1_write_back_eviction.py
+new file mode 100644
+index 0000000000000000000000000000000000000000..b677516e37c31959421ea88f777a734d7f61bd0d
+--- /dev/null
++++ b/tests/v1/distributed/test_l1_write_back_eviction.py
+@@ -0,0 +1,609 @@
++# SPDX-License-Identifier: Apache-2.0
++"""Opt-in L1 write-back tier.
++
++With ``EvictionConfig.write_back_on_evict`` enabled, L1 eviction flushes
++readable objects to L2 synchronously and deletes them from L1 only once
++every key in the batch is durable. ``periodic_flush_interval`` adds a
++below-watermark backup flush that keeps the L1 copy.
++``emergency_evict_for_prefetch`` lets the prefetch controller make room
++for large restores through the same write-back path.
++
++Uses the CPU shared-memory allocator; no GPU required.
++"""
++
++# Standard
++from collections.abc import Iterator
++import argparse
++import threading
++import time
++
++# Third Party
++import pytest
++import torch
++
++# First Party
++from lmcache.v1.distributed.api import MemoryLayoutDesc, ObjectKey
++from lmcache.v1.distributed.config import (
++    EvictionConfig,
++    L1ManagerConfig,
++    L1MemoryManagerConfig,
++    StorageManagerConfig,
++    add_storage_manager_args,
++    parse_args_to_config,
++)
++from lmcache.v1.distributed.error import L1Error
++from lmcache.v1.distributed.internal_api import (
++    EvictionAction,
++    EvictionDestination,
++)
++from lmcache.v1.distributed.l1_manager import L1Manager
++from lmcache.v1.distributed.storage_controllers.eviction_controller import (
++    L1EvictionController,
++)
++from lmcache.v1.distributed.storage_controllers.prefetch_controller import (
++    InFlightPrefetchRequest,
++    PrefetchController,
++    PrefetchPhase,
++)
++from lmcache.v1.distributed.storage_controllers.prefetch_policy import (
++    DefaultPrefetchPolicy,
++)
++from lmcache.v1.mp_observability.config import add_observability_args
++
++POOL_BYTES = 8 * 1024 * 1024
++
++# 1MB per object so a handful of objects create real memory pressure.
++OBJECT_LAYOUT = MemoryLayoutDesc(
++    shapes=[torch.Size([256, 1024])],
++    dtypes=[torch.float32],
++)
++
++
++class FakeSyncStoreAdapter:
++    """L2 adapter double exposing only the synchronous store path.
++
++    ``result`` overrides the returned tuple; by default every key is
++    reported durable.
++    """
++
++    def __init__(self) -> None:
++        self.stored_batches: list[list[ObjectKey]] = []
++        self.result: tuple[bool, int, int] | None = None
++
++    def store_objects_sync(
++        self,
++        keys: list[ObjectKey],
++        objects: list,
++        timeout: float | None = None,
++    ) -> tuple[bool, int, int]:
++        self.stored_batches.append(list(keys))
++        if self.result is not None:
++            return self.result
++        return True, len(keys), sum(obj.get_size() for obj in objects)
++
++
++class BlockingSyncStoreAdapter(FakeSyncStoreAdapter):
++    def __init__(self) -> None:
++        super().__init__()
++        self.entered = threading.Event()
++        self.release = threading.Event()
++
++    def store_objects_sync(self, keys, objects, timeout=None):
++        self.entered.set()
++        if not self.release.wait(timeout=timeout or 5.0):
++            return False, 0, 0
++        return super().store_objects_sync(keys, objects, timeout=timeout)
++
++
++@pytest.fixture
++def l1_manager() -> Iterator[L1Manager]:
++    config = L1ManagerConfig(
++        memory_config=L1MemoryManagerConfig(
++            size_in_bytes=POOL_BYTES,
++            use_lazy=False,
++            init_size_in_bytes=POOL_BYTES,
++            align_bytes=0x1000,
++        ),
++        write_ttl_seconds=600,
++        read_ttl_seconds=300,
++    )
++    manager = L1Manager(config)
++    yield manager
++    manager.close()
++
++
++def _make_controller(
++    l1_manager: L1Manager,
++    adapter: FakeSyncStoreAdapter,
++    **config_kwargs,
++) -> L1EvictionController:
++    config = EvictionConfig(eviction_policy="LRU", **config_kwargs)
++    return L1EvictionController(
++        l1_manager=l1_manager,
++        eviction_config=config,
++        l2_adapters={0: adapter},
++    )
++
++
++def _make_keys(count: int) -> list[ObjectKey]:
++    return [
++        ObjectKey(
++            chunk_hash=ObjectKey.IntHash2Bytes(i),
++            model_name="test_model",
++            kv_rank=0,
++        )
++        for i in range(count)
++    ]
++
++
++def _store_keys(l1_manager: L1Manager, keys: list[ObjectKey]) -> None:
++    result = l1_manager.reserve_write(keys, [False] * len(keys), OBJECT_LAYOUT)
++    for key in keys:
++        assert result[key][0] == L1Error.SUCCESS
++    l1_manager.finish_write(keys)
++
++
++def _readable_keys(l1_manager: L1Manager, keys: list[ObjectKey]) -> list[ObjectKey]:
++    result = l1_manager.reserve_read(keys)
++    readable = [
++        key
++        for key in keys
++        if result.get(key) is not None and result[key][0] == L1Error.SUCCESS
++    ]
++    if readable:
++        l1_manager.finish_read(readable)
++    return readable
++
++
++class TestWriteBackOnEvict:
++    def test_flush_then_delete(self, l1_manager):
++        """A durable flush deletes the batch from L1."""
++        adapter = FakeSyncStoreAdapter()
++        controller = _make_controller(l1_manager, adapter, write_back_on_evict=True)
++        keys = _make_keys(3)
++        _store_keys(l1_manager, keys)
++
++        controller.execute_eviction_action(
++            EvictionAction(keys=keys, destination=EvictionDestination.L2_CACHE)
++        )
++
++        assert adapter.stored_batches == [keys]
++        assert _readable_keys(l1_manager, keys) == []
++
++    def test_failed_flush_preserves_l1(self, l1_manager):
++        """A failed flush keeps every readable key in L1 and opens the
++        circuit breaker."""
++        adapter = FakeSyncStoreAdapter()
++        adapter.result = (False, 0, 0)
++        controller = _make_controller(l1_manager, adapter, write_back_on_evict=True)
++        keys = _make_keys(3)
++        _store_keys(l1_manager, keys)
++
++        controller.execute_eviction_action(
++            EvictionAction(keys=keys, destination=EvictionDestination.L2_CACHE)
++        )
++
++        assert _readable_keys(l1_manager, keys) == keys
++        status = controller.report_status()
++        assert status["sync_flush_failures"] == 1
++        assert status["sync_flush_backoff_seconds"] > 0.0
++
++    def test_partial_flush_preserves_l1(self, l1_manager):
++        """A partial persist is not durable; the batch stays in L1."""
++        adapter = FakeSyncStoreAdapter()
++        adapter.result = (False, 2, 1024)
++        controller = _make_controller(l1_manager, adapter, write_back_on_evict=True)
++        keys = _make_keys(3)
++        _store_keys(l1_manager, keys)
++
++        controller.execute_eviction_action(
++            EvictionAction(keys=keys, destination=EvictionDestination.L2_CACHE)
++        )
++
++        assert _readable_keys(l1_manager, keys) == keys
++
++    def test_missing_sync_adapter_fails_closed(self, l1_manager):
++        config = EvictionConfig(eviction_policy="LRU", write_back_on_evict=True)
++        controller = L1EvictionController(
++            l1_manager=l1_manager,
++            eviction_config=config,
++            l2_adapters={0: object()},
++        )
++        keys = _make_keys(2)
++        _store_keys(l1_manager, keys)
++
++        controller.execute_eviction_action(
++            EvictionAction(keys=keys, destination=EvictionDestination.L2_CACHE)
++        )
++
++        assert controller.has_l2_flush_adapter() is False
++        assert _readable_keys(l1_manager, keys) == keys
++
++    def test_reserve_read_failure_is_not_deleted(self, l1_manager, monkeypatch):
++        adapter = FakeSyncStoreAdapter()
++        controller = _make_controller(l1_manager, adapter, write_back_on_evict=True)
++        keys = _make_keys(1)
++        _store_keys(l1_manager, keys)
++        monkeypatch.setattr(
++            l1_manager,
++            "reserve_read",
++            lambda _keys: {keys[0]: (L1Error.KEY_IS_LOCKED, None)},
++        )
++
++        controller.execute_eviction_action(
++            EvictionAction(keys=keys, destination=EvictionDestination.L2_CACHE)
++        )
++
++        monkeypatch.undo()
++        assert adapter.stored_batches == []
++        assert _readable_keys(l1_manager, keys) == keys
++
++    def test_adapter_replacement_waits_for_active_flush(self, l1_manager):
++        adapter = BlockingSyncStoreAdapter()
++        controller = _make_controller(l1_manager, adapter, write_back_on_evict=True)
++        keys = _make_keys(1)
++        _store_keys(l1_manager, keys)
++        flush = threading.Thread(
++            target=lambda: controller.execute_eviction_action(
++                EvictionAction(keys=keys, destination=EvictionDestination.L2_CACHE)
++            )
++        )
++        replaced = threading.Event()
++        replace = threading.Thread(
++            target=lambda: (
++                controller.set_l2_adapters({}),
++                replaced.set(),
++            )
++        )
++
++        flush.start()
++        assert adapter.entered.wait(timeout=5.0)
++        replace.start()
++        time.sleep(0.05)
++        assert not replaced.is_set()
++
++        adapter.release.set()
++        flush.join(timeout=5.0)
++        replace.join(timeout=5.0)
++
++        assert replaced.is_set()
++        assert not flush.is_alive()
++        assert not replace.is_alive()
++
++
++class TestEmergencyEvict:
++    def test_emergency_evict_frees_bytes_via_write_back(self, l1_manager):
++        """emergency_evict_bytes flushes LRU victims to L2 and frees L1."""
++        adapter = FakeSyncStoreAdapter()
++        controller = _make_controller(l1_manager, adapter, write_back_on_evict=True)
++        keys = _make_keys(6)
++        _store_keys(l1_manager, keys)
++
++        used_before, total = l1_manager.get_memory_usage()
++        free_before = total - used_before
++
++        free_after = controller.emergency_evict_bytes(
++            free_before + 2 * 1024 * 1024, requester="test"
++        )
++
++        assert free_after > free_before
++        assert adapter.stored_batches
++        evicted = [k for batch in adapter.stored_batches for k in batch]
++        assert set(evicted) <= set(keys)
++        assert len(evicted) < len(keys)
++        # Evicted keys are gone from L1.
++        assert not set(evicted) & set(_readable_keys(l1_manager, keys))
++
++    def test_emergency_evict_noop_when_enough_free(self, l1_manager):
++        adapter = FakeSyncStoreAdapter()
++        controller = _make_controller(l1_manager, adapter, write_back_on_evict=True)
++        keys = _make_keys(2)
++        _store_keys(l1_manager, keys)
++
++        controller.emergency_evict_bytes(1024, requester="test")
++
++        assert adapter.stored_batches == []
++        assert _readable_keys(l1_manager, keys) == keys
++
++    def test_emergency_evict_skips_scan_during_backoff(self, l1_manager, monkeypatch):
++        adapter = FakeSyncStoreAdapter()
++        controller = _make_controller(l1_manager, adapter, write_back_on_evict=True)
++        keys = _make_keys(6)
++        _store_keys(l1_manager, keys)
++        controller._sync_flush_backoff_until = time.monotonic() + 60
++        monkeypatch.setattr(
++            controller._eviction_policy,
++            "get_eviction_actions",
++            lambda *args, **kwargs: pytest.fail("eviction scan should be skipped"),
++        )
++
++        used, total = l1_manager.get_memory_usage()
++        free = total - used
++        assert controller.emergency_evict_bytes(free + 1024) == free
++
++    def test_emergency_evict_has_bounded_store_wait(self, l1_manager):
++        adapter = BlockingSyncStoreAdapter()
++        controller = _make_controller(l1_manager, adapter, write_back_on_evict=True)
++        controller._EMERGENCY_FLUSH_TIMEOUT_SECONDS = 0.05
++        keys = _make_keys(6)
++        _store_keys(l1_manager, keys)
++        used, total = l1_manager.get_memory_usage()
++
++        start = time.monotonic()
++        free_after = controller.emergency_evict_bytes(total - used + 1024)
++        elapsed = time.monotonic() - start
++
++        assert adapter.entered.is_set()
++        assert elapsed < 0.5
++        assert free_after == total - used
++        assert _readable_keys(l1_manager, keys) == keys
++        status = controller.report_status()
++        assert status["sync_flush_failures"] == 0
++        assert status["sync_flush_backoff_seconds"] == 0.0
++
++
++class TestPeriodicBackupFlush:
++    def test_backup_flush_keeps_l1_copy(self, l1_manager):
++        """The periodic backup flush copies keys to L2 without deleting
++        them from L1."""
++        adapter = FakeSyncStoreAdapter()
++        controller = _make_controller(l1_manager, adapter, periodic_flush_interval=0.1)
++        keys = _make_keys(3)
++        _store_keys(l1_manager, keys)
++
++        controller.start()
++        try:
++            deadline = time.monotonic() + 5.0
++            while not adapter.stored_batches and time.monotonic() < deadline:
++                time.sleep(0.1)
++        finally:
++            controller.stop()
++
++        assert adapter.stored_batches
++        flushed = {k for batch in adapter.stored_batches for k in batch}
++        assert flushed <= set(keys)
++        assert _readable_keys(l1_manager, keys) == keys
++
++    def test_backup_batches_rotate_without_full_snapshot(self, l1_manager):
++        adapter = FakeSyncStoreAdapter()
++        controller = _make_controller(l1_manager, adapter)
++        keys = _make_keys(6)
++        _store_keys(l1_manager, keys)
++
++        for _ in range(3):
++            controller._backup_to_l2_no_delete(batch_limit=2)
++
++        assert [len(batch) for batch in adapter.stored_batches] == [2, 2, 2]
++        assert {key for batch in adapter.stored_batches for key in batch} == set(keys)
++
++    def test_backup_flush_has_bounded_store_wait(self, l1_manager):
++        adapter = BlockingSyncStoreAdapter()
++        controller = _make_controller(l1_manager, adapter)
++        controller._PERIODIC_FLUSH_TIMEOUT_SECONDS = 0.05
++        keys = _make_keys(2)
++        _store_keys(l1_manager, keys)
++
++        start = time.monotonic()
++        controller._backup_to_l2_no_delete(batch_limit=2)
++        elapsed = time.monotonic() - start
++
++        assert adapter.entered.is_set()
++        assert elapsed < 0.5
++        assert _readable_keys(l1_manager, keys) == keys
++
++    def test_evictable_batch_scan_wraps_and_is_bounded(self, l1_manager):
++        keys = _make_keys(5)
++        _store_keys(l1_manager, keys)
++        assert l1_manager.reserve_read([keys[0]])[keys[0]][0] == L1Error.SUCCESS
++        try:
++            first, cursor = l1_manager.get_evictable_keys(
++                limit=2,
++                cursor=0,
++                scan_limit=2,
++            )
++            second, cursor = l1_manager.get_evictable_keys(
++                limit=2,
++                cursor=cursor,
++                scan_limit=2,
++            )
++            third, _ = l1_manager.get_evictable_keys(
++                limit=2,
++                cursor=cursor,
++                scan_limit=2,
++            )
++        finally:
++            l1_manager.finish_read([keys[0]])
++
++        assert first == [keys[1]]
++        assert second == keys[2:4]
++        assert third == [keys[4]]
++
++
++class _RecordingEvictor:
++    """Eviction-controller double recording emergency_evict_bytes calls."""
++
++    def __init__(self) -> None:
++        self.calls: list[tuple[int, str]] = []
++
++    def emergency_evict_bytes(self, target_free_bytes: int, requester: str = "") -> int:
++        self.calls.append((target_free_bytes, requester))
++        return target_free_bytes
++
++
++@pytest.fixture
++def prefetch_controller(l1_manager: L1Manager) -> Iterator[PrefetchController]:
++    controller = PrefetchController(
++        l1_manager=l1_manager,
++        l2_adapters=[],
++        adapter_descriptors=[],
++        policy=DefaultPrefetchPolicy(),
++    )
++    yield controller
++    # The loop thread was never started, so stop() cannot join it.
++    controller._submission_efd.close()
++    controller._adapter_ctrl_efd.close()
++
++
++def _make_request(keys: list[ObjectKey]) -> InFlightPrefetchRequest:
++    return InFlightPrefetchRequest(
++        request_id=7,
++        keys=keys,
++        layout_desc=OBJECT_LAYOUT,
++        phase=PrefetchPhase.PLAN_AND_LOAD,
++    )
++
++
++class TestPrefetchMakeRoom:
++    def test_make_room_asks_evictor_when_short(self, l1_manager, prefetch_controller):
++        """A restore that does not fit in free L1 asks for eviction."""
++        controller = prefetch_controller
++        evictor = _RecordingEvictor()
++        controller.set_l1_eviction_controller(evictor)
++        resident = _make_keys(6)
++        _store_keys(l1_manager, resident)
++
++        restore_keys = [
++            ObjectKey(
++                chunk_hash=ObjectKey.IntHash2Bytes(100 + i),
++                model_name="test_model",
++                kv_rank=0,
++            )
++            for i in range(4)
++        ]
++        controller._make_room_for_restore(_make_request(restore_keys), restore_keys)
++
++        assert len(evictor.calls) == 1
++        target, requester = evictor.calls[0]
++        assert target > 0
++        assert "prefetch_request=7" in requester
++
++    def test_make_room_noop_when_space_available(self, l1_manager, prefetch_controller):
++        controller = prefetch_controller
++        evictor = _RecordingEvictor()
++        controller.set_l1_eviction_controller(evictor)
++
++        keys = _make_keys(2)
++        controller._make_room_for_restore(_make_request(keys), keys)
++
++        assert evictor.calls == []
++
++    def test_make_room_noop_without_evictor(self, l1_manager, prefetch_controller):
++        controller = prefetch_controller
++        keys = _make_keys(2)
++
++        controller._make_room_for_restore(_make_request(keys), keys)
++
++    def test_eviction_controller_can_be_disconnected(self, prefetch_controller):
++        evictor = _RecordingEvictor()
++        prefetch_controller.set_l1_eviction_controller(evictor)
++        prefetch_controller.set_l1_eviction_controller(None)
++
++        assert prefetch_controller._l1_eviction_controller is None
++
++    def test_short_retention_policy_degrades_to_temporary(
++        self, prefetch_controller, monkeypatch
++    ):
++        keys = _make_keys(3)
++        monkeypatch.setattr(
++            prefetch_controller._policy,
++            "select_l1_retentions",
++            lambda _keys: [True],
++        )
++
++        assert prefetch_controller._select_l1_retentions(7, keys) == [
++            False,
++            False,
++            False,
++        ]
++
++    def test_retry_recovers_oom_reservations(self, l1_manager, prefetch_controller):
++        """OOM reservations are retried once after emergency eviction."""
++        controller = prefetch_controller
++        evictor = _RecordingEvictor()
++        controller.set_l1_eviction_controller(evictor)
++        keys = _make_keys(2)
++        write_results = {key: (L1Error.OUT_OF_MEMORY, None) for key in keys}
++
++        merged = controller._retry_oom_reservations(
++            _make_request(keys), keys, [True, True], write_results
++        )
++
++        assert len(evictor.calls) == 1
++        for key in keys:
++            err, mem_obj = merged[key]
++            assert err == L1Error.SUCCESS
++            assert mem_obj is not None
++        l1_manager.finish_write(keys)
++
++    def test_retry_noop_when_all_reserved(self, l1_manager, prefetch_controller):
++        controller = prefetch_controller
++        evictor = _RecordingEvictor()
++        controller.set_l1_eviction_controller(evictor)
++        keys = _make_keys(2)
++        result = l1_manager.reserve_write(keys, [False, False], OBJECT_LAYOUT)
++
++        merged = controller._retry_oom_reservations(
++            _make_request(keys), keys, [True, True], result
++        )
++
++        assert evictor.calls == []
++        assert merged is result
++        l1_manager.finish_write(keys)
++
++
++class TestConfigPlumbing:
++    def test_parser_populates_write_back_fields(self):
++        parser = argparse.ArgumentParser()
++        add_storage_manager_args(parser)
++        add_observability_args(parser)
++        args = parser.parse_args(
++            [
++                "--l1-size-gb",
++                "1",
++                "--eviction-policy",
++                "LRU",
++                "--write-back-on-evict",
++                "--periodic-flush-interval",
++                "30.0",
++                "--emergency-evict-for-prefetch",
++            ]
++        )
++        config = parse_args_to_config(args)
++        assert config.eviction_config.write_back_on_evict is True
++        assert config.eviction_config.periodic_flush_interval == 30.0
++        assert config.eviction_config.emergency_evict_for_prefetch is True
++
++    def test_defaults_are_disabled(self):
++        parser = argparse.ArgumentParser()
++        add_storage_manager_args(parser)
++        add_observability_args(parser)
++        args = parser.parse_args(["--l1-size-gb", "1", "--eviction-policy", "LRU"])
++        config = parse_args_to_config(args)
++        assert config.eviction_config.write_back_on_evict is False
++        assert config.eviction_config.periodic_flush_interval == 0.0
++        assert config.eviction_config.emergency_evict_for_prefetch is False
++
++    @pytest.mark.parametrize(
++        "eviction_config",
++        [
++            EvictionConfig(
++                eviction_policy="LRU",
++                periodic_flush_interval=-1.0,
++            ),
++            EvictionConfig(
++                eviction_policy="LRU",
++                emergency_evict_for_prefetch=True,
++            ),
++        ],
++    )
++    def test_invalid_writeback_config_is_rejected(self, eviction_config):
++        with pytest.raises(ValueError):
++            StorageManagerConfig(
++                l1_manager_config=L1ManagerConfig(
++                    memory_config=L1MemoryManagerConfig(
++                        size_in_bytes=POOL_BYTES,
++                        use_lazy=False,
++                    )
++                ),
++                eviction_config=eviction_config,
++            )
+diff --git a/tests/v1/distributed/test_native_connector_l2_adapter.py b/tests/v1/distributed/test_native_connector_l2_adapter.py
+index dc16cdd1ae0161bf2306759cd2b72614a93c83fc..1f4348ad5e223aed6a96d25017a41c2b017a1126 100644
+--- a/tests/v1/distributed/test_native_connector_l2_adapter.py
++++ b/tests/v1/distributed/test_native_connector_l2_adapter.py
+@@ -10,6 +10,7 @@ C++ IStorageConnector interface, so no Redis or C++ build is needed.
+ import ctypes
+ import select
+ import threading
++import time
+ 
+ # Third Party
+ import pytest
+@@ -56,6 +57,9 @@ class MockNativeConnector:
+         self._completions: list[tuple[int, bool, str, list[bool] | None]] = []
+         self._lock = threading.Lock()
+         self._closed = False
++        self.report_set_per_key_results = True
++        self.fail_set_keys: set[str] = set()
++        self.suppress_set_completion = False
+ 
+     def event_fd(self) -> int:
+         return self._efd.fileno()
+@@ -66,9 +70,21 @@ class MockNativeConnector:
+             self._next_id += 1
+ 
+         try:
++            results = []
+             for key, mv in zip(keys, memoryviews, strict=False):
++                if key in self.fail_set_keys:
++                    results.append(False)
++                    continue
+                 self._store[key] = bytes(mv)
+-            self._push_completion(fid, True, "", None)
++                results.append(True)
++            ok = all(results)
++            if not self.suppress_set_completion:
++                self._push_completion(
++                    fid,
++                    ok,
++                    "" if ok else "injected set failure",
++                    results if self.report_set_per_key_results else None,
++                )
+         except Exception as e:
+             self._push_completion(fid, False, str(e), None)
+ 
+@@ -155,6 +171,27 @@ class MockNativeConnector:
+             pass
+ 
+ 
++class DeferredExistsConnector(MockNativeConnector):
++    """Hold EXISTS completion to expose the submit-to-lock race window."""
++
++    def __init__(self):
++        super().__init__()
++        self.pending_exists: tuple[int, list[str]] | None = None
++
++    def submit_batch_exists(self, keys: list[str]) -> int:
++        with self._lock:
++            fid = self._next_id
++            self._next_id += 1
++        self.pending_exists = (fid, list(keys))
++        return fid
++
++    def complete_exists(self) -> None:
++        assert self.pending_exists is not None
++        fid, keys = self.pending_exists
++        self.pending_exists = None
++        self._push_completion(fid, True, "", [key in self._store for key in keys])
++
++
+ # =============================================================================
+ # Test Fixtures
+ # =============================================================================
+@@ -203,6 +240,14 @@ def adapter():
+     adp.close()
+ 
+ 
++@pytest.fixture
++def adapter_and_mock():
++    mock_client = MockNativeConnector()
++    adp = NativeConnectorL2Adapter(mock_client)
++    yield adp, mock_client
++    adp.close()
++
++
+ # =============================================================================
+ # ObjectKey Serialization Tests
+ # =============================================================================
+@@ -1182,6 +1227,91 @@ class TestDeleteInterface:
+     def test_delete_empty_keys(self, adapter):
+         adapter.delete([])  # should not raise
+ 
++    def test_delete_skips_lookup_locked_keys(self, adapter):
++        """Keys lookup-locked by an in-flight prefetch survive delete();
++        unlocked keys in the same batch are still deleted, and the locked
++        key becomes deletable again after unlock."""
++        keys = [create_object_key(i) for i in range(2)]
++        objs = [create_memory_obj(fill_value=float(i)) for i in range(2)]
++        store_fd = adapter.get_store_event_fd()
++        lookup_fd = adapter.get_lookup_and_lock_event_fd()
++
++        adapter.submit_store_task(keys, objs)
++        wait_for_event_fd(store_fd, timeout=5.0)
++        adapter.pop_completed_store_tasks()
++
++        # An in-flight prefetch holds a lookup lock on keys[0].
++        task_id = adapter.submit_lookup_and_lock_task([keys[0]], _EMPTY_LAYOUT)
++        wait_for_event_fd(lookup_fd, timeout=5.0)
++        bitmap = adapter.query_lookup_and_lock_result(task_id)
++        assert bitmap.test(0) is True
++
++        adapter.delete(keys)
++
++        # keys[0] survived, keys[1] is gone. This lookup takes another
++        # lock on keys[0].
++        task_id = adapter.submit_lookup_and_lock_task(keys, _EMPTY_LAYOUT)
++        wait_for_event_fd(lookup_fd, timeout=5.0)
++        bitmap = adapter.query_lookup_and_lock_result(task_id)
++        assert bitmap.test(0) is True
++        assert bitmap.test(1) is False
++
++        # Release both locks; the key is deletable again.
++        adapter.submit_unlock([keys[0]])
++        adapter.submit_unlock([keys[0]])
++        adapter.delete([keys[0]])
++
++        task_id = adapter.submit_lookup_and_lock_task([keys[0]], _EMPTY_LAYOUT)
++        wait_for_event_fd(lookup_fd, timeout=5.0)
++        bitmap = adapter.query_lookup_and_lock_result(task_id)
++        assert bitmap.test(0) is False
++
++    def test_delete_all_keys_locked_is_noop(self, adapter):
++        """delete() returns without submitting when every key is locked."""
++        key = create_object_key(1)
++        obj = create_memory_obj()
++        store_fd = adapter.get_store_event_fd()
++        lookup_fd = adapter.get_lookup_and_lock_event_fd()
++
++        adapter.submit_store_task([key], [obj])
++        wait_for_event_fd(store_fd, timeout=5.0)
++        adapter.pop_completed_store_tasks()
++
++        task_id = adapter.submit_lookup_and_lock_task([key], _EMPTY_LAYOUT)
++        wait_for_event_fd(lookup_fd, timeout=5.0)
++        assert adapter.query_lookup_and_lock_result(task_id).test(0) is True
++
++        adapter.delete([key])
++
++        task_id = adapter.submit_lookup_and_lock_task([key], _EMPTY_LAYOUT)
++        wait_for_event_fd(lookup_fd, timeout=5.0)
++        assert adapter.query_lookup_and_lock_result(task_id).test(0) is True
++        adapter.submit_unlock([key])
++        adapter.submit_unlock([key])
++
++    def test_delete_skips_lookup_that_has_not_completed(self):
++        """Eviction cannot enter between lookup submission and lock acquire."""
++        client = DeferredExistsConnector()
++        adapter = NativeConnectorL2Adapter(client)
++        key = create_object_key(1)
++        obj = create_memory_obj()
++
++        try:
++            adapter.submit_store_task([key], [obj])
++            wait_for_event_fd(adapter.get_store_event_fd(), timeout=5.0)
++            adapter.pop_completed_store_tasks()
++
++            task_id = adapter.submit_lookup_and_lock_task([key], _EMPTY_LAYOUT)
++            adapter.delete([key])
++            assert _object_key_to_string(key) in client._store
++
++            client.complete_exists()
++            wait_for_event_fd(adapter.get_lookup_and_lock_event_fd(), timeout=5.0)
++            assert adapter.query_lookup_and_lock_result(task_id).test(0) is True
++            adapter.submit_unlock([key])
++        finally:
++            adapter.close()
++
+     def test_delete_batch(self, adapter):
+         keys = [create_object_key(i) for i in range(5)]
+         objs = [create_memory_obj(fill_value=float(i)) for i in range(5)]
+@@ -1294,7 +1424,6 @@ class TestUsageTracking:
+         # 400 bytes / 2000 bytes = 0.2
+         assert usage.usage_fraction == pytest.approx(0.2)
+         assert usage.total_bytes_used == 400
+-
+     def test_get_usage_after_delete(self, adapter_with_capacity):
+         adp = adapter_with_capacity
+         store_fd = adp.get_store_event_fd()
+@@ -1358,3 +1487,208 @@ class TestUsageTracking:
+         usage = adp.get_usage()
+         assert usage.usage_fraction == pytest.approx(0.2)
+         assert usage.total_bytes_used == 400
++
++    def test_inflight_stores_cannot_exceed_capacity(self):
++        mock_client = MockNativeConnector()
++        mock_client.suppress_set_completion = True
++        capacity = 800
++        adp = NativeConnectorL2Adapter(
++            mock_client,
++            max_capacity_gb=capacity / (1024**3),
++        )
++        try:
++            obj = create_memory_obj(size=100)  # 400 bytes
++            first = adp.submit_store_task([create_object_key(1)], [obj])
++            second = adp.submit_store_task([create_object_key(2)], [obj])
++            rejected = adp.submit_store_task([create_object_key(3)], [obj])
++
++            assert first != second != rejected
++            assert sum(len(value) for value in mock_client._store.values()) == capacity
++            assert adp.get_reserved_store_bytes() == capacity
++            assert wait_for_event_fd(adp.get_store_event_fd(), timeout=1.0)
++            result = adp.pop_completed_store_tasks()[rejected]
++            assert result.is_successful() is False
++            assert result.bytes_transferred() == 0
++        finally:
++            adp.close()
++
++    def test_failed_store_releases_capacity_reservation(self):
++        mock_client = MockNativeConnector()
++        capacity = 400
++        adp = NativeConnectorL2Adapter(
++            mock_client,
++            max_capacity_gb=capacity / (1024**3),
++        )
++        try:
++            first_key = create_object_key(1)
++            mock_client.fail_set_keys = {_object_key_to_string(first_key)}
++            first = adp.submit_store_task([first_key], [create_memory_obj(size=100)])
++            assert wait_for_event_fd(adp.get_store_event_fd(), timeout=1.0)
++            assert adp.pop_completed_store_tasks()[first].is_successful() is False
++            assert adp.get_reserved_store_bytes() == 0
++
++            mock_client.fail_set_keys.clear()
++            second = adp.submit_store_task(
++                [create_object_key(2)], [create_memory_obj(size=100)]
++            )
++            assert wait_for_event_fd(adp.get_store_event_fd(), timeout=1.0)
++            assert adp.pop_completed_store_tasks()[second].is_successful() is True
++            assert adp.get_usage().total_bytes_used == capacity
++        finally:
++            adp.close()
++
++    def test_synchronous_store_respects_capacity(self):
++        mock_client = MockNativeConnector()
++        capacity = 400
++        adp = NativeConnectorL2Adapter(
++            mock_client,
++            max_capacity_gb=capacity / (1024**3),
++        )
++        try:
++            first = adp.store_objects_sync(
++                [create_object_key(1)], [create_memory_obj(size=100)]
++            )
++            rejected = adp.store_objects_sync(
++                [create_object_key(2)], [create_memory_obj(size=100)]
++            )
++
++            assert first == (True, 1, capacity)
++            assert rejected == (False, 0, 0)
++            assert len(mock_client._store) == 1
++            assert adp.get_usage().total_bytes_used == capacity
++        finally:
++            adp.close()
++
++
++# =============================================================================
++# Durable Store Tests
++# =============================================================================
++
++
++class _BlockingStoreListener:
++    def __init__(self):
++        self.entered = threading.Event()
++        self.release = threading.Event()
++
++    def on_l2_keys_stored(self, keys, sizes) -> None:
++        self.entered.set()
++        assert self.release.wait(timeout=5.0)
++
++
++class TestStoreObjectsSync:
++    def test_success_uses_private_completion(self, adapter):
++        keys = [create_object_key(i) for i in range(2)]
++        objs = [create_memory_obj(fill_value=float(i)) for i in range(2)]
++
++        ok, persisted, bytes_written = adapter.store_objects_sync(keys, objs)
++
++        assert ok is True
++        assert persisted == 2
++        assert bytes_written == sum(obj.get_size() for obj in objs)
++        assert adapter.get_usage().total_bytes_used == bytes_written
++        assert adapter.pop_completed_store_tasks() == {}
++
++    def test_partial_failure_accounts_only_persisted_keys(self, adapter_and_mock):
++        adapter, mock_client = adapter_and_mock
++        keys = [create_object_key(i) for i in range(2)]
++        objs = [create_memory_obj(fill_value=float(i)) for i in range(2)]
++        mock_client.fail_set_keys = {_object_key_to_string(keys[1])}
++
++        ok, persisted, bytes_written = adapter.store_objects_sync(keys, objs)
++
++        assert ok is False
++        assert persisted == 1
++        assert bytes_written == objs[0].get_size()
++        assert adapter.get_usage().total_bytes_used == objs[0].get_size()
++
++    def test_async_partial_failure_uses_per_key_results(self, adapter_and_mock):
++        adapter, mock_client = adapter_and_mock
++        keys = [create_object_key(i) for i in range(2)]
++        objs = [create_memory_obj(fill_value=float(i)) for i in range(2)]
++        mock_client.fail_set_keys = {_object_key_to_string(keys[1])}
++
++        task_id = adapter.submit_store_task(keys, objs)
++        assert wait_for_event_fd(adapter.get_store_event_fd(), timeout=5.0)
++
++        result = adapter.pop_completed_store_tasks()[task_id]
++        assert result.is_successful() is False
++        assert adapter.get_usage().total_bytes_used == objs[0].get_size()
++
++    def test_batch_fallback_without_per_key_results(self, adapter_and_mock):
++        adapter, mock_client = adapter_and_mock
++        mock_client.report_set_per_key_results = False
++        keys = [create_object_key(i) for i in range(2)]
++        objs = [create_memory_obj(fill_value=float(i)) for i in range(2)]
++
++        ok, persisted, bytes_written = adapter.store_objects_sync(keys, objs)
++
++        assert ok is True
++        assert persisted == 2
++        assert bytes_written == sum(obj.get_size() for obj in objs)
++
++    def test_validates_inputs(self, adapter):
++        with pytest.raises(ValueError, match="length mismatch"):
++            adapter.store_objects_sync([create_object_key(1)], [])
++        with pytest.raises(ValueError, match="timeout must be positive"):
++            adapter.store_objects_sync(
++                [create_object_key(1)], [create_memory_obj()], timeout=0
++            )
++        assert adapter.store_objects_sync([], []) == (True, 0, 0)
++
++    def test_real_timeout_keeps_pending_operation_reserved(self, adapter_and_mock):
++        adapter, mock_client = adapter_and_mock
++        mock_client.suppress_set_completion = True
++
++        result = adapter.store_objects_sync(
++            [create_object_key(1)], [create_memory_obj()], timeout=0.05
++        )
++
++        assert result == (False, 0, 0)
++        assert adapter._pending_sync_store_events == {}
++        assert len(adapter._pending_ops) == 1
++        assert adapter.get_reserved_store_bytes() == create_memory_obj().get_size()
++
++    def test_completion_at_timeout_does_not_wait_for_observer(self, adapter):
++        listener = _BlockingStoreListener()
++        adapter.register_listener(listener)
++        result = []
++        worker = threading.Thread(
++            target=lambda: result.append(
++                adapter.store_objects_sync(
++                    [create_object_key(1)],
++                    [create_memory_obj()],
++                    timeout=0.05,
++                )
++            )
++        )
++        worker.start()
++        assert listener.entered.wait(timeout=5.0)
++        time.sleep(0.1)
++        assert not worker.is_alive()
++        assert result[0][0] is True
++        assert adapter.get_usage().total_bytes_used == result[0][2]
++
++        listener.release.set()
++        worker.join(timeout=5.0)
++
++        assert not worker.is_alive()
++
++    def test_close_unblocks_waiter(self, adapter_and_mock):
++        adapter, mock_client = adapter_and_mock
++        mock_client.suppress_set_completion = True
++        result = []
++        worker = threading.Thread(
++            target=lambda: result.append(
++                adapter.store_objects_sync(
++                    [create_object_key(1)], [create_memory_obj()], timeout=10.0
++                )
++            )
++        )
++        worker.start()
++        time.sleep(0.05)
++
++        adapter.close()
++        worker.join(timeout=5.0)
++
++        assert not worker.is_alive()
++        assert result == [(False, 0, 0)]
+diff --git a/tests/v1/distributed/test_native_connector_restart_accounting.py b/tests/v1/distributed/test_native_connector_restart_accounting.py
+new file mode 100644
+index 0000000000000000000000000000000000000000..dc5d6c68c3fcb236bafd2bfdf9a2b8c9582e00d8
+--- /dev/null
++++ b/tests/v1/distributed/test_native_connector_restart_accounting.py
+@@ -0,0 +1,66 @@
++# SPDX-License-Identifier: Apache-2.0
++"""Restart accounting behavior shared by native L2 connectors."""
++
++# Third Party
++import pytest
++
++# First Party
++from tests.v1.distributed.test_native_connector_l2_adapter import (
++    adapter,
++    create_object_key,
++)
++
++
++class _RecordingL2Listener:
++    def __init__(self):
++        self.stored = []
++
++    def on_l2_keys_stored(self, keys, sizes) -> None:
++        self.stored.append((list(keys), list(sizes)))
++
++
++class TestPrimeExistingKeys:
++    def test_priming_accounts_deduplicated_usage(self, adapter):
++        key = create_object_key(1)
++
++        adapter.prime_existing_keys([key, key], [100, 999])
++
++        assert adapter.get_usage().total_bytes_used == 100
++        assert adapter._key_sizes == {key: 100}
++
++    def test_first_listener_receives_startup_snapshot_once(self, adapter):
++        keys = [create_object_key(1), create_object_key(2)]
++        adapter.prime_existing_keys(keys, [100, 200])
++        first = _RecordingL2Listener()
++        second = _RecordingL2Listener()
++
++        adapter.register_listener(first)
++        adapter.register_listener(second)
++
++        assert first.stored == [(keys, [100, 200])]
++        assert second.stored == []
++        assert adapter.get_usage().total_bytes_used == 300
++
++    def test_empty_snapshot_is_consumed_without_callback(self, adapter):
++        adapter.prime_existing_keys([], [])
++        listener = _RecordingL2Listener()
++
++        adapter.register_listener(listener)
++
++        assert listener.stored == []
++
++    def test_rejects_invalid_or_repeated_priming(self, adapter):
++        with pytest.raises(ValueError, match="length mismatch"):
++            adapter.prime_existing_keys([create_object_key(1)], [1, 2])
++        with pytest.raises(ValueError, match="must be positive"):
++            adapter.prime_existing_keys([create_object_key(1)], [0])
++
++        adapter.prime_existing_keys([], [])
++        with pytest.raises(RuntimeError, match="already primed"):
++            adapter.prime_existing_keys([], [])
++
++    def test_rejects_priming_after_listener_registration(self, adapter):
++        adapter.register_listener(_RecordingL2Listener())
++
++        with pytest.raises(RuntimeError, match="before listeners"):
++            adapter.prime_existing_keys([], [])
+diff --git a/tests/v1/distributed/test_native_fs_connector_results.py b/tests/v1/distributed/test_native_fs_connector_results.py
+new file mode 100644
+index 0000000000000000000000000000000000000000..458fcf0edfcf8a04ab13a4431248640e557cb8c3
+--- /dev/null
++++ b/tests/v1/distributed/test_native_fs_connector_results.py
+@@ -0,0 +1,54 @@
++# SPDX-License-Identifier: Apache-2.0
++"""Native FS connector completion semantics.
++
++These tests exercise the compiled extension. They are skipped when the
++optional native FS module is not part of the test environment.
++"""
++
++# Standard
++import select
++import time
++
++# Third Party
++import pytest
++
++lmcache_fs = pytest.importorskip("lmcache.lmcache_fs")
++
++
++def _wait_for_completion(client, timeout: float = 5.0):
++    poller = select.poll()
++    poller.register(client.event_fd(), select.POLLIN)
++    deadline = time.monotonic() + timeout
++    while time.monotonic() < deadline:
++        if poller.poll(50):
++            completions = client.drain_completions()
++            if completions:
++                return completions
++    raise AssertionError("native connector completion timed out")
++
++
++def test_batch_set_reports_partial_results_and_continues(tmp_path):
++    client = lmcache_fs.LMCacheFSClient(str(tmp_path), 1)
++    try:
++        buffers = [bytearray(b"first"), bytearray(b"bad"), bytearray(b"last")]
++        keys = [
++            "model@00000000@01",
++            "malformed-key",
++            "model@00000000@03",
++        ]
++
++        future_id = client.submit_batch_set(
++            keys,
++            [memoryview(buffer) for buffer in buffers],
++        )
++        completions = _wait_for_completion(client)
++
++        assert len(completions) == 1
++        completed_id, ok, error, results = completions[0]
++        assert completed_id == future_id
++        assert ok is False
++        assert "partially failed" in error
++        assert results == [True, False, True]
++        assert len(list(tmp_path.glob("*.data"))) == 2
++    finally:
++        client.close()
+diff --git a/tests/v1/distributed/test_native_fs_key_compatibility.py b/tests/v1/distributed/test_native_fs_key_compatibility.py
+new file mode 100644
+index 0000000000000000000000000000000000000000..d18fba4e8f8c662a3826f1a8182ac681ca9a0584
+--- /dev/null
++++ b/tests/v1/distributed/test_native_fs_key_compatibility.py
+@@ -0,0 +1,55 @@
++# SPDX-License-Identifier: Apache-2.0
++"""ObjectKey compatibility of the compiled native FS connector."""
++
++# Standard
++import select
++import time
++
++# Third Party
++import pytest
++
++lmcache_fs = pytest.importorskip("lmcache.lmcache_fs")
++
++
++def _wait_for_completion(client, timeout: float = 5.0):
++    poller = select.poll()
++    poller.register(client.event_fd(), select.POLLIN)
++    deadline = time.monotonic() + timeout
++    while time.monotonic() < deadline:
++        if poller.poll(50):
++            completions = client.drain_completions()
++            if completions:
++                return completions[0]
++    raise AssertionError("native connector completion timed out")
++
++
++@pytest.mark.parametrize(
++    ("wire_key", "filename"),
++    [
++        ("model@00000000@aabb", "model@0x00000000@aabb.data"),
++        (
++            "model@00000000@aabb@salt",
++            "model@0x00000000@aabb@salt.data",
++        ),
++        (
++            "model@00000000@2@aabb",
++            "model@0x00000000@2@aabb.data",
++        ),
++        (
++            "model@00000000@2@aabb@salt",
++            "model@0x00000000@2@aabb@salt.data",
++        ),
++    ],
++)
++def test_legacy_and_current_key_shapes(wire_key, filename, tmp_path):
++    client = lmcache_fs.LMCacheFSClient(str(tmp_path), 1)
++    try:
++        payload = bytearray(b"payload")
++        future_id = client.submit_batch_set([wire_key], [memoryview(payload)])
++        completed_id, ok, error, _results = _wait_for_completion(client)
++
++        assert completed_id == future_id
++        assert ok, error
++        assert (tmp_path / filename).read_bytes() == payload
++    finally:
++        client.close()
+diff --git a/tests/v1/distributed/test_native_fs_odirect.py b/tests/v1/distributed/test_native_fs_odirect.py
+new file mode 100644
+index 0000000000000000000000000000000000000000..1d5118eca102011208e580b447f3d034cb8afd13
+--- /dev/null
++++ b/tests/v1/distributed/test_native_fs_odirect.py
+@@ -0,0 +1,80 @@
++# SPDX-License-Identifier: Apache-2.0
++"""O_DIRECT behavior of the compiled native FS connector."""
++
++# Standard
++import ctypes
++import select
++import time
++
++# Third Party
++import pytest
++
++lmcache_fs = pytest.importorskip("lmcache.lmcache_fs")
++
++
++def _aligned_view(size: int, alignment: int = 4096):
++    storage = bytearray(size + alignment)
++    address = ctypes.addressof(ctypes.c_char.from_buffer(storage))
++    offset = (-address) % alignment
++    return storage, memoryview(storage)[offset : offset + size]
++
++
++def _wait_for_completion(client, timeout: float = 5.0):
++    poller = select.poll()
++    poller.register(client.event_fd(), select.POLLIN)
++    deadline = time.monotonic() + timeout
++    while time.monotonic() < deadline:
++        if poller.poll(50):
++            completions = client.drain_completions()
++            if completions:
++                return completions[0]
++    raise AssertionError("native connector completion timed out")
++
++
++def test_odirect_falls_back_for_misaligned_buffer_address(tmp_path):
++    client = lmcache_fs.LMCacheFSClient(str(tmp_path), 1, "", True)
++    try:
++        payload_storage = bytearray(4097)
++        payload = memoryview(payload_storage)[1:]
++        payload[:] = b"x" * len(payload)
++        key = "model@00000000@01"
++
++        store_id = client.submit_batch_set([key], [payload])
++        completed_id, ok, error, _results = _wait_for_completion(client)
++        assert completed_id == store_id
++        assert ok, error
++
++        loaded_storage = bytearray(4097)
++        loaded = memoryview(loaded_storage)[1:]
++        load_id = client.submit_batch_get([key], [loaded])
++        completed_id, ok, error, results = _wait_for_completion(client)
++        assert completed_id == load_id
++        assert ok, error
++        assert results == [True]
++        assert loaded == payload
++    finally:
++        client.close()
++
++
++def test_odirect_falls_back_for_misaligned_readahead_split(tmp_path):
++    client = lmcache_fs.LMCacheFSClient(str(tmp_path), 1, "", True, 4095)
++    try:
++        payload_storage, payload = _aligned_view(8192)
++        payload[:] = b"x" * len(payload)
++        key = "model@00000000@02"
++
++        store_id = client.submit_batch_set([key], [payload])
++        completed_id, ok, error, _results = _wait_for_completion(client)
++        assert completed_id == store_id
++        assert ok, error
++
++        loaded_storage, loaded = _aligned_view(8192)
++        load_id = client.submit_batch_get([key], [loaded])
++        completed_id, ok, error, results = _wait_for_completion(client)
++        assert completed_id == load_id
++        assert ok, error
++        assert results == [True]
++        assert loaded == payload
++        del payload_storage, loaded_storage
++    finally:
++        client.close()
+diff --git a/tests/v1/distributed/test_prefetch_controller.py b/tests/v1/distributed/test_prefetch_controller.py
+index 09c06c5819646d20d65485ee446793a1a9a7f9d0..e86ac177a07f19f54bb6417858dea1d4ff116cfd 100644
+--- a/tests/v1/distributed/test_prefetch_controller.py
++++ b/tests/v1/distributed/test_prefetch_controller.py
+@@ -35,6 +35,9 @@ from lmcache.v1.distributed.l2_adapters.mock_l2_adapter import (
+     MockL2Adapter,
+     MockL2AdapterConfig,
+ )
++from lmcache.v1.distributed.storage_controllers import (
++    prefetch_controller as prefetch_controller_module,
++)
+ from lmcache.v1.distributed.storage_controllers.prefetch_controller import (
+     PrefetchController,
+     build_trim_mask,
+@@ -363,7 +366,7 @@ class TestSingleAdapterPrefetch:
+         ctrl.stop()
+         adapter.close()
+ 
+-    def test_fault_inject_load_gap_segmented_vs_prefix(self, l1_manager):
++    def test_fault_inject_load_gap_segmented_vs_prefix(self, l1_manager, monkeypatch):
+         """fault_inject (load fails at index 2) drives the segmented path.
+ 
+         Lookup reports all 5 keys present; the *load* of index 2 fails (the L2
+@@ -371,6 +374,14 @@ class TestSingleAdapterPrefetch:
+         post-gap keys {0,1,3,4}; PREFIX truncates at the hole to {0,1}. Distinct
+         key ranges per policy keep the shared L1 from serving the second pass.
+         """
++        warning_messages: list[str] = []
++
++        def capture_warning(message, *args, **_kwargs):
++            warning_messages.append(message % args)
++
++        monkeypatch.setattr(
++            prefetch_controller_module.logger, "warning", capture_warning
++        )
+         layout = make_layout()
+         for base, trim, expected in (
+             (0, TrimPolicy.SEGMENTED_PREFIX, [0, 1, 3, 4]),
+@@ -402,6 +413,11 @@ class TestSingleAdapterPrefetch:
+             ctrl.stop()
+             fault.close()
+ 
++        assert any(
++            "1/5 plan keys failed to load from L2" in message and "sample:" in message
++            for message in warning_messages
++        )
++
+     def test_key0_missing(self, l1_manager):
+         """L2 has keys {1,2,3} but not 0 → prefix = 0, nothing loaded."""
+         adapter = make_adapter()
+diff --git a/tests/v1/multiprocess/test_futures.py b/tests/v1/multiprocess/test_futures.py
+index 53cf694bc5c29ee852c5511d2753b6a8a676511a..c9086609ec879d9ed6fcceab478da9c5c7117d49 100644
+--- a/tests/v1/multiprocess/test_futures.py
++++ b/tests/v1/multiprocess/test_futures.py
+@@ -173,6 +173,27 @@ def test_messaging_future_complex_type():
+     thread.join()
+ 
+ 
++def test_messaging_future_exception_is_re_raised():
++    """A remote messaging failure completes the future instead of hanging it."""
++    future = MessagingFuture[int]()
++    error = RuntimeError("remote operation failed")
++
++    future.set_exception(error)
++
++    assert future.query()
++    assert future.wait(timeout=0.1)
++    with pytest.raises(RuntimeError, match="remote operation failed") as exc_info:
++        future.result(timeout=0.1)
++    assert exc_info.value is error
++
++
++def test_messaging_future_rejects_non_exception():
++    future = MessagingFuture[int]()
++
++    with pytest.raises(TypeError, match="must derive from BaseException"):
++        future.set_exception("not an exception")  # type: ignore[arg-type]
++
++
+ # ==============================================================================
+ # CUDAMessagingFuture Tests
+ # ==============================================================================
+diff --git a/tests/v1/multiprocess/test_mq.py b/tests/v1/multiprocess/test_mq.py
+index 75ff9cd7a0630391f0515622e36e1f38fe243764..93ef515bfc0c3a66feda76720178b2dd140a7211 100644
+--- a/tests/v1/multiprocess/test_mq.py
++++ b/tests/v1/multiprocess/test_mq.py
+@@ -21,6 +21,7 @@ from lmcache.v1.multiprocess.mq import (
+     BlockingRequestHandler,
+     MessageQueueClient,
+     MessageQueueServer,
++    RemoteHandlerError,
+ )
+ from lmcache.v1.multiprocess.protocol import (
+     RequestType,
+@@ -683,6 +684,58 @@ def test_shared_loop_dispatch():
+         server.close()
+ 
+ 
++def test_sync_handler_failure_completes_future_and_loop_recovers():
++    context = zmq.Context.instance()
++    server = MessageQueueServer("tcp://127.0.0.1:16021", context)
++    add_handler_helper(
++        server, RequestType.NOOP, test_mq_handler_helpers.failing_noop_handler
++    )
++    server.start()
++    client = MessageQueueClient("tcp://127.0.0.1:16021", context)
++
++    try:
++        failed = client.submit_request(RequestType.NOOP, [])
++        with pytest.raises(
++            RemoteHandlerError, match="intentional sync handler failure"
++        ) as exc_info:
++            failed.result(timeout=2)
++        assert exc_info.value.request_type is RequestType.NOOP
++        assert exc_info.value.error_type == "ValueError"
++
++        server.add_sync_handler(
++            RequestType.NOOP, [], test_mq_handler_helpers.noop_handler
++        )
++        assert (
++            client.submit_request(RequestType.NOOP, []).result(timeout=2) == "NOOP_OK"
++        )
++    finally:
++        client.close()
++        server.close()
++
++
++def test_blocking_handler_failure_completes_future():
++    context = zmq.Context.instance()
++    server = MessageQueueServer("tcp://127.0.0.1:16022", context)
++    add_handler_helper(
++        server, RequestType.LOOKUP, test_mq_handler_helpers.failing_lookup_handler
++    )
++    server.add_normal_thread_pool([RequestType.LOOKUP], max_workers=1)
++    server.start()
++    client = MessageQueueClient("tcp://127.0.0.1:16022", context)
++
++    try:
++        future = client.submit_request(RequestType.LOOKUP, [create_cache_key(1), 1])
++        with pytest.raises(
++            RemoteHandlerError, match="intentional blocking handler failure"
++        ) as exc_info:
++            future.result(timeout=2)
++        assert exc_info.value.request_type is RequestType.LOOKUP
++        assert exc_info.value.error_type == "OSError"
++    finally:
++        client.close()
++        server.close()
++
++
+ def test_shared_loop_recreate():
+     """
+     Test that closing all clients and creating new ones starts a fresh loop.
+diff --git a/tests/v1/multiprocess/test_mq_handler_helpers.py b/tests/v1/multiprocess/test_mq_handler_helpers.py
+index b1d65251d3fd0a615bc256fb483cf78a4a8ef16e..9837df531ef7414473af86834bc63afcb7f842c0 100644
+--- a/tests/v1/multiprocess/test_mq_handler_helpers.py
++++ b/tests/v1/multiprocess/test_mq_handler_helpers.py
+@@ -29,6 +29,11 @@ def noop_handler() -> str:
+     return "NOOP_OK"
+ 
+ 
++def failing_noop_handler() -> str:
++    """Raise a deterministic error for RPC error propagation tests."""
++    raise ValueError("intentional sync handler failure")
++
++
+ # ==============================================================================
+ # REGISTER_KV_CACHE Request Handlers
+ # ==============================================================================
+@@ -203,6 +208,12 @@ def lookup_handler(key: KeyType, tp_size: int) -> None:
+     assert isinstance(tp_size, int), f"Expected tp_size to be int, got {type(tp_size)}"
+ 
+ 
++def failing_lookup_handler(key: KeyType, tp_size: int) -> None:
++    """Raise a deterministic error from a blocking request handler."""
++    del key, tp_size
++    raise OSError("intentional blocking handler failure")
++
++
+ # ==============================================================================
+ # FREE_LOOKUP_LOCKS Request Handlers
+ # ==============================================================================
+diff --git a/tests/v1/test_vllm_mp_adapter.py b/tests/v1/test_vllm_mp_adapter.py
+index d64ca9ec7061a0714cba7c9c488e3fb0cef9179a..ddf180a64dd9e6b9d8f4af4114324bc927fbf12f 100644
+--- a/tests/v1/test_vllm_mp_adapter.py
++++ b/tests/v1/test_vllm_mp_adapter.py
+@@ -782,3 +782,65 @@ def test_recover_callback_rebuilds_transfer_ctx_without_closing_previous(
+     assert len(contexts) == 3
+     assert adapter.transfer_ctx is contexts[2]
+     contexts[1].close.assert_not_called()
++
++
++def _finished_retrieve_future(result: object) -> MagicMock:
++    """Build a completed retrieve future; an Exception *result* makes
++    ``result()`` raise it."""
++    future = MagicMock(name="retrieve_future")
++    future.query.return_value = True
++    if isinstance(result, Exception):
++        future.result.side_effect = result
++    else:
++        future.result.return_value = result
++    return future
++
++
++def test_failed_retrieve_marks_blocks_invalid(fake_adapter) -> None:
++    """A retrieve the healthy server answers with ``result=False`` is
++    reported finished AND its block ids are surfaced through
++    ``get_block_ids_with_load_errors`` so the scheduler recomputes them
++    instead of decoding over never-written blocks."""
++    adapter, _send_mock, _ = fake_adapter
++    adapter.retrieve_futures["req-1"] = (
++        _finished_retrieve_future(False),
++        [3, 4, 5],
++    )
++
++    ret_stores, finished_retrieves = adapter.get_finished(set())
++
++    assert ret_stores == set()
++    assert finished_retrieves == {"req-1"}
++    assert adapter.get_block_ids_with_load_errors() == {3, 4, 5}
++    # The error set is consumed on read.
++    assert adapter.get_block_ids_with_load_errors() == set()
++    assert adapter.retrieve_failure_count == 1
++
++
++def test_raising_retrieve_future_contained_as_failure(fake_adapter) -> None:
++    """A retrieve future whose ``result()`` raises must not propagate out
++    of ``get_finished`` (that would kill the engine step); it lands on the
++    same failure path as ``result=False``."""
++    adapter, _send_mock, _ = fake_adapter
++    adapter.retrieve_futures["req-1"] = (
++        _finished_retrieve_future(RuntimeError("ipc receive failed")),
++        [7, 8],
++    )
++
++    _ret_stores, finished_retrieves = adapter.get_finished(set())
++
++    assert finished_retrieves == {"req-1"}
++    assert adapter.get_block_ids_with_load_errors() == {7, 8}
++    assert adapter.retrieve_failure_count == 1
++
++
++def test_successful_retrieve_marks_no_blocks_invalid(fake_adapter) -> None:
++    """A successful retrieve reports no load errors."""
++    adapter, _send_mock, _ = fake_adapter
++    adapter.retrieve_futures["req-1"] = (_finished_retrieve_future(True), [1, 2])
++
++    _ret_stores, finished_retrieves = adapter.get_finished(set())
++
++    assert finished_retrieves == {"req-1"}
++    assert adapter.get_block_ids_with_load_errors() == set()
++    assert adapter.retrieve_failure_count == 0
+diff --git a/tests/v1/test_vllm_mp_connector_metadata.py b/tests/v1/test_vllm_mp_connector_metadata.py
+new file mode 100644
+index 0000000000000000000000000000000000000000..45d427bd561aed4dcc953eda04259e2854008e15
+--- /dev/null
++++ b/tests/v1/test_vllm_mp_connector_metadata.py
+@@ -0,0 +1,133 @@
++# SPDX-License-Identifier: Apache-2.0
++"""Unit tests for ``LMCacheMPRequestMetadata.GetRetrieveMetadata``.
++
++The retrieve op must only be emitted when the tracker's allocated block ids
++actually cover the retrieve token range in every engine group:
++``slice_block_ids_per_group`` validates chunk alignment only, and its plain
++Python slice truncates silently, so an uncovered range would otherwise emit
++an op with too few block ids.
++"""
++
++# Standard
++from types import SimpleNamespace
++
++# Third Party
++import pytest
++
++# First Party
++from lmcache.integration.vllm.lmcache_mp_connector import (
++    LMCacheMPRequestMetadata,
++    LMCacheMPRequestState,
++    LMCacheMPRequestTracker,
++)
++
++CHUNK_TOKENS = 64
++
++
++def _tracker(
++    num_tokens: int,
++    lmcache_hit_tokens: int,
++    vllm_hit_tokens: int,
++    allocated_block_ids: dict[int, list[int]],
++) -> LMCacheMPRequestTracker:
++    """Build a tracker that is ready for retrieving over *num_tokens*."""
++    request = SimpleNamespace(
++        request_id="req-1",
++        cache_salt="",
++        all_token_ids=list(range(num_tokens)),
++    )
++    tracker = LMCacheMPRequestTracker(request)
++    tracker.num_lmcache_hit_tokens = lmcache_hit_tokens
++    tracker.num_vllm_hit_tokens = vllm_hit_tokens
++    tracker.allocated_block_ids = allocated_block_ids
++    tracker.state = LMCacheMPRequestState.WAITING_FOR_LOAD
++    return tracker
++
++
++@pytest.mark.parametrize(
++    ("group_tokens_per_block", "allocated_block_ids", "expected_block_ids"),
++    [
++        # Single group, plain geometry: 64 tokens / 16 tokens per block.
++        ([16], {0: [0, 1, 2, 3]}, [[0, 1, 2, 3]]),
++        # Single group, DCP-scaled: one manager block id covers 64 tokens.
++        ([64], {0: [5]}, [[5]]),
++        # Hybrid geometries: each group sliced by its own tokens-per-block.
++        ([16, 32], {0: [0, 1, 2, 3], 1: [10, 11]}, [[0, 1, 2, 3], [10, 11]]),
++        # Extra allocated blocks beyond the range are fine (and not emitted).
++        ([16], {0: [0, 1, 2, 3, 4, 5]}, [[0, 1, 2, 3]]),
++    ],
++)
++def test_retrieve_metadata_emitted_when_allocation_covers_range(
++    group_tokens_per_block: list[int],
++    allocated_block_ids: dict[int, list[int]],
++    expected_block_ids: list[list[int]],
++) -> None:
++    tracker = _tracker(
++        num_tokens=CHUNK_TOKENS,
++        lmcache_hit_tokens=CHUNK_TOKENS,
++        vllm_hit_tokens=0,
++        allocated_block_ids=allocated_block_ids,
++    )
++
++    metadata = LMCacheMPRequestMetadata.GetRetrieveMetadata(
++        tracker, CHUNK_TOKENS, group_tokens_per_block
++    )
++
++    assert metadata is not None
++    assert metadata.direction == "RETRIEVE"
++    assert metadata.op.start == 0
++    assert metadata.op.end == CHUNK_TOKENS
++    assert metadata.op.block_ids == expected_block_ids
++
++
++@pytest.mark.parametrize(
++    ("group_tokens_per_block", "allocated_block_ids"),
++    [
++        # One block short in the only group.
++        ([16], {0: [0, 1, 2]}),
++        # DCP-scaled group with no allocation at all.
++        ([64], {0: []}),
++        # Group 0 covered, group 1 one block short.
++        ([16, 32], {0: [0, 1, 2, 3], 1: [10]}),
++        # Group key missing entirely (counts as zero blocks).
++        ([16, 16], {0: [0, 1, 2, 3]}),
++    ],
++)
++def test_retrieve_metadata_suppressed_when_allocation_short(
++    group_tokens_per_block: list[int],
++    allocated_block_ids: dict[int, list[int]],
++) -> None:
++    """Any engine group whose allocation does not cover the retrieve range
++    suppresses the op entirely: the request falls back to recompute instead
++    of retrieving over silently truncated block-id lists."""
++    tracker = _tracker(
++        num_tokens=CHUNK_TOKENS,
++        lmcache_hit_tokens=CHUNK_TOKENS,
++        vllm_hit_tokens=0,
++        allocated_block_ids=allocated_block_ids,
++    )
++
++    metadata = LMCacheMPRequestMetadata.GetRetrieveMetadata(
++        tracker, CHUNK_TOKENS, group_tokens_per_block
++    )
++
++    assert metadata is None
++
++
++def test_retrieve_metadata_skip_tokens_preserved_on_emitted_op() -> None:
++    """vLLM-hit tokens inside the first chunk round the start down and are
++    carried as skip_first_n_tokens; coverage is still checked against the
++    chunk-aligned end."""
++    tracker = _tracker(
++        num_tokens=CHUNK_TOKENS,
++        lmcache_hit_tokens=CHUNK_TOKENS,
++        vllm_hit_tokens=16,
++        allocated_block_ids={0: [0, 1, 2, 3]},
++    )
++
++    metadata = LMCacheMPRequestMetadata.GetRetrieveMetadata(tracker, CHUNK_TOKENS, [16])
++
++    assert metadata is not None
++    assert metadata.op.start == 0
++    assert metadata.op.end == CHUNK_TOKENS
++    assert metadata.op.skip_first_n_tokens == 16

--- a/patches/releases/gilded-gnosis-v20-r24/sparkinfer/integration.lock.json
+++ b/patches/releases/gilded-gnosis-v20-r24/sparkinfer/integration.lock.json
@@ -1,0 +1,40 @@
+{
+  "base": {
+    "commit": "59216fa25f3d5fc9d4df2d052e02d05f763906e9",
+    "ref": "refs/heads/master",
+    "repository": "https://github.com/local-inference-lab/sparkinfer.git"
+  },
+  "manifest": {
+    "sha256": "55f31c32148b814a1e4d0cd072bb4bb6ccbcb55eb9002b3de17436cc66213bc9"
+  },
+  "name": "gilded-gnosis-v20-sparkinfer",
+  "pull_requests": [
+    {
+      "disposition": "merged",
+      "head": "35588fb570d23713bcb2a81749d0fdf3c4396ace",
+      "number": 106,
+      "ref": "refs/pull/106/head",
+      "title": "Honor compressed cache physical page stride"
+    },
+    {
+      "disposition": "merged",
+      "head": "f3308fbdb6a5613dd3ba18bf6d482458c10684d2",
+      "number": 113,
+      "ref": "refs/pull/113/head",
+      "title": "Rebase replay and CUDA IPC lifecycle hardening"
+    },
+    {
+      "disposition": "merged",
+      "head": "fee1d784a798439de4e3462b0f0fc831491b5c7f",
+      "number": 112,
+      "ref": "refs/pull/112/head",
+      "title": "Consolidate mixed prefill and dense K6 runtime"
+    }
+  ],
+  "result": {
+    "patch": "integration.patch",
+    "patch_sha256": "5fa88526cf7f468efdedcb484ed6b6a4ace065e3eb7d04a69bd46ed2570fd4b1",
+    "tree": "2b9bf2a4d15770c0c23e19cc13a75843f2f0a995"
+  },
+  "schema_version": 1
+}

--- a/patches/releases/gilded-gnosis-v20-r24/sparkinfer/integration.patch
+++ b/patches/releases/gilded-gnosis-v20-r24/sparkinfer/integration.patch
@@ -1,0 +1,21866 @@
+diff --git a/MANIFEST.in b/MANIFEST.in
+new file mode 100644
+index 0000000000000000000000000000000000000000..4c7802d7c3e46eb3fc047dc7290429fc90681cd3
+--- /dev/null
++++ b/MANIFEST.in
+@@ -0,0 +1 @@
++recursive-include sparkinfer/gemm/trellis_linear/csrc *.cu *.cuh *.h LICENSE*
+diff --git a/benchmarks/benchmark_pcie_oneshot_control_node.py b/benchmarks/benchmark_pcie_oneshot_control_node.py
+new file mode 100644
+index 0000000000000000000000000000000000000000..4feac24cb1929b3edd7bcece64108127f7601a0d
+--- /dev/null
++++ b/benchmarks/benchmark_pcie_oneshot_control_node.py
+@@ -0,0 +1,1187 @@
++"""Immutable one-run worker for the PCIe oneshot control-node A/B harness.
++
++Use ``run_pcie_oneshot_control_node_ab.py`` rather than comparing two ad-hoc
++JSON files. That external controller invokes this exact file for both source
++trees in an alternating AB/BA sequence and validates every recorded contract.
++
++This harness intentionally measures only the plain staged one-shot all-reduce
++at 64 KiB by default. A public-head comparison is a net algorithm comparison;
++it must not be described as isolated control-node launch overhead or generalized
++to fused RMSNorm / two-shot collectives without their own measurements.
++"""
++
++from __future__ import annotations
++
++import argparse
++import hashlib
++import importlib
++import json
++import math
++import os
++import platform
++import socket
++import subprocess
++import sys
++import threading
++import time
++from datetime import datetime, timedelta, timezone
++from pathlib import Path
++from typing import Callable, Sequence
++
++import torch
++import torch.distributed as dist
++from cuda.bindings import runtime as cudart
++
++SCHEMA_NAME = "sparkinfer.pcie_oneshot_control_node.run"
++SCHEMA_VERSION = 3
++DTYPE_NAME = "bfloat16"
++TOP_LEVEL_KEYS = {
++    "schema",
++    "contract",
++    "scope",
++    "correctness",
++    "identity",
++    "provenance",
++    "software",
++    "hardware",
++    "environment",
++    "per_rank",
++    "distributed_critical_path",
++}
++CORRECTNESS_KEYS = {"verdict"}
++CONTRACT_KEYS = {
++    "world_size",
++    "numel",
++    "dtype",
++    "warmup",
++    "iters",
++    "preflight_replays",
++}
++SCOPE_KEYS = {
++    "operation",
++    "staging",
++    "size_bytes",
++    "comparison_semantics",
++    "excluded_paths",
++}
++IDENTITY_KEYS = {
++    "label",
++    "variant",
++    "run_index",
++    "implementation_root",
++    "implementation_git_sha",
++    "implementation_git_dirty",
++    "harness_sha256",
++    "controller_sha256",
++    "controller_argv_sha256",
++    "worker_argv",
++    "worker_argv_sha256",
++    "started_at_utc",
++}
++PROVENANCE_KEYS = {
++    "module_path",
++    "module_sha256",
++    "cuda_source_path",
++    "cuda_source_sha256",
++    "extension_path",
++    "extension_sha256",
++    "extension_build_root",
++    "extension_build_manifest",
++    "extension_build_manifest_sha256",
++    "fresh_extension_cache",
++    "post_run_verified",
++}
++METRIC_KEYS = {"cold_us", "mean_us", "p50_us", "p95_us", "min_us", "max_us"}
++RANK_MODE_KEYS = METRIC_KEYS | {"samples_us"}
++CRITICAL_MODE_KEYS = METRIC_KEYS | {"samples_us"}
++SOFTWARE_KEYS = {
++    "python",
++    "platform",
++    "torch",
++    "torch_cuda",
++    "cuda_runtime_version",
++    "cuda_driver_version",
++    "nvcc_version",
++}
++HARDWARE_KEYS = {
++    "hostname",
++    "devices",
++    "nvidia_smi_identity",
++    "nvidia_smi_sample_fields",
++    "nvidia_smi_samples",
++    "nvidia_smi_topology",
++}
++DEVICE_KEYS = {
++    "index",
++    "name",
++    "uuid",
++    "compute_capability",
++    "total_memory_bytes",
++    "multi_processor_count",
++}
++NVIDIA_QUERY_KEYS = {"fields", "returncode", "rows", "stderr"}
++NVIDIA_SAMPLE_KEYS = {"monotonic_ns", "phase", "query"}
++NVIDIA_TOPOLOGY_KEYS = {"returncode", "stdout", "stderr"}
++GRAPH_STRUCTURE_KEYS = {
++    "kernel_nodes",
++    "direct_control_worker_edge",
++    "control_grid",
++    "control_block",
++    "worker_grid",
++    "worker_block",
++}
++NVIDIA_IDENTITY_FIELDS = ("index", "uuid", "name", "driver_version")
++NVIDIA_SMI_FIELDS = (
++    "index",
++    "uuid",
++    "name",
++    "driver_version",
++    "pstate",
++    "power.limit",
++    "power.draw",
++    "clocks.current.sm",
++    "clocks.current.memory",
++    "clocks.max.sm",
++    "clocks.max.memory",
++    "utilization.gpu",
++    "utilization.memory",
++    "temperature.gpu",
++    "clocks_event_reasons.active",
++)
++EXPLICIT_ENV_KEYS = {
++    "CUDA_DEVICE_ORDER",
++    "CUDA_LAUNCH_BLOCKING",
++    "CUDA_MODULE_LOADING",
++    "CUDA_VISIBLE_DEVICES",
++    "CUBLAS_WORKSPACE_CONFIG",
++    "NCCL_P2P_DISABLE",
++    "NCCL_P2P_LEVEL",
++    "NVIDIA_VISIBLE_DEVICES",
++    "OMP_NUM_THREADS",
++    "PYTORCH_CUDA_ALLOC_CONF",
++    "TORCH_EXTENSIONS_DIR",
++}
++
++
++def _parse_args() -> argparse.Namespace:
++    parser = argparse.ArgumentParser()
++    parser.add_argument("--label", required=True)
++    parser.add_argument("--variant", choices=("baseline", "candidate"), required=True)
++    parser.add_argument("--run-index", type=int, required=True)
++    parser.add_argument("--implementation-root", type=Path, required=True)
++    parser.add_argument("--expected-git-sha", required=True)
++    parser.add_argument("--expected-graph-kernel-nodes", type=int, required=True)
++    parser.add_argument("--numel", type=int, default=32768)
++    parser.add_argument("--warmup", type=int, default=100)
++    parser.add_argument("--iters", type=int, default=1000)
++    parser.add_argument("--sampler-interval", type=float, default=0.2)
++    parser.add_argument("--preflight-replays", type=int, default=4)
++    parser.add_argument("--distributed-timeout-seconds", type=float, default=300.0)
++    parser.add_argument("--controller-sha256", required=True)
++    parser.add_argument("--controller-argv-sha256", required=True)
++    parser.add_argument("--output", type=Path, required=True)
++    parser.add_argument("--allow-dirty", action="store_true")
++    return parser.parse_args()
++
++
++def _run_command(
++    args: list[str],
++    *,
++    cwd: Path | None = None,
++    timeout: float = 30.0,
++) -> str:
++    result = subprocess.run(
++        args,
++        cwd=cwd,
++        check=True,
++        text=True,
++        stdout=subprocess.PIPE,
++        stderr=subprocess.PIPE,
++        timeout=timeout,
++    )
++    return result.stdout.strip()
++
++
++def _git_identity(root: Path) -> tuple[str, bool]:
++    sha = _run_command(["git", "rev-parse", "HEAD"], cwd=root)
++    dirty = bool(_run_command(["git", "status", "--porcelain=v1"], cwd=root))
++    return sha, dirty
++
++
++def _sha256(path: Path) -> str:
++    digest = hashlib.sha256()
++    with path.open("rb") as handle:
++        for block in iter(lambda: handle.read(1024 * 1024), b""):
++            digest.update(block)
++    return digest.hexdigest()
++
++
++def _json_sha256(value: object) -> str:
++    rendered = json.dumps(
++        value,
++        sort_keys=True,
++        separators=(",", ":"),
++    ).encode("utf-8")
++    return hashlib.sha256(rendered).hexdigest()
++
++
++def _extension_build_manifest(build_root: Path) -> list[dict[str, object]]:
++    """Hash every durable input/output in one fresh JIT extension directory."""
++
++    entries = []
++    for path in sorted(build_root.rglob("*")):
++        if not path.is_file() or path.name in {".ninja_deps", ".ninja_log", "lock"}:
++            continue
++        entries.append(
++            {
++                "path": str(path.relative_to(build_root)),
++                "size_bytes": path.stat().st_size,
++                "sha256": _sha256(path),
++            }
++        )
++    if not entries:
++        raise RuntimeError(f"extension build manifest is empty: {build_root}")
++    return entries
++
++
++def _verified_implementation(
++    implementation_root: Path,
++) -> tuple[object, type, dict[str, object]]:
++    """Import, build, and bind the implementation to exact source/binary hashes."""
++
++    module = importlib.import_module("sparkinfer.comm.pcie.pcie_oneshot")
++    module_path = Path(module.__file__).resolve()
++    expected_module = (
++        implementation_root / "sparkinfer/comm/pcie/pcie_oneshot.py"
++    ).resolve()
++    if module_path != expected_module:
++        raise RuntimeError(
++            f"imported PCIe oneshot module {module_path} != {expected_module}"
++        )
++    cuda_source = module_path.with_suffix(".cu")
++    if not cuda_source.is_file():
++        raise RuntimeError(f"PCIe oneshot CUDA source is missing: {cuda_source}")
++
++    extension = module._load_extension()
++    extension_path = Path(extension.__file__).resolve()
++    build_root = extension_path.parent
++    cache_value = os.environ.get("TORCH_EXTENSIONS_DIR")
++    if not cache_value:
++        raise RuntimeError(
++            "TORCH_EXTENSIONS_DIR must name a fresh per-run extension cache"
++        )
++    expected_cache = Path(cache_value).resolve()
++    if not extension_path.is_relative_to(expected_cache):
++        raise RuntimeError(
++            f"loaded extension {extension_path} is outside fresh cache {expected_cache}"
++        )
++    manifest = _extension_build_manifest(build_root)
++    provenance = {
++        "module_path": str(module_path),
++        "module_sha256": _sha256(module_path),
++        "cuda_source_path": str(cuda_source),
++        "cuda_source_sha256": _sha256(cuda_source),
++        "extension_path": str(extension_path),
++        "extension_sha256": _sha256(extension_path),
++        "extension_build_root": str(build_root),
++        "extension_build_manifest": manifest,
++        "extension_build_manifest_sha256": _json_sha256(manifest),
++        "fresh_extension_cache": True,
++        "post_run_verified": False,
++    }
++    return module, module.PCIeOneshotAllReducePool, provenance
++
++
++def _verify_post_run_provenance(
++    provenance: dict[str, object],
++    *,
++    implementation_root: Path,
++    expected_git_sha: str,
++) -> None:
++    git_sha, git_dirty = _git_identity(implementation_root)
++    if git_sha != expected_git_sha or git_dirty:
++        raise RuntimeError("implementation Git identity changed during benchmark")
++    checks = (
++        ("module_path", "module_sha256"),
++        ("cuda_source_path", "cuda_source_sha256"),
++        ("extension_path", "extension_sha256"),
++    )
++    for path_key, digest_key in checks:
++        if _sha256(Path(provenance[path_key])) != provenance[digest_key]:
++            raise RuntimeError(f"{path_key} changed during benchmark")
++    manifest = _extension_build_manifest(Path(provenance["extension_build_root"]))
++    if manifest != provenance["extension_build_manifest"]:
++        raise RuntimeError("extension build manifest changed during benchmark")
++    if _json_sha256(manifest) != provenance["extension_build_manifest_sha256"]:
++        raise RuntimeError("extension build manifest digest changed during benchmark")
++    provenance["post_run_verified"] = True
++
++
++def _cuda_version(call: Callable[[], tuple[object, int]]) -> int:
++    result, version = call()
++    if result != cudart.cudaError_t.cudaSuccess:
++        raise RuntimeError(f"CUDA version query failed: {result}")
++    return int(version)
++
++
++def _nvidia_smi_query(fields: tuple[str, ...]) -> dict[str, object]:
++    command = [
++        "nvidia-smi",
++        f"--query-gpu={','.join(fields)}",
++        "--format=csv,noheader,nounits",
++    ]
++    try:
++        result = subprocess.run(
++            command,
++            check=False,
++            text=True,
++            stdout=subprocess.PIPE,
++            stderr=subprocess.PIPE,
++            timeout=10,
++        )
++    except subprocess.TimeoutExpired as exc:
++        return {
++            "fields": list(fields),
++            "returncode": -1,
++            "rows": [],
++            "stderr": f"nvidia-smi timed out after {exc.timeout}s",
++        }
++    return {
++        "fields": list(fields),
++        "returncode": result.returncode,
++        "rows": [
++            [value.strip() for value in line.split(",")]
++            for line in result.stdout.splitlines()
++            if line.strip()
++        ],
++        "stderr": result.stderr.strip(),
++    }
++
++
++def _nvidia_smi_topology() -> dict[str, object]:
++    try:
++        result = subprocess.run(
++            ["nvidia-smi", "topo", "-m"],
++            check=False,
++            text=True,
++            stdout=subprocess.PIPE,
++            stderr=subprocess.PIPE,
++            timeout=10,
++        )
++    except subprocess.TimeoutExpired as exc:
++        return {
++            "returncode": -1,
++            "stdout": "",
++            "stderr": f"nvidia-smi topology timed out after {exc.timeout}s",
++        }
++    return {
++        "returncode": result.returncode,
++        "stdout": result.stdout.rstrip(),
++        "stderr": result.stderr.strip(),
++    }
++
++
++class _NvidiaSmiSampler:
++    def __init__(self, interval: float) -> None:
++        self.interval = interval
++        self.samples: list[dict[str, object]] = []
++        self._stop = threading.Event()
++        self._lock = threading.Lock()
++        self._phase = "unmarked"
++        self._thread = threading.Thread(target=self._run, daemon=True)
++
++    def _sample(self) -> None:
++        sample = {
++            "monotonic_ns": time.monotonic_ns(),
++            "phase": self._phase,
++            "query": _nvidia_smi_query(NVIDIA_SMI_FIELDS),
++        }
++        with self._lock:
++            self.samples.append(sample)
++
++    def _run(self) -> None:
++        while not self._stop.is_set():
++            self._sample()
++            self._stop.wait(self.interval)
++
++    def start(self) -> None:
++        self._thread.start()
++
++    def mark_phase(self, phase: str) -> None:
++        self._phase = phase
++        # A short timing phase must still contribute telemetry.
++        self._sample()
++
++    def stop(self) -> None:
++        self._stop.set()
++        self._thread.join(timeout=15)
++        if self._thread.is_alive():
++            raise RuntimeError("nvidia-smi sampler thread did not stop within 15s")
++        self._phase = "final"
++        self._sample()
++
++    @property
++    def is_alive(self) -> bool:
++        return self._thread.is_alive()
++
++
++def _environment_toggles() -> dict[str, str]:
++    return {
++        key: value
++        for key, value in sorted(os.environ.items())
++        if key in EXPLICIT_ENV_KEYS
++        or key.startswith("SPARKINFER_")
++        or key.startswith("NCCL_")
++        or key.startswith("TORCH_NCCL_")
++    }
++
++
++def _dim3_list(value: object) -> list[int]:
++    return [int(value.x), int(value.y), int(value.z)]
++
++
++def _graph_kernel_structure(
++    graph: torch.cuda.CUDAGraph,
++    *,
++    expected_kernel_nodes: int,
++) -> dict[str, object]:
++    """Prove the candidate's 1x1 control node directly orders its worker."""
++
++    graph_handle = graph.raw_cuda_graph()
++    result, _, num_nodes = cudart.cudaGraphGetNodes(graph_handle)
++    if result != cudart.cudaError_t.cudaSuccess:
++        raise RuntimeError(f"cudaGraphGetNodes(size) failed: {result}")
++    result, nodes, returned_nodes = cudart.cudaGraphGetNodes(
++        graph_handle,
++        num_nodes,
++    )
++    if result != cudart.cudaError_t.cudaSuccess or returned_nodes != num_nodes:
++        raise RuntimeError(
++            f"cudaGraphGetNodes(data) failed: {result}, {returned_nodes=}, {num_nodes=}"
++        )
++    kernel_type = cudart.cudaGraphNodeType.cudaGraphNodeTypeKernel
++    kernel_nodes = []
++    for node in nodes[:num_nodes]:
++        result, node_type = cudart.cudaGraphNodeGetType(node)
++        if result != cudart.cudaError_t.cudaSuccess:
++            raise RuntimeError(f"cudaGraphNodeGetType failed: {result}")
++        if node_type == kernel_type:
++            kernel_nodes.append(node)
++    if len(kernel_nodes) != expected_kernel_nodes:
++        raise AssertionError(
++            f"graph has {len(kernel_nodes)} kernel nodes, expected "
++            f"{expected_kernel_nodes}"
++        )
++
++    edge_query = cudart.cudaGraphGetEdges(graph_handle)
++    if edge_query[0] != cudart.cudaError_t.cudaSuccess:
++        raise RuntimeError(f"cudaGraphGetEdges(size) failed: {edge_query[0]}")
++    num_edges = int(edge_query[-1])
++    edges = cudart.cudaGraphGetEdges(graph_handle, num_edges)
++    result, from_nodes, to_nodes, returned_edges = (
++        edges[0],
++        edges[1],
++        edges[2],
++        edges[-1],
++    )
++    if result != cudart.cudaError_t.cudaSuccess or returned_edges != num_edges:
++        raise RuntimeError(
++            f"cudaGraphGetEdges(data) failed: {result}, {returned_edges=}, {num_edges=}"
++        )
++    kernel_edges = []
++    for source, destination in zip(
++        from_nodes[:num_edges],
++        to_nodes[:num_edges],
++        strict=True,
++    ):
++        result, source_type = cudart.cudaGraphNodeGetType(source)
++        if result != cudart.cudaError_t.cudaSuccess:
++            raise RuntimeError(f"source cudaGraphNodeGetType failed: {result}")
++        result, destination_type = cudart.cudaGraphNodeGetType(destination)
++        if result != cudart.cudaError_t.cudaSuccess:
++            raise RuntimeError(f"destination cudaGraphNodeGetType failed: {result}")
++        if source_type == kernel_type and destination_type == kernel_type:
++            kernel_edges.append((source, destination))
++
++    def geometry(node: object) -> tuple[list[int], list[int]]:
++        result, params = cudart.cudaGraphKernelNodeGetParams(node)
++        if result != cudart.cudaError_t.cudaSuccess and hasattr(
++            cudart, "cudaGraphNodeGetParams"
++        ):
++            fallback_result, node_params = cudart.cudaGraphNodeGetParams(node)
++            if fallback_result != cudart.cudaError_t.cudaSuccess:
++                raise RuntimeError(
++                    "cudaGraphKernelNodeGetParams failed: "
++                    f"{result}; cudaGraphNodeGetParams failed: {fallback_result}"
++                )
++            result, params = fallback_result, node_params.kernel
++        if result != cudart.cudaError_t.cudaSuccess:
++            raise RuntimeError(f"cudaGraphKernelNodeGetParams failed: {result}")
++        return _dim3_list(params.gridDim), _dim3_list(params.blockDim)
++
++    if expected_kernel_nodes == 2:
++        if len(kernel_edges) != 1:
++            raise AssertionError(
++                "staged candidate graph must contain one direct control-to-worker "
++                f"kernel edge, found {len(kernel_edges)}"
++            )
++        control, worker = map(geometry, kernel_edges[0])
++        if control != ([1, 1, 1], [1, 1, 1]):
++            raise AssertionError(f"control kernel is not <<<1,1>>>: {control}")
++        if worker[0][0] <= 1 or worker[1][0] < 64:
++            raise AssertionError(f"worker launch geometry is implausible: {worker}")
++        direct_edge = True
++    elif expected_kernel_nodes == 1:
++        if kernel_edges:
++            raise AssertionError("one-kernel baseline graph has a kernel edge")
++        control = (None, None)
++        worker = geometry(kernel_nodes[0])
++        direct_edge = False
++    else:
++        raise AssertionError(
++            "plain staged A/B contract supports only one-node baseline and "
++            "two-node candidate graphs"
++        )
++    return {
++        "kernel_nodes": len(kernel_nodes),
++        "direct_control_worker_edge": direct_edge,
++        "control_grid": control[0],
++        "control_block": control[1],
++        "worker_grid": worker[0],
++        "worker_block": worker[1],
++    }
++
++
++def _measure(
++    operation: Callable[[], None],
++    *,
++    stream: torch.cuda.Stream,
++    warmup: int,
++    iters: int,
++) -> tuple[float, list[float]]:
++    cold_start = torch.cuda.Event(enable_timing=True)
++    cold_end = torch.cuda.Event(enable_timing=True)
++    cold_start.record(stream)
++    operation()
++    cold_end.record(stream)
++    stream.synchronize()
++    cold_us = float(cold_start.elapsed_time(cold_end) * 1000)
++
++    for _ in range(warmup):
++        operation()
++    stream.synchronize()
++
++    starts = [torch.cuda.Event(enable_timing=True) for _ in range(iters)]
++    ends = [torch.cuda.Event(enable_timing=True) for _ in range(iters)]
++    for start, end in zip(starts, ends, strict=True):
++        start.record(stream)
++        operation()
++        end.record(stream)
++    stream.synchronize()
++    samples = [
++        float(start.elapsed_time(end) * 1000)
++        for start, end in zip(starts, ends, strict=True)
++    ]
++    return cold_us, samples
++
++
++def _mutating_replay_preflight(
++    operation: Callable[[], None],
++    *,
++    inp: torch.Tensor,
++    out: torch.Tensor,
++    stream: torch.cuda.Stream,
++    rank: int,
++    world_size: int,
++    replays: int,
++) -> None:
++    """Expose stale-slot reuse by validating changing data on both slot parities."""
++
++    if replays < 4:
++        raise ValueError("mutating preflight requires at least four replays")
++    rank_sum = world_size * (world_size + 1) // 2
++    for iteration in range(replays):
++        multiplier = iteration + 1
++        with torch.cuda.stream(stream):
++            inp.fill_(multiplier * (rank + 1))
++            operation()
++        stream.synchronize()
++        torch.testing.assert_close(
++            out,
++            torch.full_like(out, multiplier * rank_sum),
++            rtol=0,
++            atol=0,
++        )
++
++
++def _summary(samples: list[float]) -> dict[str, float]:
++    if not samples:
++        raise ValueError("cannot summarize an empty latency vector")
++    ordered = sorted(samples)
++
++    def percentile(fraction: float) -> float:
++        index = max(0, math.ceil(fraction * len(ordered)) - 1)
++        return ordered[index]
++
++    return {
++        "mean_us": sum(ordered) / len(ordered),
++        "p50_us": percentile(0.50),
++        "p95_us": percentile(0.95),
++        "min_us": ordered[0],
++        "max_us": ordered[-1],
++    }
++
++
++def _gather_rank_metrics(
++    eager_cold_us: float,
++    eager_samples: list[float],
++    graph_cold_us: float,
++    graph_samples: list[float],
++    graph_structure: dict[str, object],
++    device: torch.device,
++) -> list[dict[str, object]]:
++    if len(eager_samples) != len(graph_samples) or not eager_samples:
++        raise ValueError("eager/graph latency vectors must be non-empty and aligned")
++    control_grid = graph_structure["control_grid"] or [0, 0, 0]
++    control_block = graph_structure["control_block"] or [0, 0, 0]
++    structure_values = [
++        float(graph_structure["kernel_nodes"]),
++        float(bool(graph_structure["direct_control_worker_edge"])),
++        *map(float, control_grid),
++        *map(float, control_block),
++        *map(float, graph_structure["worker_grid"]),
++        *map(float, graph_structure["worker_block"]),
++    ]
++    if len(structure_values) != 14:
++        raise AssertionError("graph structure encoding must contain 14 values")
++    local = torch.tensor(
++        [
++            eager_cold_us,
++            *eager_samples,
++            graph_cold_us,
++            *graph_samples,
++            *structure_values,
++        ],
++        device=device,
++        dtype=torch.float64,
++    )
++    gathered = [torch.empty_like(local) for _ in range(dist.get_world_size())]
++    dist.all_gather(gathered, local)
++
++    result = []
++    for rank, values_tensor in enumerate(gathered):
++        values = values_tensor.cpu().tolist()
++        iters = len(eager_samples)
++        rank_eager_samples = values[1 : 1 + iters]
++        graph_cold_index = 1 + iters
++        rank_graph_samples = values[graph_cold_index + 1 : graph_cold_index + 1 + iters]
++        structure = values[graph_cold_index + 1 + iters :]
++        eager_summary = _summary(rank_eager_samples)
++        graph_summary = _summary(rank_graph_samples)
++        has_control = bool(int(structure[1]))
++        result.append(
++            {
++                "rank": rank,
++                "eager": {
++                    "cold_us": values[0],
++                    **eager_summary,
++                    "samples_us": rank_eager_samples,
++                },
++                "graph": {
++                    "cold_us": values[graph_cold_index],
++                    **graph_summary,
++                    "samples_us": rank_graph_samples,
++                },
++                "graph_structure": {
++                    "kernel_nodes": int(structure[0]),
++                    "direct_control_worker_edge": has_control,
++                    "control_grid": [int(v) for v in structure[2:5]]
++                    if has_control
++                    else None,
++                    "control_block": [int(v) for v in structure[5:8]]
++                    if has_control
++                    else None,
++                    "worker_grid": [int(v) for v in structure[8:11]],
++                    "worker_block": [int(v) for v in structure[11:14]],
++                },
++            }
++        )
++    return result
++
++
++def _distributed_critical_path(
++    per_rank: Sequence[dict[str, object]],
++) -> dict[str, object]:
++    """Summarize max-rank latency at each aligned timed iteration."""
++
++    if not per_rank:
++        raise ValueError("distributed critical path requires at least one rank")
++    result: dict[str, object] = {}
++    for mode in ("eager", "graph"):
++        rank_vectors = [list(row[mode]["samples_us"]) for row in per_rank]
++        lengths = {len(samples) for samples in rank_vectors}
++        if len(lengths) != 1 or not lengths or next(iter(lengths)) == 0:
++            raise ValueError(f"{mode} rank latency vectors are empty or misaligned")
++        critical_samples = [
++            max(rank_samples[index] for rank_samples in rank_vectors)
++            for index in range(next(iter(lengths)))
++        ]
++        result[mode] = {
++            "cold_us": max(float(row[mode]["cold_us"]) for row in per_rank),
++            **_summary(critical_samples),
++            "samples_us": critical_samples,
++        }
++    return result
++
++
++def _device_metadata() -> list[dict[str, object]]:
++    devices = []
++    for index in range(torch.cuda.device_count()):
++        props = torch.cuda.get_device_properties(index)
++        devices.append(
++            {
++                "index": index,
++                "name": props.name,
++                "uuid": str(getattr(props, "uuid", "unavailable")),
++                "compute_capability": [props.major, props.minor],
++                "total_memory_bytes": props.total_memory,
++                "multi_processor_count": props.multi_processor_count,
++            }
++        )
++    return devices
++
++
++def _validate_correctness(correctness: object) -> None:
++    if not isinstance(correctness, dict) or set(correctness) != CORRECTNESS_KEYS:
++        raise ValueError("benchmark correctness schema mismatch")
++    if correctness["verdict"] != "pass":
++        raise ValueError(f"benchmark correctness did not pass: {correctness}")
++
++
++def _validate_record(
++    record: dict[str, object],
++    contract: dict[str, object],
++    *,
++    expected_graph_kernel_nodes: int,
++) -> None:
++    if set(record) != TOP_LEVEL_KEYS:
++        raise ValueError(
++            f"benchmark schema keys differ: {set(record) ^ TOP_LEVEL_KEYS}"
++        )
++    if record["schema"] != {"name": SCHEMA_NAME, "version": SCHEMA_VERSION}:
++        raise ValueError(f"unsupported benchmark schema: {record['schema']}")
++    _validate_correctness(record["correctness"])
++    if set(record["contract"]) != CONTRACT_KEYS or record["contract"] != contract:
++        raise ValueError(
++            f"benchmark contract mismatch: {record['contract']} != {contract}"
++        )
++    scope = record["scope"]
++    if set(scope) != SCOPE_KEYS:
++        raise ValueError("benchmark scope schema mismatch")
++    if (
++        scope["operation"] != "plain_oneshot_all_reduce"
++        or scope["staging"] != "double_buffered_eager_ipc"
++        or int(scope["size_bytes"]) != int(contract["numel"]) * torch.bfloat16.itemsize
++        or "net algorithm" not in str(scope["comparison_semantics"]).lower()
++        or scope["excluded_paths"]
++        != ["fused_add_rms_norm", "twoshot_reduce_scatter", "twoshot_all_gather"]
++    ):
++        raise ValueError(
++            f"benchmark scope is not the narrow staged-path contract: {scope}"
++        )
++    if set(record["identity"]) != IDENTITY_KEYS:
++        raise ValueError("benchmark identity schema mismatch")
++    if set(record["provenance"]) != PROVENANCE_KEYS:
++        raise ValueError("benchmark provenance schema mismatch")
++    provenance = record["provenance"]
++    if not provenance["fresh_extension_cache"] or not provenance["post_run_verified"]:
++        raise ValueError("benchmark extension provenance was not freshly verified")
++    manifest = provenance["extension_build_manifest"]
++    if not isinstance(manifest, list) or not manifest:
++        raise ValueError("benchmark extension build manifest is empty")
++    for entry in manifest:
++        if set(entry) != {"path", "size_bytes", "sha256"}:
++            raise ValueError("benchmark extension manifest entry schema mismatch")
++    if _json_sha256(manifest) != provenance["extension_build_manifest_sha256"]:
++        raise ValueError("benchmark extension manifest digest mismatch")
++    if set(record["software"]) != SOFTWARE_KEYS:
++        raise ValueError("benchmark software schema mismatch")
++    if set(record["hardware"]) != HARDWARE_KEYS:
++        raise ValueError("benchmark hardware schema mismatch")
++    if not isinstance(record["environment"], dict):
++        raise ValueError("benchmark environment must be an object")
++    if not isinstance(record["per_rank"], list) or len(record["per_rank"]) != int(
++        contract["world_size"]
++    ):
++        raise ValueError("benchmark per-rank cardinality mismatch")
++    hardware = record["hardware"]
++    if not isinstance(hardware["devices"], list) or not hardware["devices"]:
++        raise ValueError("benchmark device inventory must be a non-empty list")
++    for device in hardware["devices"]:
++        if set(device) != DEVICE_KEYS:
++            raise ValueError("benchmark device schema mismatch")
++    identity_query = hardware["nvidia_smi_identity"]
++    if set(identity_query) != NVIDIA_QUERY_KEYS:
++        raise ValueError("benchmark NVIDIA identity schema mismatch")
++    if identity_query["fields"] != list(NVIDIA_IDENTITY_FIELDS):
++        raise ValueError("benchmark NVIDIA identity field contract mismatch")
++    if identity_query["returncode"] != 0:
++        raise ValueError(f"benchmark NVIDIA identity query failed: {identity_query}")
++    if len(identity_query["rows"]) != len(hardware["devices"]):
++        raise ValueError("benchmark NVIDIA identity/device cardinality mismatch")
++    if any(len(row) != len(NVIDIA_IDENTITY_FIELDS) for row in identity_query["rows"]):
++        raise ValueError("benchmark NVIDIA identity row schema mismatch")
++    if hardware["nvidia_smi_sample_fields"] != list(NVIDIA_SMI_FIELDS):
++        raise ValueError("benchmark NVIDIA sample field contract mismatch")
++    if (
++        not isinstance(hardware["nvidia_smi_samples"], list)
++        or not hardware["nvidia_smi_samples"]
++    ):
++        raise ValueError("benchmark NVIDIA samples must be a non-empty list")
++    successful_samples = 0
++    successful_phases: set[str] = set()
++    for sample in hardware["nvidia_smi_samples"]:
++        if set(sample) != NVIDIA_SAMPLE_KEYS:
++            raise ValueError("benchmark NVIDIA sample schema mismatch")
++        if set(sample["query"]) != NVIDIA_QUERY_KEYS:
++            raise ValueError("benchmark NVIDIA sample query schema mismatch")
++        if sample["query"]["fields"] != list(NVIDIA_SMI_FIELDS):
++            raise ValueError("benchmark NVIDIA sample query field mismatch")
++        if sample["query"]["returncode"] == 0:
++            successful_samples += 1
++            if not sample["query"]["rows"]:
++                raise ValueError("successful NVIDIA telemetry sample has zero rows")
++            successful_phases.add(str(sample["phase"]))
++            if any(
++                len(row) != len(NVIDIA_SMI_FIELDS) for row in sample["query"]["rows"]
++            ):
++                raise ValueError("benchmark NVIDIA sample row schema mismatch")
++            if len(sample["query"]["rows"]) != len(hardware["devices"]):
++                raise ValueError("benchmark NVIDIA sample/device cardinality mismatch")
++    if successful_samples == 0:
++        raise ValueError("benchmark collected no successful NVIDIA telemetry samples")
++    required_phases = {"mutating_preflight", "eager_timing", "graph_timing"}
++    if not required_phases <= successful_phases:
++        raise ValueError(
++            "benchmark lacks successful phase telemetry: "
++            f"{required_phases - successful_phases}"
++        )
++    topology = hardware["nvidia_smi_topology"]
++    if set(topology) != NVIDIA_TOPOLOGY_KEYS:
++        raise ValueError("benchmark NVIDIA topology schema mismatch")
++    if topology["returncode"] != 0 or not topology["stdout"]:
++        raise ValueError(f"benchmark NVIDIA topology query failed: {topology}")
++    for row in record["per_rank"]:
++        if set(row) != {"rank", "eager", "graph", "graph_structure"}:
++            raise ValueError("per-rank schema mismatch")
++        if set(row["eager"]) != RANK_MODE_KEYS:
++            raise ValueError("eager metric schema mismatch")
++        if set(row["graph"]) != RANK_MODE_KEYS:
++            raise ValueError("graph metric schema mismatch")
++        for mode in ("eager", "graph"):
++            samples = row[mode]["samples_us"]
++            if not isinstance(samples, list) or len(samples) != int(contract["iters"]):
++                raise ValueError(f"per-rank {mode} sample vector length mismatch")
++            if any(
++                not math.isfinite(float(value)) or float(value) <= 0
++                for value in samples
++            ):
++                raise ValueError(f"per-rank {mode} samples must be finite and positive")
++            expected_summary = _summary([float(value) for value in samples])
++            for key, expected in expected_summary.items():
++                if float(row[mode][key]) != expected:
++                    raise ValueError(f"per-rank {mode} {key} summary mismatch")
++        structure = row["graph_structure"]
++        if set(structure) != GRAPH_STRUCTURE_KEYS:
++            raise ValueError("graph structure schema mismatch")
++        if int(structure["kernel_nodes"]) != expected_graph_kernel_nodes:
++            raise ValueError("graph kernel-node count mismatch")
++        if expected_graph_kernel_nodes == 2:
++            if (
++                structure["direct_control_worker_edge"] is not True
++                or structure["control_grid"] != [1, 1, 1]
++                or structure["control_block"] != [1, 1, 1]
++            ):
++                raise ValueError("candidate graph lacks direct <<<1,1>>> control edge")
++        elif (
++            structure["direct_control_worker_edge"] is not False
++            or structure["control_grid"] is not None
++            or structure["control_block"] is not None
++        ):
++            raise ValueError("baseline graph unexpectedly records a control node")
++    if {int(row["rank"]) for row in record["per_rank"]} != set(
++        range(int(contract["world_size"]))
++    ):
++        raise ValueError("per-rank identities do not match world size")
++    critical_path = record["distributed_critical_path"]
++    if set(critical_path) != {"eager", "graph"}:
++        raise ValueError("distributed critical-path mode schema mismatch")
++    for mode in ("eager", "graph"):
++        if set(critical_path[mode]) != CRITICAL_MODE_KEYS:
++            raise ValueError(f"distributed {mode} critical-path schema mismatch")
++    expected_critical_path = _distributed_critical_path(record["per_rank"])
++    if critical_path != expected_critical_path:
++        raise ValueError(
++            "distributed critical path was not derived from aligned rank maxima"
++        )
++
++
++def main() -> None:
++    args = _parse_args()
++    if (
++        args.iters <= 0
++        or args.warmup < 0
++        or args.numel != 32768
++        or args.run_index < 0
++        or args.expected_graph_kernel_nodes not in (1, 2)
++        or args.preflight_replays < 4
++        or args.distributed_timeout_seconds <= 0
++    ):
++        raise ValueError(
++            "this narrow harness requires 32,768 BF16 elements (64 KiB), "
++            "at least four preflight replays, one/two graph nodes, positive "
++            "iterations/timeout, and non-negative warmup/run-index"
++        )
++    if args.sampler_interval <= 0:
++        raise ValueError("sampler interval must be positive")
++
++    implementation_root = args.implementation_root.resolve()
++    git_sha, git_dirty = _git_identity(implementation_root)
++    if git_sha != args.expected_git_sha:
++        raise ValueError(f"implementation SHA {git_sha} != {args.expected_git_sha}")
++    if git_dirty and not args.allow_dirty:
++        raise ValueError(f"implementation worktree is dirty: {implementation_root}")
++
++    dist.init_process_group(
++        "nccl",
++        timeout=timedelta(seconds=args.distributed_timeout_seconds),
++    )
++    rank = dist.get_rank()
++    world_size = dist.get_world_size()
++    local_rank = int(os.environ["LOCAL_RANK"])
++    torch.cuda.set_device(local_rank)
++    device = torch.device(f"cuda:{local_rank}")
++    _, pool_type, provenance = _verified_implementation(implementation_root)
++    contract = {
++        "world_size": world_size,
++        "numel": args.numel,
++        "dtype": DTYPE_NAME,
++        "warmup": args.warmup,
++        "iters": args.iters,
++        "preflight_replays": args.preflight_replays,
++    }
++    started_at = datetime.now(timezone.utc).isoformat()
++    sampler = _NvidiaSmiSampler(args.sampler_interval) if rank == 0 else None
++
++    pool = None
++    try:
++        nbytes = args.numel * torch.bfloat16.itemsize
++        pool = pool_type.from_process_group(
++            process_group=dist.group.WORLD,
++            device=device,
++            max_input_bytes=nbytes,
++            max_size=nbytes,
++        )
++        eager_channel_id = "eager:control-node-benchmark"
++        graph_channel_id = "graph:control-node-benchmark"
++        pool.prepare_channels((eager_channel_id, graph_channel_id))
++        stream = torch.cuda.Stream(device=device)
++        channel = pool.for_stream(stream, channel_id=eager_channel_id)
++        eager_inp = torch.full(
++            (args.numel,),
++            rank + 1,
++            dtype=torch.bfloat16,
++            device=device,
++        )
++        eager_out = torch.empty_like(eager_inp)
++
++        def eager_operation() -> None:
++            with torch.cuda.stream(stream):
++                channel.all_reduce(eager_inp, out=eager_out)
++
++        graph_inp = torch.full_like(eager_inp, rank + 1)
++        graph_out = torch.empty_like(graph_inp)
++        graph = torch.cuda.CUDAGraph(keep_graph=True)
++        with (
++            pool.capture(stream, channel_id=graph_channel_id) as graph_channel,
++            torch.cuda.graph(
++                graph,
++                stream=stream,
++            ),
++        ):
++            graph_channel.all_reduce(graph_inp, out=graph_out)
++        graph_structure = _graph_kernel_structure(
++            graph,
++            expected_kernel_nodes=args.expected_graph_kernel_nodes,
++        )
++
++        def graph_operation() -> None:
++            with torch.cuda.stream(stream):
++                graph.replay()
++
++        # JIT compilation and graph construction are complete. Telemetry starts
++        # here and every correctness/timing phase receives an explicit marker.
++        if sampler is not None:
++            sampler.start()
++            sampler.mark_phase("mutating_preflight")
++        _mutating_replay_preflight(
++            eager_operation,
++            inp=eager_inp,
++            out=eager_out,
++            stream=stream,
++            rank=rank,
++            world_size=world_size,
++            replays=args.preflight_replays,
++        )
++        _mutating_replay_preflight(
++            graph_operation,
++            inp=graph_inp,
++            out=graph_out,
++            stream=stream,
++            rank=rank,
++            world_size=world_size,
++            replays=args.preflight_replays,
++        )
++
++        with torch.cuda.stream(stream):
++            eager_inp.fill_(rank + 1)
++        stream.synchronize()
++        dist.barrier()
++        if sampler is not None:
++            sampler.mark_phase("eager_timing")
++        eager_cold_us, eager_samples = _measure(
++            eager_operation,
++            stream=stream,
++            warmup=args.warmup,
++            iters=args.iters,
++        )
++        expected = world_size * (world_size + 1) // 2
++        torch.testing.assert_close(
++            eager_out,
++            torch.full_like(eager_out, expected),
++            rtol=0,
++            atol=0,
++        )
++
++        with torch.cuda.stream(stream):
++            graph_inp.fill_(rank + 1)
++        stream.synchronize()
++        dist.barrier()
++        if sampler is not None:
++            sampler.mark_phase("graph_timing")
++        graph_cold_us, graph_samples = _measure(
++            graph_operation,
++            stream=stream,
++            warmup=args.warmup,
++            iters=args.iters,
++        )
++        torch.testing.assert_close(
++            graph_out,
++            torch.full_like(graph_out, expected),
++            rtol=0,
++            atol=0,
++        )
++
++        per_rank = _gather_rank_metrics(
++            eager_cold_us,
++            eager_samples,
++            graph_cold_us,
++            graph_samples,
++            graph_structure,
++            device,
++        )
++        observed_nodes = {
++            int(row["graph_structure"]["kernel_nodes"]) for row in per_rank
++        }
++        if observed_nodes != {args.expected_graph_kernel_nodes}:
++            raise AssertionError(
++                f"rank graph-node counts {observed_nodes} do not match "
++                f"{args.expected_graph_kernel_nodes}"
++            )
++        torch.cuda.synchronize(device)
++        dist.barrier()
++        _verify_post_run_provenance(
++            provenance,
++            implementation_root=implementation_root,
++            expected_git_sha=args.expected_git_sha,
++        )
++
++        if sampler is not None:
++            sampler.mark_phase("provenance_and_finalize")
++            sampler.stop()
++        if rank == 0:
++            harness_path = Path(__file__).resolve()
++            worker_argv = list(sys.argv)
++            record = {
++                "schema": {"name": SCHEMA_NAME, "version": SCHEMA_VERSION},
++                "contract": contract,
++                "scope": {
++                    "operation": "plain_oneshot_all_reduce",
++                    "staging": "double_buffered_eager_ipc",
++                    "size_bytes": nbytes,
++                    "comparison_semantics": (
++                        "net algorithm comparison between public baseline and "
++                        "candidate; not isolated launch overhead"
++                    ),
++                    "excluded_paths": [
++                        "fused_add_rms_norm",
++                        "twoshot_reduce_scatter",
++                        "twoshot_all_gather",
++                    ],
++                },
++                "correctness": {"verdict": "pass"},
++                "identity": {
++                    "label": args.label,
++                    "variant": args.variant,
++                    "run_index": args.run_index,
++                    "implementation_root": str(implementation_root),
++                    "implementation_git_sha": git_sha,
++                    "implementation_git_dirty": git_dirty,
++                    "harness_sha256": _sha256(harness_path),
++                    "controller_sha256": args.controller_sha256,
++                    "controller_argv_sha256": args.controller_argv_sha256,
++                    "worker_argv": worker_argv,
++                    "worker_argv_sha256": _json_sha256(worker_argv),
++                    "started_at_utc": started_at,
++                },
++                "provenance": provenance,
++                "software": {
++                    "python": platform.python_version(),
++                    "platform": platform.platform(),
++                    "torch": torch.__version__,
++                    "torch_cuda": torch.version.cuda,
++                    "cuda_runtime_version": _cuda_version(cudart.cudaRuntimeGetVersion),
++                    "cuda_driver_version": _cuda_version(cudart.cudaDriverGetVersion),
++                    "nvcc_version": _run_command(["nvcc", "--version"]),
++                },
++                "hardware": {
++                    "hostname": socket.gethostname(),
++                    "devices": _device_metadata(),
++                    "nvidia_smi_identity": _nvidia_smi_query(NVIDIA_IDENTITY_FIELDS),
++                    "nvidia_smi_sample_fields": list(NVIDIA_SMI_FIELDS),
++                    "nvidia_smi_samples": sampler.samples,
++                    "nvidia_smi_topology": _nvidia_smi_topology(),
++                },
++                "environment": _environment_toggles(),
++                "per_rank": per_rank,
++                "distributed_critical_path": _distributed_critical_path(per_rank),
++            }
++            _validate_record(
++                record,
++                contract,
++                expected_graph_kernel_nodes=args.expected_graph_kernel_nodes,
++            )
++            rendered = json.dumps(record, indent=2, sort_keys=True)
++            print(rendered, flush=True)
++            args.output.parent.mkdir(parents=True, exist_ok=True)
++            args.output.write_text(rendered + "\n", encoding="utf-8")
++    finally:
++        if sampler is not None and sampler.is_alive:
++            sampler.stop()
++        if pool is not None:
++            pool.close()
++        dist.destroy_process_group()
++
++
++if __name__ == "__main__":
++    main()
+diff --git a/benchmarks/run_pcie_oneshot_control_node_ab.py b/benchmarks/run_pcie_oneshot_control_node_ab.py
+new file mode 100644
+index 0000000000000000000000000000000000000000..779c764ca47c841d9c826376fabd02ba27a959d4
+--- /dev/null
++++ b/benchmarks/run_pcie_oneshot_control_node_ab.py
+@@ -0,0 +1,840 @@
++"""Run repeated immutable AB/BA measurements with one external harness.
++
++The measurement script lives outside both implementation worktrees and is
++hashed into every record. Each pair reverses execution order (AB, then BA) to
++reduce monotonic thermal/clock drift. Raw records are schema- and
++contract-validated before the aggregate report is written.
++"""
++
++from __future__ import annotations
++
++import argparse
++import hashlib
++import json
++import math
++import os
++import signal
++import statistics
++import subprocess
++import sys
++from contextlib import suppress
++from pathlib import Path
++
++
++RUN_SCHEMA = {"name": "sparkinfer.pcie_oneshot_control_node.run", "version": 3}
++SUITE_SCHEMA = {"name": "sparkinfer.pcie_oneshot_control_node.ab_suite", "version": 3}
++RUN_TOP_LEVEL_KEYS = {
++    "schema",
++    "contract",
++    "scope",
++    "correctness",
++    "identity",
++    "provenance",
++    "software",
++    "hardware",
++    "environment",
++    "per_rank",
++    "distributed_critical_path",
++}
++CORRECTNESS_KEYS = {"verdict"}
++CONTRACT_KEYS = {
++    "world_size",
++    "numel",
++    "dtype",
++    "warmup",
++    "iters",
++    "preflight_replays",
++}
++SCOPE_KEYS = {
++    "operation",
++    "staging",
++    "size_bytes",
++    "comparison_semantics",
++    "excluded_paths",
++}
++METRICS = ("mean_us", "p50_us", "p95_us")
++IDENTITY_KEYS = {
++    "label",
++    "variant",
++    "run_index",
++    "implementation_root",
++    "implementation_git_sha",
++    "implementation_git_dirty",
++    "harness_sha256",
++    "controller_sha256",
++    "controller_argv_sha256",
++    "worker_argv",
++    "worker_argv_sha256",
++    "started_at_utc",
++}
++PROVENANCE_KEYS = {
++    "module_path",
++    "module_sha256",
++    "cuda_source_path",
++    "cuda_source_sha256",
++    "extension_path",
++    "extension_sha256",
++    "extension_build_root",
++    "extension_build_manifest",
++    "extension_build_manifest_sha256",
++    "fresh_extension_cache",
++    "post_run_verified",
++}
++SOFTWARE_KEYS = {
++    "python",
++    "platform",
++    "torch",
++    "torch_cuda",
++    "cuda_runtime_version",
++    "cuda_driver_version",
++    "nvcc_version",
++}
++HARDWARE_KEYS = {
++    "hostname",
++    "devices",
++    "nvidia_smi_identity",
++    "nvidia_smi_sample_fields",
++    "nvidia_smi_samples",
++    "nvidia_smi_topology",
++}
++METRIC_KEYS = {"cold_us", "mean_us", "p50_us", "p95_us", "min_us", "max_us"}
++RANK_MODE_KEYS = METRIC_KEYS | {"samples_us"}
++CRITICAL_MODE_KEYS = METRIC_KEYS | {"samples_us"}
++GRAPH_STRUCTURE_KEYS = {
++    "kernel_nodes",
++    "direct_control_worker_edge",
++    "control_grid",
++    "control_block",
++    "worker_grid",
++    "worker_block",
++}
++DEVICE_KEYS = {
++    "index",
++    "name",
++    "uuid",
++    "compute_capability",
++    "total_memory_bytes",
++    "multi_processor_count",
++}
++NVIDIA_QUERY_KEYS = {"fields", "returncode", "rows", "stderr"}
++NVIDIA_SAMPLE_KEYS = {"monotonic_ns", "phase", "query"}
++NVIDIA_TOPOLOGY_KEYS = {"returncode", "stdout", "stderr"}
++NVIDIA_IDENTITY_FIELDS = ["index", "uuid", "name", "driver_version"]
++NVIDIA_SMI_FIELDS = [
++    "index",
++    "uuid",
++    "name",
++    "driver_version",
++    "pstate",
++    "power.limit",
++    "power.draw",
++    "clocks.current.sm",
++    "clocks.current.memory",
++    "clocks.max.sm",
++    "clocks.max.memory",
++    "utilization.gpu",
++    "utilization.memory",
++    "temperature.gpu",
++    "clocks_event_reasons.active",
++]
++SUITE_TOP_LEVEL_KEYS = {
++    "schema",
++    "contract",
++    "controller",
++    "harness",
++    "implementations",
++    "sequence",
++    "records",
++    "paired_deltas",
++    "paired_summary",
++    "aggregate",
++}
++CONTROLLER_KEYS = {"source_path", "sha256", "argv", "argv_sha256"}
++HARNESS_KEYS = {
++    "source_path",
++    "frozen_path",
++    "sha256",
++    "identical_for_all_runs",
++}
++IMPLEMENTATION_KEYS = {"root", "git_sha"}
++
++
++def _parse_args() -> argparse.Namespace:
++    parser = argparse.ArgumentParser()
++    parser.add_argument("--baseline-worktree", type=Path, required=True)
++    parser.add_argument("--candidate-worktree", type=Path, required=True)
++    parser.add_argument("--pairs", type=int, default=4)
++    parser.add_argument("--world-size", type=int, default=4)
++    parser.add_argument(
++        "--numel",
++        type=int,
++        default=32768,
++        help="fixed at 32768 BF16 elements (64 KiB); other values are rejected",
++    )
++    parser.add_argument("--warmup", type=int, default=100)
++    parser.add_argument("--iters", type=int, default=1000)
++    parser.add_argument("--sampler-interval", type=float, default=0.2)
++    parser.add_argument("--preflight-replays", type=int, default=4)
++    parser.add_argument("--run-timeout-seconds", type=float, default=1800.0)
++    parser.add_argument("--distributed-timeout-seconds", type=float, default=300.0)
++    parser.add_argument("--output-dir", type=Path, required=True)
++    parser.add_argument("--output", type=Path, required=True)
++    parser.add_argument(
++        "--harness",
++        type=Path,
++        default=Path(__file__).with_name("benchmark_pcie_oneshot_control_node.py"),
++    )
++    return parser.parse_args()
++
++
++def _run(
++    args: list[str],
++    *,
++    cwd: Path | None = None,
++    env: dict[str, str] | None = None,
++    timeout: float = 60.0,
++) -> str:
++    process = subprocess.Popen(
++        args,
++        cwd=cwd,
++        env=env,
++        text=True,
++        stdout=subprocess.PIPE,
++        stderr=subprocess.STDOUT,
++        start_new_session=True,
++    )
++    try:
++        stdout, _ = process.communicate(timeout=timeout)
++    except subprocess.TimeoutExpired:
++        with suppress(ProcessLookupError):
++            os.killpg(process.pid, signal.SIGTERM)
++        try:
++            stdout, _ = process.communicate(timeout=10)
++        except subprocess.TimeoutExpired:
++            with suppress(ProcessLookupError):
++                os.killpg(process.pid, signal.SIGKILL)
++            stdout, _ = process.communicate()
++        raise TimeoutError(
++            f"command exceeded {timeout:.1f}s and its process group was terminated: "
++            f"{' '.join(args)}\n{stdout}"
++        ) from None
++    if process.returncode != 0:
++        raise RuntimeError(
++            f"command failed ({process.returncode}): {' '.join(args)}\n{stdout}"
++        )
++    return stdout.strip()
++
++
++def _git_sha(worktree: Path) -> str:
++    sha = _run(["git", "rev-parse", "HEAD"], cwd=worktree)
++    dirty = _run(["git", "status", "--porcelain=v1"], cwd=worktree)
++    if dirty:
++        raise ValueError(f"benchmark worktree is dirty: {worktree}\n{dirty}")
++    return sha
++
++
++def _sha256(path: Path) -> str:
++    digest = hashlib.sha256()
++    with path.open("rb") as handle:
++        for block in iter(lambda: handle.read(1024 * 1024), b""):
++            digest.update(block)
++    return digest.hexdigest()
++
++
++def _json_sha256(value: object) -> str:
++    rendered = json.dumps(
++        value,
++        sort_keys=True,
++        separators=(",", ":"),
++    ).encode("utf-8")
++    return hashlib.sha256(rendered).hexdigest()
++
++
++def _expected_contract(args: argparse.Namespace) -> dict[str, object]:
++    return {
++        "world_size": args.world_size,
++        "numel": args.numel,
++        "dtype": "bfloat16",
++        "warmup": args.warmup,
++        "iters": args.iters,
++        "preflight_replays": args.preflight_replays,
++    }
++
++
++def _summary(samples: list[float]) -> dict[str, float]:
++    if not samples:
++        raise ValueError("cannot summarize an empty latency vector")
++    ordered = sorted(float(value) for value in samples)
++
++    def percentile(fraction: float) -> float:
++        return ordered[max(0, math.ceil(fraction * len(ordered)) - 1)]
++
++    return {
++        "mean_us": sum(ordered) / len(ordered),
++        "p50_us": percentile(0.50),
++        "p95_us": percentile(0.95),
++        "min_us": ordered[0],
++        "max_us": ordered[-1],
++    }
++
++
++def _distributed_critical_path(
++    per_rank: list[dict[str, object]],
++) -> dict[str, object]:
++    result = {}
++    for mode in ("eager", "graph"):
++        vectors = [list(row[mode]["samples_us"]) for row in per_rank]
++        lengths = {len(vector) for vector in vectors}
++        if len(lengths) != 1 or not lengths or next(iter(lengths)) == 0:
++            raise ValueError(f"{mode} rank vectors are empty or misaligned")
++        critical = [
++            max(float(vector[index]) for vector in vectors)
++            for index in range(next(iter(lengths)))
++        ]
++        result[mode] = {
++            "cold_us": max(float(row[mode]["cold_us"]) for row in per_rank),
++            **_summary(critical),
++            "samples_us": critical,
++        }
++    return result
++
++
++def _validate_correctness(correctness: object) -> None:
++    if not isinstance(correctness, dict) or set(correctness) != CORRECTNESS_KEYS:
++        raise ValueError("run correctness schema mismatch")
++    if correctness["verdict"] != "pass":
++        raise ValueError(f"run correctness did not pass: {correctness}")
++
++
++def _validate_run(
++    record: dict[str, object],
++    *,
++    contract: dict[str, object],
++    variant: str,
++    sha: str,
++    run_index: int,
++    harness_sha256: str,
++    expected_nodes: int,
++    implementation_root: Path,
++    controller_sha256: str,
++    controller_argv_sha256: str,
++    extension_dir: Path,
++) -> None:
++    if set(record) != RUN_TOP_LEVEL_KEYS:
++        raise ValueError(f"run schema keys differ: {set(record) ^ RUN_TOP_LEVEL_KEYS}")
++    if record["schema"] != RUN_SCHEMA:
++        raise ValueError(f"run schema mismatch: {record['schema']}")
++    _validate_correctness(record["correctness"])
++    if set(record["contract"]) != CONTRACT_KEYS or record["contract"] != contract:
++        raise ValueError(f"run contract mismatch: {record['contract']} != {contract}")
++    scope = record["scope"]
++    if set(scope) != SCOPE_KEYS:
++        raise ValueError("run scope schema mismatch")
++    if (
++        scope["operation"] != "plain_oneshot_all_reduce"
++        or scope["staging"] != "double_buffered_eager_ipc"
++        or int(scope["size_bytes"]) != int(contract["numel"]) * 2
++        or "net algorithm" not in str(scope["comparison_semantics"]).lower()
++        or scope["excluded_paths"]
++        != ["fused_add_rms_norm", "twoshot_reduce_scatter", "twoshot_all_gather"]
++    ):
++        raise ValueError(f"run scope is too broad or malformed: {scope}")
++    identity = record["identity"]
++    if set(identity) != IDENTITY_KEYS:
++        raise ValueError("run identity schema mismatch")
++    expected_identity = {
++        "label": f"{variant}-{sha[:12]}-{run_index}",
++        "variant": variant,
++        "run_index": run_index,
++        "implementation_root": str(implementation_root),
++        "implementation_git_sha": sha,
++        "implementation_git_dirty": False,
++        "harness_sha256": harness_sha256,
++        "controller_sha256": controller_sha256,
++        "controller_argv_sha256": controller_argv_sha256,
++    }
++    for key, expected in expected_identity.items():
++        if identity[key] != expected:
++            raise ValueError(f"identity {key}={identity[key]!r}, expected {expected!r}")
++    if _json_sha256(identity["worker_argv"]) != identity["worker_argv_sha256"]:
++        raise ValueError("worker argv digest mismatch")
++    provenance = record["provenance"]
++    if set(provenance) != PROVENANCE_KEYS:
++        raise ValueError("run provenance schema mismatch")
++    expected_module = (
++        implementation_root / "sparkinfer/comm/pcie/pcie_oneshot.py"
++    ).resolve()
++    expected_source = expected_module.with_suffix(".cu")
++    if Path(provenance["module_path"]).resolve() != expected_module:
++        raise ValueError("run imported module does not belong to implementation root")
++    if Path(provenance["cuda_source_path"]).resolve() != expected_source:
++        raise ValueError("run CUDA source does not belong to implementation root")
++    if (
++        not Path(provenance["extension_path"])
++        .resolve()
++        .is_relative_to(extension_dir.resolve())
++    ):
++        raise ValueError("run extension binary is outside its fresh cache")
++    if not provenance["fresh_extension_cache"] or not provenance["post_run_verified"]:
++        raise ValueError("run extension provenance was not freshly post-verified")
++    for path_key, digest_key in (
++        ("module_path", "module_sha256"),
++        ("cuda_source_path", "cuda_source_sha256"),
++        ("extension_path", "extension_sha256"),
++    ):
++        if _sha256(Path(provenance[path_key])) != provenance[digest_key]:
++            raise ValueError(f"run {path_key} digest mismatch")
++    manifest = provenance["extension_build_manifest"]
++    if not isinstance(manifest, list) or not manifest:
++        raise ValueError("run extension build manifest is empty")
++    for entry in manifest:
++        if set(entry) != {"path", "size_bytes", "sha256"}:
++            raise ValueError("run extension manifest entry schema mismatch")
++    if _json_sha256(manifest) != provenance["extension_build_manifest_sha256"]:
++        raise ValueError("run extension build manifest digest mismatch")
++    if set(record["software"]) != SOFTWARE_KEYS:
++        raise ValueError("run software schema mismatch")
++    if set(record["hardware"]) != HARDWARE_KEYS:
++        raise ValueError("run hardware schema mismatch")
++    if not isinstance(record["environment"], dict):
++        raise ValueError("run environment must be an object")
++    if not isinstance(record["per_rank"], list) or len(record["per_rank"]) != int(
++        contract["world_size"]
++    ):
++        raise ValueError("run per-rank cardinality mismatch")
++    hardware = record["hardware"]
++    if not isinstance(hardware["devices"], list) or not hardware["devices"]:
++        raise ValueError("run device inventory must be a non-empty list")
++    for device in hardware["devices"]:
++        if set(device) != DEVICE_KEYS:
++            raise ValueError("run device schema mismatch")
++    identity_query = hardware["nvidia_smi_identity"]
++    if set(identity_query) != NVIDIA_QUERY_KEYS:
++        raise ValueError("run NVIDIA identity schema mismatch")
++    if identity_query["fields"] != NVIDIA_IDENTITY_FIELDS:
++        raise ValueError("run NVIDIA identity field contract mismatch")
++    if identity_query["returncode"] != 0:
++        raise ValueError(f"run NVIDIA identity query failed: {identity_query}")
++    if len(identity_query["rows"]) != len(hardware["devices"]):
++        raise ValueError("run NVIDIA identity/device cardinality mismatch")
++    if any(len(row) != len(NVIDIA_IDENTITY_FIELDS) for row in identity_query["rows"]):
++        raise ValueError("run NVIDIA identity row schema mismatch")
++    if hardware["nvidia_smi_sample_fields"] != NVIDIA_SMI_FIELDS:
++        raise ValueError("run NVIDIA sample field contract mismatch")
++    if (
++        not isinstance(hardware["nvidia_smi_samples"], list)
++        or not hardware["nvidia_smi_samples"]
++    ):
++        raise ValueError("run NVIDIA samples must be a non-empty list")
++    successful_samples = 0
++    successful_phases: set[str] = set()
++    for sample in hardware["nvidia_smi_samples"]:
++        if set(sample) != NVIDIA_SAMPLE_KEYS:
++            raise ValueError("run NVIDIA sample schema mismatch")
++        if set(sample["query"]) != NVIDIA_QUERY_KEYS:
++            raise ValueError("run NVIDIA sample query schema mismatch")
++        if sample["query"]["fields"] != NVIDIA_SMI_FIELDS:
++            raise ValueError("run NVIDIA sample query field mismatch")
++        if sample["query"]["returncode"] == 0:
++            successful_samples += 1
++            if not sample["query"]["rows"]:
++                raise ValueError("successful NVIDIA sample has zero rows")
++            successful_phases.add(str(sample["phase"]))
++            if any(
++                len(row) != len(NVIDIA_SMI_FIELDS) for row in sample["query"]["rows"]
++            ):
++                raise ValueError("run NVIDIA sample row schema mismatch")
++            if len(sample["query"]["rows"]) != len(hardware["devices"]):
++                raise ValueError("run NVIDIA sample/device cardinality mismatch")
++    if successful_samples == 0:
++        raise ValueError("run collected no successful NVIDIA telemetry samples")
++    required_phases = {"mutating_preflight", "eager_timing", "graph_timing"}
++    if not required_phases <= successful_phases:
++        raise ValueError(
++            f"run lacks successful phase telemetry: {required_phases - successful_phases}"
++        )
++    topology = hardware["nvidia_smi_topology"]
++    if set(topology) != NVIDIA_TOPOLOGY_KEYS:
++        raise ValueError("run NVIDIA topology schema mismatch")
++    if topology["returncode"] != 0 or not topology["stdout"]:
++        raise ValueError(f"run NVIDIA topology query failed: {topology}")
++    for row in record["per_rank"]:
++        if set(row) != {"rank", "eager", "graph", "graph_structure"}:
++            raise ValueError("run per-rank schema mismatch")
++        if set(row["eager"]) != RANK_MODE_KEYS:
++            raise ValueError("run per-rank eager metric schema mismatch")
++        if set(row["graph"]) != RANK_MODE_KEYS:
++            raise ValueError("run per-rank graph metric schema mismatch")
++        for mode in ("eager", "graph"):
++            samples = row[mode]["samples_us"]
++            if not isinstance(samples, list) or len(samples) != int(contract["iters"]):
++                raise ValueError(f"run per-rank {mode} sample length mismatch")
++            if any(
++                not math.isfinite(float(value)) or float(value) <= 0
++                for value in samples
++            ):
++                raise ValueError(f"run per-rank {mode} samples are invalid")
++            expected_summary = _summary(samples)
++            for key, expected in expected_summary.items():
++                if float(row[mode][key]) != expected:
++                    raise ValueError(f"run per-rank {mode} {key} mismatch")
++        structure = row["graph_structure"]
++        if set(structure) != GRAPH_STRUCTURE_KEYS:
++            raise ValueError("run graph structure schema mismatch")
++        if int(structure["kernel_nodes"]) != expected_nodes:
++            raise ValueError("observed graph-node count differs across ranks")
++        if expected_nodes == 2:
++            if (
++                structure["direct_control_worker_edge"] is not True
++                or structure["control_grid"] != [1, 1, 1]
++                or structure["control_block"] != [1, 1, 1]
++            ):
++                raise ValueError("candidate graph lacks direct <<<1,1>>> control edge")
++        elif (
++            structure["direct_control_worker_edge"] is not False
++            or structure["control_grid"] is not None
++            or structure["control_block"] is not None
++        ):
++            raise ValueError("baseline graph unexpectedly records a control node")
++    if {int(row["rank"]) for row in record["per_rank"]} != set(
++        range(int(contract["world_size"]))
++    ):
++        raise ValueError("run rank identities do not match world size")
++    critical_path = record["distributed_critical_path"]
++    if set(critical_path) != {"eager", "graph"}:
++        raise ValueError("run distributed critical-path mode schema mismatch")
++    for mode in ("eager", "graph"):
++        if set(critical_path[mode]) != CRITICAL_MODE_KEYS:
++            raise ValueError(f"run distributed {mode} schema mismatch")
++    if critical_path != _distributed_critical_path(record["per_rank"]):
++        raise ValueError("run critical path is not the aligned per-iteration rank MAX")
++
++
++def _outside_worktrees(path: Path, roots: tuple[Path, ...], label: str) -> Path:
++    resolved = path.resolve()
++    for root in roots:
++        if resolved == root or resolved.is_relative_to(root):
++            raise ValueError(f"{label} must be outside measured worktree {root}")
++    return resolved
++
++
++def _stable_environment(record: dict[str, object]) -> dict[str, object]:
++    environment = dict(record["environment"])
++    environment.pop("TORCH_EXTENSIONS_DIR", None)
++    return environment
++
++
++def _stable_hardware(record: dict[str, object]) -> dict[str, object]:
++    hardware = record["hardware"]
++    return {
++        "hostname": hardware["hostname"],
++        "devices": hardware["devices"],
++        "nvidia_smi_identity": hardware["nvidia_smi_identity"],
++        "nvidia_smi_sample_fields": hardware["nvidia_smi_sample_fields"],
++        "nvidia_smi_topology": hardware["nvidia_smi_topology"],
++    }
++
++
++def _paired_deltas(records: list[dict[str, object]]) -> list[dict[str, object]]:
++    deltas = []
++    for pair_index in range(len(records) // 2):
++        pair = records[2 * pair_index : 2 * pair_index + 2]
++        by_variant = {record["identity"]["variant"]: record for record in pair}
++        if set(by_variant) != {"baseline", "candidate"}:
++            raise ValueError(f"pair {pair_index} does not contain one A and one B")
++        delta = {"pair_index": pair_index, "metrics": {}}
++        for mode in ("eager", "graph"):
++            delta["metrics"][mode] = {}
++            for metric in METRICS:
++                before = float(
++                    by_variant["baseline"]["distributed_critical_path"][mode][metric]
++                )
++                after = float(
++                    by_variant["candidate"]["distributed_critical_path"][mode][metric]
++                )
++                delta["metrics"][mode][metric] = {
++                    "baseline_us": before,
++                    "candidate_us": after,
++                    "delta_us": after - before,
++                    "delta_percent": (after / before - 1) * 100,
++                }
++        deltas.append(delta)
++    return deltas
++
++
++def _paired_summary(deltas: list[dict[str, object]]) -> dict[str, object]:
++    """Descriptive paired uncertainty; this harness makes no significance claim."""
++
++    result = {}
++    for mode in ("eager", "graph"):
++        result[mode] = {}
++        for metric in METRICS:
++            values = [
++                float(delta["metrics"][mode][metric]["delta_us"]) for delta in deltas
++            ]
++            mean = statistics.mean(values)
++            stdev = statistics.stdev(values) if len(values) > 1 else 0.0
++            margin = 1.96 * stdev / math.sqrt(len(values)) if len(values) > 1 else None
++            result[mode][metric] = {
++                "pairs": len(values),
++                "mean_delta_us": mean,
++                "sample_stdev_us": stdev,
++                "normal_approx_95ci_us": [mean - margin, mean + margin]
++                if margin is not None
++                else None,
++                "interpretation": "descriptive_only",
++            }
++    return result
++
++
++def _aggregate(records: list[dict[str, object]]) -> dict[str, object]:
++    result = {}
++    for variant in ("baseline", "candidate"):
++        variant_records = [
++            record for record in records if record["identity"]["variant"] == variant
++        ]
++        result[variant] = {}
++        for mode in ("eager", "graph"):
++            result[variant][mode] = {}
++            for metric in METRICS:
++                values = [
++                    float(record["distributed_critical_path"][mode][metric])
++                    for record in variant_records
++                ]
++                result[variant][mode][metric] = {
++                    "mean_us": statistics.mean(values),
++                    "median_us": statistics.median(values),
++                    "min_us": min(values),
++                    "max_us": max(values),
++                }
++    return result
++
++
++def main() -> None:
++    args = _parse_args()
++    if (
++        args.pairs <= 0
++        or args.world_size <= 0
++        or args.numel != 32768
++        or args.warmup < 0
++        or args.iters <= 0
++        or args.sampler_interval <= 0
++        or args.preflight_replays < 4
++        or args.run_timeout_seconds <= 0
++        or args.distributed_timeout_seconds <= 0
++    ):
++        raise ValueError(
++            "invalid A/B contract: this harness is scoped to 32,768 BF16 "
++            "elements (64 KiB) and requires positive timeouts/iterations plus "
++            "at least four mutating preflight replays"
++        )
++    controller_path = Path(__file__).resolve()
++    controller_sha256 = _sha256(controller_path)
++    controller_argv = list(sys.argv)
++    controller_argv_sha256 = _json_sha256(controller_argv)
++    baseline_root = args.baseline_worktree.resolve()
++    candidate_root = args.candidate_worktree.resolve()
++    roots = (baseline_root, candidate_root)
++    if baseline_root == candidate_root:
++        raise ValueError("baseline and candidate worktrees must differ")
++    output_dir = _outside_worktrees(args.output_dir, roots, "output directory")
++    output = _outside_worktrees(args.output, roots, "suite output")
++    harness_source = _outside_worktrees(args.harness, roots, "harness")
++    if not harness_source.is_file():
++        raise ValueError(f"harness does not exist: {harness_source}")
++    baseline_sha = _git_sha(baseline_root)
++    candidate_sha = _git_sha(candidate_root)
++    if baseline_sha == candidate_sha:
++        raise ValueError("baseline and candidate Git SHAs must differ")
++    harness_sha256 = _sha256(harness_source)
++    contract = _expected_contract(args)
++    output_dir.mkdir(parents=True, exist_ok=True)
++    harness = output_dir / f"harness-{harness_sha256[:16]}.py"
++    harness_bytes = harness_source.read_bytes()
++    if harness.exists() and harness.read_bytes() != harness_bytes:
++        raise ValueError(f"frozen harness collision at {harness}")
++    if not harness.exists():
++        harness.write_bytes(harness_bytes)
++    if _sha256(harness) != harness_sha256:
++        raise ValueError("frozen harness hash differs from source harness")
++
++    variants = {
++        "baseline": {
++            "root": baseline_root,
++            "sha": baseline_sha,
++            "expected_nodes": 1,
++        },
++        "candidate": {
++            "root": candidate_root,
++            "sha": candidate_sha,
++            "expected_nodes": 2,
++        },
++    }
++    records = []
++    sequence = []
++    for pair_index in range(args.pairs):
++        order = (
++            ("baseline", "candidate")
++            if pair_index % 2 == 0
++            else ("candidate", "baseline")
++        )
++        for variant in order:
++            run_index = len(sequence)
++            sequence.append(variant)
++            config = variants[variant]
++            raw_path = output_dir / f"{run_index:02d}-{variant}.json"
++            extension_dir = (
++                output_dir
++                / "torch-extensions"
++                / f"{run_index:02d}-{variant}-{config['sha'][:12]}"
++            )
++            extension_dir.parent.mkdir(parents=True, exist_ok=True)
++            extension_dir.mkdir(exist_ok=False)
++            env = dict(os.environ)
++            existing_pythonpath = env.get("PYTHONPATH")
++            env["PYTHONPATH"] = str(config["root"]) + (
++                os.pathsep + existing_pythonpath if existing_pythonpath else ""
++            )
++            env["TORCH_EXTENSIONS_DIR"] = str(extension_dir)
++            command = [
++                sys.executable,
++                "-m",
++                "torch.distributed.run",
++                "--standalone",
++                f"--nproc-per-node={args.world_size}",
++                str(harness),
++                "--label",
++                f"{variant}-{config['sha'][:12]}-{run_index}",
++                "--variant",
++                variant,
++                "--run-index",
++                str(run_index),
++                "--implementation-root",
++                str(config["root"]),
++                "--expected-git-sha",
++                config["sha"],
++                "--expected-graph-kernel-nodes",
++                str(config["expected_nodes"]),
++                "--numel",
++                str(args.numel),
++                "--warmup",
++                str(args.warmup),
++                "--iters",
++                str(args.iters),
++                "--sampler-interval",
++                str(args.sampler_interval),
++                "--preflight-replays",
++                str(args.preflight_replays),
++                "--distributed-timeout-seconds",
++                str(args.distributed_timeout_seconds),
++                "--controller-sha256",
++                controller_sha256,
++                "--controller-argv-sha256",
++                controller_argv_sha256,
++                "--output",
++                str(raw_path),
++            ]
++            print(
++                f"[{run_index + 1}/{2 * args.pairs}] {variant} {config['sha'][:12]}",
++                flush=True,
++            )
++            _run(
++                command,
++                cwd=config["root"],
++                env=env,
++                timeout=args.run_timeout_seconds,
++            )
++            record = json.loads(raw_path.read_text(encoding="utf-8"))
++            _validate_run(
++                record,
++                contract=contract,
++                variant=variant,
++                sha=config["sha"],
++                run_index=run_index,
++                harness_sha256=harness_sha256,
++                expected_nodes=config["expected_nodes"],
++                implementation_root=config["root"],
++                controller_sha256=controller_sha256,
++                controller_argv_sha256=controller_argv_sha256,
++                extension_dir=extension_dir,
++            )
++            records.append(record)
++
++    software_fingerprints = {
++        json.dumps(record["software"], sort_keys=True) for record in records
++    }
++    hardware_fingerprints = {
++        json.dumps(_stable_hardware(record), sort_keys=True) for record in records
++    }
++    environment_fingerprints = {
++        json.dumps(_stable_environment(record), sort_keys=True) for record in records
++    }
++    if len(software_fingerprints) != 1:
++        raise ValueError("software stack changed during alternating A/B suite")
++    if len(hardware_fingerprints) != 1:
++        raise ValueError(
++            "hardware/driver/topology changed during alternating A/B suite"
++        )
++    if len(environment_fingerprints) != 1:
++        raise ValueError("environment toggles changed during alternating A/B suite")
++
++    paired_deltas = _paired_deltas(records)
++    suite = {
++        "schema": SUITE_SCHEMA,
++        "contract": contract,
++        "controller": {
++            "source_path": str(controller_path),
++            "sha256": controller_sha256,
++            "argv": controller_argv,
++            "argv_sha256": controller_argv_sha256,
++        },
++        "harness": {
++            "source_path": str(harness_source),
++            "frozen_path": str(harness),
++            "sha256": harness_sha256,
++            "identical_for_all_runs": True,
++        },
++        "implementations": {
++            "baseline": {"root": str(baseline_root), "git_sha": baseline_sha},
++            "candidate": {"root": str(candidate_root), "git_sha": candidate_sha},
++        },
++        "sequence": sequence,
++        "records": records,
++        "paired_deltas": paired_deltas,
++        "paired_summary": _paired_summary(paired_deltas),
++        "aggregate": _aggregate(records),
++    }
++    if set(suite) != SUITE_TOP_LEVEL_KEYS:
++        raise ValueError("suite top-level schema mismatch")
++    if suite["schema"] != SUITE_SCHEMA or suite["contract"] != contract:
++        raise ValueError("suite identity/contract mismatch")
++    if set(suite["controller"]) != CONTROLLER_KEYS:
++        raise ValueError("suite controller schema mismatch")
++    if (
++        _sha256(Path(suite["controller"]["source_path"]))
++        != suite["controller"]["sha256"]
++    ):
++        raise ValueError("suite controller source digest mismatch")
++    if _json_sha256(suite["controller"]["argv"]) != suite["controller"]["argv_sha256"]:
++        raise ValueError("suite controller argv digest mismatch")
++    if set(suite["harness"]) != HARNESS_KEYS:
++        raise ValueError("suite harness schema mismatch")
++    if set(suite["implementations"]) != {"baseline", "candidate"}:
++        raise ValueError("suite implementation variants mismatch")
++    for implementation in suite["implementations"].values():
++        if set(implementation) != IMPLEMENTATION_KEYS:
++            raise ValueError("suite implementation schema mismatch")
++    if len(suite["sequence"]) != args.pairs * 2:
++        raise ValueError("suite sequence cardinality mismatch")
++    if len(suite["records"]) != args.pairs * 2:
++        raise ValueError("suite record cardinality mismatch")
++    if len(suite["paired_deltas"]) != args.pairs:
++        raise ValueError("suite paired-delta cardinality mismatch")
++    rendered = json.dumps(suite, indent=2, sort_keys=True)
++    output.parent.mkdir(parents=True, exist_ok=True)
++    output.write_text(rendered + "\n", encoding="utf-8")
++    print(rendered, flush=True)
++
++
++if __name__ == "__main__":
++    main()
+diff --git a/pyproject.toml b/pyproject.toml
+index ddf85f611aec805c627b376093ab23e8875048bb..6ee2c0abd43cd2bacfff67078f2b4c11c6f53574 100644
+--- a/pyproject.toml
++++ b/pyproject.toml
+@@ -39,7 +39,7 @@ where = ["."]
+ include = ["sparkinfer*"]
+ 
+ [tool.setuptools.package-data]
+-"sparkinfer.comm.pcie" = ["*.cu"]
++"sparkinfer.comm.pcie" = ["*.cu", "*.h"]
+ 
+ [tool.ruff.lint]
+ select = ["E", "F", "B", "SIM"]
+diff --git a/sparkinfer/_lib/compiler.py b/sparkinfer/_lib/compiler.py
+index 3357d377d044a3450d87f2e384aa831c7a3b8256..9bba8af21c6a6cc27e164aadee9a1d1f3275292b 100644
+--- a/sparkinfer/_lib/compiler.py
++++ b/sparkinfer/_lib/compiler.py
+@@ -2648,6 +2648,15 @@ def compile(
+     compiled = _memory_cache_get(memory_cache_key)
+     if compiled is not None:
+         return compiled
++    from sparkinfer._lib.runtime_control import (
++        raise_if_kernel_resolution_frozen,
++    )
++
++    raise_if_kernel_resolution_frozen(
++        "cute.compile",
++        target=func,
++        cache_key=compile_spec if compile_spec is not None else memory_cache_key,
++    )
+ 
+     post_engine_start_log = _cute_compile_post_engine_start_log_enabled()
+     payload = _compile_disk_cache_payload(
+@@ -2720,15 +2729,6 @@ def compile(
+ 
+             with _MEMORY_CACHE_LOCK:
+                 _COMPILE_MISSES += 1
+-            from sparkinfer._lib.runtime_control import (
+-                raise_if_kernel_resolution_frozen,
+-            )
+-
+-            raise_if_kernel_resolution_frozen(
+-                "cute.compile",
+-                target=func,
+-                cache_key=compile_spec if compile_spec is not None else payload,
+-            )
+             call_kwargs = {
+                 k: v for k, v in kwargs.items() if k != "__dsl_compile_options_key"
+             }
+@@ -2770,15 +2770,6 @@ def compile(
+ 
+     with _MEMORY_CACHE_LOCK:
+         _COMPILE_MISSES += 1
+-    from sparkinfer._lib.runtime_control import (
+-        raise_if_kernel_resolution_frozen,
+-    )
+-
+-    raise_if_kernel_resolution_frozen(
+-        "cute.compile",
+-        target=func,
+-        cache_key=compile_spec if compile_spec is not None else payload,
+-    )
+     call_kwargs = {k: v for k, v in kwargs.items() if k != "__dsl_compile_options_key"}
+     compiled = _call_cute_compile(
+         compile_callable,
+diff --git a/sparkinfer/_lib/intrinsics.py b/sparkinfer/_lib/intrinsics.py
+index f14efcac68ec37f38b3f09ee96902874be742c5f..474a8f16275c93794a419518732c639496f88891 100644
+--- a/sparkinfer/_lib/intrinsics.py
++++ b/sparkinfer/_lib/intrinsics.py
+@@ -423,9 +423,7 @@ def elem_pointer(x: cute.Tensor, coord, *, loc=None, ip=None) -> cute.Pointer:
+ 
+ 
+ @dsl_user_op
+-def ld_global_v2_u32(
+-    base_ptr: Int64, *, loc=None, ip=None
+-) -> Tuple[Uint32, Uint32]:
++def ld_global_v2_u32(base_ptr: Int64, *, loc=None, ip=None) -> Tuple[Uint32, Uint32]:
+     """Load 64 bits (2 x uint32) from coherent global memory."""
+     result = llvm.inline_asm(
+         llvm.StructType.get_literal([T.i32(), T.i32()]),
+@@ -6230,6 +6228,47 @@ def _trellis_mcg_asm_constants(asm: str) -> str:
+     )
+ 
+ 
++@dsl_user_op
++def trellis_align_stream_u32x2(z0, z1, z2, shift, word_delta, *, loc=None, ip=None):
++    """Align two words from a two- or three-word circular Trellis span.
++
++    This is the 32-bit SHF equivalent of shifting a temporary 64/96-bit integer.
++    Keeping the operation on the native integer pipe avoids compiler-generated
++    wide-integer carry chains in the K6 dequantization hot loop.
++    """
++    result = llvm.inline_asm(
++        llvm.StructType.get_literal([T.i32(), T.i32()]),
++        [
++            Uint32(z0).ir_value(loc=loc, ip=ip),
++            Uint32(z1).ir_value(loc=loc, ip=ip),
++            Uint32(z2).ir_value(loc=loc, ip=ip),
++            Uint32(shift).ir_value(loc=loc, ip=ip),
++            Uint32(word_delta).ir_value(loc=loc, ip=ip),
++        ],
++        """
++        {
++            .reg .pred two_words;
++            .reg .b32 mid, upper;
++            setp.eq.u32 two_words, $6, 1;
++            selp.b32 mid, $2, $3, two_words;
++            selp.b32 upper, 0, $2, two_words;
++            // PTX shf.r forms (b:a), so z0/mid and mid/upper are low/high.
++            shf.r.wrap.b32 $0, $4, mid, $5;
++            shf.r.wrap.b32 $1, mid, upper, $5;
++        }
++        """,
++        "=r,=r,r,r,r,r,r",
++        has_side_effects=False,
++        is_align_stack=False,
++        asm_dialect=llvm.AsmDialect.AD_ATT,
++        loc=loc,
++        ip=ip,
++    )
++    lo = llvm.extractvalue(T.i32(), result, [0], loc=loc, ip=ip)
++    hi = llvm.extractvalue(T.i32(), result, [1], loc=loc, ip=ip)
++    return Uint32(lo), Uint32(hi)
++
++
+ @dsl_user_op
+ def packed_dequant_trellis_to_half2x4(
+     win_a, win_b, bits: int = 3, *, loc=None, ip=None
+diff --git a/sparkinfer/attention/_shared/mla/compressed_api.py b/sparkinfer/attention/_shared/mla/compressed_api.py
+index ba7e57736b70f4d97ed95289ceb74b159e37a4f6..4136b59bd67739009d8f4ba4480a0ed420ea77b4 100644
+--- a/sparkinfer/attention/_shared/mla/compressed_api.py
++++ b/sparkinfer/attention/_shared/mla/compressed_api.py
+@@ -16,6 +16,7 @@ from .compressed_config import (
+     compressed_mla_split_chunks_for_contract,
+ )
+ from .compressed_reference import (
++    COMPRESSED_MLA_BYTES_PER_TOKEN,
+     COMPRESSED_MLA_DSV4_PAGE_SIZE,
+     COMPRESSED_MLA_HEAD_DIM,
+     compressed_mla_page_nbytes,
+@@ -523,11 +524,14 @@ def _validate_compressed_cache_layout(
+     page_size = int(page_size)
+     if page_size <= 0:
+         raise ValueError(f"{name} page_size must be positive, got {page_size}")
+-    expected_page_nbytes = compressed_mla_page_nbytes(page_size)
+-    if int(cache.shape[1]) != expected_page_nbytes:
++    payload_nbytes = page_size * COMPRESSED_MLA_BYTES_PER_TOKEN
++    padded_page_nbytes = compressed_mla_page_nbytes(page_size)
++    page_nbytes = int(cache.shape[1])
++    if page_nbytes not in (payload_nbytes, padded_page_nbytes):
+         raise ValueError(
+-            f"{name} page byte width must be {expected_page_nbytes} for page_size "
+-            f"{page_size}, got {int(cache.shape[1])}"
++            f"{name} page byte width must be the contiguous payload "
++            f"{payload_nbytes} or padded width {padded_page_nbytes} for "
++            f"page_size {page_size}, got {page_nbytes}"
+         )
+ 
+ 
+diff --git a/sparkinfer/attention/_shared/mla/compressed_reference.py b/sparkinfer/attention/_shared/mla/compressed_reference.py
+index ab21b4607b3ad863b8d1c7730f9eef68b16cbbea..07f3a655bd279d95f8ad4830bdd96d08d402ffbb 100644
+--- a/sparkinfer/attention/_shared/mla/compressed_reference.py
++++ b/sparkinfer/attention/_shared/mla/compressed_reference.py
+@@ -5,10 +5,11 @@ vector, a 64-dimension BF16 RoPE vector, and seven UE8M0 scale bytes for the
+ noPE groups.  Within each page the token payloads are packed first, followed by
+ the per-token scale region:
+ 
+-    [page_size * 576 payload bytes][page_size * 8 scale bytes][padding]
++    [page_size * 576 payload bytes][page_size * 8 scale bytes][optional padding]
+ 
+-The padding rounds page byte size up to a 576-byte multiple, matching the
+-SGLang memory-pool contract.
++SGLang rounds the page byte size up to a 576-byte multiple. vLLM may instead
++use a contiguous allocation whose page stride ends immediately after the scale
++region. Both layouts contain the same compressed-MLA payload.
+ """
+ 
+ from __future__ import annotations
+diff --git a/sparkinfer/attention/_shared/mla/kernel.py b/sparkinfer/attention/_shared/mla/kernel.py
+index 0568a3cd6ac442d6d28ed26e3a59b07e1d486ccf..108d87842a620189aa5670f2d97eb2edb6ba5874 100644
+--- a/sparkinfer/attention/_shared/mla/kernel.py
++++ b/sparkinfer/attention/_shared/mla/kernel.py
+@@ -2319,7 +2319,7 @@ def _cache_block_stride_bytes(
+     record_bytes: int | None = None,
+ ) -> int:
+     from sparkinfer.attention._shared.mla.compressed_reference import (
+-        compressed_mla_page_nbytes,
++        COMPRESSED_MLA_BYTES_PER_TOKEN,
+     )
+ 
+     if int(model_type) == int(ModelType.GLM_NSA):
+@@ -2328,12 +2328,9 @@ def _cache_block_stride_bytes(
+         rec = int(record_bytes) if record_bytes is not None else _GLM_KV_GMEM_STRIDE
+         expected = int(page_size) * rec
+     else:
+-        expected = int(compressed_mla_page_nbytes(int(page_size)))
+-    # Contiguous inputs are flattened before launch, so their original rank is
+-    # not a physical-layout contract and the standard page stride applies.
+-    # Packed vLLM page views are non-contiguous and carry the physical
+-    # per-block stride in dimension 0.
+-    if not cache.is_contiguous() and cache.ndim >= 2:
++        expected = int(page_size) * COMPRESSED_MLA_BYTES_PER_TOKEN
++    # Use the tensor's physical page stride for exact-payload and padded views.
++    if cache.ndim >= 2:
+         stride = int(cache.stride(0)) * int(cache.element_size())
+         if stride < expected:
+             raise ValueError(
+diff --git a/sparkinfer/attention/_shared/mla/prefill.py b/sparkinfer/attention/_shared/mla/prefill.py
+index b5f396fc1a6758009dc82c247e08d5766fe85118..87bff79dc0f9583b4a43621fae3b34d3ee5e6f11 100644
+--- a/sparkinfer/attention/_shared/mla/prefill.py
++++ b/sparkinfer/attention/_shared/mla/prefill.py
+@@ -48,7 +48,7 @@ def _cache_block_stride_bytes(
+     record_bytes: int | None = None,
+ ) -> int:
+     from sparkinfer.attention._shared.mla.compressed_reference import (
+-        compressed_mla_page_nbytes,
++        COMPRESSED_MLA_BYTES_PER_TOKEN,
+     )
+ 
+     if model_type == ModelType.GLM_NSA:
+@@ -57,12 +57,10 @@ def _cache_block_stride_bytes(
+         rec = int(record_bytes) if record_bytes is not None else _GLM_KV_GMEM_STRIDE
+         expected = int(page_size) * rec
+     else:
+-        expected = int(compressed_mla_page_nbytes(int(page_size)))
+-    # Contiguous inputs are flattened before launch, so their original rank is
+-    # not a physical-layout contract and the standard page stride applies.
+-    # Only packed, non-contiguous vLLM views preserve a real per-block stride in
+-    # dimension 0.
+-    if not cache.is_contiguous() and cache.ndim >= 2:
++        expected = int(page_size) * COMPRESSED_MLA_BYTES_PER_TOKEN
++    # The runtime page stride is part of the cache contract. It can be either
++    # the exact payload width or a larger packed/padded stride.
++    if cache.ndim >= 2:
+         stride = int(cache.stride(0)) * int(cache.element_size())
+         if stride < expected:
+             raise ValueError(
+diff --git a/sparkinfer/attention/_shared/mla/prefill_mg.py b/sparkinfer/attention/_shared/mla/prefill_mg.py
+index ea0f8987374dc5b918a9ad071fd0fcb1b5efd619..ac3edde5e3dfd114018943cc6452749d4b8459ce 100644
+--- a/sparkinfer/attention/_shared/mla/prefill_mg.py
++++ b/sparkinfer/attention/_shared/mla/prefill_mg.py
+@@ -198,7 +198,7 @@ def _cache_block_stride_bytes(
+     record_bytes: int | None = None,
+ ) -> int:
+     from sparkinfer.attention._shared.mla.compressed_reference import (
+-        compressed_mla_page_nbytes,
++        COMPRESSED_MLA_BYTES_PER_TOKEN,
+     )
+ 
+     if is_glm:
+@@ -207,12 +207,9 @@ def _cache_block_stride_bytes(
+         rec = int(record_bytes) if record_bytes is not None else _GLM_IO_STRIDE
+         expected = int(page_size) * rec
+     else:
+-        expected = int(compressed_mla_page_nbytes(int(page_size)))
+-    # Contiguous inputs are flattened before launch, so their original rank is
+-    # not a physical-layout contract and the standard page stride applies.
+-    # Packed vLLM page views are non-contiguous and carry the physical
+-    # per-block stride in dimension 0.
+-    if not cache.is_contiguous() and cache.ndim >= 2:
++        expected = int(page_size) * COMPRESSED_MLA_BYTES_PER_TOKEN
++    # Use the tensor's physical page stride for exact-payload and padded views.
++    if cache.ndim >= 2:
+         stride = int(cache.stride(0)) * int(cache.element_size())
+         if stride < expected:
+             raise ValueError(
+diff --git a/sparkinfer/comm/pcie/ipc_handle_registry.h b/sparkinfer/comm/pcie/ipc_handle_registry.h
+new file mode 100644
+index 0000000000000000000000000000000000000000..2f141a3f0b2e2b724226099ed2e20ba13f4ad7ce
+--- /dev/null
++++ b/sparkinfer/comm/pcie/ipc_handle_registry.h
+@@ -0,0 +1,66 @@
++#pragma once
++
++#include <map>
++#include <utility>
++
++namespace sparkinfer::pcie {
++
++// Owns imported IPC handles whose close routine reports an error code instead
++// of throwing. Successful closes clear their entries so repeated cleanup is
++// idempotent; failed entries remain available to an explicit retry.
++template <typename Key, typename Handle, typename Error, Error Success>
++class IpcHandleRegistry {
++ public:
++  using CloseFn = Error (*)(Handle) noexcept;
++  using Map = std::map<Key, Handle>;
++  using iterator = typename Map::iterator;
++
++  explicit IpcHandleRegistry(CloseFn close) noexcept : close_(close) {}
++
++  IpcHandleRegistry(const IpcHandleRegistry&) = delete;
++  IpcHandleRegistry& operator=(const IpcHandleRegistry&) = delete;
++  IpcHandleRegistry(IpcHandleRegistry&&) = delete;
++  IpcHandleRegistry& operator=(IpcHandleRegistry&&) = delete;
++
++  ~IpcHandleRegistry() noexcept {
++    (void)close_all_noexcept();
++  }
++
++  iterator find(const Key& key) {
++    return handles_.find(key);
++  }
++
++  iterator end() {
++    return handles_.end();
++  }
++
++  std::pair<iterator, bool> emplace(const Key& key, Handle handle) {
++    return handles_.emplace(key, handle);
++  }
++
++  Error close_all_noexcept() noexcept {
++    Error first_error = Success;
++    for (auto it = handles_.begin(); it != handles_.end();) {
++      if (it->second == Handle{}) {
++        it = handles_.erase(it);
++        continue;
++      }
++      const Error error = close_(it->second);
++      if (error == Success) {
++        it = handles_.erase(it);
++      } else {
++        if (first_error == Success) {
++          first_error = error;
++        }
++        ++it;
++      }
++    }
++    return first_error;
++  }
++
++ private:
++  Map handles_;
++  CloseFn close_;
++};
++
++}  // namespace sparkinfer::pcie
+diff --git a/sparkinfer/comm/pcie/pcie_dcp_a2a.cu b/sparkinfer/comm/pcie/pcie_dcp_a2a.cu
+index 2458198a8bf422ff4b37e6c92708fec504026b8d..b8ddf871a43a2cd48ef8e8e2c2e41ba9c075b032 100644
+--- a/sparkinfer/comm/pcie/pcie_dcp_a2a.cu
++++ b/sparkinfer/comm/pcie/pcie_dcp_a2a.cu
+@@ -20,6 +20,7 @@
+ #include <algorithm>
+ #include <array>
+ #include <cmath>
++#include <cstdint>
+ #include <cstdlib>
+ #include <sstream>
+ #include <stdexcept>
+@@ -65,7 +66,20 @@ static int dcp_block_limit_override() {
+   return value;
+ }
+ 
++static int dcp_test_delay_rank() {
++  static const int value = env_int("SPARKINFER_PCIE_DCP_TEST_DELAY_RANK", -1);
++  return value;
++}
++
++static uint64_t dcp_test_delay_cycles() {
++  static const uint64_t value = static_cast<uint64_t>(std::max(
++      0, env_int("SPARKINFER_PCIE_DCP_TEST_POST_BARRIER_DELAY_CYCLES", 0)));
++  return value;
++}
++
+ struct Signal {
++  alignas(128) FlagType staging_generation;
++  FlagType active_staging_slot;
+   alignas(128) FlagType self_counter[kMaxBlocks][kMaxRanks];
+   alignas(128) FlagType peer_counter[2][kMaxBlocks][kMaxRanks * kFlagStride];
+ };
+@@ -78,6 +92,10 @@ struct RankStaging {
+   void *ptrs[kMaxRanks];
+ };
+ 
++struct DoubleStaging {
++  RankStaging slots[2];
++};
++
+ template <typename T> struct __align__(16) Pack {
+   T values[8];
+ };
+@@ -97,6 +115,40 @@ static DINLINE FlagType load_flag(FlagType *address) {
+   return value;
+ }
+ 
++static DINLINE FlagType load_flag_gpu(FlagType *address) {
++  FlagType value;
++  asm volatile("ld.relaxed.gpu.global.u32 %0, [%1];"
++               : "=r"(value)
++               : "l"(address)
++               : "memory");
++  return value;
++}
++
++__global__ void advance_staging_slot_kernel(Signal *self) {
++  if (threadIdx.x == 0) {
++    const FlagType generation = self->staging_generation;
++    self->active_staging_slot = generation & FlagType{1};
++    self->staging_generation = generation + FlagType{1};
++  }
++}
++
++template <int world_size>
++DINLINE void select_staging(RankStaging &staging,
++                            const DoubleStaging &staging_options,
++                            Signal *self) {
++  if (threadIdx.x == 0) {
++    // The one-CTA control node runs earlier on this stream.  Every worker CTA
++    // therefore observes one operation-wide slot regardless of worker grid
++    // size or rank launch skew.
++    const int slot = int(load_flag_gpu(&self->active_staging_slot) & FlagType{1});
++#pragma unroll
++    for (int peer = 0; peer < world_size; ++peer) {
++      staging.ptrs[peer] = staging_options.slots[slot].ptrs[peer];
++    }
++  }
++  __syncthreads();
++}
++
+ // pre_sync orders in-kernel staging stores (from every warp of the block)
+ // before the flag post; without staging the flags can go out immediately.
+ template <int world_size, bool pre_sync>
+@@ -117,6 +169,16 @@ DINLINE void start_barrier(const RankSignals &signals, Signal *self, int rank) {
+   __syncthreads();
+ }
+ 
++DINLINE void test_post_barrier_delay(int rank, int delayed_rank,
++                                     uint64_t delay_cycles) {
++  if (delay_cycles != 0 && rank == delayed_rank && threadIdx.x == 0) {
++    const uint64_t start = clock64();
++    while (clock64() - start < delay_cycles) {
++    }
++  }
++  __syncthreads();
++}
++
+ DINLINE float to_float(half value) { return __half2float(value); }
+ DINLINE float to_float(nv_bfloat16 value) { return __bfloat162float(value); }
+ 
+@@ -149,14 +211,15 @@ template <typename T, int world_size>
+ __global__ void __launch_bounds__(512, 1)
+     dcp_lse_reduce_kernel(const T *__restrict__ local_output,
+                           const float *__restrict__ local_lse,
+-                          RankStaging staging, int64_t lse_offset,
++                          DoubleStaging staging_options, int64_t lse_offset,
+                           RankSignals signals, Signal *self,
+                           T *__restrict__ output, int rank, int batch,
+                           int total_heads, int head_dim,
+                           int64_t input_stride_batch,
+                           int64_t input_stride_head,
+                           int64_t output_stride_batch,
+-                          int64_t output_stride_head, bool natural_log) {
++                          int64_t output_stride_head, bool natural_log,
++                          int delayed_rank, uint64_t delay_cycles) {
+   constexpr int kPackElems = 8;
+   const int heads_per_rank = total_heads / world_size;
+   const int packs_per_head = head_dim / kPackElems;
+@@ -169,6 +232,9 @@ __global__ void __launch_bounds__(512, 1)
+   const auto *local_packs = reinterpret_cast<const Pack<T> *>(local_output);
+   auto *output_packs = reinterpret_cast<Pack<T> *>(output);
+ 
++  __shared__ RankStaging staging;
++  select_staging<world_size>(staging, staging_options, self);
++
+   auto *staging_out = reinterpret_cast<Pack<T> *>(staging.ptrs[rank]);
+   auto *staging_lse = reinterpret_cast<float *>(
+       reinterpret_cast<char *>(staging.ptrs[rank]) + lse_offset);
+@@ -192,6 +258,7 @@ __global__ void __launch_bounds__(512, 1)
+     }
+   }
+   start_barrier<world_size, true>(signals, self, rank);
++  test_post_barrier_delay(rank, delayed_rank, delay_cycles);
+ 
+   // Rotated source pointers so every later access uses a compile-time
+   // index; the self source reads the local tensors directly (still hot in
+@@ -286,9 +353,10 @@ __global__ void __launch_bounds__(512, 1)
+ template <typename T, int world_size>
+ __global__ void __launch_bounds__(512, 1)
+     all_gather_heads_kernel(const T *__restrict__ local_input,
+-                            RankStaging staging, RankSignals signals,
++                            DoubleStaging staging_options, RankSignals signals,
+                             Signal *self, T *__restrict__ output, int rank,
+-                            int batch, int local_heads, int head_dim) {
++                            int batch, int local_heads, int head_dim,
++                            int delayed_rank, uint64_t delay_cycles) {
+   constexpr int kPackElems = 8;
+   const int packs_per_head = head_dim / kPackElems;
+   const int total_heads = local_heads * world_size;
+@@ -299,6 +367,9 @@ __global__ void __launch_bounds__(512, 1)
+   const int warp_stride = gridDim.x * warps_per_block;
+   const auto *local_packs = reinterpret_cast<const Pack<T> *>(local_input);
+ 
++  __shared__ RankStaging staging;
++  select_staging<world_size>(staging, staging_options, self);
++
+   auto *staging_out = reinterpret_cast<Pack<T> *>(staging.ptrs[rank]);
+   for (int row = warp_first; row < rows; row += warp_stride) {
+     const int batch_index = row / total_heads;
+@@ -313,6 +384,7 @@ __global__ void __launch_bounds__(512, 1)
+     }
+   }
+   start_barrier<world_size, true>(signals, self, rank);
++  test_post_barrier_delay(rank, delayed_rank, delay_cycles);
+ 
+   auto *output_packs = reinterpret_cast<Pack<T> *>(output);
+   for (int row = warp_first; row < rows; row += warp_stride) {
+@@ -339,11 +411,11 @@ public:
+   int world_size_;
+   RankSignals signals_{};
+   Signal *self_signal_;
+-  RankStaging staging_[2]{};
++  DoubleStaging staging_{};
+   int64_t output_capacity_elems_;
+   int64_t lse_offset_;
+   int64_t lse_capacity_;
+-  int slot_ = 0;
++
+ 
+   PCIeDCPA2A(Signal **signals,
+              const std::vector<std::array<void *, 2>> &staging,
+@@ -354,8 +426,8 @@ public:
+         lse_capacity_(lse_capacity) {
+     for (int peer = 0; peer < world_size_; ++peer) {
+       signals_.signals[peer] = signals[peer];
+-      staging_[0].ptrs[peer] = staging[peer][0];
+-      staging_[1].ptrs[peer] = staging[peer][1];
++      staging_.slots[0].ptrs[peer] = staging[peer][0];
++      staging_.slots[1].ptrs[peer] = staging[peer][1];
+     }
+   }
+ 
+@@ -394,21 +466,25 @@ public:
+       throw std::runtime_error("threads must be a multiple of 32");
+     }
+ 
+-    // Staging happens inside the kernel (warp-per-row, before the start
+-    // barrier); no host staging memcpys are issued.
+-    const int slot = slot_++ % 2;
++    // Select one staging slot per execution in a graph-capturable device node.
++    // Worker CTA count may change large -> small -> large without leaving
++    // dormant per-block parity counters behind.
+     const int heads_per_rank = total_heads / world_size_;
+     const int rows = batch * heads_per_rank;
+     const int warps_per_block = threads / 32;
+     const int blocks = std::max(
+         1, std::min(block_limit, (rows + warps_per_block - 1) / warps_per_block));
++    advance_staging_slot_kernel<<<1, 1, 0, stream>>>(self_signal_);
++    CHECK_CUDA_SUCCESS(cudaGetLastError());
++    const int delayed_rank = dcp_test_delay_rank();
++    const uint64_t delay_cycles = dcp_test_delay_cycles();
+ 
+ #define LAUNCH(world)                                                          \
+   dcp_lse_reduce_kernel<T, world><<<blocks, threads, 0, stream>>>(             \
+-      partial_output, partial_lse, staging_[slot], lse_offset_, signals_,      \
+-      self_signal_, output, rank_, batch, total_heads, head_dim,               \
++      partial_output, partial_lse, staging_, lse_offset_, signals_,           \
++      self_signal_, output, rank_, batch, total_heads, head_dim,              \
+       input_stride_batch, input_stride_head, output_stride_batch,              \
+-      output_stride_head, natural_log)
++      output_stride_head, natural_log, delayed_rank, delay_cycles)
+     switch (world_size_) {
+     case 2:
+       LAUNCH(2);
+@@ -455,18 +531,21 @@ public:
+       throw std::runtime_error("threads must be a multiple of 32");
+     }
+ 
+-    // Staging happens inside the kernel (warp-per-row, before the start
+-    // barrier); no host staging memcpy is issued.
+-    const int slot = slot_++ % 2;
++    // Slot ownership is published by a device control node, including for
++    // back-to-back eager launches and every CUDA graph replay.
+     const int rows = batch * total_heads;
+     const int warps_per_block = threads / 32;
+     const int blocks = std::max(
+         1, std::min(block_limit, (rows + warps_per_block - 1) / warps_per_block));
++    advance_staging_slot_kernel<<<1, 1, 0, stream>>>(self_signal_);
++    CHECK_CUDA_SUCCESS(cudaGetLastError());
++    const int delayed_rank = dcp_test_delay_rank();
++    const uint64_t delay_cycles = dcp_test_delay_cycles();
+ 
+ #define LAUNCH(world)                                                          \
+   all_gather_heads_kernel<T, world><<<blocks, threads, 0, stream>>>(           \
+-      local_input, staging_[slot], signals_, self_signal_, output, rank_,      \
+-      batch, local_heads, head_dim)
++      local_input, staging_, signals_, self_signal_, output, rank_, batch,    \
++      local_heads, head_dim, delayed_rank, delay_cycles)
+     switch (world_size_) {
+     case 2:
+       LAUNCH(2);
+diff --git a/sparkinfer/comm/pcie/pcie_dcp_a2a.py b/sparkinfer/comm/pcie/pcie_dcp_a2a.py
+index 49f41ce26b4ed847f5915c6dfcfedcebe4ffaf74..4582006f559874977586d7c2abc8af0b7921d1a4 100644
+--- a/sparkinfer/comm/pcie/pcie_dcp_a2a.py
++++ b/sparkinfer/comm/pcie/pcie_dcp_a2a.py
+@@ -3,7 +3,7 @@
+ from __future__ import annotations
+ 
+ import os
+-from contextlib import contextmanager, suppress
++from contextlib import contextmanager
+ from dataclasses import dataclass
+ from functools import lru_cache
+ from pathlib import Path
+@@ -16,19 +16,32 @@ from torch.utils.cpp_extension import load
+ 
+ from ._cuda_ipc import CudaRTLibrary
+ from .pcie_oneshot import (
++    _ABANDONED_PCIE_RUNTIME_QUARANTINE,
++    _SINGLE_CHANNEL_ID,
+     IPC_SLAB_ALIGNMENT,
+     PCIeOneshotAllReduce,
++    _finish_collective_runtime_setup,
++    _raise_local_cleanup_errors,
+     _align_up,
++    _broadcast_gather_object,
++    _collective_capture_needs_preparation,
+     _coordinated_close_channels,
+     _current_stream_key,
++    _cuda_device_index,
+     _is_current_stream_capturing,
+     _normalize_device,
++    _normalize_logical_channel_id,
+     _OwnedSharedBuffer,
++    _finish_collective_unowned_runtime_setup,
++    _require_collective_contract,
++    _require_full_grid_residency,
++    _run_collective_preallocation_setup,
+ )
+ 
+ 
+ SUPPORTED_WORLD_SIZES = (2, 4, 8)
+ SUPPORTED_DTYPES = (torch.float16, torch.bfloat16)
++DCP_A2A_REQUIRED_SMS = 64
+ 
+ 
+ def _is_supported_bhd_layout(tensor: torch.Tensor) -> bool:
+@@ -37,15 +50,15 @@ def _is_supported_bhd_layout(tensor: torch.Tensor) -> bool:
+         return False
+     batch, heads, head_dim = (int(value) for value in tensor.shape)
+     stride_batch, stride_head, _ = (int(value) for value in tensor.stride())
+-    packed_token_major = (
+-        stride_batch == heads * head_dim and stride_head == head_dim
+-    )
++    packed_token_major = stride_batch == heads * head_dim and stride_head == head_dim
+     capacity_strided_head_major = (
+         stride_batch == head_dim
+         and stride_head >= batch * head_dim
+         and stride_head % 8 == 0
+     )
+     return packed_token_major or capacity_strided_head_major
++
++
+ @dataclass(frozen=True)
+ class _StagingLayout:
+     signal_bytes: int
+@@ -189,49 +202,267 @@ class PCIeDCPA2A:
+         ext_module=None,
+         stream_affine: bool = True,
+     ) -> None:
+-        if world_size not in SUPPORTED_WORLD_SIZES:
+-            raise ValueError(f"unsupported world size {world_size}")
+-        if not 0 <= rank < world_size:
+-            raise ValueError(f"invalid rank {rank} for world size {world_size}")
+-        if (
+-            len(signal_ptrs) != world_size
+-            or len(staging0_ptrs) != world_size
+-            or len(staging1_ptrs) != world_size
+-        ):
+-            raise ValueError("signal and staging pointers must match world size")
+-        if total_heads <= 0 or total_heads % world_size != 0:
+-            raise ValueError("total_heads must be divisible by world_size")
+-        if head_dim <= 0 or head_dim % 8 != 0:
+-            raise ValueError("head_dim must be a positive multiple of 8")
++        def normalize_and_validate():
++            device_obj = _normalize_device(device)
++            normalized_rank = int(rank)
++            normalized_world_size = int(world_size)
++            normalized_signals = tuple(int(ptr) for ptr in signal_ptrs)
++            normalized_staging0 = tuple(int(ptr) for ptr in staging0_ptrs)
++            normalized_staging1 = tuple(int(ptr) for ptr in staging1_ptrs)
++            normalized_max_batch = int(max_batch_size)
++            normalized_total_heads = int(total_heads)
++            normalized_head_dim = int(head_dim)
++            normalized_query_dim = int(
++                head_dim if query_head_dim is None else query_head_dim
++            )
++            normalized_output_capacity = int(output_capacity_elems)
++            normalized_lse_offset = int(lse_offset)
++            normalized_lse_capacity = int(lse_capacity)
++            if normalized_world_size not in SUPPORTED_WORLD_SIZES:
++                raise ValueError(f"unsupported world size {normalized_world_size}")
++            if not 0 <= normalized_rank < normalized_world_size:
++                raise ValueError(
++                    f"invalid rank {normalized_rank} for world size "
++                    f"{normalized_world_size}"
++                )
++            if (
++                len(normalized_signals) != normalized_world_size
++                or len(normalized_staging0) != normalized_world_size
++                or len(normalized_staging1) != normalized_world_size
++            ):
++                raise ValueError("signal and staging pointers must match world size")
++            if normalized_max_batch <= 0:
++                raise ValueError("max_batch_size must be positive")
++            if (
++                normalized_total_heads <= 0
++                or normalized_total_heads % normalized_world_size != 0
++            ):
++                raise ValueError("total_heads must be divisible by world_size")
++            if normalized_head_dim <= 0 or normalized_head_dim % 8 != 0:
++                raise ValueError("head_dim must be a positive multiple of 8")
++            if normalized_query_dim <= 0 or normalized_query_dim % 8 != 0:
++                raise ValueError("query_head_dim must be a positive multiple of 8")
++            required_output = (
++                normalized_max_batch
++                * normalized_total_heads
++                * max(normalized_head_dim, normalized_query_dim)
++            )
++            if normalized_output_capacity < required_output:
++                raise ValueError("output capacity is smaller than configured shape")
++            if normalized_lse_offset < 0:
++                raise ValueError("lse_offset must be non-negative")
++            if normalized_lse_capacity < normalized_max_batch * normalized_total_heads:
++                raise ValueError("LSE capacity is smaller than configured shape")
++            if ext_module is None and device_obj.type != "cuda":
++                raise ValueError("PCIe DCP A2A requires a CUDA device")
++            if device_obj.type == "cuda" and exchange_group is None:
++                raise ValueError(
++                    "exchange_group is required for a CUDA PCIe DCP A2A runtime; "
++                    "use from_exchange_group()"
++                )
++            if exchange_group is not None:
++                if device_obj.type != "cuda":
++                    raise ValueError("distributed PCIe DCP A2A requires a CUDA device")
++                group_rank = dist.get_rank(group=exchange_group)
++                group_world_size = dist.get_world_size(group=exchange_group)
++                if normalized_rank != group_rank:
++                    raise ValueError(
++                        f"supplied rank {normalized_rank} does not match process "
++                        f"group rank {group_rank}"
++                    )
++                if normalized_world_size != group_world_size:
++                    raise ValueError(
++                        f"supplied world size {normalized_world_size} does not "
++                        f"match process group size {group_world_size}"
++                    )
++            return (
++                device_obj,
++                normalized_rank,
++                normalized_world_size,
++                normalized_signals,
++                normalized_staging0,
++                normalized_staging1,
++                normalized_max_batch,
++                normalized_total_heads,
++                normalized_head_dim,
++                normalized_query_dim,
++                normalized_output_capacity,
++                normalized_lse_offset,
++                normalized_lse_capacity,
++            )
++
++        if exchange_group is not None:
++            normalized = _run_collective_preallocation_setup(
++                owner="PCIe DCP A2A direct constructor argument validation",
++                exchange_group=exchange_group,
++                setup=normalize_and_validate,
++            )
++        else:
++            normalized = normalize_and_validate()
++
++        (
++            prepared_device,
++            prepared_rank,
++            prepared_world_size,
++            prepared_signals,
++            prepared_staging0,
++            prepared_staging1,
++            prepared_max_batch,
++            prepared_total_heads,
++            prepared_head_dim,
++            prepared_query_dim,
++            prepared_output_capacity,
++            prepared_lse_offset,
++            prepared_lse_capacity,
++        ) = normalized
++        self._initialize_prepared_state(
++            rank=prepared_rank,
++            world_size=prepared_world_size,
++            device=prepared_device,
++            signal_ptrs=prepared_signals,
++            staging0_ptrs=prepared_staging0,
++            staging1_ptrs=prepared_staging1,
++            max_batch_size=prepared_max_batch,
++            total_heads=prepared_total_heads,
++            head_dim=prepared_head_dim,
++            query_head_dim=prepared_query_dim,
++            output_capacity_elems=prepared_output_capacity,
++            lse_offset=prepared_lse_offset,
++            lse_capacity=prepared_lse_capacity,
++            exchange_group=exchange_group,
++            ipc=ipc,
++            owned_buffers=owned_buffers,
++            ext_module=ext_module,
++            stream_affine=stream_affine,
++        )
++
++        if self.device.type == "cuda":
++            _require_full_grid_residency(
++                owner="PCIe DCP A2A direct constructor",
++                required_sms=DCP_A2A_REQUIRED_SMS,
++                device=self.device,
++                exchange_group=self.exchange_group,
++            )
++
++            def prepare():
++                return ext_module or _load_extension()
++
++            if self.exchange_group is None:
++                self._ext = prepare()
++            else:
++                self._ext = _run_collective_preallocation_setup(
++                    owner="PCIe DCP A2A direct constructor",
++                    exchange_group=self.exchange_group,
++                    setup=prepare,
++                )
++        else:
++            self._ext = self._ext or _load_extension()
++
++        if self.device.type == "cuda" and self.exchange_group is not None:
++            _require_collective_contract(
++                owner="PCIe DCP A2A direct constructor",
++                exchange_group=self.exchange_group,
++                contract=(
++                    self.world_size,
++                    self.max_batch_size,
++                    self.total_heads,
++                    self.head_dim,
++                    self.query_head_dim,
++                    self.output_capacity_elems,
++                    self.lse_offset,
++                    self.lse_capacity,
++                ),
++            )
++
++        init_error = self._initialize_native_runtime()
++        if self.device.type == "cuda" and self.exchange_group is not None:
+ 
++            def abort_native_runtime() -> None:
++                if self._ptr:
++                    self._ext.dispose(self._ptr)
++                    self._ptr = 0
++
++            _finish_collective_unowned_runtime_setup(
++                owner="PCIe DCP A2A direct constructor",
++                exchange_group=self.exchange_group,
++                local_error=init_error,
++                local_cleanup=abort_native_runtime,
++            )
++        elif init_error is not None:
++            raise init_error
++
++    def _initialize_prepared_state(
++        self,
++        *,
++        rank: int,
++        world_size: int,
++        device: torch.device,
++        signal_ptrs: Sequence[int],
++        staging0_ptrs: Sequence[int],
++        staging1_ptrs: Sequence[int],
++        max_batch_size: int,
++        total_heads: int,
++        head_dim: int,
++        query_head_dim: int,
++        output_capacity_elems: int,
++        lse_offset: int,
++        lse_capacity: int,
++        exchange_group: Optional[ProcessGroup],
++        ipc: Optional[CudaRTLibrary],
++        owned_buffers: Optional[Sequence[_OwnedSharedBuffer]],
++        ext_module,
++        stream_affine: bool,
++    ) -> None:
+         self.rank = int(rank)
+         self.world_size = int(world_size)
+-        self.device = _normalize_device(device)
++        self.device = device
+         self.exchange_group = exchange_group
+         self.max_batch_size = int(max_batch_size)
+         self.total_heads = int(total_heads)
+         self.head_dim = int(head_dim)
+-        self.query_head_dim = int(query_head_dim or head_dim)
+-        if self.query_head_dim <= 0 or self.query_head_dim % 8 != 0:
+-            raise ValueError("query_head_dim must be a positive multiple of 8")
++        self.query_head_dim = int(query_head_dim)
+         self.heads_per_rank = self.total_heads // self.world_size
++        self.output_capacity_elems = int(output_capacity_elems)
++        self.lse_offset = int(lse_offset)
++        self.lse_capacity = int(lse_capacity)
++        self._signal_ptrs = tuple(int(ptr) for ptr in signal_ptrs)
++        self._staging0_ptrs = tuple(int(ptr) for ptr in staging0_ptrs)
++        self._staging1_ptrs = tuple(int(ptr) for ptr in staging1_ptrs)
+         self._ipc = ipc
+         self._owned_buffers = list(owned_buffers or ())
+-        self._ext = ext_module or _load_extension()
++        self._ext = ext_module
+         self._stream_affine = bool(stream_affine)
+         self._owner_stream_key: Optional[int] = None
+         self._closed = False
+         self._ipc_imports_closed = False
+         self._ipc_exports_freed = False
+-        self._ptr = self._ext.init_dcp_a2a(
+-            list(signal_ptrs),
+-            list(staging0_ptrs),
+-            list(staging1_ptrs),
+-            int(output_capacity_elems),
+-            int(lse_offset),
+-            int(lse_capacity),
+-            self.rank,
+-        )
++        self._coordinated_close_complete = False
++        self._closed_ipc_import_indices: set[tuple[int, int]] = set()
++        self._ptr = 0
++
++    def _initialize_native_runtime(self) -> BaseException | None:
++        init_error: BaseException | None = None
++        try:
++            self._ptr = self._ext.init_dcp_a2a(
++                list(self._signal_ptrs),
++                list(self._staging0_ptrs),
++                list(self._staging1_ptrs),
++                self.output_capacity_elems,
++                self.lse_offset,
++                self.lse_capacity,
++                self.rank,
++            )
++        except Exception as exc:
++            init_error = exc
++        return init_error
++
++    @classmethod
++    def _from_prepared_factory(
++        cls, **kwargs
++    ) -> tuple["PCIeDCPA2A", BaseException | None]:
++        runtime = object.__new__(cls)
++        runtime._initialize_prepared_state(**kwargs)
++        return runtime, runtime._initialize_native_runtime()
+ 
+     @classmethod
+     def from_exchange_group(
+@@ -248,62 +479,130 @@ class PCIeDCPA2A:
+     ) -> "PCIeDCPA2A":
+         rank = dist.get_rank(group=exchange_group)
+         world_size = dist.get_world_size(group=exchange_group)
+-        device_obj = _normalize_device(device)
+-        if device_obj.type != "cuda":
+-            raise ValueError("PCIe DCP A2A requires a CUDA device")
+-
+-        ipc = CudaRTLibrary()
+-        ipc.cudaSetDevice(device_obj.index or 0)
+-        ext = ext_module or _load_extension()
+-        layout = _staging_layout(
+-            signal_bytes=int(ext.meta_size()),
+-            world_size=world_size,
+-            max_batch_size=max_batch_size,
+-            total_heads=total_heads,
+-            head_dim=head_dim,
+-            query_head_dim=query_head_dim,
++
++        def validate_factory_arguments():
++            device_obj = _normalize_device(device)
++            normalized_max_batch = int(max_batch_size)
++            normalized_total_heads = int(total_heads)
++            normalized_head_dim = int(head_dim)
++            normalized_query_dim = int(
++                head_dim if query_head_dim is None else query_head_dim
++            )
++            if world_size not in SUPPORTED_WORLD_SIZES:
++                raise ValueError(f"unsupported world size {world_size}")
++            if device_obj.type != "cuda":
++                raise ValueError("PCIe DCP A2A requires a CUDA device")
++            if normalized_max_batch <= 0:
++                raise ValueError("max_batch_size must be positive")
++            if normalized_total_heads <= 0 or normalized_total_heads % world_size != 0:
++                raise ValueError("total_heads must be divisible by world_size")
++            if normalized_head_dim <= 0 or normalized_head_dim % 8 != 0:
++                raise ValueError("head_dim must be a positive multiple of 8")
++            if normalized_query_dim <= 0 or normalized_query_dim % 8 != 0:
++                raise ValueError("query_head_dim must be a positive multiple of 8")
++            return (
++                device_obj,
++                normalized_max_batch,
++                normalized_total_heads,
++                normalized_head_dim,
++                normalized_query_dim,
++            )
++
++        (
++            device_obj,
++            max_batch_size,
++            total_heads,
++            head_dim,
++            query_head_dim,
++        ) = _run_collective_preallocation_setup(
++            owner="PCIe DCP A2A argument validation",
++            exchange_group=exchange_group,
++            setup=validate_factory_arguments,
+         )
+-        owned: list[_OwnedSharedBuffer] = []
+-        try:
+-            slab = PCIeOneshotAllReduce._allocate_shared_buffer(
+-                exchange_group,
+-                layout.slab_bytes,
+-                zero_fill=True,
+-                ipc=ipc,
+-            )
+-            owned.append(slab)
+-            return cls(
+-                rank=rank,
++
++        _require_full_grid_residency(
++            owner="PCIe DCP A2A",
++            required_sms=DCP_A2A_REQUIRED_SMS,
++            device=device_obj,
++            exchange_group=exchange_group,
++        )
++
++        def prepare():
++            prepared_ipc = CudaRTLibrary()
++            prepared_ipc.cudaSetDevice(_cuda_device_index(device_obj))
++            prepared_ext = ext_module or _load_extension()
++            layout = _staging_layout(
++                signal_bytes=int(prepared_ext.meta_size()),
+                 world_size=world_size,
+-                device=device_obj,
+-                signal_ptrs=slab.peer_ptrs,
+-                staging0_ptrs=tuple(
+-                    ptr + layout.staging0_offset for ptr in slab.peer_ptrs
+-                ),
+-                staging1_ptrs=tuple(
+-                    ptr + layout.staging1_offset for ptr in slab.peer_ptrs
+-                ),
+                 max_batch_size=max_batch_size,
+                 total_heads=total_heads,
+                 head_dim=head_dim,
+-                output_capacity_elems=layout.output_capacity_elems,
+-                lse_offset=layout.lse_offset,
+-                lse_capacity=layout.lse_capacity,
+                 query_head_dim=query_head_dim,
+-                exchange_group=exchange_group,
+-                ipc=ipc,
+-                owned_buffers=owned,
+-                ext_module=ext,
+-                stream_affine=stream_affine,
+-            )
+-        except Exception:
+-            for shared in owned:
+-                for ptr in shared.remote_ptrs:
+-                    with suppress(Exception):
+-                        ipc.cudaIpcCloseMemHandle(ptr)
+-                with suppress(Exception):
+-                    ipc.cudaFree(shared.local_ptr)
+-            raise
++            )
++            return prepared_ipc, prepared_ext, layout
++
++        ipc, ext, layout = _run_collective_preallocation_setup(
++            owner="PCIe DCP A2A",
++            exchange_group=exchange_group,
++            setup=prepare,
++        )
++        _require_collective_contract(
++            owner="PCIe DCP A2A channel layout",
++            exchange_group=exchange_group,
++            contract=(
++                int(max_batch_size),
++                int(total_heads),
++                int(head_dim),
++                int(query_head_dim),
++                layout,
++            ),
++        )
++        slab = PCIeOneshotAllReduce._allocate_shared_buffer(
++            exchange_group,
++            layout.slab_bytes,
++            zero_fill=True,
++            ipc=ipc,
++        )
++        runtime, init_error = cls._from_prepared_factory(
++            rank=rank,
++            world_size=world_size,
++            device=device_obj,
++            signal_ptrs=slab.peer_ptrs,
++            staging0_ptrs=tuple(ptr + layout.staging0_offset for ptr in slab.peer_ptrs),
++            staging1_ptrs=tuple(ptr + layout.staging1_offset for ptr in slab.peer_ptrs),
++            max_batch_size=max_batch_size,
++            total_heads=total_heads,
++            head_dim=head_dim,
++            output_capacity_elems=layout.output_capacity_elems,
++            lse_offset=layout.lse_offset,
++            lse_capacity=layout.lse_capacity,
++            query_head_dim=query_head_dim,
++            exchange_group=exchange_group,
++            ipc=ipc,
++            owned_buffers=[slab],
++            ext_module=ext,
++            stream_affine=stream_affine,
++        )
++
++        def abort_native_runtime() -> None:
++            pointer = getattr(runtime, "_ptr", 0)
++            if pointer:
++                ext.dispose(pointer)
++                runtime._ptr = 0
++
++        def detach_shared_ownership() -> None:
++            runtime._owned_buffers.clear()
++
++        _finish_collective_runtime_setup(
++            owner="PCIe DCP A2A",
++            exchange_group=exchange_group,
++            ipc=ipc,
++            shared=slab,
++            local_error=init_error,
++            local_cleanup=abort_native_runtime,
++            detach_shared_ownership=detach_shared_ownership,
++        )
++        return runtime
+ 
+     @classmethod
+     def from_process_group(
+@@ -386,9 +685,7 @@ class PCIeDCPA2A:
+                 f"output shape must be {expected_out}, got {tuple(out.shape)}"
+             )
+         if not _is_supported_bhd_layout(partial_output):
+-            raise ValueError(
+-                "partial_output must be packed token-major or head-major"
+-            )
++            raise ValueError("partial_output must be packed token-major or head-major")
+         if not partial_lse.is_contiguous():
+             raise ValueError("partial_lse must be contiguous")
+         if not _is_supported_bhd_layout(out):
+@@ -480,39 +777,112 @@ class PCIeDCPA2A:
+         )
+         return out
+ 
+-    def _close_ipc_imports(self) -> None:
++    def _closed_import_indices(self) -> set[tuple[int, int]]:
++        closed = getattr(self, "_closed_ipc_import_indices", None)
++        if closed is None:
++            closed = set()
++            self._closed_ipc_import_indices = closed
++        return closed
++
++    def _all_python_ipc_imports_closed(self, closed: set[tuple[int, int]]) -> bool:
++        if self._ipc is None:
++            return not any(shared.remote_ptrs for shared in self._owned_buffers)
++        return all(
++            (buffer_index, remote_index) in closed
++            for buffer_index, shared in enumerate(self._owned_buffers)
++            for remote_index, _ in enumerate(shared.remote_ptrs)
++        )
++
++    def _close_ipc_imports_strict(self) -> None:
+         if self._ipc_imports_closed:
+             return
+         self._closed = True
++        failures: list[tuple[str, Exception]] = []
+         if getattr(self, "_ptr", 0):
+-            with suppress(Exception):
++            try:
+                 self._ext.dispose(self._ptr)
+-            self._ptr = 0
++            except Exception as exc:
++                failures.append(("native runtime", exc))
++            else:
++                self._ptr = 0
++
++        closed = self._closed_import_indices()
+         if self._ipc is not None:
+-            for shared in self._owned_buffers:
+-                for ptr in shared.remote_ptrs:
+-                    with suppress(Exception):
++            for buffer_index, shared in enumerate(self._owned_buffers):
++                for remote_index, ptr in enumerate(shared.remote_ptrs):
++                    key = (buffer_index, remote_index)
++                    if key in closed:
++                        continue
++                    try:
+                         self._ipc.cudaIpcCloseMemHandle(ptr)
+-        self._ipc_imports_closed = True
++                    except Exception as exc:
++                        failures.append((f"CUDA IPC import {ptr}", exc))
++                    else:
++                        closed.add(key)
++        elif any(shared.remote_ptrs for shared in self._owned_buffers):
++            failures.append(
++                (
++                    "CUDA IPC imports",
++                    RuntimeError("CUDA runtime is unavailable for IPC unmap"),
++                )
++            )
+ 
+-    def _free_ipc_exports(self) -> None:
++        if (
++            not failures
++            and not getattr(self, "_ptr", 0)
++            and self._all_python_ipc_imports_closed(closed)
++        ):
++            self._ipc_imports_closed = True
++        if failures:
++            _raise_local_cleanup_errors("PCIe DCP A2A", "IPC import close", failures)
++
++    def _free_ipc_exports_strict(self) -> None:
+         if self._ipc_exports_freed:
+             return
+-        self._close_ipc_imports()
++        self._close_ipc_imports_strict()
++        failures: list[tuple[str, Exception]] = []
++        remaining = []
+         if self._ipc is not None:
+             for shared in self._owned_buffers:
+-                with suppress(Exception):
++                try:
+                     self._ipc.cudaFree(shared.local_ptr)
+-        self._owned_buffers.clear()
+-        self._ipc_exports_freed = True
++                except Exception as exc:
++                    remaining.append(shared)
++                    failures.append((f"CUDA IPC export {shared.local_ptr}", exc))
++        elif self._owned_buffers:
++            remaining = list(self._owned_buffers)
++            failures.append(
++                (
++                    "CUDA IPC exports",
++                    RuntimeError("CUDA runtime is unavailable for export free"),
++                )
++            )
++        self._owned_buffers = remaining
++        if not remaining:
++            self._ipc_exports_freed = True
++        if failures:
++            _raise_local_cleanup_errors("PCIe DCP A2A", "IPC export free", failures)
+ 
+     def close(self) -> None:
+-        self._close_ipc_imports()
+-        self._free_ipc_exports()
++        if getattr(self, "_coordinated_close_complete", False):
++            return
++        _coordinated_close_channels(
++            (self,),
++            exchange_group=self.exchange_group,
++            device=self.device,
++        )
+ 
+-    def __del__(self) -> None:
+-        with suppress(Exception):
+-            self.close()
++    def __del__(
++        self,
++        _quarantine: dict[int, object] = _ABANDONED_PCIE_RUNTIME_QUARANTINE,
++    ) -> None:
++        # Never unmap potentially in-flight CUDA work from GC. Retaining the
++        # complete object preserves both native ownership and Python IPC maps;
++        # explicit close() is the only synchronized teardown path.
++        if getattr(self, "_coordinated_close_complete", False):
++            return
++        if getattr(self, "_ptr", 0) or getattr(self, "_owned_buffers", ()):
++            _quarantine[id(self)] = self
+ 
+ 
+ class PCIeDCPA2APool:
+@@ -531,27 +901,115 @@ class PCIeDCPA2APool:
+         exchange_group: Optional[ProcessGroup] = None,
+         ext_module=None,
+         single_channel: bool = False,
++        max_concurrent_channels: int = 1,
+         channel_factory: Optional[Callable[[Optional[int]], PCIeDCPA2A]] = None,
+     ) -> None:
+-        if world_size not in SUPPORTED_WORLD_SIZES:
+-            raise ValueError(f"unsupported world size {world_size}")
+-        self.rank = int(rank)
+-        self.world_size = int(world_size)
+-        self.device = _normalize_device(device)
+-        self.max_batch_size = int(max_batch_size)
+-        self.total_heads = int(total_heads)
+-        self.head_dim = int(head_dim)
+-        self.query_head_dim = int(query_head_dim or head_dim)
++        def normalize_and_validate():
++            normalized_rank = int(rank)
++            normalized_world_size = int(world_size)
++            device_obj = _normalize_device(device)
++            normalized_max_batch = int(max_batch_size)
++            normalized_total_heads = int(total_heads)
++            normalized_head_dim = int(head_dim)
++            normalized_query_dim = int(
++                head_dim if query_head_dim is None else query_head_dim
++            )
++            normalized_single_channel = bool(single_channel)
++            normalized_max_concurrent_channels = int(max_concurrent_channels)
++            if normalized_world_size not in SUPPORTED_WORLD_SIZES:
++                raise ValueError(f"unsupported world size {normalized_world_size}")
++            if not 0 <= normalized_rank < normalized_world_size:
++                raise ValueError(
++                    f"invalid rank {normalized_rank} for world size "
++                    f"{normalized_world_size}"
++                )
++            if normalized_max_batch <= 0:
++                raise ValueError("max_batch_size must be positive")
++            if (
++                normalized_total_heads <= 0
++                or normalized_total_heads % normalized_world_size != 0
++            ):
++                raise ValueError("total_heads must be divisible by world_size")
++            if normalized_head_dim <= 0 or normalized_head_dim % 8 != 0:
++                raise ValueError("head_dim must be a positive multiple of 8")
++            if normalized_query_dim <= 0 or normalized_query_dim % 8 != 0:
++                raise ValueError("query_head_dim must be a positive multiple of 8")
++            if normalized_max_concurrent_channels <= 0:
++                raise ValueError("max_concurrent_channels must be positive")
++            if channel_factory is None:
++                if exchange_group is None:
++                    raise ValueError(
++                        "exchange_group is required unless channel_factory is set"
++                    )
++                if device_obj.type != "cuda":
++                    raise ValueError("PCIe DCP A2A pool requires a CUDA device")
++                group_rank = dist.get_rank(group=exchange_group)
++                group_world_size = dist.get_world_size(group=exchange_group)
++                if normalized_rank != group_rank:
++                    raise ValueError(
++                        f"supplied rank {normalized_rank} does not match process "
++                        f"group rank {group_rank}"
++                    )
++                if normalized_world_size != group_world_size:
++                    raise ValueError(
++                        f"supplied world size {normalized_world_size} does not "
++                        f"match process group size {group_world_size}"
++                    )
++            return (
++                normalized_rank,
++                normalized_world_size,
++                device_obj,
++                normalized_max_batch,
++                normalized_total_heads,
++                normalized_head_dim,
++                normalized_query_dim,
++                normalized_single_channel,
++                normalized_max_concurrent_channels,
++            )
++
++        if channel_factory is None and exchange_group is not None:
++            normalized = _run_collective_preallocation_setup(
++                owner="PCIe DCP A2A pool argument validation",
++                exchange_group=exchange_group,
++                setup=normalize_and_validate,
++            )
++        else:
++            normalized = normalize_and_validate()
++        (
++            self.rank,
++            self.world_size,
++            self.device,
++            self.max_batch_size,
++            self.total_heads,
++            self.head_dim,
++            self.query_head_dim,
++            self.single_channel,
++            self.max_concurrent_channels,
++        ) = normalized
+         self.exchange_group = exchange_group
+         self._ext = ext_module
+-        self.single_channel = bool(single_channel)
+         self._channel_factory = channel_factory
+         self._channels: dict[int, PCIeDCPA2A] = {}
++        self._logical_channels: dict[str, PCIeDCPA2A] = {}
++        self._captured_channel_ids: set[str] = set()
+         self._all_channels: list[PCIeDCPA2A] = []
+         self._capture_channel_stack: list[PCIeDCPA2A] = []
+         self._closed = False
+-        if channel_factory is None and exchange_group is None:
+-            raise ValueError("exchange_group is required unless channel_factory is set")
++        if channel_factory is None:
++            assert self.exchange_group is not None
++            _require_collective_contract(
++                owner="PCIe DCP A2A pool overlap contract",
++                exchange_group=self.exchange_group,
++                contract=self.max_concurrent_channels,
++            )
++            _require_full_grid_residency(
++                owner="PCIe DCP A2A pool",
++                required_sms=(DCP_A2A_REQUIRED_SMS * self.max_concurrent_channels),
++                device=self.device,
++                exchange_group=self.exchange_group,
++            )
++        if channel_factory is None and self.single_channel:
++            self.prepare_channels((_SINGLE_CHANNEL_ID,))
+ 
+     @classmethod
+     def from_exchange_group(
+@@ -565,6 +1023,7 @@ class PCIeDCPA2APool:
+         query_head_dim: Optional[int] = None,
+         ext_module=None,
+         single_channel: bool = False,
++        max_concurrent_channels: int = 1,
+     ) -> "PCIeDCPA2APool":
+         return cls(
+             rank=dist.get_rank(group=exchange_group),
+@@ -577,6 +1036,7 @@ class PCIeDCPA2APool:
+             exchange_group=exchange_group,
+             ext_module=ext_module,
+             single_channel=single_channel,
++            max_concurrent_channels=max_concurrent_channels,
+         )
+ 
+     @classmethod
+@@ -591,6 +1051,7 @@ class PCIeDCPA2APool:
+         query_head_dim: Optional[int] = None,
+         ext_module=None,
+         single_channel: bool = False,
++        max_concurrent_channels: int = 1,
+     ) -> "PCIeDCPA2APool":
+         return cls.from_exchange_group(
+             exchange_group=process_group,
+@@ -601,6 +1062,7 @@ class PCIeDCPA2APool:
+             query_head_dim=query_head_dim,
+             ext_module=ext_module,
+             single_channel=single_channel,
++            max_concurrent_channels=max_concurrent_channels,
+         )
+ 
+     def _new_channel(self, stream_key: Optional[int]) -> PCIeDCPA2A:
+@@ -622,17 +1084,71 @@ class PCIeDCPA2APool:
+         self._all_channels.append(channel)
+         return channel
+ 
+-    def checkpoint_channels(self) -> tuple[int, dict[int, PCIeDCPA2A]]:
++    def prepare_channels(self, channel_ids: Sequence[str]) -> None:
++        """Collectively allocate globally named channels in canonical order."""
++
++        if self._channel_factory is None:
++            assert self.exchange_group is not None
++
++            def normalize_and_validate() -> tuple[str, ...]:
++                if self._closed:
++                    raise RuntimeError("PCIeDCPA2APool is closed")
++                return tuple(
++                    sorted(
++                        {_normalize_logical_channel_id(value) for value in channel_ids}
++                    )
++                )
++
++            normalized = _run_collective_preallocation_setup(
++                owner="PCIe DCP A2A logical channel validation",
++                exchange_group=self.exchange_group,
++                setup=normalize_and_validate,
++            )
++            local_state = (normalized, tuple(sorted(self._logical_channels)))
++            gathered = _broadcast_gather_object(local_state, self.exchange_group)
++            if any(state != local_state for state in gathered):
++                raise RuntimeError(
++                    "PCIe DCP A2A logical channel preparation differs across "
++                    f"ranks: {gathered}"
++                )
++        else:
++            if self._closed:
++                raise RuntimeError("PCIeDCPA2APool is closed")
++            normalized = tuple(
++                sorted({_normalize_logical_channel_id(value) for value in channel_ids})
++            )
++
++        if not normalized:
++            return
++
++        for channel_id in normalized:
++            if channel_id in self._logical_channels:
++                continue
++            self._logical_channels[channel_id] = self._new_channel(None)
++
++    def checkpoint_channels(
++        self,
++    ) -> tuple[
++        int,
++        dict[int, PCIeDCPA2A],
++        dict[str, PCIeDCPA2A],
++        set[str],
++    ]:
+         """Snapshot channel ownership before a throwaway graph capture."""
+         if self._closed:
+             raise RuntimeError("PCIeDCPA2APool is closed")
+         if self._capture_channel_stack:
+             raise RuntimeError("cannot checkpoint channels during capture")
+-        return len(self._all_channels), dict(self._channels)
++        return (
++            len(self._all_channels),
++            dict(self._channels),
++            dict(self._logical_channels),
++            set(self._captured_channel_ids),
++        )
+ 
+     def rollback_channels(
+         self,
+-        checkpoint: tuple[int, dict[int, PCIeDCPA2A]],
++        checkpoint: tuple,
+     ) -> None:
+         """Close channels created after ``checkpoint`` and restore mappings.
+ 
+@@ -643,15 +1159,25 @@ class PCIeDCPA2APool:
+             raise RuntimeError("PCIeDCPA2APool is closed")
+         if self._capture_channel_stack:
+             raise RuntimeError("cannot roll back channels during capture")
+-        all_channels_len, channels = checkpoint
++        if len(checkpoint) == 2:
++            all_channels_len, channels = checkpoint
++            logical_channels = dict(self._logical_channels)
++            captured_channel_ids = set(self._captured_channel_ids)
++        elif len(checkpoint) == 4:
++            (
++                all_channels_len,
++                channels,
++                logical_channels,
++                captured_channel_ids,
++            ) = checkpoint
++        else:
++            raise ValueError("invalid channel checkpoint")
+         if not 0 <= all_channels_len <= len(self._all_channels):
+             raise ValueError("channel checkpoint does not belong to this pool")
+ 
+         retained = self._all_channels[:all_channels_len]
+         retained_ids = {id(channel) for channel in retained}
+         transient = self._all_channels[all_channels_len:]
+-        self._all_channels = retained
+-        self._channels = dict(channels)
+ 
+         channels_to_close = tuple(
+             dict.fromkeys(
+@@ -663,25 +1189,59 @@ class PCIeDCPA2APool:
+             exchange_group=self.exchange_group,
+             device=self.device,
+         )
++        # Ownership changes only after coordinated teardown succeeds.  A
++        # failed unmap/free remains reachable for an explicit retry.
++        self._all_channels = retained
++        self._channels = dict(channels)
++        self._logical_channels = dict(logical_channels)
++        self._captured_channel_ids = set(captured_channel_ids)
+ 
+-    def for_stream(self, stream: object = None) -> PCIeDCPA2A:
++    def for_stream(
++        self,
++        stream: object = None,
++        *,
++        channel_id: Optional[str] = None,
++    ) -> PCIeDCPA2A:
+         if self._closed:
+             raise RuntimeError("PCIeDCPA2APool is closed")
+         if self.single_channel:
+             key = 0
+             stream_key = None
++            if self._channel_factory is None and channel_id is None:
++                channel_id = _SINGLE_CHANNEL_ID
+         else:
+             stream_key = _current_stream_key(self.device, stream)
+             key = 0 if stream_key is None else int(stream_key)
+-        if (
+-            not self.single_channel
+-            and _is_current_stream_capturing(self.device)
+-            and self._capture_channel_stack
+-        ):
+-            # Independent graph managers may reuse a torch-owned nested stream
+-            # key. The enclosing capture, not a stale key mapping, determines
+-            # which IPC channel is safe for this graph.
++        if not self.single_channel and self._capture_channel_stack:
++            # The semantic capture scope also owns vLLM's eager pre-capture
++            # warmup. During actual CUDA capture torch may use an ephemeral
++            # nested stream key, which must remain only a temporary alias;
++            # outside CUDA capture retain the normal stream-affinity check.
+             channel = self._capture_channel_stack[-1]
++            if not _is_current_stream_capturing(self.device):
++                channel._bind_stream_key(stream_key)
++            self._channels[key] = channel
++            return channel
++        if self._channel_factory is None:
++            if channel_id is None:
++                raise RuntimeError(
++                    "distributed PCIe DCP A2A eager use requires an explicit "
++                    "semantic channel_id shared by every rank"
++                )
++            logical_id = _normalize_logical_channel_id(channel_id)
++            channel = self._logical_channels.get(logical_id)
++            if channel is None:
++                raise RuntimeError(
++                    f"logical channel {logical_id!r} is not prepared; call "
++                    "prepare_channels() collectively before use"
++                )
++            mapped = self._channels.get(key)
++            if mapped is not None and mapped is not channel:
++                raise RuntimeError(
++                    f"CUDA stream key {key} is already bound to another logical "
++                    "PCIe DCP A2A channel"
++                )
++            channel._bind_stream_key(stream_key)
+             self._channels[key] = channel
+             return channel
+         channel = self._channels.get(key)
+@@ -717,8 +1277,9 @@ class PCIeDCPA2APool:
+         threads: int = 256,
+         block_limit: int = 16,
+         stream: object = None,
++        channel_id: Optional[str] = None,
+     ) -> torch.Tensor:
+-        channel = self.for_stream(stream)
++        channel = self.for_stream(stream, channel_id=channel_id)
+         if stream is not None and self.device.type == "cuda":
+             with torch.cuda.stream(stream):
+                 return channel.lse_reduce_scatter(
+@@ -746,8 +1307,9 @@ class PCIeDCPA2APool:
+         threads: int = 256,
+         block_limit: int = 16,
+         stream: object = None,
++        channel_id: Optional[str] = None,
+     ) -> torch.Tensor:
+-        channel = self.for_stream(stream)
++        channel = self.for_stream(stream, channel_id=channel_id)
+         if stream is not None and self.device.type == "cuda":
+             with torch.cuda.stream(stream):
+                 return channel.all_gather_heads(
+@@ -764,16 +1326,70 @@ class PCIeDCPA2APool:
+         )
+ 
+     @contextmanager
+-    def capture(self, stream: object = None):
+-        """Bind nested CUDA captures to the enclosing stream's channel."""
++    def capture(self, stream: object = None, *, channel_id: Optional[str] = None):
++        """Bind capture to a globally named channel.
++
++        Explicit unknown ids are prepared collectively and fail closed when
++        rank ids differ. Production callers should pre-prepare the full set of
++        independently replayable graph ids before entering any capture; after
++        that collective preparation, ranks may capture members of the agreed
++        catalog in different orders. Each graph must still replay with its
++        same-id peers using collectively compatible kernel sequences and
++        shapes.
++
++        Distributed pools require this semantic id. Local ordinals and stream
++        handles cannot identify target versus draft graphs across ranks.
++        """
++        previous_channels: Optional[dict[int, PCIeDCPA2A]] = None
++        if not self.single_channel and _is_current_stream_capturing(self.device):
++            raise RuntimeError(
++                "PCIe DCP A2A capture context must be entered before CUDA graph "
++                "capture starts"
++            )
+         if self.single_channel:
+-            channel = self.for_stream(stream)
++            channel = self.for_stream(
++                stream,
++                channel_id=_SINGLE_CHANNEL_ID if channel_id is None else channel_id,
++            )
++        elif self._channel_factory is None:
++            assert self.exchange_group is not None
++
++            def validate_capture_id() -> str:
++                if channel_id is None:
++                    raise RuntimeError(
++                        "distributed PCIe DCP A2A capture requires a stable "
++                        "semantic channel_id shared by every rank"
++                    )
++                logical_id = _normalize_logical_channel_id(channel_id)
++                if logical_id in self._captured_channel_ids:
++                    raise RuntimeError(
++                        f"logical channel {logical_id!r} was already captured; "
++                        "each independently replayable graph requires a unique id"
++                    )
++                return logical_id
++
++            logical_id = _run_collective_preallocation_setup(
++                owner="PCIe DCP A2A capture channel validation",
++                exchange_group=self.exchange_group,
++                setup=validate_capture_id,
++            )
++            needs_preparation = _collective_capture_needs_preparation(
++                owner="PCIe DCP A2A",
++                logical_id=logical_id,
++                prepared_channel_ids=self._logical_channels,
++                exchange_group=self.exchange_group,
++            )
++            if needs_preparation:
++                self.prepare_channels((logical_id,))
++            previous_channels = dict(self._channels)
++            stream_key = _current_stream_key(self.device, stream)
++            key = 0 if stream_key is None else int(stream_key)
++            channel = self._logical_channels[logical_id]
++            channel._bind_stream_key(stream_key)
++            self._channels[key] = channel
++            self._captured_channel_ids.add(logical_id)
+         else:
+-            if _is_current_stream_capturing(self.device):
+-                raise RuntimeError(
+-                    "PCIe DCP A2A capture context must be entered before CUDA "
+-                    "graph capture starts"
+-                )
++            previous_channels = dict(self._channels)
+             stream_key = _current_stream_key(self.device, stream)
+             key = 0 if stream_key is None else int(stream_key)
+             # Keep a graph-owned channel even when CUDA recycles the enclosing
+@@ -787,22 +1403,48 @@ class PCIeDCPA2APool:
+             popped = self._capture_channel_stack.pop()
+             if popped is not channel:
+                 raise RuntimeError("PCIe DCP A2A capture channel stack corrupted")
++            if previous_channels is not None:
++                # Captured graph nodes retain the channel through
++                # ``_all_channels``. Restore eager mappings and discard every
++                # nested capture-stream alias so a recycled stream key cannot
++                # hand this graph-owned channel to a later unwrapped capture.
++                for key, mapped in tuple(self._channels.items()):
++                    if mapped is not channel:
++                        continue
++                    previous = previous_channels.get(key)
++                    if previous is None:
++                        del self._channels[key]
++                    else:
++                        self._channels[key] = previous
+ 
+     def close(self) -> None:
+         if self._closed:
+             return
+-        self._closed = True
+         seen: set[int] = set()
++        channels = []
+         for channel in (*self._all_channels, *self._channels.values()):
+             if id(channel) not in seen:
+                 seen.add(id(channel))
+-                channel.close()
++                channels.append(channel)
++        _coordinated_close_channels(
++            channels,
++            exchange_group=self.exchange_group,
++            device=self.device,
++        )
++        self._closed = True
+         self._all_channels.clear()
+         self._channels.clear()
++        self._logical_channels.clear()
++        self._captured_channel_ids.clear()
+ 
+-    def __del__(self) -> None:
+-        with suppress(Exception):
+-            self.close()
++    def __del__(
++        self,
++        _quarantine: dict[int, object] = _ABANDONED_PCIE_RUNTIME_QUARANTINE,
++    ) -> None:
++        # Graphs may retain these channels after Python ownership disappears.
++        # Explicit close() is required for synchronization and peer teardown.
++        if not getattr(self, "_closed", True):
++            _quarantine[id(self)] = self
+ 
+ 
+ __all__ = [
+diff --git a/sparkinfer/comm/pcie/pcie_oneshot.cu b/sparkinfer/comm/pcie/pcie_oneshot.cu
+index fc01c8273ef0a5b90d601e8208804bd162e43de8..28396a643cd5ee3f7b4498f9041f440df276f273 100644
+--- a/sparkinfer/comm/pcie/pcie_oneshot.cu
++++ b/sparkinfer/comm/pcie/pcie_oneshot.cu
+@@ -23,6 +23,8 @@
+ #include <unordered_map>
+ #include <vector>
+ 
++#include "ipc_handle_registry.h"
++
+ #define CHECK_CUDA_SUCCESS(cmd)                                         \
+   do {                                                                  \
+     cudaError_t e = cmd;                                                \
+@@ -76,6 +78,8 @@ static bool oneshot_push_enabled() {
+ }
+ 
+ struct Signal {
++  alignas(128) FlagType staging_generation;
++  FlagType active_staging_slot;
+   alignas(128) FlagType self_counter[kMaxBlocks][kMaxRanks];
+   alignas(128) FlagType peer_counter[2][kMaxBlocks][kMaxRanks * kFlagStride];
+   alignas(128) FlagType rms_arrive[kMaxBlocks];
+@@ -87,6 +91,10 @@ struct __align__(16) RankData {
+   const void* __restrict__ ptrs[kMaxRanks];
+ };
+ 
++struct DoubleRankData {
++  RankData* slots[2];
++};
++
+ struct __align__(16) RankSignals {
+   Signal* signals[kMaxRanks];
+ };
+@@ -189,6 +197,28 @@ static DINLINE FlagType ld_flag_acquire_gpu(FlagType* flag_addr) {
+   return flag;
+ }
+ 
++__global__ void advance_staging_slot_kernel(Signal* self_sg) {
++  if (threadIdx.x == 0) {
++    const FlagType generation = self_sg->staging_generation;
++    self_sg->active_staging_slot = generation & FlagType{1};
++    self_sg->staging_generation = generation + FlagType{1};
++  }
++}
++
++template <int ngpus>
++DINLINE void select_rank_data(RankData& selected, const DoubleRankData& options, Signal* self_sg) {
++  if (threadIdx.x == 0) {
++    // A one-CTA control kernel publishes the slot on this same stream before
++    // the worker launch. Kernel completion is the ordering edge, so every CTA
++    // observes one launch-wide slot without a grid rendezvous.
++    const int slot = int(ld_flag_relaxed_gpu(&self_sg->active_staging_slot) & FlagType{1});
++    const RankData* source = options.slots[slot];
++#pragma unroll
++    for (int peer = 0; peer < ngpus; ++peer) selected.ptrs[peer] = source->ptrs[peer];
++  }
++  __syncthreads();
++}
++
+ template <int ngpus, bool is_start>
+ DINLINE void multi_gpu_barrier(const RankSignals& sg, Signal* self_sg, int rank) {
+   if constexpr (!is_start) __syncthreads();
+@@ -253,17 +283,23 @@ DINLINE float block_reduce_sum(float value, float* warp_sums) {
+ // sufficient for staging visibility.
+ template <typename T, int ngpus, bool stage_input>
+ __global__ void __launch_bounds__(512, 1) pcie_allreduce_kernel(
+-    RankData* _dp,
++    DoubleRankData data_options,
+     RankSignals sg,
+     Signal* self_sg,
+     const T* __restrict__ input,
+     T* __restrict__ result,
+-    T* __restrict__ self_staging,
+     int rank,
+     int size) {
+   using P = typename packed_t<T>::P;
+   using A = typename packed_t<T>::A;
+-  auto dp = *_dp;
++  RankData dp;
++  if constexpr (stage_input) {
++    __shared__ RankData selected;
++    select_rank_data<ngpus>(selected, data_options, self_sg);
++    dp = selected;
++  } else {
++    dp = *data_options.slots[0];
++  }
+   const P* rotated[ngpus];
+ #pragma unroll
+   for (int i = 0; i < ngpus; i++) {
+@@ -271,7 +307,8 @@ __global__ void __launch_bounds__(512, 1) pcie_allreduce_kernel(
+   }
+   if constexpr (stage_input) {
+     const P* input_p = reinterpret_cast<const P*>(input);
+-    P* staging_p = reinterpret_cast<P*>(self_staging);
++    P* staging_p =
++        reinterpret_cast<P*>(const_cast<void*>(dp.ptrs[rank]));
+     for (int idx = blockIdx.x * blockDim.x + threadIdx.x; idx < size; idx += gridDim.x * blockDim.x) {
+       staging_p[idx] = input_p[idx];
+     }
+@@ -304,7 +341,9 @@ constexpr int kModeRegistered = 0;
+ constexpr int kModeStagePull = 1;
+ constexpr int kModeStagePush = 2;
+ 
+-// Complete the allreduce, residual add, and RMSNorm in one launch.
++// Complete the allreduce, residual add, and RMSNorm in one worker launch.
++// Staged paths prepend one 1-CTA slot-control launch; the registered path
++// remains a single worker launch.
+ //
+ // Geometry is uniform: gridDim.x == rows * ctas_per_row and block b serves
+ // row b / ctas_per_row, owning columns {(b % ctas_per_row) * blockDim.x +
+@@ -323,12 +362,12 @@ constexpr int kModeStagePush = 2;
+ // only. Otherwise each CTA publishes one fp32 square-sum partial, crosses a
+ // sense-reversing per-row generation barrier, and normalizes its own columns
+ // from registers, so no CTA re-reads the row it just wrote. All CTAs of a
+-// row spin, which is safe for the same reason the cross-rank start barrier
+-// is: the grid never exceeds kMaxBlocks <= SM count, so every block is
+-// resident.
++// row spin. The host derives the concrete kernel's resident-grid capacity
++// from CUDA occupancy before capture and caps the multi-CTA grid to that
++// device-specific value; no SM-count or full-GPU assumption is baked in.
+ template <typename T, int ngpus, bool single_cta, int mode>
+ __global__ void __launch_bounds__(512, 1) pcie_allreduce_fused_add_rms_norm_kernel(
+-    RankData* _dp,
++    DoubleRankData data_options,
+     RankSignals sg,
+     Signal* self_sg,
+     const T* __restrict__ input,
+@@ -336,7 +375,6 @@ __global__ void __launch_bounds__(512, 1) pcie_allreduce_fused_add_rms_norm_kern
+     const T* __restrict__ weight,
+     T* __restrict__ output,
+     T* __restrict__ residual_output,
+-    T* __restrict__ self_staging,
+     int rank,
+     int hidden_packs,
+     int ctas_per_row,
+@@ -346,6 +384,14 @@ __global__ void __launch_bounds__(512, 1) pcie_allreduce_fused_add_rms_norm_kern
+   using A = typename packed_t<T>::A;
+   __shared__ float warp_sums[32];
+   __shared__ float s_inv_rms;
++  RankData dp;
++  if constexpr (mode == kModeRegistered) {
++    dp = *data_options.slots[0];
++  } else {
++    __shared__ RankData selected;
++    select_rank_data<ngpus>(selected, data_options, self_sg);
++    dp = selected;
++  }
+ 
+   const int row = single_cta ? blockIdx.x : blockIdx.x / ctas_per_row;
+   const int row_cta = single_cta ? 0 : blockIdx.x - row * ctas_per_row;
+@@ -355,7 +401,6 @@ __global__ void __launch_bounds__(512, 1) pcie_allreduce_fused_add_rms_norm_kern
+   const int max_packs = (hidden_packs + col_stride - 1) / col_stride;
+   const bool reg_norm = max_packs <= kRegPacks;
+ 
+-  auto dp = *_dp;
+   const P* rotated[ngpus];
+ #pragma unroll
+   for (int i = 0; i < ngpus; i++) {
+@@ -367,7 +412,7 @@ __global__ void __launch_bounds__(512, 1) pcie_allreduce_fused_add_rms_norm_kern
+   const P* weight_p = reinterpret_cast<const P*>(weight);
+   P* output_p = reinterpret_cast<P*>(output);
+   P* residual_output_p = reinterpret_cast<P*>(residual_output);
+-  P* staging_p = reinterpret_cast<P*>(self_staging);
++  P* staging_p = reinterpret_cast<P*>(const_cast<void*>(dp.ptrs[rank]));
+ 
+   // Sense-reversing row barrier: latch the generation before arriving.
+   // Launches are stream-serialized, so this read cannot race a peer CTA's
+@@ -550,10 +595,51 @@ __global__ void __launch_bounds__(512, 1) pcie_allreduce_fused_add_rms_norm_kern
+   }
+ }
+ 
++template <typename T, int ngpus, int mode>
++int fused_resident_grid_capacity(int threads) {
++  int blocks_per_sm = 0;
++  CHECK_CUDA_SUCCESS(cudaOccupancyMaxActiveBlocksPerMultiprocessor(
++      &blocks_per_sm,
++      pcie_allreduce_fused_add_rms_norm_kernel<T, ngpus, false, mode>,
++      threads,
++      0));
++  int device = 0;
++  int sm_count = 0;
++  CHECK_CUDA_SUCCESS(cudaGetDevice(&device));
++  CHECK_CUDA_SUCCESS(
++      cudaDeviceGetAttribute(&sm_count, cudaDevAttrMultiProcessorCount, device));
++  if (blocks_per_sm <= 0 || sm_count <= 0) {
++    throw std::runtime_error(
++        "CUDA reported no resident capacity for fused PCIe RMSNorm");
++  }
++  return blocks_per_sm * sm_count;
++}
++
++template <typename T, int ngpus>
++std::array<int, 3> fused_resident_capacities(int threads) {
++  return {
++      fused_resident_grid_capacity<T, ngpus, kModeRegistered>(threads),
++      fused_resident_grid_capacity<T, ngpus, kModeStagePull>(threads),
++      fused_resident_grid_capacity<T, ngpus, kModeStagePush>(threads),
++  };
++}
++
++static int cap_fused_ctas_per_row(int requested, int rows,
++                                  int resident_capacity) {
++  if (rows <= 0 || resident_capacity <= 0) {
++    throw std::runtime_error("invalid fused PCIe resident-grid capacity");
++  }
++  return std::max(
++      1, std::min(requested, std::max(1, resident_capacity / rows)));
++}
++
+ using IPC_KEY = std::array<uint8_t, sizeof(cudaIpcMemHandle_t)>;
+ 
+ class PCIeAllreduce {
+  public:
++  using IPCHandles =
++      sparkinfer::pcie::IpcHandleRegistry<IPC_KEY, char*, cudaError_t, cudaSuccess>;
++
+   int rank_;
+   int world_size_;
+ 
+@@ -563,31 +649,108 @@ class PCIeAllreduce {
+ 
+   RankData *d_rank_data_base_, *d_rank_data_end_;
+   std::vector<void*> graph_unreg_buffers_;
+-  std::map<IPC_KEY, char*> ipc_handles_;
++  IPCHandles ipc_handles_;
++
++  // [float, half, bf16][registered, pull, push], queried once during native
++  // runtime construction (outside CUDA graph capture) and reused by captures.
++  std::array<std::array<int, 3>, 3> fused_resident_capacity_{};
+ 
+   bool dbuf_enabled_ = false;
+-  int dbuf_slot_ = 0;
+-  void* dbuf_raw_[2][kMaxRanks] = {};
+-  RankData* dbuf_rd_[2] = {};
++  DoubleRankData dbuf_data_ = {};
+ 
+   PCIeAllreduce(Signal** signals, void* rank_data, size_t rank_data_sz, int rank, int world_size)
+       : rank_(rank),
+         world_size_(world_size),
+         self_sg_(signals[rank]),
+         d_rank_data_base_(reinterpret_cast<RankData*>(rank_data)),
+-        d_rank_data_end_(d_rank_data_base_ + rank_data_sz / sizeof(RankData)) {
++        d_rank_data_end_(d_rank_data_base_ + rank_data_sz / sizeof(RankData)),
++        ipc_handles_(&PCIeAllreduce::close_ipc_handle) {
+     for (int i = 0; i < world_size_; i++) sg_.signals[i] = signals[i];
++    const int threads = fused_threads();
++#define CACHE_CAPACITY(ngpus)                                                   \
++    do {                                                                        \
++      fused_resident_capacity_[0] = fused_resident_capacities<float, ngpus>(threads); \
++      fused_resident_capacity_[1] = fused_resident_capacities<half, ngpus>(threads);  \
++      fused_resident_capacity_[2] =                                             \
++          fused_resident_capacities<nv_bfloat16, ngpus>(threads);               \
++    } while (0)
++    switch (world_size_) {
++      case 2: CACHE_CAPACITY(2); break;
++      case 4: CACHE_CAPACITY(4); break;
++      case 6: CACHE_CAPACITY(6); break;
++      case 8: CACHE_CAPACITY(8); break;
++      case 10: CACHE_CAPACITY(10); break;
++      default:
++        throw std::invalid_argument("unsupported PCIe allreduce world size");
++    }
++#undef CACHE_CAPACITY
++    // Deterministic reduced-capacity/MIG-like validation may lower (never
++    // raise) CUDA's measured capacity. This is a test-only safety override.
++    const int test_capacity =
++        env_int("SPARKINFER_PCIE_TEST_RESIDENT_GRID_CAPACITY", 0);
++    if (test_capacity > 0) {
++      for (auto& dtype_capacities : fused_resident_capacity_) {
++        for (int& capacity : dtype_capacities) {
++          capacity = std::min(capacity, test_capacity);
++        }
++      }
++    }
++  }
++
++  template <typename T>
++  int fused_resident_capacity(int mode) const {
++    constexpr int dtype_index = std::is_same<T, float>::value
++                                    ? 0
++                                    : (std::is_same<T, half>::value ? 1 : 2);
++    if (mode < kModeRegistered || mode > kModeStagePush) {
++      throw std::runtime_error("invalid fused PCIe transport mode");
++    }
++    return fused_resident_capacity_[dtype_index][mode];
++  }
++
++  static cudaError_t close_ipc_handle(char* ptr) noexcept {
++    return cudaIpcCloseMemHandle(ptr);
+   }
+ 
+   char* open_ipc_handle(const void* ipc_handle) {
+-    auto [it, new_handle] = ipc_handles_.insert({*((IPC_KEY*)ipc_handle), nullptr});
+-    if (new_handle) {
+-      char* ipc_ptr;
+-      CHECK_CUDA_SUCCESS(cudaIpcOpenMemHandle(
+-          (void**)&ipc_ptr, *((const cudaIpcMemHandle_t*)ipc_handle), cudaIpcMemLazyEnablePeerAccess));
+-      it->second = ipc_ptr;
++    const auto& key = *reinterpret_cast<const IPC_KEY*>(ipc_handle);
++    auto existing = ipc_handles_.find(key);
++    if (existing != ipc_handles_.end()) {
++      return existing->second;
++    }
++
++    char* ipc_ptr;
++    CHECK_CUDA_SUCCESS(cudaIpcOpenMemHandle(
++        reinterpret_cast<void**>(&ipc_ptr),
++        *reinterpret_cast<const cudaIpcMemHandle_t*>(ipc_handle),
++        cudaIpcMemLazyEnablePeerAccess));
++    try {
++      auto [inserted, is_new] = ipc_handles_.emplace(key, ipc_ptr);
++      if (!is_new) {
++        // Defensively avoid double ownership if this insertion path changes.
++        (void)cudaIpcCloseMemHandle(ipc_ptr);
++        return inserted->second;
++      }
++      return inserted->second;
++    } catch (...) {
++      // Do not leak a successfully opened mapping if map allocation fails.
++      (void)cudaIpcCloseMemHandle(ipc_ptr);
++      throw;
++    }
++  }
++
++  cudaError_t close_ipc_handles_noexcept() noexcept {
++    return ipc_handles_.close_all_noexcept();
++  }
++
++  void close_ipc_handles_strict() {
++    const cudaError_t error = close_ipc_handles_noexcept();
++    if (error != cudaSuccess) {
++      const char* description = cudaGetErrorString(error);
++      throw std::runtime_error(
++          std::string("cudaIpcCloseMemHandle failed while disposing PCIe allreduce: ") +
++          (description == nullptr ? "unknown CUDA error" : description));
+     }
+-    return it->second;
+   }
+ 
+   std::pair<std::string, std::vector<int64_t>> get_graph_buffer_ipc_meta() {
+@@ -616,17 +779,14 @@ class PCIeAllreduce {
+     for (int s = 0; s < 2; s++) {
+       void** ptrs = s == 0 ? ptrs0 : ptrs1;
+       RankData data;
+-      for (int i = 0; i < world_size_; i++) {
+-        data.ptrs[i] = ptrs[i];
+-        dbuf_raw_[s][i] = ptrs[i];
+-      }
+-      dbuf_rd_[s] = d_rank_data_base_++;
+-      CHECK_CUDA_SUCCESS(cudaMemcpy(dbuf_rd_[s], &data, sizeof(RankData), cudaMemcpyHostToDevice));
++      for (int i = 0; i < world_size_; i++) data.ptrs[i] = ptrs[i];
++      dbuf_data_.slots[s] = d_rank_data_base_++;
++      CHECK_CUDA_SUCCESS(
++          cudaMemcpy(dbuf_data_.slots[s], &data, sizeof(RankData), cudaMemcpyHostToDevice));
+     }
+-    buffers_[ptrs0[rank_]] = dbuf_rd_[0];
+-    buffers_[ptrs1[rank_]] = dbuf_rd_[1];
++    buffers_[ptrs0[rank_]] = dbuf_data_.slots[0];
++    buffers_[ptrs1[rank_]] = dbuf_data_.slots[1];
+     dbuf_enabled_ = true;
+-    dbuf_slot_ = 0;
+   }
+ 
+   void register_buffer(void** ptrs) {
+@@ -678,18 +838,16 @@ class PCIeAllreduce {
+     if (block_limit > kMaxBlocks)
+       throw std::runtime_error("max supported block limit is " + std::to_string(kMaxBlocks));
+ 
+-    RankData* ptrs;
+-    T* staging = nullptr;
++    DoubleRankData data_options = {};
++    bool stage_input = false;
+     cudaStreamCaptureStatus status;
+     CHECK_CUDA_SUCCESS(cudaStreamIsCapturing(stream, &status));
+ 
+     if (dbuf_enabled_) {
+-      // The kernel stages the input into the eager slot itself; no host
+-      // staging memcpy is issued.
+-      int slot = dbuf_slot_ % 2;
+-      dbuf_slot_++;
+-      ptrs = dbuf_rd_[slot];
+-      staging = reinterpret_cast<T*>(dbuf_raw_[slot][rank_]);
++      // A captured control kernel advances the active eager slab on every
++      // execution, including CUDA graph replay.
++      data_options = dbuf_data_;
++      stage_input = true;
+     } else if (status == cudaStreamCaptureStatusActive) {
+       throw std::runtime_error(
+           "PCIe oneshot graph capture requires eager IPC buffers; construct the runtime with eager buffers or use "
+@@ -699,22 +857,27 @@ class PCIeAllreduce {
+       if (it == buffers_.end())
+         throw std::runtime_error(
+             "buffer address " + std::to_string(reinterpret_cast<uint64_t>(input)) + " is not registered!");
+-      ptrs = it->second;
++      data_options.slots[0] = it->second;
++      data_options.slots[1] = it->second;
+     }
+ 
+     size /= d;
+     int blocks = std::min(block_limit, (size + threads - 1) / threads);
+     blocks = std::max(blocks, 1);
++    if (stage_input) {
++      advance_staging_slot_kernel<<<1, 1, 0, stream>>>(self_sg_);
++      CHECK_CUDA_SUCCESS(cudaGetLastError());
++    }
+ 
+ #define KL(ngpus)                                                                                                     \
+   do {                                                                                                               \
+-    if (staging != nullptr) {                                                                                        \
++    if (stage_input) {                                                                                               \
+       pcie_allreduce_kernel<T, ngpus, true>                                                                          \
+-          <<<blocks, threads, 0, stream>>>(ptrs, sg_, self_sg_, input, output, staging, rank_, size);                \
++          <<<blocks, threads, 0, stream>>>(data_options, sg_, self_sg_, input, output, rank_, size);                 \
+     } else {                                                                                                         \
+       pcie_allreduce_kernel<T, ngpus, false>                                                                         \
+-          <<<blocks, threads, 0, stream>>>(ptrs, sg_, self_sg_, input, output, staging, rank_, size);                \
+-    }                                                                                                                 \
++          <<<blocks, threads, 0, stream>>>(data_options, sg_, self_sg_, input, output, rank_, size);                 \
++    }                                                                                                                \
+   } while (0)
+     switch (world_size_) {
+       case 2:
+@@ -735,6 +898,7 @@ class PCIeAllreduce {
+       default:
+         throw std::runtime_error("only supports (2,4,6,8,10) gpus, got " + std::to_string(world_size_));
+     }
++    CHECK_CUDA_SUCCESS(cudaGetLastError());
+ #undef KL
+   }
+ 
+@@ -757,17 +921,15 @@ class PCIeAllreduce {
+       throw std::runtime_error(
+           "fused allreduce RMSNorm requires hidden size to be a multiple of " + std::to_string(pack_size));
+ 
+-    RankData* ptrs;
+-    T* staging = nullptr;
++    DoubleRankData data_options = {};
++    bool use_eager_staging = false;
+     cudaStreamCaptureStatus status;
+     CHECK_CUDA_SUCCESS(cudaStreamIsCapturing(stream, &status));
+     if (dbuf_enabled_) {
+-      // The kernel stages the input into the eager slot itself; no host
+-      // staging memcpy is issued.
+-      int slot = dbuf_slot_ % 2;
+-      dbuf_slot_++;
+-      ptrs = dbuf_rd_[slot];
+-      staging = reinterpret_cast<T*>(dbuf_raw_[slot][rank_]);
++      // A captured control kernel advances the active eager slab on every
++      // execution, including CUDA graph replay.
++      data_options = dbuf_data_;
++      use_eager_staging = true;
+     } else if (status == cudaStreamCaptureStatusActive) {
+       throw std::runtime_error(
+           "PCIe oneshot graph capture requires eager IPC buffers; construct the runtime with eager buffers or use "
+@@ -777,7 +939,8 @@ class PCIeAllreduce {
+       if (it == buffers_.end())
+         throw std::runtime_error(
+             "buffer address " + std::to_string(reinterpret_cast<uint64_t>(input)) + " is not registered!");
+-      ptrs = it->second;
++      data_options.slots[0] = it->second;
++      data_options.slots[1] = it->second;
+     }
+ 
+     int rows = size / hidden_size;
+@@ -797,17 +960,27 @@ class PCIeAllreduce {
+       ctas_per_row = std::max(std::max(1, 3 / rows), min_ctas);
+     }
+     ctas_per_row = std::max(1, std::min(ctas_per_row, kMaxBlocks / rows));
++    const int mode = !use_eager_staging   ? kModeRegistered
++                     : oneshot_push_enabled() ? kModeStagePush
++                                              : kModeStagePull;
++    const int resident_capacity = fused_resident_capacity<T>(mode);
++    // Multi-CTA row barriers can only be used when the complete grid is
++    // simultaneously resident. This also handles reduced/MIG-like devices;
++    // fall back to the barrier-free single-CTA path when capacity is tight.
++    ctas_per_row =
++        cap_fused_ctas_per_row(ctas_per_row, rows, resident_capacity);
+     const int blocks = rows * ctas_per_row;
+     const bool single = ctas_per_row == 1;
+     const int shard_packs = size / pack_size;
+-    const int mode = staging == nullptr ? kModeRegistered
+-                     : oneshot_push_enabled() ? kModeStagePush
+-                                              : kModeStagePull;
++    if (use_eager_staging) {
++      advance_staging_slot_kernel<<<1, 1, 0, stream>>>(self_sg_);
++      CHECK_CUDA_SUCCESS(cudaGetLastError());
++    }
+ 
+ #define KL(ngpus, SINGLE, MODE)                                                                                       \
+-  pcie_allreduce_fused_add_rms_norm_kernel<T, ngpus, SINGLE, MODE><<<blocks, threads, 0, stream>>>(                   \
+-      ptrs, sg_, self_sg_, input, residual, weight, output, residual_output, staging, rank_, hidden_packs,            \
+-      ctas_per_row, shard_packs, epsilon);
++  pcie_allreduce_fused_add_rms_norm_kernel<T, ngpus, SINGLE, MODE>                                                    \
++      <<<blocks, threads, 0, stream>>>(data_options, sg_, self_sg_, input, residual, weight, output,                \
++                                       residual_output, rank_, hidden_packs, ctas_per_row, shard_packs, epsilon);
+ #define DISPATCH_MODE(ngpus, SINGLE)                                                                                  \
+   do {                                                                                                               \
+     if (mode == kModeStagePush) {                                                                                    \
+@@ -845,14 +1018,13 @@ class PCIeAllreduce {
+       default:
+         throw std::runtime_error("only supports (2,4,6,8,10) gpus, got " + std::to_string(world_size_));
+     }
++    CHECK_CUDA_SUCCESS(cudaGetLastError());
+ #undef DISPATCH
+ #undef DISPATCH_MODE
+ #undef KL
+   }
+ 
+-  ~PCIeAllreduce() {
+-    for (auto [_, ptr] : ipc_handles_) CHECK_CUDA_SUCCESS(cudaIpcCloseMemHandle(ptr));
+-  }
++  ~PCIeAllreduce() noexcept = default;
+ };
+ 
+ }  // namespace pcie_allreduce
+@@ -995,7 +1167,18 @@ static void all_reduce_fused_add_rms_norm(
+ }
+ 
+ static void dispose(fptr_t _fa) {
+-  delete reinterpret_cast<pcie_allreduce::PCIeAllreduce*>(_fa);
++  auto* fa = reinterpret_cast<pcie_allreduce::PCIeAllreduce*>(_fa);
++  if (fa == nullptr) return;
++  fa->close_ipc_handles_strict();
++  delete fa;
++}
++
++static bool dispose_best_effort(fptr_t _fa) noexcept {
++  auto* fa = reinterpret_cast<pcie_allreduce::PCIeAllreduce*>(_fa);
++  if (fa == nullptr) return true;
++  const cudaError_t error = fa->close_ipc_handles_noexcept();
++  delete fa;
++  return error == cudaSuccess;
+ }
+ 
+ static int64_t meta_size() {
+@@ -1046,7 +1229,14 @@ PYBIND11_MODULE(TORCH_EXTENSION_NAME, m) {
+       "all_reduce_fused_add_rms_norm",
+       &all_reduce_fused_add_rms_norm,
+       "PCIe allreduce fused with residual add and RMSNorm");
+-  m.def("dispose", &dispose, "dispose PCIe allreduce");
++  m.def(
++      "dispose",
++      &dispose,
++      "strictly dispose PCIe allreduce; retain it for retry if an IPC close fails");
++  m.def(
++      "dispose_best_effort",
++      &dispose_best_effort,
++      "nonthrowing PCIe allreduce dispose; return whether every native IPC import closed");
+   m.def("meta_size", &meta_size, "signal metadata size");
+   m.def("register_buffer", &register_buffer, "register IPC buffer");
+   m.def("register_pcie_buffers", &register_pcie_buffers, "register double-buffered IPC buffers");
+diff --git a/sparkinfer/comm/pcie/pcie_oneshot.py b/sparkinfer/comm/pcie/pcie_oneshot.py
+index d75a12abe06c1602d5dcbbbcf586ba0e688f535f..29195cef5c562f88d268fc3e19e7f792ad1b1101 100644
+--- a/sparkinfer/comm/pcie/pcie_oneshot.py
++++ b/sparkinfer/comm/pcie/pcie_oneshot.py
+@@ -5,11 +5,12 @@ from __future__ import annotations
+ import logging
+ import os
+ import time
+-from contextlib import contextmanager, suppress
+-from dataclasses import dataclass
++from contextlib import contextmanager
++from dataclasses import dataclass, field
+ from functools import lru_cache
++from itertools import count
+ from pathlib import Path
+-from typing import Callable, Optional, Sequence
++from typing import Callable, Iterable, Optional, Sequence, TypeVar
+ 
+ import torch
+ import torch.distributed as dist
+@@ -28,6 +29,18 @@ DEFAULT_RANK_DATA_BYTES = 8 * 1024 * 1024
+ AUTOTUNE_CEILING = 1 * 1024 * 1024
+ AUTOTUNE_FINE_STEP = 8 * 1024
+ IPC_SLAB_ALIGNMENT = 256
++ONESHOT_REQUIRED_SMS = 36
++_SINGLE_CHANNEL_ID = "__single__"
++
++# CUDA graph nodes and the native runtime retain raw pointers into rank_data.
++# GC cannot synchronize arbitrary streams, so an abandoned runtime must keep
++# its complete Python ownership graph alive until process teardown.  Explicit
++# close() is the only path that removes this need.  A dict makes manual/finalizer
++# re-entry idempotent while the retained object prevents id reuse.
++_ABANDONED_PCIE_RUNTIME_QUARANTINE: dict[int, object] = {}
++_RETAINED_FAILED_IPC_EXPORTS: dict[tuple[int, int], "_RetryableIPCExport"] = {}
++_RETAINED_IPC_SETUP_GENERATIONS = count(1)
++_SetupResult = TypeVar("_SetupResult")
+ 
+ 
+ def parse_pcie_oneshot_max_size(value: str | int | None) -> Optional[int]:
+@@ -60,6 +73,12 @@ def _normalize_device(device: torch.device | int | str) -> torch.device:
+     return torch.device(device)
+ 
+ 
++def _cuda_device_index(device: torch.device) -> int:
++    if device.type != "cuda":
++        raise ValueError("expected a CUDA device")
++    return torch.cuda.current_device() if device.index is None else int(device.index)
++
++
+ def _current_stream_key(
+     device: torch.device | int | str, stream: object = None
+ ) -> Optional[int]:
+@@ -110,13 +129,88 @@ def _resolve_exchange_group(
+     return exchange_group if exchange_group is not None else process_group
+ 
+ 
++def _normalize_logical_channel_id(channel_id: str) -> str:
++    if not isinstance(channel_id, str):
++        raise TypeError("logical channel id must be a string")
++    normalized = channel_id.strip()
++    if not normalized:
++        raise ValueError("logical channel id must not be empty")
++    return normalized
++
++
++def _collective_capture_needs_preparation(
++    *,
++    owner: str,
++    logical_id: str,
++    prepared_channel_ids: Iterable[str],
++    exchange_group: ProcessGroup,
++) -> bool:
++    """Decide whether capture may use the prepared catalog without allocation.
++
++    Once every rank has prepared the same complete graph catalog, ranks may
++    capture those graphs in different orders.  Allocation remains collective:
++    a same-id unknown channel may use the convenience preparation path, while
++    any differing request that includes an unknown id fails before allocation.
++    """
++
++    catalog = tuple(sorted(prepared_channel_ids))
++    local_state = (logical_id, catalog)
++    gathered = _broadcast_gather_object(local_state, exchange_group)
++    if not gathered:
++        raise RuntimeError(f"{owner} capture contract returned no rank states")
++
++    requested_ids: list[str] = []
++    for group_rank, state in enumerate(gathered):
++        if not isinstance(state, (tuple, list)) or len(state) != 2:
++            raise RuntimeError(
++                f"invalid {owner} capture contract from group rank {group_rank}"
++            )
++        requested_id, peer_catalog = state
++        if not isinstance(requested_id, str) or not isinstance(
++            peer_catalog, (tuple, list)
++        ):
++            raise RuntimeError(
++                f"invalid {owner} capture contract from group rank {group_rank}"
++            )
++        peer_catalog = tuple(peer_catalog)
++        if any(not isinstance(value, str) for value in peer_catalog):
++            raise RuntimeError(
++                f"invalid {owner} capture contract from group rank {group_rank}"
++            )
++        if peer_catalog != catalog:
++            raise RuntimeError(
++                f"{owner} prepared channel catalog differs across ranks: {gathered}"
++            )
++        requested_ids.append(requested_id)
++
++    if all(requested_id in catalog for requested_id in requested_ids):
++        # The canonical catalog already fixed allocation order.  Current graph
++        # capture order is process-local and need not agree across ranks.
++        return False
++    if all(requested_id == requested_ids[0] for requested_id in requested_ids):
++        # Preserve the collective same-id convenience allocation path.
++        return True
++    raise RuntimeError(
++        f"{owner} capture requested unprepared logical channels in differing "
++        f"rank order: requested={tuple(requested_ids)}, prepared={catalog}; call "
++        "prepare_channels() collectively with the complete graph set first"
++    )
++
++
+ def _group_ranks(group: ProcessGroup) -> list[int]:
+     world_size = dist.get_world_size(group=group)
+     if hasattr(dist, "get_process_group_ranks"):
+-        ranks = sorted(dist.get_process_group_ranks(group=group))
++        # Process-group rank is an index into the order returned here.  Sorting
++        # silently changes that mapping for non-monotonic groups and makes the
++        # handle in slot N belong to a different peer than group rank N.
++        ranks = list(dist.get_process_group_ranks(group=group))
+         if len(ranks) != world_size:
+             raise RuntimeError("process-group rank list does not match world size")
+         return ranks
++    if hasattr(dist, "get_global_rank"):
++        return [
++            dist.get_global_rank(group, group_rank) for group_rank in range(world_size)
++        ]
+     return list(range(world_size))
+ 
+ 
+@@ -162,28 +256,884 @@ class _OwnedSharedBuffer:
+     remote_ptrs: tuple[int, ...]
+ 
+ 
++@dataclass
++class _RetryableIPCExport:
++    """Own a failed collective IPC setup until a coordinated retry succeeds.
++
++    The historical name is retained for compatibility with callers that only
++    need to retry a failed ``cudaFree``.  A setup can also own still-open peer
++    imports, a native runtime cleanup callback, and a collective participation
++    ticket after this rank has already released its local export.  Keeping the
++    ticket is important: a rank that succeeded locally must still join the
++    retry verdict so a peer can safely finish its rollback.
++    """
++
++    ipc: CudaRTLibrary
++    local_ptr: int
++    exchange_group: Optional[ProcessGroup] = None
++    owner: str = "PCIe shared buffer"
++    phase: str = "rollback"
++    remote_ptrs: list[int] = field(default_factory=list)
++    local_cleanup: Optional[Callable[[], None]] = None
++    state: str = "free"
++    _registry_key: tuple[int, int] | None = None
++
++    @property
++    def key(self) -> tuple[int, int]:
++        if self._registry_key is not None:
++            return self._registry_key
++        return id(self.ipc), int(self.local_ptr)
++
++    def retry(self) -> None:
++        key = self.key
++        if key not in _RETAINED_FAILED_IPC_EXPORTS:
++            return
++
++        if self.state == "native":
++            native_error: BaseException | None = None
++            if self.local_cleanup is not None:
++                try:
++                    self.local_cleanup()
++                except Exception as exc:
++                    native_error = exc
++                else:
++                    self.local_cleanup = None
++
++            if self.exchange_group is None:
++                if native_error is not None:
++                    raise RuntimeError(
++                        f"{self.owner} {self.phase} retry native cleanup failed; "
++                        "CUDA IPC ownership remains retained"
++                    ) from native_error
++            else:
++                native_statuses = _exchange_setup_failures(
++                    native_error,
++                    exchange_group=self.exchange_group,
++                    phase=f"{self.phase} retry native cleanup",
++                )
++                if any(native_statuses):
++                    raise RuntimeError(
++                        _setup_failure_message(
++                            self.owner,
++                            f"{self.phase} retry native cleanup",
++                            native_statuses,
++                            exports_retained=True,
++                        )
++                    ) from native_error
++            self.state = "unmap"
++
++        if self.state == "unmap":
++            failures: list[str] = []
++
++            remaining_remote_ptrs: list[int] = []
++            for ptr in self.remote_ptrs:
++                try:
++                    self.ipc.cudaIpcCloseMemHandle(ptr)
++                except Exception as exc:
++                    remaining_remote_ptrs.append(ptr)
++                    failures.append(
++                        f"CUDA IPC import {ptr}: {type(exc).__name__}: {exc}"
++                    )
++            self.remote_ptrs = remaining_remote_ptrs
++
++            local_error = RuntimeError(" | ".join(failures)) if failures else None
++            if self.exchange_group is None:
++                if local_error is not None:
++                    raise RuntimeError(
++                        f"{self.owner} {self.phase} retry failed; CUDA IPC "
++                        "ownership remains retained"
++                    ) from local_error
++            else:
++                statuses = _exchange_setup_failures(
++                    local_error,
++                    exchange_group=self.exchange_group,
++                    phase=f"{self.phase} retry unmap",
++                )
++                if any(statuses):
++                    raise RuntimeError(
++                        _setup_failure_message(
++                            self.owner,
++                            f"{self.phase} retry unmap",
++                            statuses,
++                            exports_retained=True,
++                        )
++                    ) from local_error
++            self.state = "free"
++
++        free_error: BaseException | None = None
++        if self.local_ptr:
++            ptr = self.local_ptr
++            try:
++                self.ipc.cudaFree(ptr)
++            except Exception as exc:
++                free_error = exc
++            else:
++                self.local_ptr = 0
++
++        if self.exchange_group is None:
++            if free_error is not None:
++                raise RuntimeError(
++                    f"{self.owner} {self.phase} retry export free failed; CUDA "
++                    "IPC ownership remains retained"
++                ) from free_error
++        else:
++            free_statuses = _exchange_setup_failures(
++                free_error,
++                exchange_group=self.exchange_group,
++                phase=f"{self.phase} retry export free",
++            )
++            if any(free_statuses):
++                raise RuntimeError(
++                    _setup_failure_message(
++                        self.owner,
++                        f"{self.phase} retry export free",
++                        free_statuses,
++                        exports_retained=True,
++                    )
++                ) from free_error
++
++        _RETAINED_FAILED_IPC_EXPORTS.pop(key, None)
++
++
++def _retain_failed_ipc_export(
++    ipc: CudaRTLibrary, local_ptr: int
++) -> _RetryableIPCExport:
++    key = id(ipc), int(local_ptr)
++    retained = _RETAINED_FAILED_IPC_EXPORTS.get(key)
++    if retained is None:
++        retained = _RetryableIPCExport(
++            ipc=ipc,
++            local_ptr=int(local_ptr),
++            _registry_key=key,
++        )
++        _RETAINED_FAILED_IPC_EXPORTS[key] = retained
++    return retained
++
++
++def _retain_failed_ipc_setup(
++    *,
++    ipc: CudaRTLibrary,
++    local_ptr: int,
++    exchange_group: ProcessGroup,
++    owner: str,
++    phase: str,
++    remote_ptrs: Sequence[int] = (),
++    local_cleanup: Optional[Callable[[], None]] = None,
++    state: str = "unmap",
++) -> _RetryableIPCExport:
++    """Retain every local resource and the rank's collective retry ticket."""
++
++    # A CUDA address is not an attempt identity: it may already have been freed
++    # on this rank while a peer still owns its export, then be reused by CUDA for
++    # a second failed setup.  Every collective failure therefore receives an
++    # independent process-local generation ticket.  The ticket need not match
++    # across ranks; it only keeps this rank participating in the same retry call.
++    key = id(ipc), -next(_RETAINED_IPC_SETUP_GENERATIONS)
++    retained = _RetryableIPCExport(
++        ipc=ipc,
++        local_ptr=int(local_ptr),
++        exchange_group=exchange_group,
++        owner=owner,
++        phase=phase,
++        remote_ptrs=list(dict.fromkeys(int(ptr) for ptr in remote_ptrs)),
++        local_cleanup=local_cleanup,
++        state=state,
++        _registry_key=key,
++    )
++    _RETAINED_FAILED_IPC_EXPORTS[key] = retained
++    return retained
++
++
++def _attach_retryable_setup(
++    error: RuntimeError, retained: _RetryableIPCExport
++) -> RuntimeError:
++    # Keep the old attribute for downstream code/tests and expose the broader
++    # meaning under a name that does not imply only cudaFree ownership.
++    error.retryable_export = retained  # type: ignore[attr-defined]
++    error.retryable_setup = retained  # type: ignore[attr-defined]
++    return error
++
++
++def _require_no_retained_ipc_setup(exchange_group: ProcessGroup) -> None:
++    """Serialize collective setup generations until rollback completes.
++
++    Retry tickets are process-local ownership objects, so allowing another IPC
++    setup on the same group would make it possible for ranks to retry different
++    generations in a different order.  Reject the new attempt collectively
++    before it allocates anything instead.
++    """
++
++    outstanding = tuple(
++        retained.key
++        for retained in _RETAINED_FAILED_IPC_EXPORTS.values()
++        if retained.exchange_group is exchange_group
++    )
++    local_error: BaseException | None = None
++    if outstanding:
++        local_error = RuntimeError(
++            "complete the retained CUDA IPC setup retry before starting "
++            f"another setup on this process group (tickets={outstanding})"
++        )
++    statuses = _exchange_setup_failures(
++        local_error,
++        exchange_group=exchange_group,
++        phase="retained CUDA IPC setup gate",
++    )
++    if any(statuses):
++        raise RuntimeError(
++            _setup_failure_message(
++                "PCIe shared buffer",
++                "retained CUDA IPC setup gate",
++                statuses,
++                exports_retained=True,
++            )
++        ) from local_error
++
++
++def _format_setup_error(error: BaseException | None) -> tuple[str, ...]:
++    if error is None:
++        return ()
++    return (f"{type(error).__name__}: {error}",)
++
++
++def _exchange_setup_failures(
++    local_error: BaseException | None,
++    *,
++    exchange_group: ProcessGroup,
++    phase: str,
++    exports_retained_on_exchange_failure: bool = True,
++) -> tuple[tuple[str, ...], ...]:
++    """Collect a setup verdict without allowing one rank to return early."""
++
++    try:
++        gathered = _broadcast_gather_object(
++            _format_setup_error(local_error), exchange_group
++        )
++    except Exception as exc:
++        retention = (
++            "; CUDA IPC exports were retained"
++            if exports_retained_on_exchange_failure
++            else ""
++        )
++        raise RuntimeError(
++            f"failed to exchange peer {phase} status{retention}"
++        ) from exc
++
++    statuses: list[tuple[str, ...]] = []
++    for group_rank, status in enumerate(gathered):
++        if not isinstance(status, (tuple, list)):
++            retention = (
++                "; CUDA IPC exports were retained"
++                if exports_retained_on_exchange_failure
++                else ""
++            )
++            raise RuntimeError(
++                f"invalid peer {phase} status from group rank {group_rank}{retention}"
++            )
++        statuses.append(tuple(str(item) for item in status))
++    return tuple(statuses)
++
++
++def _require_full_grid_residency(
++    *,
++    owner: str,
++    required_sms: int,
++    device: torch.device,
++    exchange_group: Optional[ProcessGroup],
++) -> None:
++    """Reject devices where a peer-waiting worker grid may not all reside.
++
++    The PCIe worker kernels use ``__launch_bounds__(512, 1)`` and zero dynamic
++    shared memory, so every visible SM can host at least one worker CTA.  A
++    device with at least the extension's maximum block count can therefore
++    make the complete grid resident regardless of block scheduling order.  We
++    intentionally reject smaller/MIG-like slices instead of assuming CUDA
++    schedules matching block indices in the same order on every rank.
++    """
++
++    local_error: BaseException | None = None
++    visible_sms = 0
++    try:
++        visible_sms = int(
++            torch.cuda.get_device_properties(device).multi_processor_count
++        )
++        test_visible_sms = int(
++            os.getenv("SPARKINFER_PCIE_TEST_VISIBLE_SM_COUNT", "0") or "0"
++        )
++        if test_visible_sms > 0:
++            visible_sms = min(visible_sms, test_visible_sms)
++        if visible_sms < required_sms:
++            raise RuntimeError(
++                f"{owner} requires at least {required_sms} visible SMs so every "
++                "peer-waiting CTA can be resident; this device/MIG slice exposes "
++                f"{visible_sms}"
++            )
++    except Exception as exc:
++        local_error = exc
++
++    if exchange_group is None:
++        if local_error is not None:
++            raise local_error
++        return
++
++    statuses = _exchange_setup_failures(
++        local_error,
++        exchange_group=exchange_group,
++        phase=f"{owner} resident-grid capability",
++        exports_retained_on_exchange_failure=False,
++    )
++    if any(statuses):
++        raise RuntimeError(
++            _setup_failure_message(
++                owner,
++                "resident-grid capability",
++                statuses,
++                exports_retained=False,
++            )
++        ) from local_error
++
++
++def _run_collective_preallocation_setup(
++    *,
++    owner: str,
++    exchange_group: ProcessGroup,
++    setup: Callable[[], _SetupResult],
++) -> _SetupResult:
++    """Run fallible local setup before any rank creates a CUDA IPC export."""
++
++    result: Optional[_SetupResult] = None
++    local_error: BaseException | None = None
++    try:
++        result = setup()
++    except Exception as exc:
++        local_error = exc
++
++    statuses = _exchange_setup_failures(
++        local_error,
++        exchange_group=exchange_group,
++        phase=f"{owner} pre-allocation setup",
++        exports_retained_on_exchange_failure=False,
++    )
++    if any(statuses):
++        raise RuntimeError(
++            _setup_failure_message(
++                owner,
++                "pre-allocation setup",
++                statuses,
++                exports_retained=False,
++            )
++        ) from local_error
++    assert result is not None
++    return result
++
++
++def _require_collective_contract(
++    *, owner: str, exchange_group: ProcessGroup, contract: object
++) -> None:
++    """Reject divergent rank-local layout/channel inputs before allocation."""
++
++    gathered = _broadcast_gather_object(contract, exchange_group)
++    if any(peer != contract for peer in gathered):
++        raise RuntimeError(f"{owner} contract differs across ranks: {gathered}")
++
++
++def _finish_collective_unowned_runtime_setup(
++    *,
++    owner: str,
++    exchange_group: ProcessGroup,
++    local_error: BaseException | None,
++    local_cleanup: Callable[[], None],
++) -> None:
++    """Coordinate direct-constructor init when pointer ownership is external."""
++
++    statuses = _exchange_setup_failures(
++        local_error,
++        exchange_group=exchange_group,
++        phase=f"{owner} native initialization",
++        exports_retained_on_exchange_failure=False,
++    )
++    if not any(statuses):
++        return
++
++    cleanup_error: BaseException | None = None
++    try:
++        local_cleanup()
++    except Exception as exc:
++        cleanup_error = exc
++    cleanup_statuses = _exchange_setup_failures(
++        cleanup_error,
++        exchange_group=exchange_group,
++        phase=f"{owner} native initialization rollback",
++        exports_retained_on_exchange_failure=False,
++    )
++    if any(cleanup_statuses):
++        raise RuntimeError(
++            _setup_failure_message(
++                owner,
++                "native initialization rollback",
++                cleanup_statuses,
++                exports_retained=False,
++            )
++        ) from (cleanup_error or local_error)
++    raise RuntimeError(
++        _setup_failure_message(
++            owner,
++            "native initialization",
++            statuses,
++            exports_retained=False,
++        )
++    ) from local_error
++
++
++def _setup_failure_message(
++    owner: str,
++    phase: str,
++    statuses: Sequence[Sequence[str]],
++    *,
++    exports_retained: bool,
++) -> str:
++    details = [
++        f"group rank {group_rank}: " + " | ".join(failures)
++        for group_rank, failures in enumerate(statuses)
++        if failures
++    ]
++    retention = "; CUDA IPC exports were retained" if exports_retained else ""
++    return f"{owner} {phase} failed{retention}: " + "; ".join(details)
++
++
++def _abort_collective_ipc_setup(
++    *,
++    owner: str,
++    setup_phase: str,
++    setup_statuses: Sequence[Sequence[str]],
++    exchange_group: ProcessGroup,
++    ipc: CudaRTLibrary,
++    local_ptr: int | None,
++    remote_ptrs: Sequence[int],
++    local_error: BaseException | None,
++    local_cleanup: Optional[Callable[[], None]] = None,
++) -> None:
++    """Undo a failed collective IPC setup without freeing a mapped export.
++
++    Every rank calls this function.  Each successfully opened import is closed
++    exactly once.  Export ownership is released only after every group rank
++    reports that all of its imports were unmapped; otherwise the raw CUDA
++    allocation is deliberately retained until context teardown.
++    """
++
++    retained_cleanup = local_cleanup
++    if local_cleanup is not None:
++        native_error: BaseException | None = None
++        try:
++            local_cleanup()
++        except Exception as exc:
++            native_error = exc
++        else:
++            retained_cleanup = None
++        try:
++            native_statuses = _exchange_setup_failures(
++                native_error,
++                exchange_group=exchange_group,
++                phase=f"{setup_phase} rollback native cleanup",
++            )
++        except Exception as exchange_error:
++            assert local_ptr is not None
++            retained = _retain_failed_ipc_setup(
++                ipc=ipc,
++                local_ptr=local_ptr,
++                exchange_group=exchange_group,
++                owner=owner,
++                phase=setup_phase,
++                remote_ptrs=remote_ptrs,
++                local_cleanup=retained_cleanup,
++                state="native",
++            )
++            error = RuntimeError(
++                _setup_failure_message(
++                    owner,
++                    f"{setup_phase} rollback native cleanup status exchange",
++                    setup_statuses,
++                    exports_retained=True,
++                )
++            )
++            raise _attach_retryable_setup(error, retained) from (
++                native_error or local_error or exchange_error
++            )
++        if any(native_statuses):
++            assert local_ptr is not None
++            retained = _retain_failed_ipc_setup(
++                ipc=ipc,
++                local_ptr=local_ptr,
++                exchange_group=exchange_group,
++                owner=owner,
++                phase=setup_phase,
++                remote_ptrs=remote_ptrs,
++                local_cleanup=retained_cleanup,
++                state="native",
++            )
++            error = RuntimeError(
++                _setup_failure_message(
++                    owner,
++                    f"{setup_phase} rollback native cleanup",
++                    native_statuses,
++                    exports_retained=True,
++                )
++            )
++            raise _attach_retryable_setup(error, retained) from (
++                native_error or local_error
++            )
++
++    unmap_failures: list[str] = []
++    remaining_remote_ptrs: list[int] = []
++    for ptr in remote_ptrs:
++        try:
++            ipc.cudaIpcCloseMemHandle(ptr)
++        except Exception as exc:
++            remaining_remote_ptrs.append(ptr)
++            unmap_failures.append(f"CUDA IPC import {ptr}: {type(exc).__name__}: {exc}")
++
++    try:
++        unmap_statuses = _exchange_setup_failures(
++            RuntimeError(" | ".join(unmap_failures)) if unmap_failures else None,
++            exchange_group=exchange_group,
++            phase=f"{setup_phase} rollback unmap",
++        )
++    except Exception as exchange_error:
++        assert local_ptr is not None
++        retained = _retain_failed_ipc_setup(
++            ipc=ipc,
++            local_ptr=local_ptr,
++            exchange_group=exchange_group,
++            owner=owner,
++            phase=setup_phase,
++            remote_ptrs=remaining_remote_ptrs,
++            local_cleanup=retained_cleanup,
++            state="unmap",
++        )
++        error = RuntimeError(
++            _setup_failure_message(
++                owner,
++                setup_phase,
++                setup_statuses,
++                exports_retained=True,
++            )
++        )
++        raise _attach_retryable_setup(error, retained) from (
++            local_error or exchange_error
++        )
++
++    if any(unmap_statuses):
++        assert local_ptr is not None
++        retained = _retain_failed_ipc_setup(
++            ipc=ipc,
++            local_ptr=local_ptr,
++            exchange_group=exchange_group,
++            owner=owner,
++            phase=setup_phase,
++            remote_ptrs=remaining_remote_ptrs,
++            local_cleanup=retained_cleanup,
++            state="unmap",
++        )
++        error = RuntimeError(
++            _setup_failure_message(
++                owner,
++                f"{setup_phase} rollback unmap",
++                unmap_statuses,
++                exports_retained=True,
++            )
++        )
++        raise _attach_retryable_setup(error, retained) from local_error
++
++    free_error: BaseException | None = None
++    live_local_ptr = int(local_ptr or 0)
++    if local_ptr is not None:
++        try:
++            ipc.cudaFree(local_ptr)
++        except Exception as exc:
++            free_error = exc
++        else:
++            live_local_ptr = 0
++    try:
++        free_statuses = _exchange_setup_failures(
++            free_error,
++            exchange_group=exchange_group,
++            phase=f"{setup_phase} rollback export free",
++        )
++    except Exception as exchange_error:
++        retained_export = _retain_failed_ipc_setup(
++            ipc=ipc,
++            local_ptr=live_local_ptr,
++            exchange_group=exchange_group,
++            owner=owner,
++            phase=setup_phase,
++            state="free",
++        )
++        error = RuntimeError(
++            _setup_failure_message(
++                owner,
++                f"{setup_phase} rollback export free status exchange",
++                setup_statuses,
++                exports_retained=True,
++            )
++        )
++        raise _attach_retryable_setup(error, retained_export) from (
++            free_error or local_error or exchange_error
++        )
++    if any(free_statuses):
++        retained_export = _retain_failed_ipc_setup(
++            ipc=ipc,
++            local_ptr=live_local_ptr,
++            exchange_group=exchange_group,
++            owner=owner,
++            phase=setup_phase,
++            state="free",
++        )
++        error = RuntimeError(
++            _setup_failure_message(
++                owner,
++                f"{setup_phase} rollback export free",
++                free_statuses,
++                exports_retained=True,
++            )
++        )
++        raise _attach_retryable_setup(error, retained_export) from (
++            local_error or free_error
++        )
++
++    error = RuntimeError(
++        _setup_failure_message(
++            owner,
++            setup_phase,
++            setup_statuses,
++            exports_retained=False,
++        )
++    )
++    raise error from local_error
++
++
++def _finish_collective_runtime_setup(
++    *,
++    owner: str,
++    exchange_group: ProcessGroup,
++    ipc: CudaRTLibrary,
++    shared: _OwnedSharedBuffer,
++    local_error: BaseException | None,
++    local_cleanup: Optional[Callable[[], None]] = None,
++    detach_shared_ownership: Optional[Callable[[], None]] = None,
++) -> None:
++    """Require every rank to construct its native runtime before returning."""
++
++    try:
++        statuses = _exchange_setup_failures(
++            local_error,
++            exchange_group=exchange_group,
++            phase=f"{owner} native initialization",
++        )
++    except Exception as exchange_error:
++        # A failed first verdict exchange cannot establish whether every rank
++        # observed the same outcome.  Do not locally dispose, unmap, or free:
++        # retain the complete native/import/export ownership set and the
++        # same-group generation gate until the caller deliberately coordinates
++        # retry() on every participating rank.  This is especially important
++        # for twoshot, whose runtime object is not constructed until after this
++        # verdict succeeds.
++        retained = _retain_failed_ipc_setup(
++            ipc=ipc,
++            local_ptr=shared.local_ptr,
++            exchange_group=exchange_group,
++            owner=owner,
++            phase="native initialization status exchange",
++            remote_ptrs=shared.remote_ptrs,
++            local_cleanup=local_cleanup,
++            state="native",
++        )
++        if detach_shared_ownership is not None:
++            detach_shared_ownership()
++        error = RuntimeError(
++            f"{owner} native initialization status exchange failed; CUDA IPC "
++            "native/import/export ownership was retained and retry must be "
++            "coordinated by every rank"
++        )
++        raise _attach_retryable_setup(error, retained) from exchange_error
++    if any(statuses):
++        try:
++            _abort_collective_ipc_setup(
++                owner=owner,
++                setup_phase="native initialization",
++                setup_statuses=statuses,
++                exchange_group=exchange_group,
++                ipc=ipc,
++                local_ptr=shared.local_ptr,
++                remote_ptrs=shared.remote_ptrs,
++                local_error=local_error,
++                local_cleanup=local_cleanup,
++            )
++        finally:
++            # Rollback either released the shared allocation or transferred it
++            # to a _RetryableIPCExport.  Prevent a partially constructed runtime
++            # finalizer from retaining or releasing the same resources again.
++            if detach_shared_ownership is not None:
++                detach_shared_ownership()
++
++
+ def _coordinated_close_channels(
+     channels: Sequence[object],
+     *,
+     exchange_group: Optional[ProcessGroup],
+     device: torch.device,
+ ) -> None:
+-    """Release exported CUDA IPC allocations after every peer unmaps them."""
++    """Strictly release exports only after every peer reports successful unmap."""
+     unique_channels = tuple(dict.fromkeys(channels))
+-    if exchange_group is None:
++    if not unique_channels:
++        return
++
++    if exchange_group is not None:
++        if device.type == "cuda":
++            torch.cuda.synchronize(device)
++        dist.barrier(group=exchange_group)
++
++    # Channels with strict cleanup report local unmap status before any rank
++    # releases exports. Legacy channels retain their original ordered close.
++    uses_strict_protocol = any(
++        hasattr(channel, "_close_ipc_imports_strict") for channel in unique_channels
++    )
++    if not uses_strict_protocol:
++        for channel in unique_channels:
++            channel._close_ipc_imports()
++        if exchange_group is not None:
++            dist.barrier(group=exchange_group)
+         for channel in unique_channels:
+-            channel.close()
++            channel._free_ipc_exports()
++        if exchange_group is not None:
++            dist.barrier(group=exchange_group)
+         return
+ 
+-    if device.type == "cuda":
+-        torch.cuda.synchronize(device)
+-    dist.barrier(group=exchange_group)
+-    for channel in unique_channels:
+-        channel._close_ipc_imports()
+-    dist.barrier(group=exchange_group)
++    unmap_errors = _run_close_phase(
++        unique_channels,
++        strict_method="_close_ipc_imports_strict",
++        legacy_method="_close_ipc_imports",
++    )
++    unmap_status = _exchange_close_failures(
++        tuple(_format_close_error(index, error) for index, error in unmap_errors),
++        exchange_group=exchange_group,
++        phase="IPC unmap",
++    )
++    if any(unmap_status):
++        _raise_coordinated_close_error(
++            "IPC unmap",
++            unmap_status,
++            local_errors=unmap_errors,
++            exports_retained=True,
++        )
++
++    if exchange_group is not None:
++        dist.barrier(group=exchange_group)
++
++    free_errors = _run_close_phase(
++        unique_channels,
++        strict_method="_free_ipc_exports_strict",
++        legacy_method="_free_ipc_exports",
++    )
++    free_status = _exchange_close_failures(
++        tuple(_format_close_error(index, error) for index, error in free_errors),
++        exchange_group=exchange_group,
++        phase="IPC export free",
++    )
++    if any(free_status):
++        _raise_coordinated_close_error(
++            "IPC export free",
++            free_status,
++            local_errors=free_errors,
++            exports_retained=False,
++        )
++
++    if exchange_group is not None:
++        dist.barrier(group=exchange_group)
+     for channel in unique_channels:
+-        channel._free_ipc_exports()
+-    dist.barrier(group=exchange_group)
++        if hasattr(channel, "_close_ipc_imports_strict"):
++            channel._coordinated_close_complete = True
++
++
++def _run_close_phase(
++    channels: Sequence[object],
++    *,
++    strict_method: str,
++    legacy_method: str,
++) -> list[tuple[int, Exception]]:
++    errors: list[tuple[int, Exception]] = []
++    for index, channel in enumerate(channels):
++        method = getattr(channel, strict_method, None)
++        if method is None:
++            method = getattr(channel, legacy_method)
++        try:
++            method()
++        except Exception as exc:
++            errors.append((index, exc))
++    return errors
++
++
++def _format_close_error(index: int, error: Exception) -> str:
++    return f"channel {index}: {type(error).__name__}: {error}"
++
++
++def _exchange_close_failures(
++    local_failures: tuple[str, ...],
++    *,
++    exchange_group: Optional[ProcessGroup],
++    phase: str,
++) -> tuple[tuple[str, ...], ...]:
++    if exchange_group is None:
++        return (local_failures,)
++    try:
++        gathered = _broadcast_gather_object(local_failures, exchange_group)
++    except Exception as exc:
++        raise RuntimeError(
++            f"failed to exchange peer {phase} status; exported IPC allocations "
++            "were not freed"
++        ) from exc
++
++    statuses: list[tuple[str, ...]] = []
++    for rank_index, status in enumerate(gathered):
++        if not isinstance(status, (tuple, list)):
++            raise RuntimeError(
++                f"invalid peer {phase} status from group rank {rank_index}; "
++                "exported IPC allocations were not freed"
++            )
++        statuses.append(tuple(str(item) for item in status))
++    return tuple(statuses)
++
++
++def _raise_coordinated_close_error(
++    phase: str,
++    statuses: Sequence[Sequence[str]],
++    *,
++    local_errors: Sequence[tuple[int, Exception]],
++    exports_retained: bool,
++) -> None:
++    peer_details = []
++    for rank_index, failures in enumerate(statuses):
++        if failures:
++            peer_details.append(f"group rank {rank_index}: " + " | ".join(failures))
++    retention = "; exported IPC allocations were not freed" if exports_retained else ""
++    error = RuntimeError(
++        f"coordinated PCIe close failed during {phase}{retention}: "
++        + "; ".join(peer_details)
++    )
++    if local_errors:
++        raise error from local_errors[0][1]
++    raise error
++
++
++def _raise_local_cleanup_errors(
++    owner: str,
++    phase: str,
++    failures: Sequence[tuple[str, Exception]],
++) -> None:
++    details = "; ".join(
++        f"{resource}: {type(error).__name__}: {error}" for resource, error in failures
++    )
++    error = RuntimeError(f"{owner} {phase} failed: {details}")
++    raise error from failures[0][1]
+ 
+ 
+ @dataclass(frozen=True)
+@@ -264,52 +1214,254 @@ def _compute_crossover_size(
+     return crossover, results
+ 
+ 
+-class PCIeOneshotAllReduce:
+-    """Standalone unfused PCIe oneshot allreduce runtime."""
++class PCIeOneshotAllReduce:
++    """Standalone unfused PCIe oneshot allreduce runtime."""
++
++    def __init__(
++        self,
++        *,
++        rank: int,
++        world_size: int,
++        device: torch.device | int | str,
++        signal_ptrs: Sequence[int],
++        eager_buffer_ptrs0: Optional[Sequence[int]] = None,
++        eager_buffer_ptrs1: Optional[Sequence[int]] = None,
++        eager_buffer_bytes: Optional[int] = None,
++        exchange_group: Optional[ProcessGroup] = None,
++        process_group: Optional[ProcessGroup] = None,
++        ipc: Optional[CudaRTLibrary] = None,
++        owned_buffers: Optional[Sequence[_OwnedSharedBuffer]] = None,
++        max_size: int = DEFAULT_MAX_SIZE,
++        rank_data_bytes: int = DEFAULT_RANK_DATA_BYTES,
++        ext_module=None,
++        stream_affine: bool = True,
++    ):
++        resolved_group = _resolve_exchange_group(exchange_group, process_group)
++
++        def normalize_and_validate():
++            device_obj = _normalize_device(device)
++            normalized_rank = int(rank)
++            normalized_world_size = int(world_size)
++            normalized_signals = tuple(int(ptr) for ptr in signal_ptrs)
++            normalized_eager0 = (
++                None
++                if eager_buffer_ptrs0 is None
++                else tuple(int(ptr) for ptr in eager_buffer_ptrs0)
++            )
++            normalized_eager1 = (
++                None
++                if eager_buffer_ptrs1 is None
++                else tuple(int(ptr) for ptr in eager_buffer_ptrs1)
++            )
++            normalized_max_size = int(max_size)
++            normalized_rank_data_bytes = int(rank_data_bytes)
++            normalized_eager_bytes = (
++                None if eager_buffer_bytes is None else int(eager_buffer_bytes)
++            )
++            if normalized_world_size not in SUPPORTED_WORLD_SIZES:
++                raise ValueError(f"unsupported world size {normalized_world_size}")
++            if not 0 <= normalized_rank < normalized_world_size:
++                raise ValueError(
++                    f"invalid rank {normalized_rank} for world size "
++                    f"{normalized_world_size}"
++                )
++            if len(normalized_signals) != normalized_world_size:
++                raise ValueError("signal_ptrs must match world size")
++            if (normalized_eager0 is None) != (normalized_eager1 is None):
++                raise ValueError("eager buffers must be provided as a pair")
++            if (
++                normalized_eager0 is not None
++                and len(normalized_eager0) != normalized_world_size
++            ):
++                raise ValueError("eager_buffer_ptrs0 must match world size")
++            if (
++                normalized_eager1 is not None
++                and len(normalized_eager1) != normalized_world_size
++            ):
++                raise ValueError("eager_buffer_ptrs1 must match world size")
++            if normalized_max_size <= 0:
++                raise ValueError("max_size must be positive")
++            if normalized_rank_data_bytes <= 0:
++                raise ValueError("rank_data_bytes must be positive")
++            if normalized_eager0 is not None:
++                if normalized_eager_bytes is None:
++                    raise ValueError(
++                        "eager_buffer_bytes is required with eager buffer pointers"
++                    )
++                if normalized_eager_bytes <= 0:
++                    raise ValueError("eager_buffer_bytes must be positive")
++                if normalized_max_size > normalized_eager_bytes:
++                    raise ValueError("max_size exceeds eager buffer capacity")
++            if ext_module is None and device_obj.type != "cuda":
++                raise ValueError("PCIe oneshot allreduce requires a CUDA device")
++            if device_obj.type == "cuda" and resolved_group is None:
++                raise ValueError(
++                    "exchange_group is required for a CUDA PCIe oneshot runtime; "
++                    "use from_exchange_group()"
++                )
++            if resolved_group is not None:
++                if device_obj.type != "cuda":
++                    raise ValueError(
++                        "distributed PCIe oneshot allreduce requires a CUDA device"
++                    )
++                group_rank = dist.get_rank(group=resolved_group)
++                group_world_size = dist.get_world_size(group=resolved_group)
++                if normalized_rank != group_rank:
++                    raise ValueError(
++                        f"supplied rank {normalized_rank} does not match process "
++                        f"group rank {group_rank}"
++                    )
++                if normalized_world_size != group_world_size:
++                    raise ValueError(
++                        f"supplied world size {normalized_world_size} does not "
++                        f"match process group size {group_world_size}"
++                    )
++            return (
++                device_obj,
++                normalized_rank,
++                normalized_world_size,
++                normalized_signals,
++                normalized_eager0,
++                normalized_eager1,
++                normalized_eager_bytes,
++                normalized_max_size,
++                normalized_rank_data_bytes,
++            )
++
++        if resolved_group is not None:
++            normalized = _run_collective_preallocation_setup(
++                owner="PCIe oneshot direct constructor argument validation",
++                exchange_group=resolved_group,
++                setup=normalize_and_validate,
++            )
++        else:
++            normalized = normalize_and_validate()
++
++        (
++            device_obj,
++            normalized_rank,
++            normalized_world_size,
++            normalized_signals,
++            normalized_eager0,
++            normalized_eager1,
++            normalized_eager_bytes,
++            normalized_max_size,
++            normalized_rank_data_bytes,
++        ) = normalized
++
++        self._initialize_prepared_state(
++            rank=normalized_rank,
++            world_size=normalized_world_size,
++            device=device_obj,
++            signal_ptrs=normalized_signals,
++            eager_buffer_ptrs0=normalized_eager0,
++            eager_buffer_ptrs1=normalized_eager1,
++            eager_buffer_bytes=normalized_eager_bytes,
++            exchange_group=resolved_group,
++            ipc=ipc,
++            owned_buffers=owned_buffers,
++            max_size=normalized_max_size,
++            rank_data_bytes=normalized_rank_data_bytes,
++            ext_module=ext_module,
++            stream_affine=stream_affine,
++        )
++
++        if self.device.type == "cuda":
++            _require_full_grid_residency(
++                owner="PCIe oneshot direct constructor",
++                required_sms=ONESHOT_REQUIRED_SMS,
++                device=self.device,
++                exchange_group=self.exchange_group,
++            )
++
++            def prepare() -> tuple[Optional[CudaRTLibrary], object]:
++                prepared_ipc = self._ipc
++                if prepared_ipc is None and (ext_module is None or owned_buffers):
++                    prepared_ipc = CudaRTLibrary()
++                if prepared_ipc is not None:
++                    prepared_ipc.cudaSetDevice(_cuda_device_index(self.device))
++                return prepared_ipc, ext_module or _load_extension()
++
++            if self.exchange_group is None:
++                self._ipc, self._ext = prepare()
++            else:
++                self._ipc, self._ext = _run_collective_preallocation_setup(
++                    owner="PCIe oneshot direct constructor",
++                    exchange_group=self.exchange_group,
++                    setup=prepare,
++                )
++        else:
++            self._ext = self._ext or _load_extension()
++
++        if self.device.type == "cuda" and self.exchange_group is not None:
++            _require_collective_contract(
++                owner="PCIe oneshot direct constructor",
++                exchange_group=self.exchange_group,
++                contract=(
++                    self.world_size,
++                    self.max_size,
++                    self.rank_data_bytes,
++                    self.eager_buffer_bytes,
++                    self._pending_eager_ptrs is not None,
++                ),
++            )
++
++        init_error = self._initialize_native_runtime()
++        if self.device.type == "cuda" and self.exchange_group is not None:
+ 
+-    def __init__(
++            def abort_native_runtime() -> None:
++                if self._ptr:
++                    self._ext.dispose(self._ptr)
++                    self._ptr = 0
++
++            _finish_collective_unowned_runtime_setup(
++                owner="PCIe oneshot direct constructor",
++                exchange_group=self.exchange_group,
++                local_error=init_error,
++                local_cleanup=abort_native_runtime,
++            )
++        elif init_error is not None:
++            raise init_error
++
++    def _initialize_prepared_state(
+         self,
+         *,
+         rank: int,
+         world_size: int,
+-        device: torch.device | int | str,
++        device: torch.device,
+         signal_ptrs: Sequence[int],
+-        eager_buffer_ptrs0: Optional[Sequence[int]] = None,
+-        eager_buffer_ptrs1: Optional[Sequence[int]] = None,
+-        exchange_group: Optional[ProcessGroup] = None,
+-        process_group: Optional[ProcessGroup] = None,
+-        ipc: Optional[CudaRTLibrary] = None,
+-        owned_buffers: Optional[Sequence[_OwnedSharedBuffer]] = None,
+-        max_size: int = DEFAULT_MAX_SIZE,
+-        rank_data_bytes: int = DEFAULT_RANK_DATA_BYTES,
+-        ext_module=None,
+-        stream_affine: bool = True,
+-    ):
+-        if world_size not in SUPPORTED_WORLD_SIZES:
+-            raise ValueError(f"unsupported world size {world_size}")
+-        if rank < 0 or rank >= world_size:
+-            raise ValueError(f"invalid rank {rank} for world size {world_size}")
+-        if len(signal_ptrs) != world_size:
+-            raise ValueError("signal_ptrs must match world size")
+-        if (eager_buffer_ptrs0 is None) != (eager_buffer_ptrs1 is None):
+-            raise ValueError("eager buffers must be provided as a pair")
+-        if eager_buffer_ptrs0 is not None and len(eager_buffer_ptrs0) != world_size:
+-            raise ValueError("eager_buffer_ptrs0 must match world size")
+-        if eager_buffer_ptrs1 is not None and len(eager_buffer_ptrs1) != world_size:
+-            raise ValueError("eager_buffer_ptrs1 must match world size")
+-
++        eager_buffer_ptrs0: Optional[Sequence[int]],
++        eager_buffer_ptrs1: Optional[Sequence[int]],
++        eager_buffer_bytes: Optional[int],
++        exchange_group: Optional[ProcessGroup],
++        ipc: Optional[CudaRTLibrary],
++        owned_buffers: Optional[Sequence[_OwnedSharedBuffer]],
++        max_size: int,
++        rank_data_bytes: int,
++        ext_module,
++        stream_affine: bool,
++    ) -> None:
+         self.rank = int(rank)
+         self.world_size = int(world_size)
+-        self.device = _normalize_device(device)
+-        self.exchange_group = _resolve_exchange_group(exchange_group, process_group)
+-        # Compatibility alias for older callers that still refer to this as
+-        # `process_group`.
+-        self.process_group = self.exchange_group
++        self.device = device
++        self.exchange_group = exchange_group
++        self.process_group = exchange_group
+         self.max_size = int(max_size)
++        self.rank_data_bytes = int(rank_data_bytes)
++        self.eager_buffer_bytes = (
++            None if eager_buffer_bytes is None else int(eager_buffer_bytes)
++        )
+         self._ipc = ipc
+-        if self._ipc is None and (ext_module is None or owned_buffers):
+-            self._ipc = CudaRTLibrary()
++        self._ext = ext_module
+         self._signal_ptrs = tuple(int(ptr) for ptr in signal_ptrs)
++        self._pending_eager_ptrs = (
++            None
++            if eager_buffer_ptrs0 is None or eager_buffer_ptrs1 is None
++            else (
++                tuple(int(ptr) for ptr in eager_buffer_ptrs0),
++                tuple(int(ptr) for ptr in eager_buffer_ptrs1),
++            )
++        )
+         self._owned_buffers = list(owned_buffers or [])
+         self._registered_input_ptrs: dict[int, tuple[int, ...]] = {}
+         self._stream_affine = bool(stream_affine)
+@@ -317,29 +1469,42 @@ class PCIeOneshotAllReduce:
+         self._closed = False
+         self._ipc_imports_closed = False
+         self._ipc_exports_freed = False
+-        self._ext = ext_module or _load_extension()
+-
+-        if ext_module is None and self.device.type != "cuda":
+-            raise ValueError("PCIe oneshot allreduce requires a CUDA device")
+-
+-        self.rank_data = torch.empty(
+-            rank_data_bytes, dtype=torch.uint8, device=self.device
+-        )
+-        self._ptr = self._ext.init_custom_ar(
+-            list(self._signal_ptrs), self.rank_data, self.rank
+-        )
+-
++        self._coordinated_close_complete = False
++        self._closed_ipc_import_indices: set[tuple[int, int]] = set()
++        self._ptr = 0
+         self._eager_ptrs: Optional[tuple[tuple[int, ...], tuple[int, ...]]] = None
+-        if eager_buffer_ptrs0 is not None and eager_buffer_ptrs1 is not None:
+-            self._eager_ptrs = (
+-                tuple(int(ptr) for ptr in eager_buffer_ptrs0),
+-                tuple(int(ptr) for ptr in eager_buffer_ptrs1),
++
++    def _initialize_native_runtime(self) -> BaseException | None:
++        init_error: BaseException | None = None
++        try:
++            self.rank_data = torch.empty(
++                self.rank_data_bytes, dtype=torch.uint8, device=self.device
+             )
+-            self._ext.register_pcie_buffers(
+-                self._ptr,
+-                list(self._eager_ptrs[0]),
+-                list(self._eager_ptrs[1]),
++            self._ptr = self._ext.init_custom_ar(
++                list(self._signal_ptrs), self.rank_data, self.rank
+             )
++            if self._pending_eager_ptrs is not None:
++                self._eager_ptrs = self._pending_eager_ptrs
++                self._ext.register_pcie_buffers(
++                    self._ptr,
++                    list(self._eager_ptrs[0]),
++                    list(self._eager_ptrs[1]),
++                )
++        except Exception as exc:
++            init_error = exc
++        finally:
++            self._pending_eager_ptrs = None
++        return init_error
++
++    @classmethod
++    def _from_prepared_factory(
++        cls,
++        **kwargs,
++    ) -> tuple["PCIeOneshotAllReduce", BaseException | None]:
++        runtime = object.__new__(cls)
++        runtime._initialize_prepared_state(**kwargs)
++        init_error = runtime._initialize_native_runtime()
++        return runtime, init_error
+ 
+     @classmethod
+     def from_ipc(
+@@ -351,6 +1516,7 @@ class PCIeOneshotAllReduce:
+         signal_ptrs: Sequence[int],
+         eager_buffer_ptrs0: Optional[Sequence[int]] = None,
+         eager_buffer_ptrs1: Optional[Sequence[int]] = None,
++        eager_buffer_bytes: Optional[int] = None,
+         exchange_group: Optional[ProcessGroup] = None,
+         process_group: Optional[ProcessGroup] = None,
+         max_size: int = DEFAULT_MAX_SIZE,
+@@ -365,6 +1531,7 @@ class PCIeOneshotAllReduce:
+             signal_ptrs=signal_ptrs,
+             eager_buffer_ptrs0=eager_buffer_ptrs0,
+             eager_buffer_ptrs1=eager_buffer_ptrs1,
++            eager_buffer_bytes=eager_buffer_bytes,
+             exchange_group=exchange_group,
+             process_group=process_group,
+             max_size=max_size,
+@@ -387,50 +1554,114 @@ class PCIeOneshotAllReduce:
+     ) -> "PCIeOneshotAllReduce":
+         rank = dist.get_rank(group=exchange_group)
+         world_size = dist.get_world_size(group=exchange_group)
+-        if world_size not in SUPPORTED_WORLD_SIZES:
+-            raise ValueError(f"unsupported world size {world_size}")
+-
+-        device_obj = _normalize_device(device)
+-        if device_obj.type != "cuda":
+-            raise ValueError("PCIe oneshot requires a CUDA device")
+ 
+-        ipc = CudaRTLibrary()
+-        ipc.cudaSetDevice(device_obj.index or 0)
+-        ext = ext_module or _load_extension()
+-
+-        owned_buffers: list[_OwnedSharedBuffer] = []
+-        try:
+-            channel_buffers = cls._allocate_eager_channel_buffers(
+-                exchange_group,
+-                signal_bytes=ext.meta_size(),
+-                eager_buffer_bytes=eager_buffer_bytes,
+-                ipc=ipc,
++        def validate_factory_arguments():
++            device_obj = _normalize_device(device)
++            normalized_eager_bytes = int(eager_buffer_bytes)
++            normalized_max_size = int(max_size)
++            normalized_rank_data_bytes = int(rank_data_bytes)
++            if world_size not in SUPPORTED_WORLD_SIZES:
++                raise ValueError(f"unsupported world size {world_size}")
++            if device_obj.type != "cuda":
++                raise ValueError("PCIe oneshot requires a CUDA device")
++            if normalized_eager_bytes <= 0:
++                raise ValueError("eager_buffer_bytes must be positive")
++            if normalized_max_size <= 0:
++                raise ValueError("max_size must be positive")
++            if normalized_max_size > normalized_eager_bytes:
++                raise ValueError("max_size exceeds eager buffer capacity")
++            if normalized_rank_data_bytes <= 0:
++                raise ValueError("rank_data_bytes must be positive")
++            return (
++                device_obj,
++                normalized_eager_bytes,
++                normalized_max_size,
++                normalized_rank_data_bytes,
+             )
+-            owned_buffers.append(channel_buffers.owned_buffer)
+ 
+-            return cls(
+-                rank=rank,
+-                world_size=world_size,
+-                device=device_obj,
+-                signal_ptrs=channel_buffers.signal_ptrs,
+-                eager_buffer_ptrs0=channel_buffers.eager0_ptrs,
+-                eager_buffer_ptrs1=channel_buffers.eager1_ptrs,
++        device_obj, eager_buffer_bytes, max_size, rank_data_bytes = (
++            _run_collective_preallocation_setup(
++                owner="PCIe oneshot argument validation",
+                 exchange_group=exchange_group,
+-                ipc=ipc,
+-                owned_buffers=owned_buffers,
+-                max_size=max_size,
+-                rank_data_bytes=rank_data_bytes,
+-                ext_module=ext,
+-                stream_affine=stream_affine,
+-            )
+-        except Exception:
+-            for shared in owned_buffers:
+-                for ptr in shared.remote_ptrs:
+-                    with suppress(Exception):
+-                        ipc.cudaIpcCloseMemHandle(ptr)
+-                with suppress(Exception):
+-                    ipc.cudaFree(shared.local_ptr)
+-            raise
++                setup=validate_factory_arguments,
++            )
++        )
++
++        _require_full_grid_residency(
++            owner="PCIe oneshot",
++            required_sms=ONESHOT_REQUIRED_SMS,
++            device=device_obj,
++            exchange_group=exchange_group,
++        )
++
++        def prepare() -> tuple[CudaRTLibrary, object, int]:
++            prepared_ipc = CudaRTLibrary()
++            prepared_ipc.cudaSetDevice(_cuda_device_index(device_obj))
++            prepared_ext = ext_module or _load_extension()
++            return prepared_ipc, prepared_ext, int(prepared_ext.meta_size())
++
++        ipc, ext, signal_bytes = _run_collective_preallocation_setup(
++            owner="PCIe oneshot",
++            exchange_group=exchange_group,
++            setup=prepare,
++        )
++        _require_collective_contract(
++            owner="PCIe oneshot channel layout",
++            exchange_group=exchange_group,
++            contract=(
++                signal_bytes,
++                eager_buffer_bytes,
++                max_size,
++                rank_data_bytes,
++                _push_mode_enabled(),
++            ),
++        )
++
++        channel_buffers = cls._allocate_eager_channel_buffers(
++            exchange_group,
++            signal_bytes=signal_bytes,
++            eager_buffer_bytes=eager_buffer_bytes,
++            ipc=ipc,
++        )
++        owned_buffers = [channel_buffers.owned_buffer]
++        runtime, init_error = cls._from_prepared_factory(
++            rank=rank,
++            world_size=world_size,
++            device=device_obj,
++            signal_ptrs=channel_buffers.signal_ptrs,
++            eager_buffer_ptrs0=channel_buffers.eager0_ptrs,
++            eager_buffer_ptrs1=channel_buffers.eager1_ptrs,
++            eager_buffer_bytes=eager_buffer_bytes,
++            exchange_group=exchange_group,
++            ipc=ipc,
++            owned_buffers=owned_buffers,
++            max_size=max_size,
++            rank_data_bytes=rank_data_bytes,
++            ext_module=ext,
++            stream_affine=stream_affine,
++        )
++
++        def abort_native_runtime() -> None:
++            pointer = getattr(runtime, "_ptr", 0)
++            if pointer:
++                ext.dispose(pointer)
++                runtime._ptr = 0
++            if hasattr(runtime, "rank_data"):
++                del runtime.rank_data
++
++        def detach_shared_ownership() -> None:
++            runtime._owned_buffers.clear()
++
++        _finish_collective_runtime_setup(
++            owner="PCIe oneshot",
++            exchange_group=exchange_group,
++            ipc=ipc,
++            shared=channel_buffers.owned_buffer,
++            local_error=init_error,
++            local_cleanup=abort_native_runtime,
++            detach_shared_ownership=detach_shared_ownership,
++        )
++        return runtime
+ 
+     @classmethod
+     def from_process_group(
+@@ -440,7 +1671,7 @@ class PCIeOneshotAllReduce:
+         device: torch.device | int | str,
+         max_input_bytes: int = DEFAULT_MAX_SIZE,
+         eager_buffer_bytes: Optional[int] = None,
+-        max_size: int = DEFAULT_MAX_SIZE,
++        max_size: Optional[int] = None,
+         rank_data_bytes: int = DEFAULT_RANK_DATA_BYTES,
+         ext_module=None,
+         stream_affine: bool = True,
+@@ -451,7 +1682,7 @@ class PCIeOneshotAllReduce:
+             eager_buffer_bytes=max_input_bytes
+             if eager_buffer_bytes is None
+             else eager_buffer_bytes,
+-            max_size=max_size,
++            max_size=max_input_bytes if max_size is None else max_size,
+             rank_data_bytes=rank_data_bytes,
+             ext_module=ext_module,
+             stream_affine=stream_affine,
+@@ -465,42 +1696,193 @@ class PCIeOneshotAllReduce:
+         zero_fill: bool,
+         ipc: CudaRTLibrary,
+     ) -> _OwnedSharedBuffer:
+-        local_ptr = ipc.cudaMalloc(size_in_bytes)
+-        peer_ptrs: list[int] = []
+-        remote_ptrs: list[int] = []
++        _require_no_retained_ipc_setup(exchange_group)
++        local_ptr: int | None = None
++        local_handle: bytes | None = None
++        prepare_error: BaseException | None = None
+         try:
++            local_ptr = ipc.cudaMalloc(size_in_bytes)
+             if zero_fill:
+                 ipc.cudaMemset(local_ptr, 0, size_in_bytes)
+             local_handle = ipc.cudaIpcGetMemHandleBytes(local_ptr)
++        except Exception as exc:
++            prepare_error = exc
++
++        # A rank that cannot allocate or publish its export must not leave its
++        # peers blocked in the handle exchange.  No imports exist yet, so
++        # successful ranks can safely release their local allocation.
++        try:
++            prepare_statuses = _exchange_setup_failures(
++                prepare_error,
++                exchange_group=exchange_group,
++                phase="CUDA IPC export preparation",
++            )
++        except Exception as exchange_error:
++            retained = _retain_failed_ipc_setup(
++                ipc=ipc,
++                local_ptr=int(local_ptr or 0),
++                exchange_group=exchange_group,
++                owner="PCIe shared buffer",
++                phase="CUDA IPC export preparation",
++                state="unmap",
++            )
++            error = RuntimeError(
++                "failed to exchange CUDA IPC export preparation status; "
++                "CUDA IPC ownership was retained"
++            )
++            raise _attach_retryable_setup(error, retained) from (
++                prepare_error or exchange_error
++            )
++        if any(prepare_statuses):
++            free_error: BaseException | None = None
++            live_local_ptr = int(local_ptr or 0)
++            if local_ptr is not None:
++                try:
++                    ipc.cudaFree(local_ptr)
++                except Exception as exc:
++                    free_error = exc
++                else:
++                    live_local_ptr = 0
++            try:
++                free_statuses = _exchange_setup_failures(
++                    free_error,
++                    exchange_group=exchange_group,
++                    phase="CUDA IPC export preparation rollback",
++                )
++            except Exception as exchange_error:
++                retained_export = _retain_failed_ipc_setup(
++                    ipc=ipc,
++                    local_ptr=live_local_ptr,
++                    exchange_group=exchange_group,
++                    owner="PCIe shared buffer",
++                    phase="CUDA IPC export preparation",
++                    state="free",
++                )
++                error = RuntimeError(
++                    "failed to exchange CUDA IPC export rollback status; "
++                    "CUDA IPC ownership was retained"
++                )
++                raise _attach_retryable_setup(error, retained_export) from (
++                    free_error or prepare_error or exchange_error
++                )
++            if any(free_statuses):
++                retained_export = _retain_failed_ipc_setup(
++                    ipc=ipc,
++                    local_ptr=live_local_ptr,
++                    exchange_group=exchange_group,
++                    owner="PCIe shared buffer",
++                    phase="CUDA IPC export preparation",
++                    state="free",
++                )
++                error = RuntimeError(
++                    _setup_failure_message(
++                        "PCIe shared buffer",
++                        "export preparation rollback",
++                        free_statuses,
++                        exports_retained=True,
++                    )
++                )
++                raise _attach_retryable_setup(error, retained_export) from (
++                    prepare_error or free_error
++                )
++            raise RuntimeError(
++                _setup_failure_message(
++                    "PCIe shared buffer",
++                    "export preparation",
++                    prepare_statuses,
++                    exports_retained=False,
++                )
++            ) from prepare_error
++
++        assert local_ptr is not None
++        assert local_handle is not None
++        peer_ptrs: list[int] = []
++        remote_ptrs: list[int] = []
++        try:
+             world_size = dist.get_world_size(group=exchange_group)
+             rank = dist.get_rank(group=exchange_group)
+             handles = _broadcast_gather_object(local_handle, exchange_group)
+-            for idx, handle in enumerate(handles):
+-                if idx == rank:
+-                    peer_ptrs.append(local_ptr)
+-                else:
+-                    try:
+-                        remote_ptr = ipc.cudaIpcOpenMemHandleBytes(handle)
+-                    except Exception as exc:
+-                        raise RuntimeError(
+-                            f"failed to open CUDA IPC handle for peer rank {idx}"
+-                        ) from exc
+-                    peer_ptrs.append(remote_ptr)
+-                    remote_ptrs.append(remote_ptr)
+-            if len(peer_ptrs) != world_size:
+-                raise RuntimeError("failed to gather IPC handles for all ranks")
+-            return _OwnedSharedBuffer(
++        except Exception as exchange_error:
++            # No rank has opened an import before handle exchange completes.
++            # Retain both ownership and a collective retry ticket if progress
++            # is uncertain; peers may have completed the exchange already.
++            retained = _retain_failed_ipc_setup(
++                ipc=ipc,
++                local_ptr=local_ptr,
++                exchange_group=exchange_group,
++                owner="PCIe shared buffer",
++                phase="CUDA IPC handle exchange",
++                state="unmap",
++            )
++            error = RuntimeError(
++                "CUDA IPC handle exchange failed; CUDA IPC ownership was retained"
++            )
++            raise _attach_retryable_setup(error, retained) from exchange_error
++
++        open_error: BaseException | None = None
++        for idx, handle in enumerate(handles):
++            if idx == rank:
++                peer_ptrs.append(local_ptr)
++                continue
++            try:
++                remote_ptr = ipc.cudaIpcOpenMemHandleBytes(handle)
++            except Exception as exc:
++                if open_error is None:
++                    open_error = RuntimeError(
++                        f"failed to open CUDA IPC handle for peer group rank {idx}"
++                    )
++                    open_error.__cause__ = exc
++                # Preserve group-rank indexing while every rank completes the
++                # same open loop and reaches the collective verdict.
++                peer_ptrs.append(0)
++            else:
++                peer_ptrs.append(remote_ptr)
++                remote_ptrs.append(remote_ptr)
++
++        if len(handles) != world_size or len(peer_ptrs) != world_size:
++            open_error = open_error or RuntimeError(
++                "failed to gather CUDA IPC handles for every group rank"
++            )
++        try:
++            open_statuses = _exchange_setup_failures(
++                open_error,
++                exchange_group=exchange_group,
++                phase="CUDA IPC import open",
++            )
++        except Exception as exchange_error:
++            retained = _retain_failed_ipc_setup(
++                ipc=ipc,
++                local_ptr=local_ptr,
++                exchange_group=exchange_group,
++                owner="PCIe shared buffer",
++                phase="CUDA IPC import open",
++                remote_ptrs=remote_ptrs,
++                state="unmap",
++            )
++            error = RuntimeError(
++                "failed to exchange CUDA IPC import-open status; CUDA IPC "
++                "ownership was retained"
++            )
++            raise _attach_retryable_setup(error, retained) from (
++                open_error or exchange_error
++            )
++        if any(open_statuses):
++            _abort_collective_ipc_setup(
++                owner="PCIe shared buffer",
++                setup_phase="CUDA IPC import open",
++                setup_statuses=open_statuses,
++                exchange_group=exchange_group,
++                ipc=ipc,
+                 local_ptr=local_ptr,
+-                peer_ptrs=tuple(peer_ptrs),
+-                remote_ptrs=tuple(remote_ptrs),
++                remote_ptrs=remote_ptrs,
++                local_error=open_error,
+             )
+-        except Exception:
+-            for ptr in remote_ptrs:
+-                with suppress(Exception):
+-                    ipc.cudaIpcCloseMemHandle(ptr)
+-            with suppress(Exception):
+-                ipc.cudaFree(local_ptr)
+-            raise
++
++        return _OwnedSharedBuffer(
++            local_ptr=local_ptr,
++            peer_ptrs=tuple(peer_ptrs),
++            remote_ptrs=tuple(remote_ptrs),
++        )
+ 
+     @classmethod
+     def _allocate_eager_channel_buffers(
+@@ -860,6 +2242,9 @@ class PCIeOneshotAllReduce:
+         if self.device.type != "cuda":
+             raise ValueError("autotune requires a CUDA device")
+         bench_stream = torch.cuda.Stream(device=self.device)
++        effective_ceiling = int(ceiling_bytes)
++        if self.eager_buffer_bytes is not None:
++            effective_ceiling = min(effective_ceiling, self.eager_buffer_bytes)
+         crossover, results = _compute_crossover_size(
+             lambda size_bytes: self._bench_graph_latency(
+                 size_bytes,
+@@ -868,9 +2253,11 @@ class PCIeOneshotAllReduce:
+                 warmup,
+                 iters,
+             ),
+-            ceiling_bytes=ceiling_bytes,
++            ceiling_bytes=effective_ceiling,
+             fine_step_bytes=fine_step_bytes,
+         )
++        if self.eager_buffer_bytes is not None:
++            crossover = min(crossover, self.eager_buffer_bytes)
+         self.max_size = crossover
+ 
+         if self.rank == 0:
+@@ -896,40 +2283,119 @@ class PCIeOneshotAllReduce:
+             logger.info("\n".join(lines))
+         return crossover
+ 
+-    def _close_ipc_imports(self) -> None:
++    def _closed_import_indices(self) -> set[tuple[int, int]]:
++        closed = getattr(self, "_closed_ipc_import_indices", None)
++        if closed is None:
++            closed = set()
++            self._closed_ipc_import_indices = closed
++        return closed
++
++    def _all_python_ipc_imports_closed(self, closed: set[tuple[int, int]]) -> bool:
++        if self._ipc is None:
++            return not any(shared.remote_ptrs for shared in self._owned_buffers)
++        return all(
++            (buffer_index, remote_index) in closed
++            for buffer_index, shared in enumerate(self._owned_buffers)
++            for remote_index, _ in enumerate(shared.remote_ptrs)
++        )
++
++    def _close_ipc_imports_strict(self) -> None:
+         if self._ipc_imports_closed:
+             return
+         self._closed = True
++        failures: list[tuple[str, Exception]] = []
+         if getattr(self, "_ptr", 0):
+-            with suppress(Exception):
++            try:
+                 self._ext.dispose(self._ptr)
+-            self._ptr = 0
++            except Exception as exc:
++                failures.append(("native runtime", exc))
++            else:
++                self._ptr = 0
++
++        closed = self._closed_import_indices()
+         if self._ipc is not None:
+-            for shared in self._owned_buffers:
+-                for ptr in shared.remote_ptrs:
+-                    with suppress(Exception):
++            for buffer_index, shared in enumerate(self._owned_buffers):
++                for remote_index, ptr in enumerate(shared.remote_ptrs):
++                    key = (buffer_index, remote_index)
++                    if key in closed:
++                        continue
++                    try:
+                         self._ipc.cudaIpcCloseMemHandle(ptr)
+-        self._ipc_imports_closed = True
++                    except Exception as exc:
++                        failures.append((f"CUDA IPC import {ptr}", exc))
++                    else:
++                        closed.add(key)
++        elif any(shared.remote_ptrs for shared in self._owned_buffers):
++            failures.append(
++                (
++                    "CUDA IPC imports",
++                    RuntimeError("CUDA runtime is unavailable for IPC unmap"),
++                )
++            )
++
++        if (
++            not failures
++            and not getattr(self, "_ptr", 0)
++            and self._all_python_ipc_imports_closed(closed)
++        ):
++            self._ipc_imports_closed = True
++        if failures:
++            _raise_local_cleanup_errors("PCIe oneshot", "IPC import close", failures)
+ 
+-    def _free_ipc_exports(self) -> None:
++    def _free_ipc_exports_strict(self) -> None:
+         if self._ipc_exports_freed:
+             return
+-        self._close_ipc_imports()
++        self._close_ipc_imports_strict()
++        failures: list[tuple[str, Exception]] = []
++        remaining = []
+         if self._ipc is not None:
+             for shared in self._owned_buffers:
+-                with suppress(Exception):
++                try:
+                     self._ipc.cudaFree(shared.local_ptr)
+-        self._owned_buffers.clear()
+-        self._registered_input_ptrs.clear()
+-        self._ipc_exports_freed = True
++                except Exception as exc:
++                    remaining.append(shared)
++                    failures.append((f"CUDA IPC export {shared.local_ptr}", exc))
++        elif self._owned_buffers:
++            remaining = list(self._owned_buffers)
++            failures.append(
++                (
++                    "CUDA IPC exports",
++                    RuntimeError("CUDA runtime is unavailable for export free"),
++                )
++            )
++        self._owned_buffers = remaining
++        if not remaining:
++            self._registered_input_ptrs.clear()
++            self._ipc_exports_freed = True
++        if failures:
++            _raise_local_cleanup_errors("PCIe oneshot", "IPC export free", failures)
+ 
+     def close(self) -> None:
+-        self._close_ipc_imports()
+-        self._free_ipc_exports()
++        if getattr(self, "_coordinated_close_complete", False):
++            return
++        _coordinated_close_channels(
++            (self,),
++            exchange_group=self.exchange_group,
++            device=self.device,
++        )
+ 
+-    def __del__(self) -> None:
+-        with suppress(Exception):
+-            self.close()
++    def __del__(
++        self,
++        _quarantine: dict[int, object] = _ABANDONED_PCIE_RUNTIME_QUARANTINE,
++    ) -> None:
++        # GC cannot prove that work queued on an arbitrary CUDA stream has
++        # completed, and it must not synchronize or enter a distributed
++        # barrier.  Retain the whole runtime: rank_data is a torch allocation
++        # whose raw pointer is stored in the native object and captured graph
++        # arguments, so retaining only IPC mappings/exports is insufficient.
++        if getattr(self, "_coordinated_close_complete", False):
++            return
++        if (
++            getattr(self, "_ptr", 0)
++            or hasattr(self, "rank_data")
++            or getattr(self, "_owned_buffers", ())
++        ):
++            _quarantine[id(self)] = self
+ 
+ 
+ def _is_current_stream_capturing(device: torch.device) -> bool:
+@@ -964,42 +2430,145 @@ class PCIeOneshotAllReducePool:
+         ext_module=None,
+         ipc: Optional[CudaRTLibrary] = None,
+         single_channel: bool = False,
++        max_concurrent_channels: int = 1,
+         channel_factory: Optional[
+             Callable[[Optional[int]], PCIeOneshotAllReduce]
+         ] = None,
+     ):
+-        if world_size not in SUPPORTED_WORLD_SIZES:
+-            raise ValueError(f"unsupported world size {world_size}")
+-        if rank < 0 or rank >= world_size:
+-            raise ValueError(f"invalid rank {rank} for world size {world_size}")
++        resolved_group = _resolve_exchange_group(exchange_group, process_group)
++
++        def normalize_and_validate():
++            normalized_rank = int(rank)
++            normalized_world_size = int(world_size)
++            device_obj = _normalize_device(device)
++            normalized_eager_bytes = int(eager_buffer_bytes)
++            normalized_max_size = int(max_size)
++            normalized_rank_data_bytes = int(rank_data_bytes)
++            normalized_single_channel = bool(single_channel)
++            normalized_max_concurrent_channels = int(max_concurrent_channels)
++            if normalized_world_size not in SUPPORTED_WORLD_SIZES:
++                raise ValueError(f"unsupported world size {normalized_world_size}")
++            if not 0 <= normalized_rank < normalized_world_size:
++                raise ValueError(
++                    f"invalid rank {normalized_rank} for world size "
++                    f"{normalized_world_size}"
++                )
++            if normalized_eager_bytes <= 0:
++                raise ValueError("eager_buffer_bytes must be positive")
++            if normalized_max_size <= 0:
++                raise ValueError("max_size must be positive")
++            if normalized_max_size > normalized_eager_bytes:
++                raise ValueError("max_size exceeds eager buffer capacity")
++            if normalized_rank_data_bytes <= 0:
++                raise ValueError("rank_data_bytes must be positive")
++            if normalized_max_concurrent_channels <= 0:
++                raise ValueError("max_concurrent_channels must be positive")
++            if channel_factory is None:
++                if resolved_group is None:
++                    raise ValueError(
++                        "exchange_group is required unless channel_factory is provided"
++                    )
++                if device_obj.type != "cuda":
++                    raise ValueError("PCIe oneshot pool requires a CUDA device")
++                group_rank = dist.get_rank(group=resolved_group)
++                group_world_size = dist.get_world_size(group=resolved_group)
++                if normalized_rank != group_rank:
++                    raise ValueError(
++                        f"supplied rank {normalized_rank} does not match process "
++                        f"group rank {group_rank}"
++                    )
++                if normalized_world_size != group_world_size:
++                    raise ValueError(
++                        f"supplied world size {normalized_world_size} does not "
++                        f"match process group size {group_world_size}"
++                    )
++            return (
++                normalized_rank,
++                normalized_world_size,
++                device_obj,
++                normalized_eager_bytes,
++                normalized_max_size,
++                normalized_rank_data_bytes,
++                normalized_single_channel,
++                normalized_max_concurrent_channels,
++            )
+ 
+-        self.rank = int(rank)
+-        self.world_size = int(world_size)
+-        self.device = _normalize_device(device)
+-        self.exchange_group = _resolve_exchange_group(exchange_group, process_group)
++        if channel_factory is None and resolved_group is not None:
++            normalized = _run_collective_preallocation_setup(
++                owner="PCIe oneshot pool argument validation",
++                exchange_group=resolved_group,
++                setup=normalize_and_validate,
++            )
++        else:
++            normalized = normalize_and_validate()
++
++        (
++            self.rank,
++            self.world_size,
++            self.device,
++            self.eager_buffer_bytes,
++            self.max_size,
++            self.rank_data_bytes,
++            self.single_channel,
++            self.max_concurrent_channels,
++        ) = normalized
++        self.exchange_group = resolved_group
+         self.process_group = self.exchange_group
+-        self.eager_buffer_bytes = int(eager_buffer_bytes)
+-        self.max_size = int(max_size)
+-        self.rank_data_bytes = int(rank_data_bytes)
+-        self.single_channel = bool(single_channel)
+         self._channel_factory = channel_factory
+         self._channels: dict[int, PCIeOneshotAllReduce] = {}
++        self._logical_channels: dict[str, PCIeOneshotAllReduce] = {}
++        self._captured_channel_ids: set[str] = set()
+         self._all_channels: list[PCIeOneshotAllReduce] = []
+         self._capture_channel_stack: list[PCIeOneshotAllReduce] = []
+         self._closed = False
+ 
+         self._ipc = ipc
+         self._ext = ext_module
++        self._signal_bytes = 0
+         if self._channel_factory is None:
+-            if self.exchange_group is None:
+-                raise ValueError(
+-                    "exchange_group is required unless channel_factory is provided"
++            assert self.exchange_group is not None
++            _require_full_grid_residency(
++                owner="PCIe oneshot",
++                required_sms=(ONESHOT_REQUIRED_SMS * self.max_concurrent_channels),
++                device=self.device,
++                exchange_group=self.exchange_group,
++            )
++
++            def prepare() -> tuple[CudaRTLibrary, object, int]:
++                prepared_ipc = self._ipc or CudaRTLibrary()
++                prepared_ipc.cudaSetDevice(_cuda_device_index(self.device))
++                prepared_ext = self._ext or _load_extension()
++                return (
++                    prepared_ipc,
++                    prepared_ext,
++                    int(prepared_ext.meta_size()),
+                 )
+-            if self.device.type != "cuda":
+-                raise ValueError("PCIe oneshot pool requires a CUDA device")
+-            self._ipc = self._ipc or CudaRTLibrary()
+-            self._ipc.cudaSetDevice(self.device.index or 0)
+-            self._ext = self._ext or _load_extension()
++
++            self._ipc, self._ext, self._signal_bytes = (
++                _run_collective_preallocation_setup(
++                    owner="PCIe oneshot pool",
++                    exchange_group=self.exchange_group,
++                    setup=prepare,
++                )
++            )
++            _require_collective_contract(
++                owner="PCIe oneshot pool channel layout",
++                exchange_group=self.exchange_group,
++                contract=(
++                    self._signal_bytes,
++                    self.eager_buffer_bytes,
++                    self.max_size,
++                    self.rank_data_bytes,
++                    self.single_channel,
++                    self.max_concurrent_channels,
++                    _push_mode_enabled(),
++                ),
++            )
++            # A genuine single-channel pool has no independent eager/graph
++            # owners to name. Multi-channel distributed callers must prepare
++            # explicit semantic ids before their first eager operation.
++            if self.single_channel:
++                self.prepare_channels((_SINGLE_CHANNEL_ID,))
+ 
+     @classmethod
+     def from_exchange_group(
+@@ -1012,6 +2581,7 @@ class PCIeOneshotAllReducePool:
+         rank_data_bytes: int = DEFAULT_RANK_DATA_BYTES,
+         ext_module=None,
+         single_channel: bool = False,
++        max_concurrent_channels: int = 1,
+     ) -> "PCIeOneshotAllReducePool":
+         return cls(
+             rank=dist.get_rank(group=exchange_group),
+@@ -1023,6 +2593,7 @@ class PCIeOneshotAllReducePool:
+             rank_data_bytes=rank_data_bytes,
+             ext_module=ext_module,
+             single_channel=single_channel,
++            max_concurrent_channels=max_concurrent_channels,
+         )
+ 
+     @classmethod
+@@ -1033,10 +2604,11 @@ class PCIeOneshotAllReducePool:
+         device: torch.device | int | str,
+         max_input_bytes: int = DEFAULT_MAX_SIZE,
+         eager_buffer_bytes: Optional[int] = None,
+-        max_size: int = DEFAULT_MAX_SIZE,
++        max_size: Optional[int] = None,
+         rank_data_bytes: int = DEFAULT_RANK_DATA_BYTES,
+         ext_module=None,
+         single_channel: bool = False,
++        max_concurrent_channels: int = 1,
+     ) -> "PCIeOneshotAllReducePool":
+         return cls.from_exchange_group(
+             exchange_group=process_group,
+@@ -1044,10 +2616,11 @@ class PCIeOneshotAllReducePool:
+             eager_buffer_bytes=max_input_bytes
+             if eager_buffer_bytes is None
+             else eager_buffer_bytes,
+-            max_size=max_size,
++            max_size=max_input_bytes if max_size is None else max_size,
+             rank_data_bytes=rank_data_bytes,
+             ext_module=ext_module,
+             single_channel=single_channel,
++            max_concurrent_channels=max_concurrent_channels,
+         )
+ 
+     def _new_channel(self, stream_key: Optional[int]) -> PCIeOneshotAllReduce:
+@@ -1062,56 +2635,127 @@ class PCIeOneshotAllReducePool:
+         if self.exchange_group is None or self._ipc is None or self._ext is None:
+             raise RuntimeError("pool is not configured to allocate channels")
+ 
+-        owned_buffers: list[_OwnedSharedBuffer] = []
+-        try:
+-            channel_buffers = PCIeOneshotAllReduce._allocate_eager_channel_buffers(
+-                self.exchange_group,
+-                signal_bytes=self._ext.meta_size(),
+-                eager_buffer_bytes=self.eager_buffer_bytes,
+-                ipc=self._ipc,
+-            )
+-            owned_buffers.append(channel_buffers.owned_buffer)
++        channel_buffers = PCIeOneshotAllReduce._allocate_eager_channel_buffers(
++            self.exchange_group,
++            signal_bytes=self._signal_bytes,
++            eager_buffer_bytes=self.eager_buffer_bytes,
++            ipc=self._ipc,
++        )
++        owned_buffers = [channel_buffers.owned_buffer]
++        channel, init_error = PCIeOneshotAllReduce._from_prepared_factory(
++            rank=self.rank,
++            world_size=self.world_size,
++            device=self.device,
++            signal_ptrs=channel_buffers.signal_ptrs,
++            eager_buffer_ptrs0=channel_buffers.eager0_ptrs,
++            eager_buffer_ptrs1=channel_buffers.eager1_ptrs,
++            eager_buffer_bytes=self.eager_buffer_bytes,
++            exchange_group=self.exchange_group,
++            ipc=self._ipc,
++            owned_buffers=owned_buffers,
++            max_size=self.max_size,
++            rank_data_bytes=self.rank_data_bytes,
++            ext_module=self._ext,
++            stream_affine=not self.single_channel,
++        )
+ 
+-            channel = PCIeOneshotAllReduce(
+-                rank=self.rank,
+-                world_size=self.world_size,
+-                device=self.device,
+-                signal_ptrs=channel_buffers.signal_ptrs,
+-                eager_buffer_ptrs0=channel_buffers.eager0_ptrs,
+-                eager_buffer_ptrs1=channel_buffers.eager1_ptrs,
+-                exchange_group=self.exchange_group,
+-                ipc=self._ipc,
+-                owned_buffers=owned_buffers,
+-                max_size=self.max_size,
+-                rank_data_bytes=self.rank_data_bytes,
+-                ext_module=self._ext,
+-                stream_affine=not self.single_channel,
+-            )
+-        except Exception:
+-            for shared in owned_buffers:
+-                for ptr in shared.remote_ptrs:
+-                    with suppress(Exception):
+-                        self._ipc.cudaIpcCloseMemHandle(ptr)
+-                with suppress(Exception):
+-                    self._ipc.cudaFree(shared.local_ptr)
+-            raise
++        def abort_native_runtime() -> None:
++            pointer = getattr(channel, "_ptr", 0)
++            if pointer:
++                self._ext.dispose(pointer)
++                channel._ptr = 0
++            if hasattr(channel, "rank_data"):
++                del channel.rank_data
++
++        def detach_shared_ownership() -> None:
++            channel._owned_buffers.clear()
++
++        _finish_collective_runtime_setup(
++            owner="PCIe oneshot pool channel",
++            exchange_group=self.exchange_group,
++            ipc=self._ipc,
++            shared=channel_buffers.owned_buffer,
++            local_error=init_error,
++            local_cleanup=abort_native_runtime,
++            detach_shared_ownership=detach_shared_ownership,
++        )
+         channel._bind_stream_key(stream_key)
+         self._all_channels.append(channel)
+         return channel
+ 
++    def prepare_channels(self, channel_ids: Sequence[str]) -> None:
++        """Collectively allocate named channels in canonical order.
++
++        Local CUDA stream handles are process-local and cannot identify a
++        distributed channel. Every rank may supply the same set in any order;
++        the sorted logical ids define identical IPC allocation order.
++        """
++
++        if self._channel_factory is None:
++            assert self.exchange_group is not None
++
++            def normalize_and_validate() -> tuple[str, ...]:
++                if self._closed:
++                    raise RuntimeError("pool is closed")
++                return tuple(
++                    sorted(
++                        {_normalize_logical_channel_id(value) for value in channel_ids}
++                    )
++                )
++
++            # Normalize and validate through a status collective first.  A
++            # rank-local empty/invalid id must not return or raise while peers
++            # enter the subsequent contract exchange or IPC allocation.
++            normalized = _run_collective_preallocation_setup(
++                owner="PCIe oneshot logical channel validation",
++                exchange_group=self.exchange_group,
++                setup=normalize_and_validate,
++            )
++            local_state = (normalized, tuple(sorted(self._logical_channels)))
++            gathered = _broadcast_gather_object(local_state, self.exchange_group)
++            if any(state != local_state for state in gathered):
++                raise RuntimeError(
++                    "PCIe oneshot logical channel preparation differs across "
++                    f"ranks: {gathered}"
++                )
++        else:
++            if self._closed:
++                raise RuntimeError("pool is closed")
++            normalized = tuple(
++                sorted({_normalize_logical_channel_id(value) for value in channel_ids})
++            )
++
++        if not normalized:
++            return
++
++        for channel_id in normalized:
++            if channel_id in self._logical_channels:
++                continue
++            self._logical_channels[channel_id] = self._new_channel(None)
++
+     def checkpoint_channels(
+         self,
+-    ) -> tuple[int, dict[int, PCIeOneshotAllReduce]]:
++    ) -> tuple[
++        int,
++        dict[int, PCIeOneshotAllReduce],
++        dict[str, PCIeOneshotAllReduce],
++        set[str],
++    ]:
+         """Snapshot channel ownership before a throwaway graph capture."""
+         if self._closed:
+             raise RuntimeError("pool is closed")
+         if self._capture_channel_stack:
+             raise RuntimeError("cannot checkpoint channels during capture")
+-        return len(self._all_channels), dict(self._channels)
++        return (
++            len(self._all_channels),
++            dict(self._channels),
++            dict(self._logical_channels),
++            set(self._captured_channel_ids),
++        )
+ 
+     def rollback_channels(
+         self,
+-        checkpoint: tuple[int, dict[int, PCIeOneshotAllReduce]],
++        checkpoint: tuple,
+     ) -> None:
+         """Close channels created after ``checkpoint`` and restore mappings.
+ 
+@@ -1122,15 +2766,25 @@ class PCIeOneshotAllReducePool:
+             raise RuntimeError("pool is closed")
+         if self._capture_channel_stack:
+             raise RuntimeError("cannot roll back channels during capture")
+-        all_channels_len, channels = checkpoint
++        if len(checkpoint) == 2:
++            all_channels_len, channels = checkpoint
++            logical_channels = dict(self._logical_channels)
++            captured_channel_ids = set(self._captured_channel_ids)
++        elif len(checkpoint) == 4:
++            (
++                all_channels_len,
++                channels,
++                logical_channels,
++                captured_channel_ids,
++            ) = checkpoint
++        else:
++            raise ValueError("invalid channel checkpoint")
+         if not 0 <= all_channels_len <= len(self._all_channels):
+             raise ValueError("channel checkpoint does not belong to this pool")
+ 
+         retained = self._all_channels[:all_channels_len]
+         retained_ids = {id(channel) for channel in retained}
+         transient = self._all_channels[all_channels_len:]
+-        self._all_channels = retained
+-        self._channels = dict(channels)
+ 
+         channels_to_close = tuple(
+             dict.fromkeys(
+@@ -1142,14 +2796,27 @@ class PCIeOneshotAllReducePool:
+             exchange_group=self.exchange_group,
+             device=self.device,
+         )
++        self._all_channels = retained
++        self._channels = dict(channels)
++        self._logical_channels = dict(logical_channels)
++        self._captured_channel_ids = set(captured_channel_ids)
+ 
+-    def for_stream(self, stream: object = None) -> PCIeOneshotAllReduce:
++    def for_stream(
++        self,
++        stream: object = None,
++        *,
++        channel_id: Optional[str] = None,
++    ) -> PCIeOneshotAllReduce:
+         if self._closed:
+             raise RuntimeError("pool is closed")
+         if self.single_channel:
+             channel = self._channels.get(0)
+             if channel is not None:
+                 return channel
++            if self._channel_factory is None:
++                channel = self._logical_channels[_SINGLE_CHANNEL_ID]
++                self._channels[0] = channel
++                return channel
+             if _is_current_stream_capturing(self.device):
+                 raise RuntimeError(
+                     "PCIe oneshot pool has no channel to reuse during CUDA graph "
+@@ -1162,12 +2829,40 @@ class PCIeOneshotAllReducePool:
+ 
+         stream_key = _current_stream_key(self.device, stream)
+         channel_key = 0 if stream_key is None else int(stream_key)
+-        if _is_current_stream_capturing(self.device) and self._capture_channel_stack:
+-            # CUDA and torch/Inductor may recycle a nested capture stream key
+-            # between independent target and draft graph managers. The active
+-            # enclosing capture owns the channel even if that key still maps
+-            # to a channel captured by an earlier manager.
++        if self._capture_channel_stack:
++            # The semantic capture scope starts before vLLM's eager graph
++            # warmup. Route that warmup through the graph-owned channel too,
++            # even though CUDA capture has not started yet. Once CUDA capture
++            # begins, torch/Inductor may replace the enclosing stream with an
++            # ephemeral nested capture stream; that key is deliberately not
++            # made the channel's permanent owner because graph replay runs on
++            # the enclosing stream.
+             channel = self._capture_channel_stack[-1]
++            if not _is_current_stream_capturing(self.device):
++                channel._bind_stream_key(stream_key)
++            self._channels[channel_key] = channel
++            return channel
++
++        if self._channel_factory is None:
++            if channel_id is None:
++                raise RuntimeError(
++                    "distributed PCIe oneshot eager use requires an explicit "
++                    "semantic channel_id shared by every rank"
++                )
++            logical_id = _normalize_logical_channel_id(channel_id)
++            channel = self._logical_channels.get(logical_id)
++            if channel is None:
++                raise RuntimeError(
++                    f"logical channel {logical_id!r} is not prepared; call "
++                    "prepare_channels() collectively before use"
++                )
++            mapped = self._channels.get(channel_key)
++            if mapped is not None and mapped is not channel:
++                raise RuntimeError(
++                    f"CUDA stream key {channel_key} is already bound to another "
++                    "logical PCIe oneshot channel"
++                )
++            channel._bind_stream_key(stream_key)
+             self._channels[channel_key] = channel
+             return channel
+         channel = self._channels.get(channel_key)
+@@ -1208,8 +2903,9 @@ class PCIeOneshotAllReducePool:
+         out: Optional[torch.Tensor] = None,
+         peer_input_ptrs: Optional[Sequence[int]] = None,
+         stream: object = None,
++        channel_id: Optional[str] = None,
+     ) -> torch.Tensor:
+-        channel = self.for_stream(stream)
++        channel = self.for_stream(stream, channel_id=channel_id)
+         if stream is not None and self.device.type == "cuda":
+             with torch.cuda.stream(stream):
+                 return channel.all_reduce(inp, out=out, peer_input_ptrs=peer_input_ptrs)
+@@ -1226,8 +2922,9 @@ class PCIeOneshotAllReducePool:
+         residual_out: Optional[torch.Tensor] = None,
+         peer_input_ptrs: Optional[Sequence[int]] = None,
+         stream: object = None,
++        channel_id: Optional[str] = None,
+     ) -> tuple[torch.Tensor, torch.Tensor]:
+-        channel = self.for_stream(stream)
++        channel = self.for_stream(stream, channel_id=channel_id)
+ 
+         def run() -> tuple[torch.Tensor, torch.Tensor]:
+             return channel.all_reduce_fused_add_rms_norm(
+@@ -1246,21 +2943,78 @@ class PCIeOneshotAllReducePool:
+         return run()
+ 
+     @contextmanager
+-    def capture(self, stream: object = None):
++    def capture(self, stream: object = None, *, channel_id: Optional[str] = None):
++        """Capture on a globally named channel.
++
++        An explicit id names an independently replayable graph. First use of
++        an unprepared explicit id is a collective convenience path: every rank
++        must enter with the same id or all ranks fail closed. Production
++        callers that know the full graph set should call prepare_channels()
++        once before capture; after that collective preparation, ranks may
++        capture members of the agreed catalog in different orders. Each graph
++        must still replay with its same-id peers using collectively compatible
++        kernel sequences and shapes.
++
++        Distributed pools require this semantic id. A local capture ordinal or
++        CUDA stream handle cannot distinguish target and draft graphs when
++        ranks construct them in a different order, so guessing is unsafe.
++        """
++        previous_channels: Optional[dict[int, PCIeOneshotAllReduce]] = None
++        if not self.single_channel and _is_current_stream_capturing(self.device):
++            raise RuntimeError(
++                "PCIe oneshot capture context must be entered before CUDA graph "
++                "capture starts"
++            )
+         if self.single_channel:
+-            channel = self.for_stream(stream)
++            channel = self.for_stream(
++                stream,
++                channel_id=_SINGLE_CHANNEL_ID if channel_id is None else channel_id,
++            )
++        elif self._channel_factory is None:
++            assert self.exchange_group is not None
++
++            def validate_capture_id() -> str:
++                if channel_id is None:
++                    raise RuntimeError(
++                        "distributed PCIe oneshot capture requires a stable "
++                        "semantic channel_id shared by every rank"
++                    )
++                logical_id = _normalize_logical_channel_id(channel_id)
++                if logical_id in self._captured_channel_ids:
++                    raise RuntimeError(
++                        f"logical channel {logical_id!r} was already captured; "
++                        "each independently replayable graph requires a unique id"
++                    )
++                return logical_id
++
++            logical_id = _run_collective_preallocation_setup(
++                owner="PCIe oneshot capture channel validation",
++                exchange_group=self.exchange_group,
++                setup=validate_capture_id,
++            )
++            needs_preparation = _collective_capture_needs_preparation(
++                owner="PCIe oneshot",
++                logical_id=logical_id,
++                prepared_channel_ids=self._logical_channels,
++                exchange_group=self.exchange_group,
++            )
++            if needs_preparation:
++                self.prepare_channels((logical_id,))
++            previous_channels = dict(self._channels)
++            stream_key = _current_stream_key(self.device, stream)
++            channel_key = 0 if stream_key is None else int(stream_key)
++            channel = self._logical_channels[logical_id]
++            channel._bind_stream_key(stream_key)
++            self._channels[channel_key] = channel
++            self._captured_channel_ids.add(logical_id)
+         else:
+-            if _is_current_stream_capturing(self.device):
+-                raise RuntimeError(
+-                    "PCIe oneshot capture context must be entered before CUDA "
+-                    "graph capture starts"
+-                )
+             stream_key = _current_stream_key(self.device, stream)
+             channel_key = 0 if stream_key is None else int(stream_key)
+             # A CUDA stream handle can be recycled after one graph manager
+             # finishes capture. Graphs retain the channel pointers, so a new
+             # manager must receive a fresh channel even when the numeric stream
+             # key is identical. _all_channels keeps replaced channels alive.
++            previous_channels = dict(self._channels)
+             channel = self._new_channel(stream_key)
+             self._channels[channel_key] = channel
+         with channel.capture(stream=stream):
+@@ -1271,22 +3025,50 @@ class PCIeOneshotAllReducePool:
+                 popped = self._capture_channel_stack.pop()
+                 if popped is not channel:
+                     raise RuntimeError("PCIe oneshot capture channel stack corrupted")
++                if previous_channels is not None:
++                    # Graph nodes retain this channel through _all_channels.
++                    # Restore every alias in strict LIFO order so nested or
++                    # recycled torch capture-stream keys cannot escape into a
++                    # later independent/unwrapped capture.
++                    for key, mapped in tuple(self._channels.items()):
++                        if mapped is not channel:
++                            continue
++                        previous = previous_channels.get(key)
++                        if previous is None:
++                            del self._channels[key]
++                        else:
++                            self._channels[key] = previous
+ 
+     def close(self) -> None:
+         if self._closed:
+             return
+-        self._closed = True
+         seen: set[int] = set()
++        channels = []
+         for channel in (*self._all_channels, *self._channels.values()):
+             if id(channel) not in seen:
+                 seen.add(id(channel))
+-                channel.close()
++                channels.append(channel)
++        _coordinated_close_channels(
++            channels,
++            exchange_group=self.exchange_group,
++            device=self.device,
++        )
++        self._closed = True
+         self._all_channels.clear()
+         self._channels.clear()
++        self._logical_channels.clear()
++        self._captured_channel_ids.clear()
+ 
+-    def __del__(self) -> None:
+-        with suppress(Exception):
+-            self.close()
++    def __del__(
++        self,
++        _quarantine: dict[int, object] = _ABANDONED_PCIE_RUNTIME_QUARANTINE,
++    ) -> None:
++        # A pool may be collected while graph or stream work still references
++        # its channels.  Keep the whole pool (and therefore every channel and
++        # rank_data tensor) alive; never unmap, synchronize, or communicate
++        # from GC. Explicit close() clears ownership before finalization.
++        if not getattr(self, "_closed", True):
++            _quarantine[id(self)] = self
+ 
+ 
+ __all__ = [
+diff --git a/sparkinfer/comm/pcie/pcie_twoshot.cu b/sparkinfer/comm/pcie/pcie_twoshot.cu
+index 0df42ec8abd4b2097ba18afc14e08d809ed07bdc..77859053ba53bda34ee39e98a87a9badfdd6af09 100644
+--- a/sparkinfer/comm/pcie/pcie_twoshot.cu
++++ b/sparkinfer/comm/pcie/pcie_twoshot.cu
+@@ -31,6 +31,7 @@
+ #include <torch/all.h>
+ #include <torch/extension.h>
+ 
++#include <algorithm>
+ #include <array>
+ #include <sstream>
+ #include <stdexcept>
+@@ -57,6 +58,8 @@ using FlagType = uint32_t;
+ constexpr int kFlagStride = 32;
+ 
+ struct Signal {
++  alignas(128) FlagType staging_generation;
++  FlagType active_staging_slot;
+   alignas(128) FlagType self_counter[kMaxBlocks][kMaxRanks];
+   alignas(128) FlagType peer_counter[2][kMaxBlocks][kMaxRanks * kFlagStride];
+ };
+@@ -65,6 +68,10 @@ struct __align__(16) RankPtrs {
+   void* __restrict__ ptrs[kMaxRanks];
+ };
+ 
++struct DoubleRankPtrs {
++  RankPtrs slots[2];
++};
++
+ struct RankSignals {
+   Signal* signals[kMaxRanks];
+ };
+@@ -81,6 +88,33 @@ static DINLINE FlagType ld_flag_relaxed(FlagType* flag_addr) {
+   return flag;
+ }
+ 
++static DINLINE FlagType ld_flag_relaxed_gpu(FlagType* flag_addr) {
++  FlagType flag;
++  asm volatile("ld.relaxed.gpu.global.u32 %0, [%1];" : "=r"(flag) : "l"(flag_addr) : "memory");
++  return flag;
++}
++
++__global__ void advance_staging_slot_kernel(Signal* self_sg) {
++  if (threadIdx.x == 0) {
++    const FlagType generation = self_sg->staging_generation;
++    self_sg->active_staging_slot = generation & FlagType{1};
++    self_sg->staging_generation = generation + FlagType{1};
++  }
++}
++
++template <int ngpus>
++DINLINE void select_rank_ptrs(RankPtrs& selected, const DoubleRankPtrs& options, Signal* self_sg) {
++  if (threadIdx.x == 0) {
++    // A one-CTA control kernel publishes the slot on this same stream before
++    // the worker launch. Kernel completion is the ordering edge, so every CTA
++    // observes one launch-wide slot without a grid rendezvous.
++    const int slot = int(ld_flag_relaxed_gpu(&self_sg->active_staging_slot) & FlagType{1});
++#pragma unroll
++    for (int peer = 0; peer < ngpus; ++peer) selected.ptrs[peer] = options.slots[slot].ptrs[peer];
++  }
++  __syncthreads();
++}
++
+ // Block-pairwise barrier: after it returns, all prior writes from every
+ // rank's block blockIdx.x are visible to this block.
+ template <int ngpus>
+@@ -146,9 +180,11 @@ DINLINE void block_range(int64_t total, int64_t& begin, int64_t& end) {
+ template <int ngpus>
+ __global__ void __launch_bounds__(512, 1) rs_fp8_kernel(
+     const Fp8Pack* __restrict__ src_payload, const float* __restrict__ src_scale,
+-    RankPtrs staging, int64_t pack_stride, int64_t scale_offset, int64_t scale_stride,
+-    RankSignals sg, Signal* self_sg, nv_bfloat16* __restrict__ out, int rank,
+-    int rows_per_rank, int row_elems) {
++    DoubleRankPtrs staging_options, int64_t pack_stride, int64_t scale_offset,
++    int64_t scale_stride, RankSignals sg, Signal* self_sg,
++    nv_bfloat16* __restrict__ out, int rank, int rows_per_rank, int row_elems) {
++  __shared__ RankPtrs staging;
++  select_rank_ptrs<ngpus>(staging, staging_options, self_sg);
+   const int packs_per_row = row_elems / 16;
+   const int64_t shard_packs = int64_t(rows_per_rank) * packs_per_row;
+   int64_t begin, end;
+@@ -200,9 +236,11 @@ __global__ void __launch_bounds__(512, 1) rs_fp8_kernel(
+ template <int ngpus>
+ __global__ void __launch_bounds__(512, 1) ag_fp8_kernel(
+     const Fp8Pack* __restrict__ src_payload, const float* __restrict__ src_scale,
+-    RankPtrs staging, int64_t pack_stride, int64_t scale_offset, int64_t scale_stride,
+-    RankSignals sg, Signal* self_sg, nv_bfloat16* __restrict__ out, int rank,
+-    int rows_per_rank, int row_elems) {
++    DoubleRankPtrs staging_options, int64_t pack_stride, int64_t scale_offset,
++    int64_t scale_stride, RankSignals sg, Signal* self_sg,
++    nv_bfloat16* __restrict__ out, int rank, int rows_per_rank, int row_elems) {
++  __shared__ RankPtrs staging;
++  select_rank_ptrs<ngpus>(staging, staging_options, self_sg);
+   const int packs_per_row = row_elems / 16;
+   const int64_t shard_packs = int64_t(rows_per_rank) * packs_per_row;
+   int64_t begin, end;
+@@ -256,12 +294,11 @@ class PCIeTwoShot {
+   RankSignals sg_;
+   Signal* self_sg_;
+ 
+-  RankPtrs staging_[2];
++  DoubleRankPtrs staging_;
+   int64_t pack_stride_;   // Fp8Packs per src region
+   int64_t scale_offset_;  // bytes
+   int64_t scale_stride_;  // floats per src region
+   int64_t max_shard_packs_;
+-  int slot_ = 0;
+ 
+   PCIeTwoShot(Signal** signals, const std::vector<std::array<void*, 2>>& staging,
+               int64_t pack_stride, int64_t scale_offset, int64_t scale_stride, int rank,
+@@ -269,13 +306,14 @@ class PCIeTwoShot {
+       : rank_(rank),
+         world_size_(world_size),
+         self_sg_(signals[rank]),
++        staging_{},
+         pack_stride_(pack_stride),
+         scale_offset_(scale_offset),
+         scale_stride_(scale_stride),
+         max_shard_packs_(pack_stride) {
+     for (int i = 0; i < world_size_; i++) {
+       sg_.signals[i] = signals[i];
+-      for (int s = 0; s < 2; s++) staging_[s].ptrs[i] = staging[i][s];
++      for (int s = 0; s < 2; s++) staging_.slots[s].ptrs[i] = staging[i][s];
+     }
+   }
+ 
+@@ -306,40 +344,56 @@ class PCIeTwoShot {
+       throw std::runtime_error("pcie_twoshot scale capacity exceeded");
+   }
+ 
++  void check_launch_config(int threads, int block_limit) const {
++    if (threads < world_size_ || threads > 1024 || threads % 32 != 0)
++      throw std::runtime_error(
++          "pcie_twoshot threads must be a multiple of 32 in [world size, 1024]");
++    if (block_limit <= 0)
++      throw std::runtime_error("pcie_twoshot block limit must be positive");
++    if (block_limit > kMaxBlocks)
++      throw std::runtime_error("pcie_twoshot block limit exceeds signal capacity");
++  }
++
+   void reduce_scatter(cudaStream_t stream, const void* payload, const void* scale, void* out,
+                       int64_t num_rows, int64_t row_elems, int threads, int block_limit) {
++    check_launch_config(threads, block_limit);
+     if (num_rows % world_size_ != 0)
+       throw std::runtime_error("num_rows must be divisible by world size");
+     const int64_t rows_per_rank = num_rows / world_size_;
+     check_shard(rows_per_rank, row_elems);
+-    const int s = slot_ % 2;
+-    slot_++;
+     const int64_t shard_packs = rows_per_rank * (row_elems / 16);
+     int blocks =
+         std::max<int64_t>(1, std::min<int64_t>(block_limit, (shard_packs + threads - 1) / threads));
++    advance_staging_slot_kernel<<<1, 1, 0, stream>>>(self_sg_);
++    CHECK_CUDA_SUCCESS(cudaGetLastError());
+     dispatch([&](auto ng) {
+       constexpr int ngpus = decltype(ng)::value;
+       rs_fp8_kernel<ngpus><<<blocks, threads, 0, stream>>>(
+-          reinterpret_cast<const Fp8Pack*>(payload), reinterpret_cast<const float*>(scale),
+-          staging_[s], pack_stride_, scale_offset_, scale_stride_, sg_, self_sg_,
+-          reinterpret_cast<nv_bfloat16*>(out), rank_, int(rows_per_rank), int(row_elems));
++          reinterpret_cast<const Fp8Pack*>(payload),
++          reinterpret_cast<const float*>(scale), staging_, pack_stride_, scale_offset_,
++          scale_stride_, sg_, self_sg_, reinterpret_cast<nv_bfloat16*>(out), rank_,
++          int(rows_per_rank), int(row_elems));
++      CHECK_CUDA_SUCCESS(cudaGetLastError());
+     });
+   }
+ 
+   void all_gather(cudaStream_t stream, const void* payload, const void* scale, void* out,
+                   int64_t rows_per_rank, int64_t row_elems, int threads, int block_limit) {
++    check_launch_config(threads, block_limit);
+     check_shard(rows_per_rank, row_elems);
+-    const int s = slot_ % 2;
+-    slot_++;
+     const int64_t shard_packs = rows_per_rank * (row_elems / 16);
+     int blocks =
+         std::max<int64_t>(1, std::min<int64_t>(block_limit, (shard_packs + threads - 1) / threads));
++    advance_staging_slot_kernel<<<1, 1, 0, stream>>>(self_sg_);
++    CHECK_CUDA_SUCCESS(cudaGetLastError());
+     dispatch([&](auto ng) {
+       constexpr int ngpus = decltype(ng)::value;
+       ag_fp8_kernel<ngpus><<<blocks, threads, 0, stream>>>(
+-          reinterpret_cast<const Fp8Pack*>(payload), reinterpret_cast<const float*>(scale),
+-          staging_[s], pack_stride_, scale_offset_, scale_stride_, sg_, self_sg_,
+-          reinterpret_cast<nv_bfloat16*>(out), rank_, int(rows_per_rank), int(row_elems));
++          reinterpret_cast<const Fp8Pack*>(payload),
++          reinterpret_cast<const float*>(scale), staging_, pack_stride_, scale_offset_,
++          scale_stride_, sg_, self_sg_, reinterpret_cast<nv_bfloat16*>(out), rank_,
++          int(rows_per_rank), int(row_elems));
++      CHECK_CUDA_SUCCESS(cudaGetLastError());
+     });
+   }
+ };
+diff --git a/sparkinfer/comm/pcie/pcie_twoshot.py b/sparkinfer/comm/pcie/pcie_twoshot.py
+index b24717088053595e559e35c8069b54a78064968f..d1e1f106026f83ceaf83c19208bc95b770ab245e 100644
+--- a/sparkinfer/comm/pcie/pcie_twoshot.py
++++ b/sparkinfer/comm/pcie/pcie_twoshot.py
+@@ -11,7 +11,6 @@ a runtime instance must not be shared concurrently across CUDA streams.
+ from __future__ import annotations
+ 
+ import os
+-from contextlib import suppress
+ from functools import lru_cache
+ from pathlib import Path
+ from typing import Optional, Sequence
+@@ -23,15 +22,24 @@ from torch.utils.cpp_extension import load
+ 
+ from ._cuda_ipc import CudaRTLibrary
+ from .pcie_oneshot import (
++    _ABANDONED_PCIE_RUNTIME_QUARANTINE,
+     IPC_SLAB_ALIGNMENT,
++    PCIeOneshotAllReduce,
++    _finish_collective_runtime_setup,
++    _raise_local_cleanup_errors,
+     _align_up,
+-    _broadcast_gather_object,
++    _coordinated_close_channels,
++    _cuda_device_index,
+     _normalize_device,
+     _OwnedSharedBuffer,
++    _require_collective_contract,
++    _require_full_grid_residency,
++    _run_collective_preallocation_setup,
+ )
+ 
+ SUPPORTED_WORLD_SIZES = (2, 4, 8)
+ FP8_MAX = 448.0
++TWOSHOT_REQUIRED_SMS = 64
+ 
+ 
+ @lru_cache(maxsize=1)
+@@ -59,8 +67,12 @@ def quantize_per_row(x: torch.Tensor) -> tuple[torch.Tensor, torch.Tensor]:
+ class PCIeTwoShotSP:
+     """Two-shot fp8-transport reduce_scatter / all_gather runtime."""
+ 
+-    def __init__(
+-        self,
++    def __init__(self, *args, **kwargs) -> None:
++        raise RuntimeError("use PCIeTwoShotSP.from_exchange_group()")
++
++    @classmethod
++    def _from_prepared_factory(
++        cls,
+         *,
+         rank: int,
+         world_size: int,
+@@ -69,9 +81,11 @@ class PCIeTwoShotSP:
+         fptr: int,
+         owned_buffers: Sequence[_OwnedSharedBuffer],
+         ipc: CudaRTLibrary,
++        exchange_group: ProcessGroup,
+         max_rows: int,
+         row_elems: int,
+-    ) -> None:
++    ) -> "PCIeTwoShotSP":
++        self = object.__new__(cls)
+         self.rank = rank
+         self.world_size = world_size
+         self.device = device
+@@ -79,9 +93,15 @@ class PCIeTwoShotSP:
+         self._fptr = fptr
+         self._owned_buffers = list(owned_buffers)
+         self._ipc = ipc
++        self.exchange_group = exchange_group
+         self.max_rows = max_rows
+         self.row_elems = row_elems
+         self._closed = False
++        self._ipc_imports_closed = False
++        self._ipc_exports_freed = False
++        self._coordinated_close_complete = False
++        self._closed_ipc_import_indices: set[tuple[int, int]] = set()
++        return self
+ 
+     @classmethod
+     def from_exchange_group(
+@@ -95,64 +115,107 @@ class PCIeTwoShotSP:
+     ) -> "PCIeTwoShotSP":
+         rank = dist.get_rank(group=exchange_group)
+         world_size = dist.get_world_size(group=exchange_group)
+-        if world_size not in SUPPORTED_WORLD_SIZES:
+-            raise ValueError(f"unsupported world size {world_size}")
+-        if row_elems % 16 != 0:
+-            raise ValueError("row_elems must be a multiple of 16")
+-        if max_rows % world_size != 0:
+-            raise ValueError("max_rows must be divisible by world size")
+-
+-        device_obj = _normalize_device(device)
+-        if device_obj.type != "cuda":
+-            raise ValueError("PCIe twoshot requires a CUDA device")
+-
+-        ipc = CudaRTLibrary()
+-        ipc.cudaSetDevice(device_obj.index or 0)
+-        ext = ext_module or _load_extension()
+-
+-        # Per-slot staging: [world][pack_stride] Fp8Packs then
+-        # [world][scale_stride] fp32 scales, regions 256B-aligned.
+-        max_rows_per_rank = max_rows // world_size
+-        packs_per_row = row_elems // 16
+-        pack_stride = _align_up(max_rows_per_rank * packs_per_row, 16)
+-        payload_bytes = world_size * pack_stride * 16
+-        scale_offset = _align_up(payload_bytes, IPC_SLAB_ALIGNMENT)
+-        scale_stride = _align_up(max_rows_per_rank, 64)
+-        slot_bytes = _align_up(
+-            scale_offset + world_size * scale_stride * 4, IPC_SLAB_ALIGNMENT
++
++        def validate_factory_arguments():
++            device_obj = _normalize_device(device)
++            normalized_max_rows = int(max_rows)
++            normalized_row_elems = int(row_elems)
++            if world_size not in SUPPORTED_WORLD_SIZES:
++                raise ValueError(f"unsupported world size {world_size}")
++            if device_obj.type != "cuda":
++                raise ValueError("PCIe twoshot requires a CUDA device")
++            if normalized_max_rows <= 0:
++                raise ValueError("max_rows must be positive")
++            if normalized_row_elems <= 0 or normalized_row_elems % 16 != 0:
++                raise ValueError("row_elems must be a positive multiple of 16")
++            if normalized_max_rows % world_size != 0:
++                raise ValueError("max_rows must be divisible by world size")
++            return device_obj, normalized_max_rows, normalized_row_elems
++
++        device_obj, max_rows, row_elems = _run_collective_preallocation_setup(
++            owner="PCIe twoshot argument validation",
++            exchange_group=exchange_group,
++            setup=validate_factory_arguments,
+         )
+-        signal_bytes = _align_up(int(ext.meta_size()), IPC_SLAB_ALIGNMENT)
+-        slab_bytes = signal_bytes + 2 * slot_bytes
+ 
+-        local_ptr = ipc.cudaMalloc(slab_bytes)
+-        owned: list[_OwnedSharedBuffer] = []
+-        try:
+-            # Signals must start zeroed.
+-            ipc.cudaMemset(local_ptr, 0, signal_bytes)
+-            local_handle = ipc.cudaIpcGetMemHandleBytes(local_ptr)
+-            handles = _broadcast_gather_object(local_handle, exchange_group)
+-
+-            peer_ptrs: list[int] = []
+-            remote_ptrs: list[int] = []
+-            for idx, handle in enumerate(handles):
+-                if idx == rank:
+-                    peer_ptrs.append(local_ptr)
+-                else:
+-                    remote_ptr = ipc.cudaIpcOpenMemHandleBytes(handle)
+-                    peer_ptrs.append(remote_ptr)
+-                    remote_ptrs.append(remote_ptr)
+-            owned.append(
+-                _OwnedSharedBuffer(
+-                    local_ptr=local_ptr,
+-                    peer_ptrs=tuple(peer_ptrs),
+-                    remote_ptrs=tuple(remote_ptrs),
+-                )
++        _require_full_grid_residency(
++            owner="PCIe twoshot",
++            required_sms=TWOSHOT_REQUIRED_SMS,
++            device=device_obj,
++            exchange_group=exchange_group,
++        )
++
++        def prepare():
++            prepared_ipc = CudaRTLibrary()
++            prepared_ipc.cudaSetDevice(_cuda_device_index(device_obj))
++            prepared_ext = ext_module or _load_extension()
++
++            # Per-slot staging: [world][pack_stride] Fp8Packs then
++            # [world][scale_stride] fp32 scales, regions 256B-aligned.
++            max_rows_per_rank = max_rows // world_size
++            packs_per_row = row_elems // 16
++            pack_stride = _align_up(max_rows_per_rank * packs_per_row, 16)
++            payload_bytes = world_size * pack_stride * 16
++            scale_offset = _align_up(payload_bytes, IPC_SLAB_ALIGNMENT)
++            scale_stride = _align_up(max_rows_per_rank, 64)
++            slot_bytes = _align_up(
++                scale_offset + world_size * scale_stride * 4, IPC_SLAB_ALIGNMENT
++            )
++            signal_bytes = _align_up(int(prepared_ext.meta_size()), IPC_SLAB_ALIGNMENT)
++            slab_bytes = signal_bytes + 2 * slot_bytes
++            return (
++                prepared_ipc,
++                prepared_ext,
++                pack_stride,
++                scale_offset,
++                scale_stride,
++                signal_bytes,
++                slot_bytes,
++                slab_bytes,
+             )
+ 
+-            signal_ptrs = [p for p in peer_ptrs]
+-            staging0 = [p + signal_bytes for p in peer_ptrs]
+-            staging1 = [p + signal_bytes + slot_bytes for p in peer_ptrs]
++        (
++            ipc,
++            ext,
++            pack_stride,
++            scale_offset,
++            scale_stride,
++            signal_bytes,
++            slot_bytes,
++            slab_bytes,
++        ) = _run_collective_preallocation_setup(
++            owner="PCIe twoshot",
++            exchange_group=exchange_group,
++            setup=prepare,
++        )
++        _require_collective_contract(
++            owner="PCIe twoshot channel layout",
++            exchange_group=exchange_group,
++            contract=(
++                int(max_rows),
++                int(row_elems),
++                int(pack_stride),
++                int(scale_offset),
++                int(scale_stride),
++                int(signal_bytes),
++                int(slab_bytes),
++            ),
++        )
++
++        shared = PCIeOneshotAllReduce._allocate_shared_buffer(
++            exchange_group,
++            slab_bytes,
++            zero_fill=True,
++            ipc=ipc,
++        )
++        peer_ptrs = list(shared.peer_ptrs)
++        signal_ptrs = peer_ptrs
++        staging0 = [p + signal_bytes for p in peer_ptrs]
++        staging1 = [p + signal_bytes + slot_bytes for p in peer_ptrs]
+ 
++        fptr = 0
++        init_error: BaseException | None = None
++        try:
+             fptr = ext.init_twoshot(
+                 signal_ptrs,
+                 staging0,
+@@ -162,25 +225,35 @@ class PCIeTwoShotSP:
+                 scale_stride,
+                 rank,
+             )
+-            return cls(
+-                rank=rank,
+-                world_size=world_size,
+-                device=device_obj,
+-                ext_module=ext,
+-                fptr=fptr,
+-                owned_buffers=owned,
+-                ipc=ipc,
+-                max_rows=max_rows,
+-                row_elems=row_elems,
+-            )
+-        except Exception:
+-            for shared in owned:
+-                for ptr in shared.remote_ptrs:
+-                    with suppress(Exception):
+-                        ipc.cudaIpcCloseMemHandle(ptr)
+-            with suppress(Exception):
+-                ipc.cudaFree(local_ptr)
+-            raise
++        except Exception as exc:
++            init_error = exc
++
++        def abort_native_runtime() -> None:
++            nonlocal fptr
++            if fptr:
++                ext.dispose(fptr)
++                fptr = 0
++
++        _finish_collective_runtime_setup(
++            owner="PCIe twoshot",
++            exchange_group=exchange_group,
++            ipc=ipc,
++            shared=shared,
++            local_error=init_error,
++            local_cleanup=abort_native_runtime,
++        )
++        return cls._from_prepared_factory(
++            rank=rank,
++            world_size=world_size,
++            device=device_obj,
++            ext_module=ext,
++            fptr=fptr,
++            owned_buffers=[shared],
++            ipc=ipc,
++            exchange_group=exchange_group,
++            max_rows=max_rows,
++            row_elems=row_elems,
++        )
+ 
+     def _check(self, payload: torch.Tensor, scale: torch.Tensor, rows: int) -> None:
+         if self._closed:
+@@ -240,16 +313,89 @@ class PCIeTwoShotSP:
+         self._ext.all_gather_fp8(self._fptr, payload, scale, out, threads, block_limit)
+         return out
+ 
+-    def close(self) -> None:
+-        if self._closed:
++    def _closed_import_indices(self) -> set[tuple[int, int]]:
++        closed = getattr(self, "_closed_ipc_import_indices", None)
++        if closed is None:
++            closed = set()
++            self._closed_ipc_import_indices = closed
++        return closed
++
++    def _all_python_ipc_imports_closed(self, closed: set[tuple[int, int]]) -> bool:
++        return all(
++            (buffer_index, remote_index) in closed
++            for buffer_index, shared in enumerate(self._owned_buffers)
++            for remote_index, _ in enumerate(shared.remote_ptrs)
++        )
++
++    def _close_ipc_imports_strict(self) -> None:
++        if self._ipc_imports_closed:
+             return
+         self._closed = True
+-        with suppress(Exception):
+-            self._ext.dispose(self._fptr)
+-        for shared in self._owned_buffers:
+-            for ptr in shared.remote_ptrs:
+-                with suppress(Exception):
++        failures: list[tuple[str, Exception]] = []
++        if self._fptr:
++            try:
++                self._ext.dispose(self._fptr)
++            except Exception as exc:
++                failures.append(("native runtime", exc))
++            else:
++                self._fptr = 0
++
++        closed = self._closed_import_indices()
++        for buffer_index, shared in enumerate(self._owned_buffers):
++            for remote_index, ptr in enumerate(shared.remote_ptrs):
++                key = (buffer_index, remote_index)
++                if key in closed:
++                    continue
++                try:
+                     self._ipc.cudaIpcCloseMemHandle(ptr)
+-            with suppress(Exception):
++                except Exception as exc:
++                    failures.append((f"CUDA IPC import {ptr}", exc))
++                else:
++                    closed.add(key)
++
++        if (
++            not failures
++            and not self._fptr
++            and self._all_python_ipc_imports_closed(closed)
++        ):
++            self._ipc_imports_closed = True
++        if failures:
++            _raise_local_cleanup_errors("PCIe twoshot", "IPC import close", failures)
++
++    def _free_ipc_exports_strict(self) -> None:
++        if self._ipc_exports_freed:
++            return
++        self._close_ipc_imports_strict()
++        failures: list[tuple[str, Exception]] = []
++        remaining = []
++        for shared in self._owned_buffers:
++            try:
+                 self._ipc.cudaFree(shared.local_ptr)
+-        self._owned_buffers.clear()
++            except Exception as exc:
++                remaining.append(shared)
++                failures.append((f"CUDA IPC export {shared.local_ptr}", exc))
++        self._owned_buffers = remaining
++        if not remaining:
++            self._ipc_exports_freed = True
++        if failures:
++            _raise_local_cleanup_errors("PCIe twoshot", "IPC export free", failures)
++
++    def close(self) -> None:
++        if getattr(self, "_coordinated_close_complete", False):
++            return
++        _coordinated_close_channels(
++            (self,),
++            exchange_group=self.exchange_group,
++            device=self.device,
++        )
++
++    def __del__(
++        self,
++        _quarantine: dict[int, object] = _ABANDONED_PCIE_RUNTIME_QUARANTINE,
++    ) -> None:
++        # GC cannot prove queued CUDA work is complete.  Explicit close() is the
++        # only path allowed to synchronize, unmap imports, and free exports.
++        if getattr(self, "_coordinated_close_complete", False):
++            return
++        if getattr(self, "_fptr", 0) or getattr(self, "_owned_buffers", ()):
++            _quarantine[id(self)] = self
+diff --git a/sparkinfer/gemm/trellis_linear/_small_m.py b/sparkinfer/gemm/trellis_linear/_small_m.py
+new file mode 100644
+index 0000000000000000000000000000000000000000..1e1d1f7cc5dbce4c4ee2bc828b59608f19a3e40c
+--- /dev/null
++++ b/sparkinfer/gemm/trellis_linear/_small_m.py
+@@ -0,0 +1,112 @@
++"""JIT binding for the SparkInfer-owned K6/MCG small-M CUDA kernel."""
++
++from __future__ import annotations
++
++import hashlib
++import os
++from functools import lru_cache
++from pathlib import Path
++
++import torch
++from torch.utils.cpp_extension import load
++
++
++_SOURCE_DIR = Path(__file__).resolve().parent / "csrc"
++_SOURCE = _SOURCE_DIR / "trellis_k6_small.cu"
++_VENDORED_FILES = tuple(sorted((_SOURCE_DIR / "vendor").rglob("*.[ch]*")))
++
++
++_GLM_K6_DECODE_SMS = {
++    # Q/indexer projection on the target stream.
++    (2048, 4096): 128,
++    # TP4 shared-expert FC1/FC2 run beside the target stream. These are the
++    # rank-local dimensions after column/row parallel slicing, not the full
++    # 4096/2048-wide shared MLP dimensions. The budgets match the E2E-optimal
++    # ExLlama autotuner result; using all 188 SMs serializes the graph branches.
++    (6144, 1024): 64,
++    (512, 6144): 96,
++}
++
++
++def _default_num_sms(size_k: int, size_n: int, available_sms: int) -> int:
++    """Select the measured GLM K6 decode overlap budget when applicable."""
++    target = _GLM_K6_DECODE_SMS.get((size_k, size_n))
++    return available_sms if target is None else min(available_sms, target)
++
++
++@lru_cache(maxsize=None)
++def _available_sms(device_index: int) -> int:
++    return int(torch.cuda.get_device_properties(device_index).multi_processor_count)
++
++
++def _extension_name() -> str:
++    digest = hashlib.sha256()
++    for path in (_SOURCE, *_VENDORED_FILES):
++        if path.is_file():
++            digest.update(path.relative_to(_SOURCE_DIR).as_posix().encode())
++            digest.update(path.read_bytes())
++    return f"sparkinfer_trellis_k6_{digest.hexdigest()[:12]}"
++
++
++@lru_cache(maxsize=1)
++def _extension():
++    build_directory = os.environ.get("SPARKINFER_TRELLIS_BUILD_DIR")
++    if build_directory:
++        Path(build_directory).mkdir(parents=True, exist_ok=True)
++    return load(
++        name=_extension_name(),
++        sources=[str(_SOURCE)],
++        extra_include_paths=[str(_SOURCE_DIR)],
++        extra_cuda_cflags=[
++            "-O3",
++            "--use_fast_math",
++            "--expt-relaxed-constexpr",
++            "--expt-extended-lambda",
++            "-gencode=arch=compute_120,code=sm_120",
++        ],
++        extra_cflags=["-O3"],
++        build_directory=build_directory,
++        verbose=os.environ.get("SPARKINFER_JIT_VERBOSE", "0") == "1",
++    )
++
++
++def run_k6_mcg(
++    x: torch.Tensor,
++    trellis: torch.Tensor,
++    output: torch.Tensor,
++    suh: torch.Tensor,
++    rotated_input: torch.Tensor,
++    svh: torch.Tensor,
++    locks: torch.Tensor,
++    *,
++    num_sms: int = 0,
++) -> None:
++    """Launch the capture-safe K6/MCG kernel on Torch's current stream."""
++    capability = torch.cuda.get_device_capability(x.device)
++    if capability != (12, 0):
++        raise NotImplementedError(
++            "Trellis K6 small-M kernel is built for sm_120 only; "
++            f"device reports sm_{capability[0]}{capability[1]}"
++        )
++    if num_sms <= 0:
++        device_index = x.device.index
++        if device_index is None:
++            device_index = torch.cuda.current_device()
++        num_sms = _default_num_sms(
++            int(x.shape[1]),
++            int(output.shape[1]),
++            _available_sms(int(device_index)),
++        )
++    _extension().launch_k6_mcg(
++        x,
++        trellis,
++        output,
++        suh,
++        rotated_input,
++        svh,
++        locks,
++        int(num_sms),
++    )
++
++
++__all__ = ["run_k6_mcg"]
+diff --git a/sparkinfer/gemm/trellis_linear/api.py b/sparkinfer/gemm/trellis_linear/api.py
+index 479024dd6f71b04830aede3757cc0614866ae30e..13f1c5c8f09e91e8a26aa6e30d56c231971b403f 100644
+--- a/sparkinfer/gemm/trellis_linear/api.py
++++ b/sparkinfer/gemm/trellis_linear/api.py
+@@ -57,6 +57,8 @@ def run(
+     gemm_output_f16: Optional[torch.Tensor] = None,
+     output_f16: Optional[torch.Tensor] = None,
+     hadamard_128=None,
++    _moe_block_size: int = 64,
++    _force_tile_config: tuple[int, int] | None = None,
+ ) -> torch.Tensor:
+     """Execute Trellis GEMM, optionally reusing all capture-time storage."""
+     return run_trellis256_dense(
+@@ -71,6 +73,8 @@ def run(
+         gemm_output_f16=gemm_output_f16,
+         output_f16=output_f16,
+         hadamard_128=hadamard_128,
++        _moe_block_size=_moe_block_size,
++        _force_tile_config=_force_tile_config,
+     )
+ 
+ 
+diff --git a/sparkinfer/gemm/trellis_linear/csrc/trellis_k6_small.cu b/sparkinfer/gemm/trellis_linear/csrc/trellis_k6_small.cu
+new file mode 100644
+index 0000000000000000000000000000000000000000..7258a787351a8d3a99b7c51d2ac10fcd27128c3f
+--- /dev/null
++++ b/sparkinfer/gemm/trellis_linear/csrc/trellis_k6_small.cu
+@@ -0,0 +1,152 @@
++// SPDX-License-Identifier: MIT
++//
++// Narrow K6/MCG dense launcher adapted from ExLlamaV3. The vendored kernel
++// headers retain their MIT license in vendor/LICENSE.exllamav3. SparkInfer
++// owns the tensor validation, workspace, dispatch, and CUDA-stream contract.
++
++#include <ATen/cuda/CUDAContext.h>
++#include <c10/cuda/CUDAGuard.h>
++#include <algorithm>
++#include <cuda_fp16.h>
++#include <cooperative_groups.h>
++#include <mutex>
++#include <torch/extension.h>
++
++#include "vendor/util.h"
++#include "vendor/util.cuh"
++
++namespace cg = cooperative_groups;
++
++#include "vendor/quant/exl3_gemm_kernel.cuh"
++
++namespace {
++
++constexpr int kBits = 6;
++constexpr int kCodebookMcg = 1;
++constexpr int kTileM = 16;
++constexpr int kTileK = 32;
++constexpr int kTileN = 128;
++constexpr int kSharedStages = 4;
++constexpr int kFragmentStages = 3;
++constexpr int kThreads = EXL3_GEMM_BASE_THREADS * (kTileK / 16);
++constexpr int kFragmentsNPerWarp =
++    2 * (kTileN / 16) / (EXL3_GEMM_BASE_THREADS / 32);
++constexpr int kASharedElements = kTileM * kTileK;
++constexpr int kBSharedElements =
++    (kTileK / 16) * (kTileN / 16) * 16 * kBits;
++constexpr int kCSharedElements =
++    4 * EXL3_GEMM_BASE_THREADS * kFragmentsNPerWarp > kTileN * kTileM
++        ? 4 * EXL3_GEMM_BASE_THREADS * kFragmentsNPerWarp
++        : kTileN * kTileM;
++constexpr int kDynamicSmem =
++    kSharedStages * (2 * kASharedElements + 2 * kBSharedElements) +
++    4 * kCSharedElements;
++static_assert(kDynamicSmem <= EXL3_SMEM_MAX_BYTES,
++              "Trellis K6 kernel exceeds the vendored shared-memory limit");
++
++void check_cuda(cudaError_t status, const char* operation) {
++  TORCH_CHECK(status == cudaSuccess, operation, ": ", cudaGetErrorString(status));
++}
++
++void launch_k6_mcg(
++    const torch::Tensor& input,
++    const torch::Tensor& trellis,
++    torch::Tensor& output,
++    const torch::Tensor& suh,
++    torch::Tensor& rotated_input,
++    const torch::Tensor& svh,
++    torch::Tensor& locks,
++    int64_t requested_sms) {
++  TORCH_CHECK(input.is_cuda() && trellis.is_cuda() && output.is_cuda() &&
++                  suh.is_cuda() && rotated_input.is_cuda() && svh.is_cuda() &&
++                  locks.is_cuda(),
++              "Trellis K6 tensors must be CUDA tensors");
++  const int device = input.get_device();
++  TORCH_CHECK(trellis.get_device() == device && output.get_device() == device &&
++                  suh.get_device() == device &&
++                  rotated_input.get_device() == device &&
++                  svh.get_device() == device && locks.get_device() == device,
++              "Trellis K6 tensors must share one CUDA device");
++  const c10::cuda::CUDAGuard device_guard(input.device());
++  TORCH_CHECK(input.scalar_type() == at::kHalf && output.scalar_type() == at::kHalf,
++              "Trellis K6 small-M path requires FP16 input and output");
++  TORCH_CHECK(trellis.scalar_type() == at::kShort,
++              "Trellis K6 payload must be viewed as int16");
++  TORCH_CHECK(suh.scalar_type() == at::kHalf && svh.scalar_type() == at::kHalf,
++              "Trellis K6 rotation scales must be FP16");
++  TORCH_CHECK(rotated_input.scalar_type() == at::kHalf,
++              "Trellis K6 rotated input must be FP16");
++  TORCH_CHECK(locks.scalar_type() == at::kInt,
++              "Trellis K6 lock workspace must be int32");
++  TORCH_CHECK(input.is_contiguous() && trellis.is_contiguous() &&
++                  output.is_contiguous() && suh.is_contiguous() &&
++                  rotated_input.is_contiguous() && svh.is_contiguous() &&
++                  locks.is_contiguous(),
++              "Trellis K6 small-M tensors must be contiguous");
++  TORCH_CHECK(input.dim() == 2 && output.dim() == 2 && trellis.dim() == 3,
++              "Trellis K6 expects A[M,K], B[K/16,N/16,96], C[M,N]");
++
++  int size_m = static_cast<int>(input.size(0));
++  int size_k = static_cast<int>(input.size(1));
++  int size_n = static_cast<int>(output.size(1));
++  TORCH_CHECK(size_m >= 1 && size_m <= 128,
++              "Trellis K6 small-M path supports 1..128 rows, got ", size_m);
++  TORCH_CHECK(output.size(0) == size_m && rotated_input.sizes() == input.sizes(),
++              "Trellis K6 output/scratch shapes do not match input");
++  TORCH_CHECK(trellis.size(0) * 16 == size_k &&
++                  trellis.size(1) * 16 == size_n && trellis.size(2) == 96,
++              "Trellis K6 native payload shape does not match M/K/N");
++  TORCH_CHECK(suh.numel() == size_k && svh.numel() == size_n,
++              "Trellis K6 rotation scale width mismatch");
++  // The fused H128 preamble reads 128 contiguous scale elements per warp.
++  TORCH_CHECK(size_k % 128 == 0 && size_n % kTileN == 0,
++              "Trellis K6 K/N must be divisible by 128/128, got K=", size_k,
++              " N=", size_n);
++  TORCH_CHECK(locks.numel() >= size_n / 16,
++              "Trellis K6 lock workspace is too small");
++
++  int available_sms = 0;
++  check_cuda(cudaDeviceGetAttribute(&available_sms, cudaDevAttrMultiProcessorCount,
++                                    device),
++             "cudaDeviceGetAttribute");
++  const int tiles = (size_k / kTileK) * (size_n / kTileN);
++  int num_sms = requested_sms > 0 ? static_cast<int>(requested_sms) : available_sms;
++  num_sms = std::max(1, std::min(num_sms, std::min(available_sms, tiles)));
++
++  auto kernel = exl3_gemm_kernel<kBits, false, kCodebookMcg, kTileM, kTileK,
++                                 kTileN, kSharedStages, kFragmentStages>;
++  static std::once_flag smem_attribute_once;
++  std::call_once(smem_attribute_once, [&] {
++    check_cuda(cudaFuncSetAttribute(kernel,
++                                    cudaFuncAttributeMaxDynamicSharedMemorySize,
++                                    kDynamicSmem),
++               "cudaFuncSetAttribute");
++  });
++
++  const half* a_ptr = reinterpret_cast<const half*>(input.data_ptr<at::Half>());
++  const uint16_t* b_ptr =
++      reinterpret_cast<const uint16_t*>(trellis.data_ptr<int16_t>());
++  half* c_ptr = reinterpret_cast<half*>(output.data_ptr<at::Half>());
++  int* lock_ptr = locks.data_ptr<int>();
++  const half* suh_ptr = reinterpret_cast<const half*>(suh.data_ptr<at::Half>());
++  half* rotated_ptr =
++      reinterpret_cast<half*>(rotated_input.data_ptr<at::Half>());
++  const half* svh_ptr = reinterpret_cast<const half*>(svh.data_ptr<at::Half>());
++  void* args[] = {&a_ptr,       &b_ptr,      &c_ptr,  &size_m, &size_k,
++                  &size_n,     &lock_ptr,   &suh_ptr, &rotated_ptr, &svh_ptr};
++
++  cudaStream_t stream = at::cuda::getCurrentCUDAStream(device).stream();
++  // Keep this launch one-dimensional: vendored H128 scale indexing assumes
++  // gridDim.y == 1 because the caller already supplies its per-K scale offset.
++  check_cuda(cudaLaunchCooperativeKernel(reinterpret_cast<void*>(kernel), num_sms,
++                                         kThreads, args, kDynamicSmem, stream),
++             "cudaLaunchCooperativeKernel");
++  check_cuda(cudaPeekAtLastError(), "Trellis K6 kernel launch");
++}
++
++}  // namespace
++
++PYBIND11_MODULE(TORCH_EXTENSION_NAME, module) {
++  module.def("launch_k6_mcg", &launch_k6_mcg,
++             "SparkInfer K6/MCG small-M dense GEMM");
++}
+diff --git a/sparkinfer/gemm/trellis_linear/csrc/vendor/LICENSE.exllamav3 b/sparkinfer/gemm/trellis_linear/csrc/vendor/LICENSE.exllamav3
+new file mode 100644
+index 0000000000000000000000000000000000000000..b40e3294c2cd30839e56636a3d2ccfaaa2c0f6e6
+--- /dev/null
++++ b/sparkinfer/gemm/trellis_linear/csrc/vendor/LICENSE.exllamav3
+@@ -0,0 +1,21 @@
++MIT License
++
++Copyright (c) 2025 Turboderp
++
++Permission is hereby granted, free of charge, to any person obtaining a copy
++of this software and associated documentation files (the "Software"), to deal
++in the Software without restriction, including without limitation the rights
++to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
++copies of the Software, and to permit persons to whom the Software is
++furnished to do so, subject to the following conditions:
++
++The above copyright notice and this permission notice shall be included in all
++copies or substantial portions of the Software.
++
++THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
++IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
++FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
++AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
++LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
++OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
++SOFTWARE.
+\ No newline at end of file
+diff --git a/sparkinfer/gemm/trellis_linear/csrc/vendor/compat.cuh b/sparkinfer/gemm/trellis_linear/csrc/vendor/compat.cuh
+new file mode 100644
+index 0000000000000000000000000000000000000000..b9caca4bad3a5924c3960aaead22905715f35b9e
+--- /dev/null
++++ b/sparkinfer/gemm/trellis_linear/csrc/vendor/compat.cuh
+@@ -0,0 +1,31 @@
++#pragma once
++
++// Approximate tanh
++
++__forceinline__ __device__ float copysignf_pos(float a, float b)
++{
++    float r;
++    r = __int_as_float(__float_as_int(a) | (__float_as_int(b) & 0x80000000));
++    return r;
++}
++
++#if defined(USE_ROCM) || (defined(__CUDA_ARCH__) && (__CUDA_ARCH__ < 750 || CUDART_VERSION < 11000))
++
++__inline__ __device__ float tanh_opt(float x)
++{
++    const float exp_val = -1.f * fabs(2 * x);
++    return copysignf_pos((1.0f - __expf(exp_val)) / (__expf(exp_val) + 1.0f), x);
++}
++
++#else
++
++__inline__ __device__ float tanh_opt(float x)
++{
++    float r;
++    asm("tanh.approx.f32 %0,%1; \n\t" : "=f"(r) : "f"(x));
++    return r;
++}
++
++#endif
++// Vendored from https://github.com/brandonmmusic-max/exllamav3 at 704aefd743b390af4bd0fb429d1906f9b964c7d8.
++// License: sparkinfer/gemm/trellis_linear/csrc/vendor/LICENSE.exllamav3
+diff --git a/sparkinfer/gemm/trellis_linear/csrc/vendor/ptx.cuh b/sparkinfer/gemm/trellis_linear/csrc/vendor/ptx.cuh
+new file mode 100644
+index 0000000000000000000000000000000000000000..979c77821e4b24258b069c41a4452f2d23183e95
+--- /dev/null
++++ b/sparkinfer/gemm/trellis_linear/csrc/vendor/ptx.cuh
+@@ -0,0 +1,350 @@
++#pragma once
++#include <cuda/atomic>
++
++// Tensor core fragments
++
++template <typename T, int n>
++struct Vec
++{
++    T elems[n];
++    __device__ T& operator[](int i) { return elems[i]; }
++};
++
++using FragA = Vec<half2, 4>;
++using FragB = Vec<half2, 2>;
++using FragC = Vec<float, 4>;
++using FragC_h = Vec<half2, 2>;
++
++// m8n8k4 tensor core matmul (emulated on Ampere and later), don't use
++//
++// https://docs.nvidia.com/cuda/parallel-thread-execution/index.html#matrix-fragments-for-mma-m8n8k4-with-f16-floating-point-type
++
++__device__ inline void ptx_mma_m8n8k4
++(
++    const Vec<half2, 2>& frag_a,
++    const Vec<half2, 2>& frag_b,
++    Vec<float, 8>& frag_c
++)
++{
++    const uint32_t* a = reinterpret_cast<const uint32_t*>(&frag_a);
++    const uint32_t* b = reinterpret_cast<const uint32_t*>(&frag_b);
++    float* c = reinterpret_cast<float*>(&frag_c);
++    const float* d = reinterpret_cast<const float*>(&frag_c);
++
++    asm
++    (
++        "mma.sync.aligned.m8n8k4.row.col.f32.f16.f16.f32 "
++        "{%0,%1,%2,%3,%4,%5,%6,%7}, {%8,%9}, {%10,%11}, {%12,%13,%14,%15,%16,%17,%18,%19};\n"
++
++        : "=f"(c[0]), "=f"(c[1]), "=f"(c[2]), "=f"(c[3]),"=f"(c[4]), "=f"(c[5]), "=f"(c[6]), "=f"(c[7])
++
++        :  "r"(a[0]), "r"(a[1]),
++           "r"(b[0]), "r"(b[1]),
++           "f"(d[0]), "f"(d[1]), "f"(d[2]), "f"(d[3]), "f"(d[4]), "f"(d[5]), "f"(d[6]), "f"(d[7])
++    );
++}
++
++// m16n8k16 tensor core matmul
++//
++// https://docs.nvidia.com/cuda/parallel-thread-execution/index.html#matrix-fragments-for-mma-m16n8k16-with-floating-point-type
++
++// FP16 @ FP16 + FP32 -> FP32
++__device__ inline void ptx_mma_m16n8k16
++(
++    const FragA& frag_a,
++    const FragB& frag_b,
++    FragC& frag_c
++)
++{
++    const uint32_t* a = reinterpret_cast<const uint32_t*>(&frag_a);
++    const uint32_t* b = reinterpret_cast<const uint32_t*>(&frag_b);
++    float* c = reinterpret_cast<float*>(&frag_c);
++    const float* d = reinterpret_cast<const float*>(&frag_c);
++
++    asm
++    (
++        "mma.sync.aligned.m16n8k16.row.col.f32.f16.f16.f32 "
++        "{%0,%1,%2,%3}, {%4,%5,%6,%7}, {%8,%9}, {%10,%11,%12,%13};\n"
++
++        : "=f"(c[0]), "=f"(c[1]), "=f"(c[2]), "=f"(c[3])
++        :  "r"(a[0]), "r"(a[1]), "r"(a[2]), "r"(a[3]),
++           "r"(b[0]), "r"(b[1]),
++           "f"(d[0]), "f"(d[1]), "f"(d[2]), "f"(d[3])
++    );
++}
++
++// FP16 @ FP16 + FP16 -> FP16
++__device__ inline void ptx_mma_m16n8k16
++(
++    const FragA& frag_a,
++    const FragB& frag_b,
++    FragC_h& frag_c
++)
++{
++    const uint32_t* a = reinterpret_cast<const uint32_t*>(&frag_a);
++    const uint32_t* b = reinterpret_cast<const uint32_t*>(&frag_b);
++    uint32_t* c = reinterpret_cast<uint32_t*>(&frag_c);
++    const uint32_t* d = reinterpret_cast<const uint32_t*>(&frag_c);
++
++    asm
++    (
++        "mma.sync.aligned.m16n8k16.row.col.f16.f16.f16.f16 "
++        "{%0,%1}, {%2,%3,%4,%5}, {%6,%7}, {%8,%9};\n"
++
++        : "=r"(c[0]), "=r"(c[1])
++        :  "r"(a[0]), "r"(a[1]), "r"(a[2]), "r"(a[3]),
++           "r"(b[0]), "r"(b[1]),
++           "r"(d[0]), "r"(d[1])
++    );
++}
++
++// Global barrier
++
++__device__ inline void barrier_acquire
++(
++    int* lock,
++    int stage
++)
++{
++    if (threadIdx.x == 0)
++    {
++        volatile int state = -1;
++        do
++        {
++            asm volatile ("ld.global.acquire.gpu.b32 %0, [%1];\n" : "=r"(state) : "l"(lock));
++        }
++        while (state != stage);
++    }
++    __syncthreads();
++}
++
++__device__ inline void barrier_release
++(
++    int* lock,
++    int val,
++    bool reset
++)
++{
++    __syncthreads();
++    if (threadIdx.x == 0)
++    {
++        if (reset)
++        {
++            *lock = 0;
++            return;
++        }
++        asm volatile ("fence.acq_rel.gpu;\n");
++        asm volatile ("red.relaxed.gpu.global.add.s32 [%0], %1;\n" : : "l"(lock), "r"(val));
++    }
++}
++
++// Load global to shared memory, predicated. Seems to produce incorrect code when compiling for Blackwell, but
++// `if (...) cp_async(...)` compiles to a predicated instruction anyway
++
++__device__ inline void cp_async_pred(void* smem_ptr, const void* glob_ptr, bool pred = true)
++{
++    const int bytes = 16;
++    uint32_t smem = static_cast<uint32_t>(__cvta_generic_to_shared(smem_ptr));
++    asm volatile(
++        "{\n"
++        "   .reg .pred p;\n"
++        "   setp.ne.b32 p, %0, 0;\n"
++        "   @p cp.async.cg.shared.global [%1], [%2], %3;\n"
++        "}\n" :: "r"((int) pred), "r"(smem), "l"(glob_ptr), "n"(bytes)
++    );
++}
++
++// Load global to shared memory
++
++__device__ inline void cp_async(void* smem_ptr, const void* glob_ptr)
++{
++    const int bytes = 16;
++    uint32_t smem = static_cast<uint32_t>(__cvta_generic_to_shared(smem_ptr));
++    asm volatile(
++        "{\n"
++        "   cp.async.cg.shared.global [%0], [%1], %2;\n"
++        "}\n" :: "r"(smem), "l"(glob_ptr), "n"(bytes)
++    );
++}
++
++// Load global to shared memory with cache hint to evict data from L2 ASAP
++
++__device__ inline void cp_async_stream(void* smem_ptr, const void* glob_ptr)
++{
++    uint32_t smem = static_cast<uint32_t>(__cvta_generic_to_shared(smem_ptr));
++    const int bytes = 16;
++    asm volatile
++    (
++        "{\n"
++        "   .reg .b64 p;\n"
++        "   createpolicy.fractional.L2::evict_first.b64 p, 1.0;\n"
++        "   cp.async.cg.shared.global.L2::cache_hint [%0], [%1], %2, p;\n"
++        "}\n" :: "r"(smem), "l"(glob_ptr), "n"(bytes)
++    );
++}
++
++// Async copy fence, commit all pending async copies
++
++__device__ inline void cp_async_fence()
++{
++    asm volatile("cp.async.commit_group;\n" ::);
++}
++
++// Wait until at most n async groups are still pending.
++
++template <int n>
++__device__ inline void cp_async_wait()
++{
++    asm volatile("cp.async.wait_group %0;\n" :: "n"(n));
++}
++
++// Load 16x16 matrix fragment from shared memory, directly in tensor core layout
++
++__device__ inline void ldsm4(FragA& frag_a, const void* smem_ptr)
++{
++    uint32_t* a = reinterpret_cast<uint32_t*>(&frag_a);
++    uint32_t smem = static_cast<uint32_t>(__cvta_generic_to_shared(smem_ptr));
++    asm volatile
++    (
++        "ldmatrix.sync.aligned.m8n8.x4.shared.b16 {%0,%1,%2,%3}, [%4];\n"
++        : "=r"(a[0]), "=r"(a[1]), "=r"(a[2]), "=r"(a[3]) : "r"(smem)
++    );
++}
++
++__device__ inline uint32_t mul_lo_u32(uint32_t x, uint32_t y)
++{
++    uint32_t w;
++    asm volatile
++    (
++        "mul.lo.u32 %0, %1, %2;"
++        : "=r"(w)
++        :  "r"(x), "r"(y)
++    );
++    return w;
++}
++
++__device__ inline uint32_t mul_hi_u32(uint32_t x, uint32_t y)
++{
++    uint32_t w;
++    asm volatile
++    (
++        "mul.hi.u32 %0, %1, %2;"
++        : "=r"(w)
++        :  "r"(x), "r"(y)
++    );
++    return w;
++}
++
++// Memory ops
++
++__device__ __forceinline__ void stg_wt_u32(uint32_t* p, uint32_t v)
++{
++    asm volatile("st.global.wt.u32 [%0], %1;" :: "l"(p), "r"(v));
++}
++
++__device__ __forceinline__ void stg_wt_u128(uint4* p, const uint4 v)
++{
++    asm volatile ("st.global.wt.v4.u32 [%0], {%1,%2,%3,%4};"
++                  :: "l"(p),
++                     "r"(v.x), "r"(v.y), "r"(v.z), "r"(v.w));
++}
++
++__device__ __forceinline__ uint32_t ldg_cv_u32(const uint32_t* p)
++{
++    uint32_t v;
++    asm volatile("ld.global.cv.u32 %0, [%1];" : "=r"(v) : "l"(p));
++    return v;
++}
++
++__device__ __forceinline__ uint4 ldg_cv_u128(const uint4* p)
++{
++    uint4 v;
++    asm volatile ("ld.global.cv.v4.u32 {%0,%1,%2,%3}, [%4];"
++                  : "=r"(v.x), "=r"(v.y), "=r"(v.z), "=r"(v.w)
++                  : "l"(p));
++    return v;
++}
++
++__device__ __forceinline__ uint32_t ldg_acquire_sys_u32(const uint32_t* p)
++{
++    uint32_t v;
++    asm volatile("ld.global.acquire.sys.u32 %0, [%1];"
++                 : "=r"(v) : "l"(p));
++    return v;
++}
++
++__device__ __forceinline__ uint64_t ldg_acquire_sys_u64(const uint64_t* p)
++{
++    uint64_t v;
++    asm volatile("ld.global.acquire.sys.u64 %0, [%1];" : "=l"(v) : "l"(p) : "memory");
++    return v;
++}
++
++__device__ __forceinline__ void stg_release_sys_u32(uint32_t* p, uint32_t v)
++{
++    asm volatile("st.global.release.sys.u32 [%0], %1;" :: "l"(p), "r"(v) : "memory");
++}
++
++__device__ __forceinline__ void stg_release_sys_u64(uint64_t* p, uint64_t v)
++{
++    asm volatile("st.global.release.sys.u64 [%0], %1;" :: "l"(p), "l"(v) : "memory");
++}
++
++// Global time in nanoseconds
++
++__device__ __forceinline__ uint64_t globaltimer_ns()
++{
++    uint64_t t;
++    asm volatile("mov.u64 %0, %%globaltimer;" : "=l"(t));
++    return t;
++}
++
++// Bitfield stuff
++
++static __forceinline__ __device__ uint32_t bfe64(uint32_t lo, uint32_t hi, int offset, int length)
++{
++    uint64_t value = (static_cast<uint64_t>(hi) << 32) | static_cast<uint64_t>(lo);
++    uint64_t result64;
++    asm ("bfe.u64 %0, %1, %2, %3;"
++         : "=l"(result64)
++         : "l"(value), "r"(offset), "r"(length));
++    return static_cast<uint32_t>(result64);
++}
++
++#define FSHF_IMM(dst, lo, hi, imm) asm("shf.r.wrap.b32 %0, %1, %2, " #imm ";" : "=r"(dst) : "r"(lo), "r"(hi))
++#define BFE16_IMM(dst, src, imm) asm("bfe.u32 %0, %1, " #imm ", 16;" : "=r"(dst) : "r"(src))
++
++// Inter-block barrier
++
++__device__ inline void group_barrier
++(
++    int group_id,
++    int group_size,
++    int* barrier_counters_sense  // length 2*max(group_id). odd positions are flipped after sync (sense)
++)
++{
++    __syncthreads();
++
++    if (threadIdx.x == 0)
++    {
++        cuda::atomic_ref<int, cuda::thread_scope_device> counter(barrier_counters_sense[group_id * 2]);
++        cuda::atomic_ref<int, cuda::thread_scope_device> sense(barrier_counters_sense[group_id * 2 + 1]);
++
++        int old_sense = sense.load(cuda::memory_order_relaxed);
++        int old = counter.fetch_add(1, cuda::memory_order_acq_rel);
++
++        if (old == group_size - 1)
++        {
++            counter.store(0, cuda::memory_order_relaxed);
++            sense.store(1 - old_sense, cuda::memory_order_release);
++        }
++        else
++        {
++            while (sense.load(cuda::memory_order_acquire) == old_sense) __nanosleep(32);
++        }
++    }
++
++    __syncthreads();
++}
++// Vendored from https://github.com/brandonmmusic-max/exllamav3 at 704aefd743b390af4bd0fb429d1906f9b964c7d8.
++// License: sparkinfer/gemm/trellis_linear/csrc/vendor/LICENSE.exllamav3
+diff --git a/sparkinfer/gemm/trellis_linear/csrc/vendor/quant/codebook.cuh b/sparkinfer/gemm/trellis_linear/csrc/vendor/quant/codebook.cuh
+new file mode 100644
+index 0000000000000000000000000000000000000000..43b781bd92450f2db4d36d9f3c424a2b3830f882
+--- /dev/null
++++ b/sparkinfer/gemm/trellis_linear/csrc/vendor/quant/codebook.cuh
+@@ -0,0 +1,159 @@
++#pragma once
++
++// Force integer MAD on sm<=86. For some reason this performs better than letting the compiler emit IMUL
++// TODO: Keep an eye on new behavior in future versions of nvcc. While this is faster on RTX 3090, it really shouldn't be.
++template <uint32_t w>
++__device__ __forceinline__
++uint32_t mul_const_u32(uint32_t x)
++{
++    #if defined(__CUDA_ARCH__) && (__CUDA_ARCH__ == 860)
++        uint32_t r;
++        asm volatile (
++            "{ .reg .u32 z,t;"
++            "  mov.u32 t, %laneid;"   // runtime SR
++            "  sub.u32 z, t, t;"      // z = 0 but data-dependent
++            "  mad.lo.u32 %0, %1, %2, z;"
++            "}"
++            : "=r"(r)
++            : "r"(x), "n"(w));
++        return r;
++    #else
++        return x * w;
++    #endif
++}
++
++template <int cb>
++__device__ inline half decode_3inst(uint32_t x)
++{
++    if constexpr (cb == 0)
++    {
++        x *= 89226354u;
++        x += 64248484u;
++        asm ("lop3.b32 %0, %0, 0x8fff8fff, 0x3b603b60, 0x6a;" : "+r"(x));
++        half2_uint32 xu(x);
++        return __hadd(__low2half(xu.as_half2), __high2half(xu.as_half2));
++    }
++    if constexpr (cb == 1)
++    {
++//        x *= 0xCBAC1FEDu;
++        x = mul_const_u32<0xCBAC1FEDu>(x);
++
++        asm ("lop3.b32 %0, %0, 0x8fff8fff, 0x3b603b60, 0x6a;" : "+r"(x));
++        half2_uint32 xu(x);
++        return __hadd(__low2half(xu.as_half2), __high2half(xu.as_half2));
++    }
++    if constexpr (cb == 2)
++    {
++        x *= 0x83DCD12Du;
++        uint32_t sum;
++        const uint32_t acc = 0x6400u;  // 0x6400 -> 1024.0 ..  0x67FF -> 2047.0
++        asm ("vabsdiff4.u32.u32.u32.add %0, %1, %2, %3;" : "=r"(sum) : "r"(x), "r"(0), "r"(acc) : );
++        const __half k_inv_h = __ushort_as_half(0x1eee);  //  0.00677 = 1/147.7
++        const __half k_bias_h = __ushort_as_half(0xc931);  // -10.39 = (-1024.0 - 510.0) * k_inv_h
++        half_uint16 h((uint16_t) sum);
++        return __hfma(h.as_half, k_inv_h, k_bias_h);
++    }
++}
++
++template <int cb>
++__device__ inline half2 decode_3inst_2(uint32_t x0, uint32_t x1)
++{
++    if constexpr (cb == 0)
++    {
++        x0 *= 89226354u;
++        x1 *= 89226354u;
++        x0 += 64248484u;
++        x1 += 64248484u;
++        asm ("lop3.b32 %0, %0, 0x8fff8fff, 0x3b603b60, 0x6a;" : "+r"(x0));
++        asm ("lop3.b32 %0, %0, 0x8fff8fff, 0x3b603b60, 0x6a;" : "+r"(x1));
++        half2_uint32 xu0(x0);
++        half2_uint32 xu1(x1);
++        half2 d0 = __lows2half2(xu0.as_half2, xu1.as_half2);
++        half2 d1 = __highs2half2(xu0.as_half2, xu1.as_half2);
++        return __hadd2(d0, d1);
++    }
++    if constexpr (cb == 1)
++    {
++//        x0 *= 0xCBAC1FEDu;
++//        x1 *= 0xCBAC1FEDu;
++        x0 = mul_const_u32<0xCBAC1FEDu>(x0);
++        x1 = mul_const_u32<0xCBAC1FEDu>(x1);
++        asm ("lop3.b32 %0, %0, 0x8fff8fff, 0x3b603b60, 0x6a;" : "+r"(x0));
++        asm ("lop3.b32 %0, %0, 0x8fff8fff, 0x3b603b60, 0x6a;" : "+r"(x1));
++        half2_uint32 xu0(x0);
++        half2_uint32 xu1(x1);
++        half2 d0 = __lows2half2(xu0.as_half2, xu1.as_half2);
++        half2 d1 = __highs2half2(xu0.as_half2, xu1.as_half2);
++        return __hadd2(d0, d1);
++    }
++    if constexpr (cb == 2)
++    {
++        x0 *= 0x83DCD12Du;
++        x1 *= 0x83DCD12Du;
++        uint32_t sum0;
++        uint32_t sum1;
++        const uint32_t acc = 0x6400u;  // 0x6400 -> 1024.0 ..  0x67FF -> 2047.0
++        asm ("vabsdiff4.u32.u32.u32.add %0, %1, %2, %3;" : "=r"(sum0) : "r"(x0), "r"(0), "r"(acc) : );
++        asm ("vabsdiff4.u32.u32.u32.add %0, %1, %2, %3;" : "=r"(sum1) : "r"(x1), "r"(0), "r"(acc) : );
++        half2 k_inv_h2 = __half2half2(__ushort_as_half(0x1eee));  //  0.00677 = 1/147.7
++        half2 k_bias_h2 = __half2half2(__ushort_as_half(0xc931));  // -10.39 = (-1024.0 - 510.0) * k_inv_h
++        half_uint16 h0((uint16_t) sum0);
++        half_uint16 h1((uint16_t) sum1);
++        return __hfma2(__halves2half2(h0.as_half, h1.as_half), k_inv_h2, k_bias_h2);
++    }
++}
++
++__device__ inline half2 decode_mcg_product_2(uint32_t x0, uint32_t x1)
++{
++    asm ("lop3.b32 %0, %0, 0x8fff8fff, 0x3b603b60, 0x6a;" : "+r"(x0));
++    asm ("lop3.b32 %0, %0, 0x8fff8fff, 0x3b603b60, 0x6a;" : "+r"(x1));
++    half2_uint32 xu0(x0);
++    half2_uint32 xu1(x1);
++    half2 d0 = __lows2half2(xu0.as_half2, xu1.as_half2);
++    half2 d1 = __highs2half2(xu0.as_half2, xu1.as_half2);
++    return __hadd2(d0, d1);
++}
++
++template <int cb>
++__device__ inline float decode_3inst_f(uint64_t x)
++{
++    return __half2float(decode_3inst<cb>(x));
++}
++
++template <int cb>
++__device__ inline float decode_3inst_f_diff(uint64_t x, float d)
++{
++    return __half2float(decode_3inst<cb>(x)) - d;
++}
++
++// "2MAD" procedural codebook, much more overhead than 3INST, slightly better distribution at 2bpw
++// Not used currently
++
++//__device__ inline half decode_2mad(uint64_t x)
++//{
++//    x = x * 264435761u + 1013904223u;
++//    x = ((x * 1664525u) >> 32) + x;
++//    int32_t c = (int32_t) __dp4a((uint32_t) x, 0x01010101u, 0xFFFFFE02u);
++//    half y = __hmul(__int2half_rn(c), __float2half_rn(0.008415));
++//    return y;
++//}
++//
++//__device__ inline float decode_2mad_f(uint64_t x)
++//{
++//    x = x * 264435761u + 1013904223u;
++//    x = ((x * 1664525u) >> 32) + x;
++//    int32_t c = (int32_t) __dp4a((uint32_t) x, 0x01010101u, 0xFFFFFE02u);
++//    float y = __int2float_rn(c) * 0.008415f;
++//    return y;
++//}
++//
++//__device__ inline float decode_2mad_f_diff(uint64_t x, float d)
++//{
++//    x = x * 264435761u + 1013904223u;
++//    x = ((x * 1664525u) >> 32) + x;
++//    int32_t c = (int32_t) __dp4a((uint32_t) x, 0x01010101u, 0xFFFFFE02u);
++//    float y = fma(__int2float_rn(c), 0.008415f, -d);
++//    return y;
++//}
++// Vendored from https://github.com/brandonmmusic-max/exllamav3 at 704aefd743b390af4bd0fb429d1906f9b964c7d8.
++// License: sparkinfer/gemm/trellis_linear/csrc/vendor/LICENSE.exllamav3
+diff --git a/sparkinfer/gemm/trellis_linear/csrc/vendor/quant/exl3_devctx.cuh b/sparkinfer/gemm/trellis_linear/csrc/vendor/quant/exl3_devctx.cuh
+new file mode 100644
+index 0000000000000000000000000000000000000000..f354b0cd8b013765bc4d4a0012b4b00ea590d062
+--- /dev/null
++++ b/sparkinfer/gemm/trellis_linear/csrc/vendor/quant/exl3_devctx.cuh
+@@ -0,0 +1,57 @@
++#pragma once
++
++#include <tuple>
++#include <mutex>
++
++// Max allowable output size, in tiles. Used to allocate global lock buffer per device for sync across threadblocks
++#define MAX_TILES_C (1024 * 1024)
++#define MAX_BARRIERS 1024
++#define BARRIER_LOCKS_OFFSET MAX_TILES_C
++
++// MoE expert scheduler state, after the barrier counters: [0] next ticket,
++// [1] retired groups, [2 + group] ticket published to group. The state is
++// self-resetting and is zero-initialized with the rest of the lock buffer.
++#define MOE_MAX_GROUPS 64
++#define MOE_SCHED_OFFSET (MAX_TILES_C + 2 * MAX_BARRIERS)
++#define MOE_SCHED_INTS (2 + MOE_MAX_GROUPS)
++
++// Workspace size
++#define WORKSPACE_SIZE (16*1024*1024)
++
++// Treat hopper and blackwell as same arch for now
++#define MAX_DEVICES 16
++#define CC_OLD        1
++#define CC_AMPERE     2
++#define CC_ADA        3
++#define CC_HOPPER     4
++#define CC_BLACKWELL  4
++
++// Singleton to manage context for each device. Stores device attributes and a large-enough lock buffer per device
++class DevCtx
++{
++private:
++    int num_sms[MAX_DEVICES] = {};
++    int cc[MAX_DEVICES] = {};
++    void* locks[MAX_DEVICES] = {};
++    void* ws[MAX_DEVICES] = {};
++    std::mutex mtx;
++
++public:
++    static DevCtx& instance();
++    int get_num_sms(int device);
++    int get_cc(int device);
++    void* get_ws(int device);
++    int* get_locks(int device);
++
++private:
++    DevCtx() = default;
++    DevCtx(const DevCtx&) = delete;
++    DevCtx& operator=(const DevCtx&) = delete;
++};
++
++int g_get_cc(int device);
++int g_get_num_sms(int device);
++
++void prepare_ctx(int device);
++// Vendored from https://github.com/brandonmmusic-max/exllamav3 at 704aefd743b390af4bd0fb429d1906f9b964c7d8.
++// License: sparkinfer/gemm/trellis_linear/csrc/vendor/LICENSE.exllamav3
+diff --git a/sparkinfer/gemm/trellis_linear/csrc/vendor/quant/exl3_dq.cuh b/sparkinfer/gemm/trellis_linear/csrc/vendor/quant/exl3_dq.cuh
+new file mode 100644
+index 0000000000000000000000000000000000000000..3b97cb3d4d3f95a7420303f492abcaedfc20d086
+--- /dev/null
++++ b/sparkinfer/gemm/trellis_linear/csrc/vendor/quant/exl3_dq.cuh
+@@ -0,0 +1,296 @@
++#pragma once
++
++#include "codebook.cuh"
++
++__device__ __forceinline__ uint32_t fshift(const uint32_t b, const uint32_t a, int shift)
++{
++     uint64_t merged = ((uint64_t)a << 32) | (uint64_t) b;
++     return (uint32_t)(merged >> shift);
++
++    // Conditional funnel shift is somehow no longer faster
++    // if (shift < 32) return __funnelshift_r(b, a, shift);
++    // return a >> (shift - 32);
++}
++
++template <int bits, int cb>
++__device__ __forceinline__ half dq(const uint32_t* ptr, int t_offset)
++{
++    int b0 = t_offset * bits + bits - 16 + 256 * bits;  // bit index, start of word0
++    int b1 = b0 + 16;                                   // bit index, end of word0
++    int i0 = b0 / 32;                                   // uint32 containing first bit of word0
++    int i1 = (b1 - 1) / 32;                             // uint32 containing last bit of word0, may be == i0
++    int s0 = (i1 + 1) * 32 - b1;                        // shift value to align word1 to 32-bit boundary
++
++    // Load 32 or 64 bits containing word0
++    uint32_t a = ptr[i0 % (bits * 256 / 32)];
++    uint32_t b = ptr[i1 % (bits * 256 / 32)];
++
++    // Shift into place
++    uint32_t w0 = __funnelshift_r(b, a, s0) & 0xffff;
++    return decode_3inst<cb>(w0);
++}
++
++template <int bits, int cb>
++__device__ __forceinline__ half2 dq2(const uint32_t* ptr, int t_offset)
++{
++    int b0 = t_offset * bits + bits - 16 + 256 * bits;  // bit index, start of word0
++    int b1 = b0 + 16;                                   // bit index, end of word0
++    int i0 = b0 / 32;                                   // uint32 containing first bit of word0
++    int i1 = (b1 - 1) / 32;                             // uint32 containing last bit of word0, may be == i0
++    int s0 = (i1 + 1) * 32 - b1;                        // shift value to align word1 to 32-bit boundary
++
++    // Load 32 or 64 bits containing word0
++    uint32_t a = ptr[i0 % (bits * 256 / 32)];
++    uint32_t b = ptr[i1 % (bits * 256 / 32)];
++
++    // Shift into place
++    uint32_t w1 = __funnelshift_r(b, a, s0)        & 0xffff;
++    uint32_t w0 = __funnelshift_r(b, a, s0 + bits) & 0xffff;
++    return decode_3inst_2<cb>(w0, w1);
++}
++
++template <int bits, int cb>
++__device__ __forceinline__ void dq4(const uint32_t* ptr, int t_offset, FragB& frag)
++{
++    int b0 = (t_offset + 257) * bits - 16;      // start of first word
++    int b1 = b0 + 3 * bits;                     // start of last word
++    int b2 = b1 + 16;                           // end of last word
++    int i0 = b0 / 32;                           // uint32 containing first bit of first word
++    int i2 = (b2 - 1) / 32;                     // uint32 containing last bit of last word, may be == i0
++    int s2 = (i2 + 1) * 32 - b2;                // shift value to align last word to 32-bit boundary
++
++    uint32_t a = ptr[i0 % (bits * 256 / 32)];
++    uint32_t b = ptr[i2 % (bits * 256 / 32)];
++    uint32_t w3 = fshift(b, a, s2)            & 0xffff;
++    uint32_t w2 = fshift(b, a, s2 + bits)     & 0xffff;
++    uint32_t w1 = fshift(b, a, s2 + bits * 2) & 0xffff;
++    uint32_t w0 = fshift(b, a, s2 + bits * 3) & 0xffff;
++    half2 d0d1 = decode_3inst_2<cb>(w0, w1);
++    half2 d2d3 = decode_3inst_2<cb>(w2, w3);
++    frag[0] = d0d1;
++    frag[1] = d2d3;
++}
++
++template <int bits, int cb>
++__device__ __forceinline__ void dq2x2(const uint32_t* ptr, int t_offset, FragB& frag)
++{
++    #pragma unroll
++    for (int i = 0; i < 2; ++i)
++    {
++        int b0 = (t_offset + 2 * i + 257) * bits - 16;  // start of first word
++        int b1 = b0 + 1 * bits;                         // start of last word
++        int b2 = b1 + 16;                               // end of last word
++        int i0 = b0 / 32;                               // uint32 containing first bit of first word
++        int i2 = (b2 - 1) / 32;                         // uint32 containing last bit of last word, may be == i0
++        int s2 = (i2 + 1) * 32 - b2;                    // shift value to align last word to 32-bit boundary
++
++        uint32_t a = ptr[i0 % (bits * 256 / 32)];
++        uint32_t b = ptr[i2 % (bits * 256 / 32)];
++        uint32_t w1 = fshift(b, a, s2)        & 0xffff;
++        uint32_t w0 = fshift(b, a, s2 + bits) & 0xffff;
++        half2 d0d1 = decode_3inst_2<cb>(w0, w1);
++        frag[i] = d0d1;
++    }
++}
++
++template <int bits, int cb, int align>
++__device__ __forceinline__ void dq8(const uint32_t* ptr, int t_offset, FragB& frag0, FragB& frag1)
++{
++    int b1 = (t_offset + 257) * bits;               // end of first word
++    int b0 = b1 - 16;                               // start of first word
++    int b2 = b1 + bits * 7;
++    int i0 = b0 / 32;                               // uint32 containing first bit of word0
++    int i2 = (b2 - 1) / 32;                         // uint32 containing last bit of word0, may be == i0
++    int s2 = (i2 + 1) * 32 - b2;                    // shift value to align last word to 32-bit boundary
++
++    uint32_t a = ptr[i0 % (bits * 256 / 32)];
++    uint32_t b = ptr[i2 % (bits * 256 / 32)];
++    uint32_t w0, w1, w2, w3, w4, w5, w6, w7;
++    if constexpr (align == 1)
++    {
++        w7 = fshift(b, a, s2);
++        w6 = fshift(b, a, s2 + bits);
++        w5 = fshift(b, a, s2 + bits * 2);
++        w4 = fshift(b, a, s2 + bits * 3);
++        w3 = fshift(b, a, s2 + bits * 4);
++        w2 = fshift(b, a, s2 + bits * 5);
++        w1 = fshift(b, a, s2 + bits * 6);
++        w0 = fshift(b, a, s2 + bits * 7);
++    }
++    if constexpr (align == 2)
++    {
++        w7 = fshift(b, a, s2);
++        w6 = w7 >> bits;
++        w5 = fshift(b, a, s2 + bits * 2);
++        w4 = w5 >> bits;
++        w3 = fshift(b, a, s2 + bits * 4);
++        w2 = w3 >> bits;
++        w1 = fshift(b, a, s2 + bits * 6);
++        w0 = w1 >> bits;
++    }
++    if constexpr (align == 4)
++    {
++        w7 = fshift(b, a, s2);
++        w6 = w7 >> bits;
++        w5 = w6 >> bits;
++        w4 = w5 >> bits;
++        w3 = fshift(b, a, s2 + bits * 4);
++        w2 = w3 >> bits;
++        w1 = w2 >> bits;
++        w0 = w1 >> bits;
++    }
++    if constexpr (align == 8)
++    {
++        w7 = fshift(b, a, s2);
++        w6 = w7 >> bits;
++        w5 = w6 >> bits;
++        w4 = w5 >> bits;
++        w3 = w4 >> bits;
++        w2 = w3 >> bits;
++        w1 = w2 >> bits;
++        w0 = w1 >> bits;
++    }
++    half2 d0d1 = decode_3inst_2<cb>(w0 & 0xffff, w1 & 0xffff);
++    half2 d2d3 = decode_3inst_2<cb>(w2 & 0xffff, w3 & 0xffff);
++    half2 d4d5 = decode_3inst_2<cb>(w4 & 0xffff, w5 & 0xffff);
++    half2 d6d7 = decode_3inst_2<cb>(w6 & 0xffff, w7 & 0xffff);
++    frag0[0] = d0d1;
++    frag0[1] = d2d3;
++    frag1[0] = d4d5;
++    frag1[1] = d6d7;
++}
++
++template <int cb>
++__device__ __forceinline__ void dq8_aligned_4bits(const uint32_t* ptr, int t_offset, FragB& frag0, FragB& frag1)
++{
++    uint32_t i0, i1, a, b, s, w0, w1, w2, w3, w4, w5, w6, w7;
++    i1 = t_offset >> 3;
++    i0 = (i1 + 31) & 31;
++    a = ptr[i0];
++    b = ptr[i1];
++    FSHF_IMM(s, b, a, 20);
++    w7 = b & 0xffff;
++    BFE16_IMM(w6, b, 4);
++    BFE16_IMM(w5, b, 8);
++    BFE16_IMM(w4, b, 12);
++    BFE16_IMM(w3, b, 16);
++    w2 = s & 0xffff;
++    BFE16_IMM(w1, s, 4);
++    BFE16_IMM(w0, s, 8);
++    frag0[0] = decode_3inst_2<cb>(w0, w1);
++    frag0[1] = decode_3inst_2<cb>(w2, w3);
++    frag1[0] = decode_3inst_2<cb>(w4, w5);
++    frag1[1] = decode_3inst_2<cb>(w6, w7);
++}
++
++template <int cb>
++__device__ __forceinline__ void dq8_aligned_2bits(const uint32_t* ptr, int t_offset, FragB& frag0, FragB& frag1)
++{
++    uint32_t i0, i1, a, b, w0, w1, w2, w3, w4, w5, w6, w7;
++    i1 = t_offset >> 4;
++    i0 = (i1 + 15) & 15;
++    a = ptr[i0];
++    b = ptr[i1];
++    b = fshift(b, a, ((~t_offset) & 8) << 1);
++    w7 = b & 0xffff;
++    BFE16_IMM(w6, b, 2);
++    BFE16_IMM(w5, b, 4);
++    BFE16_IMM(w4, b, 6);
++    BFE16_IMM(w3, b, 8);
++    BFE16_IMM(w2, b, 10);
++    BFE16_IMM(w1, b, 12);
++    BFE16_IMM(w0, b, 14);
++    frag0[0] = decode_3inst_2<cb>(w0, w1);
++    frag0[1] = decode_3inst_2<cb>(w2, w3);
++    frag1[0] = decode_3inst_2<cb>(w4, w5);
++    frag1[1] = decode_3inst_2<cb>(w6, w7);
++}
++
++template <int cb>
++__device__ __forceinline__ void dq8_aligned_1bit(const uint32_t* ptr, int t_offset, FragB& frag0, FragB& frag1)
++{
++    uint32_t i0, i1, a, b, w0, w1, w2, w3, w4, w5, w6, w7;
++    i1 = t_offset >> 5;
++    i0 = (i1 + 7) & 7;
++    a = ptr[i0];
++    b = ptr[i1];
++    b = fshift(b, a, ((~t_offset) & 24));
++    w7 = b & 0xffff;
++    BFE16_IMM(w6, b, 1);
++    BFE16_IMM(w5, b, 2);
++    BFE16_IMM(w4, b, 3);
++    BFE16_IMM(w3, b, 4);
++    BFE16_IMM(w2, b, 5);
++    BFE16_IMM(w1, b, 6);
++    BFE16_IMM(w0, b, 7);
++    frag0[0] = decode_3inst_2<cb>(w0, w1);
++    frag0[1] = decode_3inst_2<cb>(w2, w3);
++    frag1[0] = decode_3inst_2<cb>(w4, w5);
++    frag1[1] = decode_3inst_2<cb>(w6, w7);
++}
++
++
++template <int cb>
++__device__ __forceinline__ void dq8_aligned_4bits_bfe64(const uint32_t* ptr, int t_offset, FragB& frag0, FragB& frag1)
++{
++    int i1 = t_offset / 8;
++    int i0 = (i1 + 31) % 32;
++    uint32_t a = ptr[i0];
++    uint32_t b = ptr[i1];
++    uint32_t w7 = bfe64(b, a, 0, 16);
++    uint32_t w6 = bfe64(b, a, 4, 16);
++    uint32_t w5 = bfe64(b, a, 8, 16);
++    uint32_t w4 = bfe64(b, a, 12, 16);
++    uint32_t w3 = bfe64(b, a, 16, 16);
++    uint32_t w2 = bfe64(b, a, 20, 16);
++    uint32_t w1 = bfe64(b, a, 24, 16);
++    uint32_t w0 = bfe64(b, a, 28, 16);
++    frag0[0] = decode_3inst_2<cb>(w0, w1);
++    frag0[1] = decode_3inst_2<cb>(w2, w3);
++    frag1[0] = decode_3inst_2<cb>(w4, w5);
++    frag1[1] = decode_3inst_2<cb>(w6, w7);
++}
++
++template <int bits, int cb>
++__device__ __forceinline__ void dq_dispatch(const uint32_t* ptr, int idx, FragB& frag0, FragB& frag1)
++{
++    static_assert(bits >= 1 && bits <= 8, "unsupported EXL3 bitrate");
++    if constexpr (bits == 1)
++    {
++        dq8_aligned_1bit<cb>(ptr, idx, frag0, frag1);
++    }
++    else if constexpr (bits == 2)
++    {
++        dq8_aligned_2bits<cb>(ptr, idx, frag0, frag1);
++    }
++    else if constexpr (bits == 3)
++    {
++        dq8<bits, cb, 4>(ptr, idx, frag0, frag1);
++    }
++    else if constexpr (bits == 4)
++    {
++        dq8_aligned_4bits<cb>(ptr, idx, frag0, frag1);
++    }
++    else if constexpr (bits == 5)
++    {
++        dq4<bits, cb>(ptr, idx, frag0);
++        dq4<bits, cb>(ptr, idx + 4, frag1);
++    }
++    else if constexpr (bits == 6)
++    {
++        dq4<bits, cb>(ptr, idx, frag0);
++        dq4<bits, cb>(ptr, idx + 4, frag1);
++    }
++    else if constexpr (bits == 7)
++    {
++        dq2x2<bits, cb>(ptr, idx, frag0);
++        dq2x2<bits, cb>(ptr, idx + 4, frag1);
++    }
++    else if constexpr (bits == 8)
++    {
++        dq4<bits, cb>(ptr, idx, frag0);
++        dq4<bits, cb>(ptr, idx + 4, frag1);
++    }
++}
++// Vendored from https://github.com/brandonmmusic-max/exllamav3 at 704aefd743b390af4bd0fb429d1906f9b964c7d8.
++// License: sparkinfer/gemm/trellis_linear/csrc/vendor/LICENSE.exllamav3
+diff --git a/sparkinfer/gemm/trellis_linear/csrc/vendor/quant/exl3_gemm_inner.cuh b/sparkinfer/gemm/trellis_linear/csrc/vendor/quant/exl3_gemm_inner.cuh
+new file mode 100644
+index 0000000000000000000000000000000000000000..819464406affdbc045b8da96f910c2de9d37abe2
+--- /dev/null
++++ b/sparkinfer/gemm/trellis_linear/csrc/vendor/quant/exl3_gemm_inner.cuh
+@@ -0,0 +1,782 @@
++#pragma once
++
++#include "../ptx.cuh"
++
++// Constants
++#define EXL3_GEMM_BASE_THREADS 256
++#ifndef EXL3_SMEM_MAX_BYTES
++#define EXL3_SMEM_MAX_BYTES (90 * 1024)
++#endif
++#ifndef SMEM_MAX
++#define SMEM_MAX EXL3_SMEM_MAX_BYTES
++#endif
++
++#include "exl3_dq.cuh"
++
++// On GA10x and sm_120 consumer silicon, fp32-accumulating HMMA runs at
++// half rate. Accumulate each k-slice in fp16 and fold it into the persistent
++// fp32 accumulators before reduction. This changes numerical accumulation and
++// therefore remains an accuracy-gated optional variant.
++#ifndef EXL3_GEMM_H_ACC
++    #if defined(__CUDA_ARCH__) && \
++        ((__CUDA_ARCH__ == 860) || (__CUDA_ARCH__ == 1200))
++        #define EXL3_GEMM_H_ACC 1
++    #else
++        #define EXL3_GEMM_H_ACC 0
++    #endif
++#endif
++
++template<EXL3_GEMM_T_ARGS, bool shmem_out_had>
++inline __device__
++void exl3_gemm_kernel_inner
++(
++    const half* __restrict__  A,
++    const uint16_t* __restrict__ B,
++    void* __restrict__ C,
++    const int size_m,
++    const int size_k,
++    const int size_n,
++    int* __restrict__ locks,
++    const half* post_scale
++)
++{
++    const int TILEBLOCKS_M = TILESIZE_M / 16;
++    const int TILEBLOCKS_K = TILESIZE_K / 16;
++    const int TILEBLOCKS_N = TILESIZE_N / 16;
++    // const int FRAGS_M = TILEBLOCKS_M;
++    const int FRAGS_N_PER_WARP = 2 * TILEBLOCKS_N / (EXL3_GEMM_BASE_THREADS / 32);
++
++    const int sh_a_stage_size = TILESIZE_M * TILESIZE_K;                         // in halfs
++    const int sh_b_stage_size = TILEBLOCKS_K * TILEBLOCKS_N * 256 / 16 * bits;   // in uint16s
++    const int sh_c_size = MAX  // in floats
++    (
++        4 * EXL3_GEMM_BASE_THREADS * FRAGS_N_PER_WARP,
++        shmem_out_had ? TILESIZE_N * TILESIZE_M : 0
++    );
++
++    // XOR-swizzle constants for bank-conflict-free A fragment loads
++    // col_swizzled = col ^ ((row >> SHIFT) & MASK)
++    const int A_COLS = TILESIZE_K / 8;                                            // int4 columns per row
++    const int A_SWIZZLE_MASK = A_COLS - 1;
++    const int A_SWIZZLE_SHIFT = (A_COLS <= 2) ? 2 : 1;
++
++    // Sanity checks
++    static_assert(EXL3_GEMM_BASE_THREADS == 256);
++    static_assert(TILESIZE_M % 16 == 0, "Invalid kernel params");
++    static_assert(TILESIZE_K % 16 == 0, "Invalid kernel params");
++    static_assert(TILESIZE_N % 128 == 0, "Invalid kernel params");
++    static_assert
++    (
++        SMEM_MAX >= SH_STAGES * (2 * sh_a_stage_size + 2 * sh_b_stage_size) + 4 * sh_c_size,
++        "Invalid kernel params (insufficient shared memory for shape)"
++    );
++
++    // Shared memory
++    extern __shared__ half shared[];
++    half* sh_a = shared;
++    uint16_t* sh_b = (uint16_t*) (sh_a + SH_STAGES * sh_a_stage_size);
++    float* sh_c = (float*) (sh_b + sh_b_stage_size * SH_STAGES);
++
++    // Thread index
++    int t = threadIdx.x % EXL3_GEMM_BASE_THREADS;
++    int sub_k = threadIdx.x / EXL3_GEMM_BASE_THREADS;
++    int warp_id = t / 32;
++    int lane_id = t % 32;
++
++    // Dimensions
++    //int tiles_m = CEIL_DIVIDE(size_m, TILESIZE_M);
++    int tiles_k = size_k / TILESIZE_K;
++    int tiles_n = size_n / TILESIZE_N;
++    //int blocks_m = 1;
++    //int blocks_k = tiles_k * TILEBLOCKS_K;
++    int blocks_n = tiles_n * TILEBLOCKS_N;
++
++    // Start and end index of current slice, must span at least one tile
++    int num_slices = gridDim.x;
++    int slice_beg = tiles_k * tiles_n * blockIdx.x / num_slices;
++    int slice_end = tiles_k * tiles_n * (blockIdx.x + 1) / num_slices;
++    int slice_len = slice_end - slice_beg;
++    if (slice_len < 1) return;
++
++    auto index_m = [&] (int slice_i) { return 0; }; //blockIdx.y; };
++    auto index_k = [&] (int slice_i) { return (slice_i % tiles_k); };
++    auto index_n = [&] (int slice_i) { return (slice_i / tiles_k); };
++
++    // Batch dimension
++    // int slice_m = index_m(slice_beg);
++    // int max_m = MIN(size_m - slice_m * TILESIZE_M, TILESIZE_M);
++    const int slice_m = 0;
++
++    // Pipe 0, global A, B tile and shared A, B tile
++    int slice0_k = index_k(slice_beg);
++    int slice0_n = index_n(slice_beg);
++    int slice0_iters = slice_len;
++
++    int gl_a_stride_m = TILESIZE_M * size_k;
++    const int gl_a_stride_k = TILESIZE_K;
++    const int sh0_a_stride_m = TILESIZE_M * TILESIZE_K;
++    const half* gl_a_ptr = A + slice_m * gl_a_stride_m + slice0_k * gl_a_stride_k;
++    half* sh0_a_ptr = sh_a + (slice0_iters % SH_STAGES) * sh_a_stage_size;
++
++    const int load_a_iters = CEIL_DIVIDE(sh0_a_stride_m / 8, EXL3_GEMM_BASE_THREADS);
++    bool pred_a_gl[load_a_iters];
++    int load_a_gl[load_a_iters];
++    int load_a_sh[load_a_iters];
++    for (int i = 0; i < load_a_iters; ++i)
++    {
++        int k = (i * EXL3_GEMM_BASE_THREADS + t) % (gl_a_stride_k / 8);
++        int m = (i * EXL3_GEMM_BASE_THREADS + t) / (gl_a_stride_k / 8);
++        load_a_gl[i] = m * size_k / 8 + k;
++        load_a_sh[i] = m * A_COLS + (k ^ ((m >> A_SWIZZLE_SHIFT) & A_SWIZZLE_MASK));
++        pred_a_gl[i] = m < size_m;
++    }
++
++    int gl_b_stride_k = blocks_n * TILEBLOCKS_K * 256 / 16 * bits;
++    const int gl_b_stride_n = TILEBLOCKS_N * 256 / 16 * bits;
++    const int sh0_b_stride_k = TILEBLOCKS_K * TILEBLOCKS_N * 256 / 16 * bits;
++    const uint16_t* gl_b_ptr = B + slice0_k * gl_b_stride_k + slice0_n * gl_b_stride_n;
++    uint16_t* sh0_b_ptr = sh_b + (slice0_iters % SH_STAGES) * sh_b_stage_size;
++
++    const int load_b_iters = CEIL_DIVIDE(sh0_b_stride_k / 8, EXL3_GEMM_BASE_THREADS);
++    bool pred_b_gl[load_b_iters];
++    int load_b_gl[load_b_iters];
++    for (int i = 0; i < load_b_iters; ++i)
++    {
++        int n = (i * EXL3_GEMM_BASE_THREADS + t) % (gl_b_stride_n / 8);
++        int k = (i * EXL3_GEMM_BASE_THREADS + t) / (gl_b_stride_n / 8);
++        load_b_gl[i] = k * (blocks_n * 256 / 16 * bits / 8) + n;
++        pred_b_gl[i] = i * EXL3_GEMM_BASE_THREADS + t < sh0_b_stride_k / 8;
++    }
++
++    auto advance0 = [&] ()
++    {
++        slice0_k++;
++        slice0_iters--;
++
++        int stage = slice0_iters % SH_STAGES;
++        sh0_a_ptr = sh_a + stage * sh_a_stage_size;
++        sh0_b_ptr = sh_b + stage * sh_b_stage_size;
++
++        if (slice0_k >= tiles_k)
++        {
++            slice0_k = 0;
++            slice0_n++;
++            gl_a_ptr = A + slice_m * gl_a_stride_m + slice0_k * gl_a_stride_k;
++            gl_b_ptr = B + slice0_k * gl_b_stride_k + slice0_n * gl_b_stride_n;
++        }
++        else
++        {
++            gl_a_ptr += gl_a_stride_k;
++            gl_b_ptr += gl_b_stride_k;
++        }
++    };
++
++    // Pipe 1, shared A, B tile and registers
++    int slice1_k = slice0_k;
++    int slice1_n = slice0_n;
++    int slice1_iters = slice0_iters;
++
++    half* sh1_a_ptr = sh_a + (slice1_iters % SH_STAGES) * sh_a_stage_size;
++    uint16_t* sh1_b_ptr = sh_b + (slice1_iters % SH_STAGES) * sh_b_stage_size;
++
++    auto advance1 = [&] ()
++    {
++        slice1_k++;
++        slice1_iters--;
++
++        int stage = slice1_iters % SH_STAGES;
++        sh1_a_ptr = sh_a + stage * sh_a_stage_size;
++        sh1_b_ptr = sh_b + stage * sh_b_stage_size;
++
++        if (slice1_k >= tiles_k)
++        {
++            slice1_k = 0;
++            slice1_n++;
++        }
++    };
++
++    // Pipe 2
++    int slice2_k = slice0_k;
++    int slice2_k0 = slice0_k;
++    int slice2_n = slice0_n;
++    int slice2_iters = slice0_iters;
++
++    int gl_c_stride_n = TILESIZE_N;
++    int gl_c_stride_m = TILESIZE_M * size_n;
++
++    half* gl_c_ptr_16 = ((half*) C) + slice_m * gl_c_stride_m + slice2_n * gl_c_stride_n;
++    float* gl_c_ptr_32 = ((float*) C) + slice_m * gl_c_stride_m + slice2_n * gl_c_stride_n;
++
++    FragA frag_a[FRAG_STAGES][TILEBLOCKS_M];
++    FragB frag_b[FRAG_STAGES][FRAGS_N_PER_WARP];
++    FragC frag_c[TILEBLOCKS_M][FRAGS_N_PER_WARP];
++    #if EXL3_GEMM_H_ACC
++        FragC_h frag_c_h[TILEBLOCKS_M][FRAGS_N_PER_WARP];
++    #endif
++
++    auto advance2 = [&] ()
++    {
++        slice2_k++;
++        slice2_iters--;
++
++        if (slice2_k >= tiles_k)
++        {
++            slice2_k = 0;
++            slice2_k0 = 0;
++            slice2_n++;
++            if constexpr (c_fp32)
++                gl_c_ptr_32 += gl_c_stride_n;
++            else
++                gl_c_ptr_16 += gl_c_stride_n;
++        }
++    };
++
++    // Schedule load of the next A, B tiles to shared memory and advance the pipeline
++    auto async_load_gl = [&] ()
++    {
++        if (sub_k)
++        {
++            cp_async_fence();
++            return;
++        }
++
++        if (slice0_iters)
++        {
++            // Copy tile from row-major A matrix (XOR-swizzled for bank-conflict-free ldmatrix)
++            {
++                const int4* gl = (const int4*) gl_a_ptr;
++                int4* sh = (int4*) sh0_a_ptr;
++                #pragma unroll
++                for (int i = 0; i < load_a_iters; ++i)
++                {
++                    if (pred_a_gl[i]) cp_async(sh + load_a_sh[i], gl + load_a_gl[i]);
++                }
++            }
++
++            // Copy tile of 256-element blocks from quantized B matrix
++            {
++                const int4* gl = (const int4*) gl_b_ptr;
++                int4* sh = (int4*) sh0_b_ptr;
++                #pragma unroll
++                for (int i = 0; i < load_b_iters; ++i)
++                {
++                    // cp_async_pred(sh + EXL3_GEMM_BASE_THREADS * i + t, gl + load_b_gl[i], pred_b_gl[i]);
++                    if (pred_b_gl[i]) cp_async(sh + EXL3_GEMM_BASE_THREADS * i + t, gl + load_b_gl[i]);
++                }
++            }
++            advance0();
++        }
++
++        // Sync and advance
++        cp_async_fence();
++    };
++
++    // Load fragments
++    // Ref. for fragment layout:
++    // https://docs.nvidia.com/cuda/parallel-thread-execution/index.html#matrix-fragments-for-mma-m16n8k16-with-floating-point-type
++    auto load_frags = [&] (int buf)
++    {
++        if (!slice1_iters) return;
++
++        // A fragments (XOR-swizzled shared memory layout)
++        {
++            int r = (lane_id % 8) + 8 * ((lane_id / 8) % 2);
++            int base_c = lane_id / 16 + sub_k * 2;
++            #pragma unroll
++            for (int m = 0; m < TILEBLOCKS_M; ++m)
++            {
++                int R = r + m * 16;
++                int c_swizzled = base_c ^ ((R >> A_SWIZZLE_SHIFT) & A_SWIZZLE_MASK);
++                ldsm4(frag_a[buf][m], (int4*) sh1_a_ptr + R * A_COLS + c_swizzled);
++            }
++        }
++
++        // B fragments
++        #pragma unroll
++        for (int n2 = 0; n2 < FRAGS_N_PER_WARP; n2 += 2)
++        {
++            int sub_n2 = warp_id * FRAGS_N_PER_WARP / 2 + n2 / 2;
++            const uint32_t* shb = (const uint32_t*) (sh1_b_ptr + (sub_k * TILEBLOCKS_N + sub_n2) * 256 / 16 * bits);
++
++            dq_dispatch<bits, cb>(shb, lane_id << 3, frag_b[buf][n2], frag_b[buf][n2 + 1]);
++        }
++
++        __syncthreads();
++        advance1();
++    };
++
++    // Clear C fragments
++    auto clear_frag_c = [&] ()
++    {
++        #pragma unroll
++        for (int m = 0; m < TILEBLOCKS_M; ++m)
++        {
++            #pragma unroll
++            for (int n = 0; n < FRAGS_N_PER_WARP; ++n)
++                frag_c[m][n] = {};
++        }
++        #if EXL3_GEMM_H_ACC
++            #pragma unroll
++            for (int m = 0; m < TILEBLOCKS_M; ++m)
++            {
++                #pragma unroll
++                for (int n = 0; n < FRAGS_N_PER_WARP; ++n)
++                    frag_c_h[m][n] = {};
++            }
++        #endif
++    };
++
++    // Threadblock reduction
++    auto threadblock_reduce = [&] ()
++    {
++        auto store = [&] (int i, int m)
++        {
++            if (sub_k == i)
++            {
++                float* sh_red = sh_c + (FRAGS_N_PER_WARP * 4) * t;
++                #pragma unroll
++                for (int n = 0; n < FRAGS_N_PER_WARP; ++n)
++                {
++                    #pragma unroll
++                    for (int j = 0; j < 4; ++j) *sh_red++ = frag_c[m][n][j];
++                }
++            }
++            __syncthreads();
++        };
++
++        auto add = [&] (int i, int m)
++        {
++            if (sub_k == i)
++            {
++                float* sh_red = sh_c + (FRAGS_N_PER_WARP * 4) * t;
++                #pragma unroll
++                for (int n = 0; n < FRAGS_N_PER_WARP; ++n)
++                {
++                    #pragma unroll
++                    for (int j = 0; j < 4; ++j) frag_c[m][n][j] += *sh_red++;
++                }
++            }
++        };
++
++        auto store_small = [&] (int i, int m)
++        {
++            if (sub_k == i && m * 16 + lane_id / 4 < size_m)
++            {
++                float* sh_red = sh_c + (FRAGS_N_PER_WARP * 4) * t;
++                #pragma unroll
++                for (int n = 0; n < FRAGS_N_PER_WARP; ++n)
++                {
++                    *sh_red++ = frag_c[m][n][0];
++                    *sh_red++ = frag_c[m][n][1];
++                }
++            }
++            __syncthreads();
++        };
++
++        auto add_small = [&] (int i, int m)
++        {
++            if (sub_k == i && m * 16 + lane_id / 4 < size_m)
++            {
++                float* sh_red = sh_c + (FRAGS_N_PER_WARP * 4) * t;
++                #pragma unroll
++                for (int n = 0; n < FRAGS_N_PER_WARP; ++n)
++                {
++                    frag_c[m][n][0] += *sh_red++;
++                    frag_c[m][n][1] += *sh_red++;
++                }
++            }
++        };
++
++        // Reuse the same reduction scratch for each 16-row M block. The
++        // barrier between blocks prevents the next store from racing the
++        // preceding add without increasing the dynamic-smem footprint.
++        #pragma unroll
++        for (int m = 0; m < TILEBLOCKS_M; ++m)
++        {
++            if (size_m <= 8)
++            {
++                if constexpr (TILEBLOCKS_K == 2)
++                {
++                    store_small(1, m);
++                    add_small(0, m);
++                }
++                if constexpr (TILEBLOCKS_K == 3)
++                {
++                    store_small(1, m);
++                    add_small(0, m);
++                    store_small(2, m);
++                    add_small(0, m);
++                }
++                if constexpr (TILEBLOCKS_K == 4)
++                {
++                    store_small(3, m);
++                    add_small(2, m);
++                    store_small(1, m);
++                    add_small(0, m);
++                    store_small(2, m);
++                    add_small(0, m);
++                }
++            }
++            else
++            {
++                if constexpr (TILEBLOCKS_K == 2)
++                {
++                    store(1, m);
++                    add(0, m);
++                }
++                if constexpr (TILEBLOCKS_K == 3)
++                {
++                    store(1, m);
++                    add(0, m);
++                    store(2, m);
++                    add(0, m);
++                }
++                if constexpr (TILEBLOCKS_K == 4)
++                {
++                    store(3, m);
++                    add(2, m);
++                    store(1, m);
++                    add(0, m);
++                    store(2, m);
++                    add(0, m);
++                }
++            }
++
++            if constexpr (TILEBLOCKS_K > 1 && TILEBLOCKS_M > 1)
++                if (m + 1 < TILEBLOCKS_M) __syncthreads();
++        }
++    };
++
++    // Pre-hadamard: Write final output tile to shmem
++    auto write_sum_tile_sh = [&]()
++    {
++        const int n0 = warp_id * FRAGS_N_PER_WARP;
++        #pragma unroll
++        for (int m = 0; m < TILEBLOCKS_M; ++m)
++        {
++            const int r0 = m * 16 + lane_id / 4;
++            const int r1 = r0 + 8;
++            if (r0 < size_m)
++            {
++                const int c = (lane_id % 4) * 2;
++                #pragma unroll
++                for (int n = 0; n < FRAGS_N_PER_WARP; ++n)
++                {
++                    float* c_ptr = sh_c + r0 * TILESIZE_N + (n0 + n) * 8 + c;
++                    *c_ptr++ = frag_c[m][n][0];
++                    *c_ptr++ = frag_c[m][n][1];
++                }
++            }
++            if (r1 < size_m)
++            {
++                const int c = (lane_id % 4) * 2;
++                #pragma unroll
++                for (int n = 0; n < FRAGS_N_PER_WARP; ++n)
++                {
++                    float* c_ptr = sh_c + r1 * TILESIZE_N + (n0 + n) * 8 + c;
++                    *c_ptr++ = frag_c[m][n][2];
++                    *c_ptr++ = frag_c[m][n][3];
++                }
++            }
++        }
++    };
++
++    // Copy output tile to global with hadamard transform and out scale
++    auto output_had_sh_gl = [&]()
++    {
++        int sh_warp = warp_id;
++        constexpr int active_warps = EXL3_GEMM_BASE_THREADS / 32;
++        for (;; sh_warp += active_warps)
++        {
++            int col = sh_warp % (TILESIZE_N / 128);
++            int row = sh_warp / (TILESIZE_N / 128);
++            if (row >= size_m) break;
++
++            const float* had_in = sh_c + row * TILESIZE_N + col * 128;
++            const half* post_scale_c = post_scale + slice2_n * gl_c_stride_n + col * 128;
++
++            if constexpr (c_fp32)
++            {
++                float* had_out = gl_c_ptr_32 + row * size_n + col * 128;
++                had_ff_r_128_inner<false, true>(had_in, had_out, post_scale_c, 0.088388347648f);
++            }
++            else
++            {
++                half* had_out = gl_c_ptr_16 + row * size_n + col * 128;
++                had_fh_r_128_inner<false, true>(had_in, had_out, post_scale_c, 0.088388347648f);
++            }
++        }
++    };
++
++    auto read_sum_gl = [&]()
++    {
++        int n0 = warp_id * FRAGS_N_PER_WARP;
++        #pragma unroll
++        for (int m = 0; m < TILEBLOCKS_M; ++m)
++        {
++            #pragma unroll
++            for (int n = 0; n < FRAGS_N_PER_WARP; ++n)
++            {
++                int r0 = m * 16 + lane_id / 4;
++                int r1 = r0 + 8;
++                int c = (lane_id % 4) * 2;
++                if (r0 < size_m)
++                {
++                    if constexpr (c_fp32)
++                    {
++                        float* c_ptr = gl_c_ptr_32 + r0 * size_n + (n0 + n) * 8 + c;
++                        frag_c[m][n][0] += *c_ptr++;
++                        frag_c[m][n][1] += *c_ptr++;
++                    }
++                    else
++                    {
++                        half2* c_ptr = (half2*) (gl_c_ptr_16 + r0 * size_n + (n0 + n) * 8 + c);
++                        float2 interm = __half22float2(*c_ptr);
++                        frag_c[m][n][0] += interm.x;
++                        frag_c[m][n][1] += interm.y;
++                    }
++                }
++                if (r1 < size_m)
++                {
++                    if constexpr (c_fp32)
++                    {
++                        float* c_ptr = gl_c_ptr_32 + r1 * size_n + (n0 + n) * 8 + c;
++                        frag_c[m][n][2] += *c_ptr++;
++                        frag_c[m][n][3] += *c_ptr++;
++                    }
++                    else
++                    {
++                        half2* c_ptr = (half2*) (gl_c_ptr_16 + r1 * size_n + (n0 + n) * 8 + c);
++                        float2 interm = __half22float2(*c_ptr);
++                        frag_c[m][n][2] += interm.x;
++                        frag_c[m][n][3] += interm.y;
++                    }
++                }
++            }
++        }
++    };
++
++    auto write_sum_gl = [&]()
++    {
++        int n0 = warp_id * FRAGS_N_PER_WARP;
++        #pragma unroll
++        for (int m = 0; m < TILEBLOCKS_M; ++m)
++        {
++            #pragma unroll
++            for (int n = 0; n < FRAGS_N_PER_WARP; ++n)
++            {
++                int r0 = m * 16 + lane_id / 4;
++                int r1 = r0 + 8;
++                int c = (lane_id % 4) * 2;
++                if (r0 < size_m)
++                {
++                    if constexpr (c_fp32)
++                    {
++                        float* c_ptr = gl_c_ptr_32 + r0 * size_n + (n0 + n) * 8 + c;
++                        *c_ptr++ = frag_c[m][n][0];
++                        *c_ptr++ = frag_c[m][n][1];
++                    }
++                    else
++                    {
++                        half2* c_ptr = (half2*) (gl_c_ptr_16 + r0 * size_n + (n0 + n) * 8 + c);
++                        half2 sum = __floats2half2_rn(frag_c[m][n][0], frag_c[m][n][1]);
++                        *c_ptr = sum;
++                    }
++                }
++                if (r1 < size_m)
++                {
++                    if constexpr (c_fp32)
++                    {
++                        float* c_ptr = gl_c_ptr_32 + r1 * size_n + (n0 + n) * 8 + c;
++                        *c_ptr++ = frag_c[m][n][2];
++                        *c_ptr++ = frag_c[m][n][3];
++                    }
++                    else
++                    {
++                        half2* c_ptr = (half2*) (gl_c_ptr_16 + r1 * size_n + (n0 + n) * 8 + c);
++                        half2 sum = __floats2half2_rn(frag_c[m][n][2], frag_c[m][n][3]);
++                        *c_ptr = sum;
++                    }
++                }
++            }
++        }
++    };
++
++    // Output reduction
++    auto reduce = [&] ()
++    {
++        #if EXL3_GEMM_H_ACC
++            // Fold the fp16 MMA accumulators into fp32 once per k-slice.
++            #pragma unroll
++            for (int m = 0; m < TILEBLOCKS_M; ++m)
++            {
++                #pragma unroll
++                for (int n = 0; n < FRAGS_N_PER_WARP; ++n)
++                {
++                    float2 f0 = __half22float2(frag_c_h[m][n][0]);
++                    float2 f1 = __half22float2(frag_c_h[m][n][1]);
++                    frag_c[m][n][0] += f0.x;
++                    frag_c[m][n][1] += f0.y;
++                    frag_c[m][n][2] += f1.x;
++                    frag_c[m][n][3] += f1.y;
++                }
++            }
++        #endif
++
++        // First reduce all partial sums along k for the current slice
++        threadblock_reduce();
++
++        // Process (partial) slices within column in reverse order so the threadblock doing the bottom slice is
++        // free to proceed to the next column right away
++        int lock_i = tiles_k - slice2_k - 1;
++        int lock_d = slice2_k - slice2_k0 + 1;
++        int* lock = &locks[slice_m * blocks_n + slice2_n];
++
++        barrier_acquire(lock, lock_i);
++
++        bool first = lock_i == 0;
++        bool last = lock_i + lock_d == tiles_k;
++
++        // Second and subsequent threadblocks in column read back the intermediate sum from global memory
++        if (!sub_k && !first)
++        {
++            read_sum_gl();
++        }
++
++        // All but last threadblock in column write the intermediate result to global memory
++        if (!sub_k && !last)
++        {
++            write_sum_gl();
++        }
++
++        // Last block writes in row-major format
++        if (!sub_k && last)
++        {
++            if constexpr (shmem_out_had)
++                write_sum_tile_sh();
++            else
++                write_sum_gl();
++        }
++
++        if constexpr (shmem_out_had)
++        {
++            if (last) __syncthreads();
++            if (!sub_k && last)
++                output_had_sh_gl();
++        }
++
++        barrier_release(lock, lock_d, last);
++
++        clear_frag_c();
++    };
++
++    // Wait until there are at most SH_STAGES - 2 async copies pending, i.e. at least one stage has finished loading
++    auto wait_stage = [&] ()
++    {
++        cp_async_wait<SH_STAGES - 2>();
++        __syncthreads();
++    };
++
++    // Perform tensor core matmul on current tile
++    auto matmul = [&] (int buf)
++    {
++        #pragma unroll
++        for (int m = 0; m < TILEBLOCKS_M; ++m)
++        {
++            #pragma unroll
++            for (int n = 0; n < FRAGS_N_PER_WARP; ++n)
++            {
++                #if EXL3_GEMM_H_ACC
++                    ptx_mma_m16n8k16(frag_a[buf][m], frag_b[buf][n], frag_c_h[m][n]);
++                #else
++                    ptx_mma_m16n8k16(frag_a[buf][m], frag_b[buf][n], frag_c[m][n]);
++                #endif
++            }
++        }
++    };
++
++    // Start global to shared pipeline
++    #pragma unroll
++    for (int i = 0; i < SH_STAGES - 1; ++i)
++        async_load_gl();
++    wait_stage();
++
++    // Start shared to register pipeline.
++    clear_frag_c();
++    if constexpr (FRAG_STAGES > 1)
++        load_frags(0);
++
++    // Main loop. Fragments are double buffered to allow more interleaving. This is especially important to hide the
++    // dequantization overhead, but we need two different iterations of the main loop to avoid confusing the compiler
++    // and making it (sometimes) place the fragment arrays in local memory
++
++    #define FSTAGE_OLD(_load, _mul) \
++        async_load_gl(); \
++        wait_stage(); \
++        load_frags(_load); \
++        matmul(_mul); \
++        if (slice2_k == tiles_k - 1 || slice2_iters == 1) { reduce(); slice2_k0 = slice2_k + 1; } \
++        advance2(); \
++        if (!slice2_iters) break; \
++
++    #define FSTAGE(_load, _mul) \
++        async_load_gl(); \
++        wait_stage(); \
++        matmul(_mul); \
++        if (slice2_k == tiles_k - 1 || slice2_iters == 1) { reduce(); slice2_k0 = slice2_k + 1; } \
++        advance2(); \
++        if (!slice2_iters) break; \
++        load_frags(_load); \
++
++    if constexpr (FRAG_STAGES == 1)
++    {
++        while (true)
++        {
++            FSTAGE_OLD(0, 0);
++        }
++    }
++
++    if constexpr (FRAG_STAGES == 2)
++    {
++        while (true)
++        {
++            FSTAGE(1, 0);
++            FSTAGE(0, 1);
++        }
++    }
++
++    if constexpr (FRAG_STAGES == 3)
++    {
++        while (true)
++        {
++            FSTAGE(1, 0);
++            FSTAGE(2, 1);
++            FSTAGE(0, 2);
++        }
++    }
++
++    if constexpr (FRAG_STAGES == 4)
++    {
++        while (true)
++        {
++            FSTAGE(1, 0);
++            FSTAGE(2, 1);
++            FSTAGE(3, 2);
++            FSTAGE(0, 3);
++        }
++    }
++
++    if constexpr (FRAG_STAGES == 5)
++    {
++        while (true)
++        {
++            FSTAGE(1, 0);
++            FSTAGE(2, 1);
++            FSTAGE(3, 2);
++            FSTAGE(4, 3);
++            FSTAGE(0, 4);
++        }
++    }
++}
++// Vendored from https://github.com/brandonmmusic-max/exllamav3 at 704aefd743b390af4bd0fb429d1906f9b964c7d8.
++// License: sparkinfer/gemm/trellis_linear/csrc/vendor/LICENSE.exllamav3
+diff --git a/sparkinfer/gemm/trellis_linear/csrc/vendor/quant/exl3_gemm_kernel.cuh b/sparkinfer/gemm/trellis_linear/csrc/vendor/quant/exl3_gemm_kernel.cuh
+new file mode 100644
+index 0000000000000000000000000000000000000000..719649609d4368c3f1fd95d52bdc7d0d2ab0fa3e
+--- /dev/null
++++ b/sparkinfer/gemm/trellis_linear/csrc/vendor/quant/exl3_gemm_kernel.cuh
+@@ -0,0 +1,281 @@
++#pragma once
++
++#include "exl3_kernel_map.cuh"
++#include "hadamard_inner.cuh"
++#include "exl3_gemm_inner.cuh"
++#include "exl3_devctx.cuh"
++
++template<EXL3_GEMM_T_ARGS>
++__global__ __launch_bounds__(EXL3_GEMM_BASE_THREADS * TILESIZE_K / 16)
++void exl3_gemm_kernel(EXL3_GEMM_ARGS)
++{
++    auto grid = cg::this_grid();
++
++    // if (suh)
++    {
++        int total_warps = size_m * size_k / 128;
++        int warps_grid = gridDim.x * blockDim.x / 32;
++        int this_warp = threadIdx.x / 32 + blockDim.x / 32 * blockIdx.x;
++
++        for(; this_warp < total_warps; this_warp += warps_grid)
++            had_hf_r_128_inner<true, false>
++            (
++                A + this_warp * 128,
++                A_had + this_warp * 128,
++                suh + (this_warp * 128) % size_k,
++                0.088388347648f  // 1/sqrt(128)
++            );
++
++        grid.sync();
++        A = A_had;
++    }
++
++    int size_m_ = size_m;
++    const half* A_ = A;
++    void* C_ = C;
++
++    while (size_m_ > 0)
++    {
++        exl3_gemm_kernel_inner
++        <bits, c_fp32, cb, TILESIZE_M, TILESIZE_K, TILESIZE_N, SH_STAGES, FRAG_STAGES, true>
++        (A_, B, C_, MIN(size_m_, 16), size_k, size_n, locks, svh);
++
++        A_ += 16 * size_k;
++        if constexpr (c_fp32) C_ = (void*) (((float*) C_) + 16 * size_n);
++        else                  C_ = (void*) (((half*) C_) + 16 * size_n);
++        size_m_ -= 16;
++
++        if (size_m_ > 0 || svh)
++            grid.sync();
++    }
++
++    // if (svh)
++    /*
++    {
++        int total_warps = size_m * size_n / 128;
++        int warps_grid = gridDim.x * blockDim.x / 32;
++        int this_warp = threadIdx.x / 32 + blockDim.x / 32 * blockIdx.x;
++
++        for(; this_warp < total_warps; this_warp += warps_grid)
++        {
++            if constexpr (c_fp32)
++                had_ff_r_128_inner<false, true>
++                (
++                    ((const float*) C) + this_warp * 128,
++                    ((float*) C) + this_warp * 128,
++                    svh + (this_warp * 128) % size_n,
++                    0.088388347648f  // 1/sqrt(128)
++                );
++            else
++                had_hf_r_128_inner<false, true>
++                (
++                    ((const half*) C) + this_warp * 128,
++                    ((half*) C) + this_warp * 128,
++                    svh + (this_warp * 128) % size_n,
++                    0.088388347648f  // 1/sqrt(128)
++                );
++        }
++    }
++     */
++}
++
++#define MAX_INDICES 128
++
++__device__ int64_t v_indices[128];
++__device__ half v_weights[128];
++__device__ int bszm_sync;
++
++template<EXL3_GEMM_T_ARGS>
++__global__ __launch_bounds__(EXL3_GEMM_BASE_THREADS * TILESIZE_K / 16)
++void exl3_mgemm_kernel(EXL3_MGEMM_ARGS)
++{
++    int bszm = MAX(bszm_in, bszm_out);
++    auto grid = cg::this_grid();
++
++    #if defined(__CUDA_ARCH__) && (__CUDA_ARCH__ > 890)
++        int* barrier_counters_sense = locks + BARRIER_LOCKS_OFFSET;
++    #endif
++
++    // Pack indices within min_index <= idx < max_index
++
++    if (min_index >= 0)
++    {
++        if (blockIdx.x == 0 && blockIdx.y == 0 && blockIdx.z == 0 && threadIdx.x == 0)
++        {
++            int j = 0;
++            for (int i = 0; i < bszm; ++i)
++            {
++                int idx = B_indices[i];
++                if (idx >= min_index && idx < max_index)
++                {
++                    v_indices[j] = idx - min_index;
++                    if (B_weights) v_weights[j] = B_weights[i];
++                    j++;
++                }
++            }
++            bszm_sync = j;
++            for (; j < bszm; ++j)
++            {
++                v_indices[j] = -1;
++            }
++        }
++        __threadfence();
++        grid.sync();
++        B_indices = v_indices;
++        if (B_weights) B_weights = v_weights;
++        bszm = bszm_sync;
++    }
++
++    for (int i = 0; i < bszm; i += gridDim.z)
++    {
++        int j = i + blockIdx.z;
++        int mat_index = -1;
++        const uint16_t* B = nullptr;
++        if (j >= bszm) j = -1;
++        else
++        {
++            mat_index = B_indices ? (int) B_indices[j] : j;
++            if (mat_index >= 0)
++            {
++                B = B_list[mat_index];
++            }
++        }
++
++        // Had and input scales
++
++        if (B)
++        {
++            int total_warps = size_m * size_k / 128;
++            int warps_grid = gridDim.x * blockDim.x / 32;
++            int this_warp = threadIdx.x / 32 + blockDim.x / 32 * blockIdx.x;
++
++            const half* suh = suh_list[mat_index];
++            const half* A_ = bszm_in == 1 ? A : A + j * size_m * size_k;
++            half* A_had_ = A_had + j * size_m * size_k;
++
++            for(; this_warp < total_warps; this_warp += warps_grid)
++                had_hf_r_128_inner<true, false>
++                (
++                    A_ + this_warp * 128,
++                    A_had_ + this_warp * 128,
++                    suh + (this_warp * 128) % size_k,
++                    0.088388347648f  // 1/sqrt(128)
++                );
++        }
++
++        #if defined(__CUDA_ARCH__) && (__CUDA_ARCH__ > 890)
++            group_barrier(blockIdx.z, gridDim.x, barrier_counters_sense);
++        #else
++            grid.sync();
++        #endif
++
++        // Matmul
++
++        int size_m_ = size_m;
++        half* A_ = A_had + j * size_m * size_k;
++        void* C_;
++        if constexpr (c_fp32) C_ = (void*) (((float*) C) + j * size_m * size_n);
++        else                  C_ = (void*) (((half*) C) + j * size_m * size_n);
++
++        while (size_m_ > 0)
++        {
++            if (B)
++            {
++                int lock_offs = blockIdx.z * size_n / 128;
++
++                exl3_gemm_kernel_inner
++                <bits, c_fp32, cb, TILESIZE_M, TILESIZE_K, TILESIZE_N, SH_STAGES, FRAG_STAGES, false>
++                (A_, B, C_, MIN(size_m_, 16), size_k, size_n, locks + lock_offs, nullptr);
++            }
++
++            A_ += 16 * size_k;
++            if constexpr (c_fp32) C_ = (void*) (((float*) C_) + 16 * size_n);
++            else                  C_ = (void*) (((half*) C_) + 16 * size_n);
++            size_m_ -= 16;
++
++            #if defined(__CUDA_ARCH__) && (__CUDA_ARCH__ > 890)
++                group_barrier(blockIdx.z, gridDim.x, barrier_counters_sense);
++            #else
++                grid.sync();
++            #endif
++        }
++
++        // Had and output scales
++
++        if (B)
++        {
++            int total_warps = size_m * size_n / 128;
++            int warps_grid = gridDim.x * blockDim.x / 32;
++            int this_warp = threadIdx.x / 32 + blockDim.x / 32 * blockIdx.x;
++
++            const half* svh = svh_list[mat_index];
++            float scale = 0.088388347648f;  // 1/sqrt(128)
++            if (B_weights) scale *= __half2float(B_weights[j]);
++
++            if constexpr (c_fp32) C_ = (void*) (((float*) C) + j * size_m * size_n);
++            else                  C_ = (void*) (((half*) C) + j * size_m * size_n);
++
++            for(; this_warp < total_warps; this_warp += warps_grid)
++            {
++                if constexpr (c_fp32)
++                    had_ff_r_128_inner<false, true>
++                    (
++                        ((const float*) C_) + this_warp * 128,
++                        ((float*) C_) + this_warp * 128,
++                        svh + (this_warp * 128) % size_n,
++                        scale
++                    );
++                else
++                    had_hf_r_128_inner<false, true>
++                    (
++                        ((const half*) C_) + this_warp * 128,
++                        ((half*) C_) + this_warp * 128,
++                        svh + (this_warp * 128) % size_n,
++                        scale
++                    );
++            }
++        }
++    }
++
++    if (B_weights)
++        grid.sync();
++
++    // Final reduction
++    if (B_weights && blockIdx.z == 0)
++    {
++        int total_warps = size_m * size_n / 32;
++        int warps_grid = gridDim.x * blockDim.x / 32;
++        int this_warp = threadIdx.x / 32 + blockDim.x / 32 * blockIdx.x;
++        int this_lane = threadIdx.x % 32;
++
++        for(; this_warp < total_warps; this_warp += warps_grid)
++        {
++            if constexpr (c_fp32)
++            {
++                float* C__ = ((float*) C) + this_warp * 32 + this_lane;
++                float* C___ = C__;
++                float sum = 0.0f;
++                for (int j = 0; j < bszm; ++j)
++                {
++                    sum += *C___;
++                    C___ += size_m * size_n;
++                }
++                *C__ = sum;
++            }
++            else
++            {
++                half* C__ = ((half*) C) + this_warp * 32 + this_lane;
++                half* C___ = C__;
++                half sum = {};
++                for (int j = 0; j < bszm; ++j)
++                {
++                    sum = __hadd(sum, *C___);
++                    C___ += size_m * size_n;
++                }
++                *C__ = sum;
++            }
++        }
++    }
++}
++// Vendored from https://github.com/brandonmmusic-max/exllamav3 at 704aefd743b390af4bd0fb429d1906f9b964c7d8.
++// License: sparkinfer/gemm/trellis_linear/csrc/vendor/LICENSE.exllamav3
+diff --git a/sparkinfer/gemm/trellis_linear/csrc/vendor/quant/exl3_kernel_map.cuh b/sparkinfer/gemm/trellis_linear/csrc/vendor/quant/exl3_kernel_map.cuh
+new file mode 100644
+index 0000000000000000000000000000000000000000..90b445422139284d9c843018bef0e767cb7985dd
+--- /dev/null
++++ b/sparkinfer/gemm/trellis_linear/csrc/vendor/quant/exl3_kernel_map.cuh
+@@ -0,0 +1,144 @@
++#pragma once
++
++int select_gemm_shape(int cc, int size_m, int size_k, int size_n, int bits, bool multi);
++int exl3_gemm_num_kernel_shapes();
++bool exl3_gemm_shape_compat(int shape_idx, int size_m, int size_k, int size_n, int bits);
++
++#define EXL3_GEMM_T_ARGS \
++    const int bits, \
++    const bool c_fp32, \
++    const int cb, \
++    const int TILESIZE_M, \
++    const int TILESIZE_K, \
++    const int TILESIZE_N, \
++    const int SH_STAGES, \
++    const int FRAG_STAGES
++
++#define EXL3_GEMM_ARGS \
++    const half* __restrict__  A, \
++    const uint16_t* __restrict__ B, \
++    void* __restrict__ C, \
++    const int size_m, \
++    const int size_k, \
++    const int size_n, \
++    int* __restrict__ locks, \
++    const half* __restrict__ suh, \
++    half* __restrict__ A_had, \
++    const half* __restrict__ svh
++
++#define EXL3_MGEMM_ARGS \
++    const half* __restrict__  A, \
++    const uint16_t** __restrict__ B_list, \
++    void* __restrict__ C, \
++    const int size_m, \
++    const int size_k, \
++    const int size_n, \
++    int* __restrict__ locks, \
++    const half** __restrict__ suh_list, \
++    half* __restrict__ A_had, \
++    const half** __restrict__ svh_list, \
++    int64_t* B_indices, \
++    half* B_weights, \
++    const int bszm_in, \
++    const int bszm_out, \
++    const int min_index, \
++    const int max_index
++
++typedef void (*fp_exl3_gemm_kernel) (EXL3_GEMM_ARGS);
++typedef void (*fp_exl3_mgemm_kernel) (EXL3_MGEMM_ARGS);
++
++#define EXL3_GEMM_SHAPE_1     16,     16,    128,     6,     5
++#define EXL3_GEMM_SHAPE_2     16,     32,    128,     4,     3
++#define EXL3_GEMM_SHAPE_3     16,     32,    256,     4,     3
++#define EXL3_GEMM_SHAPE_4     16,     16,    512,     4,     3
++
++#define EXL3_GEMM_TILESIZE_K  0, 16, 32, 32, 16
++#define EXL3_GEMM_TILESIZE_N  0, 128, 128, 256, 512
++#define EXL3_GEMM_BLOCKDIM  0, 256, 512, 512, 256
++
++#define EXL3_GEMM_NUM_SHAPES 4
++
++// Shape 1 not currently used anywhere
++#define EXL3_GEMM_KERNEL_INSTANCES(_bits, _c_fp32, cb) \
++    nullptr, \
++    exl3_gemm_kernel<_bits, _c_fp32, cb, EXL3_GEMM_SHAPE_1>, \
++    exl3_gemm_kernel<_bits, _c_fp32, cb, EXL3_GEMM_SHAPE_2>, \
++    exl3_gemm_kernel<_bits, _c_fp32, cb, EXL3_GEMM_SHAPE_3>, \
++    exl3_gemm_kernel<_bits, _c_fp32, cb, EXL3_GEMM_SHAPE_4>
++
++#define EXL3_MGEMM_KERNEL_INSTANCES(_bits, _c_fp32, cb) \
++    nullptr, \
++    exl3_mgemm_kernel<_bits, _c_fp32, cb, EXL3_GEMM_SHAPE_1>, \
++    exl3_mgemm_kernel<_bits, _c_fp32, cb, EXL3_GEMM_SHAPE_2>, \
++    exl3_mgemm_kernel<_bits, _c_fp32, cb, EXL3_GEMM_SHAPE_3>, \
++    exl3_mgemm_kernel<_bits, _c_fp32, cb, EXL3_GEMM_SHAPE_4>
++
++#define EXL3_GEMM_BASE_THREADS 256
++
++#define ALL_EXL3_KERNEL_EXTERNS(K) \
++    extern fp_exl3_gemm_kernel tfp_exl3_gemm_kernel_fp32_b##K[]; \
++    extern fp_exl3_gemm_kernel tfp_exl3_gemm_kernel_fp16_b##K[]; \
++    extern fp_exl3_mgemm_kernel tfp_exl3_mgemm_kernel_fp32_b##K[]; \
++    extern fp_exl3_mgemm_kernel tfp_exl3_mgemm_kernel_fp16_b##K[]; \
++
++#define ALL_EXL3_KERNEL_INSTANCES(K) \
++    fp_exl3_gemm_kernel tfp_exl3_gemm_kernel_fp32_b##K[] = { \
++        EXL3_GEMM_KERNEL_INSTANCES(K, true, 0), \
++        EXL3_GEMM_KERNEL_INSTANCES(K, true, 1), \
++        EXL3_GEMM_KERNEL_INSTANCES(K, true, 2) \
++    }; \
++    \
++    fp_exl3_gemm_kernel tfp_exl3_gemm_kernel_fp16_b##K[] = { \
++        EXL3_GEMM_KERNEL_INSTANCES(K, false, 0), \
++        EXL3_GEMM_KERNEL_INSTANCES(K, false, 1), \
++        EXL3_GEMM_KERNEL_INSTANCES(K, false, 2) \
++    }; \
++    \
++    fp_exl3_mgemm_kernel tfp_exl3_mgemm_kernel_fp32_b##K[] = { \
++        EXL3_MGEMM_KERNEL_INSTANCES(K, true, 0), \
++        EXL3_MGEMM_KERNEL_INSTANCES(K, true, 1), \
++        EXL3_MGEMM_KERNEL_INSTANCES(K, true, 2) \
++    }; \
++    \
++    fp_exl3_mgemm_kernel tfp_exl3_mgemm_kernel_fp16_b##K[] = { \
++        EXL3_MGEMM_KERNEL_INSTANCES(K, false, 0), \
++        EXL3_MGEMM_KERNEL_INSTANCES(K, false, 1), \
++        EXL3_MGEMM_KERNEL_INSTANCES(K, false, 2) \
++    };
++
++fp_exl3_gemm_kernel select_exl3_gemm_kernel
++(
++    const int cc,
++    const int size_m,
++    const int size_k,
++    const int size_n,
++    const int bits,
++    const bool c_fp32,
++    const int force_shape_idx,
++    int* out_block_dim,
++    int* out_shape_idx,
++    int* out_num_sms,
++    const int cb
++);
++
++fp_exl3_mgemm_kernel select_exl3_mgemm_kernel
++(
++    const int cc,
++    const int size_m,
++    const int size_k,
++    const int size_n,
++    const int K,
++    const bool c_fp32,
++    const int force_shape_idx,
++    int* out_block_dim,
++    int* out_shape_idx,
++    int* out_num_sms,
++    const int cb,
++    const int bszm_in,
++    const int bszm_out
++);
++
++fp_exl3_gemm_kernel get_gemm_kernel_ptr(int K, int shape_idx, bool c_fp32, int cb);
++fp_exl3_mgemm_kernel get_mgemm_kernel_ptr(int K, int shape_idx, bool c_fp32, int cb);
++// Vendored from https://github.com/brandonmmusic-max/exllamav3 at 704aefd743b390af4bd0fb429d1906f9b964c7d8.
++// License: sparkinfer/gemm/trellis_linear/csrc/vendor/LICENSE.exllamav3
+diff --git a/sparkinfer/gemm/trellis_linear/csrc/vendor/quant/hadamard_inner.cuh b/sparkinfer/gemm/trellis_linear/csrc/vendor/quant/hadamard_inner.cuh
+new file mode 100644
+index 0000000000000000000000000000000000000000..bc4baae9514a65824af10f96fc73abad8fd0762a
+--- /dev/null
++++ b/sparkinfer/gemm/trellis_linear/csrc/vendor/quant/hadamard_inner.cuh
+@@ -0,0 +1,461 @@
++#pragma once
++#include "../compat.cuh"
++
++#define ACT_SILU 0
++#define ACT_GELU 1
++
++// Hadamard transform 128-element vector across one warp, with optional pre and post scales
++
++__device__ inline half hreduce(half2 x)
++{
++    return __hadd(__low2half(x), __high2half(x));
++}
++
++__device__ inline void shuffle_had_f4x32(float& h0, float& h1, float& h2, float& h3, const int lane_id)
++{
++    #pragma unroll
++    for (int i = 1; i < 32; i <<= 1)
++    {
++        uint32_t i0 = __float_as_uint(h0);
++        uint32_t i1 = __float_as_uint(h1);
++        uint32_t i2 = __float_as_uint(h2);
++        uint32_t i3 = __float_as_uint(h3);
++        uint64_t h01 =  (uint64_t) i0 | (((uint64_t) i1) << 32);
++        uint64_t h23 =  (uint64_t) i2 | (((uint64_t) i3) << 32);
++        uint64_t ph01 = __shfl_xor_sync(0xffffffff, h01, i);
++        uint64_t ph23 = __shfl_xor_sync(0xffffffff, h23, i);
++        float ph0 = __uint_as_float((uint32_t) (ph01 & 0xffffffff));
++        float ph1 = __uint_as_float((uint32_t) (ph01 >> 32));
++        float ph2 = __uint_as_float((uint32_t) (ph23 & 0xffffffff));
++        float ph3 = __uint_as_float((uint32_t) (ph23 >> 32));
++        int32_t sfm = -static_cast<int32_t>(lane_id & i) >> 31;
++        i0 ^= sfm & 0x80000000;
++        i1 ^= sfm & 0x80000000;
++        i2 ^= sfm & 0x80000000;
++        i3 ^= sfm & 0x80000000;
++        h0 = __uint_as_float(i0) + ph0;
++        h1 = __uint_as_float(i1) + ph1;
++        h2 = __uint_as_float(i2) + ph2;
++        h3 = __uint_as_float(i3) + ph3;
++    }
++}
++
++__device__ inline void shuffle_had_f2x32(float& v, float& w, const int lane_id)
++{
++    #pragma unroll
++    for (int i = 1; i < 32; i <<= 1)
++    {
++        uint64_t vw = ((uint64_t) __float_as_uint(v)) | (((uint64_t) __float_as_uint(w)) << 32);
++        uint64_t pvw = __shfl_xor_sync(0xffffffff, vw, i);
++        float pv = __uint_as_float((uint32_t) (pvw & 0xffffffff));
++        float pw = __uint_as_float((uint32_t) (pvw >> 32));
++        uint32_t vi = __float_as_uint(v);
++        uint32_t wi = __float_as_uint(w);
++        int32_t sfm = -static_cast<int16_t>(lane_id & i) >> 31;
++        vi ^= (sfm & 0x80000000);
++        wi ^= (sfm & 0x80000000);
++        v = __uint_as_float(vi) + pv;
++        w = __uint_as_float(wi) + pw;
++    }
++}
++
++__device__ inline float shuffle_had_fx32(float v, const int lane_id)
++{
++    for (int i = 1; i < 32; i <<= 1)
++    {
++        float pv = __shfl_xor_sync(0xffffffff, v, i);
++        uint32_t* vi = reinterpret_cast<uint32_t*>(&v);
++        int32_t sfm = -static_cast<int16_t>(lane_id & i) >> 31;
++        *vi ^= (sfm & 0x80000000);
++        v = v + pv;
++    }
++    return v;
++}
++
++__device__ inline half2 shuffle_had_h2x32(half2 v, int lane_id)
++{
++    for (int i = 1; i < 32; i <<= 1)
++    {
++        half2 pv = __shfl_xor_sync(0xffffffff, v, i);
++        uint32_t* vi = reinterpret_cast<uint32_t*>(&v);
++        int32_t sfm = -static_cast<int16_t>(lane_id & i) >> 31;
++        *vi ^= (sfm & 0x80008000);
++        v = __hadd2(v, pv);
++    }
++    return v;
++}
++
++// Half vector, half scales
++
++template <bool pre_scale, bool post_scale>
++inline __device__
++void had_hf_r_128_inner
++(
++    const half* __restrict__ input_ptr,
++    half* __restrict__ output_ptr,
++    const half* __restrict__ scale,
++    const float r_scale
++)
++{
++    int t = threadIdx.x & 31;
++
++    // Load
++    half4 v = ((half4*) input_ptr)[t];
++
++    // Pre scale
++    if constexpr (pre_scale)
++    {
++        int i = blockIdx.y * 32 + t;
++        half4 scales = ((half4*) scale)[i];
++        v.x = __hmul2(v.x, scales.x);
++        v.y = __hmul2(v.y, scales.y);
++    }
++
++    // 4 element had
++    float v0 = __half2float(__low2half(v.x));
++    float v1 = __half2float(__high2half(v.x));
++    float v2 = __half2float(__low2half(v.y));
++    float v3 = __half2float(__high2half(v.y));
++    float s0 = v0 + v1;
++    float d0 = v0 - v1;
++    float s1 = v2 + v3;
++    float d1 = v2 - v3;
++    float h0 = s0 + s1;
++    float h1 = d0 + d1;
++    float h2 = s0 - s1;
++    float h3 = d0 - d1;
++
++    // 32 element had, warp shuffle
++    shuffle_had_f4x32(h0, h1, h2, h3, t);
++    v.x = __floats2half2_rn(h0 * r_scale, h1 * r_scale);
++    v.y = __floats2half2_rn(h2 * r_scale, h3 * r_scale);
++
++    // Post scale
++    if constexpr (post_scale)
++    {
++        int i = blockIdx.y * 32 + t;
++        half4 scales = ((half4*) scale)[i];
++        v.x = __hmul2(v.x, scales.x);
++        v.y = __hmul2(v.y, scales.y);
++    }
++
++    // Store
++    ((half4*) output_ptr)[t] = v;
++}
++
++// Float vector, half scales
++
++template <bool pre_scale, bool post_scale>
++inline __device__
++void had_ff_r_128_inner
++(
++    const float* __restrict__ input_ptr,
++    float* __restrict__ output_ptr,
++    const half* __restrict__ scale,
++    const float r_scale
++)
++{
++    int t = threadIdx.x & 31;
++
++    // Load
++    float4 v = ((float4*) input_ptr)[t];
++
++    // Pre scale
++    if constexpr (pre_scale)
++    {
++        int i = blockIdx.y * 32 + t;
++        half4 scales = ((half4*) scale)[i];
++        v.x *= __low2float(scales.x);
++        v.y *= __high2float(scales.x);
++        v.z *= __low2float(scales.y);
++        v.w *= __high2float(scales.y);
++    }
++
++    // 4 element had
++    float v0 = v.x;
++    float v1 = v.y;
++    float v2 = v.z;
++    float v3 = v.w;
++    float s0 = v0 + v1;
++    float d0 = v0 - v1;
++    float s1 = v2 + v3;
++    float d1 = v2 - v3;
++    v.x = s0 + s1;
++    v.y = d0 + d1;
++    v.z = s0 - s1;
++    v.w = d0 - d1;
++
++    // 32 element had, warp shuffle
++    shuffle_had_f2x32(v.x, v.y, t);
++    shuffle_had_f2x32(v.z, v.w, t);
++    v.x *= r_scale;
++    v.y *= r_scale;
++    v.z *= r_scale;
++    v.w *= r_scale;
++
++    // Post scale
++    if constexpr (post_scale)
++    {
++        int i = blockIdx.y * 32 + t;
++        half4 scales = ((half4*) scale)[i];
++        v.x *= __low2float(scales.x);
++        v.y *= __high2float(scales.x);
++        v.z *= __low2float(scales.y);
++        v.w *= __high2float(scales.y);
++    }
++
++    // Store
++    ((float4*) output_ptr)[t] = v;
++}
++
++// Float vector, half scales, half output
++
++template <bool pre_scale, bool post_scale>
++inline __device__
++void had_fh_r_128_inner
++(
++    const float* __restrict__ input_ptr,
++    half* __restrict__ output_ptr,
++    const half* __restrict__ scale,
++    const float r_scale
++)
++{
++    int t = threadIdx.x & 31;
++
++    // Load
++    float4 v = ((float4*) input_ptr)[t];
++
++    // Pre scale
++    if constexpr (pre_scale)
++    {
++        int i = blockIdx.y * 32 + t;
++        half4 scales = ((half4*) scale)[i];
++        v.x *= __low2float(scales.x);
++        v.y *= __high2float(scales.x);
++        v.z *= __low2float(scales.y);
++        v.w *= __high2float(scales.y);
++    }
++
++    // 4 element had
++    float v0 = v.x;
++    float v1 = v.y;
++    float v2 = v.z;
++    float v3 = v.w;
++    float s0 = v0 + v1;
++    float d0 = v0 - v1;
++    float s1 = v2 + v3;
++    float d1 = v2 - v3;
++    v.x = s0 + s1;
++    v.y = d0 + d1;
++    v.z = s0 - s1;
++    v.w = d0 - d1;
++
++    // 32 element had, warp shuffle
++    shuffle_had_f2x32(v.x, v.y, t);
++    shuffle_had_f2x32(v.z, v.w, t);
++    v.x *= r_scale;
++    v.y *= r_scale;
++    v.z *= r_scale;
++    v.w *= r_scale;
++
++    half4 o;
++    o.x = __floats2half2_rn(v.x, v.y);
++    o.y = __floats2half2_rn(v.z, v.w);
++
++    // Post scale
++    if constexpr (post_scale)
++    {
++        int i = blockIdx.y * 32 + t;
++        half4 scales = ((half4*) scale)[i];
++        o.x = __hmul2(o.x, scales.x);
++        o.y = __hmul2(o.y, scales.y);
++    }
++
++    // Store
++    ((half4*) output_ptr)[t] = o;
++}
++
++// Fused op: o <- in_had(silu(out_had(g)) * out_had(u))
++
++inline __device__
++void had_hf_r_128_guad_inner
++(
++    const half* __restrict__ input_ptr_g,
++    const half* __restrict__ input_ptr_u,
++    half* __restrict__ output_ptr,
++    const half* __restrict__ post_scale_g,
++    const half* __restrict__ post_scale_u,
++    const half* __restrict__ pre_scale_d,
++    const float r_scale,
++    const float act_limit,
++    const int act_function
++)
++{
++    int t = threadIdx.x & 31;
++
++    auto had = [&](half4& v)
++    {
++        // 4 element had
++        float v0 = __half2float(__low2half(v.x));
++        float v1 = __half2float(__high2half(v.x));
++        float v2 = __half2float(__low2half(v.y));
++        float v3 = __half2float(__high2half(v.y));
++        float s0 = v0 + v1;
++        float d0 = v0 - v1;
++        float s1 = v2 + v3;
++        float d1 = v2 - v3;
++        float h0 = s0 + s1;
++        float h1 = d0 + d1;
++        float h2 = s0 - s1;
++        float h3 = d0 - d1;
++
++        // 32 element had, warp shuffle
++        shuffle_had_f4x32(h0, h1, h2, h3, t);
++        v.x = __floats2half2_rn(h0 * r_scale, h1 * r_scale);
++        v.y = __floats2half2_rn(h2 * r_scale, h3 * r_scale);
++
++        return v;
++    };
++
++    auto _silu = [&](const half2& x)
++    {
++        half2 one = __float2half2_rn(1.0f);
++        half2 neg_x = __hneg2(x);
++        half2 e = h2exp(neg_x);
++        half2 sum = __hadd2(one, e);
++        half2 r = h2rcp(sum);
++        half2 result = __hmul2(x, r);
++        return result;
++    };
++
++    auto _gelu = [&](const half2& x)
++    {
++        float2 xf = __half22float2(x);
++        const float c = 0.797884560803f;  // sqrt(2/Pi)
++        xf.x = 0.5f * xf.x * (1.0f + tanh_opt(c * (xf.x + 0.044715f * xf.x * xf.x * xf.x)));
++        xf.y = 0.5f * xf.y * (1.0f + tanh_opt(c * (xf.y + 0.044715f * xf.y * xf.y * xf.y)));
++        return __float22half2_rn(xf);
++    };
++
++    // Load
++    half4 vg = ((half4*) input_ptr_g)[t];
++    half4 vu = ((half4*) input_ptr_u)[t];
++
++    // Hadamard
++    vg = had(vg);
++    vu = had(vu);
++
++    // Post scale  TODO: should maybe do this in float32
++    int i = blockIdx.y * 32 + t;
++    half4 scales_g = ((half4*) post_scale_g)[i];
++    half4 scales_u = ((half4*) post_scale_u)[i];
++    vg.x = __hmul2(vg.x, scales_g.x);
++    vg.y = __hmul2(vg.y, scales_g.y);
++    vu.x = __hmul2(vu.x, scales_u.x);
++    vu.y = __hmul2(vu.y, scales_u.y);
++
++    // Activation
++    switch (act_function)
++    {
++        case ACT_SILU:
++            vg.x = _silu(vg.x);
++            vg.y = _silu(vg.y);
++            break;
++
++        case ACT_GELU:
++            vg.x = _gelu(vg.x);
++            vg.y = _gelu(vg.y);
++            break;
++
++        default:
++            break;
++    }
++
++    // Optional activation limits
++    if (act_limit != 0.0f)
++    {
++        vu.x = __hmax2(vu.x, __float2half2_rn(-act_limit));
++        vu.y = __hmax2(vu.y, __float2half2_rn(-act_limit));
++        vu.x = __hmin2(vu.x, __float2half2_rn(act_limit));
++        vu.y = __hmin2(vu.y, __float2half2_rn(act_limit));
++        vg.x = __hmin2(vg.x, __float2half2_rn(act_limit));
++        vg.y = __hmin2(vg.y, __float2half2_rn(act_limit));
++    }
++
++    // Gate
++    vg.x = __hmul2(vg.x, vu.x);
++    vg.y = __hmul2(vg.y, vu.y);
++
++    // Pre scale (d)
++    half4 scales_d = ((half4*) pre_scale_d)[i];
++    vg.x = __hmul2(vg.x, scales_d.x);
++    vg.y = __hmul2(vg.y, scales_d.y);
++
++    // Hadamard
++    vg = had(vg);
++
++    // Store
++    ((half4*) output_ptr)[t] = vg;
++}
++
++// Fused op: o += float(out_had(i)), atomic
++
++inline __device__
++void had_hf_r_128_d_inner
++(
++    const half* __restrict__ input_ptr,
++    float* __restrict__ output_ptr,
++    const half* __restrict__ post_scale,
++    const float r_scale
++)
++{
++    int t = threadIdx.x & 31;
++
++    // Load
++    half4 v = ((half4*) input_ptr)[t];
++
++    // 4 element had
++    float v0 = __half2float(__low2half(v.x));
++    float v1 = __half2float(__high2half(v.x));
++    float v2 = __half2float(__low2half(v.y));
++    float v3 = __half2float(__high2half(v.y));
++    float s0 = v0 + v1;
++    float d0 = v0 - v1;
++    float s1 = v2 + v3;
++    float d1 = v2 - v3;
++    float h0 = s0 + s1;
++    float h1 = d0 + d1;
++    float h2 = s0 - s1;
++    float h3 = d0 - d1;
++
++    // 32 element had, warp shuffle
++    shuffle_had_f4x32(h0, h1, h2, h3, t);
++    h0 *= r_scale;
++    h1 *= r_scale;
++    h2 *= r_scale;
++    h3 *= r_scale;
++
++    // Post scale
++    int i = blockIdx.y * 32 + t;
++    half4 scales = ((half4*) post_scale)[i];
++    h0 *= __low2float(scales.x);
++    h1 *= __high2float(scales.x);
++    h2 *= __low2float(scales.y);
++    h3 *= __high2float(scales.y);
++
++    // Reshuffle in shmem for coalesced store with atomicAdd
++    extern __shared__ float temp_shared[];
++    int warp_id = threadIdx.x / 32;
++    float* sh = temp_shared + warp_id * 128;
++    sh[t * 4 + 0] = h0;
++    sh[t * 4 + 1] = h1;
++    sh[t * 4 + 2] = h2;
++    sh[t * 4 + 3] = h3;
++    __syncwarp();
++    atomicAdd(output_ptr +  0 + t, sh[ 0 + t]);
++    atomicAdd(output_ptr + 32 + t, sh[32 + t]);
++    atomicAdd(output_ptr + 64 + t, sh[64 + t]);
++    atomicAdd(output_ptr + 96 + t, sh[96 + t]);
++}
++// Vendored from https://github.com/brandonmmusic-max/exllamav3 at 704aefd743b390af4bd0fb429d1906f9b964c7d8.
++// License: sparkinfer/gemm/trellis_linear/csrc/vendor/LICENSE.exllamav3
+diff --git a/sparkinfer/gemm/trellis_linear/csrc/vendor/util.cuh b/sparkinfer/gemm/trellis_linear/csrc/vendor/util.cuh
+new file mode 100644
+index 0000000000000000000000000000000000000000..2ea7a06ce3f6173f964b3f90ff1c5b709b6cf7e2
+--- /dev/null
++++ b/sparkinfer/gemm/trellis_linear/csrc/vendor/util.cuh
+@@ -0,0 +1,104 @@
++#pragma once
++
++typedef struct __align__(8) half4
++{
++    half2 x;
++    half2 y;
++    __device__ half4() = default;
++    __device__ half4(half2 x_, half2 y_) : x(x_), y(y_) {}
++    __device__ half4(half h0, half h1, half h2, half h3) :
++         x(__halves2half2(h0, h1)),
++         y(__halves2half2(h2, h3)) {}
++}
++half4;
++
++typedef struct __align__(8) bfloat164
++{
++    __nv_bfloat162 x;
++    __nv_bfloat162 y;
++    __device__ bfloat164() = default;
++    __device__ bfloat164(__nv_bfloat162 x_, __nv_bfloat162 y_): x(x_), y(y_) {}
++    __device__ bfloat164(__nv_bfloat16 b0, __nv_bfloat16 b1, __nv_bfloat16 b2, __nv_bfloat16 b3) :
++        x(__halves2bfloat162(b0, b1)),
++        y(__halves2bfloat162(b2, b3)) {}
++}
++bfloat164;
++
++typedef struct __align__(16) half8
++{
++    half2 x;
++    half2 y;
++    half2 z;
++    half2 w;
++     __device__ half8() = default;
++     __device__ half8(half2 x_, half2 y_, half2 z_, half2 w_) : x(x_), y(y_), z(z_), w(w_) {}
++     __device__ half8(half h0, half h1, half h2, half h3, half h4, half h5, half h6, half h7) :
++         x(__halves2half2(h0, h1)),
++         y(__halves2half2(h2, h3)),
++         z(__halves2half2(h4, h5)),
++         w(__halves2half2(h6, h7)) {}
++}
++half8;
++
++struct Dim3
++{
++    int m;
++    int k;
++    int n;
++    inline __device__ int numel_a() { return m * k; }
++    inline __device__ int numel_b() { return k * n; }
++    inline __device__ int numel_c() { return m * n; }
++};
++
++#define READ128(__x, __y) ((uint4*)&__x)[0] = ((uint4*)(__y))[0];
++#define WRITE128(__x, __y) ((uint4*)__x)[0] = ((uint4*)(&__y))[0];
++#define READ64(__x, __y) ((uint2*)&__x)[0] = ((uint2*)(__y))[0];
++#define WRITE64(__x, __y) ((uint2*)__x)[0] = ((uint2*)(&__y))[0];
++
++#define LOW_TO_FLOAT(__x) __half2float(__low2half(__x))
++#define HIGH_TO_FLOAT(__x) __half2float(__high2half(__x))
++
++#define LOW_TO_FLOAT(__x) __half2float(__low2half(__x))
++#define HIGH_TO_FLOAT(__x) __half2float(__high2half(__x))
++
++#define CLAMP(__x, __min, __max) fmaxf(__min, fminf(__x, __max))
++#define CLAMP_FP16(__x) CLAMP(__x, -65504.0f, 65504.0f)
++
++#define SWAP16(__x) __byte_perm(__x, 0, 0x1032)
++
++union half2_uint32
++{
++    uint32_t as_uint32;
++    half2 as_half2;
++    __device__ half2_uint32(uint32_t val) : as_uint32(val) {}
++    __device__ half2_uint32(half2 val) : as_half2(val) {}
++    __device__ half2_uint32() : as_uint32(0) {}
++};
++
++union half_uint16
++{
++    uint16_t as_uint16;
++    half as_half;
++    __device__ half_uint16(uint16_t val) : as_uint16(val) {}
++    __device__ half_uint16(half val) : as_half(val) {}
++    __device__ half_uint16() : as_uint16(0) {}
++};
++
++__device__ inline float fxor(float v, uint32_t mask)
++{
++    uint32_t* vi = reinterpret_cast<uint32_t*>(&v);
++    *vi ^= mask;
++    return v;
++}
++
++__device__ inline half2 h2xor(half2 v, uint32_t mask)
++{
++    uint32_t* vi = reinterpret_cast<uint32_t*>(&v);
++    *vi ^= mask;
++    return v;
++}
++
++#define NEG_INF_F16 __ushort_as_half(0xFC00)
++#define POS_INF_F16 __ushort_as_half(0x7C00)
++// Vendored from https://github.com/brandonmmusic-max/exllamav3 at 704aefd743b390af4bd0fb429d1906f9b964c7d8.
++// License: sparkinfer/gemm/trellis_linear/csrc/vendor/LICENSE.exllamav3
+diff --git a/sparkinfer/gemm/trellis_linear/csrc/vendor/util.h b/sparkinfer/gemm/trellis_linear/csrc/vendor/util.h
+new file mode 100644
+index 0000000000000000000000000000000000000000..576587166b26d01b071bbb677415935b326ba3bb
+--- /dev/null
++++ b/sparkinfer/gemm/trellis_linear/csrc/vendor/util.h
+@@ -0,0 +1,140 @@
++#pragma once
++
++#include <chrono>
++
++#define CEIL_DIVIDE(x, size) (((x) + (size) - 1) / (size))
++#define MIN(x, y) ((x) < (y) ? (x) : (y))
++#define MAX(x, y) ((x) > (y) ? (x) : (y))
++
++// Some decluttering macros
++//
++// TORCH_CHECK_DTYPE(x, T):                     assert x is dtype T
++// TORCH_CHECK_DTYPE_OPT(x, T):                 assert x is dtype T, unless x is None
++// TORCH_CHECK_FLOAT_HALF(x):                   assert x is either kFloat or kHalf
++// TORCH_CHECK_SHAPES(x, i, y, j, scale):       assert x.size(i) == y.size(j) * scale
++// TORCH_CHECK_SHAPES_OPT(x, i, y, j, scale):   assert x.size(i) == y.size(j) * scale, unless x is None
++// TORCH_CHECK_SHAPES_FULL(x, y):               assert x and y are same shape
++// TORCH_CHECK_NUMEL(x, y):                     assert x and y have same number of elements
++// TORCH_CHECK_DIV(x, i, divisor):              assert x.size(i) is divisible by divisor
++// TORCH_CHECK_DIM(x, D):                       assert x has D dimensions
++// TORCH_CHECK_DIM_OPT(x, D):                   assert x has D dimensions, unless x is None
++// TORCH_CHECK_SIZE(x, i, s):                   assert x.size(i) == s
++// OPTPTR(x):                                   x.data_ptr() or nullptr if x is None
++
++#define TORCH_CHECK_DTYPE(__x, __dtype) TORCH_CHECK((__x).dtype() == at::__dtype, #__x " is incorrect datatype, must be " #__dtype)
++#define TORCH_CHECK_DTYPE_OPT(__x, __dtype) TORCH_CHECK((!__x.has_value()) || (__x).value().dtype() == at::__dtype, #__x " is incorrect datatype, must be " #__dtype)
++#define TORCH_CHECK_FLOAT_HALF(__x) TORCH_CHECK((__x).dtype() == at::kHalf || (__x).dtype() == at::kFloat,  #__x " is incorrect datatype, must be kHalf or kFloat")
++#define TORCH_CHECK_SHAPES(__x, __dim_x, __y, __dim_y, __scale_y) TORCH_CHECK((__x).size(__dim_x) == (__y).size(__dim_y) * __scale_y, #__x " and " #__y " have incompatible shapes")
++#define TORCH_CHECK_SHAPES_OPT(__x, __dim_x, __y, __dim_y, __scale_y) TORCH_CHECK((!(__x).has_value()) || (__x).value().size(__dim_x) == (__y).size(__dim_y) * __scale_y, #__x " and " #__y " have incompatible shapes")
++#define TORCH_CHECK_SHAPES_FULL(__x, __y) TORCH_CHECK((__x).sizes() == (__y).sizes(), #__x " and " #__y " have incompatible shapes")
++#define TORCH_CHECK_NUMEL(__x, __y) TORCH_CHECK((__x).numel() == (__y).numel(), #__x " and " #__y " have incompatible shapes")
++#define TORCH_CHECK_DIV(__x, __dim_x, __div) TORCH_CHECK((__x).size(__dim_x) % __div == 0, #__x " dimension " #__dim_x " must be divisible by " #__div)
++#define TORCH_CHECK_DIM(__x, __dims) TORCH_CHECK((__x).dim() == __dims, #__x " must have " #__dims " dimensions")
++#define TORCH_CHECK_DIM_OPT(__x, __dims) TORCH_CHECK((!__x.has_value()) || (__x).value().dim() == __dims, #__x " must have " #__dims " dimensions")
++#define TORCH_CHECK_SIZE(__x, __dim_x, __s) TORCH_CHECK((__x).size(__dim_x) == (__s), #__x " dimension " #__dim_x " is incorrect size")
++#define OPTPTR(__x) (__x.has_value() ? __x.value().data_ptr() : nullptr)
++
++// Debug stuff
++
++#define DBGS(__x) printf("%s\n", __x)
++#define DBGI(__x) \
++    printf("%s: %i\n", #__x, __x)
++#define DBGI2(__x, __y) \
++    printf("%s, %s: %i, %i\n", #__x, #__y, __x, __y)
++#define DBGI3(__x, __y, __z) \
++    printf("%s, %s, %s: %i, %i, %i\n", #__x, #__y, #__z, __x, __y, __z)
++#define DBGI4(__x, __y, __z, __w) \
++    printf("%s, %s, %s, %s: %i, %i, %i, %i\n", #__x, #__y, #__z, #__w, __x, __y, __z, __w)
++#define DBGI5(__x, __y, __z, __w, __v) \
++    printf("%s, %s, %s, %s, %s: %i, %i, %i, %i, %i\n", #__x, #__y, #__z, #__w, #__v, __x, __y, __z, __w, __v)
++#define DBGI6(__x, __y, __z, __w, __v, __u) \
++    printf("%s, %s, %s, %s, %s, %s: %i, %i, %i, %i, %i, %i\n", #__x, #__y, #__z, #__w, #__v, #__u, __x, __y, __z, __w, __v, __u)
++#define DBGI7(__x, __y, __z, __w, __v, __u, __t) \
++    printf("%s, %s, %s, %s, %s, %s, %s: %i, %i, %i, %i, %i, %i, %i\n", #__x, #__y, #__z, #__w, #__v, #__u, #__t, __x, __y, __z, __w, __v, __u, __t)
++#define DBGI8(__x, __y, __z, __w, __v, __u, __t, __s) \
++    printf("%s, %s, %s, %s, %s, %s, %s, %s: %i, %i, %i, %i, %i, %i, %i, %i\n", #__x, #__y, #__z, #__w, #__v, #__u, #__t, #__s, __x, __y, __z, __w, __v, __u, __t, __s)
++#define DBGI9(__x, __y, __z, __w, __v, __u, __t, __s, __r) \
++    printf("%s, %s, %s, %s, %s, %s, %s, %s, %s: %i, %i, %i, %i, %i, %i, %i, %i, %i\n", #__x, #__y, #__z, #__w, #__v, #__u, #__t, #__s, #__r, __x, __y, __z, __w, __v, __u, __t, __s, __r)
++#define DBGI10(__x, __y, __z, __w, __v, __u, __t, __s, __r, __q) \
++    printf("%s, %s, %s, %s, %s, %s, %s, %s, %s, %s: %i, %i, %i, %i, %i, %i, %i, %i, %i, %i\n", #__x, #__y, #__z, #__w, #__v, #__u, #__t, #__s, #__r, #__q, __x, __y, __z, __w, __v, __u, __t, __s, __r, __q)
++#define DBGX(__x) printf("%s: %x\n", #__x, __x)
++#define DBGX2(__x, __y) printf("%s, %s: %x, %x\n", #__x, #__y, __x, __y)
++#define DBGX3(__x, __y, __z) printf("%s, %s, %s: %x, %x, %x\n", #__x, #__y, #__z, __x, __y, __z)
++#define DBGIX(__x, __y) printf("%s, %s: %i, %x\n", #__x, #__y, __x, __y)
++#define DBGIX2(__x, __y, __z) printf("%s, %s, %s: %i, %x, %x\n", #__x, #__y, #__z, __x, __y, __z)
++#define DBGIF(__x, __y) printf("%s, %s: %i, %f\n", #__x, #__y, __x, __y)
++#define DBGIF2(__x, __y, __z) printf("%s, %s, %s: %i, %f, %f\n", #__x, #__y, #__z, __x, __y, __z)
++#define DBGF(__x) printf("%s: %f\n", #__x, __x)
++#define DBGF2(__x, __y) printf("%s, %s: %f, %f\n", #__x, #__y, __x, __y)
++#define DBGF3(__x, __y, __z) printf("%s, %s, %s: %f, %f, %f\n", #__x, #__y, #__z, __x, __y, __z)
++#define DBGF4(__x, __y, __z, __w) printf("%s, %s, %s, %s: %f, %f, %f, %f\n", #__x, #__y, #__z, #__w, __x, __y, __z, __w)
++#define DBGH(__x) printf("%s: %f\n", #__x, __half2float(__x))
++#define DBGH2(__x, __y) printf("%s, %s: %f, %f\n", #__x, #__y, __half2float(__x), __half2float(__y))
++#define DBGH3(__x, __y, __z) printf("%s, %s, %s: %f, %f, %f\n", #__x, #__y, #__z, __half2float(__x), __half2float(__y), __half2float(__z))
++#define DBGIH(__x, __y) printf("%s, %s: %i, %f\n", #__x, #__y, __x, __half2float(__y))
++#define DBGIH2(__x, __y, __z) printf("%s, %s, %s: %i, %f, %f\n", #__x, #__y, #__z, __x, __half2float(__y), __half2float(__z))
++#define DBGI2H2(__x, __y, __z, __w) printf("%s, %s, %s, %s: %i, %i, %f, %f\n", #__x, #__y, #__z, #__w, __x, __y, __half2float(__z), __half2float(__w))
++#define DBGIH3(__x, __y, __z, __w) printf("%s, %s, %s, %s: %i, %f, %f, %f\n", #__x, #__y, #__z, #__w, __x, __half2float(__y), __half2float(__z), __half2float(__w))
++#define DBGIH4(__x, __y, __z, __w, __v) printf("%s, %s, %s, %s, %s: %i, %f, %f, %f, %f\n", #__x, #__y, #__z, #__w, #__v, __x, __half2float(__y), __half2float(__z), __half2float(__w), __half2float(__v))
++#define DBGA(__x) printf("%s: %016llx\n", #__x, __x)
++#define DBGIA(__x, __y) printf("%s, %s: %i, %016llx\n", #__x, #__y, __x, __y)
++#define DBGI2A(__x, __y, __z) printf("%s, %s, %s: %i, %i, %016llx\n", #__x, #__y, #__z, __x, __y, __z)
++
++#define TIME_START \
++    auto start = std::chrono::high_resolution_clock::now()
++
++#define TIME_STOP \
++    do { \
++        auto stop = std::chrono::high_resolution_clock::now(); \
++        auto duration_us = std::chrono::duration_cast<std::chrono::microseconds>(stop - start); \
++        DBGI(duration_us); \
++    } while (false)
++
++/*
++Compile-time for loop. Supports template instancing. Example usage:
++
++int kernel_arg = select_kernel_somehow();
++
++// Not nice
++if (kernel_arg == 2)
++    launch_kernel_instance<2><<< ... >>>( ... )
++if (kernel_arg == 3)
++    launch_kernel_instance<3><<< ... >>>( ... )
++if (kernel_arg == 4)
++    launch_kernel_instance<4><<< ... >>>( ... )
++if (kernel_arg == 6)
++    launch_kernel_instance<6><<< ... >>>( ... )
++if (kernel_arg == 8)
++    launch_kernel_instance<8><<< ... >>>( ... )
++
++// Nice?
++static_for_pack<2, 3, 4, 6, 8>([&](auto ic)
++{
++    constexpr int i = decltype(ic)::value;
++    if (kernel_arg == i)
++        launch_kernel_instance<i><<< ... >>>( ... )
++});
++
++// Ultimately much cleaner
++#define __(i, j) quant_cache_paged_kernel<i, j>
++constexpr auto quant_cache_paged_kernel_instances = std::array
++{
++    std::array{ __(2, 2), __(2, 3), __(2, 4), __(2, 5), __(2, 6), __(2, 7), __(2, 8) },
++    std::array{ __(3, 2), __(3, 3), __(3, 4), __(3, 5), __(3, 6), __(3, 7), __(3, 8) },
++    std::array{ __(4, 2), __(4, 3), __(4, 4), __(4, 5), __(4, 6), __(4, 7), __(4, 8) },
++    std::array{ __(5, 2), __(5, 3), __(5, 4), __(5, 5), __(5, 6), __(5, 7), __(5, 8) },
++    std::array{ __(6, 2), __(6, 3), __(6, 4), __(6, 5), __(6, 6), __(6, 7), __(6, 8) },
++    std::array{ __(7, 2), __(7, 3), __(7, 4), __(7, 5), __(7, 6), __(7, 7), __(7, 8) },
++    std::array{ __(8, 2), __(8, 3), __(8, 4), __(8, 5), __(8, 6), __(8, 7), __(8, 8) }
++};
++#undef __
++*/
++
++// This breaks with nesting on VC++ older than 17.13 (late 2024 preview)
++template <int... Values, class F>
++constexpr void static_for_pack(F&& f)
++{
++    (f(std::integral_constant<int, Values>{}), ...);
++}
++// Vendored from https://github.com/brandonmmusic-max/exllamav3 at 704aefd743b390af4bd0fb429d1906f9b964c7d8.
++// License: sparkinfer/gemm/trellis_linear/csrc/vendor/LICENSE.exllamav3
+diff --git a/sparkinfer/moe/_shared/kernels/dynamic.py b/sparkinfer/moe/_shared/kernels/dynamic.py
+index b7f6191d61b4dbb4ed8ff3dc277ec63bdf5556a2..745efdc0572de5da9c6e002f81bd53792165908d 100644
+--- a/sparkinfer/moe/_shared/kernels/dynamic.py
++++ b/sparkinfer/moe/_shared/kernels/dynamic.py
+@@ -822,7 +822,11 @@ class MoEDynamicKernelBackend:
+             source_tile_m=materialized_source_tile_m,
+             deterministic_output=bool(deterministic_output),
+             num_topk=self.num_topk,
+-            activation=self.activation,
++            # This helper is gated-only and is never launched unless the split
++            # materialized path is active.  Use a valid inert specialization for
++            # non-split activations (notably ReLU2) instead of rejecting them
++            # during otherwise valid monolithic-kernel construction.
++            activation=self.activation if self.w4a8_split_materialized else "silu",
+         )
+         self.materialized_phase2_kernel = W4A8MaterializedPhase2Kernel(
+             source_tile_m=materialized_source_tile_m,
+@@ -1065,12 +1069,8 @@ class MoEDynamicKernelBackend:
+         # MMA dispatch selector: FP6/FP8 byte-containers are indistinguishable
+         # from FP8 by dtype, so pass the explicit sub-format string ("e4m3"/
+         # "e2m3"/"e3m2"); the native FP4 path keeps passing the operand dtype.
+-        self._mma_fmt_a = (
+-            self.mxfp6_fmt_a if self.mxfp6_fmt_a is not None else None
+-        )
+-        self._mma_fmt_b = (
+-            self.mxfp6_fmt_b if self.mxfp6_fmt_b is not None else None
+-        )
++        self._mma_fmt_a = self.mxfp6_fmt_a if self.mxfp6_fmt_a is not None else None
++        self._mma_fmt_b = self.mxfp6_fmt_b if self.mxfp6_fmt_b is not None else None
+         self.cta_layout_mnk = cute.make_layout(self.cluster_shape_mnk)
+         self.num_m_tiles = self.tile_shape_mnk[0] // (16 * self.atom_shape[0])
+         self.num_n_tiles = self.tile_shape_mnk[1] // (8 * self.atom_shape[1])
+@@ -1405,9 +1405,7 @@ class MoEDynamicKernelBackend:
+             beta = cutlass.Float32(SITU_DEFAULT_BETA)
+             linear_beta = cutlass.Float32(SITU_DEFAULT_LINEAR_BETA)
+             situ_gate = (
+-                beta
+-                * cute.math.tanh(gate / beta, fastmath=self.fast_math)
+-                * sigmoid
++                beta * cute.math.tanh(gate / beta, fastmath=self.fast_math) * sigmoid
+             )
+             situ_up = linear_beta * cute.math.tanh(
+                 up / linear_beta,
+@@ -2636,9 +2634,7 @@ class MoEDynamicKernelBackend:
+             # for the expansion (cute.recast_tensor strips sB's swizzle), and
+             # ``storage`` must not be referenced inside warp-dispatch branches,
+             # so only these Int32 addresses may cross into them.
+-            sB_packed = cute.make_tensor(
+-                storage.sB.data_ptr(), b_packed_smem_staged
+-            )
++            sB_packed = cute.make_tensor(storage.sB.data_ptr(), b_packed_smem_staged)
+             sB_up_packed = cute.make_tensor(
+                 storage.sB_up.data_ptr(), b_packed_smem_staged
+             )
+@@ -4196,15 +4192,7 @@ class MoEDynamicKernelBackend:
+             # region; A bufs in sA past the FC2-intermediate bytes; FC1
+             # residual bufs in sC (dead until the epilogue rendezvous); FC2
+             # residual bufs alias the (FC1-only) A-buf region.
+-            if cutlass.const_expr(self.w4a8_repacked):
+-                w4a8_sa0 = (
+-                    ctrl_base_addr
+-                    + Int32(Storage._offsets["sA"])
+-                    + Int32(self.tile_shape_mnk[0] * self.tile_shape_mnk[2])
+-                )
+-                w4a8_res0 = ctrl_base_addr + Int32(Storage._offsets["sC"])
+-                w4a8_res2 = w4a8_sa0
+-            elif cutlass.const_expr(self.w4a8_small):
++            if cutlass.const_expr(self.w4a8_repacked or self.w4a8_small):
+                 w4a8_sa0 = (
+                     ctrl_base_addr
+                     + Int32(Storage._offsets["sA"])
+@@ -5912,23 +5900,17 @@ class MoEDynamicKernelBackend:
+                                 zero_total = Int32(128) * sf_blocks_per_row
+                                 zero_idx = Int32(tidx)
+                                 while zero_idx < zero_total:
+-                                    st_shared_u8(
+-                                        sfa_base_addr + zero_idx, Uint8(0)
+-                                    )
++                                    st_shared_u8(sfa_base_addr + zero_idx, Uint8(0))
+                                     zero_idx += Int32(
+-                                        self.num_mma_warps
+-                                        * self.num_threads_per_warp
++                                        self.num_mma_warps * self.num_threads_per_warp
+                                     )
+                                 self.epilog_sync_barrier.arrive_and_wait()
+                                 zero_total_sa = Int32(128) * packed_cols
+                                 zsa_idx = Int32(tidx)
+                                 while zsa_idx < zero_total_sa:
+-                                    st_shared_u8(
+-                                        sa_base_addr + zsa_idx, Uint8(0)
+-                                    )
++                                    st_shared_u8(sa_base_addr + zsa_idx, Uint8(0))
+                                     zsa_idx += Int32(
+-                                        self.num_mma_warps
+-                                        * self.num_threads_per_warp
++                                        self.num_mma_warps * self.num_threads_per_warp
+                                     )
+                                 self.epilog_sync_barrier.arrive_and_wait()
+                             quant_gs_value = gs_value
+@@ -6015,9 +5997,7 @@ class MoEDynamicKernelBackend:
+                                             ]
+                                         )
+                                         values[elem_idx] = value
+-                                        block_max = fmax_f32(
+-                                            block_max, fabs_f32(value)
+-                                        )
++                                        block_max = fmax_f32(block_max, fabs_f32(value))
+                                     containers, scale_byte = (
+                                         moe_mxfp6_quantize_input_block_containers(
+                                             values,
+@@ -6036,9 +6016,7 @@ class MoEDynamicKernelBackend:
+                                     _row_flat = row * Int32(self.tile_shape_mnk[2])
+                                     for elem_idx in cutlass.range_constexpr(32):
+                                         _flat = (
+-                                            _row_flat
+-                                            + block_start
+-                                            + Int32(elem_idx)
++                                            _row_flat + block_start + Int32(elem_idx)
+                                         )
+                                         st_shared_u8(
+                                             sa_base_addr + (_flat ^ _row_sw),
+@@ -6058,9 +6036,7 @@ class MoEDynamicKernelBackend:
+                                             ]
+                                         )
+                                         values[elem_idx] = value
+-                                        block_max = fmax_f32(
+-                                            block_max, fabs_f32(value)
+-                                        )
++                                        block_max = fmax_f32(block_max, fabs_f32(value))
+ 
+                                     packed64 = Uint64(0)
+                                     scale_byte = Uint8(0)
+diff --git a/sparkinfer/moe/_shared/kernels/micro.py b/sparkinfer/moe/_shared/kernels/micro.py
+index 37bdd339fd7cd616c02c58aa33fe26ac474df25b..8892e215d878f3a9c7800d395a693326d3887c20 100644
+--- a/sparkinfer/moe/_shared/kernels/micro.py
++++ b/sparkinfer/moe/_shared/kernels/micro.py
+@@ -106,9 +106,7 @@ def _fp6_micro_enabled() -> bool:
+     Keeps the validated dynamic FP6 fused path as the only FP6 backend until
+     the micro kernel is wired into dispatch and numerically proven.
+     """
+-    return os.environ.get(
+-        "SPARKINFER_ENABLE_FP6_MICRO", "0"
+-    ).strip().lower() not in (
++    return os.environ.get("SPARKINFER_ENABLE_FP6_MICRO", "0").strip().lower() not in (
+         "",
+         "0",
+         "false",
+@@ -562,7 +560,11 @@ class MoEMicroKernelBackend:
+         col: Int32,
+         n_cols: Int32,
+     ) -> Float32:
+-        addr = base_addr + ebase + Int64(kb16) * Int64(n_cols) + Int64(col)
++        # ModelOpt's E4M3 scale permutation is tiled in 64 output rows. Direct
++        # micro preparation retains the final padded tile so every permuted
++        # logical scale remains addressable.
++        packed_n_cols = (n_cols + Int32(63)) & ~Int32(63)
++        addr = base_addr + ebase + Int64(kb16) * Int64(packed_n_cols) + Int64(col)
+         word = ld_global_nc_u32(addr & ~Int64(3))
+         byte = (word >> Uint32((addr & Int64(3)) * Int64(8))) & Uint32(0xFF)
+         return cvt_w4a16_packed_e4m3_scale_to_f32(byte)
+@@ -712,11 +714,32 @@ class MoEMicroKernelBackend:
+                 rows_per_warp_div = 4
+             elif cfg.k_segments_aligned and cfg.k_segments == 12 and self.is_gated:
+                 rows_per_warp_div = 1
+-            num_fc1_chunks = min(num_fc1_chunks, n // (rows_per_warp_div * _BLOCK_SIZE))
++            num_fc1_chunks = min(
++                num_fc1_chunks,
++                max(1, n // (rows_per_warp_div * _BLOCK_SIZE)),
++            )
++            # The retile cap is a floor division, so it can choose a chunk
++            # count that no longer partitions a merely 16-aligned native
++            # ModelOpt intermediate (for example, n=144 caps 9 chunks at 4,
++            # yielding a truncated 36-value chunk). Walk down to the largest
++            # valid divisor so every FC1 chunk covers whole 16-value blocks.
++            # Aligned production shapes retain their existing geometry.
++            while num_fc1_chunks > 1 and (
++                n % num_fc1_chunks != 0 or (n // num_fc1_chunks) % _BLOCK_SIZE != 0
++            ):
++                num_fc1_chunks -= 1
+         if self.w4a16_mode and m > 1:
+             # Keep W4A16 multi-token FC1 chunks narrow enough to stay within
+-            # the 512-thread launch register limit.
+-            num_fc1_chunks = max(num_fc1_chunks, n // (_BLOCK_SIZE * 2))
++            # the 512-thread launch register limit. The chunk count must still
++            # divide n into whole 16-value blocks: floor(n/32) silently made
++            # i_chunk non-integral at shapes such as n=144 (four 36-value
++            # chunks), so FC1 wrote only 128 of 144 logical values.
++            num_fc1_chunks = max(
++                num_fc1_chunks,
++                (n + (_BLOCK_SIZE * 2) - 1) // (_BLOCK_SIZE * 2),
++            )
++            while n % num_fc1_chunks != 0 or (n // num_fc1_chunks) % _BLOCK_SIZE != 0:
++                num_fc1_chunks += 1
+         if self.a8_mx_mode:
+             # Per-32 self-ranging blocks: chunks must hold whole 32-blocks
+             # (the default policy picks i_chunk=16 at m<=2).
+@@ -752,9 +775,7 @@ class MoEMicroKernelBackend:
+             # Likewise FC2 can expose every output-row task directly once
+             # FC1 has completed in a prior launch.
+             grid_x = max(1, fc2_tasks)
+-        elif m == 1:
+-            grid_x = max(1, min(int(max_active_ctas), max(fc1_tasks, fc2_tasks)))
+-        elif m == 2:
++        elif m in (1, 2):
+             grid_x = max(1, min(int(max_active_ctas), max(fc1_tasks, fc2_tasks)))
+         elif num_fc1_chunks < 16:
+             grid_x = max(1, min(int(max_active_ctas), fc2_tasks))
+@@ -815,11 +836,18 @@ class MoEMicroKernelBackend:
+         k_row1 = k_row0 + Int32(1)
+ 
+         lane_byte_off = Int64(lane) * Int64(4)
+-        n_u32_per_expert = Int32(cfg.fc2_n_chunks * 128)
+         sf_cols = Int32(cfg.w2_sf_cols)
+         num_cb = sf_cols >> Int32(2)
+         lane_cb = lane >> Int32(3)
+         w_valid = Int32(1) if lane_cb < num_cb else Int32(0)
++        if cutlass.const_expr(self.w4a16_mode and cfg.n % 64 != 0):
++            # Native ModelOpt rows contain exactly n/8 packed u32 values.
++            # w2_sf_cols is padded to four scale columns, so its control-block
++            # count overstates the physical W2/packed-scale extent when n is a
++            # multiple of 16 but not 64 (for example, n=144). Keep the existing
++            # predicate byte-for-byte for the aligned production shapes, and
++            # gate odd-shape loads against the logical packed row instead.
++            w_valid = Int32(1) if lane < Int32(cfg.n // 8) else Int32(0)
+         lane_mode_c = (lane >> Int32(1)) & Int32(3)
+         bsf_byte_shift = lane_mode_c * Int32(8)
+         out_acc0 = Float32(0.0)
+@@ -857,10 +885,38 @@ class MoEMicroKernelBackend:
+             row_mode_32_1 = k_row1 & Int32(31)
+ 
+             kk_off = Int32(kk) * Int32(128)
+-            xh0 = Uint32(intermediate[kk_off + Int32(0 * 32) + lane])
+-            xh1 = Uint32(intermediate[kk_off + Int32(1 * 32) + lane])
+-            xh2 = Uint32(intermediate[kk_off + Int32(2 * 32) + lane])
+-            xh3 = Uint32(intermediate[kk_off + Int32(3 * 32) + lane])
++            if cutlass.const_expr(cfg.n < 256):
++                # The 128-u32 swizzle block pads narrow intermediates to 256
++                # logical values. FC1 writes only n/8 lanes in each 32-lane
++                # plane. Mask the remaining lanes before the dot: their
++                # weights are zero, but stale NaN scratch would make 0*NaN
++                # contaminate the warp reduction.
++                inter_valid = Int32(1) if lane < Int32(cfg.n // 8) else Int32(0)
++                xh0 = (
++                    Uint32(intermediate[kk_off + Int32(0 * 32) + lane])
++                    if inter_valid > Int32(0)
++                    else Uint32(0)
++                )
++                xh1 = (
++                    Uint32(intermediate[kk_off + Int32(1 * 32) + lane])
++                    if inter_valid > Int32(0)
++                    else Uint32(0)
++                )
++                xh2 = (
++                    Uint32(intermediate[kk_off + Int32(2 * 32) + lane])
++                    if inter_valid > Int32(0)
++                    else Uint32(0)
++                )
++                xh3 = (
++                    Uint32(intermediate[kk_off + Int32(3 * 32) + lane])
++                    if inter_valid > Int32(0)
++                    else Uint32(0)
++                )
++            else:
++                xh0 = Uint32(intermediate[kk_off + Int32(0 * 32) + lane])
++                xh1 = Uint32(intermediate[kk_off + Int32(1 * 32) + lane])
++                xh2 = Uint32(intermediate[kk_off + Int32(2 * 32) + lane])
++                xh3 = Uint32(intermediate[kk_off + Int32(3 * 32) + lane])
+ 
+             u_packed0 = (
+                 ld_global_nc_u32(
+@@ -1058,12 +1114,23 @@ class MoEMicroKernelBackend:
+                 kk_off = Int32(kk) * n_u32_per_expert + chunk_base
+                 cb_idx = Int32(nc) * Int32(4) + lane_cb
+                 w_valid = Int32(1) if cb_idx < num_cb else Int32(0)
+-                # If the last 256-wide chunk overhangs a non-256-aligned n
+-                # (e.g. n=384), lanes past num_cb index the uninitialized
+-                # intermediate tail. The weight there is already masked to 0,
+-                # but 0 * NaN = NaN, so mask the activation read too. Gated by
+-                # constexpr so 256-aligned shapes emit no extra runtime work.
+-                if cutlass.const_expr((cfg.w2_sf_cols >> 2) < cfg.fc2_n_chunks * 4):
++                if cutlass.const_expr(self.w4a16_mode and cfg.n % 64 != 0):
++                    packed_u32 = Int32(nc * 32) + lane
++                    w_valid = Int32(1) if packed_u32 < Int32(cfg.n // 8) else Int32(0)
++                # If the last 256-value chunk overhangs logical n, lanes past
++                # the exact native row read an unwritten intermediate tail.
++                # The padded scale grid can look full at widths such as n=496,
++                # so its control-block count is not a valid activation bound.
++                # The weight is zero there, but 0 * NaN still poisons the sum.
++                # Preserve the legacy predicate for non-W4A16 modes and emit
++                # no extra work for 256-aligned native ModelOpt shapes.
++                if cutlass.const_expr(
++                    (self.w4a16_mode and cfg.n % 256 != 0)
++                    or (
++                        (not self.w4a16_mode)
++                        and (cfg.w2_sf_cols >> 2) < cfg.fc2_n_chunks * 4
++                    )
++                ):
+                     xh0 = (
+                         Uint32(intermediate[kk_off + Int32(0 * 32) + lane])
+                         if w_valid > Int32(0)
+@@ -1246,7 +1313,6 @@ class MoEMicroKernelBackend:
+         k_row3 = k_row0 + Int32(3)
+ 
+         lane_byte_off = Int64(lane) * Int64(4)
+-        n_u32_per_expert = Int32(cfg.fc2_n_chunks * 128)
+         token_inter_base = t * Int32(cfg.inter_u32)
+         sf_cols = Int32(cfg.w2_sf_cols)
+         num_cb = sf_cols >> Int32(2)
+@@ -1471,6 +1537,8 @@ class MoEMicroKernelBackend:
+         num_cb = sf_cols >> Int32(2)
+         lane_cb = lane >> Int32(3)
+         w_valid = Int32(1) if lane_cb < num_cb else Int32(0)
++        if cutlass.const_expr(self.w4a16_mode and cfg.n % 64 != 0):
++            w_valid = Int32(1) if lane < Int32(cfg.n // 8) else Int32(0)
+         lane_mode_c = (lane >> Int32(1)) & Int32(3)
+         bsf_byte_shift = lane_mode_c * Int32(8)
+         out_acc0 = Float32(0.0)
+@@ -1508,10 +1576,36 @@ class MoEMicroKernelBackend:
+             ebase_sf_packed_e4m3 = Int64(eid) * Int64((cfg.n // 16) * cfg.k_dim)
+ 
+             kk_off = token_inter_base + Int32(kk) * Int32(128)
+-            xh0 = Uint32(intermediate[kk_off + Int32(0 * 32) + lane])
+-            xh1 = Uint32(intermediate[kk_off + Int32(1 * 32) + lane])
+-            xh2 = Uint32(intermediate[kk_off + Int32(2 * 32) + lane])
+-            xh3 = Uint32(intermediate[kk_off + Int32(3 * 32) + lane])
++            if cutlass.const_expr(cfg.n < 256):
++                # Match the m==1 path above: the packed 128-u32 swizzle has
++                # unwritten padding whenever the logical intermediate is
++                # narrower than 256 values.
++                inter_valid = Int32(1) if lane < Int32(cfg.n // 8) else Int32(0)
++                xh0 = (
++                    Uint32(intermediate[kk_off + Int32(0 * 32) + lane])
++                    if inter_valid > Int32(0)
++                    else Uint32(0)
++                )
++                xh1 = (
++                    Uint32(intermediate[kk_off + Int32(1 * 32) + lane])
++                    if inter_valid > Int32(0)
++                    else Uint32(0)
++                )
++                xh2 = (
++                    Uint32(intermediate[kk_off + Int32(2 * 32) + lane])
++                    if inter_valid > Int32(0)
++                    else Uint32(0)
++                )
++                xh3 = (
++                    Uint32(intermediate[kk_off + Int32(3 * 32) + lane])
++                    if inter_valid > Int32(0)
++                    else Uint32(0)
++                )
++            else:
++                xh0 = Uint32(intermediate[kk_off + Int32(0 * 32) + lane])
++                xh1 = Uint32(intermediate[kk_off + Int32(1 * 32) + lane])
++                xh2 = Uint32(intermediate[kk_off + Int32(2 * 32) + lane])
++                xh3 = Uint32(intermediate[kk_off + Int32(3 * 32) + lane])
+ 
+             u_packed0 = (
+                 ld_global_nc_u32(
+@@ -1726,9 +1820,20 @@ class MoEMicroKernelBackend:
+                 chunk_base = Int32(nc) * Int32(128)
+                 cb_idx = Int32(nc) * Int32(4) + lane_cb
+                 w_valid = Int32(1) if cb_idx < num_cb else Int32(0)
++                if cutlass.const_expr(self.w4a16_mode and cfg.n % 64 != 0):
++                    packed_u32 = Int32(nc * 32) + lane
++                    w_valid = Int32(1) if packed_u32 < Int32(cfg.n // 8) else Int32(0)
+                 if cutlass.const_expr(nc + 1 < cfg.fc2_n_chunks):
+                     next_cb_idx = Int32(nc + 1) * Int32(4) + lane_cb
+-                    if next_cb_idx < num_cb:
++                    next_w_valid = Int32(1) if next_cb_idx < num_cb else Int32(0)
++                    if cutlass.const_expr(self.w4a16_mode and cfg.n % 64 != 0):
++                        next_packed_u32 = Int32((nc + 1) * 32) + lane
++                        next_w_valid = (
++                            Int32(1)
++                            if next_packed_u32 < Int32(cfg.n // 8)
++                            else Int32(0)
++                        )
++                    if next_w_valid > Int32(0):
+                         next_chunk_base = Int32(nc + 1) * Int32(128)
+                         prefetch_global_l2(
+                             w2_base_addr
+@@ -1766,7 +1871,12 @@ class MoEMicroKernelBackend:
+                         cfg.w2_sf_rows * cfg.w2_sf_cols
+                     )
+                     next_cb_idx = lane_cb
+-                    if next_cb_idx < num_cb:
++                    next_w_valid = Int32(1) if next_cb_idx < num_cb else Int32(0)
++                    if cutlass.const_expr(self.w4a16_mode and cfg.n % 64 != 0):
++                        next_w_valid = (
++                            Int32(1) if lane < Int32(cfg.n // 8) else Int32(0)
++                        )
++                    if next_w_valid > Int32(0):
+                         prefetch_global_l2(
+                             w2_base_addr
+                             + next_ebase_w
+@@ -1831,9 +1941,15 @@ class MoEMicroKernelBackend:
+                                 w2s_base_addr + next_ebase_sf + next_bsf_off3
+                             )
+                 kk_off = token_inter_base + Int32(kk) * n_u32_per_expert + chunk_base
+-                # See _m1_fc2_rowpair_wide: mask the intermediate tail read for
+-                # non-256-aligned n (0 weight * NaN tail = NaN). constexpr-gated.
+-                if cutlass.const_expr((cfg.w2_sf_cols >> 2) < cfg.fc2_n_chunks * 4):
++                # See _m1_fc2_rowpair_wide: logical n, not the padded scale
++                # grid, determines whether the native intermediate tail is live.
++                if cutlass.const_expr(
++                    (self.w4a16_mode and cfg.n % 256 != 0)
++                    or (
++                        (not self.w4a16_mode)
++                        and (cfg.w2_sf_cols >> 2) < cfg.fc2_n_chunks * 4
++                    )
++                ):
+                     xh0 = (
+                         Uint32(intermediate[kk_off + Int32(0 * 32) + lane])
+                         if w_valid > Int32(0)
+@@ -2366,8 +2482,11 @@ class MoEMicroKernelBackend:
+             # ---- FC1 weight load + dot product ----
+             ebase_w = Int64(eid) * Int64(cfg.two_n) * Int64(cfg.k_half)
+             ebase_sf = Int64(eid) * Int64(cfg.w1_sf_rows * cfg.w1_sf_cols)
+-            ebase_sf_packed = Int64(eid) * Int64((cfg.k_dim // 32) * cfg.two_n)
+-            ebase_sf_packed_e4m3 = Int64(eid) * Int64((cfg.k_dim // 16) * cfg.two_n)
++            e8m0_w1_n_cols = _align_up(cfg.two_n, 64)
++            ebase_sf_packed = Int64(eid) * Int64((cfg.k_dim // 32) * e8m0_w1_n_cols)
++            ebase_sf_packed_e4m3 = Int64(eid) * Int64(
++                (cfg.k_dim // 16) * _align_up(cfg.two_n, 64)
++            )
+             thread_byte_off = Int64(lane) * Int64(cfg.k_half // 32)
+             xh_buf_base = Int32(0)
+             if cutlass.const_expr(cfg.k_segments == 2):
+@@ -2537,7 +2656,7 @@ class MoEMicroKernelBackend:
+ 
+                         if cutlass.const_expr(self.scale_format_e8m0_k32):
+                             kbb = (lane * Int32(cfg.k_segments)) >> Int32(1)
+-                            nc1 = Int32(cfg.two_n)
++                            nc1 = Int32(e8m0_w1_n_cols)
+                             u_k0 = self._ld_e8m0_scale(
+                                 w1s_base_addr,
+                                 ebase_sf_packed,
+@@ -2661,7 +2780,7 @@ class MoEMicroKernelBackend:
+ 
+                     if cutlass.const_expr(self.scale_format_e8m0_k32):
+                         kbbg = (lane * Int32(cfg.k_segments)) >> Int32(1)
+-                        nc1g = Int32(cfg.two_n)
++                        nc1g = Int32(e8m0_w1_n_cols)
+                         g_k0 = self._ld_e8m0_scale(
+                             w1s_base_addr,
+                             ebase_sf_packed,
+@@ -2978,7 +3097,7 @@ class MoEMicroKernelBackend:
+                         sf_u5 = Float32(0.0)
+                         if cutlass.const_expr(self.scale_format_e8m0_k32):
+                             kbb_u = lane_seg_base >> Int32(1)
+-                            nc_u = Int32(cfg.two_n)
++                            nc_u = Int32(e8m0_w1_n_cols)
+                             u_k0 = self._ld_e8m0_scale(
+                                 w1s_base_addr,
+                                 ebase_sf_packed,
+@@ -3118,7 +3237,7 @@ class MoEMicroKernelBackend:
+                     sf_g5 = Float32(0.0)
+                     if cutlass.const_expr(self.scale_format_e8m0_k32):
+                         kbb_g = lane_seg_base >> Int32(1)
+-                        nc_g = Int32(cfg.two_n)
++                        nc_g = Int32(e8m0_w1_n_cols)
+                         g_k0 = self._ld_e8m0_scale(
+                             w1s_base_addr,
+                             ebase_sf_packed,
+@@ -3356,7 +3475,7 @@ class MoEMicroKernelBackend:
+ 
+                         if cutlass.const_expr(self.scale_format_e8m0_k32):
+                             kbb_u = (lane * Int32(cfg.k_segments)) >> Int32(1)
+-                            nc_u = Int32(cfg.two_n)
++                            nc_u = Int32(e8m0_w1_n_cols)
+                             u_k0 = self._ld_e8m0_scale(
+                                 w1s_base_addr,
+                                 ebase_sf_packed,
+@@ -3538,7 +3657,7 @@ class MoEMicroKernelBackend:
+ 
+                     if cutlass.const_expr(self.scale_format_e8m0_k32):
+                         kbb_g = (lane * Int32(cfg.k_segments)) >> Int32(1)
+-                        nc_g = Int32(cfg.two_n)
++                        nc_g = Int32(e8m0_w1_n_cols)
+                         g_k0 = self._ld_e8m0_scale(
+                             w1s_base_addr,
+                             ebase_sf_packed,
+@@ -3833,7 +3952,7 @@ class MoEMicroKernelBackend:
+                                 ebase_sf_packed,
+                                 lane,
+                                 row_u,
+-                                Int32(cfg.two_n),
++                                Int32(e8m0_w1_n_cols),
+                                 Int32(cfg.k_dim // 32),
+                             )
+                             sf_u1 = sf_u0
+@@ -3869,7 +3988,7 @@ class MoEMicroKernelBackend:
+                             ebase_sf_packed,
+                             lane,
+                             row_g,
+-                            Int32(cfg.two_n),
++                            Int32(e8m0_w1_n_cols),
+                             Int32(cfg.k_dim // 32),
+                         )
+                         sf_g1 = sf_g0
+@@ -4363,7 +4482,7 @@ class MoEMicroKernelBackend:
+                                         ebase_sf_packed,
+                                         scale_col >> Int32(1),
+                                         row_g,
+-                                        Int32(cfg.two_n),
++                                        Int32(e8m0_w1_n_cols),
+                                         Int32(cfg.k_dim // 32),
+                                     )
+                                     if valid_seg > Int32(0)
+@@ -4420,7 +4539,7 @@ class MoEMicroKernelBackend:
+                                             ebase_sf_packed,
+                                             scale_col >> Int32(1),
+                                             row_u,
+-                                            Int32(cfg.two_n),
++                                            Int32(e8m0_w1_n_cols),
+                                             Int32(cfg.k_dim // 32),
+                                         )
+                                         if valid_seg > Int32(0)
+diff --git a/sparkinfer/moe/_shared/kernels/w4a16/host.py b/sparkinfer/moe/_shared/kernels/w4a16/host.py
+index e4c22cec140e0741980e5fd00f4642ce02601c0e..a586ffa890fcc5861ce2ddd36936a343aff9d86a 100644
+--- a/sparkinfer/moe/_shared/kernels/w4a16/host.py
++++ b/sparkinfer/moe/_shared/kernels/w4a16/host.py
+@@ -219,6 +219,20 @@ def select_route_block_size_m(m: int, topk: int, num_experts: int) -> int:
+     return _W4A16_ALLOWED_ROUTED_SIZES[-1]
+ 
+ 
++def route_block_sizes_for_capacity(
++    max_tokens: int,
++    topk: int,
++    num_experts: int,
++) -> tuple[int, ...]:
++    """Conservative block-size set reachable within a token capacity."""
++    max_tokens = max(int(max_tokens), 1)
++    first = select_route_block_size_m(1, topk, num_experts)
++    last = select_route_block_size_m(max_tokens, topk, num_experts)
++    first_idx = _W4A16_ALLOWED_ROUTED_SIZES.index(first)
++    last_idx = _W4A16_ALLOWED_ROUTED_SIZES.index(last)
++    return _W4A16_ALLOWED_ROUTED_SIZES[first_idx : last_idx + 1]
++
++
+ def max_packed_route_slots(numel: int, block_size: int, num_experts: int) -> int:
+     max_packed_routes = int(numel) + int(num_experts) * (int(block_size) - 1)
+     if int(numel) < int(num_experts):
+@@ -240,6 +254,27 @@ def route_pack_token_capacity(tokens: int, topk: int) -> int:
+     return 1 << (max(int(tokens), 1) - 1).bit_length()
+ 
+ 
++def route_pack_capacity(
++    numel: int,
++    block_size: int,
++    num_experts: int,
++    *,
++    topk: int = 1,
++    bucket_tokens: bool = True,
++) -> tuple[int, int, int]:
++    """Return the canonical routed-row, packed-slot, and block capacities."""
++    numel_capacity = (
++        route_pack_numel_capacity(numel, topk=topk)
++        if bucket_tokens
++        else max(int(numel), 1)
++    )
++    packed_routes = max_packed_route_slots(
++        numel_capacity, int(block_size), int(num_experts)
++    )
++    route_blocks = (packed_routes + int(block_size) - 1) // int(block_size)
++    return max(numel_capacity, 1), max(packed_routes, 1), max(route_blocks, 1)
++
++
+ def max_w4a16_route_capacity(routed_rows: int, num_experts: int) -> tuple[int, int]:
+     route_slots = 0
+     route_blocks = 0
+@@ -432,6 +467,7 @@ __all__ = [
+     "plan_w4a16_buffers",
+     "reorder_w13_to_gate_up",
+     "route_pack_numel_capacity",
++    "route_pack_capacity",
+     "route_pack_token_capacity",
+     "select_route_block_size_m",
+     "unswizzle_block_scale",
+diff --git a/sparkinfer/moe/_shared/kernels/w4a16/kernel.py b/sparkinfer/moe/_shared/kernels/w4a16/kernel.py
+index 1dfb95d046abc8641cca83a4f07fd989ae1802f2..13f76a987cd7b25f8b2c884e261f8e737b61784c 100644
+--- a/sparkinfer/moe/_shared/kernels/w4a16/kernel.py
++++ b/sparkinfer/moe/_shared/kernels/w4a16/kernel.py
+@@ -14,7 +14,7 @@ import cutlass.cute as cute
+ import torch
+ from cutlass.base_dsl.compiler import OptLevel
+ from cutlass._mlir.dialects import llvm
+-from cutlass.cutlass_dsl import Int32, Int64, T, Uint32, Uint64, dsl_user_op
++from cutlass.cutlass_dsl import Int32, Int64, T, Uint32, dsl_user_op
+ 
+ from sparkinfer._lib.compiler import (
+     KernelCompileSpec,
+@@ -78,6 +78,7 @@ from sparkinfer._lib.intrinsics import (
+     st_shared_v4_f32,
+     st_shared_v4_u32,
+     threadfence,
++    trellis_align_stream_u32x2,
+     warp_reduce,
+ )
+ from sparkinfer._lib.utils import current_cuda_stream, make_ptr
+@@ -201,10 +202,18 @@ _W4A16_REGS_SM121 = {
+     (256, 2, 16, 4, False): 212,
+     (128, 2, 4, 8, False): 215,
+     (128, 2, 8, 4, False): 214,
++    # Measured from the spill-free mixed-Trellis block-32 prefill kernel.
++    # FC2 keeps the paired-M8 schedule qualified by mixed_trellis.py.
++    (256, 2, 8, 8, False): 175,
+     (256, 3, 16, 4, False): 249,
+     (128, 3, 4, 8, False): 249,
+     (128, 3, 8, 4, False): 250,
+     (256, 4, 16, 4, False): 255,
++    # Measured by the mixed-Trellis block-64 qualification gate. This is the
++    # stock one-grid prefill tile geometry (N=128, K=128) with four 16-row
++    # route blocks per CTA. Keeping the measured entry permits block-64
++    # routing without changing the K3/K4 accumulation geometry.
++    (256, 4, 8, 8, False): 255,
+     (128, 4, 4, 8, False): 255,
+     (128, 4, 8, 4, False): 255,
+ }
+@@ -703,6 +712,8 @@ class W4A16GemmKernel:
+         fused_sum_topk: int = 1,
+         schedule_whole_tiles: bool = False,
+         dynamic_num_experts: bool = False,
++        schedule_route_block_factor: int = 1,
++        paired_m8_routes: bool = False,
+     ):
+         if element_dtype not in {"bf16", "fp16"}:
+             raise ValueError(f"unsupported element_dtype {element_dtype!r}")
+@@ -887,6 +898,18 @@ class W4A16GemmKernel:
+         # the split-K tail machinery entirely. Requires the host to bound the
+         # wave count; used by the exact-geometry hybrid decode schedule.
+         self.schedule_whole_tiles = bool(schedule_whole_tiles)
++        self.schedule_route_block_factor = int(schedule_route_block_factor)
++        if self.schedule_route_block_factor < 1:
++            raise ValueError("schedule_route_block_factor must be >= 1")
++        if self.schedule_route_block_factor != 1 and (
++            not self.schedule_whole_tiles
++            or self.direct_topk_routes
++            or self.dense_route_fast_path
++        ):
++            raise ValueError(
++                "grouped route-block scheduling requires route-packed "
++                "whole-tile execution"
++            )
+         if (
+             self.schedule_whole_tiles
+             and not self.direct_topk_routes
+@@ -901,6 +924,16 @@ class W4A16GemmKernel:
+             raise ValueError("fused_sum_topk must be >= 1")
+         self.cta_m_blocks = int(_covering_count(moe_block_size, 16))
+         self.uses_m_block_8 = moe_block_size == 8
++        self.paired_m8_routes = bool(paired_m8_routes)
++        if self.paired_m8_routes and (
++            not self.uses_m_block_8
++            or not self.schedule_whole_tiles
++            or self.schedule_route_block_factor != 2
++        ):
++            raise ValueError(
++                "paired_m8_routes requires M8 whole-tile scheduling with "
++                "schedule_route_block_factor=2"
++            )
+         self.max_m_blocks = int(max_m_blocks)
+         if torch.cuda.is_available():
+             props = torch.cuda.get_device_properties(torch.cuda.current_device())
+@@ -932,6 +965,11 @@ class W4A16GemmKernel:
+         # W4A16 shared-memory geometry, in int4 units unless noted.
+         self.a_sh_stride = 16 * self.cta_k_blocks // 8
+         self.a_sh_stage = self.a_sh_stride * (16 * self.cta_m_blocks)
++        if self.paired_m8_routes:
++            # The M8 ldmatrix mapping consumes a padded 16-row slab: rows 8-15
++            # must remain zero.  A paired tile therefore needs two independent
++            # 16-row slabs even though only eight rows in each slab are live.
++            self.a_sh_stage *= 2
+         self.a_gl_rd_delta_o = 16 * self.cta_k_blocks // 8
+         self.a_sh_wr_delta = self.a_sh_stride * (
+             self.cta_threads // self.a_gl_rd_delta_o
+@@ -973,9 +1011,10 @@ class W4A16GemmKernel:
+         self.s_sh_stage = self.s_tb_groups * self.s_sh_stride
+         self.tb_n_warps = self.cta_n_blocks // 4
+ 
+-        sh_block_route_indices = self.moe_block_size // 4
+-        sh_rd_block_route_indices = self.moe_block_size // 4
+-        sh_block_topk_weights = self.moe_block_size // 2
++        route_metadata_rows = self.moe_block_size * (2 if self.paired_m8_routes else 1)
++        sh_block_route_indices = route_metadata_rows // 4
++        sh_rd_block_route_indices = route_metadata_rows // 4
++        sh_block_topk_weights = route_metadata_rows // 2
+         self.sh_valid_count_off = (
+             sh_block_route_indices + sh_rd_block_route_indices + sh_block_topk_weights
+         )
+@@ -1045,6 +1084,8 @@ class W4A16GemmKernel:
+             # entry even when their arithmetic geometry otherwise matches.
+             self.blocks_per_sm,
+             self.schedule_whole_tiles,
++            self.schedule_route_block_factor,
++            self.paired_m8_routes,
+         )
+ 
+     @cute.jit
+@@ -1058,6 +1099,13 @@ class W4A16GemmKernel:
+     def _int4_addr(self, smem_base: Int32, int4_off: Int32) -> Int32:
+         return smem_base + int4_off * Int32(16)
+ 
++    @cute.jit
++    def _epilogue_sync(self, sync_barrier: cutlass.Constexpr = None):
++        if cutlass.const_expr(sync_barrier is None):
++            cute.arch.sync_threads()
++        else:
++            sync_barrier.arrive_and_wait()
++
+     @cute.jit
+     def _dequant_e2m1x4_to_elem2x2(self, packed: Uint32):
+         if cutlass.const_expr(self.is_fp16):
+@@ -1300,7 +1348,7 @@ class W4A16GemmKernel:
+             ) // Int32(self.moe_block_size)
+         elif cutlass.const_expr(not self.direct_topk_routes):
+             route_blocks = packed_route_count[Int32(0)].to(Int32) // Int32(
+-                self.moe_block_size
++                self.moe_block_size * self.schedule_route_block_factor
+             )
+         k_tiles = Int32(self.k_tiles)
+         global_mn_tiles = route_blocks * n_tiles
+@@ -1626,6 +1674,84 @@ class W4A16GemmKernel:
+         cute.arch.sync_threads()
+         return valid_count
+ 
++    @cute.jit
++    def _read_moe_block_data_pair(
++        self,
++        packed_route_indices: cute.Tensor,
++        topk_weights_flat: cute.Tensor,
++        smem_base: Int32,
++        tid: Int32,
++        route_block_idx: Int32,
++        global_scale_f32: cutlass.Float32,
++        active_size_m: Int32,
++    ):
++        """Load two adjacent M8 route blocks into one 16-row metadata slab."""
++        route_indices_int4_addr = self._int4_addr(
++            smem_base, Int32(self.sh_route_off) + tid
++        )
++        route_indices_gmem = get_ptr_as_int64(
++            packed_route_indices,
++            route_block_idx * Int32(self.moe_block_size) + tid * Int32(4),
++        )
++        cp_async4_shared_global_pred(
++            route_indices_int4_addr,
++            route_indices_gmem,
++            (tid < Int32(2 * self.moe_block_size // 4)).to(Int32),
++        )
++        cute.arch.cp_async_commit_group()
++        cute.arch.cp_async_wait_group(0)
++        cute.arch.sync_threads()
++
++        if tid >= Int32(self.cta_threads - 32):
++            lane = tid - Int32(self.cta_threads - 32)
++            valid0 = Int32(0)
++            valid1 = Int32(0)
++            if lane < Int32(2 * self.moe_block_size):
++                idx = ld_shared_i32_relaxed(
++                    smem_base + Int32(self.sh_route_off * 16) + lane * Int32(4)
++                )
++                valid = (idx < active_size_m * Int32(self.top_k)).to(Int32)
++                if lane < Int32(self.moe_block_size):
++                    valid0 = valid
++                else:
++                    valid1 = valid
++            valid0 = cute.arch.warp_redux_sync(valid0, "add")
++            valid1 = cute.arch.warp_redux_sync(valid1, "add")
++            if lane == Int32(0):
++                valid_addr = smem_base + Int32(self.sh_valid_count_off * 16)
++                st_shared_i32(valid_addr, valid0)
++                st_shared_i32(valid_addr + Int32(4), valid1)
++
++        if tid < Int32(2 * self.moe_block_size):
++            idx = ld_shared_i32_relaxed(
++                smem_base + Int32(self.sh_route_off * 16) + tid * Int32(4)
++            )
++            rd_row = idx // Int32(self.top_k)
++            if cutlass.const_expr(self.route_major_a):
++                rd_row = idx
++            st_shared_i32(
++                smem_base + Int32(self.sh_rd_route_off * 16) + tid * Int32(4),
++                rd_row,
++            )
++            if cutlass.const_expr(self.mul_topk_weights):
++                safe_idx = idx
++                if idx >= active_size_m * Int32(self.top_k):
++                    safe_idx = Int32(0)
++                topk = (
++                    topk_weights_flat[safe_idx].to(cutlass.Float32) * global_scale_f32
++                )
++                st_shared_u32(
++                    smem_base + Int32(self.sh_topk_off * 16) + tid * Int32(4),
++                    self._broadcast_f32_to_elem2(topk),
++                )
++
++        cute.arch.sync_threads()
++        valid_addr = smem_base + Int32(self.sh_valid_count_off * 16)
++        block_valid_rows0 = ld_shared_i32_relaxed(valid_addr)
++        block_valid_rows1 = ld_shared_i32_relaxed(valid_addr + Int32(4))
++        cute.arch.sync_threads()
++        return block_valid_rows0, block_valid_rows1
++
+     @cute.jit
+     def _run_tile(
+         self,
+@@ -1757,6 +1883,42 @@ class W4A16GemmKernel:
+             s_sh_rd,
+         )
+ 
++    @cute.jit
++    def _tile_common_prologue_pair(
++        self,
++        global_scale: cute.Tensor,
++        packed_route_indices: cute.Tensor,
++        topk_weights_flat: cute.Tensor,
++        smem_base: Int32,
++        tid: Int32,
++        route_block_idx: Int32,
++        expert_idx: Int32,
++        output_n_tile: Int32,
++        active_size_m: Int32,
++    ):
++        global_scale_f32 = global_scale[expert_idx].to(cutlass.Float32)
++        if cutlass.const_expr(self.scale_format_e8m0_k32):
++            if cutlass.const_expr(self.is_fp16):
++                global_scale_f32 *= cutlass.Float32(_E8M0_K32_FP16_GLOBAL_COMPENSATION)
++            else:
++                global_scale_f32 *= cutlass.Float32(_E8M0_K32_BF16_GLOBAL_COMPENSATION)
++        block_valid_rows0, block_valid_rows1 = self._read_moe_block_data_pair(
++            packed_route_indices,
++            topk_weights_flat,
++            smem_base,
++            tid,
++            route_block_idx,
++            global_scale_f32,
++            active_size_m,
++        )
++        offsets = self._tile_stream_offsets(tid, expert_idx, output_n_tile)
++        return (
++            global_scale_f32,
++            block_valid_rows0,
++            block_valid_rows1,
++            *offsets,
++        )
++
+     @cute.jit
+     def _tile_stream_offsets(self, tid: Int32, expert_idx: Int32, output_n_tile: Int32):
+         a_gl_stride = Int32(self.size_k // 8)
+@@ -1896,6 +2058,8 @@ class W4A16GemmKernel:
+             k_tiles,
+             reduce_k_tile,
+             block_valid_rows,
++            Int32(0),
++            False,
+             a_gl_stride,
+             b_gl_stride,
+             s_gl_stride,
+@@ -1977,12 +2141,201 @@ class W4A16GemmKernel:
+             tid,
+             output_n_tile,
+             block_valid_rows,
++            Int32(0),
++            global_scale_f32,
++            reduce_slice_count,
++            reduce_slice_idx,
++            lock_slot,
++            True,
++        )
++
++    @cute.jit
++    def _run_tile_m8_pair(
++        self,
++        a_bf16_flat: cute.Tensor,
++        a_alt_bf16_flat: cute.Tensor,
++        b_i32_flat: cute.Tensor,
++        c_bf16_flat: cute.Tensor,
++        scales_i32_flat: cute.Tensor,
++        global_scale: cute.Tensor,
++        packed_route_indices: cute.Tensor,
++        topk_weights_flat: cute.Tensor,
++        c_tmp_f32_flat: cute.Tensor,
++        locks_i32_flat: cute.Tensor,
++        smem_base: Int32,
++        tid: Int32,
++        route_block_idx: Int32,
++        expert_idx: Int32,
++        output_n_tile: Int32,
++        reduce_k_tile: Int32,
++        reduce_tile_count: Int32,
++        reduce_slice_count: Int32,
++        reduce_slice_idx: Int32,
++        lock_slot: Int32,
++        active_size_m: Int32,
++    ):
++        (
++            global_scale_f32,
++            block_valid_rows0,
++            block_valid_rows1,
++            a_gl_stride,
++            b_gl_stride,
++            s_gl_stride,
++            scales_expert_off,
++            b_gl_rd_base,
++            a_gl_rd_row,
++            a_gl_rd_col0,
++            a_sh_wr,
++            a_rows_per_iter,
++            b_sh_rd,
++            s_sh_rd,
++        ) = self._tile_common_prologue_pair(
++            global_scale,
++            packed_route_indices,
++            topk_weights_flat,
++            smem_base,
++            tid,
++            route_block_idx,
++            expert_idx,
++            output_n_tile,
++            active_size_m,
++        )
++        a0_sh_rd = self._a_shared_read_offset(tid, 8)
++        a1_sh_rd = a0_sh_rd + Int32(self.a_sh_rd_delta_i)
++
++        acc0 = [
++            cute.make_rmem_tensor((_SCALAR_ACC_FRAGMENT_WIDTH,), cutlass.Float32)
++            for _ in range(16 // _SCALAR_ACC_FRAGMENT_WIDTH)
++        ]
++        acc1 = [
++            cute.make_rmem_tensor((_SCALAR_ACC_FRAGMENT_WIDTH,), cutlass.Float32)
++            for _ in range(16 // _SCALAR_ACC_FRAGMENT_WIDTH)
++        ]
++        for frag in cutlass.range_constexpr(16 // _SCALAR_ACC_FRAGMENT_WIDTH):
++            acc0[frag].fill(0.0)
++            acc1[frag].fill(0.0)
++
++        k_tiles = reduce_tile_count
++        self._prefetch_initial_tiles(
++            a_bf16_flat,
++            a_alt_bf16_flat,
++            b_i32_flat,
++            scales_i32_flat,
++            smem_base,
++            tid,
++            k_tiles,
++            reduce_k_tile,
++            block_valid_rows0,
++            block_valid_rows1,
++            True,
++            a_gl_stride,
++            b_gl_stride,
++            s_gl_stride,
++            scales_expert_off,
++            b_gl_rd_base,
++            a_gl_rd_row,
++            a_gl_rd_col0,
++            a_sh_wr,
++            a_rows_per_iter,
++            output_n_tile,
++            expert_idx,
++        )
++
++        b_scale_cur = cute.make_rmem_tensor((2, 4), Uint32)
++        b_scale_next = cute.make_rmem_tensor((2, 4), Uint32)
++        self._load_b_scale_register_bundle(
++            b_scale_cur,
++            smem_base,
++            tid,
++            b_sh_rd,
++            s_sh_rd,
++            Int32(0),
++            Int32(0),
++        )
++        a0_regs_cur = cute.make_rmem_tensor((2,), Uint32)
++        a0_regs_next = cute.make_rmem_tensor((2,), Uint32)
++        a1_regs_cur = cute.make_rmem_tensor((2,), Uint32)
++        a1_regs_next = cute.make_rmem_tensor((2,), Uint32)
++        self._load_a_registers_m8_bundle(
++            a0_regs_cur, smem_base, a0_sh_rd, Int32(0), Int32(0)
++        )
++        self._load_a_registers_m8_bundle(
++            a1_regs_cur, smem_base, a1_sh_rd, Int32(0), Int32(0)
++        )
++        self._run_mma_pipeline_m8_pair(
++            a_bf16_flat,
++            a_alt_bf16_flat,
++            b_i32_flat,
++            scales_i32_flat,
++            smem_base,
++            tid,
++            acc0,
++            acc1,
++            b_scale_cur,
++            b_scale_next,
++            a0_regs_cur,
++            a0_regs_next,
++            a1_regs_cur,
++            a1_regs_next,
++            b_sh_rd,
++            s_sh_rd,
++            a0_sh_rd,
++            a1_sh_rd,
++            k_tiles,
++            reduce_k_tile,
++            block_valid_rows0,
++            block_valid_rows1,
++            a_gl_stride,
++            b_gl_stride,
++            s_gl_stride,
++            scales_expert_off,
++            b_gl_rd_base,
++            a_gl_rd_row,
++            a_gl_rd_col0,
++            a_sh_wr,
++            a_rows_per_iter,
++            output_n_tile,
++            expert_idx,
++        )
++
++        self._finish_tile(
++            acc0,
++            acc0,
++            acc0,
++            acc0,
++            c_bf16_flat,
++            c_tmp_f32_flat,
++            locks_i32_flat,
++            smem_base,
++            tid,
++            output_n_tile,
++            block_valid_rows0,
++            Int32(0),
+             global_scale_f32,
+             reduce_slice_count,
+             reduce_slice_idx,
+             lock_slot,
+             True,
+         )
++        self._finish_tile(
++            acc1,
++            acc1,
++            acc1,
++            acc1,
++            c_bf16_flat,
++            c_tmp_f32_flat,
++            locks_i32_flat,
++            smem_base,
++            tid,
++            output_n_tile,
++            block_valid_rows1,
++            Int32(self.moe_block_size),
++            global_scale_f32,
++            reduce_slice_count,
++            reduce_slice_idx,
++            lock_slot + Int32(1),
++            True,
++        )
+ 
+     @cute.jit
+     def _run_tile_large_m(
+@@ -2081,6 +2434,8 @@ class W4A16GemmKernel:
+             k_tiles,
+             reduce_k_tile,
+             block_valid_rows,
++            Int32(0),
++            False,
+             a_gl_stride,
+             b_gl_stride,
+             s_gl_stride,
+@@ -2162,6 +2517,7 @@ class W4A16GemmKernel:
+             tid,
+             output_n_tile,
+             block_valid_rows,
++            Int32(0),
+             global_scale_f32,
+             reduce_slice_count,
+             reduce_slice_idx,
+@@ -2239,6 +2595,8 @@ class W4A16GemmKernel:
+                             k_tiles,
+                             reduce_k_tile,
+                             block_valid_rows,
++                            Int32(0),
++                            False,
+                             a_gl_stride,
+                             b_gl_stride,
+                             s_gl_stride,
+@@ -2331,13 +2689,165 @@ class W4A16GemmKernel:
+                     Int32(0),
+                     Int32(0),
+                 )
+-                self._load_a_register_bundle(
+-                    a_regs_cur,
++                self._load_a_register_bundle(
++                    a_regs_cur,
++                    smem_base,
++                    a_sh_rd,
++                    Int32(0),
++                    Int32(0),
++                    uses_m_block_8,
++                )
++
++    @cute.jit
++    def _run_mma_pipeline_m8_pair(
++        self,
++        a_bf16_flat: cute.Tensor,
++        a_alt_bf16_flat: cute.Tensor,
++        b_i32_flat: cute.Tensor,
++        scales_i32_flat: cute.Tensor,
++        smem_base: Int32,
++        tid: Int32,
++        acc0,
++        acc1,
++        b_scale_cur: cute.Tensor,
++        b_scale_next: cute.Tensor,
++        a0_regs_cur: cute.Tensor,
++        a0_regs_next: cute.Tensor,
++        a1_regs_cur: cute.Tensor,
++        a1_regs_next: cute.Tensor,
++        b_sh_rd: Int32,
++        s_sh_rd: Int32,
++        a0_sh_rd: Int32,
++        a1_sh_rd: Int32,
++        k_tiles: Int32,
++        reduce_k_tile: Int32,
++        block_valid_rows0: Int32,
++        block_valid_rows1: Int32,
++        a_gl_stride: Int32,
++        b_gl_stride: Int32,
++        s_gl_stride: Int32,
++        scales_expert_off: Int32,
++        b_gl_rd_base: Int32,
++        a_gl_rd_row: Int32,
++        a_gl_rd_col0: Int32,
++        a_sh_wr: Int32,
++        a_rows_per_iter: Int32,
++        output_n_tile: Int32,
++        expert_idx: Int32,
++    ):
++        b_frag = cute.make_rmem_tensor((2, 2), Uint32)
++        tile_idx = Int32(0)
++        while tile_idx < k_tiles:
++            for pipe in cutlass.range_constexpr(_STAGES):
++                if tile_idx < k_tiles:
++                    for kk in cutlass.range_constexpr(self.b_sh_wr_iters):
++                        self._load_next_fragment_bundle_m8_pair(
++                            b_scale_next,
++                            a0_regs_next,
++                            a1_regs_next,
++                            smem_base,
++                            tid,
++                            b_sh_rd,
++                            s_sh_rd,
++                            a0_sh_rd,
++                            a1_sh_rd,
++                            pipe,
++                            kk,
++                            tile_idx,
++                            k_tiles,
++                        )
++
++                        self._prefetch_pipeline_step(
++                            a_bf16_flat,
++                            a_alt_bf16_flat,
++                            b_i32_flat,
++                            scales_i32_flat,
++                            smem_base,
++                            tid,
++                            pipe,
++                            kk,
++                            tile_idx,
++                            k_tiles,
++                            reduce_k_tile,
++                            block_valid_rows0,
++                            block_valid_rows1,
++                            True,
++                            a_gl_stride,
++                            b_gl_stride,
++                            s_gl_stride,
++                            scales_expert_off,
++                            b_gl_rd_base,
++                            a_gl_rd_row,
++                            a_gl_rd_col0,
++                            a_sh_wr,
++                            a_rows_per_iter,
++                            output_n_tile,
++                            expert_idx,
++                        )
++
++                        for jj in cutlass.range_constexpr(4):
++                            if cutlass.const_expr(self.weight_layout_trellis256):
++                                self._scaled_dequant_b_fragment_trellis256(
++                                    b_frag,
++                                    b_scale_cur[0, jj],
++                                    b_scale_cur[1, jj],
++                                )
++                            elif cutlass.const_expr(self.weight_layout_nf3):
++                                lo_w = b_scale_cur[0, jj // 2]
++                                lo16 = (lo_w >> Uint32(16 * (jj % 2))) & Uint32(0xFFFF)
++                                hi8 = (b_scale_cur[0, 2] >> Uint32(8 * jj)) & Uint32(
++                                    0xFF
++                                )
++                                self._scaled_dequant_b_fragment_nf3(
++                                    b_frag,
++                                    lo16,
++                                    hi8,
++                                    b_scale_cur[1, jj],
++                                )
++                            else:
++                                q, s = self._select_b_scale_register(jj, b_scale_cur)
++                                self._scaled_dequant_b_fragment(b_frag, q, s)
++                            self._mma_accumulate_m8(
++                                acc0,
++                                jj,
++                                a0_regs_cur,
++                                b_frag,
++                            )
++                            self._mma_accumulate_m8(
++                                acc1,
++                                jj,
++                                a1_regs_cur,
++                                b_frag,
++                            )
++
++                        self._copy_a_register_bundle_m8(a0_regs_cur, a0_regs_next)
++                        self._copy_a_register_bundle_m8(a1_regs_cur, a1_regs_next)
++                        self._copy_b_scale_register_bundle(b_scale_cur, b_scale_next)
++                    tile_idx += Int32(1)
++            cute.arch.sync_threads()
++            if tile_idx < k_tiles:
++                self._load_b_scale_register_bundle(
++                    b_scale_cur,
++                    smem_base,
++                    tid,
++                    b_sh_rd,
++                    s_sh_rd,
++                    Int32(0),
++                    Int32(0),
++                )
++                self._load_a_registers_m8_bundle(
++                    a0_regs_cur,
+                     smem_base,
+-                    a_sh_rd,
++                    a0_sh_rd,
++                    Int32(0),
++                    Int32(0),
++                )
++                self._load_a_registers_m8_bundle(
++                    a1_regs_cur,
++                    smem_base,
++                    a1_sh_rd,
+                     Int32(0),
+                     Int32(0),
+-                    uses_m_block_8,
+                 )
+ 
+     @cute.jit
+@@ -2354,16 +2864,26 @@ class W4A16GemmKernel:
+         tid: Int32,
+         output_n_tile: Int32,
+         block_valid_rows: Int32,
++        metadata_row_base: Int32,
+         global_scale_f32: cutlass.Float32,
+         reduce_slice_count: Int32,
+         reduce_slice_idx: Int32,
+         lock_slot: Int32,
+         uses_m_block_8: cutlass.Constexpr[bool],
++        sync_barrier: cutlass.Constexpr = None,
+     ):
+         if cutlass.const_expr(uses_m_block_8):
+             self._fold_cta_partials_m8(acc0, smem_base, tid)
+         else:
+-            self._fold_cta_partials_large_m(acc0, acc1, acc2, acc3, smem_base, tid)
++            self._fold_cta_partials_large_m(
++                acc0,
++                acc1,
++                acc2,
++                acc3,
++                smem_base,
++                tid,
++                sync_barrier,
++            )
+ 
+         if reduce_slice_count > Int32(1):
+             self._wait_for_reduction_turn(
+@@ -2398,6 +2918,7 @@ class W4A16GemmKernel:
+                     tid,
+                     output_n_tile,
+                     block_valid_rows,
++                    metadata_row_base,
+                     global_scale_f32,
+                 )
+             else:
+@@ -2412,6 +2933,7 @@ class W4A16GemmKernel:
+                     output_n_tile,
+                     block_valid_rows,
+                     global_scale_f32,
++                    sync_barrier,
+                 )
+ 
+     @cute.jit
+@@ -2970,6 +3492,80 @@ class W4A16GemmKernel:
+                     uses_m_block_8,
+                 )
+ 
++    @cute.jit
++    def _load_next_fragment_bundle_m8_pair(
++        self,
++        b_scale_next: cute.Tensor,
++        a0_regs_next: cute.Tensor,
++        a1_regs_next: cute.Tensor,
++        smem_base: Int32,
++        tid: Int32,
++        b_sh_rd: Int32,
++        s_sh_rd: Int32,
++        a0_sh_rd: Int32,
++        a1_sh_rd: Int32,
++        pipe: cutlass.Constexpr[int],
++        kk: cutlass.Constexpr[int],
++        tile_idx: Int32,
++        k_tiles: Int32,
++    ):
++        self._clear_b_scale_register_bundle(b_scale_next)
++        self._clear_a_register_bundle_m8(a0_regs_next)
++        self._clear_a_register_bundle_m8(a1_regs_next)
++
++        if cutlass.const_expr(kk + 1 < self.b_sh_wr_iters):
++            if tile_idx < k_tiles:
++                self._load_b_scale_register_bundle(
++                    b_scale_next,
++                    smem_base,
++                    tid,
++                    b_sh_rd,
++                    s_sh_rd,
++                    Int32(pipe),
++                    Int32(kk + 1),
++                )
++                self._load_a_registers_m8_bundle(
++                    a0_regs_next,
++                    smem_base,
++                    a0_sh_rd,
++                    Int32(pipe),
++                    Int32(kk + 1),
++                )
++                self._load_a_registers_m8_bundle(
++                    a1_regs_next,
++                    smem_base,
++                    a1_sh_rd,
++                    Int32(pipe),
++                    Int32(kk + 1),
++                )
++        else:
++            next_tile = tile_idx + Int32(1)
++            if next_tile < k_tiles:
++                next_pipe = Int32((pipe + 1) % _STAGES)
++                self._load_b_scale_register_bundle(
++                    b_scale_next,
++                    smem_base,
++                    tid,
++                    b_sh_rd,
++                    s_sh_rd,
++                    next_pipe,
++                    Int32(0),
++                )
++                self._load_a_registers_m8_bundle(
++                    a0_regs_next,
++                    smem_base,
++                    a0_sh_rd,
++                    next_pipe,
++                    Int32(0),
++                )
++                self._load_a_registers_m8_bundle(
++                    a1_regs_next,
++                    smem_base,
++                    a1_sh_rd,
++                    next_pipe,
++                    Int32(0),
++                )
++
+     @cute.jit
+     def _scaled_dequant_b_fragment(self, frag: cute.Tensor, q: Uint32, s: Uint32):
+         bq1 = q
+@@ -3117,16 +3713,7 @@ class W4A16GemmKernel:
+                 z0 = ld_shared_u32(b_region + (tbase + i0) * Int32(4))
+                 z1 = ld_shared_u32(b_region + (tbase + i1) * Int32(4))
+                 z2 = ld_shared_u32(b_region + (tbase + i2) * Int32(4))
+-                stream64 = Uint64(0)
+-                if delta == Int32(1):
+-                    stream64 = ((Uint64(z0) << Uint64(32)) | Uint64(z2)) >> Uint64(s2)
+-                else:
+-                    lower64 = (Uint64(z1) << Uint64(32)) | Uint64(z2)
+-                    stream64 = (lower64 >> Uint64(s2)) | (
+-                        Uint64(z0) << (Uint64(64) - Uint64(s2))
+-                    )
+-                wa[jj] = Uint32(stream64)
+-                wb[jj] = Uint32(stream64 >> Uint64(32))
++                wa[jj], wb[jj] = trellis_align_stream_u32x2(z0, z1, z2, s2, delta)
+         return wa[0], wa[1], wa[2], wa[3], wb[0], wb[1], wb[2], wb[3]
+ 
+     @cute.jit
+@@ -3422,6 +4009,8 @@ class W4A16GemmKernel:
+         pipe: Int32,
+         tile_idx: Int32,
+         block_valid_rows: Int32,
++        block_valid_rows1: Int32,
++        paired_m8: cutlass.Constexpr[bool],
+         a_gl_stride: Int32,
+         b_gl_stride: Int32,
+         s_gl_stride: Int32,
+@@ -3436,10 +4025,23 @@ class W4A16GemmKernel:
+     ):
+         for i in cutlass.range_constexpr(self.a_sh_wr_iters):
+             row = a_rows_per_iter * Int32(i) + a_gl_rd_row
++            metadata_row = row
++            route_rows = Int32(self.moe_block_size)
++            if cutlass.const_expr(paired_m8):
++                route_rows = Int32(2 * self.moe_block_size)
++                metadata_row = Int32(-1)
++                if row < Int32(self.moe_block_size):
++                    metadata_row = row
++                elif row >= Int32(2 * self.moe_block_size) and row < Int32(
++                    3 * self.moe_block_size
++                ):
++                    metadata_row = row - Int32(self.moe_block_size)
+             route_index = Int32(0)
+-            if row < Int32(self.moe_block_size):
++            if metadata_row >= Int32(0) and metadata_row < route_rows:
+                 route_index = ld_shared_i32_relaxed(
+-                    smem_base + Int32(self.sh_rd_route_off * 16) + row * Int32(4)
++                    smem_base
++                    + Int32(self.sh_rd_route_off * 16)
++                    + metadata_row * Int32(4)
+                 )
+             a_int4 = (
+                 Int64(route_index) * Int64(a_gl_stride)
+@@ -3463,9 +4065,19 @@ class W4A16GemmKernel:
+                 # stage, so this adds neither shared memory nor MMA work.
+                 if output_n_tile >= Int32(self.n_tiles // 2):
+                     a_src = get_ptr_as_int64(a_alt_bf16_flat, a_int4 * Int32(8))
++            row_valid = row < block_valid_rows
++            if cutlass.const_expr(paired_m8):
++                if row < Int32(self.moe_block_size):
++                    row_valid = row < block_valid_rows
++                elif row >= Int32(2 * self.moe_block_size) and row < Int32(
++                    3 * self.moe_block_size
++                ):
++                    row_valid = row - Int32(2 * self.moe_block_size) < block_valid_rows1
++                else:
++                    row_valid = row < Int32(0)
+             if cutlass.const_expr(self.has_k_tile_tail):
+                 a_k_int4 = tile_idx * Int32(self.a_gl_rd_delta_o) + a_gl_rd_col0
+-                if row < block_valid_rows and a_k_int4 < a_gl_stride:
++                if row_valid and a_k_int4 < a_gl_stride:
+                     cp_async4_shared_global(
+                         a_dst,
+                         a_src,
+@@ -3476,7 +4088,7 @@ class W4A16GemmKernel:
+                 cp_async4_shared_global_pred(
+                     a_dst,
+                     a_src,
+-                    (row < block_valid_rows).to(Int32),
++                    row_valid.to(Int32),
+                 )
+ 
+         if cutlass.const_expr(self.weight_layout_trellis256):
+@@ -3643,6 +4255,8 @@ class W4A16GemmKernel:
+         k_tiles: Int32,
+         reduce_k_tile: Int32,
+         block_valid_rows: Int32,
++        block_valid_rows1: Int32,
++        paired_m8: cutlass.Constexpr[bool],
+         a_gl_stride: Int32,
+         b_gl_stride: Int32,
+         s_gl_stride: Int32,
+@@ -3668,6 +4282,8 @@ class W4A16GemmKernel:
+                 k_tiles,
+                 reduce_k_tile,
+                 block_valid_rows,
++                block_valid_rows1,
++                paired_m8,
+                 a_gl_stride,
+                 b_gl_stride,
+                 s_gl_stride,
+@@ -3693,6 +4309,8 @@ class W4A16GemmKernel:
+         k_tiles: Int32,
+         reduce_k_tile: Int32,
+         block_valid_rows: Int32,
++        block_valid_rows1: Int32,
++        paired_m8: cutlass.Constexpr[bool],
+         a_gl_stride: Int32,
+         b_gl_stride: Int32,
+         s_gl_stride: Int32,
+@@ -3717,6 +4335,8 @@ class W4A16GemmKernel:
+                     Int32(pipe),
+                     reduce_k_tile + Int32(pipe),
+                     block_valid_rows,
++                    block_valid_rows1,
++                    paired_m8,
+                     a_gl_stride,
+                     b_gl_stride,
+                     s_gl_stride,
+@@ -3748,6 +4368,8 @@ class W4A16GemmKernel:
+         k_tiles: Int32,
+         reduce_k_tile: Int32,
+         block_valid_rows: Int32,
++        block_valid_rows1: Int32,
++        paired_m8: cutlass.Constexpr[bool],
+         a_gl_stride: Int32,
+         b_gl_stride: Int32,
+         s_gl_stride: Int32,
+@@ -3772,6 +4394,8 @@ class W4A16GemmKernel:
+                 Int32((pipe + _STAGES - 1) % _STAGES),
+                 reduce_k_tile + fetch_tile,
+                 block_valid_rows,
++                block_valid_rows1,
++                paired_m8,
+                 a_gl_stride,
+                 b_gl_stride,
+                 s_gl_stride,
+@@ -3998,13 +4622,16 @@ class W4A16GemmKernel:
+         c_sh_rd: Int32,
+         c_sh_rd_delta: Int32,
+         block_valid_rows: Int32,
++        metadata_row_base: Int32,
+         store_iters: cutlass.Constexpr[int],
++        sync_barrier: cutlass.Constexpr = None,
+     ):
+         for _ in cutlass.range_constexpr(store_iters):
+             row = c_gl_wr // c_gl_stride
+             if row < block_valid_rows:
++                metadata_row = metadata_row_base + row
+                 route_index = ld_shared_i32_relaxed(
+-                    smem_base + Int32(self.sh_route_off * 16) + row * Int32(4)
++                    smem_base + Int32(self.sh_route_off * 16) + metadata_row * Int32(4)
+                 )
+                 true_idx = Int64(route_index) * Int64(c_gl_stride) + Int64(
+                     c_gl_wr % c_gl_stride
+@@ -4014,7 +4641,9 @@ class W4A16GemmKernel:
+                 )
+                 if cutlass.const_expr(self.mul_topk_weights):
+                     scale_bf2 = ld_shared_u32(
+-                        smem_base + Int32(self.sh_topk_off * 16) + row * Int32(4)
++                        smem_base
++                        + Int32(self.sh_topk_off * 16)
++                        + metadata_row * Int32(4)
+                     )
+                     q0 = self._elem2_mul(q0, scale_bf2)
+                     q1 = self._elem2_mul(q1, scale_bf2)
+@@ -4050,7 +4679,7 @@ class W4A16GemmKernel:
+                     )
+             c_gl_wr += c_gl_wr_delta
+             c_sh_rd += c_sh_rd_delta
+-        cute.arch.sync_threads()
++        self._epilogue_sync(sync_barrier)
+ 
+     @cute.jit
+     def _drain_output_smem_tail(
+@@ -4064,14 +4693,17 @@ class W4A16GemmKernel:
+         c_sh_rd: Int32,
+         c_sh_rd_delta: Int32,
+         block_valid_rows: Int32,
++        metadata_row_base: Int32,
+         store_iters: cutlass.Constexpr[int],
++        sync_barrier: cutlass.Constexpr = None,
+     ):
+         for _ in cutlass.range_constexpr(store_iters):
+             row = c_gl_wr // c_gl_stride_covered
+             col_word = c_gl_wr - row * c_gl_stride_covered
+             if row < block_valid_rows and col_word < c_gl_stride:
++                metadata_row = metadata_row_base + row
+                 route_index = ld_shared_i32_relaxed(
+-                    smem_base + Int32(self.sh_route_off * 16) + row * Int32(4)
++                    smem_base + Int32(self.sh_route_off * 16) + metadata_row * Int32(4)
+                 )
+                 true_idx = Int64(route_index) * Int64(c_gl_stride) + Int64(col_word)
+                 q0, q1, q2, q3 = ld_shared_v4_u32(
+@@ -4079,7 +4711,9 @@ class W4A16GemmKernel:
+                 )
+                 if cutlass.const_expr(self.mul_topk_weights):
+                     scale_bf2 = ld_shared_u32(
+-                        smem_base + Int32(self.sh_topk_off * 16) + row * Int32(4)
++                        smem_base
++                        + Int32(self.sh_topk_off * 16)
++                        + metadata_row * Int32(4)
+                     )
+                     q0 = self._elem2_mul(q0, scale_bf2)
+                     q1 = self._elem2_mul(q1, scale_bf2)
+@@ -4108,7 +4742,7 @@ class W4A16GemmKernel:
+                     )
+             c_gl_wr += c_gl_wr_delta
+             c_sh_rd += c_sh_rd_delta
+-        cute.arch.sync_threads()
++        self._epilogue_sync(sync_barrier)
+ 
+     @cute.jit
+     def _store_tile_m8(
+@@ -4119,6 +4753,7 @@ class W4A16GemmKernel:
+         tid: Int32,
+         output_n_tile: Int32,
+         block_valid_rows: Int32,
++        metadata_row_base: Int32,
+         global_scale_f32: cutlass.Float32,
+     ):
+         if cutlass.const_expr(self.has_n_tile_tail):
+@@ -4201,6 +4836,7 @@ class W4A16GemmKernel:
+                 c_sh_rd,
+                 c_sh_rd_delta,
+                 block_valid_rows,
++                metadata_row_base,
+                 store_iters,
+             )
+         else:
+@@ -4213,6 +4849,7 @@ class W4A16GemmKernel:
+                 c_sh_rd,
+                 c_sh_rd_delta,
+                 block_valid_rows,
++                metadata_row_base,
+                 store_iters,
+             )
+ 
+@@ -4225,6 +4862,7 @@ class W4A16GemmKernel:
+         acc3,
+         smem_base: Int32,
+         tid: Int32,
++        sync_barrier: cutlass.Constexpr = None,
+     ):
+         red_off = self.cta_threads // self.b_sh_stride_threads // 2
+         if cutlass.const_expr(red_off >= 1):
+@@ -4242,6 +4880,7 @@ class W4A16GemmKernel:
+                         red_sh_stride,
+                         red_sh_delta,
+                         red_sh_rd,
++                        sync_barrier,
+                     )
+                 elif cutlass.const_expr(mb == 1):
+                     self._fold_cta_partials_large_m_block(
+@@ -4252,6 +4891,7 @@ class W4A16GemmKernel:
+                         red_sh_stride,
+                         red_sh_delta,
+                         red_sh_rd,
++                        sync_barrier,
+                     )
+                 elif cutlass.const_expr(mb == 2):
+                     self._fold_cta_partials_large_m_block(
+@@ -4262,6 +4902,7 @@ class W4A16GemmKernel:
+                         red_sh_stride,
+                         red_sh_delta,
+                         red_sh_rd,
++                        sync_barrier,
+                     )
+                 else:
+                     self._fold_cta_partials_large_m_block(
+@@ -4272,6 +4913,7 @@ class W4A16GemmKernel:
+                         red_sh_stride,
+                         red_sh_delta,
+                         red_sh_rd,
++                        sync_barrier,
+                     )
+ 
+     @cute.jit
+@@ -4284,6 +4926,7 @@ class W4A16GemmKernel:
+         red_sh_stride: Int32,
+         red_sh_delta: Int32,
+         red_sh_rd: Int32,
++        sync_barrier: cutlass.Constexpr = None,
+     ):
+         if cutlass.const_expr(red_off == 2):
+             if Int32(2) <= red_idx and red_idx < Int32(4):
+@@ -4306,7 +4949,7 @@ class W4A16GemmKernel:
+                             (flat_j * 4 + 3) % _SCALAR_ACC_FRAGMENT_WIDTH
+                         ],
+                     )
+-            cute.arch.sync_threads()
++            self._epilogue_sync(sync_barrier)
+ 
+         if Int32(1) <= red_idx and red_idx < Int32(2):
+             for flat_j in cutlass.range_constexpr(8):
+@@ -4375,7 +5018,7 @@ class W4A16GemmKernel:
+                         (flat_j * 4 + 3) % _SCALAR_ACC_FRAGMENT_WIDTH
+                     ],
+                 )
+-        cute.arch.sync_threads()
++        self._epilogue_sync(sync_barrier)
+ 
+         if red_idx == Int32(0):
+             for flat_j in cutlass.range_constexpr(8):
+@@ -4416,7 +5059,7 @@ class W4A16GemmKernel:
+                     ]
+                     + r3
+                 )
+-        cute.arch.sync_threads()
++        self._epilogue_sync(sync_barrier)
+ 
+     @cute.jit
+     def _write_bf16x2_shared(
+@@ -4446,6 +5089,7 @@ class W4A16GemmKernel:
+         output_n_tile: Int32,
+         block_valid_rows: Int32,
+         global_scale_f32: cutlass.Float32,
++        sync_barrier: cutlass.Constexpr = None,
+     ):
+         if cutlass.const_expr(self.has_n_tile_tail):
+             (
+@@ -4495,7 +5139,7 @@ class W4A16GemmKernel:
+                         acc3, smem_base, c_sh_wr, c_sh_stride, write_scale
+                     )
+                 c_sh_wr += Int32(16 * (4 * (2 * self.cta_n_blocks + 1)))
+-        cute.arch.sync_threads()
++        self._epilogue_sync(sync_barrier)
+ 
+         store_iters = _covering_count(
+             16 * self.cta_m_blocks,
+@@ -4512,7 +5156,9 @@ class W4A16GemmKernel:
+                 c_sh_rd,
+                 c_sh_rd_delta,
+                 block_valid_rows,
++                Int32(0),
+                 store_iters,
++                sync_barrier,
+             )
+         else:
+             self._drain_output_smem(
+@@ -4524,7 +5170,9 @@ class W4A16GemmKernel:
+                 c_sh_rd,
+                 c_sh_rd_delta,
+                 block_valid_rows,
++                Int32(0),
+                 store_iters,
++                sync_barrier,
+             )
+ 
+     @cute.jit
+@@ -4602,6 +5250,8 @@ class W4A16FusedMoeKernel:
+         fc2_tile_k: int,
+         moe_block_size: int,
+         max_m_blocks: int,
++        fc2_moe_block_size: int | None = None,
++        fc2_schedule_route_block_factor: int = 1,
+         element_dtype: str = "bf16",
+         fast_math: bool = True,
+         swiglu_limit: float | None = None,
+@@ -4675,6 +5325,29 @@ class W4A16FusedMoeKernel:
+         }
+         self.top_k = int(top_k)
+         self.moe_block_size = int(moe_block_size)
++        self.fc2_moe_block_size = int(
++            moe_block_size if fc2_moe_block_size is None else fc2_moe_block_size
++        )
++        self.fc2_schedule_route_block_factor = int(fc2_schedule_route_block_factor)
++        if (
++            self.fc2_moe_block_size not in _ALLOWED_ROUTED_SIZES
++            or self.moe_block_size % self.fc2_moe_block_size != 0
++        ):
++            raise ValueError(
++                "FC2 route subtile must be an allowed divisor of the packed "
++                f"route block: packed={self.moe_block_size}, "
++                f"fc2={self.fc2_moe_block_size}"
++            )
++        expected_fc2_schedule_factor = self.moe_block_size // self.fc2_moe_block_size
++        if (
++            self.fc2_schedule_route_block_factor < 1
++            or expected_fc2_schedule_factor % self.fc2_schedule_route_block_factor != 0
++        ):
++            raise ValueError(
++                "FC2 schedule factor must divide one packed route block: "
++                f"factor={self.fc2_schedule_route_block_factor}, "
++                f"maximum={expected_fc2_schedule_factor}"
++            )
+         self.activation = activation
+         self.activation_is_gated = is_gated
+         self.activation_is_situ = activation == SITU
+@@ -4781,8 +5454,10 @@ class W4A16FusedMoeKernel:
+             ),
+             tile_n=fc2_tile_n,
+             tile_k=fc2_tile_k,
+-            moe_block_size=moe_block_size,
+-            max_m_blocks=max_m_blocks,
++            moe_block_size=self.fc2_moe_block_size,
++            max_m_blocks=(
++                max_m_blocks * self.moe_block_size // self.fc2_moe_block_size
++            ),
+             element_dtype=element_dtype,
+             weight_layout=weight_layout,
+             scale_format=scale_format,
+@@ -4794,6 +5469,11 @@ class W4A16FusedMoeKernel:
+             fused_sum_topk=int(top_k),
+             schedule_whole_tiles=self.schedule_whole_tiles,
+             dynamic_num_experts=self.dynamic_num_experts,
++            schedule_route_block_factor=self.fc2_schedule_route_block_factor,
++            paired_m8_routes=(
++                self.fc2_moe_block_size == 8
++                and self.fc2_schedule_route_block_factor == 2
++            ),
+         )
+         self.cta_threads = max(self.fc1.cta_threads, self.fc2.cta_threads)
+         if self.fc1.cta_threads != self.fc2.cta_threads:
+@@ -4992,9 +5672,7 @@ class W4A16FusedMoeKernel:
+         expert_count = Int64(weight_num_experts)
+         if cutlass.const_expr(self.weight_layout == "modelopt"):
+             w13_elements = (
+-                expert_count
+-                * Int64(self.fc1_cols)
+-                * Int64(self.hidden_size // 2)
++                expert_count * Int64(self.fc1_cols) * Int64(self.hidden_size // 2)
+             )
+             w2_elements = (
+                 expert_count
+@@ -5367,7 +6045,6 @@ class W4A16FusedMoeKernel:
+                 active_m,
+             )
+             self._grid_barrier(locks_i32_flat, tid, grid_x)
+-
+         if cutlass.const_expr(self.tc_decode_fused_sum):
+             # The TC-decode FC2 epilogue atomically accumulates per-route
+             # partials directly into the per-token output, so the output must be
+@@ -5571,19 +6248,14 @@ class W4A16FusedMoeKernel:
+             route_pos = unit // nblk
+             blk = unit - route_pos * nblk
+             route = packed_route_indices[route_pos].to(Int32)
+-            expert = block_expert_ids[
+-                route_pos // Int32(self.moe_block_size)
+-            ].to(Int32)
++            expert = block_expert_ids[route_pos // Int32(self.moe_block_size)].to(Int32)
+             if cutlass.const_expr(self.direct_topk_routes):
+                 route = route_pos
+                 expert = packed_route_indices[route_pos].to(Int32)
+                 if cutlass.const_expr(self.use_expert_map):
+                     global_expert = expert
+                     expert = Int32(-1)
+-                    if (
+-                        global_expert >= Int32(0)
+-                        and global_expert < route_num_experts
+-                    ):
++                    if global_expert >= Int32(0) and global_expert < route_num_experts:
+                         expert = expert_map_flat[global_expert].to(Int32)
+             if (
+                 route >= Int32(0)
+@@ -5682,19 +6354,14 @@ class W4A16FusedMoeKernel:
+             route_pos = unit // nblk
+             blk = unit - route_pos * nblk
+             row = packed_route_indices[route_pos].to(Int32)
+-            expert = block_expert_ids[
+-                route_pos // Int32(self.moe_block_size)
+-            ].to(Int32)
++            expert = block_expert_ids[route_pos // Int32(self.moe_block_size)].to(Int32)
+             if cutlass.const_expr(self.direct_topk_routes):
+                 row = route_pos
+                 expert = packed_route_indices[route_pos].to(Int32)
+                 if cutlass.const_expr(self.use_expert_map):
+                     global_expert = expert
+                     expert = Int32(-1)
+-                    if (
+-                        global_expert >= Int32(0)
+-                        and global_expert < route_num_experts
+-                    ):
++                    if global_expert >= Int32(0) and global_expert < route_num_experts:
+                         expert = expert_map_flat[global_expert].to(Int32)
+             if (
+                 row >= Int32(0)
+@@ -6822,9 +7489,7 @@ class W4A16TopKSumKernel:
+             svh_rows = Int64(1)
+         svh_flat = cute.make_tensor(
+             svh_ptr,
+-            layout=cute.make_layout(
+-                (svh_rows * Int64(self.hidden_size),), stride=(1,)
+-            ),
++            layout=cute.make_layout((svh_rows * Int64(self.hidden_size),), stride=(1,)),
+         )
+         if cutlass.const_expr(self.full_rotation):
+             total = active_m * Int32(self.hidden_size // 128)
+@@ -6886,9 +7551,7 @@ class W4A16TopKSumKernel:
+                 route_values = cute.make_tensor(
+                     route_values_ptr, cute.make_layout(self.topk * 128)
+                 )
+-                route_weights_ptr = cute.arch.alloc_smem(
+-                    cutlass.Float32, self.topk
+-                )
++                route_weights_ptr = cute.arch.alloc_smem(cutlass.Float32, self.topk)
+                 route_weights = cute.make_tensor(
+                     route_weights_ptr, cute.make_layout(self.topk)
+                 )
+@@ -6921,9 +7584,7 @@ class W4A16TopKSumKernel:
+                         v1 = fc2_flat[base + Int32(1)].to(cutlass.Float32)
+                         v2 = fc2_flat[base + Int32(2)].to(cutlass.Float32)
+                         v3 = fc2_flat[base + Int32(3)].to(cutlass.Float32)
+-                        h0, h1, h2, h3 = self._had128_quad(
+-                            v0, v1, v2, v3, lane
+-                        )
++                        h0, h1, h2, h3 = self._had128_quad(v0, v1, v2, v3, lane)
+                         if cutlass.const_expr(self.broadcast_svh):
+                             sbase = col0
+                         else:
+@@ -6984,9 +7645,9 @@ class W4A16TopKSumKernel:
+                     if expert < Int32(0) or expert >= weight_num_experts:
+                         valid_route = Int32(0)
+                 if valid_route != Int32(0):
+-                    route_value = fc2_flat[
+-                        row * Int32(self.hidden_size) + col
+-                    ].to(cutlass.Float32)
++                    route_value = fc2_flat[row * Int32(self.hidden_size) + col].to(
++                        cutlass.Float32
++                    )
+                     acc += _materialize_w4a16_topk_route_f32(route_value)
+             output_flat[idx] = self._cast_elem(acc)
+ 
+@@ -7027,10 +7688,156 @@ class W4A16TopKSumKernel:
+         return h0 * rs, h1 * rs, h2 * rs, h3 * rs
+ 
+ 
++class W4A16DenseHadamard128Kernel:
++    """FP16 blockwise H128 used by native dense Trellis linears.
++
++    EXL3 applies an incoherence scale before the input rotation and after the
++    output rotation.  Keeping both forms in one SparkInfer kernel removes the
++    runtime dependency on exllamav3_ext while preserving that ordering.
++    """
++
++    def __init__(self, *, width: int, scale_before: bool):
++        if width <= 0 or width % 128 != 0:
++            raise ValueError("dense H128 width must be a positive multiple of 128")
++        self.width = int(width)
++        self.scale_before = bool(scale_before)
++        self.cta_threads = 256
++
++    @property
++    def __cache_key__(self) -> tuple[object, ...]:
++        return (self.width, self.scale_before, self.cta_threads)
++
++    @cute.jit
++    def __call__(
++        self,
++        input_ptr: cute.Pointer,
++        output_ptr: cute.Pointer,
++        scale_ptr: cute.Pointer,
++        active_m: cutlass.Int32,
++        stream: cuda.CUstream,
++    ):
++        input_flat = cute.make_tensor(
++            input_ptr,
++            layout=cute.make_layout((active_m * Int32(self.width),), stride=(1,)),
++        )
++        output_flat = cute.make_tensor(
++            output_ptr,
++            layout=cute.make_layout((active_m * Int32(self.width),), stride=(1,)),
++        )
++        scale_flat = cute.make_tensor(
++            scale_ptr,
++            layout=cute.make_layout((Int32(self.width),), stride=(1,)),
++        )
++        total_units = active_m * Int32(self.width // 128)
++        grid = (_covering_count(total_units, self.cta_threads // 32), 1, 1)
++        self.kernel(input_flat, output_flat, scale_flat, active_m).launch(
++            grid=grid,
++            block=[self.cta_threads, 1, 1],
++            stream=stream,
++        )
++
++    @cute.kernel
++    def kernel(
++        self,
++        input_flat: cute.Tensor,
++        output_flat: cute.Tensor,
++        scale_flat: cute.Tensor,
++        active_m: cutlass.Int32,
++    ):
++        tidx, _, _ = cute.arch.thread_idx()
++        bidx, _, _ = cute.arch.block_idx()
++        tid = Int32(tidx)
++        lane = tid & Int32(31)
++        warp = tid >> Int32(5)
++        unit = Int32(bidx) * Int32(self.cta_threads // 32) + warp
++        nblocks = Int32(self.width // 128)
++        total_units = active_m * nblocks
++        if unit < total_units:
++            row = unit // nblocks
++            block = unit - row * nblocks
++            col0 = block * Int32(128) + lane * Int32(4)
++            base = row * Int32(self.width) + col0
++            v0 = input_flat[base + Int32(0)].to(cutlass.Float32)
++            v1 = input_flat[base + Int32(1)].to(cutlass.Float32)
++            v2 = input_flat[base + Int32(2)].to(cutlass.Float32)
++            v3 = input_flat[base + Int32(3)].to(cutlass.Float32)
++            if cutlass.const_expr(self.scale_before):
++                # exllamav3 uses __hmul2 before the transform; preserve the
++                # intermediate fp16 rounding instead of promoting the product.
++                v0 = cutlass.Float16(
++                    v0 * scale_flat[col0 + Int32(0)].to(cutlass.Float32)
++                ).to(cutlass.Float32)
++                v1 = cutlass.Float16(
++                    v1 * scale_flat[col0 + Int32(1)].to(cutlass.Float32)
++                ).to(cutlass.Float32)
++                v2 = cutlass.Float16(
++                    v2 * scale_flat[col0 + Int32(2)].to(cutlass.Float32)
++                ).to(cutlass.Float32)
++                v3 = cutlass.Float16(
++                    v3 * scale_flat[col0 + Int32(3)].to(cutlass.Float32)
++                ).to(cutlass.Float32)
++            h0, h1, h2, h3 = self._had128_quad(v0, v1, v2, v3, lane)
++            if cutlass.const_expr(not self.scale_before):
++                # The reference rounds H128 to fp16 before the post-scale.
++                h0 = cutlass.Float16(h0).to(cutlass.Float32) * scale_flat[
++                    col0 + Int32(0)
++                ].to(cutlass.Float32)
++                h1 = cutlass.Float16(h1).to(cutlass.Float32) * scale_flat[
++                    col0 + Int32(1)
++                ].to(cutlass.Float32)
++                h2 = cutlass.Float16(h2).to(cutlass.Float32) * scale_flat[
++                    col0 + Int32(2)
++                ].to(cutlass.Float32)
++                h3 = cutlass.Float16(h3).to(cutlass.Float32) * scale_flat[
++                    col0 + Int32(3)
++                ].to(cutlass.Float32)
++            output_flat[base + Int32(0)] = cutlass.Float16(h0)
++            output_flat[base + Int32(1)] = cutlass.Float16(h1)
++            output_flat[base + Int32(2)] = cutlass.Float16(h2)
++            output_flat[base + Int32(3)] = cutlass.Float16(h3)
++
++    @cute.jit
++    def _had128_quad(
++        self,
++        v0: cutlass.Float32,
++        v1: cutlass.Float32,
++        v2: cutlass.Float32,
++        v3: cutlass.Float32,
++        lane: Int32,
++    ):
++        s0 = v0 + v1
++        d0 = v0 - v1
++        s1 = v2 + v3
++        d1 = v2 - v3
++        h0 = s0 + s1
++        h1 = d0 + d1
++        h2 = s0 - s1
++        h3 = d0 - d1
++        for i in cutlass.range_constexpr(5):
++            step = 1 << i
++            p0 = cute.arch.shuffle_sync_bfly(h0, offset=step)
++            p1 = cute.arch.shuffle_sync_bfly(h1, offset=step)
++            p2 = cute.arch.shuffle_sync_bfly(h2, offset=step)
++            p3 = cute.arch.shuffle_sync_bfly(h3, offset=step)
++            if (lane & Int32(step)) != Int32(0):
++                h0 = p0 - h0
++                h1 = p1 - h1
++                h2 = p2 - h2
++                h3 = p3 - h3
++            else:
++                h0 = p0 + h0
++                h1 = p1 + h1
++                h2 = p2 + h2
++                h3 = p3 + h3
++        scale = cutlass.Float32(0.088388347648)
++        return h0 * scale, h1 * scale, h2 * scale, h3 * scale
++
++
+ _CACHE: dict[tuple, W4A16GemmCompileResult] = {}
+ _FUSED_CACHE: dict[tuple, W4A16FusedMoeCompileResult] = {}
+ _ACTIVATION_CACHE: dict[tuple, W4A16ActivationCompileResult] = {}
+ _SUM_CACHE: dict[tuple, W4A16TopKSumCompileResult] = {}
++_DENSE_HAD128_CACHE: dict[tuple, object] = {}
+ _SMALL_M_DIRECT_CACHE: dict[tuple, _W4A16SmallMDirectLaunch] = {}
+ 
+ 
+@@ -7480,6 +8287,7 @@ def compile_w4a16_fused_moe(
+     full_rotation: bool = False,
+     rotation_input_dtype: str | None = None,
+     broadcast_suh: bool = False,
++    _require_cached: bool = False,
+ ) -> W4A16FusedMoeCompileResult:
+     scale_format = _normalize_scale_format(scale_format)
+     intermediate_rotation = bool(intermediate_rotation)
+@@ -7867,6 +8675,13 @@ def compile_w4a16_fused_moe(
+             max_m_blocks=max_m_blocks,
+             blocks_per_sm=kernel.blocks_per_sm,
+         )
++    if _require_cached:
++        raise RuntimeError(
++            "W4A16 fused MoE launch is not resolved for CUDA graph capture "
++            f"(m={size_m}, moe_block_size={moe_block_size}, "
++            f"max_m_blocks={max_m_blocks}); run an eager warmup at this token "
++            "count before capturing"
++        )
+ 
+     if (not collect_activation_amax) and _small_m_direct_supported(
+         m=size_m,
+@@ -8900,9 +9715,7 @@ def _w4a16_fused_moe_launch_flat(
+             or expert_map.ndim != 1
+             or not expert_map.is_contiguous()
+         ):
+-            raise ValueError(
+-                "expert_map must be contiguous int32 on the input device"
+-            )
++            raise ValueError("expert_map must be contiguous int32 on the input device")
+     if collect_activation_amax and activation_amax is None:
+         raise ValueError("activation_amax is required for calibrated W4A16 launch")
+     activation_amax_arg = (
+@@ -8932,9 +9745,7 @@ def _w4a16_fused_moe_launch_flat(
+             )
+         suh_gate_arg = suh_gate_table.reshape(-1)
+         suh_up_arg = suh_up_table.reshape(-1)
+-        broadcast_suh = (
+-            num_experts > 1 and suh_gate_arg.numel() == hidden_size
+-        )
++        broadcast_suh = num_experts > 1 and suh_gate_arg.numel() == hidden_size
+         if broadcast_suh != (suh_up_arg.numel() == hidden_size):
+             raise ValueError(
+                 "suh gate/up tables must both be per-expert or both broadcast"
+@@ -8983,9 +9794,7 @@ def _w4a16_fused_moe_launch_flat(
+         cutlass.Uint8 if weight_layout == "modelopt" else cutlass.Int32
+     )
+     expert_map_addr = (
+-        packed_route_indices.data_ptr()
+-        if expert_map is None
+-        else expert_map.data_ptr()
++        packed_route_indices.data_ptr() if expert_map is None else expert_map.data_ptr()
+     )
+     route_num_experts = 0 if expert_map is None else int(expert_map.numel())
+     fused.compiled(
+@@ -9861,6 +10670,109 @@ def _trellis256_dense_tile_config(size_k: int, size_n: int) -> tuple[int, int]:
+     )
+ 
+ 
++def _trellis256_dense_launch_geometry(
++    *,
++    size_m: int,
++    size_k: int,
++    size_n: int,
++    sms: int,
++) -> tuple[int, tuple[int, int]]:
++    """Avoid short spill waves in the persistent dense-Trellis schedule.
++
++    A default M64/N256 launch can leave only a handful of CTAs in a second or
++    third SM wave. Narrow projections benefit from a smaller M tile, while wide
++    projections already expose enough N parallelism and only need N128 for a
++    two-wave spill. Past three waves the smaller tile's scheduler overhead costs
++    more than the remaining imbalance.
++    """
++    default = (64, (64, 256 if size_n % 256 == 0 else 128))
++    if size_n % 256 != 0 or sms <= 0:
++        return default
++    tasks = _covering_count(int(size_m), 64) * (int(size_n) // 256)
++    waves = _covering_count(tasks, int(sms))
++    if waves not in (2, 3):
++        return default
++    spill = tasks - (waves - 1) * int(sms)
++    if spill > max(16, int(sms) // 10):
++        return default
++    n_tiles_256 = int(size_n) // 256
++    if n_tiles_256 <= 32:
++        return (48, (64, 128 if waves == 2 else 256))
++    if waves == 2:
++        return (64, (64, 128))
++    if int(size_k) <= 4096:
++        return (48, (64, 256))
++    return default
++
++
++def _compile_trellis_dense_hadamard128(*, width: int, scale_before: bool):
++    cache_key = ("trellis_dense_hadamard128", int(width), bool(scale_before))
++    cached = _DENSE_HAD128_CACHE.get(cache_key)
++    if cached is not None:
++        return cached
++    kernel = W4A16DenseHadamard128Kernel(
++        width=int(width),
++        scale_before=bool(scale_before),
++    )
++    fp16_fake = make_ptr(cutlass.Float16, 16, cute.AddressSpace.gmem, assumed_align=16)
++    raise_if_kernel_resolution_frozen(
++        "cute.compile", target=kernel, cache_key=cache_key
++    )
++    compiled = sparkinfer_compile(
++        kernel,
++        fp16_fake,
++        fp16_fake,
++        fp16_fake,
++        Int32(1),
++        current_cuda_stream(),
++        compile_spec=KernelCompileSpec.from_key(
++            "gemm.trellis_dense.hadamard128",
++            1,
++            cache_key,
++        ),
++    )
++    _DENSE_HAD128_CACHE[cache_key] = compiled
++    return compiled
++
++
++def _run_trellis_dense_hadamard128(
++    x: torch.Tensor,
++    output: torch.Tensor,
++    scale: torch.Tensor,
++    *,
++    scale_before: bool,
++) -> None:
++    if x.dtype != torch.float16 or output.dtype != torch.float16:
++        raise TypeError("native dense H128 requires fp16 input and output")
++    if x.ndim != 2 or output.shape != x.shape or not x.is_contiguous():
++        raise ValueError("native dense H128 requires equal contiguous rank-2 tensors")
++    if not output.is_contiguous() or output.device != x.device:
++        raise ValueError(
++            "native dense H128 output must be contiguous on the input device"
++        )
++    if (
++        scale.dtype != torch.float16
++        or scale.device != x.device
++        or not scale.is_contiguous()
++        or scale.numel() != x.shape[1]
++    ):
++        raise ValueError(
++            "native dense H128 scale must be contiguous fp16 with width elements"
++        )
++    compiled = _compile_trellis_dense_hadamard128(
++        width=int(x.shape[1]),
++        scale_before=bool(scale_before),
++    )
++    fp16 = cutlass.Float16
++    compiled(
++        make_ptr(fp16, x.data_ptr(), cute.AddressSpace.gmem, assumed_align=16),
++        make_ptr(fp16, output.data_ptr(), cute.AddressSpace.gmem, assumed_align=16),
++        make_ptr(fp16, scale.data_ptr(), cute.AddressSpace.gmem, assumed_align=16),
++        int(x.shape[0]),
++        current_cuda_stream(),
++    )
++
++
+ def _resolve_exl3_hadamard_128(hadamard_128):
+     if hadamard_128 is None:
+         try:
+@@ -9922,6 +10834,8 @@ def _run_trellis256_dense_current_device(
+     output_f16: torch.Tensor | None = None,
+     hadamard_128=None,
+     stream: cuda.CUstream | None = None,
++    _moe_block_size: int = 64,
++    _force_tile_config: tuple[int, int] | None = None,
+ ) -> torch.Tensor:
+     """Run one native EXL3 linear on the already-selected CUDA device.
+ 
+@@ -9976,6 +10890,73 @@ def _run_trellis256_dense_current_device(
+         dtype=x.dtype,
+         device=x.device,
+     )
++    if c_tmp is not None and int(c_tmp.data_ptr()) % 16 != 0:
++        raise ValueError("c_tmp must be at least 16-byte aligned")
++
++    external_hadamard_128 = (
++        None if hadamard_128 is None else _resolve_exl3_hadamard_128(hadamard_128)
++    )
++
++    # Decode and small batches use one cooperative K6 kernel that owns both
++    # H128 rotations. This avoids three launches and the generic routed-GEMM
++    # scheduler while retaining the checkpoint-native Trellis representation.
++    use_k6_small = (
++        m <= 128
++        and trellis_bits == 6
++        and compute_dtype == torch.float16
++        and external_hadamard_128 is None
++    )
++    if use_k6_small:
++        if x.dtype == torch.float16:
++            x_f16 = x
++        else:
++            input_f16 = _trellis_dense_buffer(
++                "input_f16",
++                input_f16,
++                shape=(m, size_k),
++                dtype=torch.float16,
++                device=x.device,
++            )
++            input_f16.copy_(x)
++            x_f16 = input_f16
++        rotated_f16 = _trellis_dense_buffer(
++            "rotated_f16",
++            rotated_f16,
++            shape=(m, size_k),
++            dtype=torch.float16,
++            device=x.device,
++        )
++        if output.dtype == torch.float16:
++            small_output = output
++        else:
++            output_f16 = _trellis_dense_buffer(
++                "output_f16",
++                output_f16,
++                shape=(m, size_n),
++                dtype=torch.float16,
++                device=x.device,
++            )
++            small_output = output_f16
++        from sparkinfer.gemm.trellis_linear._small_m import run_k6_mcg
++
++        trellis_i16 = prepared_dense.trellis.view(torch.int16).view(
++            size_k // 16,
++            size_n // 16,
++            96,
++        )
++        run_k6_mcg(
++            x_f16,
++            trellis_i16,
++            small_output,
++            prepared_dense.suh,
++            rotated_f16,
++            prepared_dense.svh,
++            prepared_dense.workspace,
++        )
++        if output.dtype != torch.float16:
++            output.copy_(small_output)
++        return output
++
+     gemm_output = _trellis_dense_buffer(
+         "gemm_output",
+         gemm_output,
+@@ -9983,10 +10964,6 @@ def _run_trellis256_dense_current_device(
+         dtype=compute_dtype,
+         device=x.device,
+     )
+-    if c_tmp is not None and int(c_tmp.data_ptr()) % 16 != 0:
+-        raise ValueError("c_tmp must be at least 16-byte aligned")
+-
+-    hadamard_128 = _resolve_exl3_hadamard_128(hadamard_128)
+     if x.dtype == torch.float16:
+         x_f16 = x
+     else:
+@@ -10006,7 +10983,15 @@ def _run_trellis256_dense_current_device(
+         dtype=torch.float16,
+         device=x.device,
+     )
+-    hadamard_128(x_f16, rotated_f16, prepared_dense.suh, None, 1.0)
++    if external_hadamard_128 is None:
++        _run_trellis_dense_hadamard128(
++            x_f16,
++            rotated_f16,
++            prepared_dense.suh,
++            scale_before=True,
++        )
++    else:
++        external_hadamard_128(x_f16, rotated_f16, prepared_dense.suh, None, 1.0)
+     if compute_dtype == torch.float16:
+         rotated_compute = rotated_f16
+     else:
+@@ -10024,10 +11009,24 @@ def _run_trellis256_dense_current_device(
+     max_shared_mem = int(
+         getattr(props, "shared_memory_per_block_optin", _DEFAULT_MAX_SHARED_MEM)
+     )
+-    moe_block_size = 64
++    moe_block_size = int(_moe_block_size)
++    if _force_tile_config is None and moe_block_size == 64:
++        moe_block_size, (tile_k, tile_n) = _trellis256_dense_launch_geometry(
++            size_m=m,
++            size_k=size_k,
++            size_n=size_n,
++            sms=sms,
++        )
++    else:
++        tile_k, tile_n = (
++            _trellis256_dense_tile_config(size_k, size_n)
++            if _force_tile_config is None
++            else (int(_force_tile_config[0]), int(_force_tile_config[1]))
++        )
++    if moe_block_size not in _ALLOWED_ROUTED_SIZES:
++        raise ValueError(f"unsupported Trellis dense moe_block_size={moe_block_size}")
+     route_blocks = (m + moe_block_size - 1) // moe_block_size
+     route_slots = route_blocks * moe_block_size
+-    tile_k, tile_n = _trellis256_dense_tile_config(size_k, size_n)
+     launch = _compile_w4a16_gemm_launch(
+         size_m=m,
+         size_n=size_n,
+@@ -10104,7 +11103,15 @@ def _run_trellis256_dense_current_device(
+         gemm_output_f16.copy_(gemm_output)
+         gemm_f16 = gemm_output_f16
+     if output.dtype == torch.float16:
+-        hadamard_128(gemm_f16, output, None, prepared_dense.svh, 1.0)
++        if external_hadamard_128 is None:
++            _run_trellis_dense_hadamard128(
++                gemm_f16,
++                output,
++                prepared_dense.svh,
++                scale_before=False,
++            )
++        else:
++            external_hadamard_128(gemm_f16, output, None, prepared_dense.svh, 1.0)
+     else:
+         output_f16 = _trellis_dense_buffer(
+             "output_f16",
+@@ -10113,7 +11120,15 @@ def _run_trellis256_dense_current_device(
+             dtype=torch.float16,
+             device=x.device,
+         )
+-        hadamard_128(gemm_f16, output_f16, None, prepared_dense.svh, 1.0)
++        if external_hadamard_128 is None:
++            _run_trellis_dense_hadamard128(
++                gemm_f16,
++                output_f16,
++                prepared_dense.svh,
++                scale_before=False,
++            )
++        else:
++            external_hadamard_128(gemm_f16, output_f16, None, prepared_dense.svh, 1.0)
+         output.copy_(output_f16)
+     return output
+ 
+@@ -10132,6 +11147,8 @@ def run_trellis256_dense(
+     output_f16: torch.Tensor | None = None,
+     hadamard_128=None,
+     stream: cuda.CUstream | None = None,
++    _moe_block_size: int = 64,
++    _force_tile_config: tuple[int, int] | None = None,
+ ) -> torch.Tensor:
+     """Run one native 3/4/5/6-bpw EXL3 linear through the fused t256 GEMM.
+ 
+@@ -10162,6 +11179,8 @@ def run_trellis256_dense(
+             output_f16=output_f16,
+             hadamard_128=hadamard_128,
+             stream=None,
++            _moe_block_size=_moe_block_size,
++            _force_tile_config=_force_tile_config,
+         )
+ 
+ 
+@@ -10189,6 +11208,23 @@ def _resolve_route_block_size_m(
+     return compiled
+ 
+ 
++def _w4a16_stream_is_capturing(
++    stream: cuda.CUstream,
++    *,
++    current_stream: cuda.CUstream,
++) -> bool:
++    """Observe capture on either Torch's current stream or an explicit stream."""
++    current_capturing = torch.cuda.is_current_stream_capturing()
++    if current_capturing or int(stream) == int(current_stream):
++        return current_capturing
++    result, status = cuda.cuStreamIsCapturing(stream)
++    if result != cuda.CUresult.CUDA_SUCCESS:
++        raise RuntimeError(
++            f"cuStreamIsCapturing failed for the selected W4A16 stream: {result}"
++        )
++    return int(status) != 0
++
++
+ def run_w4a16_moe(
+     a_input: torch.Tensor,
+     prepared,
+@@ -10457,7 +11493,8 @@ def run_w4a16_moe(
+     if block_size_m not in _ALLOWED_ROUTED_SIZES:
+         raise ValueError(f"unsupported W4A16 moe_block_size={block_size_m}")
+ 
+-    stream = current_cuda_stream() if stream is None else stream
++    current_stream = current_cuda_stream()
++    stream = current_stream if stream is None else stream
+     if (not collect_activation_amax) and _small_m_direct_supported(
+         m=m,
+         hidden_size=hidden_size,
+@@ -10570,9 +11607,7 @@ def run_w4a16_moe(
+ 
+     mapped_direct = expert_map is not None
+     direct_m_cap = (
+-        _W4A16_SMALL_M_DIRECT_MAX_M
+-        if mapped_direct
+-        else _MAX_DIRECT_TOPK_ROUTE_M
++        _W4A16_SMALL_M_DIRECT_MAX_M if mapped_direct else _MAX_DIRECT_TOPK_ROUTE_M
+     )
+     direct_layout_ok = weight_layout in ("packed", "nf3_2p1") or (
+         mapped_direct and full_rotation and weight_layout == "trellis3_t256"
+@@ -10592,8 +11627,7 @@ def run_w4a16_moe(
+         )
+         and (
+             fused_launch is None
+-            or bool(getattr(fused_launch, "use_expert_map", False))
+-            == mapped_direct
++            or bool(getattr(fused_launch, "use_expert_map", False)) == mapped_direct
+         )
+     )
+     if (
+@@ -10744,6 +11778,10 @@ def run_w4a16_moe(
+             intermediate_rotation=intermediate_rotation_scales is not None,
+             full_rotation=full_rotation,
+             rotation_input_dtype=rotation_input_dtype,
++            _require_cached=_w4a16_stream_is_capturing(
++                stream,
++                current_stream=current_stream,
++            ),
+         )
+     else:
+         if int(fused_launch.size_m) < m:
+diff --git a/sparkinfer/moe/_shared/kernels/w4a16/mixed_trellis.py b/sparkinfer/moe/_shared/kernels/w4a16/mixed_trellis.py
+index 71fce7554255592b890901bbd96daf9213de3337..881d06bc09bb218a83f8c6ab0dc396a22a4a1e66 100644
+--- a/sparkinfer/moe/_shared/kernels/w4a16/mixed_trellis.py
++++ b/sparkinfer/moe/_shared/kernels/w4a16/mixed_trellis.py
+@@ -55,6 +55,9 @@ class MixedTrellisCompileResult:
+     fc2_tile_k: int
+     fc2_tile_n: int
+     moe_block_size: int
++    fc2_moe_block_size: int
++    fc2_schedule_route_block_factor: int
++    fc2_paired_m8_routes: bool
+     max_m_blocks: int
+     blocks_per_sm: int
+     sms: int
+@@ -109,7 +112,7 @@ class MixedTrellisTier(Protocol):
+ class W4A16MixedTrellisKernel:
+     """One cooperative grid over two native Trellis bitrates."""
+ 
+-    ABI_VERSION = 1
++    ABI_VERSION = 4
+ 
+     def __init__(
+         self,
+@@ -145,12 +148,36 @@ class W4A16MixedTrellisKernel:
+         for phase in ("fc1", "fc2"):
+             gemms = tuple(getattr(moe, phase) for moe in (driver, tier0, tier1))
+             geometry = tuple(
+-                (g.n_tiles, g.k_tiles, g.tile_n, g.tile_k, g.cta_threads) for g in gemms
++                (
++                    g.n_tiles,
++                    g.k_tiles,
++                    g.tile_n,
++                    g.tile_k,
++                    g.cta_threads,
++                    g.moe_block_size,
++                    g.schedule_route_block_factor,
++                    g.paired_m8_routes,
++                )
++                for g in gemms
+             )
+             if geometry[1:] != geometry[:-1]:
+                 raise ValueError(
+                     f"mixed Trellis kernels disagree on {phase} geometry: {geometry}"
+                 )
++        fc2_factor = int(driver.fc2.schedule_route_block_factor)
++        expected_factor = int(driver.moe_block_size // driver.fc2.moe_block_size)
++        if fc2_factor < 1 or expected_factor % fc2_factor != 0:
++            raise ValueError(
++                "mixed Trellis FC2 schedule factor must divide one packed "
++                f"route block: factor={fc2_factor}, maximum={expected_factor}"
++            )
++        expected_pair = fc2_factor == 2 and driver.fc2.moe_block_size == 8
++        if bool(driver.fc2.paired_m8_routes) != expected_pair:
++            raise ValueError(
++                "mixed Trellis FC2 pair contract mismatch: "
++                f"factor={fc2_factor}, m={driver.fc2.moe_block_size}, "
++                f"paired={driver.fc2.paired_m8_routes}"
++            )
+         if tier0.num_experts > 256 or tier1.num_experts > 256:
+             raise ValueError("tier-local expert ids must fit in eight bits")
+         if driver.num_experts != tier0.num_experts + tier1.num_experts:
+@@ -184,6 +211,85 @@ class W4A16MixedTrellisKernel:
+             self.shared_words,
+         )
+ 
++    @cute.jit
++    def _dispatch_tier_gemm(
++        self,
++        gemm,
++        a_flat: cute.Tensor,
++        a_alt_flat: cute.Tensor,
++        b_flat: cute.Tensor,
++        c_flat: cute.Tensor,
++        scales_flat: cute.Tensor,
++        global_scale: cute.Tensor,
++        packed_route_indices: cute.Tensor,
++        topk_weights: cute.Tensor,
++        c_tmp: cute.Tensor,
++        locks: cute.Tensor,
++        smem_base: Int32,
++        tid: Int32,
++        route_block_idx: Int32,
++        local_expert: Int32,
++        output_n_tile: Int32,
++        reduce_k_tile: Int32,
++        reduce_tile_count: Int32,
++        reduce_slice_count: Int32,
++        reduce_slice_idx: Int32,
++        lock_slot: Int32,
++        active_size_m: Int32,
++    ):
++        factor = gemm.schedule_route_block_factor
++        first_route_block = route_block_idx * Int32(factor)
++        first_lock_slot = lock_slot * Int32(factor)
++        if cutlass.const_expr(gemm.paired_m8_routes):
++            gemm._run_tile_m8_pair(
++                a_flat,
++                a_alt_flat,
++                b_flat,
++                c_flat,
++                scales_flat,
++                global_scale,
++                packed_route_indices,
++                topk_weights,
++                c_tmp,
++                locks,
++                smem_base,
++                tid,
++                first_route_block,
++                local_expert,
++                output_n_tile,
++                reduce_k_tile,
++                reduce_tile_count,
++                reduce_slice_count,
++                reduce_slice_idx,
++                first_lock_slot,
++                active_size_m,
++            )
++        else:
++            for subtile in cutlass.range_constexpr(factor):
++                gemm._run_tile(
++                    a_flat,
++                    a_alt_flat,
++                    b_flat,
++                    c_flat,
++                    scales_flat,
++                    global_scale,
++                    packed_route_indices,
++                    topk_weights,
++                    c_tmp,
++                    locks,
++                    smem_base,
++                    tid,
++                    first_route_block + Int32(subtile),
++                    local_expert,
++                    output_n_tile,
++                    reduce_k_tile,
++                    reduce_tile_count,
++                    reduce_slice_count,
++                    reduce_slice_idx,
++                    first_lock_slot + Int32(subtile),
++                    active_size_m,
++                )
++
+     @cute.jit
+     def _emit_tier_tile(
+         self,
+@@ -214,7 +320,16 @@ class W4A16MixedTrellisKernel:
+         reduce_slice_idx: Int32,
+         lock_slot: Int32,
+     ):
+-        combined_expert = block_expert_ids[route_block_idx].to(Int32)
++        metadata_block_idx = route_block_idx
++        if cutlass.const_expr(not is_fc1):
++            metadata_block_idx = route_block_idx // Int32(
++                self.driver.moe_block_size
++                // (
++                    self.driver.fc2.moe_block_size
++                    * self.driver.fc2.schedule_route_block_factor
++                )
++            )
++        combined_expert = block_expert_ids[metadata_block_idx].to(Int32)
+         if combined_expert >= Int32(0) and combined_expert < Int32(self.total_experts):
+             descriptor = descriptor_map[combined_expert].to(Int32)
+             if descriptor >= Int32(0):
+@@ -225,7 +340,8 @@ class W4A16MixedTrellisKernel:
+                         gemm = self.tier0.fc1
+                     else:
+                         gemm = self.tier0.fc2
+-                    gemm._run_tile(
++                    self._dispatch_tier_gemm(
++                        gemm,
+                         a_flat,
+                         a_alt_flat,
+                         t0_b_flat,
+@@ -253,7 +369,8 @@ class W4A16MixedTrellisKernel:
+                         gemm = self.tier1.fc1
+                     else:
+                         gemm = self.tier1.fc2
+-                    gemm._run_tile(
++                    self._dispatch_tier_gemm(
++                        gemm,
+                         a_flat,
+                         a_alt_flat,
+                         t1_b_flat,
+@@ -486,6 +603,9 @@ class W4A16MixedTrellisKernel:
+             intermediate_rotations,
+             gate_suh,
+             up_suh,
++            descriptor_map,
++            Int32(self.total_experts),
++            Int32(self.total_experts),
+             smem_base,
+             tid,
+             cta,
+@@ -540,6 +660,7 @@ def compile_mixed_trellis(
+             "large-M cross-tier partial reductions"
+         )
+     total_experts = int(tier0_num_experts) + int(tier1_num_experts)
++    paired_m8_fc2 = int(moe_block_size) in (32, 64)
+ 
+     def make_kernel(num_experts: int, bits: int) -> W4A16FusedMoeKernel:
+         return W4A16FusedMoeKernel(
+@@ -557,6 +678,8 @@ def compile_mixed_trellis(
+             fc2_tile_k=fc2_tile_k,
+             moe_block_size=moe_block_size,
+             max_m_blocks=max_m_blocks,
++            fc2_moe_block_size=(8 if paired_m8_fc2 else moe_block_size),
++            fc2_schedule_route_block_factor=(2 if paired_m8_fc2 else 1),
+             element_dtype="fp16",
+             weight_layout="trellis3_t256",
+             scale_format="e4m3_k32",
+@@ -573,9 +696,15 @@ def compile_mixed_trellis(
+         tier0=make_kernel(int(tier0_num_experts), int(tier0_bits)),
+         tier1=make_kernel(int(tier1_num_experts), int(tier1_bits)),
+     )
+-    if kernel.shared_words * 4 > int(max_shared_mem) - 512:
++    # shared_words is the complete dynamically allocated MemRange used by the
++    # cooperative kernel. CUDA permits a launch exactly at the device's
++    # opt-in shared-memory limit; rejecting an additional 512 bytes here
++    # unnecessarily excludes the stock mixed-K tile geometry at block-64.
++    if kernel.shared_words * 4 > int(max_shared_mem):
+         raise ValueError(
+-            "mixed Trellis shared-memory requirement exceeds the device limit"
++            "mixed Trellis shared-memory requirement exceeds the device limit: "
++            f"required={kernel.shared_words * 4} "
++            f"limit={int(max_shared_mem)}"
+         )
+     device = int(torch.cuda.current_device())
+     cache_key = (
+@@ -698,6 +827,11 @@ def compile_mixed_trellis(
+         fc2_tile_k=fc2_tile_k,
+         fc2_tile_n=fc2_tile_n,
+         moe_block_size=int(moe_block_size),
++        fc2_moe_block_size=int(kernel.driver.fc2.moe_block_size),
++        fc2_schedule_route_block_factor=int(
++            kernel.driver.fc2.schedule_route_block_factor
++        ),
++        fc2_paired_m8_routes=bool(kernel.driver.fc2.paired_m8_routes),
+         max_m_blocks=int(max_m_blocks),
+         blocks_per_sm=int(kernel.blocks_per_sm),
+         sms=int(sms),
+@@ -995,6 +1129,8 @@ def run_mixed_trellis(
+             cute.AddressSpace.gmem,
+             assumed_align=16,
+         ),
++        Int32(launch.topk_sum.num_experts),
++        Int32(launch.topk_sum.route_num_experts),
+         m,
+         stream,
+     )
+diff --git a/sparkinfer/moe/_shared/kernels/w4a16/prepare.py b/sparkinfer/moe/_shared/kernels/w4a16/prepare.py
+index 66cd8f634a6631487b8e3f550623f6d9d4bf223b..42eaa73605d2f2dfadf938610d89120c786961dc 100644
+--- a/sparkinfer/moe/_shared/kernels/w4a16/prepare.py
++++ b/sparkinfer/moe/_shared/kernels/w4a16/prepare.py
+@@ -176,12 +176,15 @@ class PreparedTrellis256DenseWeight:
+ 
+ 
+ def _make_workspace(
+-    device: torch.device, *, max_blocks_per_sm: int = 4
++    device: torch.device,
++    *,
++    max_blocks_per_sm: int = 4,
++    min_elements: int = 0,
+ ) -> torch.Tensor:
+     props = torch.cuda.get_device_properties(device)
+     sms = int(props.multi_processor_count)
+     return torch.zeros(
+-        (sms * int(max_blocks_per_sm) + 2,),
++        (max(sms * int(max_blocks_per_sm) + 2, int(min_elements)),),
+         dtype=torch.int32,
+         device=device,
+     )
+@@ -669,6 +672,7 @@ def _permute_nvfp4_scales(
+     size_n: int,
+     a_dtype: torch.dtype,
+     row_rotation: int | None = None,
++    output_size_n: int | None = None,
+ ) -> tuple[torch.Tensor, torch.Tensor]:
+     combined_scale_factor = _nvfp4_compute_scale_factor(scales, a_dtype)
+     packed_scales: torch.Tensor | None = None
+@@ -684,6 +688,7 @@ def _permute_nvfp4_scales(
+             size_k=size_k,
+             size_n=size_n,
+             group_size=16,
++            output_size_n=output_size_n,
+         )
+         expert_packed = _process_nvfp4_packed_scales(
+             expert_scales,
+@@ -697,8 +702,9 @@ def _permute_nvfp4_scales(
+             )
+         packed_scales[expert].copy_(expert_packed)
+     if packed_scales is None:
++        packed_size_n = int(size_n) if output_size_n is None else int(output_size_n)
+         packed_scales = torch.empty(
+-            (0, size_k // _PACKED_TILE_SIZE, size_n // 2),
++            (0, size_k // _PACKED_TILE_SIZE, packed_size_n // 2),
+             dtype=torch.float8_e4m3fn,
+             device=scales.device,
+         )
+@@ -1098,6 +1104,24 @@ def prepare_w4a16_modelopt_native_weights(
+         size_n=hidden_size,
+         a_dtype=params_dtype,
+     )
++    micro_w13_scale = packed_w13_scale
++    micro_w13_global_scale = packed_w13_global_scale
++    if w13_rows % _PACKED_TILE_N_SIZE != 0:
++        # The direct micro reader uses the native 64-row scale permutation.
++        # Keep the final tile intact: truncating it after permutation discards
++        # logical rows whose permuted columns land above ``w13_rows``.
++        micro_scale_n = (
++            (w13_rows + _PACKED_TILE_N_SIZE - 1) // _PACKED_TILE_N_SIZE
++        ) * _PACKED_TILE_N_SIZE
++        micro_w13_scale, micro_w13_global_scale = _permute_nvfp4_scales(
++            w13_scale,
++            native_w13_global_scale,
++            size_k=hidden_size,
++            size_n=w13_rows,
++            a_dtype=params_dtype,
++            row_rotation=w13_row_rotation,
++            output_size_n=micro_scale_n,
++        )
+ 
+     return W4A16ModelOptWeights(
+         w13=w13_fp4,
+@@ -1113,9 +1137,9 @@ def prepare_w4a16_modelopt_native_weights(
+         is_gated=is_gated,
+         params_dtype=params_dtype,
+         source_format=source_format,
+-        micro_w13_scale=packed_w13_scale,
++        micro_w13_scale=micro_w13_scale,
+         micro_w13_global_scale=_process_nvfp4_micro_global_scale_from_packed(
+-            packed_w13_global_scale,
++            micro_w13_global_scale,
+             a_dtype=params_dtype,
+         ),
+         micro_w2_scale=packed_w2_scale,
+@@ -1162,9 +1186,12 @@ def prepare_w4a16_e8m0_native_weights(
+     w13_rows = shape.w13_rows
+     is_gated = shape.is_gated
+     allow_w2_k_tail = intermediate_size % 32 != 0
+-    padded_w13_scale_n = (
+-        _e8m0_logical_tail_scale_n(w13_rows) if allow_w2_k_tail else w13_rows
+-    )
++    # Packed E8M0 scale rows are permuted in 64-row blocks independently of
++    # whether W2 has a compact K tail.  Ungated 32-aligned intermediates such
++    # as I=224 therefore still need W13's 224 scale rows padded to 256; tying
++    # this padding to ``allow_w2_k_tail`` advertised the direct shape and then
++    # rejected it during preparation.
++    padded_w13_scale_n = _e8m0_logical_tail_scale_n(w13_rows)
+ 
+     w13_scale = _validate_e8m0_k32_scales(
+         w13_e8m0_scale,
+@@ -2126,7 +2153,11 @@ def prepare_trellis256_dense_weight(
+         svh=svh,
+         scale=dummy_scale,
+         global_scale=torch.ones(1, dtype=torch.float32, device=device),
+-        workspace=_make_workspace(device, max_blocks_per_sm=4),
++        workspace=_make_workspace(
++            device,
++            max_blocks_per_sm=4,
++            min_elements=out_features // 16,
++        ),
+         in_features=in_features,
+         out_features=out_features,
+         params_dtype=params_dtype,
+diff --git a/sparkinfer/moe/_shared/kernels/w4a16/route_pack.py b/sparkinfer/moe/_shared/kernels/w4a16/route_pack.py
+index 580078413cbe34599615d9904c7235f73146a4bf..c93236d85499cd383054d98842c3d286e4c9067d 100644
+--- a/sparkinfer/moe/_shared/kernels/w4a16/route_pack.py
++++ b/sparkinfer/moe/_shared/kernels/w4a16/route_pack.py
+@@ -6,10 +6,7 @@ import triton
+ import triton.language as tl
+ import torch
+ 
+-from sparkinfer.moe._shared.kernels.w4a16.host import (
+-    max_packed_route_slots,
+-    route_pack_numel_capacity,
+-)
++from sparkinfer.moe._shared.kernels.w4a16.host import route_pack_capacity
+ 
+ 
+ _COUNT_BLOCK_T = 256
+@@ -306,25 +303,28 @@ def pack_topk_routes_by_expert(
+ ) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor]:
+     numel = int(topk_ids.numel())
+     topk = int(topk_ids.shape[-1]) if topk_ids.ndim >= 2 else 1
+-    numel_capacity = route_pack_numel_capacity(numel, topk=topk)
+-    capacity_packed_routes = max_packed_route_slots(
+-        numel_capacity, int(block_size), int(num_experts)
+-    )
+-    capacity_route_blocks = (capacity_packed_routes + int(block_size) - 1) // int(
+-        block_size
++    numel_capacity, capacity_packed_routes, capacity_route_blocks = route_pack_capacity(
++        numel,
++        int(block_size),
++        int(num_experts),
++        topk=topk,
+     )
+     if packed_route_indices is not None and block_expert_ids is not None:
+         if (
+             int(packed_route_indices.numel()) < capacity_packed_routes
+             or int(block_expert_ids.numel()) < capacity_route_blocks
+         ):
+-            numel_capacity = numel
+-            capacity_packed_routes = max_packed_route_slots(
+-                numel, int(block_size), int(num_experts)
++            (
++                numel_capacity,
++                capacity_packed_routes,
++                capacity_route_blocks,
++            ) = route_pack_capacity(
++                numel,
++                int(block_size),
++                int(num_experts),
++                topk=topk,
++                bucket_tokens=False,
+             )
+-            capacity_route_blocks = (
+-                capacity_packed_routes + int(block_size) - 1
+-            ) // int(block_size)
+     max_packed_routes = capacity_packed_routes
+     max_route_blocks = capacity_route_blocks
+     max_packed_routes = max(max_packed_routes, 1)
+@@ -339,10 +339,7 @@ def pack_topk_routes_by_expert(
+     if (
+         provided_routes is not None
+         and provided_blocks is not None
+-        and (
+-            provided_routes < max_packed_routes
+-            or provided_blocks < max_route_blocks
+-        )
++        and (provided_routes < max_packed_routes or provided_blocks < max_route_blocks)
+     ):
+         raise ValueError(
+             "W4A16 route-packing workspace is too small: "
+diff --git a/sparkinfer/moe/ep_moe/_impl.py b/sparkinfer/moe/ep_moe/_impl.py
+index f1df49f4cbe9c9fb4a6adbd5b00c1f926e171da6..cd8e7ade4de404dc3a4eee6e17482f262f7a9bce 100644
+--- a/sparkinfer/moe/ep_moe/_impl.py
++++ b/sparkinfer/moe/ep_moe/_impl.py
+@@ -32,9 +32,9 @@ from sparkinfer.moe._shared.kernels.activations import (
+     moe_activation_w1_rows,
+ )
+ from sparkinfer.moe._shared.kernels.w4a16.host import (
+-    _W4A16_ALLOWED_ROUTED_SIZES,
+     max_packed_route_slots,
+     packed_gemm_scratch_elements,
++    route_block_sizes_for_capacity,
+     route_pack_token_capacity,
+ )
+ 
+@@ -379,7 +379,12 @@ def plan_ep_moe_scratch(caps: EPMoEScratchCaps) -> EPMoEScratchPlan:
+     route_blocks = 1
+     fc1_tmp = 1
+     fc2_tmp = 1
+-    for block_size in _W4A16_ALLOWED_ROUTED_SIZES:
++    block_sizes = route_block_sizes_for_capacity(
++        caps.max_tokens,
++        caps.num_topk,
++        caps.global_num_experts,
++    )
++    for block_size in block_sizes:
+         slots = max_packed_route_slots(
+             route_capacity_rows,
+             int(block_size),
+diff --git a/sparkinfer/moe/fused_moe/__init__.py b/sparkinfer/moe/fused_moe/__init__.py
+index f53f77b1515d2fcf362262c8259a1150981cb75f..18241439854217c30292dea98b233d3a41a99182 100644
+--- a/sparkinfer/moe/fused_moe/__init__.py
++++ b/sparkinfer/moe/fused_moe/__init__.py
+@@ -14,6 +14,8 @@ Runtime lifecycle:
+     ``plan(Caps)`` -> ``bind`` / ``bind_sparse`` / ``bind_route``
+     (allocation-free views) -> ``run`` / ``run_sparse`` / ``route``
+     (CUDA-graph capture safe)
++``required_nbytes(Caps)`` prices that scratch without compiling launches or
++retaining storage.
+ ``route_topk`` is a standalone one-shot top-k router; ``run_sparse`` fuses
+ gate -> top-k -> experts from router logits.
+ 
+@@ -52,6 +54,7 @@ META = OpMeta(
+         "Routing",
+         "WeightsPlan",
+         "plan",
++        "required_nbytes",
+         "plan_execution",
+         "plan_weights",
+         "prepare_weights",
+@@ -101,6 +104,7 @@ if TYPE_CHECKING:  # static analysis only; runtime resolution is lazy
+         clear_caches,
+         is_supported,
+         plan,
++        required_nbytes,
+         plan_execution,
+         plan_weights,
+         prepare_weights,
+diff --git a/sparkinfer/moe/fused_moe/_impl.py b/sparkinfer/moe/fused_moe/_impl.py
+index c4798cca3f84cceb75036c1b9e13422f68d48e55..18d04c817a9cec8c80a1c872731647ad4fc46862 100644
+--- a/sparkinfer/moe/fused_moe/_impl.py
++++ b/sparkinfer/moe/fused_moe/_impl.py
+@@ -865,9 +865,7 @@ class TPMoEScratchPlan:
+     _prewarmed_fused_launches: tuple[tuple[int, object], ...] = field(
+         default=(), repr=False
+     )
+-    _prewarmed_topk_sum_launches: tuple[
+-        tuple[torch.dtype, bool, object], ...
+-    ] = field(
++    _prewarmed_topk_sum_launches: tuple[tuple[torch.dtype, bool, object], ...] = field(
+         default=(), repr=False
+     )
+ 
+@@ -2306,9 +2304,7 @@ def _build_tp_moe_fp4_binding_from_views(
+             f"{m * num_topk} routed rows"
+         )
+     if output_expert_map is not None and not plan.full_rotation:
+-        raise ValueError(
+-            "output_expert_map requires a full-rotation Trellis plan"
+-        )
++        raise ValueError("output_expert_map requires a full-rotation Trellis plan")
+     if route_expert_map is not None and plan.implementation != "w4a16":
+         raise ValueError("route_expert_map is only supported for W4A16 plans")
+     for name, expert_map in (
+@@ -2537,12 +2533,13 @@ def _plan_core_workspace(
+     )
+     if implementation == "w4a16":
+         from sparkinfer.moe._shared.kernels.w4a16.host import (
+-            _W4A16_ALLOWED_ROUTED_SIZES,
+             max_packed_route_slots,
+             packed_gemm_scratch_elements,
++            route_block_sizes_for_capacity,
+             select_route_block_size_m,
+         )
+         from sparkinfer.moe._shared.kernels.w4a16.kernel import (
++            _MAX_DIRECT_TOPK_ROUTE_M,
+             _TC_DECODE_MAX_M,
+             _small_m_direct_supported,
+         )
+@@ -2558,8 +2555,9 @@ def _plan_core_workspace(
+             if w4a16_weight_layout is not None
+             else _w4a16_weight_layout_for_source(source_format)
+         )
+-        route_E = int(route_num_experts or weight_E)
++        requested_route_E = int(route_num_experts or weight_E)
+         full_rotation = weight_layout == "trellis3_t256"
++        route_E = requested_route_E if full_rotation else int(weight_E)
+         if full_rotation:
+             if source_format != "exl3_trellis_mcg":
+                 raise ValueError(
+@@ -2580,10 +2578,31 @@ def _plan_core_workspace(
+         fc1_c_tmp_elements = 1
+         fc2_c_tmp_elements = 1
+         sms = max(1, int(get_num_sm(device)))
++        topk = max(int(num_topk), 1)
++        token_capacity = (routed_capacity + topk - 1) // topk
++        direct_route_slots_by_block: dict[int, int] = {}
++        if weight_layout == "packed":
++            direct_m_cap = _MAX_DIRECT_TOPK_ROUTE_M
++            if dtype == torch.bfloat16 and is_gated_moe_activation(activation):
++                direct_m_cap = _TC_DECODE_MAX_M
++            for direct_m in range(1, min(token_capacity, direct_m_cap) + 1):
++                direct_block_size = (
++                    int(w4a16_block_size_m)
++                    if w4a16_block_size_m is not None
++                    else select_route_block_size_m(direct_m, topk, route_E)
++                )
++                direct_route_slots_by_block[direct_block_size] = max(
++                    direct_route_slots_by_block.get(direct_block_size, 0),
++                    direct_m * topk * direct_block_size,
++                )
+         block_sizes = (
+             (int(w4a16_block_size_m),)
+             if w4a16_block_size_m is not None
+-            else _W4A16_ALLOWED_ROUTED_SIZES
++            else route_block_sizes_for_capacity(
++                max_tokens=token_capacity,
++                topk=topk,
++                num_experts=route_E,
++            )
+         )
+         for block_size in block_sizes:
+             route_slots = max_packed_route_slots(
+@@ -2591,6 +2610,10 @@ def _plan_core_workspace(
+                 int(block_size),
+                 route_E,
+             )
++            scratch_route_slots = max(
++                route_slots,
++                direct_route_slots_by_block.get(int(block_size), 0),
++            )
+             route_blocks = (route_slots + int(block_size) - 1) // int(block_size)
+             route_slots_capacity = max(route_slots_capacity, route_slots)
+             route_blocks_capacity = max(route_blocks_capacity, route_blocks)
+@@ -2598,7 +2621,7 @@ def _plan_core_workspace(
+                 fc1_c_tmp_elements,
+                 packed_gemm_scratch_elements(
+                     size_n=fc1_cols,
+-                    route_slots=route_slots,
++                    route_slots=scratch_route_slots,
+                     moe_block_size=int(block_size),
+                     sms=sms,
+                 ),
+@@ -2607,7 +2630,7 @@ def _plan_core_workspace(
+                 fc2_c_tmp_elements,
+                 packed_gemm_scratch_elements(
+                     size_n=int(k),
+-                    route_slots=route_slots,
++                    route_slots=scratch_route_slots,
+                     moe_block_size=int(block_size),
+                     sms=sms,
+                 ),
+@@ -2640,9 +2663,7 @@ def _plan_core_workspace(
+                         route_E,
+                     )
+                 )
+-                direct_route_slots = (
+-                    direct_m * int(num_topk) * direct_block_size
+-                )
++                direct_route_slots = direct_m * int(num_topk) * direct_block_size
+                 fc1_c_tmp_elements = max(
+                     fc1_c_tmp_elements,
+                     packed_gemm_scratch_elements(
+@@ -5854,9 +5875,7 @@ def _w4a16_preplanned_launches(
+         _TC_DECODE_MAX_M,
+     )
+ 
+-    sum_uses_expert_map = bool(
+-        use_output_expert_map or use_route_expert_map
+-    )
++    sum_uses_expert_map = bool(use_output_expert_map or use_route_expert_map)
+     if (
+         use_route_expert_map
+         and not collect_activation_amax
+@@ -6261,9 +6280,7 @@ def _plan_full_rotation_w4a16_launches(
+     if torch.cuda.is_current_stream_capturing():
+         raise RuntimeError("Trellis launch planning cannot run during capture")
+ 
+-    from sparkinfer.moe._shared.kernels.w4a16.host import (
+-        max_packed_route_slots,
+-    )
++    from sparkinfer.moe._shared.kernels.w4a16.host import route_pack_capacity
+     from sparkinfer.moe._shared.kernels.w4a16.kernel import (
+         _DEFAULT_MAX_SHARED_MEM,
+         compile_w4a16_fused_moe,
+@@ -6278,12 +6295,10 @@ def _plan_full_rotation_w4a16_launches(
+         )
+     block_size_m = int(core_plan.route_block_size_m)
+     weight_layout = _normalize_w4a16_weight_layout(
+-        caps.w4a16_weight_layout
+-        or _w4a16_weight_layout_for_source(caps.source_format)
++        caps.w4a16_weight_layout or _w4a16_weight_layout_for_source(caps.source_format)
+     )
+     scale_format = _normalize_w4a16_scale_format(
+-        caps.w4a16_scale_format
+-        or _w4a16_scale_format_for_source(caps.source_format)
++        caps.w4a16_scale_format or _w4a16_scale_format_for_source(caps.source_format)
+     )
+     if weight_layout != "trellis3_t256" or scale_format != "e4m3_k32":
+         raise RuntimeError(
+@@ -6292,14 +6307,13 @@ def _plan_full_rotation_w4a16_launches(
+             f"got weight_layout={weight_layout!r}, scale_format={scale_format!r}"
+         )
+     w13_layout = "trellis3_t256_proj"
+-    capacity_route_slots = max_packed_route_slots(
++    _, capacity_route_slots, capacity_m_blocks = route_pack_capacity(
+         capacity_tokens * core_plan.num_topk,
+         block_size_m,
+         core_plan.route_E,
++        topk=core_plan.num_topk,
++        bucket_tokens=False,
+     )
+-    capacity_m_blocks = (
+-        capacity_route_slots + block_size_m - 1
+-    ) // block_size_m
+     rotation_input_dtype = _w4a16_element_dtype(core_plan.dtype)
+ 
+     with torch.cuda.device(core_plan.device):
+@@ -6441,14 +6455,39 @@ def _plan_full_rotation_w4a16_launches(
+     return fused_launches, topk_sum_launches
+ 
+ 
+-def plan_tp_moe_scratch(caps: TPMoEScratchCaps) -> TPMoEScratchPlan:
+-    deterministic_output = caps.deterministic_output
++def _resolve_trellis_route_block_size(caps: TPMoEScratchCaps) -> int | None:
++    """Resolve the one route geometry shared by Trellis sizing and binding."""
++    if caps.w4a16_block_size_m is not None:
++        return int(caps.w4a16_block_size_m)
++    if caps.source_format != "exl3_trellis_mcg":
++        return None
++    from sparkinfer.moe._shared.kernels.w4a16.host import select_route_block_size_m
++
++    token_counts = _arena_core_token_counts(
++        max_tokens=caps.max_tokens,
++        num_topk=caps.num_topk,
++        core_token_counts=caps.core_token_counts,
++        quant_mode=caps.quant_mode,
++        bucket_w4a16_tokens=False,
++    )
++    route_experts = caps.route_num_experts or caps.weight_E
++    return select_route_block_size_m(
++        max(token_counts),
++        caps.num_topk,
++        route_experts,
++    )
++
++
++def _plan_tp_moe_arena_layout_from_caps(
++    caps: TPMoEScratchCaps,
++    *,
++    deterministic_output: bool | None = None,
++) -> TPMoEArenaLayout:
++    if not isinstance(caps, TPMoEScratchCaps):
++        raise TypeError("caps must be a TPMoEScratchCaps")
+     if deterministic_output is None:
+-        deterministic_output = _dynamic_deterministic_output_enabled(
+-            quant_mode=caps.quant_mode,
+-            device=torch.device(caps.device),
+-        )
+-    layout = plan_tp_moe_arena_layout(
++        deterministic_output = caps.deterministic_output
++    return plan_tp_moe_arena_layout(
+         max_tokens=caps.max_tokens,
+         num_topk=caps.num_topk,
+         device=caps.device,
+@@ -6463,7 +6502,20 @@ def plan_tp_moe_scratch(caps: TPMoEScratchCaps) -> TPMoEScratchPlan:
+         swiglu_beta=caps.swiglu_beta,
+         collect_activation_amax=caps.collect_activation_amax,
+         deterministic_output=deterministic_output,
+-        w4a16_block_size_m=caps.w4a16_block_size_m,
++        w4a16_block_size_m=_resolve_trellis_route_block_size(caps),
++    )
++
++
++def tp_moe_required_nbytes(caps: TPMoEScratchCaps) -> int:
++    """Return the planned arena bytes without compiling launches or retaining storage."""
++    return _plan_tp_moe_arena_layout_from_caps(caps).total_nbytes
++
++
++def plan_tp_moe_scratch(caps: TPMoEScratchCaps) -> TPMoEScratchPlan:
++    deterministic_output = caps.deterministic_output
++    layout = _plan_tp_moe_arena_layout_from_caps(
++        caps,
++        deterministic_output=deterministic_output,
+     )
+     capacity_tokens = max(layout.core_token_counts or (int(caps.max_tokens),))
+     launch_plan = plan_tp_moe_execution(
+@@ -6478,6 +6530,7 @@ def plan_tp_moe_scratch(caps: TPMoEScratchCaps) -> TPMoEScratchPlan:
+         apply_router_weight_on_input=caps.apply_router_weight_on_input,
+         deterministic_output=deterministic_output,
+     )
++    resolved_block_size_m = _resolve_trellis_route_block_size(caps)
+     core_workspace_plan = _plan_core_workspace(
+         launch_plan.implementation,
+         launch_plan.quant_mode,
+@@ -6498,7 +6551,7 @@ def plan_tp_moe_scratch(caps: TPMoEScratchCaps) -> TPMoEScratchPlan:
+         w4a16_weight_layout=caps.w4a16_weight_layout,
+         w4a16_scale_format=caps.w4a16_scale_format,
+         route_num_experts=caps.route_num_experts,
+-        w4a16_block_size_m=caps.w4a16_block_size_m,
++        w4a16_block_size_m=resolved_block_size_m,
+         trellis_bits=caps.weight_plan.trellis_bits or 3,
+         trellis_tile_config=caps.weight_plan.trellis_tile_config,
+         apply_router_weight_on_input=caps.apply_router_weight_on_input,
+@@ -6573,7 +6626,7 @@ def _prewarm_w4a16_planned_launches(
+     collect_activation_amax = bool(collect_activation_amax)
+ 
+     from sparkinfer.moe._shared.kernels.w4a16.host import (
+-        max_packed_route_slots,
++        route_pack_capacity,
+         select_route_block_size_m,
+     )
+     from sparkinfer.moe._shared.kernels.w4a16.kernel import (
+@@ -6621,12 +6674,13 @@ def _prewarm_w4a16_planned_launches(
+                 token_count, workspace.num_topk, workspace.route_E
+             )
+             routed_rows = int(token_count) * int(workspace.num_topk)
+-            route_slots = max_packed_route_slots(
++            _, _, max_m_blocks = route_pack_capacity(
+                 routed_rows,
+                 block_size_m,
+                 workspace.route_E,
++                topk=workspace.num_topk,
++                bucket_tokens=not full_rotation,
+             )
+-            max_m_blocks = (route_slots + block_size_m - 1) // block_size_m
+             t_shape = time.perf_counter() if _SPARKINFER_TIMING else 0.0
+             fused_key = (
+                 weight_layout,
+@@ -6688,9 +6742,9 @@ def _prewarm_w4a16_planned_launches(
+                                 broadcast_svh=broadcast_svh,
+                             )
+                             if not broadcast_svh:
+-                                topk_sum_launches[
+-                                    (token_count, ids_dtype, mapped)
+-                                ] = resolved_topk_sum
++                                topk_sum_launches[(token_count, ids_dtype, mapped)] = (
++                                    resolved_topk_sum
++                                )
+             else:
+                 topk_sum_launches[token_count] = compile_w4a16_topk_sum(
+                     m=token_count,
+@@ -6798,7 +6852,7 @@ def _prewarm_w4a16_planned_launches(
+                         workspace.route_E,
+                     )
+                 )
+-                for broadcast_suh in ((False, True) if full_rotation else (False,)):
++                for broadcast_suh in (False, True) if full_rotation else (False,):
+                     resolved_mapped_direct = compile_w4a16_fused_moe(
+                         size_m=direct_m,
+                         hidden_size=workspace.k,
+@@ -6806,9 +6860,7 @@ def _prewarm_w4a16_planned_launches(
+                         num_experts=workspace.weight_E,
+                         top_k=workspace.num_topk,
+                         activation=workspace.activation,
+-                        apply_router_weight_on_input=bool(
+-                            apply_router_weight_on_input
+-                        ),
++                        apply_router_weight_on_input=bool(apply_router_weight_on_input),
+                         zero_fc2_output=False,
+                         moe_block_size=direct_block_size_m,
+                         max_m_blocks=direct_m * int(workspace.num_topk),
+@@ -6833,9 +6885,7 @@ def _prewarm_w4a16_planned_launches(
+                         broadcast_suh=broadcast_suh,
+                     )
+                     if not broadcast_suh:
+-                        mapped_direct_launches[direct_m] = (
+-                            resolved_mapped_direct
+-                        )
++                        mapped_direct_launches[direct_m] = resolved_mapped_direct
+                 if full_rotation:
+                     for broadcast_svh in (False, True):
+                         resolved_topk_sum = compile_w4a16_topk_sum(
+@@ -6851,9 +6901,9 @@ def _prewarm_w4a16_planned_launches(
+                             broadcast_svh=broadcast_svh,
+                         )
+                         if not broadcast_svh:
+-                            topk_sum_launches[
+-                                (direct_m, torch.int32, True)
+-                            ] = resolved_topk_sum
++                            topk_sum_launches[(direct_m, torch.int32, True)] = (
++                                resolved_topk_sum
++                            )
+ 
+         if build_tc_decode:
+             # The capture/route-pack token counts above are powers of two, but the
+@@ -6946,7 +6996,9 @@ def materialize_tp_moe_arena_workspaces(
+         num_topk=num_topk,
+         core_token_counts=caps.core_token_counts,
+         quant_mode=quant_mode,
++        bucket_w4a16_tokens=source_format != "exl3_trellis_mcg",
+     )
++    resolved_block_size_m = _resolve_trellis_route_block_size(caps)
+     t_counts = time.perf_counter() if _SPARKINFER_TIMING else 0.0
+     selected: dict[tuple, tuple[TPMoEPlan, _TPCoreWorkspacePlan, int]] = {}
+     for token_count in core_token_counts:
+@@ -6982,7 +7034,7 @@ def materialize_tp_moe_arena_workspaces(
+             w4a16_weight_layout=w4a16_weight_layout,
+             w4a16_scale_format=w4a16_scale_format,
+             route_num_experts=caps.route_num_experts,
+-            w4a16_block_size_m=caps.w4a16_block_size_m,
++            w4a16_block_size_m=resolved_block_size_m,
+             trellis_bits=weight_plan.trellis_bits or 3,
+             trellis_tile_config=weight_plan.trellis_tile_config,
+             apply_router_weight_on_input=apply_router_weight_on_input,
+diff --git a/sparkinfer/moe/fused_moe/api.py b/sparkinfer/moe/fused_moe/api.py
+index 5aa30de8a602601967ca64734264c62c393772a1..1c57ad6dbf48ca2571ace1bd4a88ae4155a48948 100644
+--- a/sparkinfer/moe/fused_moe/api.py
++++ b/sparkinfer/moe/fused_moe/api.py
+@@ -51,6 +51,9 @@ from ._impl import (
+ from ._impl import (
+     plan_tp_moe_scratch as plan,
+ )
++from ._impl import (
++    tp_moe_required_nbytes as required_nbytes,
++)
+ from ._impl import (
+     prepare_sparkinfer_fp4_moe_weights as prepare_weights,
+ )
+@@ -91,6 +94,7 @@ __all__ = [
+     "Routing",
+     "WeightsPlan",
+     "plan",
++    "required_nbytes",
+     "plan_execution",
+     "plan_weights",
+     "prepare_weights",
+diff --git a/tests/_lib/test_compile_cache.py b/tests/_lib/test_compile_cache.py
+index 2356cf379f3b159fc9d9da6d8d84ce237b0805f5..71ccf28ba2ec524a01df5330112300ebcdfff2dd 100644
+--- a/tests/_lib/test_compile_cache.py
++++ b/tests/_lib/test_compile_cache.py
+@@ -274,7 +274,7 @@ def test_uuid_unavailable_disables_disk_cache(monkeypatch):
+     assert not compiler._cute_compile_disk_cache_enabled_for_payload(payload)
+ 
+ 
+-def test_explicit_memory_cache_hit_skips_disk_payload(monkeypatch):
++def test_explicit_memory_cache_hit_skips_freeze_and_disk_payload(monkeypatch):
+     cute = pytest.importorskip("cutlass.cute")
+     compile_callable = object()
+     compiled = object()
+@@ -299,14 +299,55 @@ def test_explicit_memory_cache_hit_skips_disk_payload(monkeypatch):
+             AssertionError("memory hit rebuilt the disk payload")
+         ),
+     )
+-
+-    assert (
+-        compiler.compile(
+-            test_explicit_memory_cache_hit_skips_disk_payload,
+-            compile_spec=compile_spec,
++    runtime_control = importlib.import_module("sparkinfer._lib.runtime_control")
++
++    runtime_control.freeze_kernel_resolution("cached compile remains launchable")
++    try:
++        assert (
++            compiler.compile(
++                test_explicit_memory_cache_hit_skips_freeze_and_disk_payload,
++                compile_spec=compile_spec,
++            )
++            is compiled
+         )
+-        is compiled
++    finally:
++        runtime_control.unfreeze_kernel_resolution()
++
++
++def test_frozen_memory_miss_rejects_before_disk_cache_load(monkeypatch):
++    cute = pytest.importorskip("cutlass.cute")
++    runtime_control = importlib.import_module("sparkinfer._lib.runtime_control")
++    compile_spec = compiler.KernelCompileSpec.from_facts(
++        "test.freeze.disk_hit",
++        1,
++        ("rows", 8),
+     )
++    monkeypatch.setattr(cute, "compile", object())
++    monkeypatch.setattr(compiler, "_memory_cache_get", lambda _key: None)
++    monkeypatch.setattr(
++        compiler,
++        "_compile_disk_cache_payload",
++        lambda *_args, **_kwargs: (_ for _ in ()).throw(
++            AssertionError("frozen miss built a persistent-cache payload")
++        ),
++    )
++    monkeypatch.setattr(
++        compiler,
++        "_load_cute_compile_from_disk",
++        lambda _key: (_ for _ in ()).throw(
++            AssertionError("frozen miss loaded a persistent module")
++        ),
++    )
++
++    runtime_control.freeze_kernel_resolution("disk hits must not bypass freeze")
++    try:
++        with pytest.raises(runtime_control.KernelResolutionFrozenError):
++            compiler.compile(
++                test_frozen_memory_miss_rejects_before_disk_cache_load,
++                compile_spec=compile_spec,
++            )
++    finally:
++        runtime_control.unfreeze_kernel_resolution()
+ 
+ 
+ def test_v6_semantic_payload_matches_independent_validators(monkeypatch):
+diff --git a/tests/attention/test_compressed_mla.py b/tests/attention/test_compressed_mla.py
+index 68f76befd353716d4c69f02f0c82c9e3ea4e81b0..37b20d875d81c193b04973f3570b424a97a0d4ba 100644
+--- a/tests/attention/test_compressed_mla.py
++++ b/tests/attention/test_compressed_mla.py
+@@ -1,13 +1,28 @@
+ from __future__ import annotations
+ 
+ import math
++from collections.abc import Callable
+ 
+ import pytest
+ import torch
+ 
++from sparkinfer.attention._shared.mla.compressed_api import (
++    _validate_compressed_cache_layout,
++)
++from sparkinfer.attention._shared.mla.kernel import (
++    _cache_block_stride_bytes as _decode_cache_block_stride_bytes,
++)
++from sparkinfer.attention._shared.mla.prefill import (
++    _cache_block_stride_bytes as _prefill_cache_block_stride_bytes,
++)
++from sparkinfer.attention._shared.mla.prefill_mg import (
++    _cache_block_stride_bytes as _prefill_mg_cache_block_stride_bytes,
++)
+ from sparkinfer.attention._shared.mla.compressed_reference import (
++    COMPRESSED_MLA_BYTES_PER_TOKEN,
+     COMPRESSED_MLA_C128_PAGE_SIZE,
+     COMPRESSED_MLA_DSV4_PAGE_SIZE,
++    compressed_mla_page_nbytes,
+     compressed_sparse_mla_reference,
+     pack_compressed_mla_kv_cache_reference,
+ )
+@@ -28,6 +43,68 @@ _LOCAL_Q_HEADS = 32
+ _SM_SCALE = 1.0 / math.sqrt(_COMPRESSED_HEAD_DIM)
+ 
+ 
++@pytest.mark.parametrize("page_size", [16, 64, 256])
++def test_compressed_mla_layout_accepts_contiguous_and_padded_pages(
++    page_size: int,
++) -> None:
++    payload_nbytes = page_size * COMPRESSED_MLA_BYTES_PER_TOKEN
++    padded_nbytes = compressed_mla_page_nbytes(page_size)
++
++    _validate_compressed_cache_layout(
++        torch.empty((2, payload_nbytes), dtype=torch.uint8),
++        page_size=page_size,
++        name="cache",
++    )
++    _validate_compressed_cache_layout(
++        torch.empty((2, padded_nbytes), dtype=torch.uint8),
++        page_size=page_size,
++        name="cache",
++    )
++
++
++def test_compressed_mla_layout_rejects_short_page() -> None:
++    payload_nbytes = COMPRESSED_MLA_C128_PAGE_SIZE * COMPRESSED_MLA_BYTES_PER_TOKEN
++    with pytest.raises(ValueError, match="contiguous payload"):
++        _validate_compressed_cache_layout(
++            torch.empty((2, payload_nbytes - 1), dtype=torch.uint8),
++            page_size=COMPRESSED_MLA_C128_PAGE_SIZE,
++            name="cache",
++        )
++
++
++@pytest.mark.parametrize(
++    "stride_fn,kwargs",
++    [
++        (_decode_cache_block_stride_bytes, {"model_type": 0}),
++        (_prefill_cache_block_stride_bytes, {"model_type": 0}),
++        (_prefill_mg_cache_block_stride_bytes, {"is_glm": False}),
++    ],
++)
++@pytest.mark.parametrize("padded", [False, True])
++def test_compressed_mla_dispatch_uses_physical_page_stride(
++    stride_fn: Callable[..., int],
++    kwargs: dict[str, object],
++    padded: bool,
++) -> None:
++    payload_nbytes = COMPRESSED_MLA_DSV4_PAGE_SIZE * COMPRESSED_MLA_BYTES_PER_TOKEN
++    physical_nbytes = (
++        compressed_mla_page_nbytes(COMPRESSED_MLA_DSV4_PAGE_SIZE)
++        if padded
++        else payload_nbytes
++    )
++    storage = torch.empty(2 * physical_nbytes, dtype=torch.uint8)
++    cache = torch.as_strided(
++        storage,
++        size=(2, payload_nbytes),
++        stride=(physical_nbytes, 1),
++    )
++
++    assert (
++        stride_fn(cache, page_size=COMPRESSED_MLA_DSV4_PAGE_SIZE, **kwargs)
++        == physical_nbytes
++    )
++
++
+ def _make_split_merge_tensors(
+     *,
+     rows: int,
+diff --git a/tests/comm/test_pcie.py b/tests/comm/test_pcie.py
+index b1b045c788d9aabceec6cf74357b2ce643c25a04..a9ed9b6d61a5d6a447d08a5de886712fc5485f52 100644
+--- a/tests/comm/test_pcie.py
++++ b/tests/comm/test_pcie.py
+@@ -103,6 +103,7 @@ def _make_runtime(
+     if eager:
+         kwargs["eager_buffer_ptrs0"] = tuple(range(200, 200 + world_size))
+         kwargs["eager_buffer_ptrs1"] = tuple(range(300, 300 + world_size))
++        kwargs["eager_buffer_bytes"] = max_size
+     return PCIeOneshotAllReduce(
+         rank=rank,
+         world_size=world_size,
+diff --git a/tests/comm/test_pcie_collective_validation_gpu.py b/tests/comm/test_pcie_collective_validation_gpu.py
+new file mode 100644
+index 0000000000000000000000000000000000000000..c571299293f43b57ad6f351b71131e4add27a043
+--- /dev/null
++++ b/tests/comm/test_pcie_collective_validation_gpu.py
+@@ -0,0 +1,108 @@
++from __future__ import annotations
++
++import os
++import socket
++from datetime import timedelta
++
++import pytest
++import torch
++import torch.distributed as dist
++import torch.multiprocessing as mp
++
++from sparkinfer.comm.pcie.pcie_dcp_a2a import PCIeDCPA2A
++from sparkinfer.comm.pcie.pcie_oneshot import PCIeOneshotAllReduce
++from sparkinfer.comm.pcie.pcie_twoshot import PCIeTwoShotSP
++
++
++def _free_port() -> int:
++    with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as sock:
++        sock.bind(("127.0.0.1", 0))
++        return int(sock.getsockname()[1])
++
++
++def _expect_collective_rejection(operation) -> None:
++    with pytest.raises(RuntimeError, match="argument validation"):
++        operation()
++    # Prove every rank left the same failed setup round and can enter the next.
++    dist.barrier()
++
++
++def _worker(rank: int, world_size: int, port: int) -> None:
++    torch.cuda.set_device(rank)
++    device = torch.device("cuda", rank)
++    dist.init_process_group(
++        "nccl",
++        init_method=f"tcp://127.0.0.1:{port}",
++        rank=rank,
++        world_size=world_size,
++        timeout=timedelta(seconds=90),
++    )
++    group = dist.group.WORLD
++    try:
++        _expect_collective_rejection(
++            lambda: PCIeOneshotAllReduce.from_exchange_group(
++                exchange_group=group,
++                device=device,
++                eager_buffer_bytes=1 << 20,
++                max_size=(2 << 20) if rank == 0 else (1 << 20),
++                ext_module=object(),
++            )
++        )
++        _expect_collective_rejection(
++            lambda: PCIeDCPA2A.from_exchange_group(
++                exchange_group=group,
++                device=device,
++                max_batch_size=8,
++                total_heads=16,
++                head_dim=64,
++                query_head_dim=7 if rank == 0 else 64,
++                ext_module=object(),
++            )
++        )
++        _expect_collective_rejection(
++            lambda: PCIeDCPA2A.from_exchange_group(
++                exchange_group=group,
++                device=torch.device("cpu") if rank == 0 else device,
++                max_batch_size=8,
++                total_heads=16,
++                head_dim=64,
++                ext_module=object(),
++            )
++        )
++        _expect_collective_rejection(
++            lambda: PCIeTwoShotSP.from_exchange_group(
++                exchange_group=group,
++                device=device,
++                max_rows=8,
++                row_elems=17 if rank == 0 else 16,
++                ext_module=object(),
++            )
++        )
++        _expect_collective_rejection(
++            lambda: PCIeOneshotAllReduce(
++                rank=1 if rank == 0 else rank,
++                world_size=world_size,
++                device=device,
++                signal_ptrs=tuple(0 for _ in range(world_size)),
++                exchange_group=group,
++                ext_module=object(),
++            )
++        )
++    finally:
++        dist.destroy_process_group()
++
++
++def test_asymmetric_argument_failures_reject_all_ranks_before_ipc() -> None:
++    if os.getenv("SPARKINFER_PCIE_TEST_COLLECTIVE_VALIDATION") != "1":
++        pytest.skip("set the collective-validation GPU gate to run this test")
++    if not torch.cuda.is_available():
++        pytest.skip("CUDA is unavailable")
++    world_size = 2
++    if torch.cuda.device_count() < world_size:
++        pytest.skip("two CUDA devices are required")
++    mp.spawn(
++        _worker,
++        args=(world_size, _free_port()),
++        nprocs=world_size,
++        join=True,
++    )
+diff --git a/tests/comm/test_pcie_control_node_benchmark_contract.py b/tests/comm/test_pcie_control_node_benchmark_contract.py
+new file mode 100644
+index 0000000000000000000000000000000000000000..4a1005f3d47848e6b7ef5dbf922c86c86ec819a1
+--- /dev/null
++++ b/tests/comm/test_pcie_control_node_benchmark_contract.py
+@@ -0,0 +1,155 @@
++from __future__ import annotations
++
++import ast
++import math
++import os
++import signal
++import subprocess
++import sys
++from contextlib import suppress
++from pathlib import Path
++from typing import Sequence
++
++import pytest
++
++
++_ROOT = Path(__file__).resolve().parents[2]
++
++
++def test_benchmark_prepares_distinct_stable_eager_and_graph_channels() -> None:
++    source = (
++        _ROOT / "benchmarks" / "benchmark_pcie_oneshot_control_node.py"
++    ).read_text(encoding="utf-8")
++
++    assert 'eager_channel_id = "eager:control-node-benchmark"' in source
++    assert 'graph_channel_id = "graph:control-node-benchmark"' in source
++    assert "pool.prepare_channels((eager_channel_id, graph_channel_id))" in source
++    assert "pool.for_stream(stream, channel_id=eager_channel_id)" in source
++    assert "pool.capture(stream, channel_id=graph_channel_id)" in source
++
++
++def _load_functions(relative_path: str, names: set[str]) -> dict[str, object]:
++    path = _ROOT / relative_path
++    tree = ast.parse(path.read_text(encoding="utf-8"), filename=str(path))
++    selected = [
++        node
++        for node in tree.body
++        if isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef))
++        and node.name in names
++    ]
++    assert {node.name for node in selected} == names
++    module = ast.Module(body=selected, type_ignores=[])
++    ast.fix_missing_locations(module)
++    namespace: dict[str, object] = {
++        "CORRECTNESS_KEYS": {"verdict"},
++        "math": math,
++        "METRICS": ("mean_us", "p50_us", "p95_us"),
++        "os": os,
++        "Path": Path,
++        "Sequence": Sequence,
++        "signal": signal,
++        "subprocess": subprocess,
++        "suppress": suppress,
++    }
++    # Execute only the selected, dependency-injected helpers from the benchmark.
++    exec(compile(module, str(path), "exec"), namespace)
++    return namespace
++
++
++@pytest.mark.parametrize(
++    "relative_path",
++    [
++        "benchmarks/benchmark_pcie_oneshot_control_node.py",
++        "benchmarks/run_pcie_oneshot_control_node_ab.py",
++    ],
++)
++def test_benchmark_correctness_contract_requires_an_explicit_pass(
++    relative_path: str,
++) -> None:
++    functions = _load_functions(relative_path, {"_validate_correctness"})
++    validate = functions["_validate_correctness"]
++
++    validate({"verdict": "pass"})
++    with pytest.raises(ValueError, match="correctness did not pass"):
++        validate({"verdict": "fail"})
++    with pytest.raises(ValueError, match="correctness schema mismatch"):
++        validate({"verdict": "pass", "details": "unexpected"})
++
++
++def test_distributed_critical_path_uses_aligned_iteration_maxima() -> None:
++    worker = _load_functions(
++        "benchmarks/benchmark_pcie_oneshot_control_node.py",
++        {"_summary", "_distributed_critical_path"},
++    )
++    per_rank = [
++        {
++            "eager": {"cold_us": 11.0, "samples_us": [10.0, 1.0, 10.0, 1.0]},
++            "graph": {"cold_us": 7.0, "samples_us": [6.0, 2.0, 6.0, 2.0]},
++        },
++        {
++            "eager": {"cold_us": 12.0, "samples_us": [1.0, 10.0, 1.0, 10.0]},
++            "graph": {"cold_us": 8.0, "samples_us": [2.0, 6.0, 2.0, 6.0]},
++        },
++    ]
++
++    result = worker["_distributed_critical_path"](per_rank)
++
++    # The old max(mean(rank)) aggregation reports 5.5us / 4us. The actual
++    # collective critical path changes rank each iteration and is 10us / 6us.
++    assert max(sum(row["eager"]["samples_us"]) / 4 for row in per_rank) == 5.5
++    assert result["eager"]["samples_us"] == [10.0, 10.0, 10.0, 10.0]
++    assert result["eager"]["mean_us"] == 10.0
++    assert result["eager"]["cold_us"] == 12.0
++    assert result["graph"]["samples_us"] == [6.0, 6.0, 6.0, 6.0]
++    assert result["graph"]["mean_us"] == 6.0
++    assert result["graph"]["cold_us"] == 8.0
++
++
++def test_controller_paired_deltas_use_distributed_critical_path() -> None:
++    controller = _load_functions(
++        "benchmarks/run_pcie_oneshot_control_node_ab.py",
++        {"_paired_deltas"},
++    )
++
++    def record(variant: str, eager: float, graph: float) -> dict[str, object]:
++        def mode(value: float) -> dict[str, float | list[float]]:
++            return {
++                "cold_us": value,
++                "mean_us": value,
++                "p50_us": value,
++                "p95_us": value,
++                "min_us": value,
++                "max_us": value,
++                "samples_us": [value],
++            }
++
++        return {
++            "identity": {"variant": variant},
++            "distributed_critical_path": {
++                "eager": mode(eager),
++                "graph": mode(graph),
++            },
++        }
++
++    deltas = controller["_paired_deltas"](
++        [
++            record("baseline", 10.0, 20.0),
++            record("candidate", 12.0, 18.0),
++        ]
++    )
++
++    assert deltas[0]["metrics"]["eager"]["mean_us"]["delta_us"] == 2.0
++    assert deltas[0]["metrics"]["graph"]["p95_us"]["delta_us"] == -2.0
++
++
++def test_controller_timeout_terminates_the_command_process_group() -> None:
++    controller = _load_functions(
++        "benchmarks/run_pcie_oneshot_control_node_ab.py",
++        {"_run"},
++    )
++
++    with pytest.raises(TimeoutError, match="process group was terminated"):
++        controller["_run"](
++            [sys.executable, "-c", "import time; time.sleep(30)"],
++            timeout=0.05,
++        )
+diff --git a/tests/comm/test_pcie_dcp_a2a.py b/tests/comm/test_pcie_dcp_a2a.py
+index 50088b56a6e1f5b80f2426b9acfaaf5bf2531420..06df84a5bea9dc79d8a9e4599cc8793c5c7dab53 100644
+--- a/tests/comm/test_pcie_dcp_a2a.py
++++ b/tests/comm/test_pcie_dcp_a2a.py
+@@ -6,6 +6,7 @@ import torch
+ from sparkinfer.comm.pcie.pcie_dcp_a2a import (
+     PCIeDCPA2A,
+     PCIeDCPA2APool,
++    _SINGLE_CHANNEL_ID,
+     _staging_layout,
+     lse_reduce_scatter_reference,
+ )
+@@ -187,9 +188,7 @@ def test_runtime_validates_and_dispatches_to_extension():
+ def test_runtime_accepts_head_major_input_and_output():
+     ext = _FakeExt()
+     runtime = _make_runtime(ext)
+-    input_storage = torch.arange(
+-        32 * 4 * 64, dtype=torch.bfloat16
+-    ).reshape(32, 4, 64)
++    input_storage = torch.arange(32 * 4 * 64, dtype=torch.bfloat16).reshape(32, 4, 64)
+     partial_output = input_storage.transpose(0, 1)[:2]
+     partial_lse = torch.zeros(2, 32, dtype=torch.float32)
+     output_storage = torch.empty(16, 2, 64, dtype=torch.bfloat16)
+@@ -226,6 +225,54 @@ def test_runtime_rejects_shape_dtype_and_capacity_mismatches():
+         runtime.all_gather_heads(torch.zeros(5, 16, 64, dtype=torch.bfloat16))
+ 
+ 
++def test_constructor_rejects_invalid_query_and_staging_capacity():
++    common = dict(
++        rank=0,
++        world_size=2,
++        device=torch.device("cpu"),
++        signal_ptrs=(100, 200),
++        staging0_ptrs=(300, 400),
++        staging1_ptrs=(500, 600),
++        max_batch_size=4,
++        total_heads=32,
++        head_dim=64,
++        lse_offset=4 * 32 * 64 * 2,
++        lse_capacity=4 * 32,
++        ext_module=_FakeExt(),
++    )
++    with pytest.raises(ValueError, match="query_head_dim"):
++        PCIeDCPA2A(
++            **common,
++            query_head_dim=0,
++            output_capacity_elems=4 * 32 * 64,
++        )
++    with pytest.raises(ValueError, match="output capacity"):
++        PCIeDCPA2A(
++            **common,
++            query_head_dim=32,
++            output_capacity_elems=4 * 32 * 32,
++        )
++
++
++def test_cuda_direct_runtime_requires_collective_factory():
++    with pytest.raises(ValueError, match="exchange_group is required"):
++        PCIeDCPA2A(
++            rank=0,
++            world_size=2,
++            device=torch.device("cuda:0"),
++            signal_ptrs=(100, 200),
++            staging0_ptrs=(300, 400),
++            staging1_ptrs=(500, 600),
++            max_batch_size=4,
++            total_heads=32,
++            head_dim=64,
++            output_capacity_elems=4 * 32 * 64,
++            lse_offset=4 * 32 * 64 * 2,
++            lse_capacity=4 * 32,
++            ext_module=_FakeExt(),
++        )
++
++
+ def test_pool_uses_distinct_channels_for_target_and_draft_captures(monkeypatch):
+     created = []
+     current_stream = [7]
+@@ -269,10 +316,383 @@ def test_pool_uses_distinct_channels_for_target_and_draft_captures(monkeypatch):
+         capturing[0] = False
+ 
+     assert target_channel is not draft_channel
+-    assert pool._channels[70] is target_channel
+-    assert pool._channels[80] is draft_channel
++    assert pool._channels == {}
++    assert target_channel in pool._all_channels
++    assert draft_channel in pool._all_channels
+     assert [entry[0] for entry in created] == [7, 8]
+ 
++    capturing[0] = True
++    current_stream[0] = 70
++    with pytest.raises(RuntimeError, match="no channel during CUDA graph capture"):
++        pool.for_stream()
++
++
++def test_pool_collectively_prepares_logical_channels_in_canonical_order(
++    monkeypatch,
++):
++    created = []
++    pool = PCIeDCPA2APool(
++        rank=0,
++        world_size=2,
++        device=torch.device("cpu"),
++        max_batch_size=4,
++        total_heads=32,
++        head_dim=64,
++        channel_factory=lambda stream_key: _make_runtime(),
++    )
++    pool._channel_factory = None
++    pool.exchange_group = object()
++    monkeypatch.setattr(
++        pool,
++        "_new_channel",
++        lambda stream_key: created.append(stream_key) or object(),
++    )
++    monkeypatch.setattr(
++        "sparkinfer.comm.pcie.pcie_dcp_a2a._broadcast_gather_object",
++        lambda local_state, group: [local_state, local_state],
++    )
++    monkeypatch.setattr(
++        "sparkinfer.comm.pcie.pcie_oneshot._broadcast_gather_object",
++        lambda local_status, group: [local_status, local_status],
++    )
++
++    pool.prepare_channels(("target", "draft"))
++    pool.prepare_channels(("draft", "target"))
++
++    assert list(pool._logical_channels) == ["draft", "target"]
++    assert created == [None, None]
++
++
++def test_pool_rejects_logical_channel_set_mismatch_before_allocation(monkeypatch):
++    pool = PCIeDCPA2APool(
++        rank=0,
++        world_size=2,
++        device=torch.device("cpu"),
++        max_batch_size=4,
++        total_heads=32,
++        head_dim=64,
++        channel_factory=lambda stream_key: _make_runtime(),
++    )
++    pool._channel_factory = None
++    pool.exchange_group = object()
++    monkeypatch.setattr(
++        pool,
++        "_new_channel",
++        lambda stream_key: pytest.fail("channel allocation must not start"),
++    )
++
++    def gather(local_state, group):
++        if not local_state or isinstance(local_state[0], str):
++            return [local_state, ()]
++        _requested, existing = local_state
++        return [(("other",), existing), local_state]
++
++    monkeypatch.setattr(
++        "sparkinfer.comm.pcie.pcie_dcp_a2a._broadcast_gather_object", gather
++    )
++    monkeypatch.setattr(
++        "sparkinfer.comm.pcie.pcie_oneshot._broadcast_gather_object", gather
++    )
++
++    with pytest.raises(RuntimeError, match="differs across ranks"):
++        pool.prepare_channels(("target",))
++
++
++def test_pool_invalid_logical_id_is_rejected_collectively(monkeypatch):
++    pool = PCIeDCPA2APool(
++        rank=0,
++        world_size=2,
++        device=torch.device("cpu"),
++        max_batch_size=4,
++        total_heads=32,
++        head_dim=64,
++        channel_factory=lambda stream_key: _make_runtime(),
++    )
++    pool._channel_factory = None
++    pool.exchange_group = object()
++    monkeypatch.setattr(
++        pool,
++        "_new_channel",
++        lambda stream_key: pytest.fail("channel allocation must not start"),
++    )
++    monkeypatch.setattr(
++        "sparkinfer.comm.pcie.pcie_oneshot._broadcast_gather_object",
++        lambda local_status, group: [local_status, ()],
++    )
++
++    with pytest.raises(RuntimeError, match="must not be empty"):
++        pool.prepare_channels(("",))
++
++
++def test_pool_eager_channel_requires_id_and_rejects_duplicate_stream_owner(
++    monkeypatch,
++):
++    eager = _make_runtime()
++    pool = PCIeDCPA2APool(
++        rank=0,
++        world_size=2,
++        device=torch.device("cpu"),
++        max_batch_size=4,
++        total_heads=32,
++        head_dim=64,
++        channel_factory=lambda stream_key: eager,
++    )
++    pool._channel_factory = None
++    pool.exchange_group = object()
++    pool._logical_channels["eager:dcp"] = eager
++    monkeypatch.setattr(
++        "sparkinfer.comm.pcie.pcie_dcp_a2a._current_stream_key",
++        lambda device, stream=None: int(stream),
++    )
++
++    with pytest.raises(RuntimeError, match="explicit semantic channel_id"):
++        pool.for_stream(7)
++    assert pool.for_stream(7, channel_id="eager:dcp") is eager
++    with pytest.raises(RuntimeError, match="stream-affine"):
++        pool.for_stream(8, channel_id="eager:dcp")
++
++
++def test_distributed_single_channel_pool_uses_prepared_default() -> None:
++    eager = _make_runtime()
++    pool = PCIeDCPA2APool(
++        rank=0,
++        world_size=2,
++        device=torch.device("cpu"),
++        max_batch_size=4,
++        total_heads=32,
++        head_dim=64,
++        single_channel=True,
++        channel_factory=lambda stream_key: eager,
++    )
++    pool._channel_factory = None
++    pool.exchange_group = object()
++    pool._logical_channels[_SINGLE_CHANNEL_ID] = eager
++
++    assert pool.for_stream() is eager
++    assert pool._channels == {0: eager}
++
++
++def test_pool_capture_requires_stable_semantic_id(monkeypatch):
++    pool = PCIeDCPA2APool(
++        rank=0,
++        world_size=2,
++        device=torch.device("cpu"),
++        max_batch_size=4,
++        total_heads=32,
++        head_dim=64,
++        channel_factory=lambda stream_key: _make_runtime(),
++    )
++    pool._channel_factory = None
++    pool.exchange_group = object()
++
++    monkeypatch.setattr(
++        pool,
++        "_new_channel",
++        lambda stream_key: pytest.fail("channel allocation must not start"),
++    )
++    monkeypatch.setattr(
++        "sparkinfer.comm.pcie.pcie_oneshot._broadcast_gather_object",
++        lambda local_status, group: [local_status, ()],
++    )
++
++    with (
++        pytest.raises(RuntimeError, match="stable semantic channel_id"),
++        pool.capture(7),
++    ):
++        pass
++
++
++def test_pool_capture_allows_opposite_order_from_agreed_catalog(monkeypatch):
++    target = _make_runtime()
++    draft = _make_runtime()
++    pool = PCIeDCPA2APool(
++        rank=0,
++        world_size=2,
++        device=torch.device("cpu"),
++        max_batch_size=4,
++        total_heads=32,
++        head_dim=64,
++        channel_factory=lambda stream_key: _make_runtime(),
++    )
++    pool._channel_factory = None
++    pool.exchange_group = object()
++    pool._logical_channels.update({"graph:draft": draft, "graph:target": target})
++    monkeypatch.setattr(
++        pool,
++        "_new_channel",
++        lambda stream_key: pytest.fail("channel allocation must not start"),
++    )
++    monkeypatch.setattr(
++        "sparkinfer.comm.pcie.pcie_dcp_a2a._current_stream_key",
++        lambda device, stream=None: int(stream),
++    )
++
++    def gather(local_state, group):
++        if local_state == ():
++            return [(), ()]
++        requested, catalog = local_state
++        assert requested == "graph:target"
++        return [local_state, ("graph:draft", catalog)]
++
++    monkeypatch.setattr(
++        "sparkinfer.comm.pcie.pcie_oneshot._broadcast_gather_object", gather
++    )
++
++    with pool.capture(7, channel_id="graph:target") as channel:
++        assert channel is target
++
++    assert pool._captured_channel_ids == {"graph:target"}
++
++
++def test_pool_capture_rejects_divergent_catalog_before_allocation(monkeypatch):
++    target = _make_runtime()
++    pool = PCIeDCPA2APool(
++        rank=0,
++        world_size=2,
++        device=torch.device("cpu"),
++        max_batch_size=4,
++        total_heads=32,
++        head_dim=64,
++        channel_factory=lambda stream_key: _make_runtime(),
++    )
++    pool._channel_factory = None
++    pool.exchange_group = object()
++    pool._logical_channels["graph:target"] = target
++    monkeypatch.setattr(
++        pool,
++        "_new_channel",
++        lambda stream_key: pytest.fail("channel allocation must not start"),
++    )
++
++    def gather(local_state, group):
++        if local_state == ():
++            return [(), ()]
++        return [local_state, ("graph:target", ())]
++
++    monkeypatch.setattr(
++        "sparkinfer.comm.pcie.pcie_oneshot._broadcast_gather_object", gather
++    )
++
++    with (
++        pytest.raises(RuntimeError, match="prepared channel catalog differs"),
++        pool.capture(7, channel_id="graph:target"),
++    ):
++        pass
++
++
++def test_pool_capture_rejects_differing_unprepared_ids(monkeypatch):
++    target = _make_runtime()
++    pool = PCIeDCPA2APool(
++        rank=0,
++        world_size=2,
++        device=torch.device("cpu"),
++        max_batch_size=4,
++        total_heads=32,
++        head_dim=64,
++        channel_factory=lambda stream_key: _make_runtime(),
++    )
++    pool._channel_factory = None
++    pool.exchange_group = object()
++    pool._logical_channels["graph:target"] = target
++    monkeypatch.setattr(
++        pool,
++        "_new_channel",
++        lambda stream_key: pytest.fail("channel allocation must not start"),
++    )
++
++    def gather(local_state, group):
++        if local_state == ():
++            return [(), ()]
++        _, catalog = local_state
++        return [local_state, ("graph:unknown", catalog)]
++
++    monkeypatch.setattr(
++        "sparkinfer.comm.pcie.pcie_oneshot._broadcast_gather_object", gather
++    )
++
++    with (
++        pytest.raises(RuntimeError, match="unprepared logical channels"),
++        pool.capture(7, channel_id="graph:target"),
++    ):
++        pass
++
++
++def test_pool_capture_preserves_same_id_convenience_allocation(monkeypatch):
++    created = []
++    channel = _make_runtime()
++    pool = PCIeDCPA2APool(
++        rank=0,
++        world_size=2,
++        device=torch.device("cpu"),
++        max_batch_size=4,
++        total_heads=32,
++        head_dim=64,
++        channel_factory=lambda stream_key: _make_runtime(),
++    )
++    pool._channel_factory = None
++    pool.exchange_group = object()
++    monkeypatch.setattr(
++        pool,
++        "_new_channel",
++        lambda stream_key: created.append(stream_key) or channel,
++    )
++    monkeypatch.setattr(
++        "sparkinfer.comm.pcie.pcie_dcp_a2a._current_stream_key",
++        lambda device, stream=None: int(stream),
++    )
++    monkeypatch.setattr(
++        "sparkinfer.comm.pcie.pcie_oneshot._broadcast_gather_object",
++        lambda local_state, group: [local_state, local_state],
++    )
++    monkeypatch.setattr(
++        "sparkinfer.comm.pcie.pcie_dcp_a2a._broadcast_gather_object",
++        lambda local_state, group: [local_state, local_state],
++    )
++
++    with pool.capture(7, channel_id="graph:target") as captured:
++        assert captured is channel
++
++    assert created == [None]
++    assert pool._logical_channels == {"graph:target": channel}
++
++
++def test_pool_capture_routes_eager_warmup_to_graph_channel(monkeypatch):
++    eager = _make_runtime()
++    target = _make_runtime()
++    pool = PCIeDCPA2APool(
++        rank=0,
++        world_size=2,
++        device=torch.device("cpu"),
++        max_batch_size=4,
++        total_heads=32,
++        head_dim=64,
++        channel_factory=lambda stream_key: _make_runtime(),
++    )
++    pool._channel_factory = None
++    pool.exchange_group = object()
++    pool._logical_channels.update({"eager:dcp": eager, "graph:target": target})
++    monkeypatch.setattr(
++        pool,
++        "_new_channel",
++        lambda stream_key: pytest.fail("channel allocation must not start"),
++    )
++    monkeypatch.setattr(
++        "sparkinfer.comm.pcie.pcie_dcp_a2a._current_stream_key",
++        lambda device, stream=None: 7 if stream is None else int(stream),
++    )
++    monkeypatch.setattr(
++        "sparkinfer.comm.pcie.pcie_oneshot._broadcast_gather_object",
++        lambda local_state, group: [local_state, local_state],
++    )
++
++    with pool.capture(7, channel_id="graph:target") as captured:
++        assert captured is target
++        assert pool.for_stream(7, channel_id="eager:dcp") is target
++        with pytest.raises(RuntimeError, match="stream-affine"):
++            pool.for_stream(8, channel_id="eager:dcp")
++
++    assert pool.for_stream(7, channel_id="eager:dcp") is eager
++
+ 
+ def test_pool_isolates_reused_capture_stream_keys(monkeypatch):
+     created = []
+@@ -317,8 +737,7 @@ def test_pool_isolates_reused_capture_stream_keys(monkeypatch):
+         capturing[0] = False
+ 
+     assert target_channel is not draft_channel
+-    assert pool._channels[7] is draft_channel
+-    assert pool._channels[70] is draft_channel
++    assert pool._channels == {}
+     assert target_channel in pool._all_channels
+     assert draft_channel in pool._all_channels
+     assert [entry[0] for entry in created] == [7, 7]
+@@ -328,6 +747,92 @@ def test_pool_isolates_reused_capture_stream_keys(monkeypatch):
+     assert draft_channel._ext.dispose_calls == [1234]
+ 
+ 
++def test_pool_restores_eager_mapping_after_capture(monkeypatch):
++    current_stream = [7]
++    capturing = [False]
++    pool = PCIeDCPA2APool(
++        rank=0,
++        world_size=2,
++        device=torch.device("cpu"),
++        max_batch_size=4,
++        total_heads=32,
++        head_dim=64,
++        channel_factory=lambda stream_key: _make_runtime(),
++    )
++    monkeypatch.setattr(
++        "sparkinfer.comm.pcie.pcie_dcp_a2a._current_stream_key",
++        lambda device, stream=None: (
++            current_stream[0] if stream is None else int(stream)
++        ),
++    )
++    monkeypatch.setattr(
++        "sparkinfer.comm.pcie.pcie_dcp_a2a._is_current_stream_capturing",
++        lambda device: capturing[0],
++    )
++
++    eager_channel = pool.for_stream()
++    with pool.capture(7) as graph_channel:
++        capturing[0] = True
++        current_stream[0] = 70
++        assert pool.for_stream() is graph_channel
++        capturing[0] = False
++
++    assert graph_channel is not eager_channel
++    assert pool._channels == {7: eager_channel}
++    assert graph_channel in pool._all_channels
++
++
++def test_pool_restores_nested_capture_mappings(monkeypatch):
++    current_stream = [7]
++    capturing = [False]
++    pool = PCIeDCPA2APool(
++        rank=0,
++        world_size=2,
++        device=torch.device("cpu"),
++        max_batch_size=4,
++        total_heads=32,
++        head_dim=64,
++        channel_factory=lambda stream_key: _make_runtime(),
++    )
++    monkeypatch.setattr(
++        "sparkinfer.comm.pcie.pcie_dcp_a2a._current_stream_key",
++        lambda device, stream=None: (
++            current_stream[0] if stream is None else int(stream)
++        ),
++    )
++    monkeypatch.setattr(
++        "sparkinfer.comm.pcie.pcie_dcp_a2a._is_current_stream_capturing",
++        lambda device: capturing[0],
++    )
++
++    eager_channel = pool.for_stream()
++    with pool.capture(7) as outer_channel:
++        assert pool._channels == {7: outer_channel}
++
++        current_stream[0] = 8
++        with pool.capture() as inner_channel:
++            capturing[0] = True
++            current_stream[0] = 80
++            assert pool.for_stream() is inner_channel
++            assert pool._channels == {
++                7: outer_channel,
++                8: inner_channel,
++                80: inner_channel,
++            }
++            capturing[0] = False
++
++        assert pool._channels == {7: outer_channel}
++        capturing[0] = True
++        current_stream[0] = 70
++        assert pool.for_stream() is outer_channel
++        capturing[0] = False
++
++    assert eager_channel is not outer_channel
++    assert outer_channel is not inner_channel
++    assert pool._channels == {7: eager_channel}
++    assert pool._capture_channel_stack == []
++
++
+ def test_pool_rolls_back_throwaway_capture_channels(monkeypatch):
+     created = []
+ 
+diff --git a/tests/comm/test_pcie_dcp_a2a_gpu.py b/tests/comm/test_pcie_dcp_a2a_gpu.py
+index 48cc0acf81f6e2fbc738e9fce3a4c2cf93399f9f..84fccdb90178c9307205f66f973141b0bcea7808 100644
+--- a/tests/comm/test_pcie_dcp_a2a_gpu.py
++++ b/tests/comm/test_pcie_dcp_a2a_gpu.py
+@@ -1,5 +1,6 @@
+ from __future__ import annotations
+ 
++import ctypes
+ import os
+ import socket
+ 
+@@ -8,9 +9,13 @@ import torch
+ import torch.distributed as dist
+ import torch.multiprocessing as mp
+ 
++import sparkinfer.comm.pcie.pcie_dcp_a2a as pcie_dcp_a2a
++from sparkinfer.comm.pcie.pcie_oneshot import PCIeOneshotAllReduce
+ from sparkinfer.comm.pcie.pcie_dcp_a2a import (
++    PCIeDCPA2A,
+     PCIeDCPA2APool,
+     _load_extension,
++    _staging_layout,
+     lse_reduce_scatter_reference,
+ )
+ 
+@@ -99,6 +104,34 @@ def _reference(
+     )
+ 
+ 
++def _local_staging_words(channel, stream: torch.cuda.Stream) -> tuple[int, int]:
++    assert channel._ipc is not None
++    assert len(channel._owned_buffers) == 1
++    layout = _staging_layout(
++        signal_bytes=int(channel._ext.meta_size()),
++        world_size=channel.world_size,
++        max_batch_size=channel.max_batch_size,
++        total_heads=channel.total_heads,
++        head_dim=channel.head_dim,
++        query_head_dim=channel.query_head_dim,
++    )
++    words = (ctypes.c_uint16(), ctypes.c_uint16())
++    local_ptr = channel._owned_buffers[0].local_ptr
++    for word, offset in zip(
++        words,
++        (layout.staging0_offset, layout.staging1_offset),
++        strict=True,
++    ):
++        channel._ipc.cudaMemcpyAsync(
++            ctypes.addressof(word),
++            local_ptr + offset,
++            ctypes.sizeof(word),
++            int(stream.cuda_stream),
++        )
++    stream.synchronize()
++    return words[0].value, words[1].value
++
++
+ def _check_eager(
+     pool: PCIeDCPA2APool,
+     rank: int,
+@@ -115,7 +148,7 @@ def _check_eager(
+                 dtype,
+                 device,
+             )
+-            gathered_q = pool.all_gather_heads(local_q)
++            gathered_q = pool.all_gather_heads(local_q, channel_id="eager:dcp")
+             expected_q = torch.cat(
+                 [
+                     _rank_query(
+@@ -133,7 +166,9 @@ def _check_eager(
+             torch.testing.assert_close(gathered_q, expected_q, rtol=0, atol=0)
+ 
+             partial_output, partial_lse = _rank_inputs(step, rank, batch, dtype, device)
+-            out = pool.lse_reduce_scatter(partial_output, partial_lse)
++            out = pool.lse_reduce_scatter(
++                partial_output, partial_lse, channel_id="eager:dcp"
++            )
+             torch.cuda.synchronize(device)
+             expected = _reference(
+                 step,
+@@ -166,6 +201,7 @@ def _check_eager(
+                 head_major_input,
+                 partial_lse,
+                 out=head_major_output,
++                channel_id="eager:dcp",
+             )
+             torch.cuda.synchronize(device)
+             assert actual is head_major_output
+@@ -173,6 +209,63 @@ def _check_eager(
+             torch.testing.assert_close(actual, expected, rtol=2e-2, atol=2e-2)
+ 
+ 
++def _check_eager_adjacency(
++    pool: PCIeDCPA2APool,
++    rank: int,
++    world_size: int,
++    device: torch.device,
++) -> None:
++    channel = pool.for_stream(channel_id="eager:dcp")
++    first_query = _rank_query(700, rank, world_size, MAX_BATCH, torch.bfloat16, device)
++    second_query = _rank_query(701, rank, world_size, MAX_BATCH, torch.bfloat16, device)
++    partial_output, partial_lse = _rank_inputs(702, rank, 1, torch.bfloat16, device)
++    first_gather = torch.empty(
++        MAX_BATCH,
++        TOTAL_HEADS,
++        QUERY_HEAD_DIM,
++        dtype=torch.bfloat16,
++        device=device,
++    )
++    second_gather = torch.empty_like(first_gather)
++    reduced = torch.empty(
++        1,
++        TOTAL_HEADS // world_size,
++        HEAD_DIM,
++        dtype=torch.bfloat16,
++        device=device,
++    )
++
++    # Issue large-grid AG -> small-grid RS -> large-grid AG without a host
++    # synchronization so adjacent eager executions exercise slot advancement.
++    channel.all_gather_heads(first_query, first_gather)
++    channel.lse_reduce_scatter(partial_output, partial_lse, reduced)
++    channel.all_gather_heads(second_query, second_gather)
++    torch.cuda.synchronize(device)
++
++    expected_first = torch.cat(
++        [
++            _rank_query(700, source, world_size, MAX_BATCH, torch.bfloat16, device)
++            for source in range(world_size)
++        ],
++        dim=1,
++    )
++    expected_second = torch.cat(
++        [
++            _rank_query(701, source, world_size, MAX_BATCH, torch.bfloat16, device)
++            for source in range(world_size)
++        ],
++        dim=1,
++    )
++    torch.testing.assert_close(first_gather, expected_first, rtol=0, atol=0)
++    torch.testing.assert_close(second_gather, expected_second, rtol=0, atol=0)
++    torch.testing.assert_close(
++        reduced,
++        _reference(702, rank, world_size, 1, torch.bfloat16, device),
++        rtol=2e-2,
++        atol=2e-2,
++    )
++
++
+ def _check_graph(
+     pool: PCIeDCPA2APool,
+     rank: int,
+@@ -180,7 +273,8 @@ def _check_graph(
+     device: torch.device,
+ ) -> None:
+     stream = torch.cuda.Stream(device=device)
+-    channel = pool.for_stream(stream)
++    pool.prepare_channels(("graph",))
++    channel = pool.for_stream(stream, channel_id="graph")
+     layers = 7
+     input_storages = [
+         torch.empty(
+@@ -244,7 +338,10 @@ def _check_graph(
+             channel.lse_reduce_scatter(inputs[layer], lses[layer], outputs[layer])
+     stream.synchronize()
+ 
+-    for replay in range(8):
++    replay_count = int(os.getenv("SPARKINFER_PCIE_DCP_GRAPH_REPLAYS", "8"))
++    if replay_count <= 0:
++        raise ValueError("SPARKINFER_PCIE_DCP_GRAPH_REPLAYS must be positive")
++    for replay in range(replay_count):
+         expected = []
+         expected_queries = []
+         for layer in range(layers):
+@@ -302,6 +399,165 @@ def _check_graph(
+         for out, reference in zip(gathered_queries, expected_queries, strict=True):
+             torch.testing.assert_close(out, reference, rtol=0, atol=0)
+ 
++    # One captured operation has odd capture-time parity. Adjacent A -> A
++    # replays must advance the device-owned slot at execution time.
++    odd_input = torch.empty(
++        1,
++        TOTAL_HEADS // world_size,
++        QUERY_HEAD_DIM,
++        dtype=torch.bfloat16,
++        device=device,
++    )
++    odd_output = torch.empty(
++        1,
++        TOTAL_HEADS,
++        QUERY_HEAD_DIM,
++        dtype=torch.bfloat16,
++        device=device,
++    )
++    with torch.cuda.stream(stream):
++        channel.all_gather_heads(odd_input, odd_output)
++    stream.synchronize()
++    dist.barrier()
++
++    odd_graph = torch.cuda.CUDAGraph()
++    with torch.cuda.graph(odd_graph, stream=stream):
++        channel.all_gather_heads(odd_input, odd_output)
++    stream.synchronize()
++
++    # Prime both slots after capture, then observe them read-only. A graph with
++    # a host-baked slot changes the same word on both replays; execution-owned
++    # parity changes alternate words.
++    with torch.cuda.stream(stream):
++        for value in (11.0, 12.0):
++            odd_input.fill_(value)
++            channel.all_gather_heads(odd_input, odd_output)
++    snapshots = [_local_staging_words(channel, stream)]
++    for value in (1.0, 2.0):
++        with torch.cuda.stream(stream):
++            odd_input.fill_(value)
++            odd_graph.replay()
++        snapshots.append(_local_staging_words(channel, stream))
++        torch.testing.assert_close(
++            odd_output, torch.full_like(odd_output, value), rtol=0, atol=0
++        )
++
++    changed_slots = [
++        {
++            slot
++            for slot, (before, after) in enumerate(
++                zip(snapshots[index], snapshots[index + 1], strict=True)
++            )
++            if before != after
++        }
++        for index in range(2)
++    ]
++    assert all(len(changed) == 1 for changed in changed_slots)
++    assert changed_slots[0] != changed_slots[1]
++
++
++def _check_semantic_capture_warmup(
++    pool: PCIeDCPA2APool,
++    rank: int,
++    world_size: int,
++    device: torch.device,
++) -> None:
++    """Match vLLM's eager DCP warmup inside a graph-owner scope."""
++    stream = torch.cuda.Stream(device=device)
++    local_query = _rank_query(
++        900,
++        rank,
++        world_size,
++        1,
++        torch.bfloat16,
++        device,
++    )
++    gathered = torch.empty(
++        1,
++        TOTAL_HEADS,
++        QUERY_HEAD_DIM,
++        dtype=torch.bfloat16,
++        device=device,
++    )
++    expected = torch.cat(
++        [
++            _rank_query(
++                900,
++                source,
++                world_size,
++                1,
++                torch.bfloat16,
++                device,
++            )
++            for source in range(world_size)
++        ],
++        dim=1,
++    )
++    pool.prepare_channels(("graph:warmup",))
++
++    graph = torch.cuda.CUDAGraph()
++    with (
++        torch.cuda.stream(stream),
++        pool.capture(stream, channel_id="graph:warmup") as graph_channel,
++    ):
++        warmup_channel = pool.for_stream(stream, channel_id="eager:dcp")
++        assert warmup_channel is graph_channel
++        warmup_channel.all_gather_heads(local_query, gathered)
++        stream.synchronize()
++        torch.testing.assert_close(gathered, expected, rtol=0, atol=0)
++
++        with torch.cuda.graph(graph, stream=stream):
++            graph_channel.all_gather_heads(local_query, gathered)
++
++    # The eager DCP channel was already bound to vLLM's default stream. Its
++    # original mapping must be usable again after the graph-owner scope exits.
++    eager_channel = pool.for_stream(channel_id="eager:dcp")
++    assert eager_channel is not graph_channel
++    with torch.cuda.stream(stream):
++        graph.replay()
++    stream.synchronize()
++    torch.testing.assert_close(gathered, expected, rtol=0, atol=0)
++
++
++def _check_teardown_retry(
++    pool: PCIeDCPA2APool,
++    rank: int,
++    device: torch.device,
++) -> None:
++    """Inject one local unmap failure and prove every rank retries coherently."""
++
++    assert pool._all_channels
++    channel = pool._all_channels[0]
++    assert channel._ipc is not None
++    original_close = channel._ipc.cudaIpcCloseMemHandle
++    injected = False
++
++    if rank == 0:
++
++        def fail_once(ptr):
++            nonlocal injected
++            if not injected:
++                injected = True
++                raise RuntimeError("injected DCP IPC unmap failure")
++            return original_close(ptr)
++
++        channel._ipc.cudaIpcCloseMemHandle = fail_once
++
++    failed = False
++    try:
++        pool.close()
++    except RuntimeError as exc:
++        failed = "IPC unmap" in str(exc)
++    verdict = torch.tensor(int(failed), device=device, dtype=torch.int32)
++    dist.all_reduce(verdict, op=dist.ReduceOp.MIN)
++    assert int(verdict.item()) == 1
++    assert not pool._closed
++
++    if rank == 0:
++        channel._ipc.cudaIpcCloseMemHandle = original_close
++    pool.close()
++    assert pool._closed
++
+ 
+ def _worker(rank: int, world_size: int, port: int) -> None:
+     torch.cuda.set_device(rank)
+@@ -319,18 +575,117 @@ def _worker(rank: int, world_size: int, port: int) -> None:
+         total_heads=TOTAL_HEADS,
+         head_dim=HEAD_DIM,
+         query_head_dim=QUERY_HEAD_DIM,
++        max_concurrent_channels=2,
+     )
++    closed = False
+     try:
++        pool.prepare_channels(("eager:dcp", "graph"))
+         _check_eager(pool, rank, world_size, device)
+         dist.barrier()
++        _check_eager_adjacency(pool, rank, world_size, device)
++        dist.barrier()
++        _check_semantic_capture_warmup(pool, rank, world_size, device)
++        dist.barrier()
+         _check_graph(pool, rank, world_size, device)
+         torch.cuda.synchronize(device)
++        if os.getenv("SPARKINFER_PCIE_DCP_TEST_TEARDOWN_RETRY", "0") == "1":
++            _check_teardown_retry(pool, rank, device)
++            closed = True
+     finally:
+-        pool.close()
++        if not closed:
++            pool.close()
++        dist.destroy_process_group()
++
++
++def _residency_rejection_worker(rank: int, world_size: int, port: int) -> None:
++    if rank != 0:
++        # Simulate one constrained/MIG-like rank in an otherwise full device
++        # group; every peer must reject before any IPC allocation.
++        os.environ.pop("SPARKINFER_PCIE_TEST_VISIBLE_SM_COUNT", None)
++    torch.cuda.set_device(rank)
++    device = torch.device("cuda", rank)
++    dist.init_process_group(
++        "nccl",
++        init_method=f"tcp://127.0.0.1:{port}",
++        rank=rank,
++        world_size=world_size,
++    )
++
++    original_cuda_rt = pcie_dcp_a2a.CudaRTLibrary
++
++    def unexpected_cuda_rt():
++        raise AssertionError("CUDA IPC allocation started before residency rejection")
++
++    pcie_dcp_a2a.CudaRTLibrary = unexpected_cuda_rt
++    try:
++        with pytest.raises(RuntimeError, match="requires at least 64 visible SMs"):
++            PCIeDCPA2A.from_process_group(
++                process_group=dist.group.WORLD,
++                device=device,
++                max_batch_size=MAX_BATCH,
++                total_heads=TOTAL_HEADS,
++                head_dim=HEAD_DIM,
++                query_head_dim=QUERY_HEAD_DIM,
++            )
++        dist.barrier()
++    finally:
++        pcie_dcp_a2a.CudaRTLibrary = original_cuda_rt
++        dist.destroy_process_group()
++
++
++def _preflight_rejection_worker(rank: int, world_size: int, port: int) -> None:
++    torch.cuda.set_device(rank)
++    device = torch.device("cuda", rank)
++    dist.init_process_group(
++        "nccl",
++        init_method=f"tcp://127.0.0.1:{port}",
++        rank=rank,
++        world_size=world_size,
++    )
++
++    original_cuda_rt = pcie_dcp_a2a.CudaRTLibrary
++    original_allocate = PCIeOneshotAllReduce._allocate_shared_buffer
++
++    class FakeExt:
++        @staticmethod
++        def meta_size():
++            return 256
++
++    def fail_cuda_rt():
++        raise RuntimeError("injected rank-zero pre-allocation failure")
++
++    def unexpected_allocate(*args, **kwargs):
++        raise AssertionError(
++            "CUDA IPC allocation started after a peer preflight failure"
++        )
++
++    if rank == 0:
++        pcie_dcp_a2a.CudaRTLibrary = fail_cuda_rt
++    PCIeOneshotAllReduce._allocate_shared_buffer = staticmethod(unexpected_allocate)
++    try:
++        with pytest.raises(RuntimeError, match="pre-allocation setup"):
++            PCIeDCPA2A.from_process_group(
++                process_group=dist.group.WORLD,
++                device=device,
++                max_batch_size=MAX_BATCH,
++                total_heads=TOTAL_HEADS,
++                head_dim=HEAD_DIM,
++                query_head_dim=QUERY_HEAD_DIM,
++                ext_module=FakeExt(),
++            )
++        dist.barrier()
++    finally:
++        pcie_dcp_a2a.CudaRTLibrary = original_cuda_rt
++        PCIeOneshotAllReduce._allocate_shared_buffer = original_allocate
+         dist.destroy_process_group()
+ 
+ 
+ def test_pcie_dcp_a2a_eager_and_cuda_graph_correctness():
++    if (
++        os.getenv("SPARKINFER_PCIE_DCP_TEST_EXPECT_RESIDENCY_REJECTION") == "1"
++        or os.getenv("SPARKINFER_PCIE_DCP_TEST_EXPECT_PREFLIGHT_REJECTION") == "1"
++    ):
++        pytest.skip("running the reduced-SM residency rejection gate")
+     if not torch.cuda.is_available():
+         pytest.skip("CUDA is unavailable")
+     world_size = int(os.getenv("SPARKINFER_PCIE_DCP_A2A_WORLD_SIZE", "2"))
+@@ -342,3 +697,48 @@ def test_pcie_dcp_a2a_eager_and_cuda_graph_correctness():
+         )
+     _load_extension()
+     mp.spawn(_worker, args=(world_size, _free_port()), nprocs=world_size, join=True)
++
++
++def test_pcie_dcp_a2a_rejects_reduced_sm_slice_before_ipc_allocation():
++    if os.getenv("SPARKINFER_PCIE_DCP_TEST_EXPECT_RESIDENCY_REJECTION") != "1":
++        pytest.skip("set the reduced-SM residency rejection gate to run this test")
++    visible_sms = int(os.getenv("SPARKINFER_PCIE_TEST_VISIBLE_SM_COUNT", "0") or "0")
++    assert 0 < visible_sms < pcie_dcp_a2a.DCP_A2A_REQUIRED_SMS, (
++        "set SPARKINFER_PCIE_TEST_VISIBLE_SM_COUNT below "
++        f"{pcie_dcp_a2a.DCP_A2A_REQUIRED_SMS} to exercise the residency gate"
++    )
++    if not torch.cuda.is_available():
++        pytest.skip("CUDA is unavailable")
++    world_size = int(os.getenv("SPARKINFER_PCIE_DCP_A2A_WORLD_SIZE", "2"))
++    if world_size not in (2, 4, 8):
++        pytest.skip("PCIe DCP A2A supports world sizes 2, 4, and 8")
++    if torch.cuda.device_count() < world_size:
++        pytest.skip(
++            f"need {world_size} CUDA devices, found {torch.cuda.device_count()}"
++        )
++    mp.spawn(
++        _residency_rejection_worker,
++        args=(world_size, _free_port()),
++        nprocs=world_size,
++        join=True,
++    )
++
++
++def test_pcie_dcp_a2a_coordinates_one_rank_preflight_failure_before_ipc():
++    if os.getenv("SPARKINFER_PCIE_DCP_TEST_EXPECT_PREFLIGHT_REJECTION") != "1":
++        pytest.skip("set the one-rank preflight rejection gate to run this test")
++    if not torch.cuda.is_available():
++        pytest.skip("CUDA is unavailable")
++    world_size = int(os.getenv("SPARKINFER_PCIE_DCP_A2A_WORLD_SIZE", "2"))
++    if world_size not in (2, 4, 8):
++        pytest.skip("PCIe DCP A2A supports world sizes 2, 4, and 8")
++    if torch.cuda.device_count() < world_size:
++        pytest.skip(
++            f"need {world_size} CUDA devices, found {torch.cuda.device_count()}"
++        )
++    mp.spawn(
++        _preflight_rejection_worker,
++        args=(world_size, _free_port()),
++        nprocs=world_size,
++        join=True,
++    )
+diff --git a/tests/comm/test_pcie_ipc_lifecycle.py b/tests/comm/test_pcie_ipc_lifecycle.py
+new file mode 100644
+index 0000000000000000000000000000000000000000..2bbd734ae95f708484c5f4466dde71571e0268eb
+--- /dev/null
++++ b/tests/comm/test_pcie_ipc_lifecycle.py
+@@ -0,0 +1,683 @@
++from __future__ import annotations
++
++import gc
++import weakref
++
++import pytest
++import torch
++
++from sparkinfer.comm.pcie.pcie_dcp_a2a import PCIeDCPA2A, PCIeDCPA2APool
++from sparkinfer.comm.pcie.pcie_oneshot import (
++    _ABANDONED_PCIE_RUNTIME_QUARANTINE,
++    PCIeOneshotAllReduce,
++    PCIeOneshotAllReducePool,
++)
++from sparkinfer.comm.pcie.pcie_twoshot import PCIeTwoShotSP
++
++
++class _FakeChannel:
++    def __init__(self, name: str, events: list[str]) -> None:
++        self.name = name
++        self.events = events
++
++    def _close_ipc_imports(self) -> None:
++        self.events.append(f"imports:{self.name}")
++
++    def _free_ipc_exports(self) -> None:
++        self.events.append(f"exports:{self.name}")
++
++
++def test_pool_explicit_close_coordinates_imports_before_exports(monkeypatch) -> None:
++    events = []
++    group = object()
++    channel_a = _FakeChannel("a", events)
++    channel_b = _FakeChannel("b", events)
++    pool = PCIeOneshotAllReducePool(
++        rank=0,
++        world_size=2,
++        device=torch.device("cuda:0"),
++        exchange_group=group,
++        channel_factory=lambda stream_key: channel_a,
++    )
++    pool._all_channels = [channel_a, channel_b]
++    pool._channels = {1: channel_a, 2: channel_b}
++    monkeypatch.setattr(
++        "sparkinfer.comm.pcie.pcie_oneshot.dist.barrier",
++        lambda *, group: events.append("barrier"),
++    )
++    monkeypatch.setattr(
++        "sparkinfer.comm.pcie.pcie_oneshot.torch.cuda.synchronize",
++        lambda device: events.append("synchronize"),
++    )
++    monkeypatch.setattr(
++        "sparkinfer.comm.pcie.pcie_oneshot._broadcast_gather_object",
++        lambda local_status, group: [local_status, ()],
++    )
++
++    pool.close()
++    pool.close()
++
++    assert events == [
++        "synchronize",
++        "barrier",
++        "imports:a",
++        "imports:b",
++        "barrier",
++        "exports:a",
++        "exports:b",
++        "barrier",
++    ]
++    assert pool._closed
++    assert pool._all_channels == []
++    assert pool._channels == {}
++
++
++def test_pool_destructor_is_nonblocking_and_does_not_touch_cuda_ownership(
++    monkeypatch,
++) -> None:
++    events = []
++    channel = _FakeChannel("a", events)
++    pool = PCIeOneshotAllReducePool(
++        rank=0,
++        world_size=2,
++        device=torch.device("cpu"),
++        exchange_group=object(),
++        channel_factory=lambda stream_key: pytest.fail("factory must not run"),
++    )
++    pool._all_channels = [channel]
++    pool._channels = {1: channel}
++    monkeypatch.setattr(
++        "sparkinfer.comm.pcie.pcie_oneshot.dist.barrier",
++        lambda *, group: events.append("barrier"),
++    )
++
++    pool.__del__()
++
++    assert events == []
++
++
++class _FakeExt:
++    def __init__(self, events: list[object], *, dispose_failures: int = 0) -> None:
++        self.events = events
++        self.dispose_failures = dispose_failures
++
++    def dispose(self, ptr: int) -> None:
++        self.events.append(("dispose", ptr))
++        if self.dispose_failures:
++            self.dispose_failures -= 1
++            raise RuntimeError("dispose failed")
++
++    def dispose_best_effort(self, ptr: int) -> None:
++        self.events.append(("dispose_best_effort", ptr))
++
++
++class _FakeIPC:
++    def __init__(
++        self,
++        events: list[object],
++        *,
++        close_failures: dict[int, int] | None = None,
++        free_failures: dict[int, int] | None = None,
++    ) -> None:
++        self.events = events
++        self.close_failures = dict(close_failures or {})
++        self.free_failures = dict(free_failures or {})
++
++    def cudaIpcCloseMemHandle(self, ptr: int) -> None:
++        self.events.append(("close", ptr))
++        if self.close_failures.get(ptr, 0):
++            self.close_failures[ptr] -= 1
++            raise RuntimeError(f"close {ptr} failed")
++
++    def cudaFree(self, ptr: int) -> None:
++        self.events.append(("free", ptr))
++        if self.free_failures.get(ptr, 0):
++            self.free_failures[ptr] -= 1
++            raise RuntimeError(f"free {ptr} failed")
++
++
++class _Shared:
++    def __init__(self, local_ptr: int, remote_ptrs: tuple[int, ...]) -> None:
++        self.local_ptr = local_ptr
++        self.remote_ptrs = remote_ptrs
++
++
++def _fake_twoshot(events: list[object]) -> PCIeTwoShotSP:
++    runtime = object.__new__(PCIeTwoShotSP)
++    runtime.rank = 0
++    runtime.world_size = 2
++    runtime.device = torch.device("cpu")
++    runtime.exchange_group = object()
++    runtime._ext = _FakeExt(events)
++    runtime._fptr = 123
++    runtime._owned_buffers = [_Shared(1000, (2000, 3000))]
++    runtime._ipc = _FakeIPC(events)
++    runtime.max_rows = 8
++    runtime.row_elems = 16
++    runtime._closed = False
++    runtime._ipc_imports_closed = False
++    runtime._ipc_exports_freed = False
++    return runtime
++
++
++def _fake_oneshot(events: list[object]) -> PCIeOneshotAllReduce:
++    runtime = object.__new__(PCIeOneshotAllReduce)
++    runtime.rank = 0
++    runtime.world_size = 2
++    runtime.device = torch.device("cpu")
++    runtime.exchange_group = None
++    runtime._ext = _FakeExt(events)
++    runtime._ptr = 123
++    runtime._owned_buffers = [_Shared(1000, (2000, 3000))]
++    runtime._ipc = _FakeIPC(events)
++    runtime._registered_input_ptrs = {10: (20,)}
++    runtime._closed = False
++    runtime._ipc_imports_closed = False
++    runtime._ipc_exports_freed = False
++    return runtime
++
++
++def _fake_dcp(events: list[object]) -> PCIeDCPA2A:
++    runtime = object.__new__(PCIeDCPA2A)
++    runtime.rank = 0
++    runtime.world_size = 2
++    runtime.device = torch.device("cpu")
++    runtime.exchange_group = None
++    runtime._ext = _FakeExt(events)
++    runtime._ptr = 123
++    runtime._owned_buffers = [_Shared(1000, (2000, 3000))]
++    runtime._ipc = _FakeIPC(events)
++    runtime._closed = False
++    runtime._ipc_imports_closed = False
++    runtime._ipc_exports_freed = False
++    runtime._coordinated_close_complete = False
++    runtime._closed_ipc_import_indices = set()
++    return runtime
++
++
++def test_dcp_explicit_close_retries_failed_unmap_before_export_free() -> None:
++    events: list[object] = []
++    runtime = _fake_dcp(events)
++    runtime._ipc = _FakeIPC(events, close_failures={2000: 1})
++
++    with pytest.raises(RuntimeError, match="failed during IPC unmap"):
++        runtime.close()
++
++    assert events == [
++        ("dispose", 123),
++        ("close", 2000),
++        ("close", 3000),
++    ]
++    assert runtime._ptr == 0
++    assert not runtime._ipc_imports_closed
++    assert not runtime._ipc_exports_freed
++
++    runtime.close()
++    assert events[-2:] == [("close", 2000), ("free", 1000)]
++    assert runtime._ipc_imports_closed
++    assert runtime._ipc_exports_freed
++
++
++def test_dcp_pool_failed_rollback_retains_transient_channel() -> None:
++    retained = _fake_dcp([])
++    transient_events: list[object] = []
++    transient = _fake_dcp(transient_events)
++    transient._ipc = _FakeIPC(transient_events, close_failures={2000: 1})
++    pool = PCIeDCPA2APool(
++        rank=0,
++        world_size=2,
++        device=torch.device("cpu"),
++        max_batch_size=4,
++        total_heads=32,
++        head_dim=64,
++        channel_factory=lambda stream_key: retained,
++    )
++    pool._all_channels = [retained, transient]
++    pool._channels = {1: retained, 2: transient}
++
++    with pytest.raises(RuntimeError, match="failed during IPC unmap"):
++        pool.rollback_channels((1, {1: retained}))
++
++    assert pool._all_channels == [retained, transient]
++    assert pool._channels == {1: retained, 2: transient}
++    assert ("free", 1000) not in transient_events
++
++
++def test_twoshot_explicit_close_coordinates_unmap_then_free(monkeypatch) -> None:
++    events: list[object] = []
++    runtime = _fake_twoshot(events)
++    runtime.device = torch.device("cuda:0")
++    monkeypatch.setattr(
++        "sparkinfer.comm.pcie.pcie_oneshot.dist.barrier",
++        lambda *, group: events.append("barrier"),
++    )
++    monkeypatch.setattr(
++        "sparkinfer.comm.pcie.pcie_oneshot.torch.cuda.synchronize",
++        lambda device: events.append("synchronize"),
++    )
++    monkeypatch.setattr(
++        "sparkinfer.comm.pcie.pcie_oneshot._broadcast_gather_object",
++        lambda local_status, group: [local_status, ()],
++    )
++
++    runtime.close()
++    runtime.close()
++
++    assert events == [
++        "synchronize",
++        "barrier",
++        ("dispose", 123),
++        ("close", 2000),
++        ("close", 3000),
++        "barrier",
++        ("free", 1000),
++        "barrier",
++    ]
++    assert runtime._fptr == 0
++    assert runtime._owned_buffers == []
++    assert runtime._ipc_imports_closed
++    assert runtime._ipc_exports_freed
++
++
++def test_twoshot_destructor_retains_imports_and_exports_without_cuda_calls(
++    monkeypatch,
++) -> None:
++    events: list[object] = []
++    runtime = _fake_twoshot(events)
++    monkeypatch.setattr(
++        "sparkinfer.comm.pcie.pcie_oneshot.dist.barrier",
++        lambda *, group: events.append("barrier"),
++    )
++
++    runtime.__del__()
++
++    assert events == []
++    assert runtime._fptr == 123
++    assert runtime._owned_buffers != []
++    assert not runtime._ipc_exports_freed
++
++
++@pytest.mark.parametrize("runtime_factory", (_fake_dcp, _fake_twoshot))
++def test_real_gc_quarantines_dcp_and_twoshot_ownership(runtime_factory) -> None:
++    events: list[object] = []
++    runtime = runtime_factory(events)
++    runtime_id = id(runtime)
++    runtime_ref = weakref.ref(runtime)
++
++    del runtime
++    gc.collect()
++
++    retained = _ABANDONED_PCIE_RUNTIME_QUARANTINE.pop(runtime_id)
++    assert runtime_ref() is retained
++    assert events == []
++    pointer_attr = "_ptr" if isinstance(retained, PCIeDCPA2A) else "_fptr"
++    assert getattr(retained, pointer_attr) == 123
++    assert retained._owned_buffers
++    assert not retained._ipc_exports_freed
++
++    # Production deliberately keeps this ownership until process teardown.
++    # The fake can be released after marking the coordinated path complete.
++    retained._coordinated_close_complete = True
++    del retained
++    gc.collect()
++    assert runtime_ref() is None
++
++
++@pytest.mark.parametrize("runtime_factory", (_fake_dcp, _fake_twoshot))
++def test_explicitly_closed_dcp_and_twoshot_are_not_quarantined(runtime_factory) -> None:
++    events: list[object] = []
++    runtime = runtime_factory(events)
++    runtime.exchange_group = None
++    runtime.close()
++    runtime_id = id(runtime)
++    runtime_ref = weakref.ref(runtime)
++
++    del runtime
++    gc.collect()
++
++    assert runtime_ref() is None
++    assert runtime_id not in _ABANDONED_PCIE_RUNTIME_QUARANTINE
++
++
++def test_real_gc_quarantines_dcp_pool_and_its_channel() -> None:
++    channel = _fake_dcp([])
++    pool = PCIeDCPA2APool(
++        rank=0,
++        world_size=2,
++        device=torch.device("cpu"),
++        max_batch_size=4,
++        total_heads=32,
++        head_dim=64,
++        channel_factory=lambda stream_key: pytest.fail("factory must not run"),
++    )
++    pool._all_channels = [channel]
++    pool._channels = {0: channel}
++    pool_id = id(pool)
++    pool_ref = weakref.ref(pool)
++
++    del pool
++    gc.collect()
++
++    retained = _ABANDONED_PCIE_RUNTIME_QUARANTINE.pop(pool_id)
++    assert pool_ref() is retained
++    assert retained._all_channels == [channel]
++    assert retained._channels
++
++    retained._closed = True
++    channel._coordinated_close_complete = True
++    del retained
++    del channel
++    gc.collect()
++    assert pool_ref() is None
++
++
++@pytest.mark.parametrize("runtime_factory", (_fake_oneshot, _fake_twoshot))
++def test_strict_close_reports_unmap_failure_retains_exports_and_retries_only_failure(
++    runtime_factory,
++) -> None:
++    events: list[object] = []
++    runtime = runtime_factory(events)
++    runtime.exchange_group = None
++    runtime._ipc = _FakeIPC(events, close_failures={2000: 1})
++
++    with pytest.raises(
++        RuntimeError,
++        match=r"coordinated PCIe close failed during IPC unmap.*not freed",
++    ):
++        runtime.close()
++
++    assert events == [
++        ("dispose", 123),
++        ("close", 2000),
++        ("close", 3000),
++    ]
++    pointer_attr = "_ptr" if isinstance(runtime, PCIeOneshotAllReduce) else "_fptr"
++    assert getattr(runtime, pointer_attr) == 0
++    assert runtime._closed
++    assert not runtime._ipc_imports_closed
++    assert not runtime._ipc_exports_freed
++    assert [shared.local_ptr for shared in runtime._owned_buffers] == [1000]
++
++    runtime.close()
++
++    assert events == [
++        ("dispose", 123),
++        ("close", 2000),
++        ("close", 3000),
++        ("close", 2000),
++        ("free", 1000),
++    ]
++    assert runtime._ipc_imports_closed
++    assert runtime._ipc_exports_freed
++    assert runtime._owned_buffers == []
++
++
++@pytest.mark.parametrize("runtime_factory", (_fake_oneshot, _fake_twoshot))
++def test_strict_close_reports_native_dispose_failure_without_losing_pointer(
++    runtime_factory,
++) -> None:
++    events: list[object] = []
++    runtime = runtime_factory(events)
++    runtime.exchange_group = None
++    runtime._ext = _FakeExt(events, dispose_failures=1)
++
++    with pytest.raises(RuntimeError, match="failed during IPC unmap"):
++        runtime.close()
++
++    pointer_attr = "_ptr" if isinstance(runtime, PCIeOneshotAllReduce) else "_fptr"
++    assert getattr(runtime, pointer_attr) == 123
++    assert events == [
++        ("dispose", 123),
++        ("close", 2000),
++        ("close", 3000),
++    ]
++    assert not runtime._ipc_imports_closed
++    assert not runtime._ipc_exports_freed
++
++    runtime.close()
++
++    assert getattr(runtime, pointer_attr) == 0
++    assert events == [
++        ("dispose", 123),
++        ("close", 2000),
++        ("close", 3000),
++        ("dispose", 123),
++        ("free", 1000),
++    ]
++    assert runtime._ipc_imports_closed
++    assert runtime._ipc_exports_freed
++
++
++@pytest.mark.parametrize("runtime_factory", (_fake_oneshot, _fake_twoshot))
++def test_strict_close_reports_free_failure_and_retains_only_failed_export(
++    runtime_factory,
++) -> None:
++    events: list[object] = []
++    runtime = runtime_factory(events)
++    runtime.exchange_group = None
++    runtime._owned_buffers.append(_Shared(4000, (5000,)))
++    runtime._ipc = _FakeIPC(events, free_failures={1000: 1})
++
++    with pytest.raises(RuntimeError, match="failed during IPC export free"):
++        runtime.close()
++
++    assert events == [
++        ("dispose", 123),
++        ("close", 2000),
++        ("close", 3000),
++        ("close", 5000),
++        ("free", 1000),
++        ("free", 4000),
++    ]
++    assert runtime._ipc_imports_closed
++    assert not runtime._ipc_exports_freed
++    assert [shared.local_ptr for shared in runtime._owned_buffers] == [1000]
++
++    runtime.close()
++
++    assert events[-1] == ("free", 1000)
++    assert runtime._ipc_exports_freed
++    assert runtime._owned_buffers == []
++
++
++def test_peer_unmap_failure_is_exchanged_before_any_local_export_free(
++    monkeypatch,
++) -> None:
++    events: list[object] = []
++    runtime = _fake_oneshot(events)
++    runtime.device = torch.device("cuda:0")
++    runtime.exchange_group = object()
++    peer_statuses = iter(
++        [
++            lambda local: [local, ("peer close failed",)],
++            lambda local: [local, ()],
++            lambda local: [local, ()],
++        ]
++    )
++
++    monkeypatch.setattr(
++        "sparkinfer.comm.pcie.pcie_oneshot.dist.barrier",
++        lambda *, group: events.append("barrier"),
++    )
++    monkeypatch.setattr(
++        "sparkinfer.comm.pcie.pcie_oneshot.torch.cuda.synchronize",
++        lambda device: events.append("synchronize"),
++    )
++    monkeypatch.setattr(
++        "sparkinfer.comm.pcie.pcie_oneshot._broadcast_gather_object",
++        lambda local_status, group: next(peer_statuses)(local_status),
++    )
++
++    with pytest.raises(RuntimeError, match="group rank 1: peer close failed"):
++        runtime.close()
++
++    assert ("free", 1000) not in events
++    assert runtime._ipc_imports_closed
++    assert not runtime._ipc_exports_freed
++
++    runtime.close()
++
++    assert events == [
++        "synchronize",
++        "barrier",
++        ("dispose", 123),
++        ("close", 2000),
++        ("close", 3000),
++        "synchronize",
++        "barrier",
++        "barrier",
++        ("free", 1000),
++        "barrier",
++    ]
++    assert runtime._ipc_exports_freed
++
++
++def test_status_exchange_failure_retains_local_exports(monkeypatch) -> None:
++    events: list[object] = []
++    runtime = _fake_oneshot(events)
++    runtime.exchange_group = object()
++
++    def fail_status_exchange(local_status, group):
++        raise RuntimeError("status exchange failed")
++
++    monkeypatch.setattr(
++        "sparkinfer.comm.pcie.pcie_oneshot.dist.barrier",
++        lambda *, group: events.append("barrier"),
++    )
++    monkeypatch.setattr(
++        "sparkinfer.comm.pcie.pcie_oneshot._broadcast_gather_object",
++        fail_status_exchange,
++    )
++
++    with pytest.raises(RuntimeError, match="failed to exchange peer IPC unmap"):
++        runtime.close()
++
++    assert events == [
++        "barrier",
++        ("dispose", 123),
++        ("close", 2000),
++        ("close", 3000),
++    ]
++    assert runtime._ipc_imports_closed
++    assert not runtime._ipc_exports_freed
++    assert runtime._owned_buffers
++
++
++@pytest.mark.parametrize("runtime_factory", (_fake_oneshot, _fake_twoshot))
++def test_rank_that_freed_locally_retries_until_peer_free_succeeds(
++    monkeypatch,
++    runtime_factory,
++) -> None:
++    events: list[object] = []
++    runtime = runtime_factory(events)
++    runtime.device = torch.device("cuda:0")
++    runtime.exchange_group = object()
++    peer_statuses = iter(
++        [
++            lambda local: [local, ()],
++            lambda local: [local, ("peer export free failed",)],
++            lambda local: [local, ()],
++            lambda local: [local, ()],
++        ]
++    )
++
++    monkeypatch.setattr(
++        "sparkinfer.comm.pcie.pcie_oneshot.dist.barrier",
++        lambda *, group: events.append("barrier"),
++    )
++    monkeypatch.setattr(
++        "sparkinfer.comm.pcie.pcie_oneshot.torch.cuda.synchronize",
++        lambda device: events.append("synchronize"),
++    )
++    monkeypatch.setattr(
++        "sparkinfer.comm.pcie.pcie_oneshot._broadcast_gather_object",
++        lambda local_status, group: next(peer_statuses)(local_status),
++    )
++
++    with pytest.raises(RuntimeError, match="group rank 1: peer export free failed"):
++        runtime.close()
++
++    assert runtime._ipc_exports_freed
++    assert not getattr(runtime, "_coordinated_close_complete", False)
++
++    runtime.close()
++    events_after_success = list(events)
++    runtime.close()
++
++    assert events == events_after_success
++    assert events == [
++        "synchronize",
++        "barrier",
++        ("dispose", 123),
++        ("close", 2000),
++        ("close", 3000),
++        "barrier",
++        ("free", 1000),
++        "synchronize",
++        "barrier",
++        "barrier",
++        "barrier",
++    ]
++    assert runtime._coordinated_close_complete
++
++
++@pytest.mark.parametrize("runtime_factory", (_fake_oneshot, _fake_twoshot))
++def test_gc_never_attempts_native_dispose_or_ipc_unmap(
++    runtime_factory,
++) -> None:
++    events: list[object] = []
++    runtime = runtime_factory(events)
++    runtime._ipc = _FakeIPC(events, close_failures={2000: 1})
++
++    runtime.__del__()
++
++    assert events == []
++    pointer_attr = "_ptr" if isinstance(runtime, PCIeOneshotAllReduce) else "_fptr"
++    assert getattr(runtime, pointer_attr) == 123
++    assert not runtime._ipc_imports_closed
++    assert not runtime._ipc_exports_freed
++    assert runtime._owned_buffers
++
++
++def test_gc_retention_preserves_explicit_close_retry_path() -> None:
++    events: list[object] = []
++    runtime = _fake_oneshot(events)
++
++    runtime.__del__()
++
++    assert events == []
++    assert runtime._ptr == 123
++    assert not runtime._ipc_imports_closed
++    runtime.close()
++    assert events == [
++        ("dispose", 123),
++        ("close", 2000),
++        ("close", 3000),
++        ("free", 1000),
++    ]
++    assert runtime._ipc_exports_freed
++
++
++def test_failed_rollback_keeps_transient_channel_owned_for_retry() -> None:
++    retained_events: list[object] = []
++    transient_events: list[object] = []
++    retained = _fake_oneshot(retained_events)
++    transient = _fake_oneshot(transient_events)
++    transient._ipc = _FakeIPC(transient_events, close_failures={2000: 1})
++    pool = PCIeOneshotAllReducePool(
++        rank=0,
++        world_size=2,
++        device=torch.device("cpu"),
++        channel_factory=lambda stream_key: retained,
++    )
++    pool._all_channels = [retained, transient]
++    pool._channels = {1: retained, 2: transient}
++    checkpoint = (1, {1: retained})
++
++    with pytest.raises(RuntimeError, match="failed during IPC unmap"):
++        pool.rollback_channels(checkpoint)
++
++    assert pool._all_channels == [retained, transient]
++    assert pool._channels == {1: retained, 2: transient}
++    assert not pool._closed
++    assert ("free", 1000) not in transient_events
+diff --git a/tests/comm/test_pcie_native_teardown.py b/tests/comm/test_pcie_native_teardown.py
+new file mode 100644
+index 0000000000000000000000000000000000000000..e4747becef970f259908afbfbf928b785e40174b
+--- /dev/null
++++ b/tests/comm/test_pcie_native_teardown.py
+@@ -0,0 +1,179 @@
++from __future__ import annotations
++
++import shutil
++import subprocess
++import textwrap
++from pathlib import Path
++
++import pytest
++
++
++ROOT = Path(__file__).resolve().parents[2]
++PCIE_ONESHOT = ROOT / "sparkinfer" / "comm" / "pcie" / "pcie_oneshot.cu"
++
++
++def test_oneshot_native_dispose_has_strict_and_best_effort_paths() -> None:
++    source = PCIE_ONESHOT.read_text(encoding="utf-8")
++
++    assert "IpcHandleRegistry<IPC_KEY, char*, cudaError_t, cudaSuccess>" in source
++    assert "IPCHandles ipc_handles_;" in source
++    assert "~PCIeAllreduce() noexcept = default;" in source
++    assert "cudaError_t close_ipc_handles_noexcept() noexcept" in source
++    assert "void close_ipc_handles_strict()" in source
++    assert "&dispose," in source
++    assert '"dispose_best_effort"' in source
++
++    dispose = source[source.index("static void dispose(fptr_t _fa)") :]
++    dispose = dispose[: dispose.index("static int64_t meta_size()")]
++    assert dispose.index("fa->close_ipc_handles_strict();") < dispose.index(
++        "delete fa;"
++    )
++    assert "static bool dispose_best_effort(fptr_t _fa) noexcept" in dispose
++
++
++def test_native_ipc_registry_destructor_survives_injected_close_failure(
++    tmp_path: Path,
++) -> None:
++    """Compile the production RAII helper and fail a close inside destruction.
++
++    Throwing for this injected status from an implicitly-noexcept destructor,
++    as the old PCIeAllreduce destructor did, would invoke the terminate handler
++    and make the subprocess exit 86.
++    """
++
++    compiler = shutil.which("c++") or shutil.which("clang++") or shutil.which("g++")
++    if compiler is None:
++        pytest.skip("no C++ compiler available for native teardown regression")
++
++    source = tmp_path / "ipc_registry_failure_injection.cpp"
++    binary = tmp_path / "ipc_registry_failure_injection"
++    source.write_text(
++        textwrap.dedent(
++            r"""
++            #include "sparkinfer/comm/pcie/ipc_handle_registry.h"
++
++            #include <cstdlib>
++            #include <exception>
++            #include <type_traits>
++
++            namespace {
++
++            constexpr int kSuccess = 0;
++            constexpr int kInjectedFailure = 7;
++            int close_calls = 0;
++            int failed_handle = 0;
++            int failures_remaining = 0;
++
++            int injected_close(int handle) noexcept {
++              ++close_calls;
++              if (handle == failed_handle && failures_remaining > 0) {
++                --failures_remaining;
++                return kInjectedFailure;
++              }
++              return kSuccess;
++            }
++
++            using Registry =
++                sparkinfer::pcie::IpcHandleRegistry<int, int, int, kSuccess>;
++
++            struct Owner {
++              Registry handles{&injected_close};
++              ~Owner() noexcept = default;
++            };
++
++            static_assert(std::is_nothrow_destructible_v<Registry>);
++            static_assert(std::is_nothrow_destructible_v<Owner>);
++
++            }  // namespace
++
++            int main() {
++              std::set_terminate([] { std::_Exit(86); });
++
++              failed_handle = 22;
++              failures_remaining = 1;
++              {
++                Owner owner;
++                owner.handles.emplace(1, 11);
++                owner.handles.emplace(2, 22);
++                owner.handles.emplace(3, 33);
++              }
++              if (close_calls != 3 || failures_remaining != 0) {
++                return 10;
++              }
++
++              close_calls = 0;
++              failures_remaining = 1;
++              {
++                Owner owner;
++                owner.handles.emplace(1, 11);
++                owner.handles.emplace(2, 22);
++                owner.handles.emplace(3, 33);
++                if (owner.handles.close_all_noexcept() != kInjectedFailure) {
++                  return 11;
++                }
++                if (close_calls != 3) {
++                  return 12;
++                }
++                if (owner.handles.find(1) != owner.handles.end() ||
++                    owner.handles.find(2) == owner.handles.end() ||
++                    owner.handles.find(3) != owner.handles.end()) {
++                  return 17;
++                }
++                if (owner.handles.close_all_noexcept() != kSuccess) {
++                  return 13;
++                }
++                if (close_calls != 4) {
++                  return 14;
++                }
++                if (owner.handles.find(2) != owner.handles.end()) {
++                  return 18;
++                }
++                if (owner.handles.close_all_noexcept() != kSuccess ||
++                    close_calls != 4) {
++                  return 15;
++                }
++              }
++              return close_calls == 4 ? 0 : 16;
++            }
++            """
++        ),
++        encoding="utf-8",
++    )
++
++    compile_result = subprocess.run(
++        [
++            compiler,
++            "-std=c++17",
++            "-Wall",
++            "-Wextra",
++            "-Werror",
++            "-I",
++            str(ROOT),
++            str(source),
++            "-o",
++            str(binary),
++        ],
++        check=False,
++        capture_output=True,
++        text=True,
++        timeout=30,
++    )
++    assert compile_result.returncode == 0, (
++        "native teardown regression failed to compile\n"
++        f"stdout:\n{compile_result.stdout}\n"
++        f"stderr:\n{compile_result.stderr}"
++    )
++
++    run_result = subprocess.run(
++        [str(binary)],
++        check=False,
++        capture_output=True,
++        text=True,
++        timeout=10,
++    )
++    assert run_result.returncode == 0, (
++        "injected native close failure terminated or violated idempotency\n"
++        f"returncode: {run_result.returncode}\n"
++        f"stdout:\n{run_result.stdout}\n"
++        f"stderr:\n{run_result.stderr}"
++    )
+diff --git a/tests/comm/test_pcie_oneshot.py b/tests/comm/test_pcie_oneshot.py
+index e065eafb2710fd6c79497a55d373738b247610f8..bd6c540b1ee91f5818d5dc28ffa251fef40f85ee 100644
+--- a/tests/comm/test_pcie_oneshot.py
++++ b/tests/comm/test_pcie_oneshot.py
+@@ -1,5 +1,8 @@
+ from __future__ import annotations
+ 
++import gc
++from types import SimpleNamespace
++
+ import pytest
+ import torch
+ 
+@@ -7,11 +10,29 @@ from sparkinfer.comm.pcie.pcie_oneshot import (
+     IPC_SLAB_ALIGNMENT,
+     PCIeOneshotAllReduce,
+     PCIeOneshotAllReducePool,
++    _abort_collective_ipc_setup,
++    _broadcast_gather_object,
+     _compute_crossover_size,
++    _finish_collective_runtime_setup,
++    _group_ranks,
++    _OwnedSharedBuffer,
++    _require_no_retained_ipc_setup,
++    _require_full_grid_residency,
++    _ABANDONED_PCIE_RUNTIME_QUARANTINE,
++    _RETAINED_FAILED_IPC_EXPORTS,
+     parse_pcie_oneshot_max_size,
+ )
+ 
+ 
++@pytest.fixture(autouse=True)
++def _isolate_pcie_global_registries():
++    _RETAINED_FAILED_IPC_EXPORTS.clear()
++    _ABANDONED_PCIE_RUNTIME_QUARANTINE.clear()
++    yield
++    _RETAINED_FAILED_IPC_EXPORTS.clear()
++    _ABANDONED_PCIE_RUNTIME_QUARANTINE.clear()
++
++
+ class _FakeExt:
+     def __init__(self):
+         self.init_calls = []
+@@ -106,6 +127,7 @@ def _make_runtime(
+     if eager:
+         kwargs["eager_buffer_ptrs0"] = tuple(range(200, 200 + world_size))
+         kwargs["eager_buffer_ptrs1"] = tuple(range(300, 300 + world_size))
++        kwargs["eager_buffer_bytes"] = max_size
+     return PCIeOneshotAllReduce(
+         rank=rank,
+         world_size=world_size,
+@@ -127,6 +149,63 @@ def test_parse_pcie_oneshot_max_size_accepts_auto_and_suffixes():
+     assert parse_pcie_oneshot_max_size(4096) == 4096
+ 
+ 
++def test_full_grid_residency_accepts_device_with_enough_visible_sms(
++    monkeypatch,
++):
++    monkeypatch.setattr(
++        torch.cuda,
++        "get_device_properties",
++        lambda device: SimpleNamespace(multi_processor_count=84),
++    )
++
++    _require_full_grid_residency(
++        owner="test collective",
++        required_sms=64,
++        device=torch.device("cuda:0"),
++        exchange_group=None,
++    )
++
++
++def test_full_grid_residency_rejects_mig_like_capacity_collectively(
++    monkeypatch,
++):
++    monkeypatch.setattr(
++        torch.cuda,
++        "get_device_properties",
++        lambda device: SimpleNamespace(multi_processor_count=84),
++    )
++    monkeypatch.setenv("SPARKINFER_PCIE_TEST_VISIBLE_SM_COUNT", "32")
++    exchanged = []
++
++    def exchange(
++        local_error,
++        *,
++        exchange_group,
++        phase,
++        exports_retained_on_exchange_failure,
++    ):
++        assert not exports_retained_on_exchange_failure
++        exchanged.append((local_error, exchange_group, phase))
++        return ((f"RuntimeError: {local_error}",), ())
++
++    monkeypatch.setattr(
++        "sparkinfer.comm.pcie.pcie_oneshot._exchange_setup_failures", exchange
++    )
++
++    group = object()
++    with pytest.raises(RuntimeError, match="requires at least 64 visible SMs") as exc:
++        _require_full_grid_residency(
++            owner="test collective",
++            required_sms=64,
++            device=torch.device("cuda:0"),
++            exchange_group=group,
++        )
++
++    assert exchanged
++    assert exchanged[0][1:] == (group, "test collective resident-grid capability")
++    assert "exports were retained" not in str(exc.value)
++
++
+ def test_compute_crossover_size_runs_fine_sweep():
+     seen_sizes = []
+ 
+@@ -347,6 +426,76 @@ def test_should_allreduce_checks_device_dtype_size_alignment_and_contiguity():
+     )
+ 
+ 
++def test_eager_runtime_rejects_threshold_above_buffer_capacity():
++    with pytest.raises(ValueError, match="exceeds eager buffer capacity"):
++        PCIeOneshotAllReduce(
++            rank=0,
++            world_size=2,
++            device=torch.device("cpu"),
++            signal_ptrs=(100, 200),
++            eager_buffer_ptrs0=(300, 400),
++            eager_buffer_ptrs1=(500, 600),
++            eager_buffer_bytes=16,
++            max_size=32,
++            ext_module=_FakeExt(),
++        )
++
++
++def test_cuda_direct_runtime_requires_collective_factory():
++    with pytest.raises(ValueError, match="exchange_group is required"):
++        PCIeOneshotAllReduce(
++            rank=0,
++            world_size=2,
++            device=torch.device("cuda:0"),
++            signal_ptrs=(100, 200),
++            ext_module=_FakeExt(),
++        )
++
++
++@pytest.mark.parametrize(
++    "runtime_class", (PCIeOneshotAllReduce, PCIeOneshotAllReducePool)
++)
++def test_process_group_max_input_sets_threshold_and_capacity(
++    monkeypatch, runtime_class
++):
++    captured = {}
++
++    def fake_from_exchange_group(cls, **kwargs):
++        captured.update(kwargs)
++        return object()
++
++    monkeypatch.setattr(
++        runtime_class, "from_exchange_group", classmethod(fake_from_exchange_group)
++    )
++
++    runtime_class.from_process_group(
++        process_group=object(),
++        device=torch.device("cuda:0"),
++        max_input_bytes=1 << 20,
++    )
++
++    assert captured["eager_buffer_bytes"] == 1 << 20
++    assert captured["max_size"] == 1 << 20
++
++
++def test_autotune_never_benchmarks_past_eager_capacity(monkeypatch):
++    runtime = _make_runtime(eager=True, max_size=4096)
++    runtime.device = torch.device("cuda:0")
++    observed = {}
++
++    def fake_compute(benchmark, *, ceiling_bytes, fine_step_bytes):
++        observed["ceiling_bytes"] = ceiling_bytes
++        return ceiling_bytes, []
++
++    monkeypatch.setattr(
++        "sparkinfer.comm.pcie.pcie_oneshot._compute_crossover_size", fake_compute
++    )
++    monkeypatch.setattr(torch.cuda, "Stream", lambda *, device: object())
++
++    assert runtime.find_crossover_size(object(), ceiling_bytes=1 << 20) == 4096
++    assert observed["ceiling_bytes"] == 4096
++
++
+ def test_graph_buffer_api_exposes_explicit_registration_hooks():
+     runtime = _make_runtime()
+     ext = runtime._ext
+@@ -395,10 +544,14 @@ def test_allocate_shared_buffer_cleans_up_on_failed_peer_open(monkeypatch):
+     monkeypatch.setattr("torch.distributed.get_rank", lambda group=None: 0)
+     monkeypatch.setattr(
+         "sparkinfer.comm.pcie.pcie_oneshot._broadcast_gather_object",
+-        lambda local_object, group: [local_object, b"remote0", b"remote1"],
++        lambda local_object, group: (
++            [local_object, (), ()]
++            if isinstance(local_object, tuple)
++            else [local_object, b"remote0", b"remote1"]
++        ),
+     )
+ 
+-    with pytest.raises(RuntimeError, match="peer rank 2"):
++    with pytest.raises(RuntimeError, match="peer group rank 2"):
+         PCIeOneshotAllReduce._allocate_shared_buffer(
+             object(), 256, zero_fill=True, ipc=ipc
+         )
+@@ -407,74 +560,116 @@ def test_allocate_shared_buffer_cleans_up_on_failed_peer_open(monkeypatch):
+     assert ipc.freed == [1000]
+ 
+ 
+-def test_eager_channel_buffers_use_single_ipc_slab(monkeypatch):
++def test_failed_setup_export_free_is_retained_and_retryable(monkeypatch):
+     class FakeIPC:
+         def __init__(self):
+-            self.malloc_sizes = []
+-            self.memsets = []
+-            self.opened = []
++            self.free_attempts = 0
+ 
+         def cudaMalloc(self, size):
+-            self.malloc_sizes.append(size)
+             return 1000
+ 
+         def cudaMemset(self, ptr, value, size):
+-            self.memsets.append((ptr, value, size))
++            raise RuntimeError("injected setup failure")
++
++        def cudaIpcGetMemHandleBytes(self, ptr):
++            return b"local"
++
++        def cudaFree(self, ptr):
++            self.free_attempts += 1
++            if self.free_attempts == 1:
++                raise RuntimeError("transient free failure")
++
++    ipc = FakeIPC()
++    monkeypatch.setattr("torch.distributed.get_world_size", lambda group=None: 2)
++    monkeypatch.setattr("torch.distributed.get_rank", lambda group=None: 0)
++    monkeypatch.setattr(
++        "sparkinfer.comm.pcie.pcie_oneshot._broadcast_gather_object",
++        lambda local_object, group: [local_object, ()],
++    )
++
++    with pytest.raises(RuntimeError, match="exports were retained") as exc:
++        PCIeOneshotAllReduce._allocate_shared_buffer(
++            object(), 256, zero_fill=True, ipc=ipc
++        )
++
++    retained = exc.value.retryable_export
++    assert _RETAINED_FAILED_IPC_EXPORTS[retained.key] is retained
++    retained.retry()
++    assert ipc.free_attempts == 2
++    assert retained.local_ptr == 0
++    assert _RETAINED_FAILED_IPC_EXPORTS == {}
++
++
++def test_failed_peer_setup_export_free_is_retained_and_retryable(monkeypatch):
++    class FakeIPC:
++        def __init__(self):
++            self.closed = []
++            self.free_attempts = 0
++
++        def cudaMalloc(self, size):
++            return 1000
++
++        def cudaMemset(self, ptr, value, size):
++            pass
+ 
+         def cudaIpcGetMemHandleBytes(self, ptr):
+             return b"local"
+ 
+         def cudaIpcOpenMemHandleBytes(self, handle):
+-            ptr = {b"remote0": 2000, b"remote1": 3000}[handle]
+-            self.opened.append(ptr)
+-            return ptr
++            return 2000
+ 
+         def cudaIpcCloseMemHandle(self, ptr):
+-            raise AssertionError("success path should not close remote ptrs")
++            self.closed.append(ptr)
+ 
+         def cudaFree(self, ptr):
+-            raise AssertionError("success path should not free local ptr")
++            self.free_attempts += 1
++            if self.free_attempts == 1:
++                raise RuntimeError("transient free failure")
+ 
+     ipc = FakeIPC()
+-    exchange_group = object()
+-    signal_bytes = 300
+-    eager_bytes = 128
+-    eager0_offset = IPC_SLAB_ALIGNMENT * 2
+-    eager1_offset = eager0_offset + IPC_SLAB_ALIGNMENT
++    status_round = 0
++
++    def exchange(local_object, group):
++        nonlocal status_round
++        if not isinstance(local_object, tuple):
++            return [local_object, b"remote"]
++        status_round += 1
++        if status_round == 1:  # retained-setup gate
++            return [local_object, ()]
++        if status_round == 2:  # export preparation
++            return [local_object, ()]
++        if status_round == 3:  # import-open verdict
++            return [local_object, ("peer open failed",)]
++        if status_round == 4:  # rollback-unmap verdict
++            return [local_object, ()]
++        if status_round == 5:  # rollback-export-free verdict
++            return [local_object, ()]
++        if status_round == 6:  # retry export-free verdict
++            return [local_object, ()]
++        raise AssertionError(f"unexpected status round {status_round}")
+ 
+-    monkeypatch.setattr("torch.distributed.get_world_size", lambda group=None: 3)
++    monkeypatch.setattr("torch.distributed.get_world_size", lambda group=None: 2)
+     monkeypatch.setattr("torch.distributed.get_rank", lambda group=None: 0)
+     monkeypatch.setattr(
+-        "sparkinfer.comm.pcie.pcie_oneshot._broadcast_gather_object",
+-        lambda local_object, group: [local_object, b"remote0", b"remote1"],
++        "sparkinfer.comm.pcie.pcie_oneshot._broadcast_gather_object", exchange
+     )
+ 
+-    buffers = PCIeOneshotAllReduce._allocate_eager_channel_buffers(
+-        exchange_group,
+-        signal_bytes=signal_bytes,
+-        eager_buffer_bytes=eager_bytes,
+-        ipc=ipc,
+-    )
++    with pytest.raises(RuntimeError, match="exports were retained") as exc:
++        PCIeOneshotAllReduce._allocate_shared_buffer(
++            object(), 256, zero_fill=True, ipc=ipc
++        )
+ 
+-    assert ipc.malloc_sizes == [eager1_offset + eager_bytes]
+-    assert ipc.memsets == [(1000, 0, eager1_offset + eager_bytes)]
+-    assert ipc.opened == [2000, 3000]
+-    assert buffers.owned_buffer.local_ptr == 1000
+-    assert buffers.owned_buffer.remote_ptrs == (2000, 3000)
+-    assert buffers.signal_ptrs == (1000, 2000, 3000)
+-    assert buffers.eager0_ptrs == (
+-        1000 + eager0_offset,
+-        2000 + eager0_offset,
+-        3000 + eager0_offset,
+-    )
+-    assert buffers.eager1_ptrs == (
+-        1000 + eager1_offset,
+-        2000 + eager1_offset,
+-        3000 + eager1_offset,
+-    )
++    retained = exc.value.retryable_export
++    assert ipc.closed == [2000]
++    assert _RETAINED_FAILED_IPC_EXPORTS[retained.key] is retained
++    retained.retry()
++    assert ipc.free_attempts == 2
++    assert _RETAINED_FAILED_IPC_EXPORTS == {}
+ 
+ 
+-def test_eager_channel_buffers_cleanup_when_slab_zero_fails(monkeypatch):
++def test_peer_setup_and_unmap_failure_retains_export_and_closes_each_import_once(
++    monkeypatch,
++):
+     class FakeIPC:
+         def __init__(self):
+             self.closed = []
+@@ -484,7 +679,7 @@ def test_eager_channel_buffers_cleanup_when_slab_zero_fails(monkeypatch):
+             return 1000
+ 
+         def cudaMemset(self, ptr, value, size):
+-            raise RuntimeError("memset failed")
++            pass
+ 
+         def cudaIpcGetMemHandleBytes(self, ptr):
+             return b"local"
+@@ -499,125 +694,711 @@ def test_eager_channel_buffers_cleanup_when_slab_zero_fails(monkeypatch):
+             self.freed.append(ptr)
+ 
+     ipc = FakeIPC()
++    status_round = 0
++
++    def exchange(local_object, group):
++        nonlocal status_round
++        if not isinstance(local_object, tuple):
++            return [local_object, b"remote0", b"remote1"]
++        status_round += 1
++        if status_round == 1:  # retained-setup gate
++            return [local_object, (), ()]
++        if status_round == 2:  # export preparation
++            return [local_object, (), ()]
++        if status_round == 3:  # import-open verdict
++            return [local_object, ("peer open failed",), ()]
++        if status_round == 4:  # rollback-unmap verdict
++            return [local_object, ("peer unmap failed",), ()]
++        if status_round in (5, 6):  # retry unmap / retry export free
++            return [local_object, (), ()]
++        raise AssertionError(f"unexpected status round {status_round}")
+ 
+     monkeypatch.setattr("torch.distributed.get_world_size", lambda group=None: 3)
+     monkeypatch.setattr("torch.distributed.get_rank", lambda group=None: 0)
+     monkeypatch.setattr(
+-        "sparkinfer.comm.pcie.pcie_oneshot._broadcast_gather_object",
+-        lambda local_object, group: [local_object, b"remote0", b"remote1"],
++        "sparkinfer.comm.pcie.pcie_oneshot._broadcast_gather_object", exchange
+     )
+ 
+-    with pytest.raises(RuntimeError, match="memset failed"):
+-        PCIeOneshotAllReduce._allocate_eager_channel_buffers(
+-            object(),
+-            signal_bytes=300,
+-            eager_buffer_bytes=128,
+-            ipc=ipc,
++    with pytest.raises(RuntimeError, match=r"retained.*peer unmap failed") as exc:
++        PCIeOneshotAllReduce._allocate_shared_buffer(
++            object(), 256, zero_fill=True, ipc=ipc
+         )
+ 
+-    assert ipc.closed == []
++    assert ipc.closed == [2000, 3000]
++    assert ipc.freed == []
++    exc.value.retryable_setup.retry()
++    assert ipc.closed == [2000, 3000]
+     assert ipc.freed == [1000]
++    assert _RETAINED_FAILED_IPC_EXPORTS == {}
+ 
+ 
+-def test_register_graph_buffers_uses_exchange_group_broadcast(monkeypatch):
+-    remote_meta = {
+-        0: ([1, 2, 3], [0, 64]),
+-        1: ([9, 8, 7], [16, 80]),
+-    }
+-
+-    monkeypatch.setattr("torch.distributed.get_world_size", lambda group=None: 2)
+-    monkeypatch.setattr("torch.distributed.get_rank", lambda group=None: 0)
+-    monkeypatch.setattr(
+-        "torch.distributed.get_process_group_ranks", lambda group=None: [0, 1]
+-    )
+-    monkeypatch.setattr(
+-        "sparkinfer.comm.pcie.pcie_oneshot._object_broadcast_device",
+-        lambda group: "cpu",
+-    )
++def test_handle_exchange_failure_retains_export_until_collective_retry(monkeypatch):
++    class FakeIPC:
++        def __init__(self):
++            self.freed = []
+ 
+-    def fake_broadcast(object_list, src, group=None, device=None):
+-        object_list[0] = remote_meta[src]
++        def cudaMalloc(self, size):
++            return 1000
+ 
+-    monkeypatch.setattr("torch.distributed.broadcast_object_list", fake_broadcast)
++        def cudaMemset(self, ptr, value, size):
++            pass
+ 
+-    runtime = _make_runtime(exchange_group=object())
+-    ext = runtime._ext
+-    runtime.register_graph_buffers()
++        def cudaIpcGetMemHandleBytes(self, ptr):
++            return b"local"
+ 
+-    assert ext.register_graph_buffers_calls == [
+-        (12345, [[1, 2, 3], [9, 8, 7]], [[0, 64], [16, 80]])
+-    ]
++        def cudaFree(self, ptr):
++            self.freed.append(ptr)
+ 
++    ipc = FakeIPC()
++    status_round = 0
++    fail_handle_exchange = True
++
++    def exchange(local_object, group):
++        nonlocal status_round, fail_handle_exchange
++        if not isinstance(local_object, tuple):
++            if fail_handle_exchange:
++                fail_handle_exchange = False
++                raise RuntimeError("injected handle exchange failure")
++            return [local_object, b"remote"]
++        status_round += 1
++        return [local_object, ()]
+ 
+-def test_register_graph_buffers_noops_when_no_rank_registered_buffers(monkeypatch):
+     monkeypatch.setattr("torch.distributed.get_world_size", lambda group=None: 2)
+     monkeypatch.setattr("torch.distributed.get_rank", lambda group=None: 0)
+     monkeypatch.setattr(
+-        "torch.distributed.get_process_group_ranks", lambda group=None: [0, 1]
+-    )
+-    monkeypatch.setattr(
+-        "sparkinfer.comm.pcie.pcie_oneshot._object_broadcast_device",
+-        lambda group: "cpu",
+-    )
+-    monkeypatch.setattr(
+-        "torch.distributed.broadcast_object_list",
+-        lambda object_list, src, group=None, device=None: object_list.__setitem__(
+-            0, ([], [])
+-        ),
++        "sparkinfer.comm.pcie.pcie_oneshot._broadcast_gather_object", exchange
+     )
+ 
+-    runtime = _make_runtime(exchange_group=object())
+-    ext = runtime._ext
+-    ext.handle_bytes = []
+-    ext.offsets = []
++    with pytest.raises(RuntimeError, match="handle exchange failed") as exc:
++        PCIeOneshotAllReduce._allocate_shared_buffer(
++            object(), 256, zero_fill=True, ipc=ipc
++        )
+ 
+-    runtime.register_graph_buffers()
++    retained = exc.value.retryable_setup
++    assert retained.local_ptr == 1000
++    assert ipc.freed == []
++    retained.retry()
++    assert ipc.freed == [1000]
++    assert status_round == 4  # gate, export verdict, retry unmap, retry free
++    assert _RETAINED_FAILED_IPC_EXPORTS == {}
+ 
+-    assert ext.register_graph_buffers_calls == []
+ 
++def test_import_status_exchange_failure_retains_imports_for_retry(monkeypatch):
++    class FakeIPC:
++        def __init__(self):
++            self.closed = []
++            self.freed = []
+ 
+-def test_capture_registers_graph_buffers_after_context(monkeypatch):
+-    runtime = _make_runtime(exchange_group=object())
+-    calls = []
++        def cudaMalloc(self, size):
++            return 1000
+ 
+-    monkeypatch.setattr(
+-        runtime, "register_graph_buffers", lambda: calls.append("registered")
+-    )
++        def cudaMemset(self, ptr, value, size):
++            pass
+ 
+-    with runtime.capture():
+-        pass
++        def cudaIpcGetMemHandleBytes(self, ptr):
++            return b"local"
+ 
+-    assert calls == ["registered"]
++        def cudaIpcOpenMemHandleBytes(self, handle):
++            return 2000
++
++        def cudaIpcCloseMemHandle(self, ptr):
++            self.closed.append(ptr)
++
++        def cudaFree(self, ptr):
++            self.freed.append(ptr)
+ 
++    ipc = FakeIPC()
++    status_round = 0
+ 
+-def test_eager_capture_skips_graph_buffer_registration(monkeypatch):
+-    runtime = _make_runtime(eager=True, exchange_group=object())
+-    calls = []
++    def exchange(local_object, group):
++        nonlocal status_round
++        if not isinstance(local_object, tuple):
++            return [local_object, b"remote"]
++        status_round += 1
++        if status_round == 3:
++            raise RuntimeError("injected import verdict exchange failure")
++        return [local_object, ()]
+ 
++    monkeypatch.setattr("torch.distributed.get_world_size", lambda group=None: 2)
++    monkeypatch.setattr("torch.distributed.get_rank", lambda group=None: 0)
+     monkeypatch.setattr(
+-        runtime, "register_graph_buffers", lambda: calls.append("registered")
++        "sparkinfer.comm.pcie.pcie_oneshot._broadcast_gather_object", exchange
+     )
+ 
+-    with runtime.capture():
+-        pass
++    with pytest.raises(RuntimeError, match="import-open status") as exc:
++        PCIeOneshotAllReduce._allocate_shared_buffer(
++            object(), 256, zero_fill=True, ipc=ipc
++        )
+ 
+-    assert calls == []
++    retained = exc.value.retryable_setup
++    assert retained.remote_ptrs == [2000]
++    assert ipc.closed == []
++    retained.retry()
++    assert ipc.closed == [2000]
++    assert ipc.freed == [1000]
++    assert _RETAINED_FAILED_IPC_EXPORTS == {}
+ 
+ 
+-def test_pool_creates_distinct_channels_per_stream_key(monkeypatch):
+-    created = []
++def test_failed_native_cleanup_is_owned_and_retried_before_export_free(monkeypatch):
++    class FakeIPC:
++        def __init__(self):
++            self.closed = []
++            self.freed = []
+ 
+-    def make_channel(stream_key):
+-        runtime = _make_runtime(eager=True)
+-        created.append((stream_key, runtime))
+-        return runtime
++        def cudaIpcCloseMemHandle(self, ptr):
++            self.closed.append(ptr)
+ 
+-    pool = PCIeOneshotAllReducePool(
+-        rank=0,
+-        world_size=2,
+-        device=torch.device("cpu"),
+-        channel_factory=make_channel,
+-    )
++        def cudaFree(self, ptr):
++            self.freed.append(ptr)
++
++    ipc = FakeIPC()
++    cleanup_calls = 0
++
++    def cleanup():
++        nonlocal cleanup_calls
++        cleanup_calls += 1
++        if cleanup_calls == 1:
++            raise RuntimeError("transient native dispose failure")
++
++    monkeypatch.setattr(
++        "sparkinfer.comm.pcie.pcie_oneshot._broadcast_gather_object",
++        lambda local_status, group: [local_status, ()],
++    )
++
++    with pytest.raises(RuntimeError, match="rollback native cleanup") as exc:
++        _abort_collective_ipc_setup(
++            owner="test runtime",
++            setup_phase="native initialization",
++            setup_statuses=(("peer init failed",), ()),
++            exchange_group=object(),
++            ipc=ipc,
++            local_ptr=1000,
++            remote_ptrs=(2000,),
++            local_error=RuntimeError("peer init failed"),
++            local_cleanup=cleanup,
++        )
++
++    retained = exc.value.retryable_setup
++    assert cleanup_calls == 1
++    assert retained.state == "native"
++    assert ipc.closed == []
++    assert ipc.freed == []
++    retained.retry()
++    assert cleanup_calls == 2
++    assert ipc.closed == [2000]
++    assert ipc.freed == [1000]
++    assert _RETAINED_FAILED_IPC_EXPORTS == {}
++
++
++def test_peer_native_cleanup_failure_blocks_every_rank_from_unmapping(monkeypatch):
++    class FakeIPC:
++        def __init__(self):
++            self.closed = []
++            self.freed = []
++
++        def cudaIpcCloseMemHandle(self, ptr):
++            self.closed.append(ptr)
++
++        def cudaFree(self, ptr):
++            self.freed.append(ptr)
++
++    ipc = FakeIPC()
++    cleanup_calls = 0
++    status_round = 0
++
++    def cleanup():
++        nonlocal cleanup_calls
++        cleanup_calls += 1
++
++    def exchange(local_status, group):
++        nonlocal status_round
++        status_round += 1
++        if status_round == 1:
++            return [local_status, ("peer native dispose failed",)]
++        return [local_status, ()]
++
++    monkeypatch.setattr(
++        "sparkinfer.comm.pcie.pcie_oneshot._broadcast_gather_object", exchange
++    )
++
++    with pytest.raises(RuntimeError, match="rollback native cleanup") as exc:
++        _abort_collective_ipc_setup(
++            owner="test runtime",
++            setup_phase="native initialization",
++            setup_statuses=(("peer init failed",), ()),
++            exchange_group=object(),
++            ipc=ipc,
++            local_ptr=1000,
++            remote_ptrs=(2000,),
++            local_error=RuntimeError("peer init failed"),
++            local_cleanup=cleanup,
++        )
++
++    retained = exc.value.retryable_setup
++    assert retained.state == "native"
++    assert retained.local_cleanup is None
++    assert cleanup_calls == 1
++    assert ipc.closed == []
++    assert ipc.freed == []
++
++    retained.retry()
++    assert cleanup_calls == 1
++    assert ipc.closed == [2000]
++    assert ipc.freed == [1000]
++    assert _RETAINED_FAILED_IPC_EXPORTS == {}
++
++
++def test_native_cleanup_verdict_exchange_failure_retains_imports(monkeypatch):
++    events = []
++
++    class FakeIPC:
++        def cudaIpcCloseMemHandle(self, ptr):
++            events.append(("close", ptr))
++
++        def cudaFree(self, ptr):
++            events.append(("free", ptr))
++
++    ipc = FakeIPC()
++    status_round = 0
++
++    def exchange(local_status, group):
++        nonlocal status_round
++        status_round += 1
++        if status_round == 1:
++            raise RuntimeError("injected native cleanup verdict exchange failure")
++        return [local_status, ()]
++
++    monkeypatch.setattr(
++        "sparkinfer.comm.pcie.pcie_oneshot._broadcast_gather_object", exchange
++    )
++
++    with pytest.raises(RuntimeError, match="cleanup status exchange") as exc:
++        _abort_collective_ipc_setup(
++            owner="test runtime",
++            setup_phase="native initialization",
++            setup_statuses=(("peer init failed",), ()),
++            exchange_group=object(),
++            ipc=ipc,
++            local_ptr=1000,
++            remote_ptrs=(2000,),
++            local_error=RuntimeError("peer init failed"),
++            local_cleanup=lambda: events.append(("dispose", 3000)),
++        )
++
++    retained = exc.value.retryable_setup
++    assert retained.state == "native"
++    assert retained.local_cleanup is None
++    assert events == [("dispose", 3000)]
++
++    retained.retry()
++    assert events == [("dispose", 3000), ("close", 2000), ("free", 1000)]
++    assert _RETAINED_FAILED_IPC_EXPORTS == {}
++
++
++def test_initial_native_verdict_exchange_retains_complete_setup_until_retry(
++    monkeypatch,
++):
++    events = []
++
++    class FakeIPC:
++        def cudaIpcCloseMemHandle(self, ptr):
++            events.append(("close", ptr))
++
++        def cudaFree(self, ptr):
++            events.append(("free", ptr))
++
++    ipc = FakeIPC()
++    group = object()
++    status_round = 0
++
++    def exchange(local_status, exchange_group):
++        nonlocal status_round
++        assert exchange_group is group
++        status_round += 1
++        if status_round == 1:
++            raise RuntimeError("injected first native verdict exchange failure")
++        return [local_status, ()]
++
++    monkeypatch.setattr(
++        "sparkinfer.comm.pcie.pcie_oneshot._broadcast_gather_object", exchange
++    )
++
++    with pytest.raises(RuntimeError, match="must be coordinated by every rank") as exc:
++        _finish_collective_runtime_setup(
++            owner="PCIe twoshot proof",
++            exchange_group=group,
++            ipc=ipc,
++            shared=_OwnedSharedBuffer(
++                local_ptr=1000,
++                peer_ptrs=(1000, 2000),
++                remote_ptrs=(2000,),
++            ),
++            local_error=None,
++            local_cleanup=lambda: events.append(("dispose", 3000)),
++        )
++
++    retained = exc.value.retryable_setup
++    assert retained.local_ptr == 1000
++    assert retained.remote_ptrs == [2000]
++    assert retained.local_cleanup is not None
++    assert events == []
++    assert _RETAINED_FAILED_IPC_EXPORTS[retained.key] is retained
++
++    # The retained generation gate rejects another setup on this process group
++    # before CUDA allocation.  A caller may only retry after arranging the same
++    # retry call on every rank that participated in the failed exchange.
++    with pytest.raises(RuntimeError, match="retained CUDA IPC setup gate"):
++        _require_no_retained_ipc_setup(group)
++    assert events == []
++
++    retained.retry()
++    assert events == [("dispose", 3000), ("close", 2000), ("free", 1000)]
++    assert _RETAINED_FAILED_IPC_EXPORTS == {}
++
++
++def test_free_status_exchange_failure_keeps_coordination_ticket_without_double_free(
++    monkeypatch,
++):
++    class FakeIPC:
++        def __init__(self):
++            self.freed = []
++
++        def cudaFree(self, ptr):
++            self.freed.append(ptr)
++
++    ipc = FakeIPC()
++    status_round = 0
++
++    def exchange(local_status, group):
++        nonlocal status_round
++        status_round += 1
++        if status_round == 2:
++            raise RuntimeError("injected free verdict exchange failure")
++        return [local_status, ()]
++
++    monkeypatch.setattr(
++        "sparkinfer.comm.pcie.pcie_oneshot._broadcast_gather_object", exchange
++    )
++
++    with pytest.raises(RuntimeError, match="free status exchange") as exc:
++        _abort_collective_ipc_setup(
++            owner="test runtime",
++            setup_phase="native initialization",
++            setup_statuses=(("peer init failed",), ()),
++            exchange_group=object(),
++            ipc=ipc,
++            local_ptr=1000,
++            remote_ptrs=(),
++            local_error=RuntimeError("peer init failed"),
++        )
++
++    retained = exc.value.retryable_setup
++    assert retained.local_ptr == 0
++    assert ipc.freed == [1000]
++    retained.retry()
++    assert ipc.freed == [1000]
++    assert _RETAINED_FAILED_IPC_EXPORTS == {}
++
++
++def test_retained_generation_blocks_second_setup_before_cuda_allocation(monkeypatch):
++    class FakeIPC:
++        def __init__(self):
++            self.malloc_calls = 0
++
++        def cudaMalloc(self, size):
++            self.malloc_calls += 1
++            raise RuntimeError("injected no-local-export allocation failure")
++
++    ipc = FakeIPC()
++    group = object()
++    status_round = 0
++
++    def exchange(local_status, exchange_group):
++        nonlocal status_round
++        status_round += 1
++        if status_round == 2:
++            raise RuntimeError("injected preparation verdict exchange failure")
++        return [local_status, ()]
++
++    monkeypatch.setattr(
++        "sparkinfer.comm.pcie.pcie_oneshot._broadcast_gather_object", exchange
++    )
++
++    with pytest.raises(RuntimeError, match="preparation status") as exc:
++        PCIeOneshotAllReduce._allocate_shared_buffer(
++            group, 256, zero_fill=True, ipc=ipc
++        )
++    retained = exc.value.retryable_setup
++    first_key = retained.key
++    assert retained.local_ptr == 0
++    assert ipc.malloc_calls == 1
++
++    with pytest.raises(RuntimeError, match="retained CUDA IPC setup gate"):
++        PCIeOneshotAllReduce._allocate_shared_buffer(
++            group, 256, zero_fill=True, ipc=ipc
++        )
++    assert ipc.malloc_calls == 1
++    assert tuple(_RETAINED_FAILED_IPC_EXPORTS) == (first_key,)
++
++    retained.retry()
++    assert _RETAINED_FAILED_IPC_EXPORTS == {}
++
++
++def test_eager_channel_buffers_use_single_ipc_slab(monkeypatch):
++    class FakeIPC:
++        def __init__(self):
++            self.malloc_sizes = []
++            self.memsets = []
++            self.opened = []
++
++        def cudaMalloc(self, size):
++            self.malloc_sizes.append(size)
++            return 1000
++
++        def cudaMemset(self, ptr, value, size):
++            self.memsets.append((ptr, value, size))
++
++        def cudaIpcGetMemHandleBytes(self, ptr):
++            return b"local"
++
++        def cudaIpcOpenMemHandleBytes(self, handle):
++            ptr = {b"remote0": 2000, b"remote1": 3000}[handle]
++            self.opened.append(ptr)
++            return ptr
++
++        def cudaIpcCloseMemHandle(self, ptr):
++            raise AssertionError("success path should not close remote ptrs")
++
++        def cudaFree(self, ptr):
++            raise AssertionError("success path should not free local ptr")
++
++    ipc = FakeIPC()
++    exchange_group = object()
++    signal_bytes = 300
++    eager_bytes = 128
++    eager0_offset = IPC_SLAB_ALIGNMENT * 2
++    eager1_offset = eager0_offset + IPC_SLAB_ALIGNMENT
++
++    monkeypatch.setattr("torch.distributed.get_world_size", lambda group=None: 3)
++    monkeypatch.setattr("torch.distributed.get_rank", lambda group=None: 0)
++    monkeypatch.setattr(
++        "sparkinfer.comm.pcie.pcie_oneshot._broadcast_gather_object",
++        lambda local_object, group: (
++            [local_object, (), ()]
++            if isinstance(local_object, tuple)
++            else [local_object, b"remote0", b"remote1"]
++        ),
++    )
++
++    buffers = PCIeOneshotAllReduce._allocate_eager_channel_buffers(
++        exchange_group,
++        signal_bytes=signal_bytes,
++        eager_buffer_bytes=eager_bytes,
++        ipc=ipc,
++    )
++
++    assert ipc.malloc_sizes == [eager1_offset + eager_bytes]
++    assert ipc.memsets == [(1000, 0, eager1_offset + eager_bytes)]
++    assert ipc.opened == [2000, 3000]
++    assert buffers.owned_buffer.local_ptr == 1000
++    assert buffers.owned_buffer.remote_ptrs == (2000, 3000)
++    assert buffers.signal_ptrs == (1000, 2000, 3000)
++    assert buffers.eager0_ptrs == (
++        1000 + eager0_offset,
++        2000 + eager0_offset,
++        3000 + eager0_offset,
++    )
++    assert buffers.eager1_ptrs == (
++        1000 + eager1_offset,
++        2000 + eager1_offset,
++        3000 + eager1_offset,
++    )
++
++
++def test_eager_channel_buffers_cleanup_when_slab_zero_fails(monkeypatch):
++    class FakeIPC:
++        def __init__(self):
++            self.closed = []
++            self.freed = []
++
++        def cudaMalloc(self, size):
++            return 1000
++
++        def cudaMemset(self, ptr, value, size):
++            raise RuntimeError("memset failed")
++
++        def cudaIpcGetMemHandleBytes(self, ptr):
++            return b"local"
++
++        def cudaIpcOpenMemHandleBytes(self, handle):
++            return {b"remote0": 2000, b"remote1": 3000}[handle]
++
++        def cudaIpcCloseMemHandle(self, ptr):
++            self.closed.append(ptr)
++
++        def cudaFree(self, ptr):
++            self.freed.append(ptr)
++
++    ipc = FakeIPC()
++
++    monkeypatch.setattr("torch.distributed.get_world_size", lambda group=None: 3)
++    monkeypatch.setattr("torch.distributed.get_rank", lambda group=None: 0)
++    monkeypatch.setattr(
++        "sparkinfer.comm.pcie.pcie_oneshot._broadcast_gather_object",
++        lambda local_object, group: (
++            [local_object, (), ()]
++            if isinstance(local_object, tuple)
++            else [local_object, b"remote0", b"remote1"]
++        ),
++    )
++
++    with pytest.raises(RuntimeError, match="memset failed"):
++        PCIeOneshotAllReduce._allocate_eager_channel_buffers(
++            object(),
++            signal_bytes=300,
++            eager_buffer_bytes=128,
++            ipc=ipc,
++        )
++
++    assert ipc.closed == []
++    assert ipc.freed == [1000]
++
++
++def test_register_graph_buffers_uses_exchange_group_broadcast(monkeypatch):
++    remote_meta = {
++        0: ([1, 2, 3], [0, 64]),
++        1: ([9, 8, 7], [16, 80]),
++    }
++
++    monkeypatch.setattr("torch.distributed.get_world_size", lambda group=None: 2)
++    monkeypatch.setattr("torch.distributed.get_rank", lambda group=None: 0)
++    monkeypatch.setattr(
++        "torch.distributed.get_process_group_ranks", lambda group=None: [0, 1]
++    )
++    monkeypatch.setattr(
++        "sparkinfer.comm.pcie.pcie_oneshot._object_broadcast_device",
++        lambda group: "cpu",
++    )
++
++    def fake_broadcast(object_list, src, group=None, device=None):
++        object_list[0] = remote_meta[src]
++
++    monkeypatch.setattr("torch.distributed.broadcast_object_list", fake_broadcast)
++
++    runtime = _make_runtime()
++    runtime.exchange_group = object()
++    ext = runtime._ext
++    runtime.register_graph_buffers()
++
++    assert ext.register_graph_buffers_calls == [
++        (12345, [[1, 2, 3], [9, 8, 7]], [[0, 64], [16, 80]])
++    ]
++
++
++def test_nonmonotonic_process_group_order_is_preserved_for_handle_slots(
++    monkeypatch,
++):
++    group = object()
++    sources: list[int] = []
++    nonmonotonic_ranks = [7, 2, 9]
++    monkeypatch.setattr("torch.distributed.get_world_size", lambda group=None: 3)
++    monkeypatch.setattr("torch.distributed.get_rank", lambda group=None: 1)
++    monkeypatch.setattr(
++        "torch.distributed.get_process_group_ranks",
++        lambda group=None: list(nonmonotonic_ranks),
++    )
++    monkeypatch.setattr(
++        "sparkinfer.comm.pcie.pcie_oneshot._object_broadcast_device",
++        lambda group: "cpu",
++    )
++
++    def fake_broadcast(object_list, src, group=None, device=None):
++        sources.append(src)
++        object_list[0] = f"from-{src}"
++
++    monkeypatch.setattr("torch.distributed.broadcast_object_list", fake_broadcast)
++
++    assert _group_ranks(group) == nonmonotonic_ranks
++    assert _broadcast_gather_object("local", group) == [
++        "from-7",
++        "from-2",
++        "from-9",
++    ]
++    assert sources == nonmonotonic_ranks
++
++
++def test_register_graph_buffers_noops_when_no_rank_registered_buffers(monkeypatch):
++    monkeypatch.setattr("torch.distributed.get_world_size", lambda group=None: 2)
++    monkeypatch.setattr("torch.distributed.get_rank", lambda group=None: 0)
++    monkeypatch.setattr(
++        "torch.distributed.get_process_group_ranks", lambda group=None: [0, 1]
++    )
++    monkeypatch.setattr(
++        "sparkinfer.comm.pcie.pcie_oneshot._object_broadcast_device",
++        lambda group: "cpu",
++    )
++    monkeypatch.setattr(
++        "torch.distributed.broadcast_object_list",
++        lambda object_list, src, group=None, device=None: object_list.__setitem__(
++            0, ([], [])
++        ),
++    )
++
++    runtime = _make_runtime()
++    runtime.exchange_group = object()
++    ext = runtime._ext
++    ext.handle_bytes = []
++    ext.offsets = []
++
++    runtime.register_graph_buffers()
++
++    assert ext.register_graph_buffers_calls == []
++
++
++def test_capture_registers_graph_buffers_after_context(monkeypatch):
++    runtime = _make_runtime()
++    runtime.exchange_group = object()
++    calls = []
++
++    monkeypatch.setattr(
++        runtime, "register_graph_buffers", lambda: calls.append("registered")
++    )
++
++    with runtime.capture():
++        pass
++
++    assert calls == ["registered"]
++
++
++def test_eager_capture_skips_graph_buffer_registration(monkeypatch):
++    runtime = _make_runtime(eager=True)
++    runtime.exchange_group = object()
++    calls = []
++
++    monkeypatch.setattr(
++        runtime, "register_graph_buffers", lambda: calls.append("registered")
++    )
++
++    with runtime.capture():
++        pass
++
++    assert calls == []
++
++
++def test_pool_creates_distinct_channels_per_stream_key(monkeypatch):
++    created = []
++
++    def make_channel(stream_key):
++        runtime = _make_runtime(eager=True)
++        created.append((stream_key, runtime))
++        return runtime
++
++    pool = PCIeOneshotAllReducePool(
++        rank=0,
++        world_size=2,
++        device=torch.device("cpu"),
++        channel_factory=make_channel,
++    )
+ 
+     monkeypatch.setattr(
+         "sparkinfer.comm.pcie.pcie_oneshot._current_stream_key",
+@@ -633,6 +1414,337 @@ def test_pool_creates_distinct_channels_per_stream_key(monkeypatch):
+     assert [entry[0] for entry in created] == [7, 8]
+ 
+ 
++def test_collective_logical_channel_preparation_is_canonical(monkeypatch):
++    created = []
++    pool = PCIeOneshotAllReducePool(
++        rank=0,
++        world_size=2,
++        device=torch.device("cpu"),
++        channel_factory=lambda stream_key: _make_runtime(eager=True),
++    )
++    pool._channel_factory = None
++    pool.exchange_group = object()
++    monkeypatch.setattr(
++        pool,
++        "_new_channel",
++        lambda stream_key: created.append(stream_key) or object(),
++    )
++    monkeypatch.setattr(
++        "sparkinfer.comm.pcie.pcie_oneshot._broadcast_gather_object",
++        lambda local_state, group: [local_state, local_state],
++    )
++
++    pool.prepare_channels(("draft", "target"))
++    pool.prepare_channels(("target", "draft"))
++
++    assert list(pool._logical_channels) == ["draft", "target"]
++    assert created == [None, None]
++
++
++def test_collective_logical_channel_mismatch_rejects_before_allocation(monkeypatch):
++    pool = PCIeOneshotAllReducePool(
++        rank=0,
++        world_size=2,
++        device=torch.device("cpu"),
++        channel_factory=lambda stream_key: _make_runtime(eager=True),
++    )
++    pool._channel_factory = None
++    pool.exchange_group = object()
++    monkeypatch.setattr(
++        pool,
++        "_new_channel",
++        lambda stream_key: pytest.fail("channel allocation must not start"),
++    )
++
++    def gather(local_state, group):
++        if not local_state or isinstance(local_state[0], str):
++            return [local_state, ()]
++        _requested, existing = local_state
++        return [local_state, (("other",), existing)]
++
++    monkeypatch.setattr(
++        "sparkinfer.comm.pcie.pcie_oneshot._broadcast_gather_object", gather
++    )
++
++    with pytest.raises(RuntimeError, match="differs across ranks"):
++        pool.prepare_channels(("target",))
++
++
++def test_invalid_logical_channel_id_is_rejected_collectively_before_allocation(
++    monkeypatch,
++):
++    pool = PCIeOneshotAllReducePool(
++        rank=0,
++        world_size=2,
++        device=torch.device("cpu"),
++        channel_factory=lambda stream_key: _make_runtime(eager=True),
++    )
++    pool._channel_factory = None
++    pool.exchange_group = object()
++    monkeypatch.setattr(
++        pool,
++        "_new_channel",
++        lambda stream_key: pytest.fail("channel allocation must not start"),
++    )
++    monkeypatch.setattr(
++        "sparkinfer.comm.pcie.pcie_oneshot._broadcast_gather_object",
++        lambda local_status, group: [local_status, ()],
++    )
++
++    with pytest.raises(RuntimeError, match="must not be empty"):
++        pool.prepare_channels(("  ",))
++
++
++def test_empty_logical_channel_set_still_enters_collective_contract(monkeypatch):
++    pool = PCIeOneshotAllReducePool(
++        rank=0,
++        world_size=2,
++        device=torch.device("cpu"),
++        channel_factory=lambda stream_key: _make_runtime(eager=True),
++    )
++    pool._channel_factory = None
++    pool.exchange_group = object()
++
++    def gather(local_state, group):
++        if not local_state or isinstance(local_state[0], str):
++            return [local_state, ()]
++        _, existing = local_state
++        return [local_state, (("peer-channel",), existing)]
++
++    monkeypatch.setattr(
++        "sparkinfer.comm.pcie.pcie_oneshot._broadcast_gather_object", gather
++    )
++
++    with pytest.raises(RuntimeError, match="differs across ranks"):
++        pool.prepare_channels(())
++
++
++def test_collective_capture_requires_stable_semantic_id(monkeypatch):
++    pool = PCIeOneshotAllReducePool(
++        rank=0,
++        world_size=2,
++        device=torch.device("cpu"),
++        channel_factory=lambda stream_key: _make_runtime(eager=True),
++    )
++    pool._channel_factory = None
++    pool.exchange_group = object()
++
++    monkeypatch.setattr(
++        pool,
++        "_new_channel",
++        lambda stream_key: pytest.fail("channel allocation must not start"),
++    )
++    monkeypatch.setattr(
++        "sparkinfer.comm.pcie.pcie_oneshot._broadcast_gather_object",
++        lambda local_status, group: [local_status, ()],
++    )
++
++    with (
++        pytest.raises(RuntimeError, match="stable semantic channel_id"),
++        pool.capture(7),
++    ):
++        pass
++
++
++def test_collective_capture_allows_opposite_order_from_agreed_catalog(monkeypatch):
++    target = _make_runtime(eager=True)
++    draft = _make_runtime(eager=True)
++    pool = PCIeOneshotAllReducePool(
++        rank=0,
++        world_size=2,
++        device=torch.device("cpu"),
++        channel_factory=lambda stream_key: _make_runtime(eager=True),
++    )
++    pool._channel_factory = None
++    pool.exchange_group = object()
++    pool._logical_channels.update({"graph:draft": draft, "graph:target": target})
++    monkeypatch.setattr(
++        pool,
++        "_new_channel",
++        lambda stream_key: pytest.fail("channel allocation must not start"),
++    )
++    monkeypatch.setattr(
++        "sparkinfer.comm.pcie.pcie_oneshot._current_stream_key",
++        lambda device, stream=None: int(stream),
++    )
++
++    def gather(local_state, group):
++        if local_state == ():
++            return [(), ()]
++        requested, catalog = local_state
++        assert requested == "graph:target"
++        return [local_state, ("graph:draft", catalog)]
++
++    monkeypatch.setattr(
++        "sparkinfer.comm.pcie.pcie_oneshot._broadcast_gather_object", gather
++    )
++
++    with pool.capture(7, channel_id="graph:target") as channel:
++        assert channel is target
++
++    assert pool._captured_channel_ids == {"graph:target"}
++
++
++def test_collective_capture_rejects_divergent_catalog_before_allocation(monkeypatch):
++    target = _make_runtime(eager=True)
++    pool = PCIeOneshotAllReducePool(
++        rank=0,
++        world_size=2,
++        device=torch.device("cpu"),
++        channel_factory=lambda stream_key: _make_runtime(eager=True),
++    )
++    pool._channel_factory = None
++    pool.exchange_group = object()
++    pool._logical_channels["graph:target"] = target
++    monkeypatch.setattr(
++        pool,
++        "_new_channel",
++        lambda stream_key: pytest.fail("channel allocation must not start"),
++    )
++
++    def gather(local_state, group):
++        if local_state == ():
++            return [(), ()]
++        return [local_state, ("graph:target", ())]
++
++    monkeypatch.setattr(
++        "sparkinfer.comm.pcie.pcie_oneshot._broadcast_gather_object", gather
++    )
++
++    with (
++        pytest.raises(RuntimeError, match="prepared channel catalog differs"),
++        pool.capture(7, channel_id="graph:target"),
++    ):
++        pass
++
++
++def test_collective_capture_rejects_differing_unprepared_ids(monkeypatch):
++    target = _make_runtime(eager=True)
++    pool = PCIeOneshotAllReducePool(
++        rank=0,
++        world_size=2,
++        device=torch.device("cpu"),
++        channel_factory=lambda stream_key: _make_runtime(eager=True),
++    )
++    pool._channel_factory = None
++    pool.exchange_group = object()
++    pool._logical_channels["graph:target"] = target
++    monkeypatch.setattr(
++        pool,
++        "_new_channel",
++        lambda stream_key: pytest.fail("channel allocation must not start"),
++    )
++
++    def gather(local_state, group):
++        if local_state == ():
++            return [(), ()]
++        _, catalog = local_state
++        return [local_state, ("graph:unknown", catalog)]
++
++    monkeypatch.setattr(
++        "sparkinfer.comm.pcie.pcie_oneshot._broadcast_gather_object", gather
++    )
++
++    with (
++        pytest.raises(RuntimeError, match="unprepared logical channels"),
++        pool.capture(7, channel_id="graph:target"),
++    ):
++        pass
++
++
++def test_collective_capture_preserves_same_id_convenience_allocation(monkeypatch):
++    created = []
++    channel = _make_runtime(eager=True)
++    pool = PCIeOneshotAllReducePool(
++        rank=0,
++        world_size=2,
++        device=torch.device("cpu"),
++        channel_factory=lambda stream_key: _make_runtime(eager=True),
++    )
++    pool._channel_factory = None
++    pool.exchange_group = object()
++    monkeypatch.setattr(
++        pool,
++        "_new_channel",
++        lambda stream_key: created.append(stream_key) or channel,
++    )
++    monkeypatch.setattr(
++        "sparkinfer.comm.pcie.pcie_oneshot._current_stream_key",
++        lambda device, stream=None: int(stream),
++    )
++    monkeypatch.setattr(
++        "sparkinfer.comm.pcie.pcie_oneshot._broadcast_gather_object",
++        lambda local_state, group: [local_state, local_state],
++    )
++
++    with pool.capture(7, channel_id="graph:target") as captured:
++        assert captured is channel
++
++    assert created == [None]
++    assert pool._logical_channels == {"graph:target": channel}
++
++
++def test_collective_capture_routes_eager_warmup_to_graph_channel(monkeypatch):
++    eager = _make_runtime(eager=True)
++    target = _make_runtime(eager=True)
++    pool = PCIeOneshotAllReducePool(
++        rank=0,
++        world_size=2,
++        device=torch.device("cpu"),
++        channel_factory=lambda stream_key: _make_runtime(eager=True),
++    )
++    pool._channel_factory = None
++    pool.exchange_group = object()
++    pool._logical_channels.update({"eager:model": eager, "graph:target": target})
++    monkeypatch.setattr(
++        pool,
++        "_new_channel",
++        lambda stream_key: pytest.fail("channel allocation must not start"),
++    )
++    monkeypatch.setattr(
++        "sparkinfer.comm.pcie.pcie_oneshot._current_stream_key",
++        lambda device, stream=None: 7 if stream is None else int(stream),
++    )
++    monkeypatch.setattr(
++        "sparkinfer.comm.pcie.pcie_oneshot._broadcast_gather_object",
++        lambda local_state, group: [local_state, local_state],
++    )
++
++    with pool.capture(7, channel_id="graph:target") as captured:
++        assert captured is target
++        assert pool.for_stream(7, channel_id="eager:model") is target
++        with pytest.raises(RuntimeError, match="stream-affine"):
++            pool.for_stream(8, channel_id="eager:model")
++
++    assert pool.for_stream(7, channel_id="eager:model") is eager
++
++
++def test_collective_eager_channel_requires_id_and_rejects_duplicate_stream_owner(
++    monkeypatch,
++):
++    eager = _make_runtime(eager=True)
++    pool = PCIeOneshotAllReducePool(
++        rank=0,
++        world_size=2,
++        device=torch.device("cpu"),
++        channel_factory=lambda stream_key: eager,
++    )
++    pool._channel_factory = None
++    pool.exchange_group = object()
++    pool._logical_channels["eager:model"] = eager
++    monkeypatch.setattr(
++        "sparkinfer.comm.pcie.pcie_oneshot._current_stream_key",
++        lambda device, stream=None: int(stream),
++    )
++
++    with pytest.raises(RuntimeError, match="explicit semantic channel_id"):
++        pool.for_stream(7)
++
++    assert pool.for_stream(7, channel_id="eager:model") is eager
++    with pytest.raises(RuntimeError, match="stream-affine"):
++        pool.for_stream(8, channel_id="eager:model")
++
++
+ def test_pool_reuses_single_channel_across_stream_keys(monkeypatch):
+     created = []
+ 
+@@ -726,11 +1838,60 @@ def test_nested_capture_reuses_its_outer_channel(monkeypatch):
+         capturing[0] = False
+ 
+     assert target_channel is not draft_channel
+-    assert pool._channels[70] is target_channel
+-    assert pool._channels[80] is draft_channel
++    assert pool._channels == {}
++    assert target_channel in pool._all_channels
++    assert draft_channel in pool._all_channels
+     assert [entry[0] for entry in created] == [7, 8]
+ 
+ 
++def test_pool_restores_nested_capture_mappings_in_lifo_order(monkeypatch):
++    current_stream = [7]
++    capturing = [False]
++    pool = PCIeOneshotAllReducePool(
++        rank=0,
++        world_size=2,
++        device=torch.device("cpu"),
++        channel_factory=lambda stream_key: _make_runtime(eager=True),
++    )
++    monkeypatch.setattr(
++        "sparkinfer.comm.pcie.pcie_oneshot._current_stream_key",
++        lambda device, stream=None: (
++            current_stream[0] if stream is None else int(stream)
++        ),
++    )
++    monkeypatch.setattr(
++        "sparkinfer.comm.pcie.pcie_oneshot._is_current_stream_capturing",
++        lambda device: capturing[0],
++    )
++
++    eager_channel = pool.for_stream()
++    with pool.capture(7) as outer_channel:
++        assert pool._channels == {7: outer_channel}
++
++        current_stream[0] = 8
++        with pool.capture() as inner_channel:
++            capturing[0] = True
++            current_stream[0] = 80
++            assert pool.for_stream() is inner_channel
++            assert pool._channels == {
++                7: outer_channel,
++                8: inner_channel,
++                80: inner_channel,
++            }
++            capturing[0] = False
++
++        assert pool._channels == {7: outer_channel}
++        capturing[0] = True
++        current_stream[0] = 70
++        assert pool.for_stream() is outer_channel
++        capturing[0] = False
++
++    assert eager_channel is not outer_channel
++    assert outer_channel is not inner_channel
++    assert pool._channels == {7: eager_channel}
++    assert pool._capture_channel_stack == []
++
++
+ def test_reused_capture_stream_keys_get_distinct_channels(monkeypatch):
+     created = []
+     current_stream = [7]
+@@ -773,8 +1934,7 @@ def test_reused_capture_stream_keys_get_distinct_channels(monkeypatch):
+         capturing[0] = False
+ 
+     assert target_channel is not draft_channel
+-    assert pool._channels[7] is draft_channel
+-    assert pool._channels[70] is draft_channel
++    assert pool._channels == {}
+     assert target_channel in pool._all_channels
+     assert draft_channel in pool._all_channels
+     assert [entry[0] for entry in created] == [7, 7]
+@@ -859,13 +2019,12 @@ def test_pool_coordinates_ipc_teardown_across_ranks(monkeypatch):
+     assert pool._channels == {3: retained}
+ 
+ 
+-def test_channel_teardown_completes_when_ipc_cleanup_raises():
++def test_channel_destructor_retains_all_cuda_ownership_without_side_effects():
+     events = []
+ 
+     class FailingExt:
+-        def dispose(self, ptr):
+-            events.append(("dispose", ptr))
+-            raise RuntimeError("dispose failed")
++        def dispose_best_effort(self, ptr):
++            events.append(("dispose_best_effort", ptr))
+ 
+     class FailingIPC:
+         def cudaIpcCloseMemHandle(self, ptr):
+@@ -873,8 +2032,7 @@ def test_channel_teardown_completes_when_ipc_cleanup_raises():
+             raise RuntimeError("close failed")
+ 
+         def cudaFree(self, ptr):
+-            events.append(("free", ptr))
+-            raise RuntimeError("free failed")
++            raise AssertionError("GC must not free exported IPC allocations")
+ 
+     class SharedBuffer:
+         def __init__(self, local_ptr, remote_ptrs):
+@@ -885,6 +2043,8 @@ def test_channel_teardown_completes_when_ipc_cleanup_raises():
+     channel._closed = False
+     channel._ipc_imports_closed = False
+     channel._ipc_exports_freed = False
++    channel.exchange_group = None
++    channel.device = torch.device("cpu")
+     channel._ptr = 123
+     channel._ext = FailingExt()
+     channel._ipc = FailingIPC()
+@@ -893,24 +2053,48 @@ def test_channel_teardown_completes_when_ipc_cleanup_raises():
+         SharedBuffer(4000, (5000,)),
+     ]
+     channel._registered_input_ptrs = {1: (2,)}
++    channel._coordinated_close_complete = False
+ 
+-    channel.close()
+-    channel.close()
++    channel.__del__()
+ 
+-    assert events == [
+-        ("dispose", 123),
+-        ("close", 2000),
+-        ("close", 3000),
+-        ("close", 5000),
+-        ("free", 1000),
+-        ("free", 4000),
+-    ]
+-    assert channel._ptr == 0
+-    assert channel._closed
+-    assert channel._ipc_imports_closed
+-    assert channel._ipc_exports_freed
+-    assert channel._owned_buffers == []
+-    assert channel._registered_input_ptrs == {}
++    assert events == []
++    assert channel._ptr == 123
++    assert not channel._closed
++    assert not channel._ipc_imports_closed
++    assert not channel._ipc_exports_freed
++    assert [shared.local_ptr for shared in channel._owned_buffers] == [1000, 4000]
++    assert channel._registered_input_ptrs == {1: (2,)}
++    assert _ABANDONED_PCIE_RUNTIME_QUARANTINE.pop(id(channel)) is channel
++    channel._coordinated_close_complete = True
++
++
++def test_channel_gc_quarantines_rank_data_tensor_and_native_pointer():
++    events = []
++
++    class RankData:
++        def __del__(self):
++            events.append("rank_data_freed")
++
++    channel = object.__new__(PCIeOneshotAllReduce)
++    channel._ptr = 123
++    channel._owned_buffers = []
++    channel._coordinated_close_complete = False
++    channel.rank_data = RankData()
++    channel_id = id(channel)
++
++    del channel
++    gc.collect()
++
++    retained = _ABANDONED_PCIE_RUNTIME_QUARANTINE.pop(channel_id)
++    assert retained._ptr == 123
++    assert events == []
++
++    # The production quarantine is process-lifetime. Tests may release this
++    # fake only after proving the owned allocation survived object GC.
++    retained._coordinated_close_complete = True
++    del retained
++    gc.collect()
++    assert events == ["rank_data_freed"]
+ 
+ 
+ def test_pool_rejects_channel_rollback_during_capture():
+diff --git a/tests/comm/test_pcie_oneshot_fused_rmsnorm_gpu.py b/tests/comm/test_pcie_oneshot_fused_rmsnorm_gpu.py
+index 34f9e5e04ec74eda3d9886abe64ad10721374359..fae489373fb4acd468a1fc1ef4f6edf5bbbc03d9 100644
+--- a/tests/comm/test_pcie_oneshot_fused_rmsnorm_gpu.py
++++ b/tests/comm/test_pcie_oneshot_fused_rmsnorm_gpu.py
+@@ -1,7 +1,10 @@
+ from __future__ import annotations
+ 
++import ctypes
+ import os
+ import socket
++import time
++from datetime import timedelta
+ 
+ import pytest
+ import torch
+@@ -19,6 +22,9 @@ pytestmark = pytest.mark.skipif(
+         "RMSNorm GPU tests"
+     ),
+ )
++TEST_TIMEOUT_SECONDS = float(
++    os.getenv("SPARKINFER_PCIE_ONESHOT_RMS_TIMEOUT_SECONDS", "300")
++)
+ 
+ 
+ def _free_port() -> int:
+@@ -71,7 +77,33 @@ def _assert_close(
+         torch.testing.assert_close(actual, expected, rtol=2e-2, atol=2e-2)
+ 
+ 
+-def _cuda_graph_kernel_count(graph: torch.cuda.CUDAGraph) -> int:
++def _local_eager_words(
++    channel, stream: torch.cuda.Stream, *, offset: int = 0
++) -> tuple[int, int]:
++    assert channel._ipc is not None
++    assert channel._eager_ptrs is not None
++    words = (ctypes.c_uint64(), ctypes.c_uint64())
++    for word, slot_ptrs in zip(words, channel._eager_ptrs, strict=True):
++        channel._ipc.cudaMemcpyAsync(
++            ctypes.addressof(word),
++            slot_ptrs[channel.rank] + offset,
++            ctypes.sizeof(word),
++            int(stream.cuda_stream),
++        )
++    stream.synchronize()
++    return words[0].value, words[1].value
++
++
++def _dim3_tuple(value) -> tuple[int, int, int]:
++    return int(value.x), int(value.y), int(value.z)
++
++
++def _cuda_graph_kernel_chain(
++    graph: torch.cuda.CUDAGraph,
++) -> tuple[
++    tuple[tuple[int, int, int], tuple[int, int, int]],
++    tuple[tuple[int, int, int], tuple[int, int, int]],
++]:
+     graph_handle = graph.raw_cuda_graph()
+     result, _, num_nodes = cudart.cudaGraphGetNodes(graph_handle)
+     assert result == cudart.cudaError_t.cudaSuccess
+@@ -82,12 +114,62 @@ def _cuda_graph_kernel_count(graph: torch.cuda.CUDAGraph) -> int:
+     assert result == cudart.cudaError_t.cudaSuccess
+     assert returned_nodes == num_nodes
+     kernel_type = cudart.cudaGraphNodeType.cudaGraphNodeTypeKernel
+-    kernel_count = 0
++    kernel_nodes = []
+     for node in nodes[:num_nodes]:
+         result, node_type = cudart.cudaGraphNodeGetType(node)
+         assert result == cudart.cudaError_t.cudaSuccess
+-        kernel_count += node_type == kernel_type
+-    return kernel_count
++        if node_type == kernel_type:
++            kernel_nodes.append(node)
++    assert len(kernel_nodes) == 2, (
++        "staged fused capture must contain one slot-control node followed by "
++        f"one worker node, found {len(kernel_nodes)} kernel nodes"
++    )
++
++    edge_query = cudart.cudaGraphGetEdges(graph_handle)
++    assert edge_query[0] == cudart.cudaError_t.cudaSuccess
++    num_edges = int(edge_query[-1])
++    edges = cudart.cudaGraphGetEdges(graph_handle, num_edges)
++    result, from_nodes, to_nodes, returned_edges = (
++        edges[0],
++        edges[1],
++        edges[2],
++        edges[-1],
++    )
++    assert result == cudart.cudaError_t.cudaSuccess
++    assert returned_edges == num_edges
++    kernel_edges = []
++    for source, destination in zip(
++        from_nodes[:num_edges],
++        to_nodes[:num_edges],
++        strict=True,
++    ):
++        result, source_type = cudart.cudaGraphNodeGetType(source)
++        assert result == cudart.cudaError_t.cudaSuccess
++        result, destination_type = cudart.cudaGraphNodeGetType(destination)
++        assert result == cudart.cudaError_t.cudaSuccess
++        if source_type == kernel_type and destination_type == kernel_type:
++            kernel_edges.append((source, destination))
++    assert len(kernel_edges) == 1, (
++        "staged fused capture must directly order its control node before its "
++        f"worker node, found {len(kernel_edges)} kernel-to-kernel edges"
++    )
++
++    def geometry(node) -> tuple[tuple[int, int, int], tuple[int, int, int]]:
++        result, params = cudart.cudaGraphKernelNodeGetParams(node)
++        if result != cudart.cudaError_t.cudaSuccess and hasattr(
++            cudart, "cudaGraphNodeGetParams"
++        ):
++            fallback_result, node_params = cudart.cudaGraphNodeGetParams(node)
++            assert fallback_result == cudart.cudaError_t.cudaSuccess
++            result, params = fallback_result, node_params.kernel
++        assert result == cudart.cudaError_t.cudaSuccess
++        return _dim3_tuple(params.gridDim), _dim3_tuple(params.blockDim)
++
++    control, worker = map(geometry, kernel_edges[0])
++    assert control == ((1, 1, 1), (1, 1, 1))
++    assert worker[0][0] > 1
++    assert worker[1][0] >= 64
++    return control, worker
+ 
+ 
+ def _run_eager(
+@@ -129,6 +211,7 @@ def _run_eager(
+                 residual,
+                 weight,
+                 epsilon,
++                channel_id="eager:fused-rmsnorm",
+             )
+             torch.cuda.synchronize(device)
+             _assert_close(out, expected_out, dtype)
+@@ -152,10 +235,11 @@ def _run_graph(
+         rank,
+     )
+     out = torch.empty_like(inp)
+-    pool.for_stream()
+-
+     graph = torch.cuda.CUDAGraph(keep_graph=True)
+-    with pool.capture(), torch.cuda.graph(graph):
++    with (
++        pool.capture(channel_id="graph:fused-rmsnorm") as channel,
++        torch.cuda.graph(graph),
++    ):
+         pool.all_reduce_fused_add_rms_norm(
+             inp,
+             residual,
+@@ -163,8 +247,19 @@ def _run_graph(
+             epsilon,
+             out=out,
+             residual_out=residual,
++            channel_id="graph:fused-rmsnorm",
+         )
+-    assert _cuda_graph_kernel_count(graph) == 1
++    # Staged capture is now control + worker, in that order. The registered
++    # path still launches only its worker, but public graph capture deliberately
++    # requires stable eager staging buffers and therefore exercises this
++    # two-node contract.
++    _cuda_graph_kernel_chain(graph)
++    stream = torch.cuda.current_stream(device)
++    offset = 0
++    if os.getenv("SPARKINFER_PCIE_ONESHOT_PUSH", "0") not in ("", "0"):
++        remote_source = (rank + 1) % dist.get_world_size()
++        offset = remote_source * inp.numel() * inp.element_size()
++    snapshots = [_local_eager_words(channel, stream, offset=offset)]
+ 
+     for iteration in range(3):
+         next_inp, next_residual, _ = _make_inputs(
+@@ -187,6 +282,23 @@ def _run_graph(
+         torch.cuda.synchronize(device)
+         _assert_close(out, expected_out, dtype)
+         _assert_close(residual, expected_residual, dtype)
++        snapshots.append(_local_eager_words(channel, stream, offset=offset))
++
++    changed_slots = [
++        {
++            slot
++            for slot, (before, after) in enumerate(
++                zip(snapshots[index], snapshots[index + 1], strict=True)
++            )
++            if before != after
++        }
++        for index in range(3)
++    ]
++    assert all(len(changed) == 1 for changed in changed_slots)
++    assert all(
++        changed_slots[index] != changed_slots[index + 1]
++        for index in range(len(changed_slots) - 1)
++    )
+ 
+ 
+ def _worker(rank: int, world_size: int, port: int) -> None:
+@@ -197,14 +309,18 @@ def _worker(rank: int, world_size: int, port: int) -> None:
+         init_method=f"tcp://127.0.0.1:{port}",
+         rank=rank,
+         world_size=world_size,
++        timeout=timedelta(seconds=TEST_TIMEOUT_SECONDS),
+     )
+     pool = PCIeOneshotAllReducePool.from_process_group(
+         process_group=dist.group.WORLD,
+         device=device,
+         max_input_bytes=128 * 1024,
+         max_size=128 * 1024,
++        max_concurrent_channels=2,
+     )
+     try:
++        pool.prepare_channels(("eager:fused-rmsnorm", "graph:fused-rmsnorm"))
++        pool.for_stream(channel_id="eager:fused-rmsnorm")
+         _run_eager(pool, device, rank)
+         dist.barrier()
+         _run_graph(pool, device, rank)
+@@ -224,4 +340,27 @@ def test_pcie_oneshot_fused_add_rms_norm_eager_and_graph() -> None:
+         pytest.skip(
+             f"need {world_size} CUDA devices, found {torch.cuda.device_count()}"
+         )
+-    mp.spawn(_worker, args=(world_size, _free_port()), nprocs=world_size, join=True)
++    context = mp.spawn(
++        _worker,
++        args=(world_size, _free_port()),
++        nprocs=world_size,
++        join=False,
++    )
++    deadline = time.monotonic() + TEST_TIMEOUT_SECONDS
++    while time.monotonic() < deadline:
++        remaining = deadline - time.monotonic()
++        if context.join(timeout=min(1.0, remaining), grace_period=5):
++            return
++    for process in context.processes:
++        if process.is_alive():
++            process.terminate()
++    for process in context.processes:
++        process.join(timeout=5)
++    for process in context.processes:
++        if process.is_alive():
++            process.kill()
++        process.join()
++    pytest.fail(
++        "PCIe oneshot fused RMSNorm test exceeded "
++        f"{TEST_TIMEOUT_SECONDS:.0f}s; probable collective deadlock"
++    )
+diff --git a/tests/comm/test_pcie_oneshot_opposite_order_gpu.py b/tests/comm/test_pcie_oneshot_opposite_order_gpu.py
+new file mode 100644
+index 0000000000000000000000000000000000000000..99559e07f3d07e6a4fcb7aa486590f9f409d0536
+--- /dev/null
++++ b/tests/comm/test_pcie_oneshot_opposite_order_gpu.py
+@@ -0,0 +1,295 @@
++from __future__ import annotations
++
++import os
++import socket
++import time
++from datetime import timedelta
++
++import pytest
++import torch
++import torch.distributed as dist
++import torch.multiprocessing as mp
++
++from sparkinfer.comm.pcie.pcie_oneshot import PCIeOneshotAllReducePool
++
++
++pytestmark = pytest.mark.skipif(
++    os.getenv("SPARKINFER_RUN_PCIE_ONESHOT_OPPOSITE_ORDER") != "1",
++    reason=(
++        "set SPARKINFER_RUN_PCIE_ONESHOT_OPPOSITE_ORDER=1 to run the "
++        "four-rank opposite-order PCIe oneshot GPU test"
++    ),
++)
++
++WORLD_SIZE = 4
++EAGER_ITERS = int(os.getenv("SPARKINFER_PCIE_OPPOSITE_EAGER_ITERS", "64"))
++GRAPH_REPLAYS = int(os.getenv("SPARKINFER_PCIE_OPPOSITE_GRAPH_REPLAYS", "64"))
++TEST_TIMEOUT_SECONDS = float(
++    os.getenv("SPARKINFER_PCIE_OPPOSITE_TIMEOUT_SECONDS", "180")
++)
++NUMEL = int(os.getenv("SPARKINFER_PCIE_OPPOSITE_NUMEL", "32768"))
++
++
++def _free_port() -> int:
++    with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as sock:
++        sock.bind(("127.0.0.1", 0))
++        return int(sock.getsockname()[1])
++
++
++def _expected(base: float, world_size: int, device: torch.device) -> torch.Tensor:
++    rank_sum = world_size * (world_size - 1) // 2
++    return torch.tensor(
++        world_size * base + rank_sum,
++        dtype=torch.float32,
++        device=device,
++    )
++
++
++def _assert_reduced(
++    out: torch.Tensor,
++    base: float,
++    world_size: int,
++    device: torch.device,
++) -> None:
++    torch.testing.assert_close(
++        out,
++        _expected(base, world_size, device).expand_as(out),
++        rtol=0,
++        atol=0,
++    )
++
++
++def _rank_order(rank: int) -> tuple[str, str]:
++    # Every rank executes the same ordered sequence within each channel. Only
++    # the cross-channel enqueue order differs, which is valid because each
++    # stream owns a distinct signal/staging pair.
++    return ("a", "b") if rank % 2 == 0 else ("b", "a")
++
++
++def _run_eager_opposite_order(
++    pool: PCIeOneshotAllReducePool,
++    device: torch.device,
++    rank: int,
++    world_size: int,
++) -> None:
++    stream_a = torch.cuda.Stream(device=device)
++    stream_b = torch.cuda.Stream(device=device)
++
++    # Each rank supplies the same logical set in opposite local order. The pool
++    # must canonicalize allocation by id rather than pairing local stream keys.
++    logical_ids = ("eager:a", "eager:b")
++    if rank % 2:
++        logical_ids = tuple(reversed(logical_ids))
++    pool.prepare_channels(logical_ids)
++    channel_a = pool.for_stream(stream_a, channel_id="eager:a")
++    channel_b = pool.for_stream(stream_b, channel_id="eager:b")
++    dist.barrier()
++    assert channel_a is not channel_b
++    assert channel_a._signal_ptrs != channel_b._signal_ptrs
++
++    inputs = {
++        "a": torch.empty(NUMEL, device=device, dtype=torch.float32),
++        "b": torch.empty(NUMEL, device=device, dtype=torch.float32),
++    }
++    outputs = {name: torch.empty_like(inp) for name, inp in inputs.items()}
++    streams = {"a": stream_a, "b": stream_b}
++    channels = {"a": channel_a, "b": channel_b}
++
++    for iteration in range(EAGER_ITERS):
++        bases = {
++            "a": float(4 * (iteration % 32)),
++            "b": float(1024 + 8 * (iteration % 32)),
++        }
++        for name in _rank_order(rank):
++            with torch.cuda.stream(streams[name]):
++                inputs[name].fill_(bases[name] + rank)
++                channels[name].all_reduce(inputs[name], out=outputs[name])
++
++        # Both valid channel collectives are now enqueued on every rank. A
++        # device-wide wait makes a deadlock visible to the parent timeout.
++        torch.cuda.synchronize(device)
++        for name in ("a", "b"):
++            _assert_reduced(outputs[name], bases[name], world_size, device)
++
++
++def _capture_channel(
++    pool: PCIeOneshotAllReducePool,
++    stream: torch.cuda.Stream,
++    inp: torch.Tensor,
++    out: torch.Tensor,
++    channel_id: str,
++) -> tuple[object, torch.cuda.CUDAGraph]:
++    graph = torch.cuda.CUDAGraph()
++    with (
++        pool.capture(stream, channel_id=channel_id) as channel,
++        torch.cuda.graph(graph, stream=stream),
++    ):
++        channel.all_reduce(inp, out=out)
++    return channel, graph
++
++
++def _run_capture_warmup_scope(
++    pool: PCIeOneshotAllReducePool,
++    device: torch.device,
++    rank: int,
++    world_size: int,
++) -> None:
++    """Match vLLM's eager warmup inside its semantic graph-owner scope."""
++    stream = torch.cuda.Stream(device=device)
++    inp = torch.full(
++        (NUMEL,),
++        float(4096 + rank),
++        dtype=torch.float32,
++        device=device,
++    )
++    out = torch.empty_like(inp)
++    pool.prepare_channels(("eager:warmup", "graph:warmup"))
++
++    graph = torch.cuda.CUDAGraph()
++    with (
++        torch.cuda.stream(stream),
++        pool.capture(stream, channel_id="graph:warmup") as graph_channel,
++    ):
++        # CUDA capture has not begun. The active semantic scope must still
++        # override the call site's static eager id on this same owner stream.
++        warmup_channel = pool.for_stream(stream, channel_id="eager:warmup")
++        assert warmup_channel is graph_channel
++        warmup_channel.all_reduce(inp, out=out)
++        stream.synchronize()
++        _assert_reduced(out, 4096.0, world_size, device)
++
++        with torch.cuda.graph(graph, stream=stream):
++            graph_channel.all_reduce(inp, out=out)
++
++    # Leaving the semantic scope restores normal eager routing even though
++    # the graph-owned channel remains alive for replay on the same stream.
++    eager_channel = pool.for_stream(stream, channel_id="eager:warmup")
++    assert eager_channel is not graph_channel
++    with torch.cuda.stream(stream):
++        inp.fill_(8192.0 + rank)
++        graph.replay()
++    stream.synchronize()
++    _assert_reduced(out, 8192.0, world_size, device)
++
++
++def _run_graph_opposite_order(
++    pool: PCIeOneshotAllReducePool,
++    device: torch.device,
++    rank: int,
++    world_size: int,
++) -> None:
++    stream_a = torch.cuda.Stream(device=device)
++    stream_b = torch.cuda.Stream(device=device)
++    inputs = {
++        "a": torch.empty(NUMEL, device=device, dtype=torch.float32),
++        "b": torch.empty(NUMEL, device=device, dtype=torch.float32),
++    }
++    outputs = {name: torch.empty_like(inp) for name, inp in inputs.items()}
++
++    logical_ids = ("graph:a", "graph:b")
++    if rank % 2:
++        logical_ids = tuple(reversed(logical_ids))
++    pool.prepare_channels(logical_ids)
++    captured = {}
++    for name in _rank_order(rank):
++        captured[name] = _capture_channel(
++            pool,
++            {"a": stream_a, "b": stream_b}[name],
++            inputs[name],
++            outputs[name],
++            f"graph:{name}",
++        )
++        {"a": stream_a, "b": stream_b}[name].synchronize()
++    dist.barrier()
++    channel_a, graph_a = captured["a"]
++    channel_b, graph_b = captured["b"]
++    assert channel_a is not channel_b
++    assert channel_a._signal_ptrs != channel_b._signal_ptrs
++
++    streams = {"a": stream_a, "b": stream_b}
++    graphs = {"a": graph_a, "b": graph_b}
++    for iteration in range(GRAPH_REPLAYS):
++        bases = {
++            "a": float(256 + 4 * (iteration % 32)),
++            "b": float(2048 + 8 * (iteration % 32)),
++        }
++        for name in _rank_order(rank):
++            with torch.cuda.stream(streams[name]):
++                inputs[name].fill_(bases[name] + rank)
++                graphs[name].replay()
++
++        torch.cuda.synchronize(device)
++        for name in ("a", "b"):
++            _assert_reduced(outputs[name], bases[name], world_size, device)
++
++
++def _worker(rank: int, world_size: int, port: int) -> None:
++    torch.cuda.set_device(rank)
++    device = torch.device(f"cuda:{rank}")
++    dist.init_process_group(
++        "nccl",
++        init_method=f"tcp://127.0.0.1:{port}",
++        rank=rank,
++        world_size=world_size,
++        timeout=timedelta(seconds=TEST_TIMEOUT_SECONDS),
++    )
++    pool = PCIeOneshotAllReducePool.from_process_group(
++        process_group=dist.group.WORLD,
++        device=device,
++        max_input_bytes=NUMEL * torch.float32.itemsize,
++        max_size=NUMEL * torch.float32.itemsize,
++        # Two independent streams intentionally enqueue peer-waiting grids at
++        # once; gate residency for the complete overlap, not one grid.
++        max_concurrent_channels=2,
++    )
++    try:
++        _run_capture_warmup_scope(pool, device, rank, world_size)
++        dist.barrier()
++        _run_eager_opposite_order(pool, device, rank, world_size)
++        dist.barrier()
++        _run_graph_opposite_order(pool, device, rank, world_size)
++        torch.cuda.synchronize(device)
++        dist.barrier()
++    finally:
++        try:
++            pool.close()
++        finally:
++            dist.destroy_process_group()
++
++
++def _spawn_with_timeout(port: int) -> None:
++    context = mp.spawn(
++        _worker,
++        args=(WORLD_SIZE, port),
++        nprocs=WORLD_SIZE,
++        join=False,
++    )
++    deadline = time.monotonic() + TEST_TIMEOUT_SECONDS
++    while time.monotonic() < deadline:
++        remaining = deadline - time.monotonic()
++        if context.join(timeout=min(1.0, remaining), grace_period=5):
++            return
++
++    for process in context.processes:
++        if process.is_alive():
++            process.terminate()
++    for process in context.processes:
++        process.join(timeout=5)
++    for process in context.processes:
++        if process.is_alive():
++            process.kill()
++        process.join()
++    pytest.fail(
++        "four-rank opposite-order eager/graph PCIe oneshot test exceeded "
++        f"{TEST_TIMEOUT_SECONDS:.0f}s; probable collective deadlock"
++    )
++
++
++def test_pcie_oneshot_four_rank_opposite_channel_order() -> None:
++    if not torch.cuda.is_available():
++        pytest.skip("CUDA is not available")
++    if torch.cuda.device_count() < WORLD_SIZE:
++        pytest.skip(
++            f"need {WORLD_SIZE} CUDA devices, found {torch.cuda.device_count()}"
++        )
++    _spawn_with_timeout(_free_port())
+diff --git a/tests/comm/test_pcie_oneshot_torture.py b/tests/comm/test_pcie_oneshot_torture.py
+index a5ab20a8d2678bfe7990dd32c6e1fad89811eb42..3269e14295aeacfba4d877df241ffdbc0806409f 100644
+--- a/tests/comm/test_pcie_oneshot_torture.py
++++ b/tests/comm/test_pcie_oneshot_torture.py
+@@ -1,5 +1,6 @@
+ from __future__ import annotations
+ 
++import ctypes
+ import os
+ import socket
+ 
+@@ -16,9 +17,15 @@ pytestmark = pytest.mark.skipif(
+     reason="set SPARKINFER_RUN_PCIE_ONESHOT_TORTURE=1 to run PCIe oneshot CUDA torture tests",
+ )
+ 
+-TORTURE_EAGER_ITERS = int(os.getenv("SPARKINFER_PCIE_ONESHOT_TORTURE_EAGER_ITERS", "256"))
+-TORTURE_GRAPH_REPLAYS = int(os.getenv("SPARKINFER_PCIE_ONESHOT_TORTURE_GRAPH_REPLAYS", "256"))
+-TORTURE_MULTISTREAM_ITERS = int(os.getenv("SPARKINFER_PCIE_ONESHOT_TORTURE_MULTISTREAM_ITERS", "256"))
++TORTURE_EAGER_ITERS = int(
++    os.getenv("SPARKINFER_PCIE_ONESHOT_TORTURE_EAGER_ITERS", "256")
++)
++TORTURE_GRAPH_REPLAYS = int(
++    os.getenv("SPARKINFER_PCIE_ONESHOT_TORTURE_GRAPH_REPLAYS", "256")
++)
++TORTURE_MULTISTREAM_ITERS = int(
++    os.getenv("SPARKINFER_PCIE_ONESHOT_TORTURE_MULTISTREAM_ITERS", "256")
++)
+ 
+ 
+ def _free_port() -> int:
+@@ -36,7 +43,26 @@ def _rank_sum(world_size: int) -> int:
+     return world_size * (world_size - 1) // 2
+ 
+ 
+-def _run_eager(pool: PCIeOneshotAllReducePool, device: torch.device, rank: int, world_size: int) -> None:
++def _local_eager_words(
++    channel, stream: torch.cuda.Stream, *, offset: int = 0
++) -> tuple[int, int]:
++    assert channel._ipc is not None
++    assert channel._eager_ptrs is not None
++    words = (ctypes.c_uint64(), ctypes.c_uint64())
++    for word, slot_ptrs in zip(words, channel._eager_ptrs, strict=True):
++        channel._ipc.cudaMemcpyAsync(
++            ctypes.addressof(word),
++            slot_ptrs[channel.rank] + offset,
++            ctypes.sizeof(word),
++            int(stream.cuda_stream),
++        )
++    stream.synchronize()
++    return words[0].value, words[1].value
++
++
++def _run_eager(
++    pool: PCIeOneshotAllReducePool, device: torch.device, rank: int, world_size: int
++) -> None:
+     dtypes = (torch.float16, torch.bfloat16, torch.float32)
+     numels = (8, 256, 4096, 32768)
+     rank_sum = _rank_sum(world_size)
+@@ -48,7 +74,7 @@ def _run_eager(pool: PCIeOneshotAllReducePool, device: torch.device, rank: int,
+             for iteration in range(TORTURE_EAGER_ITERS):
+                 base = float((iteration % 64) * 3)
+                 inp.fill_(base + rank)
+-                pool.all_reduce(inp, out=out)
++                pool.all_reduce(inp, out=out, channel_id="eager:default")
+                 torch.cuda.synchronize(device)
+                 _assert_constant(out, world_size * base + rank_sum)
+ 
+@@ -60,7 +86,6 @@ def _run_graph_scratch_reuse(
+     world_size: int,
+ ) -> None:
+     stream = torch.cuda.Stream(device=device)
+-    channel = pool.for_stream(stream)
+     rank_sum = _rank_sum(world_size)
+     layers = 17
+     numel = 4096
+@@ -77,20 +102,57 @@ def _run_graph_scratch_reuse(
+     torch.cuda.synchronize(device)
+ 
+     graph = torch.cuda.CUDAGraph()
+-    with pool.capture(stream), torch.cuda.graph(graph, stream=stream):
++    with (
++        pool.capture(stream, channel_id="graph:torture") as channel,
++        torch.cuda.graph(graph, stream=stream),
++    ):
+         for layer in range(layers):
+             scratch.copy_(sources[layer])
+             channel.all_reduce(scratch, out=outs[layer])
+     stream.synchronize()
+ 
+     for iteration in range(TORTURE_GRAPH_REPLAYS):
+-        fill_sources(iteration)
+-        graph.replay()
++        with torch.cuda.stream(stream):
++            fill_sources(iteration)
++            graph.replay()
+         stream.synchronize()
+         for layer, out in enumerate(outs):
+             base = float((iteration % 32) * 5 + layer)
+             _assert_constant(out, world_size * base + rank_sum)
+ 
++    # A graph with an odd number of collectives must swap which slot receives
++    # the final layer on every replay. Both slots are overwritten by this
++    # 17-layer graph, so merely counting changed slots cannot identify the
++    # selected parity: the final two layer markers must exchange positions.
++    snapshots = [_local_eager_words(channel, stream)]
++    expected_words = [
++        tuple(int(source.view(torch.uint64)[0].item()) for source in sources[-2:])
++    ]
++    for iteration in (101, 102):
++        with torch.cuda.stream(stream):
++            fill_sources(iteration)
++            graph.replay()
++        stream.synchronize()
++        snapshots.append(_local_eager_words(channel, stream))
++        expected_words.append(
++            tuple(int(source.view(torch.uint64)[0].item()) for source in sources[-2:])
++        )
++        for layer, out in enumerate(outs):
++            base = float((iteration % 32) * 5 + layer)
++            _assert_constant(out, world_size * base + rank_sum)
++
++    final_slots = []
++    for snapshot, expected in zip(snapshots, expected_words, strict=True):
++        assert set(snapshot) == set(expected), (
++            f"staging slots {snapshot} do not contain the final layer markers "
++            f"{expected}"
++        )
++        final_slots.append(snapshot.index(expected[-1]))
++    assert all(
++        final_slots[index] != final_slots[index + 1]
++        for index in range(len(final_slots) - 1)
++    ), f"odd-collective graph did not alternate final staging slots: {final_slots}"
++
+ 
+ def _run_multistream(
+     pool: PCIeOneshotAllReducePool,
+@@ -100,8 +162,8 @@ def _run_multistream(
+ ) -> None:
+     stream_a = torch.cuda.Stream(device=device)
+     stream_b = torch.cuda.Stream(device=device)
+-    pool.for_stream(stream_a)
+-    pool.for_stream(stream_b)
++    pool.for_stream(stream_a, channel_id="eager:a")
++    pool.for_stream(stream_b, channel_id="eager:b")
+     rank_sum = _rank_sum(world_size)
+ 
+     inp_a = torch.empty(2048, device=device, dtype=torch.float16)
+@@ -114,10 +176,10 @@ def _run_multistream(
+         base_b = float(100 + (iteration % 64) * 2)
+         with torch.cuda.stream(stream_a):
+             inp_a.fill_(base_a + rank)
+-            pool.all_reduce(inp_a, out=out_a)
++            pool.all_reduce(inp_a, out=out_a, channel_id="eager:a")
+         with torch.cuda.stream(stream_b):
+             inp_b.fill_(base_b + rank)
+-            pool.all_reduce(inp_b, out=out_b)
++            pool.all_reduce(inp_b, out=out_b, channel_id="eager:b")
+         stream_a.synchronize()
+         stream_b.synchronize()
+         _assert_constant(out_a, world_size * base_a + rank_sum)
+@@ -137,8 +199,10 @@ def _worker(rank: int, world_size: int, port: int) -> None:
+         process_group=dist.group.WORLD,
+         device=device,
+         max_input_bytes=1 << 20,
++        max_concurrent_channels=2,
+     )
+     try:
++        pool.prepare_channels(("eager:default", "eager:a", "eager:b", "graph:torture"))
+         _run_eager(pool, device, rank, world_size)
+         dist.barrier()
+         _run_graph_scratch_reuse(pool, device, rank, world_size)
+diff --git a/tests/comm/test_pcie_preallocation_setup.py b/tests/comm/test_pcie_preallocation_setup.py
+new file mode 100644
+index 0000000000000000000000000000000000000000..a6c02d91522d73289942ed46d7c55ff933834af3
+--- /dev/null
++++ b/tests/comm/test_pcie_preallocation_setup.py
+@@ -0,0 +1,486 @@
++from __future__ import annotations
++
++import pytest
++import torch
++
++import sparkinfer.comm.pcie.pcie_dcp_a2a as dcp
++import sparkinfer.comm.pcie.pcie_oneshot as oneshot
++import sparkinfer.comm.pcie.pcie_twoshot as twoshot
++
++
++def _mock_collective_failure(monkeypatch) -> None:
++    def exchange(
++        local_error,
++        *,
++        exchange_group,
++        phase,
++        exports_retained_on_exchange_failure=True,
++    ):
++        assert not exports_retained_on_exchange_failure
++        if local_error is None:
++            return ((), ())
++        return ((f"RuntimeError: {local_error}",), ())
++
++    monkeypatch.setattr(oneshot, "_exchange_setup_failures", exchange)
++
++
++def _fail_cuda_runtime():
++    raise RuntimeError("injected one-rank CUDA runtime load failure")
++
++
++def test_oneshot_factory_coordinates_preallocation_failure_before_ipc(
++    monkeypatch,
++) -> None:
++    _mock_collective_failure(monkeypatch)
++    monkeypatch.setattr(oneshot.dist, "get_rank", lambda group=None: 0)
++    monkeypatch.setattr(oneshot.dist, "get_world_size", lambda group=None: 2)
++    monkeypatch.setattr(oneshot, "_require_full_grid_residency", lambda **kwargs: None)
++    monkeypatch.setattr(oneshot, "CudaRTLibrary", _fail_cuda_runtime)
++    monkeypatch.setattr(
++        oneshot.PCIeOneshotAllReduce,
++        "_allocate_eager_channel_buffers",
++        lambda *args, **kwargs: pytest.fail("IPC allocation must not start"),
++    )
++
++    with pytest.raises(RuntimeError, match="pre-allocation setup") as exc:
++        oneshot.PCIeOneshotAllReduce.from_exchange_group(
++            exchange_group=object(),
++            device=torch.device("cuda:0"),
++        )
++
++    assert "exports were retained" not in str(exc.value)
++
++
++def test_dcp_factory_coordinates_preallocation_failure_before_ipc(monkeypatch) -> None:
++    _mock_collective_failure(monkeypatch)
++    monkeypatch.setattr(dcp.dist, "get_rank", lambda group=None: 0)
++    monkeypatch.setattr(dcp.dist, "get_world_size", lambda group=None: 2)
++    monkeypatch.setattr(dcp, "_require_full_grid_residency", lambda **kwargs: None)
++    monkeypatch.setattr(dcp, "CudaRTLibrary", _fail_cuda_runtime)
++    monkeypatch.setattr(
++        oneshot.PCIeOneshotAllReduce,
++        "_allocate_shared_buffer",
++        lambda *args, **kwargs: pytest.fail("IPC allocation must not start"),
++    )
++
++    with pytest.raises(RuntimeError, match="pre-allocation setup") as exc:
++        dcp.PCIeDCPA2A.from_exchange_group(
++            exchange_group=object(),
++            device=torch.device("cuda:0"),
++            max_batch_size=8,
++            total_heads=16,
++            head_dim=64,
++        )
++
++    assert "exports were retained" not in str(exc.value)
++
++
++def test_twoshot_factory_coordinates_preallocation_failure_before_ipc(
++    monkeypatch,
++) -> None:
++    _mock_collective_failure(monkeypatch)
++    monkeypatch.setattr(twoshot.dist, "get_rank", lambda group=None: 0)
++    monkeypatch.setattr(twoshot.dist, "get_world_size", lambda group=None: 2)
++    monkeypatch.setattr(twoshot, "_require_full_grid_residency", lambda **kwargs: None)
++    monkeypatch.setattr(twoshot, "CudaRTLibrary", _fail_cuda_runtime)
++    monkeypatch.setattr(
++        oneshot.PCIeOneshotAllReduce,
++        "_allocate_shared_buffer",
++        lambda *args, **kwargs: pytest.fail("IPC allocation must not start"),
++    )
++
++    with pytest.raises(RuntimeError, match="pre-allocation setup") as exc:
++        twoshot.PCIeTwoShotSP.from_exchange_group(
++            exchange_group=object(),
++            device=torch.device("cuda:0"),
++            max_rows=8,
++            row_elems=16,
++        )
++
++    assert "exports were retained" not in str(exc.value)
++
++
++@pytest.mark.parametrize("module_name", ("oneshot", "dcp"))
++def test_direct_constructor_coordinates_argument_failure_before_residency(
++    monkeypatch,
++    module_name: str,
++) -> None:
++    _mock_collective_failure(monkeypatch)
++    if module_name == "oneshot":
++        monkeypatch.setattr(
++            oneshot,
++            "_require_full_grid_residency",
++            lambda **kwargs: pytest.fail("residency gate must not start"),
++        )
++
++        def constructor():
++            return oneshot.PCIeOneshotAllReduce(
++                rank=0,
++                world_size=2,
++                device=torch.device("cuda:0"),
++                signal_ptrs=(100,),
++                exchange_group=object(),
++                ext_module=object(),
++            )
++    else:
++        monkeypatch.setattr(
++            dcp,
++            "_require_full_grid_residency",
++            lambda **kwargs: pytest.fail("residency gate must not start"),
++        )
++
++        def constructor():
++            return dcp.PCIeDCPA2A(
++                rank=0,
++                world_size=2,
++                device=torch.device("cuda:0"),
++                signal_ptrs=(100,),
++                staging0_ptrs=(200, 300),
++                staging1_ptrs=(400, 500),
++                max_batch_size=8,
++                total_heads=16,
++                head_dim=64,
++                output_capacity_elems=8 * 16 * 64,
++                lse_offset=8 * 16 * 64 * 2,
++                lse_capacity=8 * 16,
++                exchange_group=object(),
++                ext_module=object(),
++            )
++
++    with pytest.raises(RuntimeError, match="argument validation"):
++        constructor()
++
++
++@pytest.mark.parametrize(
++    ("module", "class_name"),
++    (
++        (oneshot, "PCIeOneshotAllReduce"),
++        (dcp, "PCIeDCPA2A"),
++    ),
++)
++def test_exported_direct_constructor_contains_capability_and_setup_coordination(
++    module,
++    class_name: str,
++) -> None:
++    import inspect
++
++    source = inspect.getsource(getattr(module, class_name).__init__)
++    assert "_require_full_grid_residency(" in source
++    assert "_run_collective_preallocation_setup(" in source
++    assert "_finish_collective_unowned_runtime_setup(" in source
++    assert "_factory_managed_setup" not in source
++
++
++def test_twoshot_direct_construction_cannot_bypass_factory_gates() -> None:
++    with pytest.raises(RuntimeError, match="from_exchange_group"):
++        twoshot.PCIeTwoShotSP()
++
++
++def test_pool_overlap_residency_scales_with_declared_concurrency(monkeypatch) -> None:
++    events: list[tuple[str, object]] = []
++
++    class FakeIPC:
++        def cudaSetDevice(self, device):
++            events.append(("device", device))
++
++    class FakeOneshotExt:
++        @staticmethod
++        def meta_size():
++            return 256
++
++    monkeypatch.setattr(oneshot.dist, "get_rank", lambda group=None: 0)
++    monkeypatch.setattr(oneshot.dist, "get_world_size", lambda group=None: 2)
++    monkeypatch.setattr(
++        oneshot,
++        "_run_collective_preallocation_setup",
++        lambda **kwargs: kwargs["setup"](),
++    )
++    monkeypatch.setattr(
++        oneshot,
++        "_require_full_grid_residency",
++        lambda **kwargs: events.append(("oneshot_sms", kwargs["required_sms"])),
++    )
++    monkeypatch.setattr(
++        oneshot,
++        "_require_collective_contract",
++        lambda **kwargs: events.append(("oneshot_contract", kwargs["contract"])),
++    )
++
++    oneshot_pool = oneshot.PCIeOneshotAllReducePool(
++        rank=0,
++        world_size=2,
++        device=torch.device("cuda:0"),
++        exchange_group=object(),
++        ipc=FakeIPC(),
++        ext_module=FakeOneshotExt(),
++        max_concurrent_channels=3,
++    )
++    oneshot_pool._closed = True
++
++    monkeypatch.setattr(dcp.dist, "get_rank", lambda group=None: 0)
++    monkeypatch.setattr(dcp.dist, "get_world_size", lambda group=None: 2)
++    monkeypatch.setattr(
++        dcp,
++        "_run_collective_preallocation_setup",
++        lambda **kwargs: kwargs["setup"](),
++    )
++    monkeypatch.setattr(
++        dcp,
++        "_require_collective_contract",
++        lambda **kwargs: events.append(("dcp_contract", kwargs["contract"])),
++    )
++    monkeypatch.setattr(
++        dcp,
++        "_require_full_grid_residency",
++        lambda **kwargs: events.append(("dcp_sms", kwargs["required_sms"])),
++    )
++
++    dcp_pool = dcp.PCIeDCPA2APool(
++        rank=0,
++        world_size=2,
++        device=torch.device("cuda:0"),
++        max_batch_size=8,
++        total_heads=16,
++        head_dim=64,
++        exchange_group=object(),
++        max_concurrent_channels=2,
++    )
++    dcp_pool._closed = True
++
++    assert ("oneshot_sms", oneshot.ONESHOT_REQUIRED_SMS * 3) in events
++    oneshot_contract = next(
++        contract for name, contract in events if name == "oneshot_contract"
++    )
++    assert oneshot_contract[-2] == 3
++    assert ("dcp_contract", 2) in events
++    assert ("dcp_sms", dcp.DCP_A2A_REQUIRED_SMS * 2) in events
++
++
++@pytest.mark.parametrize("module_name", ("oneshot", "dcp"))
++def test_pool_rejects_nonpositive_overlap_before_allocation(
++    monkeypatch, module_name: str
++) -> None:
++    if module_name == "oneshot":
++        with pytest.raises(ValueError, match="max_concurrent_channels"):
++            oneshot.PCIeOneshotAllReducePool(
++                rank=0,
++                world_size=2,
++                device=torch.device("cpu"),
++                max_concurrent_channels=0,
++                channel_factory=lambda stream_key: object(),
++            )
++    else:
++        with pytest.raises(ValueError, match="max_concurrent_channels"):
++            dcp.PCIeDCPA2APool(
++                rank=0,
++                world_size=2,
++                device=torch.device("cpu"),
++                max_batch_size=8,
++                total_heads=16,
++                head_dim=64,
++                max_concurrent_channels=0,
++                channel_factory=lambda stream_key: object(),
++            )
++
++
++def test_oneshot_overlap_contract_mismatch_fails_before_channel_allocation(
++    monkeypatch,
++) -> None:
++    class FakeIPC:
++        def cudaSetDevice(self, device):
++            pass
++
++    class FakeExt:
++        @staticmethod
++        def meta_size():
++            return 256
++
++    monkeypatch.setattr(oneshot.dist, "get_rank", lambda group=None: 0)
++    monkeypatch.setattr(oneshot.dist, "get_world_size", lambda group=None: 2)
++    monkeypatch.setattr(
++        oneshot,
++        "_run_collective_preallocation_setup",
++        lambda **kwargs: kwargs["setup"](),
++    )
++    monkeypatch.setattr(oneshot, "_require_full_grid_residency", lambda **kwargs: None)
++    monkeypatch.setattr(
++        oneshot,
++        "_broadcast_gather_object",
++        lambda contract, group: [contract, (*contract[:-2], 2, contract[-1])],
++    )
++    monkeypatch.setattr(
++        oneshot.PCIeOneshotAllReduce,
++        "_allocate_eager_channel_buffers",
++        lambda *args, **kwargs: pytest.fail("channel allocation must not start"),
++    )
++
++    with pytest.raises(RuntimeError, match="contract differs across ranks"):
++        oneshot.PCIeOneshotAllReducePool(
++            rank=0,
++            world_size=2,
++            device=torch.device("cuda:0"),
++            exchange_group=object(),
++            ipc=FakeIPC(),
++            ext_module=FakeExt(),
++            max_concurrent_channels=3,
++        )
++
++
++def test_dcp_overlap_contract_mismatch_fails_before_channel_allocation(
++    monkeypatch,
++) -> None:
++    monkeypatch.setattr(dcp.dist, "get_rank", lambda group=None: 0)
++    monkeypatch.setattr(dcp.dist, "get_world_size", lambda group=None: 2)
++    monkeypatch.setattr(
++        dcp,
++        "_run_collective_preallocation_setup",
++        lambda **kwargs: kwargs["setup"](),
++    )
++    monkeypatch.setattr(
++        oneshot,
++        "_broadcast_gather_object",
++        lambda contract, group: [contract, 1],
++    )
++    monkeypatch.setattr(
++        dcp,
++        "_require_full_grid_residency",
++        lambda **kwargs: pytest.fail("residency/allocation must not start"),
++    )
++
++    with pytest.raises(RuntimeError, match="contract differs across ranks"):
++        dcp.PCIeDCPA2APool(
++            rank=0,
++            world_size=2,
++            device=torch.device("cuda:0"),
++            max_batch_size=8,
++            total_heads=16,
++            head_dim=64,
++            exchange_group=object(),
++            max_concurrent_channels=2,
++        )
++
++
++def test_oneshot_direct_cuda_constructor_executes_all_collective_gates(
++    monkeypatch,
++) -> None:
++    events = []
++
++    class FakeTensor:
++        pass
++
++    class FakeExt:
++        def init_custom_ar(self, signal_ptrs, rank_data, rank):
++            events.append("native-init")
++            return 123
++
++    class FakeIPC:
++        def cudaSetDevice(self, device):
++            events.append(("set-device", device))
++
++    monkeypatch.setattr(
++        oneshot,
++        "_require_full_grid_residency",
++        lambda **kwargs: events.append("residency"),
++    )
++    monkeypatch.setattr(
++        oneshot,
++        "_run_collective_preallocation_setup",
++        lambda **kwargs: (events.append("preflight"), kwargs["setup"]())[1],
++    )
++    monkeypatch.setattr(
++        oneshot,
++        "_require_collective_contract",
++        lambda **kwargs: events.append("contract"),
++    )
++    monkeypatch.setattr(
++        oneshot,
++        "_finish_collective_unowned_runtime_setup",
++        lambda **kwargs: events.append("native-verdict"),
++    )
++    monkeypatch.setattr(oneshot.torch, "empty", lambda *args, **kwargs: FakeTensor())
++    monkeypatch.setattr(oneshot.dist, "get_rank", lambda group=None: 0)
++    monkeypatch.setattr(oneshot.dist, "get_world_size", lambda group=None: 2)
++
++    runtime = oneshot.PCIeOneshotAllReduce(
++        rank=0,
++        world_size=2,
++        device=torch.device("cuda:0"),
++        signal_ptrs=(100, 200),
++        exchange_group=object(),
++        ipc=FakeIPC(),
++        ext_module=FakeExt(),
++    )
++
++    assert runtime._ptr == 123
++    assert events == [
++        "preflight",
++        "residency",
++        "preflight",
++        ("set-device", 0),
++        "contract",
++        "native-init",
++        "native-verdict",
++    ]
++    runtime._coordinated_close_complete = True
++
++
++def test_dcp_direct_cuda_constructor_executes_all_collective_gates(
++    monkeypatch,
++) -> None:
++    events = []
++
++    class FakeExt:
++        def init_dcp_a2a(self, *args):
++            events.append("native-init")
++            return 456
++
++    monkeypatch.setattr(
++        dcp,
++        "_require_full_grid_residency",
++        lambda **kwargs: events.append("residency"),
++    )
++    monkeypatch.setattr(
++        dcp,
++        "_run_collective_preallocation_setup",
++        lambda **kwargs: (events.append("preflight"), kwargs["setup"]())[1],
++    )
++    monkeypatch.setattr(
++        dcp,
++        "_require_collective_contract",
++        lambda **kwargs: events.append("contract"),
++    )
++    monkeypatch.setattr(
++        dcp,
++        "_finish_collective_unowned_runtime_setup",
++        lambda **kwargs: events.append("native-verdict"),
++    )
++    monkeypatch.setattr(dcp.dist, "get_rank", lambda group=None: 0)
++    monkeypatch.setattr(dcp.dist, "get_world_size", lambda group=None: 2)
++
++    runtime = dcp.PCIeDCPA2A(
++        rank=0,
++        world_size=2,
++        device=torch.device("cuda:0"),
++        signal_ptrs=(100, 200),
++        staging0_ptrs=(300, 400),
++        staging1_ptrs=(500, 600),
++        max_batch_size=8,
++        total_heads=16,
++        head_dim=64,
++        output_capacity_elems=8 * 16 * 64,
++        lse_offset=8 * 16 * 64 * 2,
++        lse_capacity=8 * 16,
++        exchange_group=object(),
++        ext_module=FakeExt(),
++    )
++
++    assert runtime._ptr == 456
++    assert events == [
++        "preflight",
++        "residency",
++        "preflight",
++        "contract",
++        "native-init",
++        "native-verdict",
++    ]
++    runtime._coordinated_close_complete = True
+diff --git a/tests/comm/test_pcie_staging_control.py b/tests/comm/test_pcie_staging_control.py
+new file mode 100644
+index 0000000000000000000000000000000000000000..2fa7d9e8ba83c67381fd5d4a10e740556e2b8605
+--- /dev/null
++++ b/tests/comm/test_pcie_staging_control.py
+@@ -0,0 +1,279 @@
++from __future__ import annotations
++
++from pathlib import Path
++
++import pytest
++
++
++ROOT = Path(__file__).resolve().parents[2]
++PCIE = ROOT / "sparkinfer" / "comm" / "pcie"
++UINT32_MASK = (1 << 32) - 1
++
++
++def _advance(generation: int) -> tuple[int, int]:
++    """Model the device control kernel's unsigned generation update."""
++    return generation & 1, (generation + 1) & UINT32_MASK
++
++
++def _section(source: str, start: str, end: str) -> str:
++    return source[source.index(start) : source.index(end, source.index(start))]
++
++
++def test_slot_control_alternates_across_replays_and_wraps() -> None:
++    generation = 0
++    slots = []
++    for _ in range(7):
++        slot, generation = _advance(generation)
++        slots.append(slot)
++
++    assert slots == [0, 1, 0, 1, 0, 1, 0]
++    assert _advance(UINT32_MASK) == (1, 0)
++    assert _advance(0) == (0, 1)
++
++
++def test_same_stream_capture_replay_handles_variable_worker_grids() -> None:
++    generation = 0
++    replay_slots = []
++    worker_slots = []
++
++    for worker_blocks in (1, 64, 3, 36, 8):
++        slot, generation = _advance(generation)
++        replay_slots.append(slot)
++        worker_slots.append([slot] * worker_blocks)
++
++    assert replay_slots == [0, 1, 0, 1, 0]
++    assert all(len(set(cta_slots)) == 1 for cta_slots in worker_slots)
++
++
++def test_multistream_separate_channels_match_across_rank_interleavings() -> None:
++    schedules = {
++        0: ("decode", "prefill", "decode", "prefill"),
++        1: ("prefill", "decode", "prefill", "decode"),
++    }
++    rank_observations = {}
++
++    for rank, schedule in schedules.items():
++        generations = {"decode": 0, "prefill": 0}
++        observed = {"decode": [], "prefill": []}
++        for channel in schedule:
++            slot, generations[channel] = _advance(generations[channel])
++            observed[channel].append(slot)
++        rank_observations[rank] = observed
++
++    assert rank_observations[0] == rank_observations[1]
++    assert rank_observations[0] == {
++        "decode": [0, 1],
++        "prefill": [0, 1],
++    }
++
++
++@pytest.mark.parametrize("source_name", ("pcie_oneshot.cu", "pcie_twoshot.cu"))
++def test_worker_slot_selection_has_no_grid_rendezvous(source_name: str) -> None:
++    source = (PCIE / source_name).read_text(encoding="utf-8")
++
++    assert "active_staging_slot" in source
++    assert "advance_staging_slot_kernel" in source
++    assert "staging_arrive" not in source
++    assert "cudaLaunchCooperativeKernel" not in source
++    assert "launch_cooperative" not in source
++
++    selector_name = (
++        "DINLINE void select_rank_data"
++        if source_name == "pcie_oneshot.cu"
++        else "DINLINE void select_rank_ptrs"
++    )
++    selector = _section(source, selector_name, "template <")
++    assert "active_staging_slot" in selector
++    assert "atomicAdd" not in selector
++    assert "while (" not in selector
++
++
++def test_fused_rms_residency_is_runtime_derived_and_capture_cached() -> None:
++    source = (PCIE / "pcie_oneshot.cu").read_text(encoding="utf-8")
++
++    assert "cudaOccupancyMaxActiveBlocksPerMultiprocessor" in source
++    assert "cudaDevAttrMultiProcessorCount" in source
++    assert "fused_resident_capacity_" in source
++    assert "cap_fused_ctas_per_row" in source
++    assert "SPARKINFER_PCIE_TEST_RESIDENT_GRID_CAPACITY" in source
++    assert "kMaxBlocks <= SM count" not in source
++
++    # Model the native clamp for reduced/MIG-like capacities. A capacity below
++    # the requested multi-CTA grid must select the barrier-free single-CTA path.
++    def cap(requested: int, rows: int, resident: int) -> int:
++        return max(1, min(requested, max(1, resident // rows)))
++
++    assert cap(3, 1, 1) == 1
++    assert cap(3, 1, 2) == 2
++    assert cap(3, 2, 2) == 1
++    assert cap(3, 2, 8) == 3
++
++
++@pytest.mark.parametrize(
++    ("source_name", "python_name", "constant_name", "required_sms"),
++    (
++        ("pcie_oneshot.cu", "pcie_oneshot.py", "ONESHOT_REQUIRED_SMS", 36),
++        ("pcie_twoshot.cu", "pcie_twoshot.py", "TWOSHOT_REQUIRED_SMS", 64),
++        ("pcie_dcp_a2a.cu", "pcie_dcp_a2a.py", "DCP_A2A_REQUIRED_SMS", 64),
++    ),
++)
++def test_peer_waiting_grid_is_fully_resident_or_rejected_before_ipc(
++    source_name: str,
++    python_name: str,
++    constant_name: str,
++    required_sms: int,
++) -> None:
++    source = (PCIE / source_name).read_text(encoding="utf-8")
++    wrapper = (PCIE / python_name).read_text(encoding="utf-8")
++
++    assert f"constexpr int kMaxBlocks = {required_sms};" in source
++    assert source.count("__global__ void __launch_bounds__(512, 1)") == 2
++    assert f"{constant_name} = {required_sms}" in wrapper
++    assert "_require_full_grid_residency(" in wrapper
++
++    # All peer-waiting worker launches use no dynamic shared memory. Combined
++    # with launch_bounds(..., 1), one CTA is resident per visible SM; requiring
++    # kMaxBlocks SMs makes every possible worker CTA simultaneously resident.
++    worker_launches = [
++        line
++        for line in source.splitlines()
++        if "<<<blocks, threads, 0, stream>>>" in line
++    ]
++    assert worker_launches
++    assert all(", 0, stream>>>" in line for line in worker_launches)
++
++
++def test_oneshot_control_is_staged_only_and_precedes_each_worker() -> None:
++    source = (PCIE / "pcie_oneshot.cu").read_text(encoding="utf-8")
++    control_launch = "advance_staging_slot_kernel<<<1, 1, 0, stream>>>(self_sg_);"
++    assert source.count(control_launch) == 2
++
++    regular = _section(
++        source,
++        "void allreduce(cudaStream_t stream",
++        "void allreduce_fused_add_rms_norm",
++    )
++    assert f"if (stage_input) {{\n      {control_launch}" in regular
++    assert regular.index(control_launch) < regular.index("#define KL(ngpus)")
++
++    fused = _section(
++        source,
++        "void allreduce_fused_add_rms_norm",
++        "~PCIeAllreduce",
++    )
++    assert f"if (use_eager_staging) {{\n      {control_launch}" in fused
++    assert fused.index(control_launch) < fused.index("#define KL(ngpus, SINGLE, MODE)")
++
++    # Registered one-shot and fused registered paths retain their original
++    # direct buffer route; only the double-buffered staged route advances.
++    assert "if (stage_input)" in regular
++    assert "pcie_allreduce_kernel<T, ngpus, true>" in regular
++    assert "pcie_allreduce_kernel<T, ngpus, false>" in regular
++    assert "if (mode == kModeStagePush)" in fused
++    assert "KL(ngpus, SINGLE, kModeStagePush)" in fused
++    assert "KL(ngpus, SINGLE, kModeStagePull)" in fused
++    assert "kModeRegistered" in fused
++
++
++def test_twoshot_control_precedes_reduce_scatter_and_all_gather_workers() -> None:
++    source = (PCIE / "pcie_twoshot.cu").read_text(encoding="utf-8")
++    control_launch = "advance_staging_slot_kernel<<<1, 1, 0, stream>>>(self_sg_);"
++    assert source.count(control_launch) == 2
++
++    reduce_scatter = _section(source, "void reduce_scatter(", "void all_gather(")
++    assert reduce_scatter.index(control_launch) < reduce_scatter.index(
++        "rs_fp8_kernel<ngpus><<<blocks, threads, 0, stream>>>"
++    )
++
++    all_gather = _section(source, "void all_gather(", "\n};")
++    assert all_gather.index(control_launch) < all_gather.index(
++        "ag_fp8_kernel<ngpus><<<blocks, threads, 0, stream>>>"
++    )
++
++
++def test_twoshot_validates_launch_geometry_before_grid_division() -> None:
++    source = (PCIE / "pcie_twoshot.cu").read_text(encoding="utf-8")
++    validator = _section(source, "void check_launch_config(", "void reduce_scatter(")
++
++    assert "threads < world_size_" in validator
++    assert "threads > 1024" in validator
++    assert "threads % 32 != 0" in validator
++    assert "block_limit <= 0" in validator
++    assert "block_limit > kMaxBlocks" in validator
++
++    reduce_scatter = _section(source, "void reduce_scatter(", "void all_gather(")
++    all_gather = _section(source, "void all_gather(", "\n};")
++    for operation in (reduce_scatter, all_gather):
++        assert operation.index("check_launch_config(threads, block_limit);") < (
++            operation.index("(shard_packs + threads - 1) / threads")
++        )
++
++
++def test_dcp_control_selects_one_slot_per_operation_before_workers() -> None:
++    source = (PCIE / "pcie_dcp_a2a.cu").read_text(encoding="utf-8")
++    control_launch = "advance_staging_slot_kernel<<<1, 1, 0, stream>>>(self_signal_);"
++    assert source.count(control_launch) == 2
++
++    selector = _section(source, "DINLINE void select_staging", "// pre_sync")
++    assert "active_staging_slot" in selector
++    assert "self_counter[blockIdx.x]" not in selector
++    assert "atomicAdd" not in selector
++    assert "while (" not in selector
++
++    reduce_scatter = _section(
++        source, "void run(cudaStream_t stream", "void all_gather_heads("
++    )
++    gather = _section(source, "void all_gather_heads(", "\n};")
++    assert reduce_scatter.index(control_launch) < reduce_scatter.index(
++        "#define LAUNCH(world)"
++    )
++    assert gather.index(control_launch) < gather.index("#define LAUNCH(world)")
++    assert "SPARKINFER_PCIE_DCP_TEST_POST_BARRIER_DELAY_CYCLES" in source
++    assert "test_post_barrier_delay(rank, delayed_rank, delay_cycles);" in source
++
++
++@pytest.mark.parametrize(
++    "source_name", ("pcie_oneshot.cu", "pcie_twoshot.cu", "pcie_dcp_a2a.cu")
++)
++def test_control_kernel_is_graph_replay_dynamic(source_name: str) -> None:
++    source = (PCIE / source_name).read_text(encoding="utf-8")
++    control = _section(
++        source,
++        "__global__ void advance_staging_slot_kernel",
++        "template <",
++    )
++
++    # The generation update runs in a CUDA kernel—not on the host—so capture
++    # records it as a graph node and every replay advances the channel slot.
++    assert "staging_generation" in control
++    assert "active_staging_slot = generation & FlagType{1}" in control
++    assert "staging_generation = generation + FlagType{1}" in control
++
++
++@pytest.mark.parametrize(
++    ("source_name", "expected_checks"),
++    (("pcie_oneshot.cu", 4), ("pcie_twoshot.cu", 4)),
++)
++def test_control_and_worker_launches_have_immediate_error_checks(
++    source_name: str, expected_checks: int
++) -> None:
++    source = (PCIE / source_name).read_text(encoding="utf-8")
++    assert source.count("CHECK_CUDA_SUCCESS(cudaGetLastError());") >= expected_checks
++
++    control_launch = "advance_staging_slot_kernel<<<1, 1, 0, stream>>>(self_sg_);"
++    for suffix in source.split(control_launch)[1:]:
++        assert suffix.lstrip().startswith("CHECK_CUDA_SUCCESS(cudaGetLastError());")
++
++
++@pytest.mark.parametrize(
++    "source_name",
++    ("pcie_oneshot.cu", "pcie_twoshot.cu", "pcie_dcp_a2a.cu"),
++)
++def test_each_staged_collective_has_one_control_launch(source_name: str) -> None:
++    source = (PCIE / source_name).read_text(encoding="utf-8")
++    control_launch = "advance_staging_slot_kernel<<<1, 1, 0, stream>>>"
++
++    # Each source implements exactly two staged collectives. Registered
++    # one-shot paths remain control-free; their conditional gating is covered
++    # by the neighboring source and GPU graph tests.
++    assert source.count(control_launch) == 2
+diff --git a/tests/comm/test_pcie_twoshot.py b/tests/comm/test_pcie_twoshot.py
+index 0862089c5bf687b5753a849891ff2c5d94f210b4..d9ab1548f137470abce4a83b377a42452375ba43 100644
+--- a/tests/comm/test_pcie_twoshot.py
++++ b/tests/comm/test_pcie_twoshot.py
+@@ -6,12 +6,19 @@ Run with torchrun on 2, 4 or 8 GPUs:
+         --nproc-per-node=8 tests/distributed/test_pcie_twoshot.py
+ """
+ 
++import ctypes
+ import os
+ import time
+ 
++import pytest
+ import torch
+ import torch.distributed as dist
+ 
++from sparkinfer.comm.pcie.pcie_oneshot import (
++    PCIeOneshotAllReduce,
++    _OwnedSharedBuffer,
++    _RETAINED_FAILED_IPC_EXPORTS,
++)
+ from sparkinfer.comm.pcie.pcie_twoshot import (
+     PCIeTwoShotSP,
+     quantize_per_row,
+@@ -21,6 +28,159 @@ ROWS = 4096
+ ROW_ELEMS = 6144
+ 
+ 
++def test_factory_retains_twoshot_native_and_ipc_ownership_when_verdict_fails(
++    monkeypatch,
++) -> None:
++    events: list[tuple[str, int]] = []
++
++    class FakeIPC:
++        def cudaIpcCloseMemHandle(self, ptr):
++            events.append(("close", ptr))
++
++        def cudaFree(self, ptr):
++            events.append(("free", ptr))
++
++    class FakeExt:
++        @staticmethod
++        def init_twoshot(*args):
++            return 3000
++
++        @staticmethod
++        def dispose(ptr):
++            events.append(("dispose", ptr))
++
++    ipc = FakeIPC()
++    ext = FakeExt()
++    group = object()
++    shared = _OwnedSharedBuffer(
++        local_ptr=1000,
++        peer_ptrs=(1000, 2000),
++        remote_ptrs=(2000,),
++    )
++    preallocation_round = 0
++
++    def fake_preallocation(*, owner, exchange_group, setup):
++        nonlocal preallocation_round
++        assert exchange_group is group
++        preallocation_round += 1
++        if preallocation_round == 1:
++            return torch.device("cuda:0"), 8, 16
++        assert preallocation_round == 2
++        return ipc, ext, 1, 256, 64, 256, 512, 1280
++
++    verdict_round = 0
++
++    def exchange(local_status, exchange_group):
++        nonlocal verdict_round
++        assert exchange_group is group
++        verdict_round += 1
++        if verdict_round == 1:
++            raise RuntimeError("injected twoshot native verdict exchange failure")
++        return [local_status, ()]
++
++    monkeypatch.setattr(dist, "get_rank", lambda group=None: 0)
++    monkeypatch.setattr(dist, "get_world_size", lambda group=None: 2)
++    monkeypatch.setattr(
++        "sparkinfer.comm.pcie.pcie_twoshot._run_collective_preallocation_setup",
++        fake_preallocation,
++    )
++    monkeypatch.setattr(
++        "sparkinfer.comm.pcie.pcie_twoshot._require_full_grid_residency",
++        lambda **kwargs: None,
++    )
++    monkeypatch.setattr(
++        "sparkinfer.comm.pcie.pcie_twoshot._require_collective_contract",
++        lambda **kwargs: None,
++    )
++    monkeypatch.setattr(
++        PCIeOneshotAllReduce,
++        "_allocate_shared_buffer",
++        classmethod(lambda cls, *args, **kwargs: shared),
++    )
++    monkeypatch.setattr(
++        "sparkinfer.comm.pcie.pcie_oneshot._broadcast_gather_object",
++        exchange,
++    )
++
++    with pytest.raises(RuntimeError, match="must be coordinated by every rank") as exc:
++        PCIeTwoShotSP.from_exchange_group(
++            exchange_group=group,
++            device="cuda:0",
++            max_rows=8,
++            row_elems=16,
++            ext_module=ext,
++        )
++
++    retained = exc.value.retryable_setup
++    assert retained.local_ptr == 1000
++    assert retained.remote_ptrs == [2000]
++    assert retained.local_cleanup is not None
++    assert events == []
++    assert _RETAINED_FAILED_IPC_EXPORTS[retained.key] is retained
++
++    retained.retry()
++    assert events == [("dispose", 3000), ("close", 2000), ("free", 1000)]
++    assert _RETAINED_FAILED_IPC_EXPORTS == {}
++
++
++def _align_up(value: int, alignment: int) -> int:
++    return (value + alignment - 1) // alignment * alignment
++
++
++def _local_staging_words(
++    pool: PCIeTwoShotSP, stream: torch.cuda.Stream
++) -> tuple[int, int]:
++    assert len(pool._owned_buffers) == 1
++    max_rows_per_rank = pool.max_rows // pool.world_size
++    pack_stride = _align_up(max_rows_per_rank * (pool.row_elems // 16), 16)
++    payload_bytes = pool.world_size * pack_stride * 16
++    scale_offset = _align_up(payload_bytes, 256)
++    scale_stride = _align_up(max_rows_per_rank, 64)
++    slot_bytes = _align_up(
++        scale_offset + pool.world_size * scale_stride * 4,
++        256,
++    )
++    signal_bytes = _align_up(int(pool._ext.meta_size()), 256)
++    remote_source = (pool.rank + 1) % pool.world_size
++    source_offset = remote_source * pack_stride * 16
++    words = (ctypes.c_uint64(), ctypes.c_uint64())
++    local_ptr = pool._owned_buffers[0].local_ptr
++    for word, offset in zip(
++        words,
++        (
++            signal_bytes + source_offset,
++            signal_bytes + slot_bytes + source_offset,
++        ),
++        strict=True,
++    ):
++        pool._ipc.cudaMemcpyAsync(
++            ctypes.addressof(word),
++            local_ptr + offset,
++            ctypes.sizeof(word),
++            int(stream.cuda_stream),
++        )
++    stream.synchronize()
++    return words[0].value, words[1].value
++
++
++def _assert_alternating_slots(snapshots: list[tuple[int, int]]) -> None:
++    changed_slots = [
++        {
++            slot
++            for slot, (before, after) in enumerate(
++                zip(snapshots[index], snapshots[index + 1], strict=True)
++            )
++            if before != after
++        }
++        for index in range(len(snapshots) - 1)
++    ]
++    assert all(len(changed) == 1 for changed in changed_slots)
++    assert all(
++        changed_slots[index] != changed_slots[index + 1]
++        for index in range(len(changed_slots) - 1)
++    )
++
++
+ def _partial(seed: int, rows: int, device: torch.device) -> torch.Tensor:
+     gen = torch.Generator(device="cpu").manual_seed(seed)
+     x = torch.randn(rows, ROW_ELEMS, generator=gen, dtype=torch.float32)
+@@ -127,6 +287,56 @@ def _check_graph_capture(pool: PCIeTwoShotSP, rank: int, world: int) -> None:
+         )
+         assert torch.equal(ag_out, ag_ref)
+ 
++    # Capture a single collective so adjacent replays must alternate the
++    # device-selected staging slot. The two-op graph above has even parity.
++    odd_graph = torch.cuda.CUDAGraph()
++    with torch.cuda.graph(odd_graph):
++        pool.all_gather_fp8(ag_q, ag_s, ag_out)
++
++    for value in (11, 12):
++        ag_q.fill_(float(value + rank))
++        ag_s.fill_(1.0)
++        pool.all_gather_fp8(ag_q, ag_s, ag_out)
++    torch.cuda.synchronize()
++    snapshots = [_local_staging_words(pool, torch.cuda.current_stream(device))]
++
++    for value in (1, 2):
++        ag_q.fill_(float(value + rank))
++        ag_s.fill_(1.0)
++        dist.barrier()
++        odd_graph.replay()
++        torch.cuda.synchronize()
++        snapshots.append(_local_staging_words(pool, torch.cuda.current_stream(device)))
++        for source_rank in range(world):
++            lo = source_rank * rows_per_rank
++            hi = lo + rows_per_rank
++            assert torch.all(ag_out[lo:hi] == float(value + source_rank))
++
++    _assert_alternating_slots(snapshots)
++
++    rs_graph = torch.cuda.CUDAGraph()
++    with torch.cuda.graph(rs_graph):
++        pool.reduce_scatter_fp8(q_in, s_in, rs_out)
++
++    for value in (21, 22):
++        q_in.fill_(float(value + rank))
++        s_in.fill_(1.0)
++        pool.reduce_scatter_fp8(q_in, s_in, rs_out)
++    torch.cuda.synchronize()
++    snapshots = [_local_staging_words(pool, torch.cuda.current_stream(device))]
++
++    rank_sum = world * (world - 1) // 2
++    for value in (3, 4):
++        q_in.fill_(float(value + rank))
++        s_in.fill_(1.0)
++        dist.barrier()
++        rs_graph.replay()
++        torch.cuda.synchronize()
++        snapshots.append(_local_staging_words(pool, torch.cuda.current_stream(device)))
++        assert torch.all(rs_out == float(world * value + rank_sum))
++
++    _assert_alternating_slots(snapshots)
++
+ 
+ def _bench(pool: PCIeTwoShotSP, rank: int, world: int) -> None:
+     device = pool.device
+diff --git a/tests/gemm/test_trellis_linear.py b/tests/gemm/test_trellis_linear.py
+index de853adf1842c50e017b509572230250d1d196da..1223cf1e3559acc8fb2644310ffb809ee18693e5 100644
+--- a/tests/gemm/test_trellis_linear.py
++++ b/tests/gemm/test_trellis_linear.py
+@@ -7,6 +7,12 @@ import torch
+ 
+ from sparkinfer.gemm import trellis_linear
+ from sparkinfer.gemm.trellis_linear import api
++from sparkinfer.gemm.trellis_linear import _small_m
++from sparkinfer.gemm.trellis_linear._small_m import _default_num_sms
++from sparkinfer.moe._shared.kernels.w4a16.kernel import (
++    _run_trellis_dense_hadamard128,
++    _trellis256_dense_launch_geometry,
++)
+ 
+ 
+ def _sm12x_available() -> bool:
+@@ -101,6 +107,191 @@ def test_is_supported_uses_standard_sm12x_gate(monkeypatch) -> None:
+     assert seen == {"device": "cuda:3", "requires": trellis_linear.META.requires}
+ 
+ 
++@pytest.mark.parametrize(
++    ("size_k", "size_n", "available_sms", "expected"),
++    [
++        (2048, 4096, 188, 128),
++        (2048, 4096, 120, 120),
++        (6144, 1024, 188, 64),
++        (6144, 1024, 48, 48),
++        (512, 6144, 188, 96),
++        (512, 6144, 80, 80),
++        # The unsharded dimensions are deliberately not inferred from TP4.
++        (6144, 4096, 188, 188),
++        (2048, 6144, 188, 188),
++        (3072, 6144, 188, 188),
++        (4096, 6144, 188, 188),
++        (6144, 6144, 188, 188),
++    ],
++)
++def test_k6_small_m_default_sms_preserves_glm_decode_overlap(
++    size_k: int,
++    size_n: int,
++    available_sms: int,
++    expected: int,
++) -> None:
++    assert _default_num_sms(size_k, size_n, available_sms) == expected
++
++
++def test_k6_small_m_rejects_unsupported_arch_before_jit(monkeypatch) -> None:
++    monkeypatch.setattr(torch.cuda, "get_device_capability", lambda _device: (9, 0))
++    monkeypatch.setattr(
++        _small_m,
++        "_extension",
++        lambda: pytest.fail("extension must not compile for an unsupported GPU"),
++    )
++
++    with pytest.raises(NotImplementedError, match="built for sm_120 only"):
++        _small_m.run_k6_mcg(*(torch.empty(0) for _ in range(7)))
++
++
++@pytest.mark.parametrize(
++    ("size_m", "size_k", "size_n", "expected"),
++    [
++        # Narrow profile: avoid a short spill by increasing both M and N work.
++        (512, 16384, 6144, (48, (64, 128))),
++        (1024, 16384, 6144, (48, (64, 256))),
++        # Wide model projection: N already supplies enough work. Splitting N is
++        # useful for the second wave, while M48 only adds scheduler overhead.
++        (192, 2048, 16384, (64, (64, 128))),
++        (384, 2048, 16384, (48, (64, 256))),
++        # A deeper K makes M48 scheduler overhead more expensive.
++        (384, 6144, 16384, (64, (64, 256))),
++        # Full waves retain the throughput-oriented default geometry.
++        (2048, 4096, 6144, (64, (64, 256))),
++    ],
++)
++def test_dense_launch_geometry_avoids_short_spill_waves(
++    size_m: int,
++    size_k: int,
++    size_n: int,
++    expected: tuple[int, tuple[int, int]],
++) -> None:
++    assert (
++        _trellis256_dense_launch_geometry(
++            size_m=size_m,
++            size_k=size_k,
++            size_n=size_n,
++            sms=188,
++        )
++        == expected
++    )
++
++
++@pytest.mark.parametrize(
++    ("m", "size_k", "size_n"),
++    [
++        (7, 128, 128),
++        (1, 2048, 4096),
++        (7, 6144, 1024),
++        (32, 512, 6144),
++    ],
++)
++@pytest.mark.skipif(not _sm12x_available(), reason="requires an SM120/SM121 GPU")
++def test_k6_small_m_matches_separate_cute_pipeline(
++    m: int,
++    size_k: int,
++    size_n: int,
++) -> None:
++    device = torch.device("cuda", torch.cuda.current_device())
++    torch.manual_seed(0)
++    trellis = torch.randint(
++        -32768,
++        32767,
++        (size_k // 16, size_n // 16, 96),
++        dtype=torch.int16,
++        device=device,
++    )
++    suh = torch.randn((size_k,), dtype=torch.float16, device=device)
++    svh = torch.randn((size_n,), dtype=torch.float16, device=device)
++    weight = trellis_linear.prepare_weight(
++        trellis,
++        suh,
++        svh,
++        mcg=torch.tensor(0xCBAC1FED, dtype=torch.uint32, device=device),
++        params_dtype=torch.float16,
++    )
++    x = torch.randn((m, size_k), dtype=torch.float16, device=device)
++
++    def separate_hadamard(
++        source: torch.Tensor,
++        destination: torch.Tensor,
++        left_scale,
++        right_scale,
++        _scale: float,
++    ) -> None:
++        _run_trellis_dense_hadamard128(
++            source,
++            destination,
++            left_scale if left_scale is not None else right_scale,
++            scale_before=left_scale is not None,
++        )
++
++    expected = trellis_linear.run(
++        x,
++        weight,
++        hadamard_128=separate_hadamard,
++    ).clone()
++    weight.workspace.zero_()
++    actual = trellis_linear.run(x, weight).clone()
++    torch.cuda.synchronize(device)
++
++    # The cooperative kernel and CuTe fallback use different legal FP16 MMA
++    # accumulation orders. Compare their direction and normalized error rather
++    # than imposing a large absolute tolerance on values near zero.
++    actual_f32 = actual.float()
++    expected_f32 = expected.float()
++    delta = actual_f32 - expected_f32
++    relative_l2 = delta.norm() / expected_f32.norm().clamp_min(1e-12)
++    cosine = torch.nn.functional.cosine_similarity(
++        actual_f32.flatten(), expected_f32.flatten(), dim=0
++    )
++    max_relative_to_range = delta.abs().max() / expected_f32.abs().max().clamp_min(
++        1e-12
++    )
++
++    assert float(relative_l2) < 1.5e-3
++    assert float(cosine) > 0.999998
++    assert float(max_relative_to_range) < 2e-3
++
++
++@pytest.mark.skipif(not _sm12x_available(), reason="requires an SM120/SM121 GPU")
++def test_k6_small_m_cuda_graph_replay_is_stable() -> None:
++    device = torch.device("cuda", torch.cuda.current_device())
++    m = 3
++    features = 128
++    trellis = torch.randint(
++        -32768,
++        32767,
++        (features // 16, features // 16, 96),
++        dtype=torch.int16,
++        device=device,
++    )
++    scale = torch.ones((features,), dtype=torch.float16, device=device)
++    weight = trellis_linear.prepare_weight(
++        trellis,
++        scale,
++        scale.clone(),
++        mcg=torch.tensor(0xCBAC1FED, dtype=torch.uint32, device=device),
++        params_dtype=torch.float16,
++    )
++    x = torch.randn((m, features), dtype=torch.float16, device=device)
++    output = torch.empty_like(x)
++    rotated_f16 = torch.empty_like(x)
++    kwargs = {"output": output, "rotated_f16": rotated_f16}
++
++    expected = trellis_linear.run(x, weight, **kwargs).clone()
++    torch.cuda.synchronize(device)
++    graph = torch.cuda.CUDAGraph()
++    with torch.cuda.graph(graph):
++        captured = trellis_linear.run(x, weight, **kwargs)
++    output.fill_(float("nan"))
++    graph.replay()
++    torch.cuda.synchronize(device)
++
++    assert torch.equal(captured, expected)
++
++
+ @pytest.mark.skipif(not _sm12x_available(), reason="requires an SM120/SM121 GPU")
+ def test_dense_bf16_reuses_all_scratch_during_cuda_graph_capture() -> None:
+     device = torch.device("cuda", torch.cuda.current_device())
+diff --git a/tests/gemm/test_trellis_packaging.py b/tests/gemm/test_trellis_packaging.py
+new file mode 100644
+index 0000000000000000000000000000000000000000..bfc316e80ecc0cf1b4bc22e3ab5cb03974fdab33
+--- /dev/null
++++ b/tests/gemm/test_trellis_packaging.py
+@@ -0,0 +1,37 @@
++from __future__ import annotations
++
++from fnmatch import fnmatch
++from pathlib import Path
++
++
++ROOT = Path(__file__).parents[2]
++TRELLIS_SOURCE_DIR = ROOT / "sparkinfer" / "gemm" / "trellis_linear" / "csrc"
++
++
++def test_trellis_runtime_sources_and_license_are_in_source_manifest() -> None:
++    manifest = (ROOT / "MANIFEST.in").read_text(encoding="utf-8")
++    assert (
++        "recursive-include sparkinfer/gemm/trellis_linear/csrc *.cu *.cuh *.h LICENSE*"
++    ) in manifest.splitlines()
++
++    required = (
++        TRELLIS_SOURCE_DIR / "trellis_k6_small.cu",
++        TRELLIS_SOURCE_DIR / "vendor" / "LICENSE.exllamav3",
++        TRELLIS_SOURCE_DIR / "vendor" / "quant" / "exl3_gemm_kernel.cuh",
++    )
++    assert all(path.is_file() for path in required)
++    packaged_patterns = ("*.cu", "*.cuh", "*.h", "LICENSE*")
++    source_files = (path for path in TRELLIS_SOURCE_DIR.rglob("*") if path.is_file())
++    assert all(
++        any(fnmatch(path.name, pattern) for pattern in packaged_patterns)
++        for path in source_files
++    )
++    provenance = "Vendored from https://github.com/brandonmmusic-max/exllamav3"
++    vendor_sources = (
++        path
++        for path in (TRELLIS_SOURCE_DIR / "vendor").rglob("*")
++        if path.is_file() and not path.name.startswith("LICENSE")
++    )
++    assert all(
++        provenance in path.read_text(encoding="utf-8") for path in vendor_sources
++    )
+diff --git a/tests/moe/test_ep_moe_api.py b/tests/moe/test_ep_moe_api.py
+index fbf791ecc7e5543c2e252aa5b8162fc478e5a05a..31cb14b66eecf0346e3b43691530791badf1ae09 100644
+--- a/tests/moe/test_ep_moe_api.py
++++ b/tests/moe/test_ep_moe_api.py
+@@ -5,9 +5,18 @@ import torch
+ 
+ import sparkinfer.moe.ep_moe._impl as ep_moe
+ from sparkinfer._lib.intrinsics import swizzle_block_scale
+-from sparkinfer.moe.ep_moe._impl import EPMoEScratchCaps, plan_ep_moe_scratch, prepare_ep_expert_map, sparkinfer_ep_moe_fp4
++from sparkinfer.moe.ep_moe._impl import (
++    EPMoEScratchCaps,
++    plan_ep_moe_scratch,
++    prepare_ep_expert_map,
++    sparkinfer_ep_moe_fp4,
++)
+ from sparkinfer.moe.fused_moe._impl import plan_sparkinfer_fp4_moe_weights
+-from sparkinfer.moe._shared.kernels.w4a16.host import max_w4a16_route_capacity
++from sparkinfer.moe._shared.kernels.w4a16.host import (
++    max_packed_route_slots,
++    route_block_sizes_for_capacity,
++    route_pack_token_capacity,
++)
+ from tests._reference.helpers import prepare_tp_moe_fp4_experts, run_tp_moe_fp4
+ 
+ 
+@@ -116,7 +125,17 @@ def test_ep_scratch_reserves_route_pack_power_of_two_capacity(
+     )
+ 
+     layout = {spec.name: spec for spec in plan._layout}
+-    expected_slots, expected_blocks = max_w4a16_route_capacity(4 * 2, 10)
++    block_sizes = route_block_sizes_for_capacity(3, 2, 10)
++    capacity_rows = route_pack_token_capacity(3, 2) * 2
++    expected_slots = max(
++        max_packed_route_slots(capacity_rows, block_size, 10)
++        for block_size in block_sizes
++    )
++    expected_blocks = max(
++        (max_packed_route_slots(capacity_rows, block_size, 10) + block_size - 1)
++        // block_size
++        for block_size in block_sizes
++    )
+     assert layout["packed_route_indices"].elements == expected_slots
+     assert layout["block_expert_ids"].elements == expected_blocks
+     assert layout["intermediate_cache2"].elements == 3 * 2 * 128
+@@ -154,14 +173,18 @@ def _make_modelopt_weights(
+         device="cuda",
+     )
+     w13_scale = swizzle_block_scale(
+-        (torch.rand(experts, 2 * intermediate_size, hidden_size // 16, device="cuda")
+-         * 0.25
+-         + 0.03125).to(torch.float8_e4m3fn)
++        (
++            torch.rand(experts, 2 * intermediate_size, hidden_size // 16, device="cuda")
++            * 0.25
++            + 0.03125
++        ).to(torch.float8_e4m3fn)
+     )
+     w2_scale = swizzle_block_scale(
+-        (torch.rand(experts, hidden_size, intermediate_size // 16, device="cuda")
+-         * 0.25
+-         + 0.03125).to(torch.float8_e4m3fn)
++        (
++            torch.rand(experts, hidden_size, intermediate_size // 16, device="cuda")
++            * 0.25
++            + 0.03125
++        ).to(torch.float8_e4m3fn)
+     )
+     w13_alpha = (torch.rand(experts, device="cuda") * 0.1 + 0.05).float()
+     w2_alpha = (torch.rand(experts, device="cuda") * 0.1 + 0.05).float()
+@@ -318,9 +341,11 @@ def test_ep_binding_replays_with_changed_routes_under_cuda_graph() -> None:
+     global_ids = torch.tensor([0, 2])
+     experts = _prepare_experts(a, weights, global_ids)
+     expert_map = torch.tensor([0, -1, 1, -1], dtype=torch.int32, device="cuda")
+-    topk_ids = torch.tensor([[1, 3]], dtype=torch.int32, device="cuda").expand(
+-        m, -1
+-    ).contiguous()
++    topk_ids = (
++        torch.tensor([[1, 3]], dtype=torch.int32, device="cuda")
++        .expand(m, -1)
++        .contiguous()
++    )
+     topk_weights = torch.full((m, topk), 0.5, dtype=torch.float32, device="cuda")
+     nonlocal_output, binding = _run_ep_rank(
+         a=a,
+diff --git a/tests/moe/test_fused_moe_planning.py b/tests/moe/test_fused_moe_planning.py
+new file mode 100644
+index 0000000000000000000000000000000000000000..fe38b5d10c4476d0a1e828a0cfd36129110e1850
+--- /dev/null
++++ b/tests/moe/test_fused_moe_planning.py
+@@ -0,0 +1,171 @@
++from __future__ import annotations
++
++import pytest
++import torch
++
++from sparkinfer.moe import fused_moe
++import sparkinfer.moe.fused_moe._impl as fused_moe_impl
++
++
++def _weight_plan() -> fused_moe.WeightsPlan:
++    return fused_moe.plan_weights(
++        quant_modes="w4a16",
++        source_format="modelopt_nvfp4",
++        activation="silu",
++        params_dtype=torch.bfloat16,
++        num_experts=160,
++        hidden_size=6144,
++        intermediate_size=512,
++        w13_layout="w13",
++    )
++
++
++def _caps(*, block_size_m: int | None) -> fused_moe.Caps:
++    return fused_moe.Caps(
++        max_tokens=64,
++        num_topk=8,
++        route_num_experts=160,
++        device="cpu",
++        weight_plan=_weight_plan(),
++        quant_mode="w4a16",
++        w4a16_block_size_m=block_size_m,
++    )
++
++
++def _trellis_caps() -> fused_moe.Caps:
++    weight_plan = fused_moe.plan_weights(
++        quant_modes="w4a16",
++        source_format="exl3_trellis_mcg",
++        activation="silu",
++        params_dtype=torch.bfloat16,
++        num_experts=160,
++        hidden_size=6144,
++        intermediate_size=512,
++        w13_layout="w13",
++        trellis_bits=3,
++        trellis_tile_config=(64, 256, 64, 256),
++    )
++    return fused_moe.Caps(
++        max_tokens=3072,
++        num_topk=8,
++        route_num_experts=160,
++        device="cpu",
++        weight_plan=weight_plan,
++        quant_mode="w4a16",
++        w4a16_block_size_m=64,
++    )
++
++
++def _small_packed_caps() -> fused_moe.Caps:
++    weight_plan = fused_moe.plan_weights(
++        quant_modes="w4a16",
++        source_format="compressed_tensors",
++        activation="silu",
++        params_dtype=torch.bfloat16,
++        num_experts=16,
++        hidden_size=128,
++        intermediate_size=128,
++        w13_layout="w13",
++    )
++    return fused_moe.Caps(
++        max_tokens=4,
++        num_topk=8,
++        route_num_experts=16,
++        device="cpu",
++        weight_plan=weight_plan,
++        quant_mode="w4a16",
++    )
++
++
++def _subset_router_caps() -> fused_moe.Caps:
++    weight_plan = fused_moe.plan_weights(
++        quant_modes="w4a16",
++        source_format="compressed_tensors",
++        activation="silu",
++        params_dtype=torch.bfloat16,
++        num_experts=160,
++        hidden_size=128,
++        intermediate_size=128,
++        w13_layout="w13",
++    )
++    return fused_moe.Caps(
++        max_tokens=8,
++        num_topk=8,
++        route_num_experts=16,
++        device="cpu",
++        weight_plan=weight_plan,
++        quant_mode="w4a16",
++    )
++
++
++def test_required_nbytes_avoids_launch_prewarm(
++    monkeypatch: pytest.MonkeyPatch,
++) -> None:
++    monkeypatch.setattr(fused_moe_impl, "get_num_sm", lambda _device: 188)
++
++    def fail_launch_prewarm(**_kwargs) -> None:
++        raise AssertionError("launch prewarm called")
++
++    monkeypatch.setattr(
++        fused_moe_impl,
++        "_plan_full_rotation_w4a16_launches",
++        fail_launch_prewarm,
++    )
++    caps = _trellis_caps()
++
++    required = fused_moe.required_nbytes(caps)
++
++    assert required > 1024 * 1024 * 1024
++    assert "required_nbytes" in fused_moe.META.entry_points
++    with pytest.raises(TypeError, match="TPMoEScratchCaps"):
++        fused_moe.required_nbytes(object())
++
++
++def test_required_nbytes_matches_scratch_plan(
++    monkeypatch: pytest.MonkeyPatch,
++) -> None:
++    monkeypatch.setattr(fused_moe_impl, "get_num_sm", lambda _device: 188)
++    caps = _caps(block_size_m=8)
++
++    plan = fused_moe.plan(caps)
++
++    assert fused_moe.required_nbytes(caps) == plan.scratch_specs()[0].shape[0]
++
++
++def test_small_packed_plan_covers_direct_topk_scratch(
++    monkeypatch: pytest.MonkeyPatch,
++) -> None:
++    monkeypatch.setattr(fused_moe_impl, "get_num_sm", lambda _device: 188)
++
++    plan = fused_moe.plan(_small_packed_caps())
++    specs = {spec.name: spec for spec in plan._core_workspace_plan.tensor_specs}
++
++    assert specs["fc1_c_tmp"].shape == (131072,)
++    assert specs["fc2_c_tmp"].shape == (65536,)
++
++
++def test_non_trellis_core_sizes_routes_for_weight_experts(
++    monkeypatch: pytest.MonkeyPatch,
++) -> None:
++    monkeypatch.setattr(fused_moe_impl, "get_num_sm", lambda _device: 188)
++
++    plan = fused_moe.plan(_subset_router_caps())
++    specs = {spec.name: spec for spec in plan._core_workspace_plan.tensor_specs}
++
++    assert plan._core_workspace_plan.route_E == 160
++    assert specs["packed_route_indices"].shape == (512,)
++    assert specs["block_expert_ids"].shape == (64,)
++    assert specs["expert_offsets"].shape == (161,)
++
++
++def test_unpinned_small_capacity_matches_reachable_block_8(
++    monkeypatch: pytest.MonkeyPatch,
++) -> None:
++    monkeypatch.setattr(fused_moe_impl, "get_num_sm", lambda _device: 188)
++
++    automatic = fused_moe.required_nbytes(_caps(block_size_m=None))
++    exact = fused_moe.required_nbytes(_caps(block_size_m=8))
++    oversized = fused_moe.required_nbytes(_caps(block_size_m=64))
++
++    assert automatic == exact
++    assert oversized - automatic > 64 * 1024 * 1024
+diff --git a/tests/moe/test_tp_moe_scratch_bindings.py b/tests/moe/test_tp_moe_scratch_bindings.py
+index f44216a3adc1f91cdae1d31eb5ec9fb7d7e9a2ca..b99c8072aa2223364c2e58998b8b21aa7d0d07e8 100644
+--- a/tests/moe/test_tp_moe_scratch_bindings.py
++++ b/tests/moe/test_tp_moe_scratch_bindings.py
+@@ -570,6 +570,43 @@ def test_trellis_scratch_plan_preserves_exact_fixed_capacity(
+     assert plan.layout.total_nbytes == plan.layout.core_workspace_nbytes
+ 
+ 
++def test_trellis_scratch_plan_resolves_default_route_block(
++    monkeypatch: pytest.MonkeyPatch,
++) -> None:
++    monkeypatch.setattr(tp_moe_impl, "get_num_sm", lambda _device: 188)
++    monkeypatch.setattr(
++        tp_moe_impl,
++        "_plan_full_rotation_w4a16_launches",
++        lambda **_kwargs: ((), ()),
++    )
++    weight_plan = plan_sparkinfer_fp4_moe_weights(
++        quant_modes="w4a16",
++        source_format="exl3_trellis_mcg",
++        activation="silu",
++        params_dtype=torch.bfloat16,
++        num_experts=256,
++        hidden_size=6144,
++        intermediate_size=512,
++        trellis_bits=3,
++        trellis_tile_config=(64, 256, 64, 256),
++    )
++    caps = TPMoEScratchCaps(
++        max_tokens=3072,
++        core_token_counts=(3072,),
++        num_topk=8,
++        route_num_experts=0,
++        device="cpu",
++        weight_plan=weight_plan,
++        quant_mode="w4a16",
++    )
++
++    plan = plan_tp_moe_scratch(caps)
++
++    assert plan._core_workspace_plan.route_block_size_m == 64
++    assert plan.layout.core_token_counts[0] == 3072
++    assert 4096 not in plan.layout.core_token_counts
++
++
+ @pytest.mark.skipif(not torch.cuda.is_available(), reason="requires CUDA")
+ def test_trellis_launch_planner_compiles_fixed_launch_matrix() -> None:
+     """The real planner must cover every fixed decode and route-pack variant."""
+@@ -708,10 +745,7 @@ def test_w4a16_decode_scratch_covers_direct_topk_geometry(
+             route_num_experts=0,
+         )
+     )
+-    specs = {
+-        spec.name: spec
+-        for spec in plan._core_workspace_plan.tensor_specs
+-    }
++    specs = {spec.name: spec for spec in plan._core_workspace_plan.tensor_specs}
+     block_size = select_route_block_size_m(tokens, topk, weight_plan.num_experts)
+     packed_slots = max_packed_route_slots(
+         tokens * topk,
+diff --git a/tests/moe/test_w4a16_e2e.py b/tests/moe/test_w4a16_e2e.py
+index 7238acd95dd47d718b8488b498ecc71ed6b8b65b..1f71bdf951e44898834b88911f205f2925ec6946 100644
+--- a/tests/moe/test_w4a16_e2e.py
++++ b/tests/moe/test_w4a16_e2e.py
+@@ -19,10 +19,15 @@ from sparkinfer.moe._shared.kernels.reference import (
+     moe_reference_w4a16_f32,
+     moe_reference_w4a16_fp4_e8m0_k32,
+ )
+-from sparkinfer.moe._shared.kernels.w4a16.host import max_packed_route_slots, select_route_block_size_m
++from sparkinfer.moe._shared.kernels.w4a16.host import (
++    max_packed_route_slots,
++    route_pack_capacity,
++    select_route_block_size_m,
++)
+ from sparkinfer.moe._shared.kernels.w4a16.kernel import (
+     _DEFAULT_MAX_SHARED_MEM,
+     MoEMicroKernelW4A16SmallMDirect,
++    _w4a16_stream_is_capturing,
+     _small_m_direct_supported,
+     compile_w4a16_fused_moe,
+     compile_w4a16_topk_sum,
+@@ -35,10 +40,221 @@ from sparkinfer.moe._shared.kernels.w4a16.prepare import (
+     prepare_w4a16_modelopt_nvfp4_weights as prepare_w4a16_weights,
+     prepare_w4a16_packed_weights,
+ )
+-from tests._reference.helpers import prepare_tp_moe_fp4_experts, run_tp_moe_fp4
++from tests._reference.helpers import (
++    make_tp_moe_fp4_binding,
++    prepare_tp_moe_fp4_experts,
++    run_tp_moe_fp4,
++)
+ from tests._reference.w4a16_reference import compare_to_reference, moe_reference_w4a16
+ 
+ 
++def test_w4a16_fused_compile_rejects_unresolved_capture_launch(
++    monkeypatch: pytest.MonkeyPatch,
++) -> None:
++    from sparkinfer.moe._shared.kernels.w4a16 import kernel as w4a16_kernel
++
++    monkeypatch.setattr(w4a16_kernel, "_FUSED_CACHE", {})
++    monkeypatch.setattr(w4a16_kernel.torch.cuda, "is_available", lambda: False)
++
++    with pytest.raises(
++        RuntimeError,
++        match="W4A16 fused MoE launch is not resolved for CUDA graph capture",
++    ):
++        compile_w4a16_fused_moe(
++            size_m=16,
++            hidden_size=128,
++            intermediate_size=128,
++            num_experts=8,
++            top_k=2,
++            activation="silu",
++            apply_router_weight_on_input=False,
++            zero_fc2_output=False,
++            moe_block_size=8,
++            max_m_blocks=16,
++            sms=188,
++            max_shared_mem=_DEFAULT_MAX_SHARED_MEM,
++            _require_cached=True,
++        )
++
++
++def test_w4a16_capture_guard_checks_selected_stream(
++    monkeypatch: pytest.MonkeyPatch,
++) -> None:
++    from sparkinfer.moe._shared.kernels.w4a16 import kernel as w4a16_kernel
++
++    selected_stream = 22
++    queried: list[object] = []
++    monkeypatch.setattr(
++        w4a16_kernel.torch.cuda,
++        "is_current_stream_capturing",
++        lambda: False,
++    )
++    monkeypatch.setattr(
++        w4a16_kernel.cuda,
++        "cuStreamIsCapturing",
++        lambda stream: (
++            queried.append(stream) or w4a16_kernel.cuda.CUresult.CUDA_SUCCESS,
++            1,
++        ),
++    )
++
++    assert _w4a16_stream_is_capturing(selected_stream, current_stream=11)
++    assert queried == [selected_stream]
++
++
++def test_w4a16_capture_guard_preserves_current_stream_capture(
++    monkeypatch: pytest.MonkeyPatch,
++) -> None:
++    from sparkinfer.moe._shared.kernels.w4a16 import kernel as w4a16_kernel
++
++    monkeypatch.setattr(
++        w4a16_kernel.torch.cuda,
++        "is_current_stream_capturing",
++        lambda: True,
++    )
++    monkeypatch.setattr(
++        w4a16_kernel.cuda,
++        "cuStreamIsCapturing",
++        lambda _stream: (_ for _ in ()).throw(
++            AssertionError("current-stream capture queried the selected stream")
++        ),
++    )
++
++    assert _w4a16_stream_is_capturing(22, current_stream=11)
++
++
++@pytest.mark.parametrize(
++    ("tokens", "bucket_tokens"),
++    (
++        (1, 1),
++        (8, 8),
++        (9, 16),
++        (3072, 4096),
++        (4096, 4096),
++        (4097, 8192),
++    ),
++)
++def test_generic_w4a16_planner_runtime_key_agrees_at_bucket_boundaries(
++    tokens: int,
++    bucket_tokens: int,
++) -> None:
++    topk = 8
++    block_size = 64
++    num_experts = 160
++    routed_capacity, packed_routes, max_m_blocks = route_pack_capacity(
++        tokens * topk,
++        block_size,
++        num_experts,
++        topk=topk,
++    )
++    expected_routes = bucket_tokens * topk
++    expected_packed = max_packed_route_slots(
++        expected_routes,
++        block_size,
++        num_experts,
++    )
++
++    assert routed_capacity == expected_routes
++    assert packed_routes == expected_packed
++    assert max_m_blocks == (expected_packed + block_size - 1) // block_size
++    if tokens == 3072:
++        assert max_m_blocks == 670
++
++
++def test_trellis_w4a16_planner_runtime_key_preserves_exact_capacity() -> None:
++    topk = 8
++    block_size = 64
++    num_experts = 160
++    routed_capacity, packed_routes, max_m_blocks = route_pack_capacity(
++        3072 * topk,
++        block_size,
++        num_experts,
++        topk=topk,
++        bucket_tokens=False,
++    )
++
++    assert routed_capacity == 3072 * topk
++    assert packed_routes == max_packed_route_slots(
++        3072 * topk,
++        block_size,
++        num_experts,
++    )
++    assert max_m_blocks == 542
++
++
++def test_trellis_w4a16_capture_prewarm_uses_exact_runtime_key(
++    monkeypatch: pytest.MonkeyPatch,
++) -> None:
++    from contextlib import nullcontext
++    from types import SimpleNamespace
++
++    from sparkinfer.moe.fused_moe import _impl as tp_moe_impl
++    from sparkinfer.moe._shared.kernels.w4a16 import kernel as w4a16_kernel
++
++    workspace = SimpleNamespace(
++        device=torch.device("cuda"),
++        dtype=torch.bfloat16,
++        full_rotation=True,
++        route_block_size_m=64,
++        num_topk=8,
++        route_E=160,
++        weight_E=160,
++        k=6144,
++        n=2048,
++        activation="silu",
++        trellis_bits=3,
++        trellis_tile_config=None,
++    )
++    fused_calls: list[dict[str, object]] = []
++    resolved_fused = object()
++    monkeypatch.setattr(tp_moe_impl.torch.cuda, "device", lambda _device: nullcontext())
++    monkeypatch.setattr(
++        tp_moe_impl.torch.cuda,
++        "is_current_stream_capturing",
++        lambda: True,
++    )
++    monkeypatch.setattr(
++        tp_moe_impl.torch.cuda,
++        "get_device_properties",
++        lambda _device: SimpleNamespace(
++            multi_processor_count=188,
++            shared_memory_per_block_optin=_DEFAULT_MAX_SHARED_MEM,
++        ),
++    )
++    monkeypatch.setattr(w4a16_kernel, "_rot_scales_dummy", lambda _device: None)
++    monkeypatch.setattr(
++        w4a16_kernel,
++        "compile_w4a16_fused_moe",
++        lambda **kwargs: fused_calls.append(kwargs) or resolved_fused,
++    )
++    monkeypatch.setattr(
++        w4a16_kernel,
++        "compile_w4a16_topk_sum",
++        lambda **_kwargs: object(),
++    )
++
++    tp_moe_impl._prewarm_w4a16_planned_launches(
++        workspace,
++        token_counts=(3072,),
++        apply_router_weight_on_input=False,
++        swiglu_limit=None,
++        swiglu_alpha=1.0,
++        swiglu_beta=1.0,
++        scale_format="e4m3_k32",
++        weight_layout="trellis3_t256",
++        w13_layout="trellis3_t256_proj",
++        collect_activation_amax=False,
++    )
++
++    assert len(fused_calls) == 2
++    assert {call["size_m"] for call in fused_calls} == {3072}
++    assert {call["max_m_blocks"] for call in fused_calls} == {542}
++    assert (
++        workspace.planned_fused_moe_launches[("trellis3_t256", "e4m3_k32", 3072, False)]
++        is resolved_fused
++    )
++
++
+ def _positive_fp8(shape: tuple[int, ...]) -> torch.Tensor:
+     return (torch.rand(shape, device="cuda") * 0.25 + 0.03125).to(torch.float8_e4m3fn)
+ 
+@@ -57,7 +273,7 @@ def _pattern_e8m0(shape: tuple[int, ...], *, offset: int = 0) -> torch.Tensor:
+     numel = 1
+     for dim in shape:
+         numel *= int(dim)
+-    storage = ((torch.arange(numel, device="cuda", dtype=torch.int64) + offset) % 4 + 119)
++    storage = (torch.arange(numel, device="cuda", dtype=torch.int64) + offset) % 4 + 119
+     return storage.to(torch.uint8).reshape(shape).view(e8m0_dtype)
+ 
+ 
+@@ -84,9 +300,7 @@ def _quantize_dense_moe_weight_storage(
+             torch.float8_e4m3fn
+         )
+         scale = scale.to(torch.float32)
+-        output_scale = 1.0 / (scale * (1.0 / global_scale[group_idx])).clamp(
+-            min=1e-30
+-        )
++        output_scale = 1.0 / (scale * (1.0 / global_scale[group_idx])).clamp(min=1e-30)
+         clipped = torch.clamp(
+             sliced * output_scale,
+             -FLOAT4_E2M1_MAX,
+@@ -106,7 +320,9 @@ def _make_weights(
+     hidden_size: int,
+     intermediate_size: int,
+     activation: str,
+-) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor, torch.Tensor, torch.Tensor, torch.Tensor]:
++) -> tuple[
++    torch.Tensor, torch.Tensor, torch.Tensor, torch.Tensor, torch.Tensor, torch.Tensor
++]:
+     is_gated = activation in {"silu", "situ"}
+     w13_rows = intermediate_size * (2 if is_gated else 1)
+     w13 = torch.randint(
+@@ -129,8 +345,12 @@ def _make_weights(
+     w2_blockscale = swizzle_block_scale(
+         _positive_fp8((experts, hidden_size, intermediate_size // 16))
+     )
+-    w13_global_scale = (torch.rand(experts, device="cuda") * 0.1 + 0.05).to(torch.float32)
+-    w2_global_scale = (torch.rand(experts, device="cuda") * 0.1 + 0.05).to(torch.float32)
++    w13_global_scale = (torch.rand(experts, device="cuda") * 0.1 + 0.05).to(
++        torch.float32
++    )
++    w2_global_scale = (torch.rand(experts, device="cuda") * 0.1 + 0.05).to(
++        torch.float32
++    )
+     return w13, w13_blockscale, w13_global_scale, w2, w2_blockscale, w2_global_scale
+ 
+ 
+@@ -263,6 +483,57 @@ def test_w4a16_packed_weights_do_not_route_to_small_m_direct(
+     )
+ 
+ 
++@pytest.mark.parametrize(
++    "intermediate_size",
++    [16, 144, 352, 464, 480, 496, 512],
++)
++@pytest.mark.parametrize("activation", ["relu2", "silu"])
++@pytest.mark.parametrize("m", [1, 3])
++def test_w4a16_modelopt_direct_keeps_non64_intermediate_contract(
++    m: int,
++    activation: str,
++    intermediate_size: int,
++) -> None:
++    """Native ModelOpt decode supports every 16-aligned intermediate shape."""
++    assert _small_m_direct_supported(
++        m=m,
++        hidden_size=128,
++        intermediate_size=intermediate_size,
++        num_experts=1,
++        topk=1,
++        activation=activation,
++        apply_router_weight_on_input=False,
++        swiglu_limit=None,
++        swiglu_alpha=None,
++        swiglu_beta=None,
++        element_dtype="bf16",
++        weight_layout="modelopt",
++        w13_layout="w13",
++        scale_format="e4m3_k16",
++    )
++    kernel = MoEMicroKernelW4A16SmallMDirect(
++        activation=activation,
++        fast_math=True,
++        share_input_across_experts=True,
++        share_expert_scales=True,
++        single_token=m == 1,
++    )
++    kernel.configure(
++        m=m,
++        k=128,
++        n=intermediate_size,
++        num_topk=1,
++        weight_E=1,
++        max_active_ctas=1,
++    )
++    assert kernel._cfg is not None
++    assert kernel._cfg.n % kernel._cfg.fc1_chunks == 0
++    assert kernel._cfg.i_chunk % 16 == 0
++    assert kernel._cfg.inter_blocks * 16 == kernel._cfg.i_chunk
++    if m > 1:
++        assert kernel._cfg.i_chunk <= 32
++
++
+ @pytest.mark.skipif(not torch.cuda.is_available(), reason="requires CUDA")
+ @pytest.mark.parametrize("activation", ["relu2", "silu"])
+ def test_w4a16_fp4_e8m0_k32_kernel_matches_raw_e8m0_oracle(
+@@ -536,6 +807,7 @@ def test_w4a16_packed_runtime_expert_count_reuses_compiled_kernel(
+ 
+ 
+ @pytest.mark.skipif(not torch.cuda.is_available(), reason="requires CUDA")
++@pytest.mark.parametrize("intermediate_size", [128, 224])
+ @pytest.mark.parametrize("w13_layout", ["w13", "w31"])
+ # 0.5 is small enough to actually engage the SwiGLU clamp at these scales.
+ @pytest.mark.parametrize("swiglu_limit", [None, 0.5])
+@@ -546,6 +818,7 @@ def test_w4a16_e8m0_native_micro_matches_raw_e8m0_oracle(
+     m: int,
+     swiglu_limit: float | None,
+     w13_layout: str,
++    intermediate_size: int,
+ ) -> None:
+     """Small-M micro decode path with native MXFP4 (E8M0 K/32) scales."""
+     if swiglu_limit is not None and activation != "silu":
+@@ -558,14 +831,10 @@ def test_w4a16_e8m0_native_micro_matches_raw_e8m0_oracle(
+             share_expert_scales=True,
+             single_token=True,
+         )
+-        e4m3 = MoEMicroKernelW4A16SmallMDirect(
+-            scale_format="e4m3_k16", **common
+-        )
+-        e8m0 = MoEMicroKernelW4A16SmallMDirect(
+-            scale_format="e8m0_k32", **common
+-        )
++        e4m3 = MoEMicroKernelW4A16SmallMDirect(scale_format="e4m3_k16", **common)
++        e8m0 = MoEMicroKernelW4A16SmallMDirect(scale_format="e8m0_k32", **common)
+         assert e4m3.__cache_key__ != e8m0.__cache_key__
+-    experts, hidden_size, intermediate_size = 4, 128, 128
++    experts, hidden_size = 4, 128
+     rows = intermediate_size * (2 if activation == "silu" else 1)
+     topk = 2
+     torch.manual_seed(20260601 + (1000 if activation == "silu" else 0) + m)
+@@ -613,6 +882,16 @@ def test_w4a16_e8m0_native_micro_matches_raw_e8m0_oracle(
+         params_dtype=torch.bfloat16,
+         w13_layout=w13_layout,
+     )
++    expected_w13_scale_rows = ((rows + 63) // 64) * 64
++    assert tuple(prepared.w13_scale.shape) == (
++        experts,
++        hidden_size // 32,
++        expected_w13_scale_rows,
++    )
++    assert prepared.micro_w13_scale is not None
++    assert int(prepared.micro_w13_scale.numel()) == (
++        experts * (hidden_size // 32) * expected_w13_scale_rows
++    )
+     buffers = make_w4a16_buffers(
+         prepared, m=m, topk=topk, dtype=torch.bfloat16, device=torch.device("cuda")
+     )
+@@ -623,9 +902,7 @@ def test_w4a16_e8m0_native_micro_matches_raw_e8m0_oracle(
+         2 * m * fc2_n_chunks * 128 * topk, dtype=torch.bfloat16, device="cuda"
+     )
+     x = torch.randn(m, hidden_size, dtype=torch.bfloat16, device="cuda")
+-    topk_ids = torch.randint(
+-        0, experts, (m, topk), dtype=torch.int32, device="cuda"
+-    )
++    topk_ids = torch.randint(0, experts, (m, topk), dtype=torch.int32, device="cuda")
+     topk_weights = torch.rand(m, topk, dtype=torch.float32, device="cuda")
+ 
+     def launch() -> torch.Tensor:
+@@ -919,20 +1196,15 @@ def test_w4a16_beats_nvfp4_against_true_fp32_oracle_for_odd_shapes(
+     for batch_size, seq_len, topk, ids_dtype, input_scale in cases:
+         m = batch_size * seq_len
+         torch.manual_seed(
+-            20260525
+-            + m * 31
+-            + topk
+-            + (1000 if activation == "silu" else 0)
++            20260525 + m * 31 + topk + (1000 if activation == "silu" else 0)
+         )
+         rows = intermediate_size * (2 if activation == "silu" else 1)
+-        w13_dense = (
+-            torch.randn(experts, rows, hidden_size, device="cuda")
+-            * (0.18 if activation == "silu" else 0.08)
+-        )
+-        w2_dense = (
+-            torch.randn(experts, hidden_size, intermediate_size, device="cuda")
+-            * (0.18 if activation == "silu" else 0.08)
++        w13_dense = torch.randn(experts, rows, hidden_size, device="cuda") * (
++            0.18 if activation == "silu" else 0.08
+         )
++        w2_dense = torch.randn(
++            experts, hidden_size, intermediate_size, device="cuda"
++        ) * (0.18 if activation == "silu" else 0.08)
+         w13_global_scale = torch.ones(experts, dtype=torch.float32, device="cuda")
+         w2_global_scale = torch.ones(experts, dtype=torch.float32, device="cuda")
+         w13, w13_blockscale = _quantize_dense_moe_weight_storage(
+@@ -1046,6 +1318,310 @@ def test_w4a16_beats_nvfp4_against_true_fp32_oracle_for_odd_shapes(
+         )
+ 
+ 
++@pytest.mark.skipif(not torch.cuda.is_available(), reason="requires CUDA")
++@pytest.mark.parametrize("activation", ["relu2", "silu"])
++@pytest.mark.parametrize("m", [1, 3])
++@pytest.mark.parametrize(
++    "intermediate_size",
++    [32, 128, 144, 224, 352, 464, 480, 496, 512],
++)
++def test_w4a16_modelopt_direct_replay_ignores_stale_swizzle_tail(
++    activation: str,
++    m: int,
++    intermediate_size: int,
++    monkeypatch: pytest.MonkeyPatch,
++) -> None:
++    import sparkinfer.moe._shared.kernels.w4a16.kernel as w4a16_kernel
++
++    experts, hidden_size = 8, 128
++    topk = 2
++    monkeypatch.setenv("SPARKINFER_W4A16_SMALL_M_DIRECT", "1")
++    torch.manual_seed(
++        20260730 + (1000 if activation == "silu" else 0) + m + intermediate_size
++    )
++    real_direct_launch = w4a16_kernel._w4a16_small_m_direct_launch_flat
++    direct_launches: list[tuple[int, int]] = []
++
++    def spy_direct_launch(*args, **kwargs) -> None:
++        direct_launches.append((int(kwargs["m"]), int(kwargs["intermediate_size"])))
++        real_direct_launch(*args, **kwargs)
++
++    monkeypatch.setattr(
++        w4a16_kernel,
++        "_w4a16_small_m_direct_launch_flat",
++        spy_direct_launch,
++    )
++    rows = intermediate_size * (2 if activation == "silu" else 1)
++    w13_dense = torch.randn(experts, rows, hidden_size, device="cuda") * 0.12
++    w2_dense = (
++        torch.randn(experts, hidden_size, intermediate_size, device="cuda") * 0.12
++    )
++    w13_global_scale = torch.ones(experts, dtype=torch.float32, device="cuda")
++    w2_global_scale = torch.ones(experts, dtype=torch.float32, device="cuda")
++    w13, w13_blockscale = _quantize_dense_moe_weight_storage(
++        w13_dense,
++        w13_global_scale,
++    )
++    w2, w2_blockscale = _quantize_dense_moe_weight_storage(
++        w2_dense,
++        w2_global_scale,
++    )
++    x = (torch.randn(m, hidden_size, device="cuda") * 0.5).to(torch.bfloat16)
++    topk_ids = torch.randint(
++        0,
++        experts,
++        (m, topk),
++        device="cuda",
++        dtype=torch.int32,
++    )
++    topk_weights = torch.softmax(torch.randn(m, topk, device="cuda"), dim=-1)
++    a_gscale = torch.ones(experts, dtype=torch.float32, device="cuda")
++    w4a16_experts = prepare_tp_moe_fp4_experts(
++        a=x,
++        a1_gscale=a_gscale,
++        w1_fp4=w13,
++        w1_blockscale=w13_blockscale,
++        w1_alphas=w13_global_scale,
++        a2_gscale=a_gscale,
++        w2_fp4=w2,
++        w2_blockscale=w2_blockscale,
++        w2_alphas=w2_global_scale,
++        activation=activation,
++        quant_mode="w4a16",
++    )
++    prepared_w4a16 = w4a16_experts.representation_for("w4a16")
++    assert prepared_w4a16.weight_layout == "modelopt"
++    micro_w13_scale = prepared_w4a16.micro_w13_scale
++    assert micro_w13_scale is not None
++    expected_micro_w13_rows = ((rows + 63) // 64) * 64
++    assert int(micro_w13_scale.numel()) == (
++        experts * (hidden_size // 16) * expected_micro_w13_rows
++    )
++    assert _small_m_direct_supported(
++        m=m,
++        hidden_size=hidden_size,
++        intermediate_size=intermediate_size,
++        num_experts=experts,
++        topk=topk,
++        activation=activation,
++        apply_router_weight_on_input=False,
++        swiglu_limit=None,
++        swiglu_alpha=None,
++        swiglu_beta=None,
++        element_dtype="bf16",
++        weight_layout=prepared_w4a16.weight_layout,
++        w13_layout="w13",
++        scale_format="e4m3_k16",
++    )
++    binding = make_tp_moe_fp4_binding(
++        a=x,
++        experts=w4a16_experts,
++        topk_weights=topk_weights,
++        topk_ids=topk_ids,
++        output=torch.empty(
++            (m, hidden_size),
++            dtype=x.dtype,
++            device=x.device,
++        ),
++        quant_mode="w4a16",
++    )
++    expected = moe_reference_w4a16_f32(
++        x,
++        w13,
++        w13_blockscale,
++        w13_global_scale,
++        w2,
++        w2_blockscale,
++        w2_global_scale,
++        topk_ids,
++        topk_weights,
++        experts,
++        hidden_size,
++        intermediate_size,
++        activation=activation,
++    )
++
++    first = binding.run().clone()
++    torch.cuda.synchronize()
++    first_metrics = compare_to_reference(first, expected)
++    assert bool(torch.isfinite(first).all().item())
++    assert first_metrics.cos > 0.999, first_metrics
++
++    # The arena legitimately preserves the padded half of each 128-u32
++    # swizzle block. Poison it all, then prove FC1 rewrites every logical lane
++    # and FC2 ignores every inactive lane on the same-binding replay.
++    binding.intermediate_cache2.fill_(float("nan"))
++    replay = binding.run().clone()
++    torch.cuda.synchronize()
++    replay_metrics = compare_to_reference(replay, expected)
++    assert bool(torch.isfinite(replay).all().item())
++    assert replay_metrics.cos > 0.999, replay_metrics
++    torch.testing.assert_close(replay, first, atol=0.0, rtol=0.0)
++
++    # Capture the same direct path once, then repeatedly replay it after
++    # poisoning the arena tail. Graph replay does not re-enter the Python spy,
++    # so three launches prove two eager calls plus one captured custom-op node.
++    graph = torch.cuda.CUDAGraph()
++    torch.cuda.synchronize()
++    with torch.cuda.graph(graph):
++        graph_output = binding.run()
++    for _ in range(16):
++        binding.intermediate_cache2.fill_(float("nan"))
++        graph.replay()
++    torch.cuda.synchronize()
++    graph_metrics = compare_to_reference(graph_output, expected)
++    assert bool(torch.isfinite(graph_output).all().item())
++    assert graph_metrics.cos > 0.999, graph_metrics
++    torch.testing.assert_close(graph_output, first, atol=0.0, rtol=0.0)
++    assert direct_launches == [(m, intermediate_size)] * 3
++
++
++@pytest.mark.skipif(not torch.cuda.is_available(), reason="requires CUDA")
++@pytest.mark.parametrize(
++    "intermediate_size",
++    [144, 352, 464, 480, 496, 512],
++)
++@pytest.mark.parametrize("activation", ["relu2", "silu"])
++@pytest.mark.parametrize("m", [1, 3])
++def test_w4a16_modelopt_direct_non64_intermediate_is_bounds_safe(
++    m: int,
++    activation: str,
++    intermediate_size: int,
++    monkeypatch: pytest.MonkeyPatch,
++) -> None:
++    """Exercise the exact native row tail under CUDA memcheck.
++
++    I=144 exercises the narrow one-chunk kernel: it has 18 logical packed-u32
++    values per W2 row while the ModelOpt scale grid pads its control geometry
++    to 24. I=352 exercises a partial scale/control tail in the wide kernel.
++    I=496 is the boundary case where that padded control grid looks completely
++    full even though the final two activation lanes are unwritten. Selecting
++    the only expert makes an unmasked W2 tail load cross the tensor allocation
++    instead of merely reading the next expert. Run this test under
++    compute-sanitizer with ``PYTORCH_NO_CUDA_MEMORY_CACHING=1`` to audit
++    m==1/m>=2 and ungated/gated direct-FC2 implementations.
++    """
++    import sparkinfer.moe._shared.kernels.w4a16.kernel as w4a16_kernel
++
++    experts, hidden_size, topk = 1, 128, 1
++    monkeypatch.setenv("SPARKINFER_W4A16_SMALL_M_DIRECT", "1")
++    real_direct_launch = w4a16_kernel._w4a16_small_m_direct_launch_flat
++    direct_launches: list[tuple[int, int]] = []
++
++    def spy_direct_launch(*args, **kwargs) -> None:
++        direct_launches.append((int(kwargs["m"]), int(kwargs["intermediate_size"])))
++        real_direct_launch(*args, **kwargs)
++
++    monkeypatch.setattr(
++        w4a16_kernel,
++        "_w4a16_small_m_direct_launch_flat",
++        spy_direct_launch,
++    )
++    torch.manual_seed(
++        20260731 + m + intermediate_size + (1000 if activation == "silu" else 0)
++    )
++
++    rows = intermediate_size * (2 if activation == "silu" else 1)
++    w13_dense = (
++        torch.randn(
++            experts,
++            rows,
++            hidden_size,
++            device="cuda",
++        )
++        * 0.12
++    )
++    w2_dense = (
++        torch.randn(
++            experts,
++            hidden_size,
++            intermediate_size,
++            device="cuda",
++        )
++        * 0.12
++    )
++    w13_global_scale = torch.ones(experts, dtype=torch.float32, device="cuda")
++    w2_global_scale = torch.ones(experts, dtype=torch.float32, device="cuda")
++    w13, w13_blockscale = _quantize_dense_moe_weight_storage(
++        w13_dense,
++        w13_global_scale,
++    )
++    w2, w2_blockscale = _quantize_dense_moe_weight_storage(
++        w2_dense,
++        w2_global_scale,
++    )
++    x = (torch.randn(m, hidden_size, device="cuda") * 0.5).to(torch.bfloat16)
++    topk_ids = torch.zeros((m, topk), device="cuda", dtype=torch.int32)
++    topk_weights = torch.ones((m, topk), device="cuda", dtype=torch.float32)
++    a_gscale = torch.ones(experts, dtype=torch.float32, device="cuda")
++
++    experts_w4a16 = prepare_tp_moe_fp4_experts(
++        a=x,
++        a1_gscale=a_gscale,
++        w1_fp4=w13,
++        w1_blockscale=w13_blockscale,
++        w1_alphas=w13_global_scale,
++        a2_gscale=a_gscale,
++        w2_fp4=w2,
++        w2_blockscale=w2_blockscale,
++        w2_alphas=w2_global_scale,
++        activation=activation,
++        quant_mode="w4a16",
++    )
++    prepared = experts_w4a16.representation_for("w4a16")
++    assert prepared.weight_layout == "modelopt"
++    assert _small_m_direct_supported(
++        m=m,
++        hidden_size=hidden_size,
++        intermediate_size=intermediate_size,
++        num_experts=experts,
++        topk=topk,
++        activation=activation,
++        apply_router_weight_on_input=False,
++        swiglu_limit=None,
++        swiglu_alpha=None,
++        swiglu_beta=None,
++        element_dtype="bf16",
++        weight_layout=prepared.weight_layout,
++        w13_layout="w13",
++        scale_format="e4m3_k16",
++    )
++
++    binding = make_tp_moe_fp4_binding(
++        a=x,
++        experts=experts_w4a16,
++        topk_weights=topk_weights,
++        topk_ids=topk_ids,
++        quant_mode="w4a16",
++    )
++    expected = moe_reference_w4a16_f32(
++        x,
++        w13,
++        w13_blockscale,
++        w13_global_scale,
++        w2,
++        w2_blockscale,
++        w2_global_scale,
++        topk_ids,
++        topk_weights,
++        experts,
++        hidden_size,
++        intermediate_size,
++        activation=activation,
++    )
++
++    first = binding.run().clone()
++    binding.intermediate_cache2.fill_(float("nan"))
++    replay = binding.run().clone()
++    torch.cuda.synchronize()
++    for actual in (first, replay):
++        metrics = compare_to_reference(actual, expected)
++        assert bool(torch.isfinite(actual).all().item())
++        assert metrics.cos > 0.999, metrics
++    assert direct_launches == [(m, intermediate_size), (m, intermediate_size)]
++    torch.testing.assert_close(first, replay, rtol=0, atol=0)
++
++
+ @pytest.mark.skipif(not torch.cuda.is_available(), reason="requires CUDA")
+ @pytest.mark.parametrize("m", [1, 2, 3, 4, 5, 6, 7, 8])
+ def test_w4a16_tc_decode_fused_sum_matches_oracle(
+@@ -1908,7 +2484,11 @@ def test_w4a16_modelopt_nvfp4_explicit_w13_layout_matches_oracle(
+             [w13_blockscale[:, half:], w13_blockscale[:, :half]], dim=1
+         ).contiguous()
+ 
+-    prepare = prepare_w4a16_modelopt_native_weights if prepare_native else prepare_w4a16_weights
++    prepare = (
++        prepare_w4a16_modelopt_native_weights
++        if prepare_native
++        else prepare_w4a16_weights
++    )
+     kwargs = {"source_format": "modelopt_nvfp4"} if prepare_native else {}
+     prepared = prepare(
+         source_w13,
+@@ -1973,9 +2553,7 @@ def test_tp_moe_w4a16_modelopt_nvfp4_uses_normal_nvfp4_scale_contract(
+         activation=activation,
+     )
+     w13, w13_blockscale, w13_global_scale, w2, w2_blockscale, w2_global_scale = weights
+-    w13_input_scale = (torch.rand(experts, device="cuda") * 2.0 + 1.5).to(
+-        torch.float32
+-    )
++    w13_input_scale = (torch.rand(experts, device="cuda") * 2.0 + 1.5).to(torch.float32)
+     w2_input_scale = (torch.rand(experts, device="cuda") * 2.0 + 1.5).to(torch.float32)
+     a1_gscale = (1.0 / w13_input_scale).contiguous()
+     a2_gscale = (1.0 / w2_input_scale).contiguous()
+@@ -2019,8 +2597,9 @@ def test_tp_moe_w4a16_modelopt_nvfp4_uses_normal_nvfp4_scale_contract(
+ 
+ 
+ @pytest.mark.skipif(not torch.cuda.is_available(), reason="requires CUDA")
+-def test_tp_moe_w4a16_prepared_reuse_path_is_deterministic_under_odd_shape_stress(
+-) -> None:
++def test_tp_moe_w4a16_prepared_reuse_path_is_deterministic_under_odd_shape_stress() -> (
++    None
++):
+     torch.manual_seed(20260526)
+     experts, hidden_size, intermediate_size = 8, 128, 128
+     activation = "silu"
+@@ -2031,9 +2610,7 @@ def test_tp_moe_w4a16_prepared_reuse_path_is_deterministic_under_odd_shape_stres
+         activation=activation,
+     )
+     reference_weights = tuple(t.clone() for t in weights)
+-    w13, w13_blockscale, w13_global_scale, w2, w2_blockscale, w2_global_scale = (
+-        weights
+-    )
++    w13, w13_blockscale, w13_global_scale, w2, w2_blockscale, w2_global_scale = weights
+     a_gscale = torch.ones(experts, dtype=torch.float32, device="cuda")
+     weight_plan = plan_sparkinfer_fp4_moe_weights(
+         quant_modes="w4a16",
+@@ -2145,7 +2722,9 @@ def test_w4a16_moe_matches_oracle_with_expert_map(
+     expert_map = torch.full((global_experts,), -1, dtype=torch.int32, device="cuda")
+     expert_map[::2] = torch.arange(local_experts, dtype=torch.int32, device="cuda")
+ 
+-    valid_global_ids = torch.arange(0, global_experts, 2, dtype=torch.int32, device="cuda")
++    valid_global_ids = torch.arange(
++        0, global_experts, 2, dtype=torch.int32, device="cuda"
++    )
+     x = (torch.randn(m, hidden_size, device="cuda") * 0.25).to(torch.bfloat16)
+     topk_ids = valid_global_ids[
+         torch.randint(0, local_experts, (m, topk), device="cuda")
+@@ -2187,9 +2766,7 @@ def test_w4a16_moe_swiglu_limit_matches_oracle_under_cuda_graph() -> None:
+         activation=activation,
+     )
+     w13, w13_blockscale, _, w2, w2_blockscale, w2_global_scale = weights
+-    w13_global_scale = torch.full(
+-        (experts,), 8.0, dtype=torch.float32, device="cuda"
+-    )
++    w13_global_scale = torch.full((experts,), 8.0, dtype=torch.float32, device="cuda")
+     weights = (
+         w13,
+         w13_blockscale,
+@@ -2277,9 +2854,9 @@ def test_w4a16_preplanned_capacity_launch_accepts_smaller_live_m() -> None:
+     experts, hidden_size, intermediate_size = 8, 128, 128
+     topk, live_m, capacity_m = 2, 24, 32
+     activation = "relu2"
+-    assert select_route_block_size_m(live_m, topk, experts) != select_route_block_size_m(
+-        capacity_m, topk, experts
+-    )
++    assert select_route_block_size_m(
++        live_m, topk, experts
++    ) != select_route_block_size_m(capacity_m, topk, experts)
+     weights = _make_weights(
+         experts=experts,
+         hidden_size=hidden_size,
+@@ -2287,7 +2864,9 @@ def test_w4a16_preplanned_capacity_launch_accepts_smaller_live_m() -> None:
+         activation=activation,
+     )
+     x = (torch.randn(live_m, hidden_size, device="cuda") * 0.25).to(torch.bfloat16)
+-    topk_ids = torch.randint(0, experts, (live_m, topk), device="cuda", dtype=torch.int32)
++    topk_ids = torch.randint(
++        0, experts, (live_m, topk), device="cuda", dtype=torch.int32
++    )
+     topk_weights = torch.softmax(torch.randn(live_m, topk, device="cuda"), dim=-1)
+     prepared = prepare_w4a16_weights(
+         *weights,
+diff --git a/tests/moe/test_w4a16_mixed_trellis.py b/tests/moe/test_w4a16_mixed_trellis.py
+index 3949583ac89cf2891b4b0194f43f3a1cb2d02726..e8d7d54f1ca93951f6788c70ad131da4b7843772 100644
+--- a/tests/moe/test_w4a16_mixed_trellis.py
++++ b/tests/moe/test_w4a16_mixed_trellis.py
+@@ -1,5 +1,9 @@
+ from __future__ import annotations
+ 
++import ast
++import inspect
++import textwrap
++
+ import pytest
+ import torch
+ 
+@@ -9,8 +13,13 @@ from sparkinfer.moe._shared.kernels.w4a16.host import (
+     make_w4a16_packed_buffers,
+     max_packed_route_slots,
+ )
+-from sparkinfer.moe._shared.kernels.w4a16.kernel import run_w4a16_moe
++from sparkinfer.moe._shared.kernels.w4a16.kernel import (
++    W4A16FusedMoeKernel,
++    W4A16TopKSumKernel,
++    run_w4a16_moe,
++)
+ from sparkinfer.moe._shared.kernels.w4a16.mixed_trellis import (
++    W4A16MixedTrellisKernel,
+     build_tiered_maps,
+     combine_trellis_rotations,
+     compile_mixed_trellis,
+@@ -29,6 +38,60 @@ def _sm12x_available() -> bool:
+     return major == 12 and minor in (0, 1)
+ 
+ 
++def test_mixed_kernel_tracks_shared_moe_body_contract() -> None:
++    """Keep the direct CuTe call aligned with the shared driver's ABI."""
++
++    tree = ast.parse(textwrap.dedent(inspect.getsource(W4A16MixedTrellisKernel.kernel)))
++    calls = [
++        node
++        for node in ast.walk(tree)
++        if isinstance(node, ast.Call)
++        and isinstance(node.func, ast.Attribute)
++        and node.func.attr == "_moe_body"
++    ]
++    assert len(calls) == 1
++
++    driver_parameters = inspect.signature(W4A16FusedMoeKernel._moe_body).parameters
++    assert len(calls[0].args) + len(calls[0].keywords) == len(driver_parameters) - 1
++    assert [ast.unparse(arg) for arg in calls[0].args[-10:]] == [
++        "descriptor_map",
++        "Int32(self.total_experts)",
++        "Int32(self.total_experts)",
++        "smem_base",
++        "tid",
++        "cta",
++        "grid_x",
++        "active_m",
++        "fc1_emit",
++        "fc2_emit",
++    ]
++
++
++def test_mixed_runtime_tracks_topk_sum_contract() -> None:
++    """Keep the direct compiled top-k launch aligned with its runtime ABI."""
++
++    tree = ast.parse(textwrap.dedent(inspect.getsource(run_mixed_trellis)))
++    calls = [
++        node
++        for node in ast.walk(tree)
++        if isinstance(node, ast.Call)
++        and isinstance(node.func, ast.Attribute)
++        and node.func.attr == "compiled"
++        and isinstance(node.func.value, ast.Attribute)
++        and node.func.value.attr == "topk_sum"
++    ]
++    assert len(calls) == 1
++
++    sum_parameters = inspect.signature(W4A16TopKSumKernel.__call__).parameters
++    assert len(calls[0].args) + len(calls[0].keywords) == len(sum_parameters) - 1
++    assert [ast.unparse(arg) for arg in calls[0].args[-4:]] == [
++        "Int32(launch.topk_sum.num_experts)",
++        "Int32(launch.topk_sum.route_num_experts)",
++        "m",
++        "stream",
++    ]
++
++
+ def _prepared(
+     *,
+     experts: int,
+@@ -72,6 +135,7 @@ def _serial_tier(
+     topk_weights: torch.Tensor,
+     topk_ids: torch.Tensor,
+     expert_map: torch.Tensor,
++    block_size_m: int = 8,
+ ) -> torch.Tensor:
+     m, topk = int(topk_ids.shape[0]), int(topk_ids.shape[1])
+     buffers = make_w4a16_packed_buffers(
+@@ -82,7 +146,7 @@ def _serial_tier(
+         device=x.device,
+         route_num_experts=int(expert_map.numel()),
+         full_rotation=True,
+-        block_size_m=8,
++        block_size_m=block_size_m,
+     )
+     assert buffers.rotation_a_gate is not None
+     assert buffers.rotation_a_up is not None
+@@ -104,7 +168,7 @@ def _serial_tier(
+         expert_counts=buffers.expert_counts,
+         expert_map=expert_map,
+         output_expert_map=expert_map,
+-        route_block_size_m=8,
++        route_block_size_m=block_size_m,
+         intermediate_rotation_scales=prepared.intermediate_rotations,
+         full_rotation=True,
+         suh_gate_table=prepared.gate_suh,
+@@ -260,6 +324,121 @@ def test_build_tiered_maps_rejects_invalid_partitions() -> None:
+         build_tiered_maps((0, 4), (1, 2), device=torch.device("cpu"))
+ 
+ 
++@pytest.mark.skipif(not _sm12x_available(), reason="requires an SM120/SM121 GPU")
++@pytest.mark.parametrize("candidate_block_size", [32, 64])
++def test_one_grid_large_blocks_avoid_serial_prefill_drift(
++    candidate_block_size: int,
++) -> None:
++    """Large route blocks with paired-M8 FC2 preserve one-grid arithmetic."""
++
++    torch.manual_seed(20260801)
++    device = torch.device("cuda", torch.cuda.current_device())
++    m, hidden, intermediate, topk = 64, 512, 256, 8
++    tile_config = (128, 128, 32, 512)
++    tier0_experts, tier1_experts = 6, 2
++
++    prepared_tiers = tuple(
++        _prepared(
++            experts=experts,
++            hidden=hidden,
++            intermediate=intermediate,
++            bits=bits,
++            seed=seed,
++            device=device,
++            tile_config=tile_config,
++        )
++        for experts, bits, seed in (
++            (tier0_experts, 3, 301),
++            (tier1_experts, 4, 401),
++        )
++    )
++
++    x = (torch.randn((m, hidden), device=device) * 1.0e-3).to(torch.bfloat16)
++    topk_ids = (
++        torch.tensor([0, 6, 1, 7, 2, 3, 4, 5], dtype=torch.int32, device=device)
++        .expand(m, -1)
++        .contiguous()
++    )
++    topk_weights = torch.softmax(
++        torch.randn((m, topk), dtype=torch.float32, device=device), dim=-1
++    )
++    props = torch.cuda.get_device_properties(device)
++    global_to_combined, descriptor = build_tiered_maps(
++        range(tier0_experts), range(tier0_experts, 8), device=device
++    )
++
++    def one_grid(
++        block_size_m: int,
++    ) -> tuple[torch.Tensor, object, tuple[torch.Tensor, torch.Tensor, torch.Tensor]]:
++        route_slots = max_packed_route_slots(m * topk, block_size_m, 8)
++        launch = compile_mixed_trellis(
++            size_m=m,
++            hidden_size=hidden,
++            intermediate_size=intermediate,
++            tier0_num_experts=tier0_experts,
++            tier1_num_experts=tier1_experts,
++            top_k=topk,
++            max_m_blocks=(route_slots + block_size_m - 1) // block_size_m,
++            moe_block_size=block_size_m,
++            sms=int(props.multi_processor_count),
++            max_shared_mem=int(props.shared_memory_per_block_optin),
++            force_tile_config=tile_config,
++        )
++        buffers = make_mixed_trellis_buffers(
++            launch, device=device, sms=int(props.multi_processor_count)
++        )
++        output = run_mixed_trellis(
++            x,
++            prepared_tiers[0],
++            prepared_tiers[1],
++            topk_weights,
++            topk_ids,
++            global_to_combined,
++            descriptor,
++            combine_trellis_rotations(*prepared_tiers),
++            launch,
++            buffers,
++        ).clone()
++        phase_outputs = (
++            buffers.fc1.clone(),
++            buffers.activated.clone(),
++            buffers.fc2.clone(),
++        )
++        return output, launch, phase_outputs
++
++    reference, reference_launch, reference_phases = one_grid(8)
++    candidate, candidate_launch, candidate_phases = one_grid(candidate_block_size)
++    torch.cuda.synchronize(device)
++
++    phase_equal = tuple(
++        torch.equal(candidate_phase, reference_phase)
++        for candidate_phase, reference_phase in zip(
++            candidate_phases, reference_phases, strict=True
++        )
++    )
++    geometry = (
++        f"packed_block={candidate_launch.moe_block_size} "
++        f"fc2_subtile={candidate_launch.fc2_moe_block_size} "
++        f"fc2_schedule_factor={candidate_launch.fc2_schedule_route_block_factor} "
++        f"regs={candidate_launch.registers_per_thread} "
++        f"local={candidate_launch.local_memory_bytes} "
++        f"smem={candidate_launch.shared_memory_bytes}"
++    )
++    assert reference_launch.moe_block_size == 8
++    assert reference_launch.fc2_moe_block_size == 8
++    assert reference_launch.fc2_schedule_route_block_factor == 1
++    assert candidate_launch.moe_block_size == candidate_block_size
++    assert candidate_launch.fc2_moe_block_size == 8
++    assert candidate_launch.fc2_schedule_route_block_factor == 2
++    assert candidate_launch.fc2_paired_m8_routes is True
++    assert phase_equal == (True, True, True), geometry
++    assert torch.equal(candidate, reference), geometry
++    assert candidate_launch.local_memory_bytes == 0
++    assert candidate_launch.shared_memory_bytes <= int(
++        props.shared_memory_per_block_optin
++    )
++
++
+ @pytest.mark.skipif(not _sm12x_available(), reason="requires an SM120/SM121 GPU")
+ def test_glm52_large_m_mixed_k3_k4_matches_serial() -> None:
+     """Cover the production prefill shape that exposed lost FC1 reductions."""
+diff --git a/tests/moe/test_w4a16_route_pack.py b/tests/moe/test_w4a16_route_pack.py
+index 529c37c4f21b369e550f6b8100be47fb4efc8878..27f0451539b1337a667ccfba0902e184de31c452 100644
+--- a/tests/moe/test_w4a16_route_pack.py
++++ b/tests/moe/test_w4a16_route_pack.py
+@@ -6,6 +6,44 @@ import pytest
+ import torch
+ 
+ from sparkinfer.moe._shared.kernels.w4a16.kernel import pack_topk_routes_by_expert
++from sparkinfer.moe._shared.kernels.w4a16.host import (
++    route_block_sizes_for_capacity,
++    select_route_block_size_m,
++)
++
++
++@pytest.mark.parametrize(
++    ("max_tokens", "topk", "num_experts"),
++    [
++        (1, 8, 160),
++        (64, 8, 160),
++        (144, 8, 160),
++        (1024, 8, 256),
++        (32, 64, 8),
++    ],
++)
++def test_capacity_block_sizes_cover_every_live_selection(
++    max_tokens: int,
++    topk: int,
++    num_experts: int,
++) -> None:
++    planned = route_block_sizes_for_capacity(max_tokens, topk, num_experts)
++    selected = {
++        select_route_block_size_m(m, topk, num_experts)
++        for m in range(1, max_tokens + 1)
++    }
++
++    assert selected.issubset(planned)
++    assert planned[0] == select_route_block_size_m(1, topk, num_experts)
++    assert planned[-1] == select_route_block_size_m(
++        max_tokens,
++        topk,
++        num_experts,
++    )
++
++
++def test_small_capacity_needs_only_block_8() -> None:
++    assert route_block_sizes_for_capacity(64, 8, 160) == (8,)
+ 
+ 
+ def _expected_route_pack(
+@@ -79,14 +117,19 @@ def test_pack_topk_routes_by_expert_groups_and_pads_routes(
+         device="cuda",
+     )
+ 
+-    local_packed_routes, local_block_experts, local_packed_route_count = pack_topk_routes_by_expert(
+-        topk_ids,
+-        block_size,
+-        num_experts,
+-    )
+-    expected_ids, expected_valid, expected_packed_route_count, expected_block_experts = (
+-        _expected_route_pack(topk_ids, block_size, num_experts)
++    local_packed_routes, local_block_experts, local_packed_route_count = (
++        pack_topk_routes_by_expert(
++            topk_ids,
++            block_size,
++            num_experts,
++        )
+     )
++    (
++        expected_ids,
++        expected_valid,
++        expected_packed_route_count,
++        expected_block_experts,
++    ) = _expected_route_pack(topk_ids, block_size, num_experts)
+ 
+     sentinel = int(topk_ids.numel())
+     valid = int(expected_packed_route_count.item())
+@@ -99,12 +142,18 @@ def test_pack_topk_routes_by_expert_groups_and_pads_routes(
+     host_route_payload = host_packed_routes[host_packed_routes < sentinel]
+     assert host_route_payload.numel() == int(expected_valid.sum().item())
+     for expert in range(num_experts):
+-        actual = host_route_payload[expected_ids[host_route_payload] == expert].sort().values
+-        expected = torch.nonzero(expected_valid & (expected_ids == expert), as_tuple=False)
++        actual = (
++            host_route_payload[expected_ids[host_route_payload] == expert].sort().values
++        )
++        expected = torch.nonzero(
++            expected_valid & (expected_ids == expert), as_tuple=False
++        )
+         expected = expected.flatten().sort().values
+         assert torch.equal(actual, expected), expert
+ 
+-    host_block_experts = local_block_experts[:valid_blocks].detach().cpu().to(torch.int64)
++    host_block_experts = (
++        local_block_experts[:valid_blocks].detach().cpu().to(torch.int64)
++    )
+     for block, expert in enumerate(host_block_experts.tolist()):
+         block_routes = host_packed_routes[block * block_size : (block + 1) * block_size]
+         payload = block_routes[block_routes < sentinel]
+@@ -131,9 +180,12 @@ def test_pack_topk_routes_by_expert_handles_large_prefill_plan_shape() -> None:
+             num_experts,
+         )
+     )
+-    expected_ids, expected_valid, expected_packed_route_count, expected_block_experts = (
+-        _expected_route_pack(topk_ids, block_size, num_experts)
+-    )
++    (
++        expected_ids,
++        expected_valid,
++        expected_packed_route_count,
++        expected_block_experts,
++    ) = _expected_route_pack(topk_ids, block_size, num_experts)
+ 
+     sentinel = int(topk_ids.numel())
+     valid = int(expected_packed_route_count.item())
+@@ -146,8 +198,12 @@ def test_pack_topk_routes_by_expert_handles_large_prefill_plan_shape() -> None:
+     host_route_payload = host_packed_routes[host_packed_routes < sentinel]
+     assert host_route_payload.numel() == int(expected_valid.sum().item())
+     for expert in range(num_experts):
+-        actual = host_route_payload[expected_ids[host_route_payload] == expert].sort().values
+-        expected = torch.nonzero(expected_valid & (expected_ids == expert), as_tuple=False)
++        actual = (
++            host_route_payload[expected_ids[host_route_payload] == expert].sort().values
++        )
++        expected = torch.nonzero(
++            expected_valid & (expected_ids == expert), as_tuple=False
++        )
+         expected = expected.flatten().sort().values
+         assert torch.equal(actual, expected), expert
+ 
+@@ -173,15 +229,20 @@ def test_pack_topk_routes_by_expert_applies_expert_map(
+     expert_map = torch.full((global_experts,), -1, dtype=torch.int32, device="cuda")
+     expert_map[::2] = torch.arange(local_experts, dtype=torch.int32, device="cuda")
+ 
+-    local_packed_routes, local_block_experts, local_packed_route_count = pack_topk_routes_by_expert(
+-        topk_ids,
+-        block_size,
+-        global_experts,
+-        expert_map=expert_map,
+-    )
+-    expected_ids, expected_valid, expected_packed_route_count, expected_block_experts = (
+-        _expected_route_pack(topk_ids, block_size, global_experts, expert_map)
++    local_packed_routes, local_block_experts, local_packed_route_count = (
++        pack_topk_routes_by_expert(
++            topk_ids,
++            block_size,
++            global_experts,
++            expert_map=expert_map,
++        )
+     )
++    (
++        expected_ids,
++        expected_valid,
++        expected_packed_route_count,
++        expected_block_experts,
++    ) = _expected_route_pack(topk_ids, block_size, global_experts, expert_map)
+ 
+     sentinel = int(topk_ids.numel())
+     valid = int(expected_packed_route_count.item())
+@@ -194,7 +255,11 @@ def test_pack_topk_routes_by_expert_applies_expert_map(
+     host_route_payload = host_packed_routes[host_packed_routes < sentinel]
+     assert host_route_payload.numel() == int(expected_valid.sum().item())
+     for local_expert in range(local_experts):
+-        actual = host_route_payload[expected_ids[host_route_payload] == local_expert].sort().values
++        actual = (
++            host_route_payload[expected_ids[host_route_payload] == local_expert]
++            .sort()
++            .values
++        )
+         expected = torch.nonzero(
+             expected_valid & (expected_ids == local_expert),
+             as_tuple=False,
+@@ -213,14 +278,19 @@ def test_pack_topk_routes_by_expert_ignores_invalid_ids() -> None:
+     block_size = 4
+     num_experts = 8
+ 
+-    local_packed_routes, local_block_experts, local_packed_route_count = pack_topk_routes_by_expert(
+-        topk_ids,
+-        block_size,
+-        num_experts,
+-    )
+-    expected_ids, expected_valid, expected_packed_route_count, expected_block_experts = (
+-        _expected_route_pack(topk_ids, block_size, num_experts)
++    local_packed_routes, local_block_experts, local_packed_route_count = (
++        pack_topk_routes_by_expert(
++            topk_ids,
++            block_size,
++            num_experts,
++        )
+     )
++    (
++        expected_ids,
++        expected_valid,
++        expected_packed_route_count,
++        expected_block_experts,
++    ) = _expected_route_pack(topk_ids, block_size, num_experts)
+ 
+     sentinel = int(topk_ids.numel())
+     valid = int(expected_packed_route_count.item())
+@@ -230,4 +300,6 @@ def test_pack_topk_routes_by_expert_ignores_invalid_ids() -> None:
+     payload = local_packed_routes[:valid].detach().cpu().to(torch.int64)
+     payload = payload[payload < sentinel]
+     assert payload.numel() == int(expected_valid.sum().item())
+-    assert torch.equal(payload[expected_ids[payload] == 4].sort().values, torch.tensor([2, 5]))
++    assert torch.equal(
++        payload[expected_ids[payload] == 4].sort().values, torch.tensor([2, 5])
++    )
+diff --git a/tests/test_packaging.py b/tests/test_packaging.py
+index ce1cb089ec80b18a487a9fbfc4eb0b9880617df8..156713879c8f92d3e126a03cf0a57f2d8e51b727 100644
+--- a/tests/test_packaging.py
++++ b/tests/test_packaging.py
+@@ -1,5 +1,6 @@
+ from __future__ import annotations
+ 
++import re
+ from pathlib import Path
+ 
+ try:
+@@ -10,6 +11,8 @@ except ModuleNotFoundError:  # Python 3.10
+ 
+ ROOT = Path(__file__).parents[1]
+ PCIE_PACKAGE = "sparkinfer.comm.pcie"
++PCIE_SOURCE_DIR = ROOT / "sparkinfer" / "comm" / "pcie"
++PCIE_PACKAGE_PATTERNS = {"*.cu", "*.h"}
+ RUNTIME_CUDA_SOURCES = {
+     "pcie_dcp_a2a.cu",
+     "pcie_dcp_topk.cu",
+@@ -17,13 +20,48 @@ RUNTIME_CUDA_SOURCES = {
+     "pcie_oneshot.cu",
+     "pcie_twoshot.cu",
+ }
++LOCAL_INCLUDE_RE = re.compile(r'^\s*#include\s+"([^"]+)"', re.MULTILINE)
++
++
++def _packaged_paths(root: Path, patterns: list[str]) -> set[Path]:
++    return {
++        candidate.resolve()
++        for pattern in patterns
++        for candidate in root.glob(pattern)
++    }
+ 
+ 
+ def test_runtime_cuda_sources_are_in_package_data() -> None:
+     config = tomllib.loads((ROOT / "pyproject.toml").read_text())
+     package_data = config["tool"]["setuptools"]["package-data"]
+ 
+-    assert package_data[PCIE_PACKAGE] == ["*.cu"]
++    assert set(package_data[PCIE_PACKAGE]) == PCIE_PACKAGE_PATTERNS
+     assert {
+-        path.name for path in (ROOT / "sparkinfer" / "comm" / "pcie").glob("*.cu")
+-    } == RUNTIME_CUDA_SOURCES
++        path.name for path in PCIE_SOURCE_DIR.glob("*.cu")
++    } >= RUNTIME_CUDA_SOURCES
++
++
++def test_runtime_cuda_local_includes_are_packaged() -> None:
++    config = tomllib.loads((ROOT / "pyproject.toml").read_text())
++    package_patterns = config["tool"]["setuptools"]["package-data"][PCIE_PACKAGE]
++    packaged_paths = _packaged_paths(PCIE_SOURCE_DIR, package_patterns)
++
++    for source in PCIE_SOURCE_DIR.glob("*.cu"):
++        for include in LOCAL_INCLUDE_RE.findall(source.read_text(encoding="utf-8")):
++            dependency = source.parent / include
++            assert dependency.is_file(), f"{source.name} includes missing {include}"
++            assert dependency.resolve() in packaged_paths, (
++                f"{source.name} includes {include}, but {include} is not package data"
++            )
++
++
++def test_package_root_glob_does_not_hide_nested_header_omissions(
++    tmp_path: Path,
++) -> None:
++    package_root = tmp_path / "pcie"
++    nested_header = package_root / "nested" / "runtime.h"
++    nested_header.parent.mkdir(parents=True)
++    nested_header.write_text("#pragma once\n", encoding="utf-8")
++
++    assert nested_header.resolve() not in _packaged_paths(package_root, ["*.h"])
++    assert nested_header.resolve() in _packaged_paths(package_root, ["**/*.h"])

--- a/patches/releases/gilded-gnosis-v20-r24/vllm/integration.lock.json
+++ b/patches/releases/gilded-gnosis-v20-r24/vllm/integration.lock.json
@@ -1,0 +1,82 @@
+{
+  "base": {
+    "commit": "30038602b71395f481ef4a6edfe4fcf8551d9c15",
+    "ref": "refs/heads/dev/gilded-gnosis",
+    "repository": "https://github.com/local-inference-lab/vllm.git"
+  },
+  "manifest": {
+    "sha256": "25c6cf315003771fcdf9c41ea8ea5ea431950f9f53815a1ec19c5567684cd4b4"
+  },
+  "name": "gilded-gnosis-v20",
+  "pull_requests": [
+    {
+      "disposition": "merged",
+      "head": "99bf3f13f13012b72d6d67e49572d686b45b2833",
+      "number": 145,
+      "ref": "refs/pull/145/head",
+      "title": "GLM-5.2 calibrated NVFP4 MLA KV outer scales"
+    },
+    {
+      "disposition": "merged",
+      "head": "672aec40dc664de014bd1e92d9a2885d7658c37f",
+      "number": 229,
+      "ref": "refs/pull/229/head",
+      "title": "Harden compressed MLA cache and workspace contracts"
+    },
+    {
+      "disposition": "merged",
+      "head": "5f144274d6e092237f4f4f437b7e9d3aaa427157",
+      "number": 213,
+      "ref": "refs/pull/213/head",
+      "title": "Skip pre-KV V2 attention during FlashInfer autotune"
+    },
+    {
+      "disposition": "merged",
+      "head": "e63a190ee1b48d051ccebce485de343dbe2b3505",
+      "number": 214,
+      "ref": "refs/pull/214/head",
+      "title": "Add DeepSeek-V4-Flash-0731 DSpark profile"
+    },
+    {
+      "disposition": "merged",
+      "head": "c7ac22d5bfe923803cc923f2293085faac7d1dd0",
+      "number": 217,
+      "ref": "refs/pull/217/head",
+      "title": "Harden shared regions for native CPU KV offload"
+    },
+    {
+      "disposition": "merged",
+      "head": "3b89c7a113f92522aa07cc3271422c04e458d771",
+      "number": 218,
+      "ref": "refs/pull/218/head",
+      "title": "Align native SWA/MTP retention and shared-prefix tails"
+    },
+    {
+      "disposition": "merged",
+      "head": "52201611719edf67f18bc0cbec17802880a4afb7",
+      "number": 216,
+      "ref": "refs/pull/216/head",
+      "title": "Isolate semantic PCIe graph channels"
+    },
+    {
+      "disposition": "merged",
+      "head": "1702ed2d28342d84551539f8d7e2de637f7ca04e",
+      "number": 228,
+      "ref": "refs/pull/228/head",
+      "title": "Consolidate r20 EXL3 prefill and online K6 cache"
+    },
+    {
+      "disposition": "merged",
+      "head": "9401f9d8916f3bdf34123d2d493a918b748c8132",
+      "number": 230,
+      "ref": "refs/pull/230/head",
+      "title": "Keep broadcast MHC pre behind the compile boundary"
+    }
+  ],
+  "result": {
+    "patch": "integration.patch",
+    "patch_sha256": "11e6c2b80b25d6433f01229bf9f0a0cafbfee8bd7125332a708398f93d8d77e9",
+    "tree": "f5981f14b4d39979bc0d799c020d42002b707257"
+  },
+  "schema_version": 1
+}

--- a/patches/releases/gilded-gnosis-v20-r24/vllm/integration.patch
+++ b/patches/releases/gilded-gnosis-v20-r24/vllm/integration.patch
@@ -1,0 +1,9266 @@
+diff --git a/docs/features/quantization/online.md b/docs/features/quantization/online.md
+index bd4db0e0194320db6ea081be349d8f9b764f9162..169d2d01baac036213a13db54675db969be1fa76 100644
+--- a/docs/features/quantization/online.md
++++ b/docs/features/quantization/online.md
+@@ -100,7 +100,7 @@ vllm serve <glm-5.2-modelopt-checkpoint> \
+ Serialized checkpoint-quantized shared experts are preserved; only excluded
+ BF16 projection weights are converted at load time.
+ 
+-### MXFP8 dense linears on ModelOpt checkpoints
++### MXFP8 dense linears on quantized checkpoints
+ 
+ The `linear` field overlays online MXFP8 the same way onto every other
+ BF16 dense linear the ModelOpt checkpoint excludes: attention projections,
+@@ -143,6 +143,22 @@ vllm serve lukealonso/GLM-5.2-NVFP4 \
+   --quantization-config '{"linear":{"weight":"mxfp8"},"ignore":["re:.*kv_b_proj"]}'
+ ```
+ 
++EXL3 checkpoints can use the same overlay for dense and shared-expert
++projections that are absent from the EXL3 tensor metadata. Serialized EXL3
++dense matrices and routed experts always retain their checkpoint format;
++`moe` overlays are rejected. `lm_head` also remains in its checkpoint format
++or BF16. For example:
++
++```bash
++vllm serve <exl3-checkpoint> \
++  --quantization exl3 \
++  --quantization-config '{"linear":{"weight":"mxfp8"},"shared_experts":{"weight":"mxfp8"},"ignore":["re:.*\\.q_a_proj$","re:.*kv_a_proj_with_mqa","lm_head"]}'
++```
++
++As with ModelOpt, `linear` does not select shared experts. Add the
++`shared_experts` field explicitly when those BF16 projections should also be
++converted. Ignore patterns are matched against unfused checkpoint names.
++
+ ### Activation overrides on already-quantized checkpoints
+ 
+ For checkpoint-quantized models, `quantization_config` lets you pick an
+diff --git a/kv-scales/README.md b/kv-scales/README.md
+new file mode 100644
+index 0000000000000000000000000000000000000000..36b37d5aa188027675ec9eaa447e9597b3921e4c
+--- /dev/null
++++ b/kv-scales/README.md
+@@ -0,0 +1,49 @@
++# GLM-5.2 NVFP4 MLA KV outer scales
++
++Per-layer calibration for the `nvfp4_ds_mla` KV cache writer
++(`VLLM_NVFP4_MLA_SCALES_FILE`, format `nvfp4_ds_mla_outer_scale_v1`).
++
++GLM-5.2's post-RMSNorm 512-dim `kv_c` latent spans a ~240x amplitude range
++across layers. With the default outer scale of 1.0, shallow layers quantize
++with E4M3 block scales at or below the subnormal floor, and shallow-layer KV
++error is strongly amplified downstream. `s_l = max_abs(kv_c_normed) / (6*448)`
++re-centers every layer so its largest block scale lands at the top of the
++E4M3 range.
++
++## Files
++
++- `glm52-nvfp4-nf3-hybrid_mla_outer_scales_v1.json` — calibrated on
++  `madeby561/GLM-5.2-MXFP8-NVFP4-NF3-Hybrid` (K64R16), Salesforce/wikitext
++  (wikitext-2-raw-v1, test), 2048-token context, TP4; per-layer envelope with
++  an independent community capture of the same base model for shallow-layer
++  headroom. `max_abs` per layer is included for auditability.
++
++## Usage
++
++```bash
++VLLM_NVFP4_MLA_SCALES_FILE=/path/to/glm52-nvfp4-nf3-hybrid_mla_outer_scales_v1.json \
++  ./serve-glm52.sh   # nvfp4_ds_mla + B12X_MLA_SPARSE only; inert otherwise
++```
++
++## Results (teacher-forced prefill KLD vs BF16 reference, 5 fresh boots each)
++
++| KV config | mean +/- sd | max ctx (4x96GB) |
++|---|---|---|
++| fp8_ds_mla | 0.1263 +/- 0.0030 | 373k |
++| nvfp4_ds_mla + scales, bf16 rope | 0.1345 +/- 0.0035 | 550k |
++| nvfp4_ds_mla + scales, fp8 rope (`KV_FP8_ROPE=1`) | 0.1356 +/- 0.0054 | 600k+ |
++| nvfp4_ds_mla, no scales, bf16 rope | 0.158 | 550k |
++| nvfp4_ds_mla, no scales, fp8 rope | 0.168 | 600k+ |
++
++Protocol: local-inference-lab/rtx6kpro `benchmarks/glm52-kld-evaluation.md`
++(festr2 2026-07-08 reference logits, one fixed 2048-token window, 2047
++positions, full 154,880 vocab, `KL(ref || candidate)`).
++
++## Cache invalidation (required)
++
++CuTeDSL folds the outer-scale multiply out of the kernel when `latent_scale`
++traces at exactly 1.0. b12x builds without the identity/dynamic compile-spec
++fact (see lukealonso/b12x PR "mla: split latent_scale identity/dynamic
++compile-cache entries") replay stale identity cubins from persistent compile
++caches, silently dropping the restore. Clear mounted b12x compile caches once
++when enabling scales on such builds.
+diff --git a/kv-scales/glm52-nvfp4-nf3-hybrid_mla_outer_scales_v1.json b/kv-scales/glm52-nvfp4-nf3-hybrid_mla_outer_scales_v1.json
+new file mode 100644
+index 0000000000000000000000000000000000000000..7ae9d9351c4e8de79f6387b5f64a5fa9618bf155
+--- /dev/null
++++ b/kv-scales/glm52-nvfp4-nf3-hybrid_mla_outer_scales_v1.json
+@@ -0,0 +1,178 @@
++{
++ "format": "nvfp4_ds_mla_outer_scale_v1",
++ "num_layers": 78,
++ "latent_dim": 512,
++ "denominator": 2688.0,
++ "formula": "s_l = max_abs(kv_c_normed) / (6 * 448)",
++ "model": "madeby561/GLM-5.2-MXFP8-NVFP4-NF3-Hybrid (local K64R16 build; own capture)",
++ "dataset": {
++  "name": "Salesforce/wikitext",
++  "config": "wikitext-2-raw-v1",
++  "split": "test",
++  "context_length": 2048,
++  "windows": 1,
++  "note": "the canonical festr2-0708 census window"
++ },
++ "created_utc": "2026-07-20T16:40:43.312260+00:00",
++ "hook": "mla.py kv_a_layernorm output (bind-mount capture patch), per-TP-rank agreement checked",
++ "max_abs": [
++  0.04833984375,
++  0.021728515625,
++  0.03662109375,
++  0.1005859375,
++  0.023681640625,
++  0.03515625,
++  0.046875,
++  0.033203125,
++  0.259765625,
++  0.1474609375,
++  0.7734375,
++  1.0,
++  1.1171875,
++  0.150390625,
++  0.76171875,
++  0.392578125,
++  0.25390625,
++  0.455078125,
++  0.80859375,
++  0.80078125,
++  0.96875,
++  0.78515625,
++  0.58203125,
++  0.330078125,
++  0.89453125,
++  0.73046875,
++  1.0390625,
++  1.578125,
++  1.0078125,
++  0.92578125,
++  1.25,
++  1.5859375,
++  1.234375,
++  1.9140625,
++  1.9453125,
++  1.7578125,
++  1.7890625,
++  2.546875,
++  2.296875,
++  2.4375,
++  1.921875,
++  2.171875,
++  2.875,
++  2.546875,
++  2.765625,
++  3.234375,
++  2.5625,
++  3.390625,
++  2.40625,
++  2.546875,
++  3.09375,
++  2.90625,
++  3.671875,
++  2.46875,
++  2.609375,
++  2.359375,
++  3.078125,
++  3.171875,
++  2.578125,
++  2.359375,
++  3.890625,
++  2.953125,
++  4.09375,
++  4.09375,
++  5.0625,
++  5.1875,
++  2.984375,
++  2.875,
++  2.984375,
++  3.296875,
++  3.828125,
++  2.859375,
++  3.59375,
++  3.734375,
++  4.25,
++  4.1875,
++  4.84375,
++  3.75
++ ],
++ "scales": [
++  1.7983572823660715e-05,
++  8.083525158110119e-06,
++  1.3623918805803572e-05,
++  3.742036365327381e-05,
++  8.810134161086309e-06,
++  1.3078962053571428e-05,
++  1.743861607142857e-05,
++  1.2352353050595238e-05,
++  9.663899739583333e-05,
++  5.485897972470238e-05,
++  0.00028773716517857144,
++  0.0003720238095238095,
++  0.00041562034970238094,
++  5.5948893229166664e-05,
++  0.0002833775111607143,
++  0.00014604840959821428,
++  9.445917038690477e-05,
++  0.00016929989769345238,
++  0.00030081612723214287,
++  0.0002979096912202381,
++  0.0003603980654761905,
++  0.00029209681919642856,
++  0.00021652948288690475,
++  0.0001227969215029762,
++  0.00033278692336309525,
++  0.00027175176711309525,
++  0.0003865559895833333,
++  0.0005871000744047619,
++  0.0003749302455357143,
++  0.0003444126674107143,
++  0.0004650297619047619,
++  0.0005900065104166666,
++  0.0004592168898809524,
++  0.0007120768229166666,
++  0.0007237025669642857,
++  0.0006539481026785714,
++  0.0006655738467261905,
++  0.0009474981398809524,
++  0.0008544921875,
++  0.0009068080357142857,
++  0.0007149832589285714,
++  0.0008079892113095238,
++  0.0010695684523809525,
++  0.0009474981398809524,
++  0.0010288783482142857,
++  0.0012032645089285715,
++  0.0009533110119047619,
++  0.0012613932291666667,
++  0.0008951822916666666,
++  0.0009474981398809524,
++  0.0011509486607142857,
++  0.0010811941964285715,
++  0.001366024925595238,
++  0.0009184337797619048,
++  0.0009707496279761905,
++  0.0008777436755952381,
++  0.0011451357886904762,
++  0.0011800130208333333,
++  0.0009591238839285714,
++  0.0008777436755952381,
++  0.0014474051339285715,
++  0.0010986328125,
++  0.0015229724702380952,
++  0.0015229724702380952,
++  0.0018833705357142857,
++  0.001929873511904762,
++  0.001110258556547619,
++  0.0010695684523809525,
++  0.001110258556547619,
++  0.0012265159970238095,
++  0.0014241536458333333,
++  0.0010637555803571428,
++  0.0013369605654761905,
++  0.0013892764136904762,
++  0.0015811011904761905,
++  0.0015578497023809525,
++  0.0018019903273809525,
++  0.0013950892857142857
++ ]
++}
+\ No newline at end of file
+diff --git a/serve-ds4-flash.sh b/serve-ds4-flash.sh
+index f9a640bed07f8e82381274cc027f6723c9ed57d5..ee0da27992a6ca220b6576c482c3970a966f65bc 100755
+--- a/serve-ds4-flash.sh
++++ b/serve-ds4-flash.sh
+@@ -40,9 +40,10 @@ case "${mode}" in
+   off|mtp0|standard-mtp0) mode=mtp0 ;;
+   mtp2|standard-mtp2) mode=mtp2 ;;
+   mtp3|standard-mtp3) mode=mtp3 ;;
++  dspark-off|dspark-mtp0) mode=dspark-mtp0 ;;
+   dspark) ;;
+   *)
+-    echo "MODE must be mtp0, mtp2, mtp3, or dspark; got '${mode}'" >&2
++    echo "MODE must be mtp0, mtp2, mtp3, dspark-mtp0, or dspark; got '${mode}'" >&2
+     exit 2
+     ;;
+ esac
+@@ -59,13 +60,13 @@ case "${backend}" in
+ esac
+ 
+ standard_model=${STANDARD_MODEL:-deepseek-ai/DeepSeek-V4-Flash}
+-dspark_model=${DSPARK_MODEL:-deepseek-ai/DeepSeek-V4-Flash-DSpark}
++dspark_model=${DSPARK_MODEL:-deepseek-ai/DeepSeek-V4-Flash-0731}
+ standard_model_revision=${STANDARD_MODEL_REVISION:-60d8d70770c6776ff598c94bb586a859a38244f1}
+-dspark_model_revision=${DSPARK_MODEL_REVISION:-62af8fffb2f7030cac4de2f0169f5b8d1101b646}
+-if [[ "${mode}" == "dspark" ]]; then
++dspark_model_revision=${DSPARK_MODEL_REVISION:-9e165c30e2704aec5d9d593cce3eebd58bbef1cb}
++if [[ "${mode}" == "dspark" || "${mode}" == "dspark-mtp0" ]]; then
+   model=${MODEL_PATH:-${MODEL:-${dspark_model}}}
+   spec_model=${SPEC_MODEL_PATH:-${model}}
+-  served_model_name=${SERVED_MODEL_NAME:-DeepSeek-V4-Flash-DSpark}
++  served_model_name=${SERVED_MODEL_NAME:-DeepSeek-V4-Flash-0731}
+   default_model_revision=${dspark_model_revision}
+ else
+   model=${MODEL_PATH:-${MODEL:-${standard_model}}}
+@@ -88,13 +89,19 @@ fi
+ host=${HOST:-0.0.0.0}
+ port=${PORT:-8000}
+ tp_size=${TP_SIZE:-${TP:-2}}
+-dcp_size=${DCP_SIZE:-1}
+-max_num_seqs=${MAX_NUM_SEQS:-64}
+-max_model_len=${MAX_MODEL_LEN:-262144}
++dcp_size=${DCP_SIZE:-${DCP:-1}}
++if [[ "${mode}" == "dspark" || "${mode}" == "dspark-mtp0" ]]; then
++  max_num_seqs=${MAX_NUM_SEQS:-16}
++  max_model_len=${MAX_MODEL_LEN:-131072}
++else
++  max_num_seqs=${MAX_NUM_SEQS:-64}
++  max_model_len=${MAX_MODEL_LEN:-262144}
++fi
+ max_num_batched_tokens=${MAX_NUM_BATCHED_TOKENS:-8192}
+ gpu_memory_utilization=${GPU_MEMORY_UTILIZATION:-}
+ block_size=${BLOCK_SIZE:-256}
+ load_format=${LOAD_FORMAT:-instanttensor}
++kv_offloading_size=${KV_OFFLOADING_SIZE:-}
+ prefix_cache=$(bool_value PREFIX_CACHE "${PREFIX_CACHE:-1}")
+ enable_flashinfer_autotune=$(bool_value ENABLE_FLASHINFER_AUTOTUNE "${ENABLE_FLASHINFER_AUTOTUNE:-1}")
+ draft_sample_method=${DRAFT_SAMPLE_METHOD:-probabilistic}
+@@ -105,6 +112,11 @@ require_positive_int DCP_SIZE "${dcp_size}"
+ require_positive_int MAX_NUM_SEQS "${max_num_seqs}"
+ require_positive_int MAX_NUM_BATCHED_TOKENS "${max_num_batched_tokens}"
+ require_positive_int BLOCK_SIZE "${block_size}"
++if [[ -n "${kv_offloading_size}" \
++  && ! "${kv_offloading_size}" =~ ^([0-9]+([.][0-9]*)?|[.][0-9]+)$ ]]; then
++  echo "KV_OFFLOADING_SIZE must be a non-negative GiB value; got '${kv_offloading_size}'" >&2
++  exit 2
++fi
+ if [[ "${mode}" == "dspark" && "${dcp_size}" != "1" ]]; then
+   echo "DSpark non-causal attention currently requires DCP_SIZE=1" >&2
+   exit 2
+@@ -246,6 +258,7 @@ esac
+ spec_args=()
+ spec_tokens=0
+ graph_multiplier=4
++dspark_depth_mode=disabled
+ if [[ "${mode}" == "mtp2" || "${mode}" == "mtp3" ]]; then
+   if [[ "${mode}" == "mtp2" ]]; then spec_tokens=2; else spec_tokens=3; fi
+   mtp_moe_json=
+@@ -259,7 +272,7 @@ if [[ "${mode}" == "mtp2" || "${mode}" == "mtp3" ]]; then
+   spec_args=(--speculative-config "${spec_json}")
+   graph_multiplier=8
+ elif [[ "${mode}" == "dspark" ]]; then
+-  spec_tokens=${DSPARK_TOKENS:-5}
++  spec_tokens=${DSPARK_TOKENS:-${NUM_SPECULATIVE_TOKENS:-7}}
+   require_positive_int DSPARK_TOKENS "${spec_tokens}"
+   # Target verification schedules at most one sampled token plus K drafts per
+   # request. Capturing beyond that physical row count only consumes graph
+@@ -280,7 +293,25 @@ elif [[ "${mode}" == "dspark" ]]; then
+     draft_attention_json=$(printf \
+       ',"draft_attention_backend":"%s"' "${draft_attention_backend}")
+   fi
+-  dspark_capacity=$(bool_value DSPARK_CAPACITY "${DSPARK_CAPACITY:-0}")
++  dspark_depth_mode=${DSPARK_DEPTH_MODE:-fixed}
++  case "${dspark_depth_mode}" in
++    fixed)
++      default_dspark_capacity=0
++      default_dynamic_depth=0
++      default_activation_batch_size=0
++      ;;
++    dynamic)
++      default_dspark_capacity=1
++      default_dynamic_depth=1
++      default_activation_batch_size=1
++      ;;
++    *)
++      echo "DSPARK_DEPTH_MODE must be fixed or dynamic" >&2
++      exit 2
++      ;;
++  esac
++  dspark_capacity=$(bool_value DSPARK_CAPACITY \
++    "${DSPARK_CAPACITY:-${default_dspark_capacity}}")
+   capacity_json=
+   if [[ "${dspark_capacity}" == "1" ]]; then
+     capacity_mode=${DSPARK_CAPACITY_VERIFICATION_MODE:-}
+@@ -319,11 +350,14 @@ elif [[ "${mode}" == "dspark" ]]; then
+     "${rejection_sample_method}" "${draft_attention_json}" "${capacity_json}")
+   spec_args=(--speculative-config "${spec_json}")
+   export VLLM_DSPARK_FP8_DRAFT_HEAD=$(bool_value DSPARK_FP8_DRAFT_HEAD "${DSPARK_FP8_DRAFT_HEAD:-0}")
+-  export VLLM_DSPARK_DYNAMIC_DRAFT_DEPTH=$(bool_value DSPARK_DYNAMIC_DRAFT_DEPTH "${DSPARK_DYNAMIC_DRAFT_DEPTH:-0}")
++  dynamic_depth=${DSPARK_DYNAMIC_DRAFT_DEPTH:-${VLLM_DSPARK_DYNAMIC_DRAFT_DEPTH:-${default_dynamic_depth}}}
++  export VLLM_DSPARK_DYNAMIC_DRAFT_DEPTH=$(bool_value \
++    DSPARK_DYNAMIC_DRAFT_DEPTH "${dynamic_depth}")
+   export VLLM_DSPARK_DYNAMIC_DRAFT_DEPTH_WINDOW=${DSPARK_DYNAMIC_DRAFT_DEPTH_WINDOW:-8}
+   require_positive_int DSPARK_DYNAMIC_DRAFT_DEPTH_WINDOW \
+     "${VLLM_DSPARK_DYNAMIC_DRAFT_DEPTH_WINDOW}"
+-  export VLLM_DSPARK_CAPACITY_ACTIVATION_BATCH_SIZE=${DSPARK_CAPACITY_ACTIVATION_BATCH_SIZE:-0}
++  activation_batch_size=${DSPARK_CAPACITY_ACTIVATION_BATCH_SIZE:-${VLLM_DSPARK_CAPACITY_ACTIVATION_BATCH_SIZE:-${default_activation_batch_size}}}
++  export VLLM_DSPARK_CAPACITY_ACTIVATION_BATCH_SIZE=${activation_batch_size}
+   require_nonnegative_int DSPARK_CAPACITY_ACTIVATION_BATCH_SIZE \
+     "${VLLM_DSPARK_CAPACITY_ACTIVATION_BATCH_SIZE}"
+   export VLLM_DSPARK_CAPACITY_LOG_INTERVAL=${DSPARK_CAPACITY_LOG_INTERVAL:-0}
+@@ -358,8 +392,10 @@ if [[ "${sp_async_tp}" == "1" ]]; then
+ fi
+ 
+ if [[ -z "${gpu_memory_utilization}" ]]; then
+-  # The v10 profiler includes attention and FULL-graph allocations. These
+-  # defaults preserve the 262k serving limit used by v9 after that accounting.
++  # The 0731 DSpark draft head is larger than the historical MTP head. Its
++  # B12X TP2 profile needs 0.975 to retain the default 131k serving limit after
++  # attention and FULL-graph allocations are accounted for. At 0.97 the r15
++  # stack exposed 7.11 GiB of KV storage while this profile needs 7.37 GiB.
+   if [[ "${mode}" == "dspark" ]]; then
+     if [[ "${backend}" == "lucifer-default" ]]; then
+       # The default DeepGEMM MoE path retains more model/runtime memory than
+@@ -377,7 +413,7 @@ if [[ -z "${gpu_memory_utilization}" ]]; then
+     elif [[ "${backend}" == lucifer-* ]]; then
+       gpu_memory_utilization=0.9465
+     else
+-      gpu_memory_utilization=0.95
++      gpu_memory_utilization=0.975
+     fi
+   elif [[ "${backend}" == lucifer-* \
+     && ( "${mode}" == "mtp2" || "${mode}" == "mtp3" ) ]]; then
+@@ -398,6 +434,26 @@ if [[ "${enable_flashinfer_autotune}" == "0" ]]; then
+   autotune_args=(--no-enable-flashinfer-autotune)
+ fi
+ 
++offloading_args=()
++if [[ -n "${kv_offloading_size}" \
++  && ! "${kv_offloading_size}" =~ ^0*([.]0*)?$ ]]; then
++  # This is the total host-cache capacity across all TP ranks, matching the
++  # vLLM CLI contract. LMCache remains a separate deployment mode. Native KV
++  # offload pins/registers GPU cache allocations, so PyTorch's remappable VMM
++  # segments must be disabled while preserving any other allocator settings.
++  allocator_config=${PYTORCH_CUDA_ALLOC_CONF:-}
++  if [[ -z "${allocator_config}" ]]; then
++    allocator_config=expandable_segments:False
++  elif [[ "${allocator_config}" =~ (^|,)expandable_segments:True(,|$) ]]; then
++    allocator_config=${allocator_config//expandable_segments:True/expandable_segments:False}
++  fi
++  export PYTORCH_CUDA_ALLOC_CONF=${allocator_config}
++  offloading_args=(
++    --kv-offloading-size "${kv_offloading_size}"
++    --kv-offloading-backend native
++  )
++fi
++
+ capture_args=()
+ capture_sizes=${CUDAGRAPH_CAPTURE_SIZES:-default}
+ if [[ "${capture_sizes}" == "auto" ]]; then
+@@ -465,6 +521,7 @@ command=(
+   "${autotune_args[@]}"
+   "${prefix_args[@]}"
+   "${capture_args[@]}"
++  "${offloading_args[@]}"
+   "${spec_args[@]}"
+   "${backend_args[@]}"
+   "${allreduce_args[@]}"
+@@ -478,10 +535,12 @@ if [[ -n "${EXTRA_VLLM_ARGS:-}" ]]; then
+ fi
+ command+=("$@")
+ 
+-printf 'DS4 launch: mode=%s backend=%s allreduce=%s b12x_dma=%s indexer=%s tp=%s dcp=%s max_seqs=%s graph=%s load_format=%s instanttensor_backend=%s model=%s\n' \
+-  "${mode}" "${backend}" "${allreduce_mode}" "${b12x_pcie_dma}" \
++printf 'DS4 launch: mode=%s depth=%s backend=%s allreduce=%s b12x_dma=%s indexer=%s tp=%s dcp=%s max_seqs=%s graph=%s load_format=%s instanttensor_backend=%s allocator=%s model=%s\n' \
++  "${mode}" "${dspark_depth_mode}" \
++  "${backend}" "${allreduce_mode}" "${b12x_pcie_dma}" \
+   "${indexer_backend}" "${tp_size}" "${dcp_size}" "${max_num_seqs}" \
+-  "${graph_cap}" "${load_format}" "${INSTANTTENSOR_BACKEND}" "${model}" >&2
++  "${graph_cap}" "${load_format}" "${INSTANTTENSOR_BACKEND}" \
++  "${PYTORCH_CUDA_ALLOC_CONF:-<unset>}" "${model}" >&2
+ printf 'Command:' >&2
+ printf ' %q' "${command[@]}" >&2
+ printf '\n' >&2
+diff --git a/serve-glm52.sh b/serve-glm52.sh
+index 68f7501b3d618dea5c4ae93047b281cd56efd85d..8933ad62d752aabbc9f2e6a80bc3b17945afef41 100755
+--- a/serve-glm52.sh
++++ b/serve-glm52.sh
+@@ -107,6 +107,8 @@ MOE_BACKEND="${MOE_BACKEND:-b12x}"
+ MOE_SPEC_BACKEND="${MOE_SPEC_BACKEND:-b12x}"
+ ATTENTION_BACKEND="${ATTENTION_BACKEND:-B12X_MLA_SPARSE}"
+ KV_CACHE_DTYPE="${KV_CACHE_DTYPE:-fp8}"
++# Calibrated per-layer outer scales for nvfp4_ds_mla KV (empty = disabled).
++export VLLM_NVFP4_MLA_SCALES_FILE="${VLLM_NVFP4_MLA_SCALES_FILE:-}"
+ GLM51_PROFILE="${GLM51_PROFILE:-0}"
+ GLM52_CAUSAL_CASCADE="${GLM52_CAUSAL_CASCADE:-0}"
+ GLM52_DSPARK="${GLM52_DSPARK:-0}"
+diff --git a/tests/distributed/test_b12x_fused_all_reduce.py b/tests/distributed/test_b12x_fused_all_reduce.py
+index a789e2a6aca8a7c59feb75c7876c2dacf427dce8..2457d3c4cade325d2e7ce584efba6086e12b05ca 100644
+--- a/tests/distributed/test_b12x_fused_all_reduce.py
++++ b/tests/distributed/test_b12x_fused_all_reduce.py
+@@ -1,6 +1,7 @@
+ # SPDX-License-Identifier: Apache-2.0
+ # SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+ 
++from types import SimpleNamespace
+ from unittest.mock import MagicMock
+ 
+ import pytest
+@@ -25,6 +26,7 @@ from vllm.config import (
+     set_current_vllm_config,
+ )
+ from vllm.distributed import tensor_model_parallel_all_reduce
++from vllm.distributed.device_communicators import custom_all_reduce
+ from vllm.distributed.device_communicators.custom_all_reduce import (
+     CustomAllreduce,
+     _b12x_pcie_dma_min_bytes,
+@@ -106,7 +108,66 @@ def test_b12x_fused_allreduce_uses_independent_cutoff() -> None:
+         out=inp,
+         residual_out=residual,
+         stream=None,
++        channel_id="vllm:eager:allreduce",
+     )
++    runtime.for_stream.assert_called_with(
++        None,
++        channel_id="vllm:eager:allreduce",
++    )
++
++
++def test_b12x_eager_allreduce_forwards_stable_semantic_channel() -> None:
++    custom_allreduce, runtime = make_b12x_custom_allreduce(
++        allreduce_max_size=64,
++        fused_max_size=64,
++    )
++    inp = torch.randn(2, 4)
++    expected = torch.empty_like(inp)
++    runtime.all_reduce.return_value = expected
++
++    actual = custom_allreduce.all_reduce(inp)
++
++    assert actual is expected
++    runtime.all_reduce.assert_called_once_with(
++        inp,
++        out=None,
++        stream=None,
++        channel_id="vllm:eager:allreduce",
++    )
++
++
++def test_b12x_eager_owner_fails_closed_on_second_stream_bind() -> None:
++    custom_allreduce, runtime = make_b12x_custom_allreduce(
++        allreduce_max_size=64,
++        fused_max_size=64,
++    )
++    first_stream = object()
++    second_stream = object()
++    custom_allreduce._pcie_runtime_stream = MagicMock(  # type: ignore[method-assign]
++        side_effect=(first_stream, second_stream)
++    )
++    bound_stream = None
++
++    def for_stream(stream, *, channel_id):
++        nonlocal bound_stream
++        assert channel_id == "vllm:eager:allreduce"
++        if bound_stream is None:
++            bound_stream = stream
++        elif stream is not bound_stream:
++            raise RuntimeError("stream-affine logical owner rebound")
++        channel = MagicMock()
++        channel.should_allreduce.return_value = True
++        return channel
++
++    runtime.for_stream.side_effect = for_stream
++    inp = torch.randn(2, 4)
++
++    assert custom_allreduce.should_custom_ar(inp)
++    with pytest.raises(RuntimeError, match="stream-affine"):
++        custom_allreduce.should_custom_ar(inp)
++    assert [
++        call.kwargs["channel_id"] for call in runtime.for_stream.call_args_list
++    ] == ["vllm:eager:allreduce", "vllm:eager:allreduce"]
+ 
+ 
+ def test_b12x_fused_allreduce_falls_back_above_its_cutoff() -> None:
+@@ -142,6 +203,121 @@ def test_b12x_oneshot_defaults_to_stream_isolation(
+     assert not envs.environment_variables["VLLM_PCIE_ONESHOT_SINGLE_CHANNEL"]()
+ 
+ 
++def test_b12x_pool_prepares_single_stable_eager_owner(
++    monkeypatch: pytest.MonkeyPatch,
++) -> None:
++    captured = {}
++    runtime = MagicMock()
++
++    class FakePool:
++        @classmethod
++        def from_exchange_group(cls, **kwargs):
++            captured.update(kwargs)
++            return runtime
++
++    def fake_all_gather(gather_list, tensor, *, group):
++        for index, slot in enumerate(gather_list):
++            slot.fill_(index)
++
++    fake_config = SimpleNamespace(
++        model_config=SimpleNamespace(get_hidden_size=lambda: 4),
++        scheduler_config=SimpleNamespace(max_num_batched_tokens=8),
++    )
++    monkeypatch.setattr(custom_all_reduce, "custom_ar", True)
++    monkeypatch.setattr(custom_all_reduce.dist, "get_backend", lambda group: "gloo")
++    monkeypatch.setattr(
++        custom_all_reduce,
++        "in_the_same_node_as",
++        lambda group, source_rank=0: [True, True],
++    )
++    monkeypatch.setattr(custom_all_reduce.dist, "get_rank", lambda group=None: 0)
++    monkeypatch.setattr(custom_all_reduce.dist, "get_world_size", lambda group=None: 2)
++    monkeypatch.setattr(custom_all_reduce.dist, "all_gather", fake_all_gather)
++    monkeypatch.setattr(
++        custom_all_reduce.dist, "all_reduce", lambda *args, **kwargs: None
++    )
++    monkeypatch.setattr(
++        custom_all_reduce,
++        "_b12x_pcie_allreduce_requested",
++        lambda: True,
++    )
++    monkeypatch.setattr(custom_all_reduce, "_can_p2p", lambda *args: True)
++    monkeypatch.setattr(
++        custom_all_reduce,
++        "_is_cross_numa_topology",
++        lambda ids: False,
++    )
++    monkeypatch.setattr(
++        custom_all_reduce,
++        "_load_b12x_pcie_oneshot_pool",
++        lambda: FakePool,
++    )
++    monkeypatch.setattr(
++        custom_all_reduce,
++        "_b12x_pcie_dma_min_bytes",
++        lambda: None,
++    )
++    monkeypatch.setattr(
++        custom_all_reduce.current_platform,
++        "get_device_capability",
++        lambda: None,
++    )
++    monkeypatch.setattr(
++        custom_all_reduce.current_platform,
++        "visible_device_id_to_physical_device_id",
++        lambda index: index,
++    )
++    monkeypatch.setattr(
++        custom_all_reduce.current_platform,
++        "is_cuda_alike",
++        lambda: True,
++    )
++    monkeypatch.setattr(
++        custom_all_reduce.current_platform,
++        "is_fully_connected",
++        lambda ids: False,
++        raising=False,
++    )
++    monkeypatch.setattr(
++        custom_all_reduce.current_platform,
++        "is_cuda",
++        lambda: True,
++    )
++    monkeypatch.setattr(
++        custom_all_reduce.current_platform,
++        "is_rocm",
++        lambda: False,
++    )
++    monkeypatch.setattr(
++        "vllm.config.get_current_vllm_config",
++        lambda: fake_config,
++    )
++    monkeypatch.setattr(
++        custom_all_reduce.envs,
++        "VLLM_PCIE_ONESHOT_SINGLE_CHANNEL",
++        False,
++        raising=False,
++    )
++    monkeypatch.setattr(
++        custom_all_reduce.envs,
++        "VLLM_ALLOW_CUSTOM_ALLREDUCE_PCIE",
++        False,
++        raising=False,
++    )
++
++    built = CustomAllreduce(
++        object(),  # type: ignore[arg-type]
++        torch.device("cuda:0"),
++        nccl_group=object(),  # type: ignore[arg-type]
++    )
++
++    assert not built.disabled
++    assert captured["single_channel"] is False
++    assert captured["max_concurrent_channels"] == 2
++    runtime.prepare_channels.assert_called_once_with(("vllm:eager:allreduce",))
++    runtime.for_stream.assert_called_once_with(channel_id="vllm:eager:allreduce")
++
++
+ def test_b12x_channel_checkpoint_delegates_to_runtime() -> None:
+     custom_allreduce, runtime = make_b12x_custom_allreduce(
+         allreduce_max_size=64,
+@@ -157,6 +333,40 @@ def test_b12x_channel_checkpoint_delegates_to_runtime() -> None:
+     runtime.rollback_channels.assert_called_once_with(checkpoint)
+ 
+ 
++def test_b12x_capture_forwards_semantic_channel_id() -> None:
++    custom_allreduce, runtime = make_b12x_custom_allreduce(
++        allreduce_max_size=64,
++        fused_max_size=64,
++    )
++    stream = object()
++
++    with custom_allreduce.capture(  # type: ignore[arg-type]
++        stream,
++        channel_id="vllm:target:profile",
++    ):
++        pass
++
++    runtime.capture.assert_called_once_with(
++        stream=stream,
++        channel_id="vllm:target:profile",
++    )
++
++
++def test_b12x_capture_rejects_missing_semantic_channel_id() -> None:
++    custom_allreduce, runtime = make_b12x_custom_allreduce(
++        allreduce_max_size=64,
++        fused_max_size=64,
++    )
++
++    with (
++        pytest.raises(RuntimeError, match="semantic channel_id"),
++        custom_allreduce.capture(),
++    ):
++        pass
++
++    runtime.capture.assert_not_called()
++
++
+ def test_b12x_oneshot_buffer_tracks_dispatch_limits(
+     monkeypatch: pytest.MonkeyPatch,
+ ) -> None:
+@@ -357,7 +567,10 @@ def _run_b12x_fused_allreduce_gpu(rank: int, port: int) -> None:
+     )
+     inp.copy_(original_inp)
+     residual.copy_(original_residual)
+-    with graph_capture(device=device) as capture_context:
++    with graph_capture(
++        device=device,
++        channel_id="vllm:test:b12x-fused",
++    ) as capture_context:
+         graph = torch.cuda.CUDAGraph()
+         with torch.cuda.graph(graph, stream=capture_context.stream):
+             torch.ops.vllm.b12x_fused_allreduce_add_rms_norm.default(
+diff --git a/tests/distributed/test_custom_allreduce_lifecycle.py b/tests/distributed/test_custom_allreduce_lifecycle.py
+new file mode 100644
+index 0000000000000000000000000000000000000000..c5806ccbddeb65c3af7ec2ab38a6dac2d8b79980
+--- /dev/null
++++ b/tests/distributed/test_custom_allreduce_lifecycle.py
+@@ -0,0 +1,144 @@
++# SPDX-License-Identifier: Apache-2.0
++# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
++
++import gc
++import weakref
++from unittest.mock import MagicMock
++
++import pytest
++import torch
++
++from vllm.distributed.device_communicators.cuda_communicator import CudaCommunicator
++from vllm.distributed.device_communicators.custom_all_reduce import CustomAllreduce
++from vllm.distributed.parallel_state import GroupCoordinator
++
++
++def make_b12x_custom_allreduce() -> tuple[CustomAllreduce, MagicMock]:
++    runtime = MagicMock()
++    custom_allreduce = object.__new__(CustomAllreduce)
++    custom_allreduce.disabled = False
++    custom_allreduce._pcie_runtime = runtime
++    custom_allreduce._pcie_dma = None
++    custom_allreduce._ptr = 0
++    return custom_allreduce, runtime
++
++
++def test_b12x_destructor_skips_collective_close_without_retention() -> None:
++    custom_allreduce, runtime = make_b12x_custom_allreduce()
++    dma = MagicMock()
++    custom_allreduce._pcie_dma = dma
++    custom_allreduce_ref = weakref.ref(custom_allreduce)
++
++    del custom_allreduce
++    gc.collect()
++
++    dma.close.assert_not_called()
++    runtime.close.assert_not_called()
++    assert custom_allreduce_ref() is None
++
++
++def test_b12x_explicit_close_remains_coordinated() -> None:
++    custom_allreduce, runtime = make_b12x_custom_allreduce()
++    dma = MagicMock()
++    custom_allreduce._pcie_dma = dma
++    close_order = []
++    runtime.close.side_effect = lambda: close_order.append("runtime")
++    dma.close.side_effect = lambda: close_order.append("dma")
++
++    custom_allreduce.close()
++
++    assert close_order == ["runtime", "dma"]
++    dma.close.assert_called_once_with()
++    runtime.close.assert_called_once_with()
++    assert custom_allreduce._pcie_dma is None
++    assert custom_allreduce._pcie_runtime is None
++
++
++def test_b12x_close_retains_owners_when_runtime_close_fails() -> None:
++    custom_allreduce, runtime = make_b12x_custom_allreduce()
++    dma = MagicMock()
++    runtime.close.side_effect = RuntimeError("close failed")
++    custom_allreduce._pcie_dma = dma
++
++    with pytest.raises(RuntimeError, match="close failed"):
++        custom_allreduce.close()
++
++    assert custom_allreduce._pcie_runtime is runtime
++    assert custom_allreduce._pcie_dma is dma
++    dma.close.assert_not_called()
++
++
++def test_cuda_communicator_closes_custom_allreduce_before_nccl() -> None:
++    communicator = object.__new__(CudaCommunicator)
++    communicator.ca_comm = MagicMock()
++    communicator.pynccl_comm = MagicMock()
++    communicator.aiter_ar_comm = None
++    communicator.fi_ar_comm = None
++    communicator.all2all_manager = None
++    close_order = []
++    communicator.ca_comm.close.side_effect = lambda: close_order.append("custom")
++    communicator.pynccl_comm.destroy.side_effect = lambda: close_order.append("nccl")
++
++    communicator.destroy()
++
++    assert close_order == ["custom", "nccl"]
++    assert communicator.ca_comm is None
++    assert communicator.pynccl_comm is None
++
++
++def test_cuda_communicator_retains_owners_when_custom_close_fails() -> None:
++    communicator = object.__new__(CudaCommunicator)
++    custom_allreduce = MagicMock()
++    custom_allreduce.close.side_effect = RuntimeError("close failed")
++    communicator.ca_comm = custom_allreduce
++    communicator.pynccl_comm = MagicMock()
++    communicator.aiter_ar_comm = None
++    communicator.fi_ar_comm = None
++    communicator.all2all_manager = None
++
++    with pytest.raises(RuntimeError, match="close failed"):
++        communicator.destroy()
++
++    assert communicator.ca_comm is custom_allreduce
++    communicator.pynccl_comm.destroy.assert_not_called()
++
++
++def test_group_destroy_keeps_process_groups_live_for_communicator(
++    monkeypatch: pytest.MonkeyPatch,
++) -> None:
++    coordinator = object.__new__(GroupCoordinator)
++    coordinator.device_group = object()
++    coordinator.cpu_group = object()
++    coordinator.device_communicator = MagicMock()
++    coordinator.mq_broadcaster = None
++    device_group = coordinator.device_group
++    destroy_order = []
++    coordinator.device_communicator.destroy.side_effect = lambda: destroy_order.append(
++        "communicator"
++    )
++    monkeypatch.setattr(
++        torch.distributed,
++        "destroy_process_group",
++        lambda group: destroy_order.append(
++            "device" if group is device_group else "cpu"
++        ),
++    )
++
++    coordinator.destroy()
++
++    assert destroy_order == ["communicator", "device", "cpu"]
++
++
++def test_group_destroy_retains_process_groups_when_communicator_close_fails() -> None:
++    coordinator = object.__new__(GroupCoordinator)
++    coordinator.device_group = object()
++    coordinator.cpu_group = object()
++    coordinator.device_communicator = MagicMock()
++    coordinator.device_communicator.destroy.side_effect = RuntimeError("close failed")
++    coordinator.mq_broadcaster = None
++
++    with pytest.raises(RuntimeError, match="close failed"):
++        coordinator.destroy()
++
++    assert hasattr(coordinator, "device_group")
++    assert hasattr(coordinator, "cpu_group")
+diff --git a/tests/distributed/test_dcp_a2a.py b/tests/distributed/test_dcp_a2a.py
+index 85ec4d74deb3f64de8c5523f3b81061dea8ae7f1..c0a3ae9f4be6fa70f54b8fe57d322826ff8c2135 100644
+--- a/tests/distributed/test_dcp_a2a.py
++++ b/tests/distributed/test_dcp_a2a.py
+@@ -10,7 +10,7 @@ Tests cover:
+ 
+ import importlib.util
+ import math
+-from contextlib import contextmanager
++from contextlib import contextmanager, nullcontext
+ from typing import Any
+ 
+ import multiprocess as mp
+@@ -552,8 +552,11 @@ def test_b12x_pool_uses_independent_stream_channels(
+             captured.update(kwargs)
+             return cls()
+ 
+-        def for_stream(self):
+-            captured["warmed"] = True
++        def prepare_channels(self, channel_ids):
++            captured["prepared"] = tuple(channel_ids)
++
++        def for_stream(self, *, channel_id):
++            captured["warmed"] = channel_id
+ 
+     group = _FakeCPGroup(2, object())  # type: ignore[arg-type]
+     monkeypatch.setattr(dcp_alltoall, "_B12X_DCP_A2A_POOLS", {})
+@@ -577,25 +580,27 @@ def test_b12x_pool_uses_independent_stream_channels(
+ 
+     assert pool is not None
+     assert captured["single_channel"] is False
+-    assert captured["warmed"] is True
++    assert captured["max_concurrent_channels"] == 2
++    assert captured["prepared"] == ("vllm:eager:dcp",)
++    assert captured["warmed"] == "vllm:eager:dcp"
+ 
+ 
+ def test_b12x_dcp_capture_selects_only_current_group_pools(monkeypatch):
+     from vllm.v1.attention.ops import dcp_alltoall
+ 
+-    events = []
++    events: list[Any] = []
+ 
+     class _FakePool:
+         def __init__(self, name):
+             self.name = name
+ 
+         @contextmanager
+-        def capture(self, *, stream):
+-            events.append(("enter", self.name, stream))
++        def capture(self, *, stream, channel_id):
++            events.append(("enter", self.name, stream, channel_id))
+             try:
+                 yield
+             finally:
+-                events.append(("exit", self.name, stream))
++                events.append(("exit", self.name, stream, channel_id))
+ 
+     device_group = object()
+     group = _FakeCPGroup(2, device_group)  # type: ignore[arg-type]
+@@ -607,24 +612,47 @@ def test_b12x_dcp_capture_selects_only_current_group_pools(monkeypatch):
+     }
+     monkeypatch.setattr(dcp_alltoall, "_B12X_DCP_A2A_POOLS", pools)
+ 
+-    with dcp_alltoall.capture_b12x_dcp_a2a(group, stream):  # type: ignore[arg-type]
+-        events.append(("body", None, stream))
++    with dcp_alltoall.capture_b12x_dcp_a2a(  # type: ignore[arg-type]
++        group,
++        stream,
++        channel_id="vllm:target:profile",
++    ):
++        events.append(("body", None, stream, "vllm:target:profile"))
+ 
+     assert events == [
+-        ("enter", "output", stream),
+-        ("enter", "query", stream),
+-        ("body", None, stream),
+-        ("exit", "query", stream),
+-        ("exit", "output", stream),
++        ("enter", "output", stream, "vllm:target:profile"),
++        ("enter", "query", stream, "vllm:target:profile"),
++        ("body", None, stream, "vllm:target:profile"),
++        ("exit", "query", stream, "vllm:target:profile"),
++        ("exit", "output", stream, "vllm:target:profile"),
+     ]
+ 
+ 
++def test_b12x_dcp_capture_rejects_missing_semantic_id(monkeypatch):
++    from vllm.v1.attention.ops import dcp_alltoall
++
++    device_group = object()
++    group = _FakeCPGroup(2, device_group)  # type: ignore[arg-type]
++    key = (id(device_group), 0, 64, 512, 576, 64)
++    monkeypatch.setattr(
++        dcp_alltoall,
++        "_B12X_DCP_A2A_POOLS",
++        {key: object()},
++    )
++
++    with (
++        pytest.raises(RuntimeError, match="semantic channel_id"),
++        dcp_alltoall.capture_b12x_dcp_a2a(group),
++    ):
++        pass
++
++
+ def test_b12x_dcp_channel_rollback_restores_existing_and_closes_new_pools(
+     monkeypatch,
+ ):
+     from vllm.v1.attention.ops import dcp_alltoall
+ 
+-    events = []
++    events: list[Any] = []
+ 
+     class _FakePool:
+         def __init__(self, name):
+@@ -667,7 +695,7 @@ def test_profile_channel_checkpoint_rolls_back_all_b12x_transports(monkeypatch):
+     from vllm.distributed import parallel_state
+     from vllm.v1.attention.ops import dcp_alltoall
+ 
+-    events = []
++    events: list[Any] = []
+ 
+     class _FakeCommunicator:
+         def checkpoint_pcie_channels(self):
+@@ -691,10 +719,15 @@ def test_profile_channel_checkpoint_rolls_back_all_b12x_transports(monkeypatch):
+     monkeypatch.setattr(parallel_state, "_TP", tp_group)
+     monkeypatch.setattr(parallel_state, "_PP", pp_group)
+     monkeypatch.setattr(parallel_state, "_DCP", dcp_group)
++
++    def checkpoint_dcp(group):
++        events.append("checkpoint-dcp")
++        return "dcp-checkpoint"
++
+     monkeypatch.setattr(
+         dcp_alltoall,
+         "checkpoint_b12x_dcp_a2a_channels",
+-        lambda group: events.append("checkpoint-dcp") or "dcp-checkpoint",
++        checkpoint_dcp,
+     )
+     monkeypatch.setattr(
+         dcp_alltoall,
+@@ -717,25 +750,38 @@ def test_global_graph_capture_enters_b12x_dcp_pool(monkeypatch):
+     from vllm.distributed import parallel_state
+     from vllm.v1.attention.ops import dcp_alltoall
+ 
+-    events = []
++    events: list[Any] = []
+ 
+     class _FakeGroup:
+         world_size = 2
+ 
++        def __init__(self, name):
++            self.name = name
++
+         @contextmanager
+         def graph_capture(self, context):
+-            yield context
++            events.append(("enter-group", self.name, context.channel_id))
++            try:
++                yield context
++            finally:
++                events.append(("exit-group", self.name, context.channel_id))
+ 
+-    tp_group = _FakeGroup()
+-    pp_group = _FakeGroup()
+-    dcp_group = _FakeGroup()
++    tp_group = _FakeGroup("tp")
++    pp_group = _FakeGroup("pp")
++    dcp_group = _FakeGroup("dcp")
+     stream = object()
+-    context = parallel_state.GraphCaptureContext(stream)  # type: ignore[arg-type]
++    context = parallel_state.GraphCaptureContext(  # type: ignore[arg-type]
++        stream,
++        channel_id="vllm:target:profile",
++    )
+ 
+     @contextmanager
+-    def fake_b12x_capture(group, selected_stream):
+-        events.append((group, selected_stream))
+-        yield
++    def fake_b12x_capture(group, selected_stream, *, channel_id):
++        events.append(("enter-b12x", group, selected_stream, channel_id))
++        try:
++            yield
++        finally:
++            events.append(("exit-b12x", group, selected_stream, channel_id))
+ 
+     monkeypatch.setattr(parallel_state, "_DCP", dcp_group)
+     monkeypatch.setattr(parallel_state, "get_tp_group", lambda: tp_group)
+@@ -746,7 +792,75 @@ def test_global_graph_capture_enters_b12x_dcp_pool(monkeypatch):
+     with parallel_state.graph_capture(torch.device("cpu"), context) as actual:
+         assert actual is context
+ 
+-    assert events == [(dcp_group, stream)]
++    assert events == [
++        ("enter-group", "tp", "vllm:target:profile"),
++        ("enter-group", "pp", "vllm:target:profile"),
++        ("enter-group", "dcp", "vllm:target:profile"),
++        (
++            "enter-b12x",
++            dcp_group,
++            stream,
++            "vllm:target:profile",
++        ),
++        (
++            "exit-b12x",
++            dcp_group,
++            stream,
++            "vllm:target:profile",
++        ),
++        ("exit-group", "dcp", "vllm:target:profile"),
++        ("exit-group", "pp", "vllm:target:profile"),
++        ("exit-group", "tp", "vllm:target:profile"),
++    ]
++
++
++def test_group_capture_forwards_semantic_id_to_custom_allreduce(monkeypatch):
++    from vllm._aiter_ops import rocm_aiter_ops
++    from vllm.distributed import parallel_state
++    from vllm.distributed.device_communicators.cuda_communicator import (
++        CudaCommunicator,
++    )
++
++    events: list[Any] = []
++
++    class FakeCustomAllreduce:
++        @contextmanager
++        def capture(self, *, stream, channel_id):
++            events.append(("enter", stream, channel_id))
++            try:
++                yield
++            finally:
++                events.append(("exit", stream, channel_id))
++
++    communicator = object.__new__(CudaCommunicator)
++    communicator.ca_comm = FakeCustomAllreduce()
++    group = object.__new__(parallel_state.GroupCoordinator)
++    group.device_communicator = communicator
++    stream = object()
++    context = parallel_state.GraphCaptureContext(  # type: ignore[arg-type]
++        stream,
++        channel_id="vllm:draft:decode:production",
++    )
++
++    monkeypatch.setattr(rocm_aiter_ops, "is_enabled", lambda: False)
++    monkeypatch.setattr(
++        parallel_state.torch.cuda,
++        "current_stream",
++        lambda: stream,
++    )
++    monkeypatch.setattr(
++        parallel_state.torch.cuda,
++        "stream",
++        lambda selected: nullcontext(),
++    )
++
++    with parallel_state.GroupCoordinator.graph_capture(group, context) as actual:
++        assert actual is context
++
++    assert events == [
++        ("enter", stream, "vllm:draft:decode:production"),
++        ("exit", stream, "vllm:draft:decode:production"),
++    ]
+ 
+ 
+ @pytest.mark.skipif(torch.accelerator.device_count() < 1, reason="CUDA is required.")
+@@ -760,8 +874,15 @@ def test_b12x_lse_reduce_honors_token_cap(monkeypatch: pytest.MonkeyPatch):
+ 
+     class _FakePool:
+         def lse_reduce_scatter(
+-            self, partial, lse, out=None, *, is_lse_base_on_e
++            self,
++            partial,
++            lse,
++            out=None,
++            *,
++            is_lse_base_on_e,
++            channel_id,
+         ):
++            created["channel_id"] = channel_id
+             return sentinel
+ 
+     def fake_get_pool(
+@@ -787,6 +908,7 @@ def test_b12x_lse_reduce_honors_token_cap(monkeypatch: pytest.MonkeyPatch):
+     # Batch within the cap uses B12X, with the staging pool capped too.
+     assert result is sentinel
+     assert created["max_batch_size"] == 4
++    assert created["channel_id"] == "vllm:eager:dcp"
+ 
+     out_large = torch.zeros(8, 16, 64, dtype=torch.bfloat16, device="cuda")
+     lse_large = torch.zeros(8, 16, dtype=torch.float32, device="cuda")
+@@ -813,7 +935,8 @@ def test_b12x_query_gather_honors_token_cap(monkeypatch: pytest.MonkeyPatch):
+     sentinel = torch.zeros(1)
+ 
+     class _FakePool:
+-        def all_gather_heads(self, local_input):
++        def all_gather_heads(self, local_input, *, channel_id):
++            created["channel_id"] = channel_id
+             return sentinel
+ 
+     def fake_get_pool(
+@@ -834,6 +957,7 @@ def test_b12x_query_gather_honors_token_cap(monkeypatch: pytest.MonkeyPatch):
+     )
+     assert result is sentinel
+     assert created["max_batch_size"] == 4
++    assert created["channel_id"] == "vllm:eager:dcp"
+ 
+     large = torch.zeros(8, 8, 64, dtype=torch.bfloat16, device="cuda")
+     result = dcp_alltoall._try_b12x_dcp_all_gather_heads(
+@@ -856,9 +980,20 @@ def test_b12x_lse_reduce_preserves_supported_layouts(monkeypatch: pytest.MonkeyP
+ 
+     class _FakePool:
+         def lse_reduce_scatter(
+-            self, partial, lse, out=None, *, is_lse_base_on_e
++            self,
++            partial,
++            lse,
++            out=None,
++            *,
++            is_lse_base_on_e,
++            channel_id,
+         ):
+-            received.update(partial=partial, lse=lse, out=out)
++            received.update(
++                partial=partial,
++                lse=lse,
++                out=out,
++                channel_id=channel_id,
++            )
+             return sentinel
+ 
+     monkeypatch.setattr(
+@@ -889,10 +1024,9 @@ def test_b12x_lse_reduce_preserves_supported_layouts(monkeypatch: pytest.MonkeyP
+     assert received["partial"].is_contiguous()
+     assert received["lse"].is_contiguous()
+     assert received["out"].movedim(0, 1).is_contiguous()
++    assert received["channel_id"] == "vllm:eager:dcp"
+ 
+-    head_major_storage = torch.zeros(
+-        16, 8, 64, dtype=torch.bfloat16, device="cuda"
+-    )
++    head_major_storage = torch.zeros(16, 8, 64, dtype=torch.bfloat16, device="cuda")
+     head_major = head_major_storage.transpose(0, 1)[:4]
+     result = dcp_alltoall._try_b12x_dcp_lse_reduce(
+         head_major,
+@@ -1267,7 +1401,15 @@ def _distributed_b12x_a2a_worker(env: dict[str, str]) -> None:
+         dcp_alltoall._dcp_a2a_send_recv_buffers = fail_packed_nccl
+         group.all_gather = fail_query_nccl  # type: ignore[attr-defined]
+         graph = torch.cuda.CUDAGraph()
+-        with torch.cuda.graph(graph):
++        capture_stream = torch.cuda.Stream(device=f"cuda:{local_rank}")
++        with (
++            dcp_alltoall.capture_b12x_dcp_a2a(
++                group,  # type: ignore[arg-type]
++                capture_stream,
++                channel_id="test:dcp:graph",
++            ),
++            torch.cuda.graph(graph, stream=capture_stream),
++        ):
+             graph_query = dcp_alltoall.dcp_b12x_all_gather_heads(
+                 static_query,
+                 group,  # type: ignore[arg-type]
+diff --git a/tests/entrypoints/test_ds4_flash_launcher.py b/tests/entrypoints/test_ds4_flash_launcher.py
+new file mode 100644
+index 0000000000000000000000000000000000000000..f19d90d42db5a6b85198567987690c3df4e230a5
+--- /dev/null
++++ b/tests/entrypoints/test_ds4_flash_launcher.py
+@@ -0,0 +1,134 @@
++# SPDX-License-Identifier: Apache-2.0
++# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
++
++import os
++import subprocess
++from pathlib import Path
++
++_REPO_ROOT = Path(__file__).parents[2]
++_LAUNCHER = _REPO_ROOT / "serve-ds4-flash.sh"
++
++
++def _dry_run(tmp_path: Path, **overrides: str) -> str:
++    env = {
++        "PATH": os.environ["PATH"],
++        "HOME": str(tmp_path),
++        "XDG_CACHE_HOME": str(tmp_path / "cache"),
++        "DRY_RUN": "1",
++        **overrides,
++    }
++    result = subprocess.run(
++        ["bash", str(_LAUNCHER)],
++        env=env,
++        check=True,
++        capture_output=True,
++        text=True,
++    )
++    return result.stderr
++
++
++def test_ds4_launcher_defaults_to_0731_fixed_k7(tmp_path: Path) -> None:
++    output = _dry_run(tmp_path)
++
++    assert "mode=dspark depth=fixed" in output
++    assert "model=deepseek-ai/DeepSeek-V4-Flash-0731" in output
++    assert "9e165c30e2704aec5d9d593cce3eebd58bbef1cb" in output
++    assert 'num_speculative_tokens\\":7' in output
++    assert "max_seqs=16 graph=128" in output
++    assert "--max-model-len 131072" in output
++    assert "--gpu-memory-utilization 0.975" in output
++
++
++def test_ds4_launcher_dynamic_depth_enables_capacity_mode(tmp_path: Path) -> None:
++    output = _dry_run(tmp_path, DSPARK_DEPTH_MODE="dynamic")
++
++    assert "mode=dspark depth=dynamic" in output
++    assert 'dspark_capacity_verification_mode\\":\\"varlen' in output
++    assert 'dspark_sps_curve\\":\\"auto' in output
++
++
++def test_ds4_launcher_accepts_cluster_style_aliases(tmp_path: Path) -> None:
++    output = _dry_run(
++        tmp_path,
++        DCP="1",
++        NUM_SPECULATIVE_TOKENS="5",
++    )
++
++    assert "dcp=1" in output
++    assert 'num_speculative_tokens\\":5' in output
++
++
++def test_ds4_launcher_standard_mtp_uses_standard_checkpoint(tmp_path: Path) -> None:
++    output = _dry_run(tmp_path, MODE="mtp2")
++
++    assert "mode=mtp2 depth=disabled" in output
++    assert "model=deepseek-ai/DeepSeek-V4-Flash" in output
++    assert "DeepSeek-V4-Flash-0731" not in output
++    assert 'method\\":\\"mtp' in output
++    assert 'num_speculative_tokens\\":2' in output
++
++
++def test_ds4_launcher_can_disable_dspark_on_0731(tmp_path: Path) -> None:
++    output = _dry_run(tmp_path, MODE="dspark-mtp0")
++
++    assert "mode=dspark-mtp0 depth=disabled" in output
++    assert "model=deepseek-ai/DeepSeek-V4-Flash-0731" in output
++    assert "--speculative-config" not in output
++
++
++def test_ds4_launcher_enables_native_kv_offload(tmp_path: Path) -> None:
++    output = _dry_run(tmp_path, KV_OFFLOADING_SIZE="5.5")
++
++    assert "--kv-offloading-size 5.5" in output
++    assert "--kv-offloading-backend native" in output
++    assert "allocator=expandable_segments:False" in output
++
++
++def test_ds4_launcher_native_offload_preserves_other_allocator_settings(
++    tmp_path: Path,
++) -> None:
++    output = _dry_run(
++        tmp_path,
++        KV_OFFLOADING_SIZE="5.5",
++        PYTORCH_CUDA_ALLOC_CONF=(
++            "max_split_size_mb:256,expandable_segments:True"
++        ),
++    )
++
++    assert (
++        "allocator=max_split_size_mb:256,expandable_segments:False" in output
++    )
++
++
++def test_ds4_launcher_without_offload_keeps_expandable_segments(
++    tmp_path: Path,
++) -> None:
++    output = _dry_run(tmp_path)
++
++    assert "allocator=expandable_segments:True" in output
++
++
++def test_ds4_launcher_zero_kv_offload_stays_disabled(tmp_path: Path) -> None:
++    output = _dry_run(tmp_path, KV_OFFLOADING_SIZE="0.0")
++
++    assert "--kv-offloading-size" not in output
++
++
++def test_ds4_launcher_rejects_invalid_kv_offload_size(tmp_path: Path) -> None:
++    env = {
++        "PATH": os.environ["PATH"],
++        "HOME": str(tmp_path),
++        "XDG_CACHE_HOME": str(tmp_path / "cache"),
++        "DRY_RUN": "1",
++        "KV_OFFLOADING_SIZE": "five",
++    }
++    result = subprocess.run(
++        ["bash", str(_LAUNCHER)],
++        env=env,
++        check=False,
++        capture_output=True,
++        text=True,
++    )
++
++    assert result.returncode == 2
++    assert "KV_OFFLOADING_SIZE must be a non-negative GiB value" in result.stderr
+diff --git a/tests/kernels/test_mhc_broadcast_compile.py b/tests/kernels/test_mhc_broadcast_compile.py
+new file mode 100644
+index 0000000000000000000000000000000000000000..101c3d50dbde933305e9824447baa6aea23e1fe8
+--- /dev/null
++++ b/tests/kernels/test_mhc_broadcast_compile.py
+@@ -0,0 +1,74 @@
++# SPDX-License-Identifier: Apache-2.0
++# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
++import torch
++
++from vllm.model_executor.kernels.mhc.tilelang import mhc_pre_broadcast_tilelang
++
++
++def _inputs(device: str = "meta") -> tuple[torch.Tensor, ...]:
++    num_tokens = 6
++    hidden_size = 128
++    hc_mult = 4
++    hc_mult3 = 2 * hc_mult + hc_mult * hc_mult
++    return (
++        torch.empty(num_tokens, hidden_size, dtype=torch.bfloat16, device=device),
++        torch.empty(
++            hc_mult3,
++            hc_mult * hidden_size,
++            dtype=torch.float32,
++            device=device,
++        ),
++        torch.empty(3, dtype=torch.float32, device=device),
++        torch.empty(hc_mult3, dtype=torch.float32, device=device),
++        torch.empty(hidden_size, dtype=torch.bfloat16, device=device),
++        torch.empty(
++            hc_mult3,
++            hidden_size,
++            dtype=torch.float32,
++            device=device,
++        ),
++    )
++
++
++def _run_broadcast_mhc(
++    residual: torch.Tensor,
++    fn: torch.Tensor,
++    hc_scale: torch.Tensor,
++    hc_base: torch.Tensor,
++    norm_weight: torch.Tensor,
++    fn_broadcast: torch.Tensor,
++) -> tuple[torch.Tensor, ...]:
++    return mhc_pre_broadcast_tilelang(
++        residual,
++        fn,
++        hc_scale,
++        hc_base,
++        1e-6,
++        1e-6,
++        1e-6,
++        2.0,
++        20,
++        norm_weight=norm_weight,
++        fn_broadcast=fn_broadcast,
++    )
++
++
++def _assert_output_contract(outputs: tuple[torch.Tensor, ...]) -> None:
++    residual, post_mix, res_mix, layer_input = outputs
++    assert residual.shape == (6, 4, 128)
++    assert residual.dtype == torch.bfloat16
++    assert post_mix.shape == (6, 4, 1)
++    assert post_mix.dtype == torch.float32
++    assert res_mix.shape == (6, 4, 4)
++    assert res_mix.dtype == torch.float32
++    assert layer_input.shape == (6, 128)
++    assert layer_input.dtype == torch.bfloat16
++
++
++def test_mhc_pre_broadcast_fake_output_contract() -> None:
++    _assert_output_contract(_run_broadcast_mhc(*_inputs()))
++
++
++def test_mhc_pre_broadcast_is_fullgraph_compile_boundary() -> None:
++    compiled = torch.compile(_run_broadcast_mhc, backend="eager", fullgraph=True)
++    _assert_output_contract(compiled(*_inputs()))
+diff --git a/tests/model_executor/test_flashinfer_autotune_cache.py b/tests/model_executor/test_flashinfer_autotune_cache.py
+index 65b8e8f55d2da000353a80317babdf02885096ac..dc0bf6a13e9b9ca71a332efe8d73e7f39e16ff9e 100644
+--- a/tests/model_executor/test_flashinfer_autotune_cache.py
++++ b/tests/model_executor/test_flashinfer_autotune_cache.py
+@@ -128,6 +128,53 @@ def _patch_flashinfer_autotune_deps(monkeypatch):
+     return calls
+ 
+ 
++def test_flashinfer_autotune_dummy_run_skips_pre_kv_v2_attention() -> None:
++    runner = SimpleNamespace(
++        scheduler_config=SimpleNamespace(max_num_batched_tokens=8192),
++        vllm_config=SimpleNamespace(use_v2_model_runner=True),
++    )
++
++    kwargs = kernel_warmup._flashinfer_autotune_dummy_run_kwargs(runner)
++
++    assert kwargs == {
++        "num_tokens": 8192,
++        "skip_eplb": True,
++        "is_profile": True,
++        "skip_attn": True,
++    }
++
++
++def test_flashinfer_autotune_dummy_run_keeps_attention_after_kv_init() -> None:
++    runner = SimpleNamespace(
++        scheduler_config=SimpleNamespace(max_num_batched_tokens=8192),
++        vllm_config=SimpleNamespace(use_v2_model_runner=True),
++        block_tables=object(),
++    )
++
++    kwargs = kernel_warmup._flashinfer_autotune_dummy_run_kwargs(runner)
++
++    assert kwargs == {
++        "num_tokens": 8192,
++        "skip_eplb": True,
++        "is_profile": True,
++    }
++
++
++def test_flashinfer_autotune_dummy_run_keeps_v1_signature() -> None:
++    runner = SimpleNamespace(
++        scheduler_config=SimpleNamespace(max_num_batched_tokens=8192),
++        vllm_config=SimpleNamespace(use_v2_model_runner=False),
++    )
++
++    kwargs = kernel_warmup._flashinfer_autotune_dummy_run_kwargs(runner)
++
++    assert kwargs == {
++        "num_tokens": 8192,
++        "skip_eplb": True,
++        "is_profile": True,
++    }
++
++
+ def test_b12x_dcp_warmup_finds_generic_mla_attention(monkeypatch) -> None:
+     from vllm.distributed import parallel_state
+     from vllm.model_executor.layers.attention.mla_attention import MLAAttention
+diff --git a/tests/models/deepseek_v4/test_b12x_cache_page_view.py b/tests/models/deepseek_v4/test_b12x_cache_page_view.py
+new file mode 100644
+index 0000000000000000000000000000000000000000..2a626dc73d673f4b3b70ddce3f3aae28d9e40f26
+--- /dev/null
++++ b/tests/models/deepseek_v4/test_b12x_cache_page_view.py
+@@ -0,0 +1,70 @@
++# SPDX-License-Identifier: Apache-2.0
++# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
++
++import pytest
++import torch
++
++from vllm.models.deepseek_v4.nvidia.b12x import _b12x_cache_page_view
++
++_PAGE_SIZE = 64
++_PAYLOAD_BYTES = _PAGE_SIZE * 584
++_PADDED_PAGE_BYTES = 37_440
++
++
++def test_b12x_cache_page_view_accepts_contiguous_payload_pages() -> None:
++    cache = torch.empty((3, _PAGE_SIZE, 584), dtype=torch.uint8)
++
++    view = _b12x_cache_page_view(cache, _PAGE_SIZE, "cache")
++
++    assert view.shape == (3, _PAYLOAD_BYTES)
++    assert view.stride() == (_PAYLOAD_BYTES, 1)
++
++
++def test_b12x_cache_page_view_preserves_padded_physical_stride() -> None:
++    storage = torch.empty(3 * _PADDED_PAGE_BYTES, dtype=torch.uint8)
++    cache = torch.as_strided(
++        storage,
++        size=(3, _PAGE_SIZE, 584),
++        stride=(_PADDED_PAGE_BYTES, 584, 1),
++    )
++
++    view = _b12x_cache_page_view(cache, _PAGE_SIZE, "cache")
++
++    assert view.shape == (3, _PAYLOAD_BYTES)
++    assert view.stride() == (_PADDED_PAGE_BYTES, 1)
++
++
++def test_b12x_cache_page_view_rejects_short_physical_stride() -> None:
++    storage = torch.empty(2 * _PAYLOAD_BYTES, dtype=torch.uint8)
++    cache = torch.as_strided(
++        storage,
++        size=(2, _PAGE_SIZE, 584),
++        stride=(_PAYLOAD_BYTES - 1, 584, 1),
++    )
++
++    with pytest.raises(RuntimeError, match=r"page stride .* is smaller"):
++        _b12x_cache_page_view(cache, _PAGE_SIZE, "cache")
++
++
++def test_b12x_cache_page_view_rejects_overlapping_2d_pages() -> None:
++    storage = torch.empty(2 * _PAYLOAD_BYTES, dtype=torch.uint8)
++    cache = torch.as_strided(
++        storage,
++        size=(2, _PAYLOAD_BYTES),
++        stride=(_PAYLOAD_BYTES - 1, 1),
++    )
++
++    with pytest.raises(RuntimeError, match=r"page stride .* is smaller"):
++        _b12x_cache_page_view(cache, _PAGE_SIZE, "cache")
++
++
++def test_b12x_cache_page_view_rejects_gapped_page_payload() -> None:
++    storage = torch.empty(2 * _PAYLOAD_BYTES + _PAGE_SIZE, dtype=torch.uint8)
++    cache = torch.as_strided(
++        storage,
++        size=(2, _PAGE_SIZE, 584),
++        stride=(_PAYLOAD_BYTES, 585, 1),
++    )
++
++    with pytest.raises(RuntimeError, match=r"page payload must be contiguous"):
++        _b12x_cache_page_view(cache, _PAGE_SIZE, "cache")
+diff --git a/tests/models/deepseek_v4/test_b12x_compressed_mla_workspace.py b/tests/models/deepseek_v4/test_b12x_compressed_mla_workspace.py
+new file mode 100644
+index 0000000000000000000000000000000000000000..bb228c9396fab9441c85c78f685b75b13532f916
+--- /dev/null
++++ b/tests/models/deepseek_v4/test_b12x_compressed_mla_workspace.py
+@@ -0,0 +1,293 @@
++# SPDX-License-Identifier: Apache-2.0
++# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
++
++import math
++import sys
++import types
++from types import SimpleNamespace
++
++import pytest
++import torch
++
++from vllm.models.deepseek_v4.nvidia import b12x as b12x_mod
++from vllm.utils.math_utils import round_up
++from vllm.v1.attention.backends.mla.compressor_utils import (
++    get_c128a_topk_width,
++    get_compressed_mla_max_q_chunks,
++    get_compressed_mla_split_cap,
++    get_dspark_swa_index_width,
++)
++
++_MAX_ROWS = 2048
++_LOCAL_HEADS = 32
++_PAGE_SIZE = 64
++_WINDOW_SIZE = 128
++_INDEX_TOPK = 2048
++
++
++class _RecordingWorkspaceManager:
++    def __init__(self) -> None:
++        self.specs: tuple[tuple[tuple[int, ...], torch.dtype], ...] | None = None
++
++    def get_simultaneous(
++        self, *specs: tuple[tuple[int, ...], torch.dtype]
++    ) -> list[torch.Tensor]:
++        self.specs = specs
++        return []
++
++
++def _install_recording_sparkinfer(monkeypatch, caps_calls: list[SimpleNamespace]):
++    sparkinfer = types.ModuleType("sparkinfer")
++    sparkinfer.__path__ = []
++    attention = types.ModuleType("sparkinfer.attention")
++    attention.__path__ = []
++    compressed_mla = types.ModuleType("sparkinfer.attention.compressed_mla")
++
++    def caps(**kwargs) -> SimpleNamespace:
++        return SimpleNamespace(**kwargs)
++
++    def plan(caps_value):
++        caps_calls.append(caps_value)
++        return SimpleNamespace(
++            shapes_and_dtypes=lambda: (((1,), torch.uint8),),
++        )
++
++    def split_chunks_for_contract(*, rows: int, width: int, max_chunks: int) -> int:
++        del width
++        return min(max_chunks, 8 if rows <= 256 else 1)
++
++    compressed_mla.Caps = caps  # type: ignore[attr-defined]
++    compressed_mla.plan = plan  # type: ignore[attr-defined]
++    compressed_mla.split_chunks_for_contract = (  # type: ignore[attr-defined]
++        split_chunks_for_contract
++    )
++    monkeypatch.setitem(sys.modules, "sparkinfer", sparkinfer)
++    monkeypatch.setitem(sys.modules, "sparkinfer.attention", attention)
++    monkeypatch.setitem(
++        sys.modules,
++        "sparkinfer.attention.compressed_mla",
++        compressed_mla,
++    )
++    return split_chunks_for_contract
++
++
++def _make_layer(
++    *,
++    compress_ratio: int,
++    dspark: bool,
++    dcp_world_size: int = 1,
++):
++    layer = object.__new__(b12x_mod.DeepseekV4B12xMLAAttention)
++    torch.nn.Module.__init__(layer)
++    layer.compress_ratio = compress_ratio
++    layer.topk_indices_buffer = (
++        torch.empty((1, _INDEX_TOPK), dtype=torch.int32)
++        if compress_ratio == 4
++        else None
++    )
++    layer.indexer = None
++    layer.max_model_len = 524288
++    layer.window_size = _WINDOW_SIZE
++    layer.max_num_batched_tokens = _MAX_ROWS
++    layer.swa_cache_layer = SimpleNamespace(block_size=_PAGE_SIZE)
++    speculative_config = (
++        SimpleNamespace(
++            use_dspark=lambda: True,
++            num_speculative_tokens=5,
++        )
++        if dspark
++        else None
++    )
++    layer.vllm_config = SimpleNamespace(
++        speculative_config=speculative_config,
++        parallel_config=SimpleNamespace(
++            decode_context_parallel_size=dcp_world_size,
++        ),
++    )
++    return layer
++
++
++@pytest.mark.parametrize(
++    ("compress_ratio", "dspark", "expected_width"),
++    [
++        pytest.param(1, False, 128, id="swa-causal"),
++        pytest.param(1, True, 512, id="swa-dspark"),
++        pytest.param(4, False, 2176, id="c4-causal"),
++        pytest.param(4, True, 2560, id="c4-dspark"),
++        pytest.param(128, False, 4224, id="c128-causal"),
++        pytest.param(128, True, 4608, id="c128-dspark"),
++    ],
++)
++def test_reserve_uses_full_runtime_width(
++    monkeypatch,
++    compress_ratio: int,
++    dspark: bool,
++    expected_width: int,
++) -> None:
++    caps_calls: list[SimpleNamespace] = []
++    split_chunks = _install_recording_sparkinfer(monkeypatch, caps_calls)
++    workspace = _RecordingWorkspaceManager()
++    monkeypatch.setattr(b12x_mod, "current_workspace_manager", lambda: workspace)
++    layer = _make_layer(compress_ratio=compress_ratio, dspark=dspark)
++
++    layer._reserve_dummy_compressed_mla_scratch(
++        torch.empty((1, _LOCAL_HEADS, 512), dtype=torch.bfloat16)
++    )
++
++    caps = caps_calls[-1]
++    split_cap = get_compressed_mla_split_cap(expected_width)
++    assert caps.max_width == expected_width
++    assert caps.max_q_rows == _MAX_ROWS
++    assert caps.max_q_chunks == get_compressed_mla_max_q_chunks(
++        _MAX_ROWS,
++        expected_width,
++        split_cap,
++        split_chunks,
++    )
++    assert workspace.specs is not None
++
++
++def test_reserve_uses_dcp_gathered_heads(monkeypatch) -> None:
++    caps_calls: list[SimpleNamespace] = []
++    _install_recording_sparkinfer(monkeypatch, caps_calls)
++    monkeypatch.setattr(
++        b12x_mod,
++        "current_workspace_manager",
++        lambda: _RecordingWorkspaceManager(),
++    )
++    layer = _make_layer(compress_ratio=128, dspark=False, dcp_world_size=2)
++
++    layer._reserve_dummy_compressed_mla_scratch(
++        torch.empty((1, _LOCAL_HEADS, 512), dtype=torch.bfloat16)
++    )
++
++    assert caps_calls[-1].num_q_heads == _LOCAL_HEADS * 2
++
++
++def test_workspace_width_helpers_match_reporter_geometry() -> None:
++    assert get_c128a_topk_width(524288, 128) == 4096
++    assert get_dspark_swa_index_width(128, 5) == 512
++    assert get_dspark_swa_index_width(512, 5) == 1024
++
++
++def test_q_chunk_envelope_is_cached() -> None:
++    call_count = 0
++
++    def split_chunks_for_contract(**kwargs) -> int:
++        nonlocal call_count
++        call_count += 1
++        return min(kwargs["max_chunks"], 8 if kwargs["rows"] <= 256 else 1)
++
++    get_compressed_mla_max_q_chunks.cache_clear()
++    split_cap = get_compressed_mla_split_cap(4608)
++    for _ in range(2):
++        assert (
++            get_compressed_mla_max_q_chunks(
++                _MAX_ROWS,
++                4608,
++                split_cap,
++                split_chunks_for_contract,
++            )
++            == _MAX_ROWS
++        )
++    assert call_count == _MAX_ROWS
++
++
++def _aligned_nbytes(
++    specs: tuple[tuple[tuple[int, ...], torch.dtype], ...],
++) -> int:
++    return sum(
++        round_up(math.prod(shape) * dtype.itemsize, 256) for shape, dtype in specs
++    )
++
++
++def _runtime_plan_nbytes(compressed_mla, *, rows: int, width: int, heads: int) -> int:
++    split_cap = get_compressed_mla_split_cap(width)
++    splits = compressed_mla.split_chunks_for_contract(
++        rows=rows,
++        width=width,
++        max_chunks=split_cap,
++    )
++    runtime_plan = compressed_mla.plan(
++        compressed_mla.Caps(
++            device="cpu",
++            num_q_heads=heads,
++            max_q_rows=rows,
++            max_width=width,
++            head_dim=512,
++            v_head_dim=512,
++            page_size=_PAGE_SIZE,
++            max_chunks_per_row=splits,
++        )
++    )
++    return _aligned_nbytes(runtime_plan.shapes_and_dtypes())
++
++
++@pytest.mark.parametrize(
++    (
++        "compress_ratio",
++        "dspark",
++        "dcp_world_size",
++        "runtime_widths",
++        "expected_reserve_mib",
++    ),
++    [
++        pytest.param(1, False, 1, (128,), 64.502929688, id="swa-causal"),
++        pytest.param(1, True, 1, (128, 512), 64.502929688, id="swa-dspark"),
++        pytest.param(4, False, 1, (2176,), 273.315429688, id="c4-causal"),
++        pytest.param(
++            4,
++            True,
++            1,
++            (2176, 2560),
++            321.502929688,
++            id="c4-dspark",
++        ),
++        pytest.param(128, False, 1, (4224,), 530.315429688, id="c128-causal"),
++        pytest.param(
++            128,
++            True,
++            1,
++            (4224, 4608),
++            578.502929688,
++            id="c128-dspark",
++        ),
++        pytest.param(128, False, 2, (4224,), 1060.627929688, id="c128-dcp2"),
++    ],
++)
++def test_real_sparkinfer_reserve_dominates_runtime_envelope(
++    monkeypatch,
++    compress_ratio: int,
++    dspark: bool,
++    dcp_world_size: int,
++    runtime_widths: tuple[int, ...],
++    expected_reserve_mib: float,
++) -> None:
++    compressed_mla = pytest.importorskip("sparkinfer.attention.compressed_mla")
++    workspace = _RecordingWorkspaceManager()
++    monkeypatch.setattr(b12x_mod, "current_workspace_manager", lambda: workspace)
++    layer = _make_layer(
++        compress_ratio=compress_ratio,
++        dspark=dspark,
++        dcp_world_size=dcp_world_size,
++    )
++
++    layer._reserve_dummy_compressed_mla_scratch(
++        torch.empty((1, _LOCAL_HEADS, 512), dtype=torch.bfloat16)
++    )
++
++    assert workspace.specs is not None
++    reserve_bytes = _aligned_nbytes(workspace.specs)
++    assert reserve_bytes / (1 << 20) == pytest.approx(expected_reserve_mib)
++    runtime_heads = _LOCAL_HEADS * dcp_world_size
++    runtime_bytes = max(
++        _runtime_plan_nbytes(
++            compressed_mla,
++            rows=rows,
++            width=runtime_width,
++            heads=runtime_heads,
++        )
++        for runtime_width in runtime_widths
++        for rows in range(1, _MAX_ROWS + 1)
++    )
++    assert reserve_bytes >= runtime_bytes
+diff --git a/tests/quantization/test_exl3.py b/tests/quantization/test_exl3.py
+index 5f6c72d43d1b9a7c46e3a13d813fe7cea56e0d76..61c809d69e1eb80fd36198d1349577c494f11bf8 100644
+--- a/tests/quantization/test_exl3.py
++++ b/tests/quantization/test_exl3.py
+@@ -1,20 +1,31 @@
+ # SPDX-License-Identifier: Apache-2.0
+ # SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+ 
++import gc
++import weakref
+ from types import SimpleNamespace
++from unittest.mock import Mock
+ 
+ import pytest
+ import torch
+ 
+ import vllm.model_executor.layers.quantization.exl3 as exl3_module
++import vllm.model_executor.layers.quantization.online.fp8 as fp8_module
+ import vllm.model_executor.parameter as parameter_module
+ from vllm.config import CompilationMode
+-from vllm.model_executor.layers.fused_moe import MoEActivation
++from vllm.config.quantization import QuantizationConfigArgs
++from vllm.model_executor.layers.fused_moe import MoEActivation, RoutedExperts
++from vllm.model_executor.layers.linear import LinearBase, UnquantizedLinearMethod
+ from vllm.model_executor.layers.quantization import get_quantization_config
+ from vllm.model_executor.layers.quantization.exl3 import (
+     Exl3Config,
++    Exl3LinearMethod,
+     Exl3MoEMethod,
+     Exl3MoEParameter,
++    Exl3OnlineLinearMethod,
++)
++from vllm.model_executor.layers.quantization.exl3_online_cache import (
++    Exl3OnlineCacheResult,
+ )
+ from vllm.model_executor.models import glm4_moe
+ 
+@@ -35,6 +46,244 @@ def _rank_sliced_metadata(**overrides):
+     return metadata
+ 
+ 
++def _set_online_overlay(monkeypatch, args: QuantizationConfigArgs) -> object:
++    current = SimpleNamespace(
++        model_config=SimpleNamespace(
++            quantization_config=args,
++            enforce_eager=True,
++        )
++    )
++    sentinel = object()
++    monkeypatch.setattr(exl3_module, "get_current_vllm_config_or_none", lambda: current)
++    monkeypatch.setattr(exl3_module, "Mxfp8OnlineLinearMethod", lambda: sentinel)
++    return sentinel
++
++
++def _mock_linear() -> Mock:
++    return Mock(spec=LinearBase)
++
++
++def test_exl3_online_overlay_quantizes_only_bf16_dense_and_shared(monkeypatch):
++    config = Exl3Config(
++        tensor_storage={"model.layers.3.self_attn.q_b_proj": {"quant_format": "exl3"}}
++    )
++    sentinel = _set_online_overlay(
++        monkeypatch,
++        QuantizationConfigArgs(linear="mxfp8", shared_experts="mxfp8"),
++    )
++
++    serialized = config.get_quant_method(
++        _mock_linear(), "model.layers.3.self_attn.q_b_proj"
++    )
++    dense_bf16 = config.get_quant_method(
++        _mock_linear(), "model.layers.3.self_attn.kv_b_proj"
++    )
++    shared_bf16 = config.get_quant_method(
++        _mock_linear(), "model.layers.3.mlp.shared_experts.down_proj"
++    )
++
++    assert isinstance(serialized, Exl3LinearMethod)
++    assert dense_bf16 is sentinel
++    assert shared_bf16 is sentinel
++
++
++def test_exl3_linear_overlay_does_not_select_shared_experts(monkeypatch):
++    config = Exl3Config()
++    sentinel = _set_online_overlay(monkeypatch, QuantizationConfigArgs(linear="mxfp8"))
++
++    dense = config.get_quant_method(
++        _mock_linear(), "model.layers.3.self_attn.kv_b_proj"
++    )
++    shared = config.get_quant_method(
++        _mock_linear(), "model.layers.3.mlp.shared_experts.down_proj"
++    )
++
++    assert dense is sentinel
++    assert isinstance(shared, UnquantizedLinearMethod)
++
++
++def test_exl3_online_overlay_honors_unfused_ignore_names(monkeypatch):
++    config = Exl3Config()
++    config.packed_modules_mapping = {
++        "fused_qkv_a_proj": ["q_a_proj", "kv_a_proj_with_mqa"]
++    }
++    sentinel = _set_online_overlay(
++        monkeypatch,
++        QuantizationConfigArgs(
++            linear="mxfp8",
++            ignore=["re:.*\\.q_a_proj$", "re:.*kv_a_proj_with_mqa"],
++        ),
++    )
++
++    ignored = config.get_quant_method(
++        _mock_linear(), "model.layers.3.self_attn.fused_qkv_a_proj"
++    )
++    kept = config.get_quant_method(_mock_linear(), "model.layers.3.self_attn.kv_b_proj")
++
++    assert isinstance(ignored, UnquantizedLinearMethod)
++    assert kept is sentinel
++
++
++def test_exl3_online_overlay_rejects_split_packed_quantization(monkeypatch):
++    config = Exl3Config()
++    config.packed_modules_mapping = {
++        "fused_qkv_a_proj": ["q_a_proj", "kv_a_proj_with_mqa"]
++    }
++    _set_online_overlay(
++        monkeypatch,
++        QuantizationConfigArgs(linear="mxfp8", ignore=["re:.*\\.q_a_proj$"]),
++    )
++
++    with pytest.raises(ValueError, match="different quantization schemes"):
++        config.get_quant_method(
++            _mock_linear(), "model.layers.3.self_attn.fused_qkv_a_proj"
++        )
++
++
++def test_exl3_online_overlay_rejects_mixed_packed_storage(monkeypatch):
++    config = Exl3Config(
++        tensor_storage={"model.layers.3.self_attn.q_a_proj": {"quant_format": "exl3"}}
++    )
++    config.packed_modules_mapping = {
++        "fused_qkv_a_proj": ["q_a_proj", "kv_a_proj_with_mqa"]
++    }
++    _set_online_overlay(monkeypatch, QuantizationConfigArgs(linear="mxfp8"))
++
++    with pytest.raises(ValueError, match="mixes EXL3 and BF16 source shards"):
++        config.get_quant_method(
++            _mock_linear(), "model.layers.3.self_attn.fused_qkv_a_proj"
++        )
++
++
++def test_exl3_online_overlay_never_quantizes_bf16_lm_head(monkeypatch):
++    config = Exl3Config()
++    _set_online_overlay(monkeypatch, QuantizationConfigArgs(linear="mxfp8"))
++    lm_head = type("ParallelLMHead", (torch.nn.Module,), {})()
++
++    method = config.get_quant_method(lm_head, "lm_head")
++
++    assert isinstance(method, UnquantizedLinearMethod)
++
++
++def test_exl3_online_overlay_preserves_rank_sliced_routed_experts(monkeypatch):
++    config = Exl3Config()
++    config.rank_sliced_metadata = _rank_sliced_metadata()
++    _set_online_overlay(
++        monkeypatch,
++        QuantizationConfigArgs(linear="mxfp8", shared_experts="mxfp8"),
++    )
++    routed = Mock(spec=RoutedExperts)
++    routed.moe_config = object()
++
++    method = config.get_quant_method(routed, "model.layers.3.mlp.experts")
++
++    assert isinstance(method, Exl3MoEMethod)
++
++
++def test_exl3_online_trellis_selects_cached_k6_method(monkeypatch):
++    config = Exl3Config()
++    config._online_model_identity = "model"  # noqa: SLF001
++    config._online_encoder_identity = "encoder"  # noqa: SLF001
++    _set_online_overlay(monkeypatch, QuantizationConfigArgs(linear="mxfp8"))
++    monkeypatch.setattr(
++        fp8_module,
++        "get_current_vllm_config",
++        lambda: SimpleNamespace(model_config=SimpleNamespace(dtype=torch.bfloat16)),
++    )
++    monkeypatch.setenv("VLLM_EXL3_ONLINE_TRELLIS_BITS", "6")
++
++    method = config.get_quant_method(_mock_linear(), "model.layers.3.self_attn.o_proj")
++
++    assert isinstance(method, Exl3OnlineLinearMethod)
++    assert method.bits == 6
++    assert method.model_identity == "model"
++    assert method.encoder_identity == "encoder"
++
++
++def test_online_trellis_cache_off_does_not_require_hub_commit(tmp_path, monkeypatch):
++    config = Exl3Config()
++    monkeypatch.setenv("VLLM_EXL3_ONLINE_CACHE_MODE", "off")
++    monkeypatch.setenv("VLLM_EXL3_ENCODER_SOURCE", str(tmp_path))
++
++    config._configure_online_cache_identity(  # noqa: SLF001
++        "org/model", hf_config=None, revision=None
++    )
++
++    assert config._online_model_identity == "cache-disabled"  # noqa: SLF001
++    assert config._online_encoder_identity == "cache-disabled"  # noqa: SLF001
++
++
++def test_online_trellis_encoder_requires_quantize_entrypoint(tmp_path, monkeypatch):
++    encoder = tmp_path / "encoder"
++    quantizer = encoder / "modules" / "quant" / "exl3_lib"
++    quantizer.mkdir(parents=True)
++    (quantizer / "quantize.py").write_text("VALUE = 1\n", encoding="utf-8")
++    monkeypatch.setenv("VLLM_EXL3_ENCODER_SOURCE", str(encoder))
++    monkeypatch.setattr(exl3_module, "_EXL3_ONLINE_QUANTIZER", None)
++    monkeypatch.setattr(
++        exl3_module.importlib,
++        "import_module",
++        lambda name: SimpleNamespace(),
++    )
++
++    with pytest.raises(RuntimeError, match="has no quantize_exl3"):
++        exl3_module._load_exl3_online_quantizer()
++    for name in tuple(exl3_module.sys.modules):
++        if name == "_vllm_exl3_encoder" or name.startswith("_vllm_exl3_encoder."):
++            monkeypatch.delitem(exl3_module.sys.modules, name, raising=False)
++
++
++def test_exl3_online_trellis_cache_hit_skips_encoder(monkeypatch):
++    monkeypatch.setattr(
++        fp8_module,
++        "get_current_vllm_config",
++        lambda: SimpleNamespace(model_config=SimpleNamespace(dtype=torch.bfloat16)),
++    )
++    method = Exl3OnlineLinearMethod(
++        bits=6,
++        prefix="model.layers.3.self_attn.o_proj",
++        model_identity="model",
++        encoder_identity="encoder",
++    )
++    layer = torch.nn.Module()
++    layer.register_parameter(
++        "weight",
++        torch.nn.Parameter(torch.zeros((256, 128), dtype=torch.float16)),
++    )
++    layer.exl3_online_input_size = 128
++    layer.exl3_online_output_size = 256
++    tensors = {
++        "trellis": torch.zeros((8, 16, 96), dtype=torch.int16),
++        "suh": torch.ones(128, dtype=torch.float16),
++        "svh": torch.ones(256, dtype=torch.float16),
++    }
++    captured = {}
++
++    def cache_hit(key, *, device, quantize):
++        del quantize
++        captured["key"] = key
++        captured["device"] = device
++        return Exl3OnlineCacheResult(tensors, 0.25, True, None)
++
++    monkeypatch.setattr(exl3_module, "load_or_quantize", cache_hit)
++    monkeypatch.setattr(
++        exl3_module,
++        "_load_exl3_online_quantizer",
++        lambda: pytest.fail("cache hit must not import the encoder"),
++    )
++    monkeypatch.setattr(exl3_module, "get_tensor_model_parallel_world_size", lambda: 4)
++    monkeypatch.setattr(exl3_module, "get_tensor_model_parallel_rank", lambda: 2)
++    monkeypatch.setattr(method, "_warm_decode_shapes", lambda layer: None)
++
++    method.process_weights_after_loading(layer)
++
++    assert captured["key"].tp_world_size == 4
++    assert captured["key"].tp_rank == 2
++    assert captured["device"] == torch.device("cpu")
++    assert layer.weight.numel() == 0
++    assert layer.exl3_online_trellis_weight is tensors["trellis"]
++
++
+ def test_rank_sliced_checkpoint_selects_exl3_override():
+     hf_config = SimpleNamespace(hybrid_tr3_tail=_rank_sliced_metadata())
+ 
+@@ -92,6 +341,8 @@ def test_glm_model_retains_quant_config_for_weight_loading(monkeypatch):
+         ({"codebook": "mul1"}, "MCG codebook"),
+         ({"moe_layers": [77, 3]}, "moe_layers"),
+         ({"tensor_schema": "unsupported"}, "tensor schema"),
++        ({"rotation_layout": "implicit_magic"}, "rotation_layout"),
++        ({"rotation_layout": "shared_h_v1"}, "shared_h_tensor_schema"),
+     ],
+ )
+ def test_rank_sliced_metadata_fails_closed(overrides, message):
+@@ -118,6 +369,28 @@ def test_rank_sliced_metadata_admits_only_declared_moe_layers():
+     )
+ 
+ 
++def test_rank_sliced_shared_h_metadata_is_explicit_and_legacy_defaults_unchanged():
++    legacy = Exl3Config()
++    legacy.maybe_update_config(
++        "unused", SimpleNamespace(hybrid_tr3_tail=_rank_sliced_metadata())
++    )
++    shared = Exl3Config()
++    shared.maybe_update_config(
++        "unused",
++        SimpleNamespace(
++            hybrid_tr3_tail=_rank_sliced_metadata(
++                rotation_layout="shared_h_v1",
++                shared_h_tensor_schema=(
++                    "model.layers.{L}.mlp.experts.shared_h.{proj}.rank{r}.{suh|svh}"
++                ),
++            )
++        ),
++    )
++
++    assert legacy.rank_sliced_rotation_layout == "per_expert_v1"
++    assert shared.rank_sliced_rotation_layout == "shared_h_v1"
++
++
+ def test_mixed_rank_sliced_metadata_hydrates_per_layer_bitrates(monkeypatch):
+     metadata = _rank_sliced_metadata(
+         bits="mixed",
+@@ -179,6 +452,49 @@ def test_rank_sliced_weight_name_keeps_only_local_tp_rank(monkeypatch):
+     )
+ 
+ 
++def test_rank_sliced_shared_h_names_map_once_and_fail_closed(monkeypatch):
++    config = Exl3Config()
++    config.maybe_update_config(
++        "unused",
++        SimpleNamespace(
++            hybrid_tr3_tail=_rank_sliced_metadata(
++                rotation_layout="shared_h_v1",
++                shared_h_tensor_schema=(
++                    "model.layers.{L}.mlp.experts.shared_h.{proj}.rank{r}.{suh|svh}"
++                ),
++            )
++        ),
++    )
++    monkeypatch.setattr(exl3_module, "get_tensor_model_parallel_rank", lambda: 2)
++    prefix = "model.layers.3.mlp.experts"
++
++    assert (
++        config.normalize_rank_sliced_weight_name(
++            f"{prefix}.shared_h.gate_proj.rank2.suh"
++        )
++        == f"{prefix}.0.gate_proj.suh"
++    )
++    assert (
++        config.normalize_rank_sliced_weight_name(
++            f"{prefix}.shared_h.down_proj.rank1.svh"
++        )
++        is None
++    )
++    with pytest.raises(ValueError, match="requires suh"):
++        config.normalize_rank_sliced_weight_name(
++            f"{prefix}.shared_h.gate_proj.rank2.svh"
++        )
++    with pytest.raises(ValueError, match="must store H-side rotations"):
++        config.normalize_rank_sliced_weight_name(f"{prefix}.7.down_proj.rank2.svh")
++
++    legacy = Exl3Config()
++    legacy.maybe_update_config(
++        "unused", SimpleNamespace(hybrid_tr3_tail=_rank_sliced_metadata())
++    )
++    with pytest.raises(ValueError, match="does not declare"):
++        legacy.normalize_rank_sliced_weight_name(f"{prefix}.shared_h.up_proj.rank2.suh")
++
++
+ def test_rank_sliced_parameter_preallocates_projection_major_slab(monkeypatch):
+     monkeypatch.setattr(parameter_module, "get_tensor_model_parallel_rank", lambda: 0)
+     monkeypatch.setattr(
+@@ -208,6 +524,70 @@ def test_rank_sliced_parameter_preallocates_projection_major_slab(monkeypatch):
+     torch.testing.assert_close(param.exl3_tensors[(2, "w3")], w3)
+ 
+ 
++def test_rank_sliced_broadcast_pointer_table_repeats_one_physical_row():
++    slab = torch.ones((1, 128), dtype=torch.float16)
++
++    table = Exl3MoEMethod._pointer_table(slab, num_experts=4)
++
++    assert table.tolist() == [slab.data_ptr()] * 4
++    with pytest.raises(RuntimeError, match="per-expert or broadcast"):
++        Exl3MoEMethod._pointer_table(
++            torch.ones((2, 128), dtype=torch.float16), num_experts=4
++        )
++
++
++def test_rank_sliced_shared_h_create_weights_allocates_one_physical_row(
++    monkeypatch,
++):
++    monkeypatch.setattr(parameter_module, "get_tensor_model_parallel_rank", lambda: 0)
++    monkeypatch.setattr(
++        parameter_module, "get_tensor_model_parallel_world_size", lambda: 4
++    )
++    config = Exl3Config()
++    config.maybe_update_config(
++        "unused",
++        SimpleNamespace(
++            hybrid_tr3_tail=_rank_sliced_metadata(
++                rotation_layout="shared_h_v1",
++                shared_h_tensor_schema=(
++                    "model.layers.{L}.mlp.experts.shared_h.{proj}.rank{r}.{suh|svh}"
++                ),
++            )
++        ),
++    )
++    monkeypatch.setattr(
++        exl3_module,
++        "get_current_vllm_config_or_none",
++        lambda: SimpleNamespace(
++            scheduler_config=SimpleNamespace(max_num_batched_tokens=8192),
++            model_config=SimpleNamespace(runner_type="generate"),
++        ),
++    )
++    layer = torch.nn.Module()
++    layer.layer_name = "model.layers.3.mlp.experts"
++    moe = SimpleNamespace(
++        moe_parallel_config=SimpleNamespace(use_ep=False, tp_rank=0, tp_size=4),
++        has_bias=False,
++    )
++    method = Exl3MoEMethod(config, moe)
++
++    method.create_weights(
++        layer,
++        num_experts=256,
++        hidden_size=6144,
++        intermediate_size_per_partition=512,
++        params_dtype=torch.bfloat16,
++    )
++
++    assert layer.exl3_shared_h_rotations
++    assert layer.w13_suh.exl3_num_experts == 1
++    assert layer.w2_svh.exl3_num_experts == 1
++    assert layer.w13_svh.exl3_num_experts == 256
++    assert layer.w2_suh.exl3_num_experts == 256
++    assert layer.w13_trellis.exl3_num_experts == 256
++    assert layer.w2_trellis.exl3_num_experts == 256
++
++
+ def test_rank_sliced_weights_use_unified_fused_moe_contract(monkeypatch):
+     experts = 2
+     hidden = intermediate = 128
+@@ -278,7 +658,66 @@ def test_rank_sliced_weights_use_unified_fused_moe_contract(monkeypatch):
+     assert api.prepare_kwargs["trellis_mcg"] is marker
+ 
+ 
+-def test_mixed_rank_sliced_weights_are_partitioned_by_declared_bitrate(monkeypatch):
++def test_rank_sliced_weights_pass_shared_h_rows_without_expansion(monkeypatch):
++    experts = 3
++    hidden = intermediate = 128
++    bits = 3
++    slabs = {
++        "w13_trellis": torch.zeros(
++            (2, experts, hidden // 16, intermediate // 16, 16 * bits),
++            dtype=torch.int16,
++        ),
++        "w2_trellis": torch.zeros(
++            (experts, intermediate // 16, hidden // 16, 16 * bits),
++            dtype=torch.int16,
++        ),
++        "w13_suh": torch.ones((2, 1, hidden), dtype=torch.float16),
++        "w13_svh": torch.ones((2, experts, intermediate), dtype=torch.float16),
++        "w2_suh": torch.ones((experts, intermediate), dtype=torch.float16),
++        "w2_svh": torch.ones((1, hidden), dtype=torch.float16),
++    }
++
++    class FakeFusedMoe:
++        @staticmethod
++        def plan_weights(**kwargs):
++            return SimpleNamespace(source_format=kwargs["source_format"])
++
++        @staticmethod
++        def prepare_weights(**kwargs):
++            return SimpleNamespace(**kwargs)
++
++    monkeypatch.setattr(
++        exl3_module, "_load_sparkinfer_fused_moe", lambda: FakeFusedMoe()
++    )
++    method = object.__new__(Exl3MoEMethod)
++    method.quant_config = SimpleNamespace(bits=float(bits))
++    method._rank_sliced_backing = lambda _layer, name: slabs[name]
++    marker = torch.tensor(0xCBAC1FED - (1 << 32), dtype=torch.int32)
++    layer = SimpleNamespace(
++        local_num_experts=experts,
++        exl3_hidden_size=hidden,
++        exl3_intermediate_size_per_partition=intermediate,
++        exl3_params_dtype=torch.float16,
++        exl3_layer_bitrates=(bits,) * experts,
++        exl3_mixed_bitrate=False,
++        exl3_shared_h_rotations=True,
++        activation=MoEActivation.SILU,
++        w13_mcg=SimpleNamespace(exl3_tensors={(0, "w1"): marker}),
++    )
++
++    method._prepare_rank_sliced_weights(layer)
++
++    prepared = layer.exl3_trellis_weights
++    assert tuple(prepared.gate_suh.shape) == (1, hidden)
++    assert tuple(prepared.up_suh.shape) == (1, hidden)
++    assert tuple(prepared.down_svh.shape) == (1, hidden)
++    assert all(tuple(table.shape) == (experts,) for table in layer.exl3_pointer_tables)
++
++
++@pytest.mark.parametrize("shared_h", [False, True])
++def test_mixed_rank_sliced_weights_are_partitioned_by_declared_bitrate(
++    monkeypatch, shared_h
++):
+     experts = 4
+     hidden = intermediate = 128
+     bitrates = (3, 4, 3, 4)
+@@ -304,15 +743,18 @@ def test_mixed_rank_sliced_weights_are_partitioned_by_declared_bitrate(monkeypat
+         )
+ 
+     slabs = {
+-        "w13_suh": torch.ones((2, experts, hidden), dtype=torch.float16),
++        "w13_suh": torch.ones(
++            (2, 1 if shared_h else experts, hidden), dtype=torch.float16
++        ),
+         "w13_svh": torch.ones((2, experts, intermediate), dtype=torch.float16),
+         "w2_suh": torch.ones((experts, intermediate), dtype=torch.float16),
+-        "w2_svh": torch.ones((experts, hidden), dtype=torch.float16),
++        "w2_svh": torch.ones((1 if shared_h else experts, hidden), dtype=torch.float16),
+     }
+     layer = SimpleNamespace(
+         local_num_experts=experts,
+         exl3_hidden_size=hidden,
+         exl3_intermediate_size_per_partition=intermediate,
++        exl3_params_dtype=torch.float16,
+         exl3_layer_bitrates=bitrates,
+         activation=MoEActivation.SILU,
+         layer_name="model.layers.3.mlp.experts",
+@@ -353,8 +795,8 @@ def test_mixed_rank_sliced_weights_are_partitioned_by_declared_bitrate(monkeypat
+ 
+     method._prepare_mixed_rank_sliced_weights(layer)
+ 
+-    assert [entry["trellis_bits"] for entry in api.prepared] == [3, 4]
+-    assert [entry["num_experts"] for entry in api.prepared] == [2, 2]
++    assert [entry["trellis_bits"] for entry in api.prepared] == [3, 3, 4, 4]
++    assert [entry["num_experts"] for entry in api.prepared] == [2] * 4
+     for entry in api.prepared:
+         bits = entry["trellis_bits"]
+         assert tuple(entry["w13"].shape) == (
+@@ -373,9 +815,27 @@ def test_mixed_rank_sliced_weights_are_partitioned_by_declared_bitrate(monkeypat
+     assert [entry["tile_config"] for entry in api.prepared] == [
+         (128, 128, 128, 128),
+         (128, 128, 128, 128),
++        (128, 128, 128, 128),
++        (128, 128, 128, 128),
+     ]
+     assert layer.exl3_mixed_trellis["tier_ids"] == ((0, 2), (1, 3))
+     assert layer.exl3_mixed_trellis["tier_bits"] == (3, 4)
++    assert len(layer.exl3_mixed_trellis["tiers"]) == 2
++    assert len(layer.exl3_mixed_trellis["prefill_tiers"]) == 2
++    rotations = layer.exl3_mixed_trellis["rotations"]
++    expected_h_rows = 1 if shared_h else experts
++    assert rotations.gate_suh.shape[0] == expected_h_rows
++    assert rotations.up_suh.shape[0] == expected_h_rows
++    assert rotations.down_svh.shape[0] == expected_h_rows
++    for entry in api.prepared:
++        expected_tier_rows = 1 if shared_h else 2
++        assert entry["gate_suh"].shape[0] == expected_tier_rows
++        assert entry["up_suh"].shape[0] == expected_tier_rows
++        assert entry["down_svh"].shape[0] == expected_tier_rows
++        assert (
++            entry["gate_suh"].untyped_storage().data_ptr()
++            == rotations.gate_suh.untyped_storage().data_ptr()
++        )
+     assert layer.w13_trellis.exl3_tensors == {}
+     assert layer.w2_trellis.exl3_tensors == {}
+     assert layer.w13_suh.exl3_backing is None
+@@ -390,6 +850,121 @@ def test_mixed_trellis_buffer_accounting_ignores_metadata() -> None:
+     assert exl3_module._unique_tensor_storage_bytes(first, second) == 8
+ 
+ 
++def test_prepared_dense_weight_is_owned_by_source_tensor(monkeypatch) -> None:
++    class FakeApi:
++        def __init__(self):
++            self.calls = 0
++
++        def prepare_weight(self, trellis, suh, svh, **kwargs):
++            del kwargs
++            self.calls += 1
++            return SimpleNamespace(trellis=trellis, suh=suh, svh=svh)
++
++    api = FakeApi()
++    monkeypatch.setattr(exl3_module, "_load_sparkinfer_trellis_linear", lambda: api)
++    trellis = torch.empty((8, 8, 96), dtype=torch.int16)
++    suh = torch.empty(128, dtype=torch.float16)
++    svh = torch.empty(128, dtype=torch.float16)
++
++    first = exl3_module._sparkinfer_trellis_weight(trellis, suh, svh, torch.float16)
++    second = exl3_module._sparkinfer_trellis_weight(trellis, suh, svh, torch.float16)
++    assert first is second
++    assert api.calls == 1
++
++    source_ref = weakref.ref(trellis)
++    del first, second, trellis
++    gc.collect()
++    assert source_ref() is None
++
++
++def test_mixed_trellis_dispatches_decode_and_one_grid_prefill(monkeypatch):
++    class FakeMixedApi:
++        def __init__(self):
++            self.calls = []
++
++        def run_mixed_trellis(self, x, *args):
++            launch = args[7]
++            self.calls.append((int(x.shape[0]), args[0], args[1], launch))
++            return torch.full_like(x, launch.value)
++
++    mixed_api = FakeMixedApi()
++    decode_tiers = (object(), object())
++    prefill_tiers = (object(), object())
++    runtime = {
++        "mixed_api": mixed_api,
++        "decode": {
++            "launch": SimpleNamespace(value=1),
++            "buffers": object(),
++        },
++        "prefill": {
++            "launch": SimpleNamespace(value=3),
++            "buffers": object(),
++        },
++        "max_decode_m": 8,
++        "max_batched_tokens": 16,
++        "prefill_capacity": 8,
++    }
++    layer = SimpleNamespace(
++        exl3_mixed_trellis={
++            "tiers": decode_tiers,
++            "prefill_tiers": prefill_tiers,
++            "global_to_combined": object(),
++            "descriptor_map": object(),
++            "rotations": object(),
++        }
++    )
++    method = object.__new__(Exl3MoEMethod)
++    monkeypatch.setattr(
++        method, "_mixed_rank_sliced_runtime", lambda layer, x, ids: runtime
++    )
++    weights = torch.ones((16, 2), dtype=torch.float32)
++    ids = torch.zeros((16, 2), dtype=torch.int64)
++
++    decode = method._apply_mixed_rank_sliced(
++        layer, torch.zeros((4, 4)), weights[:4], ids[:4]
++    )
++    prefill = method._apply_mixed_rank_sliced(layer, torch.zeros((16, 4)), weights, ids)
++
++    torch.testing.assert_close(decode, torch.ones_like(decode))
++    torch.testing.assert_close(prefill, torch.full_like(prefill, 3))
++    assert [call[0] for call in mixed_api.calls] == [4, 8, 8]
++    assert mixed_api.calls[0][1:3] == decode_tiers
++    assert all(call[1:3] == prefill_tiers for call in mixed_api.calls[1:])
++
++
++def test_mixed_trellis_prefill_block_policy_is_narrow_and_overridable() -> None:
++    common = {
++        "configured_block_m": 64,
++        "explicit_override": False,
++        "hidden_size": 6144,
++        "intermediate_size": 512,
++        "tier_signature": ((3, 192), (4, 64)),
++        "topk": 8,
++        "device_major": 12,
++        "prefill_tile_config": (128, 128, 32, 512),
++    }
++
++    assert exl3_module._resolve_mixed_trellis_prefill_block_m(**common) == 32
++    assert (
++        exl3_module._resolve_mixed_trellis_prefill_block_m(
++            **{**common, "explicit_override": True}
++        )
++        == 64
++    )
++    assert (
++        exl3_module._resolve_mixed_trellis_prefill_block_m(
++            **{**common, "tier_signature": ((4, 256),)}
++        )
++        == 64
++    )
++    assert (
++        exl3_module._resolve_mixed_trellis_prefill_block_m(
++            **{**common, "device_major": 11}
++        )
++        == 64
++    )
++
++
+ @pytest.mark.parametrize(
+     ("hidden", "intermediate", "expected"),
+     [
+diff --git a/tests/quantization/test_exl3_online_cache.py b/tests/quantization/test_exl3_online_cache.py
+new file mode 100644
+index 0000000000000000000000000000000000000000..7c02cc5915ed928f87c7f99441a7fe08360a745d
+--- /dev/null
++++ b/tests/quantization/test_exl3_online_cache.py
+@@ -0,0 +1,213 @@
++# SPDX-License-Identifier: Apache-2.0
++# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
++
++from __future__ import annotations
++
++from dataclasses import replace
++
++import pytest
++import torch
++
++from vllm.model_executor.layers.quantization.exl3_online_cache import (
++    Exl3OnlineCacheKey,
++    cache_mode,
++    cache_path,
++    load_or_quantize,
++    resolve_encoder_identity,
++    resolve_model_identity,
++)
++
++
++def _key() -> Exl3OnlineCacheKey:
++    return Exl3OnlineCacheKey(
++        model_identity="model-identity",
++        encoder_identity="encoder-identity",
++        prefix="model.layers.0.self_attn.o_proj",
++        bits=6,
++        seed=123,
++        tp_world_size=4,
++        tp_rank=2,
++        input_size=128,
++        output_size=256,
++    )
++
++
++def _tensors(key: Exl3OnlineCacheKey) -> dict[str, torch.Tensor]:
++    return {
++        "trellis": torch.arange(
++            key.input_size // 16 * key.output_size // 16 * key.bits * 16,
++            dtype=torch.int16,
++        ).reshape(key.input_size // 16, key.output_size // 16, key.bits * 16),
++        "suh": torch.ones(key.input_size, dtype=torch.float16),
++        "svh": torch.full((key.output_size,), 2, dtype=torch.float16),
++    }
++
++
++def test_cache_round_trip_skips_second_quantization(tmp_path, monkeypatch):
++    monkeypatch.setenv("VLLM_EXL3_ONLINE_CACHE_DIR", str(tmp_path))
++    monkeypatch.setenv("VLLM_EXL3_ONLINE_CACHE_MODE", "readwrite")
++    key = _key()
++    calls = 0
++
++    def quantize():
++        nonlocal calls
++        calls += 1
++        return _tensors(key), 0.125
++
++    first = load_or_quantize(key, device=torch.device("cpu"), quantize=quantize)
++    second = load_or_quantize(key, device=torch.device("cpu"), quantize=quantize)
++
++    assert calls == 1
++    assert not first.hit
++    assert second.hit
++    assert second.proxy_error == pytest.approx(0.125)
++    assert second.path == cache_path(key)
++    for name, expected in _tensors(key).items():
++        assert torch.equal(second.tensors[name], expected)
++
++
++def test_corrupt_cache_is_replaced_atomically(tmp_path, monkeypatch):
++    monkeypatch.setenv("VLLM_EXL3_ONLINE_CACHE_DIR", str(tmp_path))
++    monkeypatch.setenv("VLLM_EXL3_ONLINE_CACHE_MODE", "readwrite")
++    key = _key()
++    path = cache_path(key)
++    path.parent.mkdir(parents=True)
++    path.write_bytes(b"not a safetensors file")
++    calls = 0
++
++    def quantize():
++        nonlocal calls
++        calls += 1
++        return _tensors(key), None
++
++    result = load_or_quantize(key, device=torch.device("cpu"), quantize=quantize)
++    reloaded = load_or_quantize(
++        key,
++        device=torch.device("cpu"),
++        quantize=lambda: pytest.fail("valid replacement must be reused"),
++    )
++
++    assert calls == 1
++    assert not result.hit
++    assert reloaded.hit
++
++
++def test_readonly_miss_does_not_publish(tmp_path, monkeypatch):
++    monkeypatch.setenv("VLLM_EXL3_ONLINE_CACHE_DIR", str(tmp_path))
++    monkeypatch.setenv("VLLM_EXL3_ONLINE_CACHE_MODE", "readonly")
++    key = _key()
++
++    result = load_or_quantize(
++        key,
++        device=torch.device("cpu"),
++        quantize=lambda: (_tensors(key), 0.5),
++    )
++
++    assert not result.hit
++    assert result.path is None
++    assert not cache_path(key).exists()
++
++
++@pytest.mark.parametrize(
++    ("raw", "expected"),
++    [
++        ("off", "off"),
++        ("none", "off"),
++        ("readonly", "readonly"),
++        ("read-only", "readonly"),
++        ("readwrite", "readwrite"),
++        ("rw", "readwrite"),
++    ],
++)
++def test_cache_mode_aliases(raw, expected, monkeypatch):
++    monkeypatch.setenv("VLLM_EXL3_ONLINE_CACHE_MODE", raw)
++    assert cache_mode() == expected
++
++
++def test_cache_mode_rejects_unknown_value(monkeypatch):
++    monkeypatch.setenv("VLLM_EXL3_ONLINE_CACHE_MODE", "sometimes")
++    with pytest.raises(ValueError, match="must be off, readonly, or readwrite"):
++        cache_mode()
++
++
++def test_off_mode_neither_reads_nor_writes(tmp_path, monkeypatch):
++    monkeypatch.setenv("VLLM_EXL3_ONLINE_CACHE_DIR", str(tmp_path))
++    monkeypatch.setenv("VLLM_EXL3_ONLINE_CACHE_MODE", "off")
++    key = _key()
++    cache_path(key).parent.mkdir(parents=True)
++    cache_path(key).write_bytes(b"must not be read")
++
++    result = load_or_quantize(
++        key,
++        device=torch.device("cpu"),
++        quantize=lambda: (_tensors(key), 0.5),
++    )
++
++    assert not result.hit
++    assert result.path is None
++    assert cache_path(key).read_bytes() == b"must not be read"
++
++
++def test_cache_key_covers_every_rank_local_encoding_input():
++    key = _key()
++    variants = [
++        replace(key, model_identity="other-model"),
++        replace(key, encoder_identity="other-encoder"),
++        replace(key, prefix="model.layers.1.self_attn.o_proj"),
++        replace(key, bits=5),
++        replace(key, seed=456),
++        replace(key, tp_world_size=8),
++        replace(key, tp_rank=3),
++        replace(key, input_size=256),
++        replace(key, output_size=128),
++    ]
++
++    assert len({key.digest(), *(variant.digest() for variant in variants)}) == 10
++
++
++def test_local_model_identity_tracks_metadata_and_shards(tmp_path):
++    model = tmp_path / "model"
++    model.mkdir()
++    config = model / "config.json"
++    shard = model / "model-00001-of-00001.safetensors"
++    config.write_text('{"model_type":"test"}', encoding="utf-8")
++    shard.write_bytes(b"weight payload")
++
++    before = resolve_model_identity(str(model))
++    config.write_text('{"model_type":"changed"}', encoding="utf-8")
++    after = resolve_model_identity(str(model))
++
++    assert before != after
++
++
++def test_hub_model_identity_tracks_resolved_revision():
++    first = resolve_model_identity("org/model", revision="commit-a")
++    second = resolve_model_identity("org/model", revision="commit-b")
++
++    assert first != second
++
++    resolved = resolve_model_identity(
++        "org/model",
++        revision="main",
++        hf_config=type("Config", (), {"_commit_hash": "commit-a"})(),
++    )
++    assert resolved == first
++
++
++def test_hub_model_identity_rejects_unresolved_revision():
++    with pytest.raises(ValueError, match="requires a resolved revision"):
++        resolve_model_identity("org/model")
++
++
++def test_encoder_identity_tracks_source_without_explicit_revision(tmp_path):
++    package = tmp_path / "exllamav3"
++    package.mkdir()
++    source = package / "quantize.py"
++    source.write_text("VALUE = 1\n", encoding="utf-8")
++    before = resolve_encoder_identity(package)
++    source.write_text("VALUE = 2\n", encoding="utf-8")
++    after = resolve_encoder_identity(package)
++
++    assert before != after
++    explicit = resolve_encoder_identity(package, revision="abc")
++    assert explicit == resolve_encoder_identity(package, revision="abc")
+diff --git a/tests/quantization/test_exl3_prefill_plan.py b/tests/quantization/test_exl3_prefill_plan.py
+index c55be20ee366173ca5bc5d96d3fb6090b8dd11b4..06d989d079723093d105664ed86ba805e3b093ed 100644
+--- a/tests/quantization/test_exl3_prefill_plan.py
++++ b/tests/quantization/test_exl3_prefill_plan.py
+@@ -7,7 +7,8 @@ The planned Trellis API and the ExLlamaV3 extension are mocked; these tests
+ prove backend policy only:
+ 
+ * decode window m in [min, max] binds the decode plan;
+-* max < m <= capacity binds the prefill plan (block_size_m=64 by default);
++* max < m <= scheduler capacity binds capacity-bounded prefill slices;
++* the opt-in prefill capacity defaults to the scheduler capacity;
+ * m < min stays on the parity path with chunk-capped staging buffers;
+ * VLLM_EXL3_PREFILL_TRELLIS=0 restores the single-plan parity behavior
+   with full-capacity staging;
+@@ -50,6 +51,7 @@ class _FakeFusedMoeApi:
+     def __init__(self):
+         self.planned = []
+         self.bound = []
++        self.routed = []
+ 
+     def Caps(self, **kwargs):
+         return kwargs
+@@ -59,13 +61,64 @@ class _FakeFusedMoeApi:
+         self.planned.append(caps)
+         return plan
+ 
+-    def bind(self, plan, *, scratch, a, experts, topk_weights, topk_ids):
+-        del scratch, experts, topk_weights, topk_ids
++    def bind(
++        self,
++        plan,
++        *,
++        scratch,
++        a,
++        experts,
++        topk_weights,
++        topk_ids,
++        route_expert_map=None,
++        output_expert_map=None,
++        output=None,
++    ):
++        del scratch, experts
+         self.bound.append((plan, int(a.shape[0])))
+-        return SimpleNamespace(plan=plan, m=int(a.shape[0]))
++        self.routed.append((topk_weights.clone(), topk_ids.clone()))
++        return SimpleNamespace(
++            plan=plan,
++            a=a,
++            route_expert_map=route_expert_map,
++            output_expert_map=output_expert_map,
++            output=output,
++        )
+ 
+     def run(self, *, binding):
+-        return torch.zeros((binding.m, HIDDEN), dtype=torch.float32)
++        if binding.route_expert_map is not None:
++            tier_output = binding.a.to(torch.float32).mul(0.5)
++            if binding.output is not None:
++                binding.output.copy_(tier_output)
++                return binding.output
++            return tier_output
++        return binding.a.to(torch.float32)
++
++
++class _FakeMixedTrellisApi:
++    def __init__(self):
++        self.compiled = []
++        self.routed = []
++        self.calls = []
++
++    def max_packed_route_slots(self, routed_rows, block_size, experts):
++        del block_size, experts
++        return routed_rows
++
++    def compile_mixed_trellis(self, **kwargs):
++        launch = SimpleNamespace(**kwargs)
++        self.compiled.append(launch)
++        return launch
++
++    def make_mixed_trellis_buffers(self, launch, **kwargs):
++        del kwargs
++        return SimpleNamespace(scratch=torch.empty(launch.size_m, dtype=torch.uint8))
++
++    def run_mixed_trellis(self, *args):
++        x, tier0, tier1, topk_weights, topk_ids = args[:5]
++        self.calls.append((int(x.shape[0]), tier0, tier1))
++        self.routed.append((topk_weights.clone(), topk_ids.clone()))
++        return x.to(torch.float32)
+ 
+ 
+ class _FakeExt:
+@@ -96,6 +149,23 @@ def _make_layer():
+     )
+ 
+ 
++def _make_mixed_layer():
++    layer = _make_layer()
++    layer.exl3_mixed_bitrate = True
++    layer.exl3_mixed_trellis = {
++        "tiers": (object(), object()),
++        "prefill_tiers": (object(), object()),
++        "tier_ids": ((0, 1, 2, 3), (4, 5, 6, 7)),
++        "tier_bits": (3, 4),
++        "global_to_combined": object(),
++        "descriptor_map": object(),
++        "rotations": object(),
++        "tile_config": (64, 128, 64, 128),
++        "prefill_tile_config": (128, 128, 128, 128),
++    }
++    return layer
++
++
+ def _make_method():
+     method = object.__new__(Exl3MoEMethod)
+     method.quant_config = SimpleNamespace(
+@@ -112,6 +182,7 @@ class _Harness:
+         self._saved_capturing = None
+         self.api = _FakeFusedMoeApi()
+         self.ext = _FakeExt()
++        self.mixed_api = _FakeMixedTrellisApi()
+ 
+     def __enter__(self):
+         for name, value in self._env.items():
+@@ -122,30 +193,41 @@ class _Harness:
+                 os.environ[name] = value
+         self._saved_loaders = (
+             exl3_module._load_sparkinfer_fused_moe,
++            exl3_module._load_sparkinfer_mixed_trellis,
+             exl3_module._load_exl3_ext,
+         )
+         exl3_module._load_sparkinfer_fused_moe = lambda: self.api
++        exl3_module._load_sparkinfer_mixed_trellis = lambda: self.mixed_api
+         exl3_module._load_exl3_ext = lambda: self.ext
+         self._saved_capturing = torch.cuda.is_current_stream_capturing
+         torch.cuda.is_current_stream_capturing = lambda: False
+         self._saved_current_device = torch.cuda.current_device
+         torch.cuda.current_device = lambda: 0
++        self._saved_device_properties = torch.cuda.get_device_properties
++        torch.cuda.get_device_properties = lambda device: SimpleNamespace(
++            multi_processor_count=1,
++            shared_memory_per_block_optin=1,
++        )
+         exl3_module._RANK_SLICED_RUNTIMES.clear()
++        exl3_module._MIXED_TRELLIS_RUNTIMES.clear()
+         return self
+ 
+     def __exit__(self, *exc):
+         (
+             exl3_module._load_sparkinfer_fused_moe,
++            exl3_module._load_sparkinfer_mixed_trellis,
+             exl3_module._load_exl3_ext,
+         ) = self._saved_loaders
+         torch.cuda.is_current_stream_capturing = self._saved_capturing
+         torch.cuda.current_device = self._saved_current_device
++        torch.cuda.get_device_properties = self._saved_device_properties
+         for name, value in self._saved_env.items():
+             if value is None:
+                 os.environ.pop(name, None)
+             else:
+                 os.environ[name] = value
+         exl3_module._RANK_SLICED_RUNTIMES.clear()
++        exl3_module._MIXED_TRELLIS_RUNTIMES.clear()
+         return False
+ 
+     def planned_caps(self):
+@@ -159,24 +241,24 @@ def _apply(method, layer, m):
+     return method._apply_rank_sliced(layer, x, weights, ids)
+ 
+ 
+-def test_dual_plan_construction_and_dispatch():
+-    with _Harness() as h:
++def test_opt_in_prefill_capacity_slices_dispatch():
++    with _Harness(env={"VLLM_EXL3_PREFILL_CAPACITY": "128"}) as h:
+         method = _make_method()
+         layer = _make_layer()
+ 
+         out = _apply(method, layer, 16)
+         assert out.dtype == torch.bfloat16 and out.shape == (16, HIDDEN)
+-        # Two plans: decode (32, block 8) then prefill (capacity, block 64).
++        # Two plans: decode (32, block 8), then bounded prefill (block 64).
+         assert [
+             (caps["max_tokens"], caps["w4a16_block_size_m"])
+             for caps in h.planned_caps()
+-        ] == [(32, 8), (MAX_BATCHED, 64)]
++        ] == [(32, 8), (128, 64)]
+         assert all(caps["route_num_experts"] == 0 for caps in h.planned_caps())
+         assert h.api.bound[-1][0].caps["max_tokens"] == 32
+ 
+         _apply(method, layer, 200)
+-        assert h.api.bound[-1][0].caps["max_tokens"] == MAX_BATCHED
+-        assert h.api.bound[-1][1] == 200
++        assert all(bound[0].caps["max_tokens"] == 128 for bound in h.api.bound[-2:])
++        assert [bound[1] for bound in h.api.bound[-2:]] == [128, 72]
+         assert not h.ext.moe_calls
+ 
+         _apply(method, layer, 2)
+@@ -188,6 +270,7 @@ def test_dual_plan_construction_and_dispatch():
+         assert runtime["parity_rows"] == 128
+         assert runtime["xh"].shape[0] == 128
+         assert runtime["token_sorted"].numel() == 128 * TOPK
++        assert runtime["prefill_capacity"] == 128
+ 
+         # Batches above the scheduler contract must fail before allocating a
+         # replacement runtime or a larger Trellis arena during serving.
+@@ -204,6 +287,104 @@ def test_dual_plan_construction_and_dispatch():
+         assert len(h.planned_caps()) == plan_count
+ 
+ 
++@pytest.mark.parametrize(
++    ("rows", "expected_slice_rows"),
++    ((127, [127]), (128, [128]), (129, [128, 1])),
++)
++def test_prefill_capacity_boundaries_preserve_rows_and_routing(
++    rows, expected_slice_rows
++):
++    with _Harness(env={"VLLM_EXL3_PREFILL_CAPACITY": "128"}) as h:
++        method = _make_method()
++        layer = _make_layer()
++        x = torch.arange(rows, dtype=torch.bfloat16).unsqueeze(1).expand(-1, HIDDEN)
++        weights = torch.arange(rows * TOPK, dtype=torch.float32).reshape(rows, TOPK)
++        ids = torch.arange(rows * TOPK, dtype=torch.int64).reshape(rows, TOPK)
++        ids = ids.remainder(EXPERTS)
++
++        out = method._apply_rank_sliced(layer, x, weights, ids)
++
++        assert [bound[1] for bound in h.api.bound] == expected_slice_rows
++        assert torch.equal(out, x)
++        assert torch.equal(torch.cat([route[0] for route in h.api.routed]), weights)
++        assert torch.equal(torch.cat([route[1] for route in h.api.routed]), ids)
++        assert all(bound[0] is h.api.bound[0][0] for bound in h.api.bound)
++
++
++def test_default_prefill_capacity_keeps_single_dispatch():
++    with _Harness() as h:
++        out = _apply(_make_method(), _make_layer(), 200)
++
++        assert h.planned_caps()[-1]["max_tokens"] == MAX_BATCHED
++        assert [bound[1] for bound in h.api.bound] == [200]
++        assert out.shape == (200, HIDDEN)
++
++
++def test_mixed_prefill_capacity_slices_rows_and_routing():
++    with _Harness(env={"VLLM_EXL3_PREFILL_CAPACITY": "128"}) as h:
++        method = _make_method()
++        layer = _make_mixed_layer()
++        rows = 200
++        x = torch.arange(rows, dtype=torch.bfloat16).unsqueeze(1).expand(-1, HIDDEN)
++        weights = torch.arange(rows * TOPK, dtype=torch.float32).reshape(rows, TOPK)
++        ids = torch.arange(rows * TOPK, dtype=torch.int64).reshape(rows, TOPK)
++        ids = ids.remainder(EXPERTS)
++
++        out = method._apply_rank_sliced(layer, x, weights, ids)
++
++        assert [launch.size_m for launch in h.mixed_api.compiled] == [32, 128]
++        assert [launch.moe_block_size for launch in h.mixed_api.compiled] == [8, 64]
++        assert h.mixed_api.compiled[1].force_tile_config == (128, 128, 128, 128)
++        assert not h.planned_caps()
++        assert not h.api.bound
++        assert [call[0] for call in h.mixed_api.calls] == [128, 72]
++        assert all(
++            call[1:] == layer.exl3_mixed_trellis["prefill_tiers"]
++            for call in h.mixed_api.calls
++        )
++        assert torch.equal(out, x)
++        assert torch.equal(
++            torch.cat([route[0] for route in h.mixed_api.routed]), weights
++        )
++        assert torch.equal(torch.cat([route[1] for route in h.mixed_api.routed]), ids)
++
++
++def test_mixed_runtime_policy_is_resolved_once(monkeypatch):
++    calls = 0
++
++    def properties(device):
++        nonlocal calls
++        del device
++        calls += 1
++        return SimpleNamespace(
++            major=12,
++            multi_processor_count=1,
++            shared_memory_per_block_optin=1,
++        )
++
++    with _Harness() as h:
++        monkeypatch.setattr(torch.cuda, "get_device_properties", properties)
++        method = _make_method()
++        layer = _make_mixed_layer()
++        x = torch.zeros((16, HIDDEN), dtype=torch.bfloat16)
++        ids = torch.zeros((16, TOPK), dtype=torch.int64)
++
++        first = method._mixed_rank_sliced_runtime(layer, x, ids)
++        second = method._mixed_rank_sliced_runtime(layer, x, ids)
++
++        assert first is second
++        assert calls == 1
++        assert len(h.mixed_api.compiled) == 2
++
++
++def test_prefill_capacity_cannot_exceed_scheduler_bound():
++    env = {"VLLM_EXL3_PREFILL_CAPACITY": str(MAX_BATCHED + 1)}
++    with _Harness(env=env) as h:
++        with pytest.raises(ValueError, match="cannot exceed max_num_batched_tokens"):
++            _apply(_make_method(), _make_layer(), 16)
++        assert not h.planned_caps()
++
++
+ def test_prefill_trellis_disabled_restores_parity():
+     with _Harness(env={"VLLM_EXL3_PREFILL_TRELLIS": "0"}) as h:
+         method = _make_method()
+@@ -221,16 +402,19 @@ def test_prefill_trellis_disabled_restores_parity():
+         runtime = next(iter(exl3_module._RANK_SLICED_RUNTIMES.values()))
+         assert runtime["prefill_plan"] is None
+         assert runtime["parity_rows"] == MAX_BATCHED
+-        assert runtime["xh"].shape[0] == MAX_BATCHED
+ 
+ 
+ def test_prefill_block_m_env_override():
+-    with _Harness(env={"VLLM_EXL3_PREFILL_BLOCK_M": "48"}) as h:
++    env = {
++        "VLLM_EXL3_PREFILL_BLOCK_M": "48",
++        "VLLM_EXL3_PREFILL_CAPACITY": "128",
++    }
++    with _Harness(env=env) as h:
+         method = _make_method()
+         layer = _make_layer()
+         _apply(method, layer, 40)
+         assert h.planned_caps()[-1]["w4a16_block_size_m"] == 48
+-        assert h.api.bound[-1][0].caps["max_tokens"] == MAX_BATCHED
++        assert h.api.bound[-1][0].caps["max_tokens"] == 128
+ 
+ 
+ def test_parity_window_capacity_is_validated_before_planning():
+@@ -259,7 +443,11 @@ def test_disabled_prefill_plan_keeps_full_parity_capacity():
+ 
+ 
+ def test_explicit_parity_path_guarded_against_capture():
+-    with _Harness(env={"VLLM_EXL3_TRELLIS_MIN_M": "4"}) as h:
++    env = {
++        "VLLM_EXL3_TRELLIS_MIN_M": "4",
++        "VLLM_EXL3_PREFILL_CAPACITY": "128",
++    }
++    with _Harness(env=env) as h:
+         method = _make_method()
+         layer = _make_layer()
+         # Plan eagerly, then flip into "capturing" state.
+@@ -268,18 +456,14 @@ def test_explicit_parity_path_guarded_against_capture():
+         # Both trellis plans stay capture-safe.
+         _apply(method, layer, 16)
+         _apply(method, layer, 200)
+-        assert h.api.bound[-1][1] == 200
++        assert [bound[1] for bound in h.api.bound[-2:]] == [128, 72]
+         # The eager parity path must refuse to be recorded.
+-        try:
++        with pytest.raises(RuntimeError, match="capture"):
+             _apply(method, layer, 2)
+-        except RuntimeError as err:
+-            assert "capture" in str(err)
+-        else:
+-            raise AssertionError("parity path must raise during capture")
+ 
+ 
+ if __name__ == "__main__":
+-    test_dual_plan_construction_and_dispatch()
++    test_opt_in_prefill_capacity_slices_dispatch()
+     test_prefill_trellis_disabled_restores_parity()
+     test_prefill_block_m_env_override()
+     test_explicit_parity_path_guarded_against_capture()
+diff --git a/tests/quantization/test_quantization_config_args.py b/tests/quantization/test_quantization_config_args.py
+index 2ec8761fc75de25e7c156375ec67041cb74fcd66..d881f82cbe82a40d587128095cb0ed38d886fe36 100644
+--- a/tests/quantization/test_quantization_config_args.py
++++ b/tests/quantization/test_quantization_config_args.py
+@@ -187,6 +187,35 @@ def test_resolve_rejects_modelopt_moe_override():
+         )
+ 
+ 
++def test_resolve_allows_exl3_bf16_mxfp8_overlay():
++    args = resolve_quantization_config(
++        "exl3",
++        {
++            "linear": {"weight": "mxfp8"},
++            "shared_experts": "mxfp8",
++            "ignore": ["re:.*q_a_proj$", "lm_head"],
++        },
++    )
++
++    assert args.linear == QuantSpec(weight=kMxfp8Dynamic)
++    assert args.shared_experts == QuantSpec(weight=kMxfp8Dynamic)
++    assert args.ignore == ["re:.*q_a_proj$", "lm_head"]
++
++
++@pytest.mark.parametrize(
++    "config",
++    [
++        {"linear": {"weight": "fp8_per_block_static"}},
++        {"linear": {"weight": "mxfp8", "activation": "mxfp8"}},
++        {"linear": {"weight": "mxfp8"}, "moe": "mxfp8"},
++        {"shared_experts": "mxfp8", "ignore": ["lm_head"]},
++    ],
++)
++def test_resolve_rejects_unsupported_exl3_overlay(config):
++    with pytest.raises(ValueError, match="checkpoint online overlay"):
++        resolve_quantization_config("exl3", config)
++
++
+ def test_resolve_rejects_quantization_config_with_non_shorthand_quant():
+     # If --quantization names something other than an online shorthand,
+     # quantization_config is not allowed via this path (checkpoint quant
+diff --git a/tests/v1/cudagraph/test_breakable_cudagraph.py b/tests/v1/cudagraph/test_breakable_cudagraph.py
+index 72a9a11d3cb81cf388b7a42fc7ba7af68ae9a288..aedc99a1787da628151a439d96f7d175cce94649 100644
+--- a/tests/v1/cudagraph/test_breakable_cudagraph.py
++++ b/tests/v1/cudagraph/test_breakable_cudagraph.py
+@@ -99,6 +99,7 @@ def test_memory_profile_reuses_production_pool_and_destroys_graphs(monkeypatch):
+         def capture(self, *args, **kwargs):
+             assert self.pool is production_pool
+             assert wrapper.graph_pool is production_pool
++            assert kwargs["channel_id"] == "vllm:target:profile"
+             lazy_wrapper = FakeWrapper()
+             lazy_wrapper.graph_pool = self.pool
+             lazy_wrappers.append(lazy_wrapper)
+@@ -112,8 +113,9 @@ def test_memory_profile_reuses_production_pool_and_destroys_graphs(monkeypatch):
+         def get_cudagraph_managers(self):
+             return []
+ 
+-        def capture(self):
++        def capture(self, *, capture_phase):
+             assert workspace_module._workspace_lane.get() == 1
++            assert capture_phase == "profile"
+             events.append("spec_capture")
+ 
+     manager = FakeManager()
+@@ -235,6 +237,7 @@ def test_production_capture_releases_pool_anchor_on_failure(monkeypatch):
+ 
+         @staticmethod
+         def capture(*args, **kwargs):
++            assert kwargs["channel_id"] == "vllm:target:production"
+             events.append("capture")
+             raise RuntimeError("capture failed")
+ 
+@@ -269,6 +272,60 @@ def test_production_capture_releases_pool_anchor_on_failure(monkeypatch):
+     assert events == ["capture", "anchor_reset"]
+ 
+ 
++def test_production_capture_assigns_target_and_draft_phase_ids(monkeypatch):
++    from vllm.v1.worker.gpu import model_runner as model_runner_module
++
++    events = []
++
++    class FakeManager:
++        @staticmethod
++        def needs_capture():
++            return True
++
++        @staticmethod
++        def capture(*args, **kwargs):
++            events.append(("target", kwargs["channel_id"]))
++
++    class FakeSpeculator:
++        @staticmethod
++        def capture(*, capture_phase):
++            events.append(("draft", capture_phase))
++
++    runner = model_runner_module.GPUModelRunner.__new__(
++        model_runner_module.GPUModelRunner
++    )
++    runner.cudagraph_manager = FakeManager()
++    runner._cudagraph_pool_anchor = None
++    runner.lora_config = None
++    runner.model = object()
++    runner.model_state = object()
++    runner.input_buffers = object()
++    runner.intermediate_tensors = object()
++    runner.block_tables = object()
++    runner.attn_groups = object()
++    runner.kv_cache_config = object()
++    runner.use_aux_hidden_state_outputs = False
++    runner.speculator = FakeSpeculator()
++    runner.maybe_setup_dummy_loras = lambda _: nullcontext()
++    runner._zero_cudagraph_capture_kv_blocks = lambda: None
++
++    monkeypatch.setattr(model_runner_module.gc, "collect", lambda: None)
++    monkeypatch.setattr(torch.accelerator, "empty_cache", lambda: None)
++    monkeypatch.setattr(
++        torch.accelerator,
++        "get_memory_info",
++        lambda: (1000, 0),
++    )
++    monkeypatch.setattr(model_runner_module, "lock_workspace", lambda: None)
++
++    runner.capture_model()
++
++    assert events == [
++        ("target", "vllm:target:production"),
++        ("draft", "production"),
++    ]
++
++
+ def test_skipped_production_capture_releases_pool_anchor():
+     from vllm.v1.worker.gpu import model_runner as model_runner_module
+ 
+@@ -372,13 +429,21 @@ def test_piecewise_capture_builds_fresh_metadata_for_both_passes():
+         patch(
+             "vllm.v1.worker.gpu.cudagraph_utils.graph_capture",
+             return_value=nullcontext(),
+-        ),
++        ) as graph_capture_mock,
+         patch(
+             "vllm.v1.worker.gpu.cudagraph_utils.is_global_first_rank",
+             return_value=False,
+         ),
+     ):
+-        manager.capture(create_forward_fn)
++        manager.capture(
++            create_forward_fn,
++            channel_id="vllm:target:profile",
++        )
++
++    graph_capture_mock.assert_called_once_with(
++        device=torch.device("cpu"),
++        channel_id="vllm:target:profile",
++    )
+ 
+     assert [warmup for warmup, _ in create_calls] == [True, False]
+     assert [mode for _, mode, _ in forward_calls] == [
+diff --git a/tests/v1/kv_connector/unit/offloading_connector/test_scheduler.py b/tests/v1/kv_connector/unit/offloading_connector/test_scheduler.py
+index c783957de6717a633d46e78f210735fc6dfacd45..90800361815b1cc1ac541011b411e4d0206fe97f 100644
+--- a/tests/v1/kv_connector/unit/offloading_connector/test_scheduler.py
++++ b/tests/v1/kv_connector/unit/offloading_connector/test_scheduler.py
+@@ -1783,6 +1783,288 @@ def test_swa_alignment_skip(request_runner, async_scheduling: bool):
+     )
+ 
+ 
++@pytest.mark.parametrize("async_scheduling", [True, False])
++def test_swa_alignment_skip_eagle(request_runner, async_scheduling: bool):
++    """EAGLE/MTP SWA groups store their per-segment tail run shifted one
++    block past the segment boundary.
++
++    _lookup requires sliding_window_size_in_chunks + 1 consecutive stored
++    blocks for eagle groups (the "+1 peek" block, dropped after matching).
++    Mirroring SlidingWindowManager.reachable_block_mask (shift=1), the store
++    path retains a run of tail + 1 blocks ending one block PAST each segment
++    boundary, so the post-drop hit lands exactly on the boundary.
++
++    Setup:
++      - Group 0: full attention, block_size=16
++      - Group 1: SWA + eagle, block_size=4, sliding_window=8
++
++    alignment_chunk_count = 16 / 4 = 4, tail = 2, need = 3 (incl. peek).
++    Reachable block positions: {2, 3, 4} and {6, 7, 8} (shifted by one).
++
++    With a 36-token prompt (2 full full-attn blocks, 9 SWA blocks):
++      - Group 0 stores: blocks 0, 1
++      - Group 1 stores: blocks 2, 3, 4, 6, 7, 8
++
++    A replay then hits exactly 32 tokens (the second segment boundary): the
++    eagle lookup matches the run [6, 7, 8], drops peek block 8, and the
++    load fetches window blocks [6, 7].
++    """
++    full_attn_block_size = 16
++    swa_block_size = 4
++    sliding_window = 8
++    num_gpu_blocks = 200
++
++    kv_cache_groups = [
++        KVCacheGroupSpec(
++            ["layer0"],
++            FullAttentionSpec(
++                block_size=full_attn_block_size,
++                num_kv_heads=1,
++                head_size=1,
++                dtype=torch.float32,
++            ),
++        ),
++        KVCacheGroupSpec(
++            ["layer1"],
++            SlidingWindowSpec(
++                block_size=swa_block_size,
++                num_kv_heads=1,
++                head_size=1,
++                dtype=torch.float32,
++                sliding_window=sliding_window,
++            ),
++            is_eagle_group=True,
++        ),
++    ]
++
++    runner = request_runner(
++        block_size=swa_block_size,
++        num_gpu_blocks=num_gpu_blocks,
++        async_scheduling=async_scheduling,
++        kv_cache_groups=kv_cache_groups,
++    )
++
++    kv_group_configs = runner.connector_scheduler.config.kv_group_configs
++    assert kv_group_configs[1].is_eagle_group
++    assert kv_group_configs[1].alignment_chunk_count == 4
++    assert kv_group_configs[1].sliding_window_size_in_chunks == 2
++    # No sparse retention -> no per-request replay tail.
++    assert runner.connector_scheduler.config.replay_alignment_tokens is None
++
++    # Track stored keys so lookups reflect the actual store-side filtering.
++    stored_keys: set = set()
++
++    def _prepare_store(keys, req_context):
++        keys = list(keys)
++        stored_keys.update(keys)
++        return generate_store_output(keys)
++
++    runner.manager.prepare_store.side_effect = _prepare_store
++    runner.manager.lookup.side_effect = lambda key, req_context: (
++        LookupResult.HIT if key in stored_keys else LookupResult.MISS
++    )
++
++    num_tokens = 36
++    runner.new_request(token_ids=[0] * num_tokens)
++    runner.run(decoded_tokens=[0])
++    runner.run(
++        decoded_tokens=[EOS_TOKEN_ID],
++        expected_stored=(
++            (0, 0),
++            (0, 1),
++            (1, 2),
++            (1, 3),
++            (1, 4),
++            (1, 6),
++            (1, 7),
++            (1, 8),
++        ),
++    )
++
++    # Replay the same prompt; the eagle group must hit exactly at the
++    # 32-token segment boundary via the shifted run [6, 7, 8].
++    runner.scheduler.reset_prefix_cache()
++    # Avoid re-storing the (unloaded) peek block during the replay.
++    runner.manager.prepare_store.side_effect = lambda keys, req_context: (
++        generate_store_output([])
++    )
++    runner.new_request(token_ids=[0] * num_tokens)
++    runner.run(
++        decoded_tokens=[EOS_TOKEN_ID],
++        expected_loaded=(
++            (0, 0),
++            (0, 1),
++            (1, 6),
++            (1, 7),
++        ),
++    )
++
++
++@pytest.mark.parametrize("async_scheduling", [True, False])
++def test_swa_alignment_retention_interval(
++    request_runner, monkeypatch, async_scheduling: bool
++):
++    """VLLM_PREFIX_CACHE_RETENTION_INTERVAL sets the sparsity segment size,
++    and a per-request replay-boundary tail keeps exact replays servable.
++
++    Mirrors SlidingWindowManager.reachable_block_mask: with sparse retention
++    the local GPU cache keeps SWA tails once per retention interval (not at
++    every full-attention block boundary), plus one tail run at the latest
++    full-attention-aligned boundary of the prompt (the "replay boundary") so
++    a replay of the same prompt does not fall back a whole retention segment.
++
++    Setup:
++      - retention interval = 32 tokens
++      - Group 0: full attention, block_size=16
++      - Group 1: SWA, block_size=4, sliding_window=8
++
++    alignment_chunk_count = 32 / 4 = 8 (retention-based, not 16 / 4 = 4).
++
++    With a 56-token prompt (3 full full-attn blocks, 14 SWA blocks):
++      - segment tails: blocks {6, 7} (the second segment is incomplete:
++        blocks 14, 15 never fill)
++      - replay boundary: (56 - 1) // 16 * 16 = 48 -> tail run {10, 11}
++      - Group 1 stores: blocks 6, 7, 10, 11
++
++    A replay of the prompt hits 48 tokens via the replay tail {10, 11};
++    without it, the hit would fall back to 32 (the only segment boundary).
++    """
++    monkeypatch.setenv("VLLM_PREFIX_CACHE_RETENTION_INTERVAL", "32")
++
++    full_attn_block_size = 16
++    swa_block_size = 4
++    sliding_window = 8
++    num_gpu_blocks = 200
++
++    kv_cache_groups = [
++        KVCacheGroupSpec(
++            ["layer0"],
++            FullAttentionSpec(
++                block_size=full_attn_block_size,
++                num_kv_heads=1,
++                head_size=1,
++                dtype=torch.float32,
++            ),
++        ),
++        KVCacheGroupSpec(
++            ["layer1"],
++            SlidingWindowSpec(
++                block_size=swa_block_size,
++                num_kv_heads=1,
++                head_size=1,
++                dtype=torch.float32,
++                sliding_window=sliding_window,
++            ),
++        ),
++    ]
++
++    runner = request_runner(
++        block_size=swa_block_size,
++        num_gpu_blocks=num_gpu_blocks,
++        async_scheduling=async_scheduling,
++        kv_cache_groups=kv_cache_groups,
++    )
++
++    config = runner.connector_scheduler.config
++    # Segment granularity comes from the retention interval.
++    assert config.kv_group_configs[1].alignment_chunk_count == 8
++    assert config.kv_group_configs[1].sliding_window_size_in_chunks == 2
++    # Replay tails align to the full-attention block size.
++    assert config.replay_alignment_tokens == full_attn_block_size
++
++    # Track stored keys so lookups reflect the actual store-side filtering.
++    stored_keys: set = set()
++
++    def _prepare_store(keys, req_context):
++        keys = list(keys)
++        stored_keys.update(keys)
++        return generate_store_output(keys)
++
++    runner.manager.prepare_store.side_effect = _prepare_store
++    runner.manager.lookup.side_effect = lambda key, req_context: (
++        LookupResult.HIT if key in stored_keys else LookupResult.MISS
++    )
++
++    num_tokens = 56
++    runner.new_request(token_ids=[0] * num_tokens)
++    runner.run(decoded_tokens=[0])
++    runner.run(
++        decoded_tokens=[EOS_TOKEN_ID],
++        expected_stored=(
++            (0, 0),
++            (0, 1),
++            (0, 2),
++            (1, 6),
++            (1, 7),
++            (1, 10),
++            (1, 11),
++        ),
++    )
++
++    # Replay the same prompt; the hit must reach the 48-token replay
++    # boundary served by the replay tail run {10, 11}.
++    runner.scheduler.reset_prefix_cache()
++    runner.manager.prepare_store.side_effect = lambda keys, req_context: (
++        generate_store_output([])
++    )
++    runner.new_request(token_ids=[0] * num_tokens)
++    runner.run(
++        decoded_tokens=[EOS_TOKEN_ID],
++        expected_loaded=(
++            (0, 0),
++            (0, 1),
++            (0, 2),
++            (1, 10),
++            (1, 11),
++        ),
++    )
++
++
++def test_swa_alignment_retains_shared_prefix_boundary(request_runner, monkeypatch):
++    """Native offload retains the same sparse shared-prefix tail as APC."""
++    monkeypatch.setenv("VLLM_PREFIX_CACHE_RETENTION_INTERVAL", "64")
++
++    kv_cache_groups = [
++        KVCacheGroupSpec(
++            ["layer0"],
++            FullAttentionSpec(
++                block_size=16,
++                num_kv_heads=1,
++                head_size=1,
++                dtype=torch.float32,
++            ),
++        ),
++        KVCacheGroupSpec(
++            ["layer1"],
++            SlidingWindowSpec(
++                block_size=4,
++                num_kv_heads=1,
++                head_size=1,
++                dtype=torch.float32,
++                sliding_window=8,
++            ),
++        ),
++    ]
++    runner = request_runner(
++        block_size=4,
++        num_gpu_blocks=200,
++        async_scheduling=False,
++        kv_cache_groups=kv_cache_groups,
++    )
++
++    runner.new_request(token_ids=[0] * 56)
++    request = runner.scheduler.requests[str(runner.req_id)]
++    request.shared_prefix_boundary = 32
++
++    group_config = runner.connector_scheduler.config.kv_group_configs[1]
++    assert runner.connector_scheduler._reachable_tail_end_chunks(
++        group_config, request, shift=0
++    ) == (
++        12,  # Latest replay boundary: floor((56 - 1) / 16) * 16 / 4.
++        8,  # Shared-prefix junction: 32 / 4.
++    )
++
++
+ @pytest.mark.parametrize("async_scheduling", [True, False])
+ def test_stale_sliding_window_block_after_prepare_store_failure(
+     request_runner, async_scheduling: bool
+diff --git a/tests/v1/kv_offload/cpu/test_gpu_worker.py b/tests/v1/kv_offload/cpu/test_gpu_worker.py
+index 2f1ce67e9c4103a45ccc195683e656e6d38279d7..3dd254128a5777295f6edd806356107800869dfe 100644
+--- a/tests/v1/kv_offload/cpu/test_gpu_worker.py
++++ b/tests/v1/kv_offload/cpu/test_gpu_worker.py
+@@ -3,7 +3,10 @@
+ import random
+ import time
+ import uuid
++from types import SimpleNamespace
++from unittest.mock import MagicMock, call
+ 
++import numpy as np
+ import pytest
+ import torch
+ 
+@@ -16,8 +19,15 @@ from vllm.v1.kv_offload.base import (
+     CanonicalKVCacheTensor,
+     GPULoadStoreSpec,
+ )
++from vllm.v1.kv_offload.cpu import gpu_worker
+ from vllm.v1.kv_offload.cpu.common import CPULoadStoreSpec
+-from vllm.v1.kv_offload.cpu.gpu_worker import CPUOffloadingWorker
++from vllm.v1.kv_offload.cpu.gpu_worker import (
++    HOST_REGISTER_ALIGNMENT_BYTES,
++    HOST_REGISTER_SEGMENT_BYTES,
++    CPUOffloadingWorker,
++    _split_copy_descriptors_at_host_boundaries,
++    pin_mmap_region,
++)
+ from vllm.v1.kv_offload.cpu.shared_offload_region import SharedOffloadRegion
+ 
+ NUM_GPU_BLOCKS = [64]
+@@ -32,6 +42,179 @@ NUM_MAPPINGS = [3]
+ NUM_MAPPINGS_PER_GROUP = [2]
+ 
+ 
++def _mock_mmap_region(
++    total_size_bytes: int = 4096, row_stride: int = 4096
++) -> SimpleNamespace:
++    return SimpleNamespace(
++        rank=2,
++        total_size_bytes=total_size_bytes,
++        _row_stride=row_stride,
++        _base=SimpleNamespace(data_ptr=lambda: 0x1000),
++        _registered_host_ptrs=[],
++        _host_register_segment_bytes=None,
++        is_pinned=False,
++    )
++
++
++def test_pin_mmap_region_falls_back_after_failed_registration(monkeypatch) -> None:
++    region = _mock_mmap_region()
++    register = MagicMock(return_value=1)
++    monkeypatch.setattr(gpu_worker.current_platform, "is_cuda_alike", lambda: True)
++    monkeypatch.setattr(gpu_worker, "register_host_memory", register)
++
++    pin_mmap_region(region)
++
++    register.assert_called_once_with(0x1000, 4096)
++    assert region.is_pinned is False
++
++
++def test_pin_mmap_region_keeps_successful_registration(monkeypatch) -> None:
++    region = _mock_mmap_region()
++    register = MagicMock(return_value=0)
++    monkeypatch.setattr(gpu_worker.current_platform, "is_cuda_alike", lambda: True)
++    monkeypatch.setattr(gpu_worker, "register_host_memory", register)
++
++    pin_mmap_region(region)
++
++    register.assert_called_once_with(0x1000, 4096)
++    assert region.is_pinned is True
++    assert region._registered_host_ptrs == [0x1000]
++
++
++def test_pin_mmap_region_retries_large_mapping_as_segments(monkeypatch) -> None:
++    tail_bytes = 4096
++    total_bytes = 2 * HOST_REGISTER_SEGMENT_BYTES + tail_bytes
++    region = _mock_mmap_region(total_bytes)
++    register = MagicMock(side_effect=[1, 0, 0, 0])
++    monkeypatch.setattr(gpu_worker.current_platform, "is_cuda_alike", lambda: True)
++    monkeypatch.setattr(gpu_worker, "register_host_memory", register)
++
++    pin_mmap_region(region)
++
++    assert register.call_args_list == [
++        call(0x1000, total_bytes),
++        call(0x1000, HOST_REGISTER_SEGMENT_BYTES),
++        call(
++            0x1000 + HOST_REGISTER_SEGMENT_BYTES,
++            HOST_REGISTER_SEGMENT_BYTES,
++        ),
++        call(0x1000 + 2 * HOST_REGISTER_SEGMENT_BYTES, tail_bytes),
++    ]
++    assert region.is_pinned is True
++    assert region._registered_host_ptrs == [
++        0x1000,
++        0x1000 + HOST_REGISTER_SEGMENT_BYTES,
++        0x1000 + 2 * HOST_REGISTER_SEGMENT_BYTES,
++    ]
++    assert region._host_register_segment_bytes == HOST_REGISTER_SEGMENT_BYTES
++
++
++def test_pin_mmap_region_aligns_segments_to_kv_rows(monkeypatch) -> None:
++    row_stride = 3 * 4096
++    segment_alignment = np.lcm(row_stride, HOST_REGISTER_ALIGNMENT_BYTES)
++    segment_bytes = (
++        HOST_REGISTER_SEGMENT_BYTES // segment_alignment
++    ) * segment_alignment
++    total_bytes = 2 * segment_bytes + row_stride
++    region = _mock_mmap_region(total_bytes, row_stride)
++    register = MagicMock(side_effect=[1, 0, 0, 0])
++    monkeypatch.setattr(gpu_worker.current_platform, "is_cuda_alike", lambda: True)
++    monkeypatch.setattr(gpu_worker, "register_host_memory", register)
++
++    pin_mmap_region(region)
++
++    assert register.call_args_list == [
++        call(0x1000, total_bytes),
++        call(0x1000, segment_bytes),
++        call(0x1000 + segment_bytes, segment_bytes),
++        call(0x1000 + 2 * segment_bytes, row_stride),
++    ]
++    assert region.is_pinned is True
++    assert region._host_register_segment_bytes == segment_bytes
++    assert segment_bytes % row_stride == 0
++    assert segment_bytes % HOST_REGISTER_ALIGNMENT_BYTES == 0
++
++
++def test_pin_mmap_region_rolls_back_partial_segment_registration(
++    monkeypatch,
++) -> None:
++    total_bytes = 3 * HOST_REGISTER_SEGMENT_BYTES
++    region = _mock_mmap_region(total_bytes)
++    register = MagicMock(side_effect=[1, 0, 0, 2])
++    unregister = MagicMock(return_value=0)
++    monkeypatch.setattr(gpu_worker.current_platform, "is_cuda_alike", lambda: True)
++    monkeypatch.setattr(gpu_worker, "register_host_memory", register)
++    monkeypatch.setattr(gpu_worker, "unregister_host_memory", unregister)
++
++    pin_mmap_region(region)
++
++    assert unregister.call_args_list == [
++        call(0x1000 + HOST_REGISTER_SEGMENT_BYTES),
++        call(0x1000),
++    ]
++    assert region.is_pinned is False
++    assert region._registered_host_ptrs == []
++
++
++@pytest.mark.parametrize("host_is_src", [False, True])
++def test_split_copy_descriptors_at_host_boundaries(host_is_src: bool) -> None:
++    host_base = 10_000
++    segment_bytes = 100
++    src = np.full(6, -1, dtype=np.int64)
++    dst = np.full(6, -1, dtype=np.int64)
++    sizes = np.full(6, -1, dtype=np.int64)
++
++    host_ptrs = [host_base + 90, host_base + 196]
++    device_ptrs = [20_000, 30_000]
++    if host_is_src:
++        src[:2], dst[:2] = host_ptrs, device_ptrs
++    else:
++        src[:2], dst[:2] = device_ptrs, host_ptrs
++    sizes[:2] = [20, 12]
++
++    count = _split_copy_descriptors_at_host_boundaries(
++        src,
++        dst,
++        sizes,
++        2,
++        host_is_src=host_is_src,
++        host_base=host_base,
++        segment_bytes=segment_bytes,
++    )
++
++    assert count == 4
++    expected_host = [host_base + 90, host_base + 100, host_base + 196, host_base + 200]
++    expected_device = [20_000, 20_010, 30_000, 30_004]
++    if host_is_src:
++        assert src[:count].tolist() == expected_host
++        assert dst[:count].tolist() == expected_device
++    else:
++        assert src[:count].tolist() == expected_device
++        assert dst[:count].tolist() == expected_host
++    assert sizes[:count].tolist() == [10, 10, 4, 8]
++
++
++def test_split_copy_descriptors_keeps_in_segment_copy() -> None:
++    src = np.array([20_000], dtype=np.int64)
++    dst = np.array([10_010], dtype=np.int64)
++    sizes = np.array([20], dtype=np.int64)
++
++    count = _split_copy_descriptors_at_host_boundaries(
++        src,
++        dst,
++        sizes,
++        1,
++        host_is_src=False,
++        host_base=10_000,
++        segment_bytes=100,
++    )
++
++    assert count == 1
++    assert src.tolist() == [20_000]
++    assert dst.tolist() == [10_010]
++    assert sizes.tolist() == [20]
++
++
+ @pytest.mark.parametrize("gpu_to_cpu", [True, False])
+ @pytest.mark.parametrize("num_mappings", NUM_MAPPINGS)
+ @pytest.mark.parametrize("gpu_page_size_bytes", GPU_PAGE_SIZES)
+diff --git a/tests/v1/kv_offload/cpu/test_host_mem_ops.py b/tests/v1/kv_offload/cpu/test_host_mem_ops.py
+new file mode 100644
+index 0000000000000000000000000000000000000000..02d527c9d58ce101d69a861f87c620ab7bfed332
+--- /dev/null
++++ b/tests/v1/kv_offload/cpu/test_host_mem_ops.py
+@@ -0,0 +1,44 @@
++# SPDX-License-Identifier: Apache-2.0
++# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
++from types import SimpleNamespace
++from unittest.mock import MagicMock
++
++import torch
++
++from vllm.v1.kv_offload.cpu import host_mem_ops
++
++
++def _driver_result(code: int) -> tuple[SimpleNamespace]:
++    return (SimpleNamespace(value=code),)
++
++
++def test_cuda_registration_uses_driver_api(monkeypatch) -> None:
++    driver = MagicMock()
++    driver.cuMemHostRegister.return_value = _driver_result(2)
++    driver.cuMemHostUnregister.return_value = _driver_result(0)
++    runtime_factory = MagicMock()
++    monkeypatch.setattr(host_mem_ops.current_platform, "is_cuda", lambda: True)
++    monkeypatch.setattr(host_mem_ops, "_get_cuda_driver", lambda: driver)
++    monkeypatch.setattr(host_mem_ops, "CudaRTLibrary", runtime_factory)
++
++    assert host_mem_ops.register_host_memory(0x1000, 4096) == 2
++    assert host_mem_ops.unregister_host_memory(0x1000) == 0
++
++    driver.cuMemHostRegister.assert_called_once_with(0x1000, 4096, 0)
++    driver.cuMemHostUnregister.assert_called_once_with(0x1000)
++    runtime_factory.assert_not_called()
++
++
++def test_rocm_registration_clears_runtime_failures(monkeypatch) -> None:
++    cudart = MagicMock()
++    cudart.cudaHostRegister.return_value = SimpleNamespace(value=1)
++    cudart.cudaHostUnregister.return_value = SimpleNamespace(value=2)
++    runtime = MagicMock()
++    monkeypatch.setattr(host_mem_ops.current_platform, "is_cuda", lambda: False)
++    monkeypatch.setattr(torch.cuda, "cudart", lambda: cudart)
++    monkeypatch.setattr(host_mem_ops, "CudaRTLibrary", lambda: runtime)
++
++    assert host_mem_ops.register_host_memory(0x2000, 8192) == 1
++    assert host_mem_ops.unregister_host_memory(0x2000) == 2
++
++    assert runtime.cudaGetLastError.call_count == 2
+diff --git a/tests/v1/kv_offload/cpu/test_shared_offload_region.py b/tests/v1/kv_offload/cpu/test_shared_offload_region.py
+index ca7295f1978e1cca51ceb3dfc3fcd7c54e3c90ba..c717c86c325ad35013dd2faccef1509beeb68a22 100644
+--- a/tests/v1/kv_offload/cpu/test_shared_offload_region.py
++++ b/tests/v1/kv_offload/cpu/test_shared_offload_region.py
+@@ -8,10 +8,12 @@ import os
+ import threading
+ import time
+ import uuid
++from unittest.mock import MagicMock, call
+ 
+ import pytest
+ 
+ from vllm.utils.system_utils import get_mp_context
++from vllm.v1.kv_offload.cpu import shared_offload_region
+ from vllm.v1.kv_offload.cpu.shared_offload_region import (
+     SharedOffloadRegion,
+     _wait_for_file_size,
+@@ -404,6 +406,77 @@ def test_file_has_correct_size(iid):
+         assert os.path.getsize(r.mmap_path) == 4 * PAGE_SIZE
+ 
+ 
++def test_unlink_after_all_workers_map_keeps_shared_mapping(iid):
++    """The production mode unlinks only after every worker owns its mmap."""
++    num_workers = 2
++    regions: list[SharedOffloadRegion | None] = [None, None]
++    errors: list[BaseException] = []
++    mmap_path = f"/dev/shm/vllm_offload_{iid}.mmap"
++
++    def create_rank0() -> None:
++        try:
++            regions[0] = SharedOffloadRegion(
++                engine_id=iid,
++                num_blocks=4,
++                rank=0,
++                kv_bytes_per_block=num_workers * PAGE_SIZE,
++                cpu_page_size=PAGE_SIZE,
++                unlink_after_workers_map=True,
++                num_workers=num_workers,
++            )
++        except BaseException as exc:
++            errors.append(exc)
++
++    rank0_thread = threading.Thread(target=create_rank0)
++    rank0_thread.start()
++    marker0 = f"{mmap_path}.mapped.0"
++    deadline = time.monotonic() + 5
++    while not os.path.exists(marker0):
++        assert time.monotonic() < deadline, "rank 0 did not publish its mmap marker"
++        time.sleep(0.005)
++
++    assert os.path.exists(mmap_path), "joiners still need the pathname"
++    regions[1] = SharedOffloadRegion(
++        engine_id=iid,
++        num_blocks=4,
++        rank=1,
++        kv_bytes_per_block=num_workers * PAGE_SIZE,
++        cpu_page_size=PAGE_SIZE,
++        unlink_after_workers_map=True,
++        num_workers=num_workers,
++    )
++    rank0_thread.join(timeout=5)
++
++    try:
++        assert not rank0_thread.is_alive()
++        assert not errors
++        assert regions[0] is not None
++        assert regions[1] is not None
++        assert not os.path.exists(mmap_path)
++        assert not os.path.exists(marker0)
++        assert not os.path.exists(f"{mmap_path}.mapped.1")
++
++        regions[0].mmap_obj[0:1] = b"\x2a"
++        assert regions[1].mmap_obj[0:1] == b"\x2a"
++    finally:
++        for region in regions:
++            if region is not None:
++                region.cleanup()
++        _cleanup_file(mmap_path)
++
++
++def test_unlink_after_workers_map_requires_worker_count(iid):
++    with pytest.raises(ValueError, match="num_workers must be positive"):
++        SharedOffloadRegion(
++            engine_id=iid,
++            num_blocks=4,
++            rank=0,
++            kv_bytes_per_block=PAGE_SIZE,
++            cpu_page_size=PAGE_SIZE,
++            unlink_after_workers_map=True,
++        )
++
++
+ # ---------------------------------------------------------------------------
+ # Multi-worker race — concurrent construction
+ # ---------------------------------------------------------------------------
+@@ -568,6 +641,34 @@ def test_cleanup_after_create_next_view_releases_mmap(iid):
+     assert mmap_obj.closed, "mmap should be closed after releasing the tensor"
+ 
+ 
++def test_cleanup_unregisters_tracked_segments_in_reverse(iid, monkeypatch):
++    """cleanup() must unregister the exact segments accepted during pinning."""
++    r = _make_region(iid)
++    unregister = MagicMock(return_value=0)
++    monkeypatch.setattr(
++        shared_offload_region.current_platform,
++        "is_cuda_alike",
++        lambda: True,
++    )
++    monkeypatch.setattr(
++        shared_offload_region,
++        "unregister_host_memory",
++        unregister,
++    )
++    r._registered_host_ptrs = [0x1000, 0x2000, 0x3000]
++    r.is_pinned = True
++
++    r.cleanup()
++
++    assert unregister.call_args_list == [
++        call(0x3000),
++        call(0x2000),
++        call(0x1000),
++    ]
++    assert r._registered_host_ptrs == []
++    assert r.is_pinned is False
++
++
+ # ---------------------------------------------------------------------------
+ # _wait_for_file_size
+ # ---------------------------------------------------------------------------
+diff --git a/tests/v1/kv_offload/test_factory.py b/tests/v1/kv_offload/test_factory.py
+index 98191db57b735fba639f7e809ac85a47645c2482..616b52ac306e2b5fe4caaf58ef22b4d3cbdca30e 100644
+--- a/tests/v1/kv_offload/test_factory.py
++++ b/tests/v1/kv_offload/test_factory.py
+@@ -328,7 +328,8 @@ def test_create_cpu_offloading_spec_end_to_end():
+ 
+ @pytest.mark.parametrize("packed", [False, True])
+ def test_cpu_spec_sizing_preserves_tensor_layout(packed: bool):
+-    cpu_bytes_to_use = 1920
++    alignment = SharedOffloadRegion.BLOCK_SIZE_ALIGNMENT
++    cpu_bytes_to_use = alignment * 3
+     config = _make_layout_vllm_config(
+         cpu_bytes_to_use=cpu_bytes_to_use,
+         extra_config={"block_size": 32},
+@@ -340,8 +341,85 @@ def test_cpu_spec_sizing_preserves_tensor_layout(packed: bool):
+ 
+     assert isinstance(spec, CPUOffloadingSpec)
+     assert spec.cpu_page_size_per_worker == 32
+-    assert spec.kv_bytes_per_chunk == 192
+-    assert spec.num_blocks == cpu_bytes_to_use // 192
++    assert spec.kv_bytes_per_chunk == alignment
++    assert spec.num_blocks == 3
++
++
++def test_cpu_spec_create_worker_uses_shared_region_on_cuda(monkeypatch):
++    import vllm.v1.kv_offload.cpu.spec as cpu_spec_module
++
++    alignment = SharedOffloadRegion.BLOCK_SIZE_ALIGNMENT
++    config = _make_layout_vllm_config(
++        cpu_bytes_to_use=alignment * 2,
++        tensor_parallel_size=4,
++    )
++    spec = _create_spec(config, _make_sizing_kv_cache_config(packed=False))
++    assert isinstance(spec, CPUOffloadingSpec)
++
++    region = MagicMock()
++    region_ctor = MagicMock(return_value=region)
++    worker_ctor = MagicMock(return_value=MagicMock())
++    monkeypatch.setattr(cpu_spec_module.current_platform, "is_cuda_alike", lambda: True)
++    monkeypatch.setattr(cpu_spec_module, "SharedOffloadRegion", region_ctor)
++    monkeypatch.setattr(cpu_spec_module, "CPUOffloadingWorker", worker_ctor)
++    monkeypatch.setattr(
++        cpu_spec_module.torch.accelerator, "current_device_index", lambda: 5
++    )
++
++    kv_caches = MagicMock()
++    spec.create_worker(kv_caches)
++
++    region_ctor.assert_called_once_with(
++        engine_id=spec.config.engine_id,
++        num_blocks=spec.num_blocks,
++        rank=1,
++        kv_bytes_per_block=spec.kv_bytes_per_chunk,
++        cpu_page_size=spec.cpu_page_size_per_worker,
++        unlink_after_workers_map=True,
++        num_workers=4,
++    )
++    worker_ctor.assert_called_once_with(
++        kv_caches=kv_caches,
++        blocks_per_chunk=spec.blocks_per_chunk,
++        num_cpu_blocks=spec.num_blocks,
++        mmap_region=region,
++    )
++
++
++@pytest.mark.parametrize("num_blocks", [0, 2])
++def test_cpu_spec_create_worker_keeps_tensor_path_without_cuda_or_blocks(
++    monkeypatch, num_blocks: int
++):
++    import vllm.v1.kv_offload.cpu.spec as cpu_spec_module
++
++    alignment = SharedOffloadRegion.BLOCK_SIZE_ALIGNMENT
++    config = _make_layout_vllm_config(cpu_bytes_to_use=alignment * 2)
++    kv_cache_config = _make_sizing_kv_cache_config(packed=False)
++    if num_blocks == 0:
++        kv_cache_config.num_blocks = 0
++    spec = _create_spec(config, kv_cache_config)
++    assert isinstance(spec, CPUOffloadingSpec)
++
++    region_ctor = MagicMock()
++    worker_ctor = MagicMock(return_value=MagicMock())
++    monkeypatch.setattr(
++        cpu_spec_module.current_platform,
++        "is_cuda_alike",
++        lambda: num_blocks == 0,
++    )
++    monkeypatch.setattr(cpu_spec_module, "SharedOffloadRegion", region_ctor)
++    monkeypatch.setattr(cpu_spec_module, "CPUOffloadingWorker", worker_ctor)
++
++    kv_caches = MagicMock()
++    spec.create_worker(kv_caches)
++
++    region_ctor.assert_not_called()
++    worker_ctor.assert_called_once_with(
++        kv_caches=kv_caches,
++        blocks_per_chunk=spec.blocks_per_chunk,
++        num_cpu_blocks=spec.num_blocks,
++        mmap_region=None,
++    )
+ 
+ 
+ def test_cpu_spec_rejects_partially_packed_tensor_layout():
+diff --git a/tests/v1/spec_decode/test_dflash_cudagraph_lifetime.py b/tests/v1/spec_decode/test_dflash_cudagraph_lifetime.py
+index 11fb1b66e85b09cf4f5cb74ee88a19c87dbd6a3a..89e5e79d0af63f12f19b69c50f0cdadaab030815 100644
+--- a/tests/v1/spec_decode/test_dflash_cudagraph_lifetime.py
++++ b/tests/v1/spec_decode/test_dflash_cudagraph_lifetime.py
+@@ -63,3 +63,34 @@ def test_dflash_does_not_retain_eager_backbone_output(monkeypatch):
+     )
+ 
+     assert speculator._captured_backbone_outputs == []
++
++
++def test_dflash_capture_uses_phase_specific_draft_channel_ids():
++    events = []
++
++    class FakeManager:
++        def capture(self, *args, **kwargs):
++            events.append(kwargs["channel_id"])
++
++    speculator = SimpleNamespace(
++        _speculator_name="DFlash",
++        sample_indices=torch.zeros(1),
++        sample_pos=torch.zeros(1),
++        sample_idx_mapping=torch.zeros(1),
++        query_cudagraph_manager=FakeManager(),
++        _generate_draft=object(),
++        input_buffers=object(),
++        block_tables=object(),
++        attn_groups=object(),
++        kv_cache_config=object(),
++        max_model_len=1,
++        _group_causal=True,
++    )
++
++    DFlashSpeculator.capture(speculator, capture_phase="profile")
++    DFlashSpeculator.capture(speculator, capture_phase="production")
++
++    assert events == [
++        "vllm:draft:dflash:profile",
++        "vllm:draft:dflash:production",
++    ]
+diff --git a/tests/v1/worker/test_gpu_autoregressive_speculator.py b/tests/v1/worker/test_gpu_autoregressive_speculator.py
+index 89dc32ee4c68d96afc57d5e2c380657364a9f4fe..53772397b56d3dd810ac4ce4f02f23079c75d45d 100644
+--- a/tests/v1/worker/test_gpu_autoregressive_speculator.py
++++ b/tests/v1/worker/test_gpu_autoregressive_speculator.py
+@@ -166,3 +166,42 @@ def test_ar_probabilistic_draft_uses_shared_sampler(monkeypatch):
+ 
+     assert captured["positions"] is positions
+     assert captured["active_rows"] is speculator.active_num_reqs
++
++
++def test_autoregressive_capture_ids_are_deterministic_and_phase_separated():
++    def capture_channel_ids() -> list[str]:
++        events = []
++
++        class FakeManager:
++            use_breakable_cg = False
++
++            def capture(self, *args, **kwargs):
++                events.append(kwargs["channel_id"])
++
++        speculator = object.__new__(_TestSpeculator)
++        speculator.last_token_indices = torch.zeros(1)
++        speculator.prefill_cudagraph_manager = FakeManager()
++        speculator.decode_cudagraph_manager = FakeManager()
++        speculator.model = object()
++        speculator._prefill = object()
++        speculator._generate_draft = object()
++        speculator.model_state = object()
++        speculator.target_input_buffers = object()
++        speculator.input_buffers = object()
++        speculator.block_tables = object()
++        speculator.target_attn_groups = object()
++        speculator.attn_groups = object()
++        speculator.kv_cache_config = object()
++        speculator.num_speculative_steps = 3
++
++        speculator.capture(capture_phase="profile")
++        speculator.capture(capture_phase="production")
++        return events
++
++    expected = [
++        "vllm:draft:prefill:profile",
++        "vllm:draft:decode:profile",
++        "vllm:draft:prefill:production",
++        "vllm:draft:decode:production",
++    ]
++    assert capture_channel_ids() == capture_channel_ids() == expected
+diff --git a/tests/v1/worker/test_gpu_model_runner.py b/tests/v1/worker/test_gpu_model_runner.py
+index 254432312cb3209f44a504e389a67ef8a382f46d..e341d2cbe7b469d6a1e120364a7a987891c5bc54 100644
+--- a/tests/v1/worker/test_gpu_model_runner.py
++++ b/tests/v1/worker/test_gpu_model_runner.py
+@@ -1,6 +1,7 @@
+ # SPDX-License-Identifier: Apache-2.0
+ # SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+ 
++from contextlib import contextmanager, nullcontext
+ from types import SimpleNamespace
+ from unittest.mock import Mock
+ 
+@@ -12,6 +13,7 @@ import vllm.v1.worker.gpu_model_runner as gpu_model_runner_module
+ from vllm.config import (
+     AttentionConfig,
+     CacheConfig,
++    CUDAGraphMode,
+     ModelConfig,
+     ParallelConfig,
+     SchedulerConfig,
+@@ -1779,3 +1781,367 @@ def test_mamba_cache_raises_when_max_num_seqs_exceeds_blocks():
+ 
+         with pytest.raises(ValueError, match="max_num_seqs"):
+             runner.initialize_kv_cache(kv_cache_config)
++
++
++def test_v1_capture_separates_target_and_draft_semantic_channels(monkeypatch):
++    runner = GPUModelRunner.__new__(GPUModelRunner)
++    runner.compilation_config = SimpleNamespace(cudagraph_mode=CUDAGraphMode.PIECEWISE)
++    runner.speculative_config = SimpleNamespace(
++        enforce_eager=False,
++        use_eagle=lambda: False,
++        uses_draft_model=lambda: True,
++        uses_extract_hidden_states=lambda: False,
++    )
++    runner.cudagraph_dispatcher = SimpleNamespace(
++        get_capture_descs=lambda: [
++            (CUDAGraphMode.FULL, []),
++            (CUDAGraphMode.PIECEWISE, [object()]),
++        ]
++    )
++    runner.encoder_cudagraph_manager = None
++    runner.device = torch.device("cpu")
++    runner._maybe_init_encoder_cudagraph_manager = lambda: None
++    runner._freeze_gc = nullcontext
++
++    active_channel: list[str] = []
++    channel_entries: list[str] = []
++    captures: list[tuple[str, bool]] = []
++
++    @contextmanager
++    def fake_graph_capture(*, device, channel_id, **kwargs):
++        assert device == runner.device
++        active_channel.append(channel_id)
++        channel_entries.append(channel_id)
++        try:
++            yield SimpleNamespace(channel_id=channel_id)
++        finally:
++            assert active_channel.pop() == channel_id
++
++    def fake_capture_cudagraphs(*, run_drafter, **kwargs):
++        assert len(active_channel) == 1
++        captures.append((active_channel[0], run_drafter))
++
++    runner._capture_cudagraphs = fake_capture_cudagraphs
++    runner.encoder_cudagraph_manager = SimpleNamespace(
++        capture=lambda **_: captures.append((active_channel[0], True))
++    )
++    memory_info = iter(((1000, 0), (900, 0)))
++    monkeypatch.setattr(gpu_model_runner_module, "graph_capture", fake_graph_capture)
++    monkeypatch.setattr(
++        gpu_model_runner_module,
++        "set_cudagraph_capturing_enabled",
++        lambda _: None,
++    )
++    monkeypatch.setattr(gpu_model_runner_module, "lock_workspace", lambda: None)
++    monkeypatch.setattr(
++        gpu_model_runner_module,
++        "current_platform",
++        SimpleNamespace(graph_pool_handle=object),
++    )
++    monkeypatch.setattr(
++        torch.accelerator,
++        "synchronize",
++        lambda: None,
++    )
++    monkeypatch.setattr(torch.accelerator, "empty_cache", lambda: None)
++    monkeypatch.setattr(
++        torch.accelerator,
++        "get_memory_info",
++        lambda: next(memory_info),
++    )
++
++    assert runner.capture_model() == 100
++    assert captures == [
++        ("vllm:target:production", False),
++        ("vllm:draft:production", True),
++        ("vllm:encoder:production", True),
++    ]
++    assert channel_entries == [
++        "vllm:target:production",
++        "vllm:draft:production",
++        "vllm:encoder:production",
++    ]
++
++
++def test_v1_full_capture_without_speculation_is_target_only(monkeypatch):
++    runner = GPUModelRunner.__new__(GPUModelRunner)
++    runner.compilation_config = SimpleNamespace(cudagraph_mode=CUDAGraphMode.FULL)
++    runner.speculative_config = None
++    runner.cudagraph_dispatcher = SimpleNamespace(
++        get_capture_descs=lambda: [(CUDAGraphMode.FULL, [object()])]
++    )
++    runner.encoder_cudagraph_manager = None
++    runner.device = torch.device("cpu")
++    runner._maybe_init_encoder_cudagraph_manager = lambda: None
++    runner._freeze_gc = nullcontext
++
++    channels: list[str] = []
++    captures: list[bool] = []
++
++    @contextmanager
++    def fake_graph_capture(*, channel_id, **kwargs):
++        channels.append(channel_id)
++        yield SimpleNamespace(channel_id=channel_id)
++
++    runner._capture_cudagraphs = lambda *, run_drafter, **_: captures.append(
++        run_drafter
++    )
++    memory_info = iter(((1000, 0), (900, 0)))
++    monkeypatch.setattr(gpu_model_runner_module, "graph_capture", fake_graph_capture)
++    monkeypatch.setattr(
++        gpu_model_runner_module,
++        "set_cudagraph_capturing_enabled",
++        lambda _: None,
++    )
++    monkeypatch.setattr(gpu_model_runner_module, "lock_workspace", lambda: None)
++    monkeypatch.setattr(
++        torch.accelerator,
++        "synchronize",
++        lambda: None,
++    )
++    monkeypatch.setattr(torch.accelerator, "empty_cache", lambda: None)
++    monkeypatch.setattr(
++        torch.accelerator,
++        "get_memory_info",
++        lambda: next(memory_info),
++    )
++
++    assert runner.capture_model() == 100
++    assert channels == ["vllm:target:production"]
++    assert captures == [True]
++
++
++def test_v1_profile_rolls_back_distinct_target_and_draft_channels(monkeypatch):
++    runner = GPUModelRunner.__new__(GPUModelRunner)
++    runner.vllm_config = object()
++    runner.device = torch.device("cpu")
++    runner.speculative_config = SimpleNamespace(
++        enforce_eager=False,
++        use_eagle=lambda: False,
++        uses_draft_model=lambda: True,
++        uses_extract_hidden_states=lambda: False,
++    )
++    desc = SimpleNamespace(num_tokens=32)
++    runner.cudagraph_dispatcher = SimpleNamespace(
++        get_capture_descs=lambda: [
++            (CUDAGraphMode.FULL, []),
++            (CUDAGraphMode.PIECEWISE, [desc]),
++        ],
++        cudagraph_keys={},
++        keys_initialized=True,
++    )
++    runner.max_model_len = 4096
++    runner.max_num_tokens = 256
++    runner.lora_config = None
++    runner._freeze_gc = nullcontext
++    runner._init_minimal_kv_cache_for_profiling = lambda: None
++    runner._create_encoder_cudagraph_manager = lambda: None
++    runner.maybe_remove_all_loras = lambda _: None
++
++    events: list[object] = []
++    active_channel: list[str] = []
++
++    @contextmanager
++    def fake_graph_capture(*, device, channel_id, **kwargs):
++        assert device == runner.device
++        active_channel.append(channel_id)
++        events.append(("enter", channel_id))
++        try:
++            yield SimpleNamespace(channel_id=channel_id)
++        finally:
++            assert active_channel.pop() == channel_id
++            events.append(("exit", channel_id))
++
++    def fake_warmup_and_capture(*args, run_drafter, **kwargs):
++        assert len(active_channel) == 1
++        events.append(("capture", active_channel[0], run_drafter))
++
++    runner._warmup_and_capture = fake_warmup_and_capture
++    runner._cleanup_profiling_kv_cache = lambda: events.extend(
++        ("cleanup-sync", "cleanup")
++    )
++
++    checkpoint = ((lambda _: None, "checkpoint"),)
++
++    def checkpoint_graph_channels():
++        events.append("checkpoint")
++        return checkpoint
++
++    monkeypatch.setattr(
++        gpu_model_runner_module,
++        "checkpoint_b12x_graph_channels",
++        checkpoint_graph_channels,
++    )
++    monkeypatch.setattr(
++        gpu_model_runner_module,
++        "rollback_b12x_graph_channels",
++        lambda value: events.append(("rollback", value)),
++    )
++    monkeypatch.setattr(gpu_model_runner_module, "graph_capture", fake_graph_capture)
++    monkeypatch.setattr(
++        gpu_model_runner_module,
++        "set_current_vllm_config",
++        lambda _: nullcontext(),
++    )
++    monkeypatch.setattr(
++        gpu_model_runner_module,
++        "current_platform",
++        SimpleNamespace(
++            graph_pool_handle=object,
++            is_rocm=lambda: False,
++        ),
++    )
++    monkeypatch.setattr(
++        gpu_model_runner_module,
++        "set_cudagraph_capturing_enabled",
++        lambda enabled: events.append(("capture-enabled", enabled)),
++    )
++    monkeypatch.setattr(
++        gpu_model_runner_module.CUDAGraphWrapper,
++        "_all_instances",
++        [],
++    )
++    monkeypatch.setattr(
++        gpu_model_runner_module.BreakableCUDAGraphWrapper,
++        "_all_instances",
++        [],
++    )
++    monkeypatch.setattr(
++        gpu_model_runner_module.CUDAGraphWrapper,
++        "clear_all_graphs",
++        lambda: events.append("clear-target"),
++    )
++    monkeypatch.setattr(
++        gpu_model_runner_module.BreakableCUDAGraphWrapper,
++        "clear_all_graphs",
++        lambda: events.append("clear-breakable"),
++    )
++    memory_info = iter(((1000, 0), (900, 0), (900, 0), (800, 0)))
++    monkeypatch.setattr(
++        torch.accelerator,
++        "synchronize",
++        lambda: events.append("sync"),
++    )
++    monkeypatch.setattr(torch.accelerator, "empty_cache", lambda: None)
++    monkeypatch.setattr(
++        torch.accelerator,
++        "get_memory_info",
++        lambda: next(memory_info),
++    )
++
++    assert runner.profile_cudagraph_memory() == 200
++    assert ("capture", "vllm:target:profile", False) in events
++    assert ("capture", "vllm:draft:profile", True) in events
++    assert events.index("clear-target") < events.index("cleanup")
++    assert events.index("cleanup-sync") < events.index("cleanup")
++    assert events.index("cleanup") < events.index(("rollback", checkpoint))
++    assert events[-1] == ("rollback", checkpoint)
++
++
++@pytest.mark.parametrize("cleanup_fails", [False, True])
++def test_v1_profile_restores_state_when_capture_or_cleanup_fails(
++    monkeypatch,
++    cleanup_fails,
++):
++    runner = GPUModelRunner.__new__(GPUModelRunner)
++    runner.vllm_config = object()
++    runner.device = torch.device("cpu")
++    runner.speculative_config = None
++    desc = SimpleNamespace(num_tokens=32)
++    runner.cudagraph_dispatcher = SimpleNamespace(
++        get_capture_descs=lambda: [(CUDAGraphMode.FULL, [desc])],
++        cudagraph_keys={},
++        keys_initialized=True,
++    )
++    runner.max_model_len = 4096
++    runner.max_num_tokens = 256
++    runner.lora_config = None
++    runner._freeze_gc = nullcontext
++    runner._init_minimal_kv_cache_for_profiling = lambda: None
++    runner._create_encoder_cudagraph_manager = lambda: None
++    runner.maybe_remove_all_loras = lambda _: None
++
++    events: list[object] = []
++
++    @contextmanager
++    def fake_graph_capture(**kwargs):
++        yield SimpleNamespace(channel_id=kwargs["channel_id"])
++
++    def fail_capture(*args, **kwargs):
++        events.append("capture-failed")
++        raise RuntimeError("expected capture failure")
++
++    runner._warmup_and_capture = fail_capture
++    runner._cleanup_profiling_kv_cache = lambda: events.extend(
++        ("cleanup-sync", "cleanup")
++    )
++    checkpoint = ((lambda _: None, "checkpoint"),)
++
++    monkeypatch.setattr(
++        gpu_model_runner_module,
++        "checkpoint_b12x_graph_channels",
++        lambda: checkpoint,
++    )
++    monkeypatch.setattr(
++        gpu_model_runner_module,
++        "rollback_b12x_graph_channels",
++        lambda value: events.append(("rollback", value)),
++    )
++    monkeypatch.setattr(gpu_model_runner_module, "graph_capture", fake_graph_capture)
++    monkeypatch.setattr(
++        gpu_model_runner_module,
++        "set_current_vllm_config",
++        lambda _: nullcontext(),
++    )
++    monkeypatch.setattr(
++        gpu_model_runner_module,
++        "current_platform",
++        SimpleNamespace(graph_pool_handle=object, is_rocm=lambda: False),
++    )
++    monkeypatch.setattr(
++        gpu_model_runner_module,
++        "set_cudagraph_capturing_enabled",
++        lambda enabled: events.append(("capture-enabled", enabled)),
++    )
++    original_pool = object()
++    wrapper = SimpleNamespace(graph_pool=original_pool)
++    monkeypatch.setattr(
++        gpu_model_runner_module.CUDAGraphWrapper,
++        "_all_instances",
++        [wrapper],
++    )
++    monkeypatch.setattr(
++        gpu_model_runner_module.BreakableCUDAGraphWrapper,
++        "_all_instances",
++        [],
++    )
++
++    def clear_target_graphs():
++        events.append("clear-target")
++        if cleanup_fails:
++            raise RuntimeError("expected cleanup failure")
++
++    monkeypatch.setattr(
++        gpu_model_runner_module.CUDAGraphWrapper,
++        "clear_all_graphs",
++        clear_target_graphs,
++    )
++    monkeypatch.setattr(
++        gpu_model_runner_module.BreakableCUDAGraphWrapper,
++        "clear_all_graphs",
++        lambda: events.append("clear-breakable"),
++    )
++    monkeypatch.setattr(torch.accelerator, "synchronize", lambda: None)
++    monkeypatch.setattr(torch.accelerator, "empty_cache", lambda: None)
++    monkeypatch.setattr(torch.accelerator, "get_memory_info", lambda: (1000, 0))
++
++    expected_error = "expected cleanup failure" if cleanup_fails else "capture failure"
++    with pytest.raises(RuntimeError, match=expected_error):
++        runner.profile_cudagraph_memory()
++
++    assert wrapper.graph_pool is original_pool
++    if not cleanup_fails:
++        assert events.index("clear-target") < events.index("cleanup")
++        assert events.index("cleanup-sync") < events.index("cleanup")
++        assert events.index("cleanup") < events.index(("rollback", checkpoint))
++    assert events[-1] == ("rollback", checkpoint)
+diff --git a/vllm/config/quantization.py b/vllm/config/quantization.py
+index b1a42cd8bfd5527cbb1e00caef4a0bb65f2fa7cf..826704b1918f71bdde8f587db64b75237b63fd41 100644
+--- a/vllm/config/quantization.py
++++ b/vllm/config/quantization.py
+@@ -153,11 +153,14 @@ ONLINE_QUANT_SHORTHAND_NAMES: tuple[str, ...] = (
+ )
+ 
+ 
+-# Checkpoint formats that support overlaying online quantization on BF16 projections
+-# which the checkpoint explicitly leaves unquantized (shared experts via
+-# `shared_experts`, other dense linears via `linear`).
+-_MODELOPT_ONLINE_OVERLAY_NAMES = frozenset(
+-    {
++# Checkpoint formats that support overlaying online quantization on projections
++# which the checkpoint explicitly leaves in BF16 (shared experts via
++# `shared_experts`, other dense linears via `linear`). Each checkpoint backend
++# still owns the layer-level dispatch, so serialized weights always take
++# precedence over this overlay.
++_CHECKPOINT_ONLINE_OVERLAY_WEIGHTS = {
++    name: frozenset({kMxfp8Dynamic, kFp8Static128BlockSym})
++    for name in {
+         "modelopt",
+         "modelopt_fp4",
+         "modelopt_mxfp8",
+@@ -165,16 +168,15 @@ _MODELOPT_ONLINE_OVERLAY_NAMES = frozenset(
+         "mxfp4",
+         "nvfp4_nf3_hybrid",
+     }
+-)
+-
+-
+-_MODELOPT_ONLINE_OVERLAY_WEIGHTS = frozenset({kMxfp8Dynamic, kFp8Static128BlockSym})
++}
++_CHECKPOINT_ONLINE_OVERLAY_WEIGHTS["exl3"] = frozenset({kMxfp8Dynamic})
+ 
+ 
+-def _is_modelopt_online_overlay(
++def _is_checkpoint_online_overlay(
+     quantization: str | None, args: QuantizationConfigArgs
+ ) -> bool:
+-    if quantization not in _MODELOPT_ONLINE_OVERLAY_NAMES or args.moe is not None:
++    supported_weights = _CHECKPOINT_ONLINE_OVERLAY_WEIGHTS.get(quantization)
++    if supported_weights is None or args.moe is not None:
+         return False
+     specs = [s for s in (args.linear, args.shared_experts) if s is not None]
+     if not specs:
+@@ -183,8 +185,7 @@ def _is_modelopt_online_overlay(
+         # `ignore` only filters the dense-linear overlay.
+         return False
+     return all(
+-        spec.weight in _MODELOPT_ONLINE_OVERLAY_WEIGHTS and spec.activation is None
+-        for spec in specs
++        spec.weight in supported_weights and spec.activation is None for spec in specs
+     )
+ 
+ 
+@@ -192,28 +193,39 @@ def resolve_quantization_config(
+     quantization: str | None,
+     quantization_config: dict[str, Any] | QuantizationConfigArgs | None,
+ ) -> QuantizationConfigArgs | None:
+-    """Resolve `--quantization` shorthand and `--quantization-config` into a
+-    QuantizationConfigArgs.
++    """Resolve quantization CLI settings into structured arguments.
+ 
+     `quantization` may be a CLI shorthand that desugars into a base config via
+     `_ONLINE_SHORTHANDS`. `quantization_config` is a dict or pre-built args
+     object. When both are online settings, fields explicitly set in
+-    `quantization_config` take precedence over the shorthand. ModelOpt accepts
+-    online overlays for BF16 dense/shared-expert projections.
++    `quantization_config` take precedence over the shorthand. Selected
++    checkpoint formats accept online overlays for BF16 dense/shared-expert
++    projections.
++
++    Args:
++        quantization: Quantization method name or online shorthand.
++        quantization_config: Explicit online quantization fields, if any.
++
++    Returns:
++        The resolved quantization arguments, or ``None`` when no online
++        configuration was requested.
++
++    Raises:
++        ValueError: If an explicit configuration cannot overlay the selected
++            checkpoint quantization method.
+     """
+     if isinstance(quantization_config, dict):
+         quantization_config = QuantizationConfigArgs(**quantization_config)
+ 
+     if quantization is not None and quantization not in ONLINE_QUANT_SHORTHAND_NAMES:
+-        if quantization_config is not None and not _is_modelopt_online_overlay(
++        if quantization_config is not None and not _is_checkpoint_online_overlay(
+             quantization, quantization_config
+         ):
+             raise ValueError(
+                 f"quantization_config is only supported when quantization is "
+                 f"one of {sorted(ONLINE_QUANT_SHORTHAND_NAMES)}, or when "
+-                f"using the ModelOpt online overlay (weight='mxfp8' or "
+-                f"weight='fp8_per_block_static' on 'shared_experts' and/or "
+-                f"'linear', optional 'ignore'), "
++                f"using a supported checkpoint online overlay on "
++                f"'shared_experts' and/or 'linear' (optional 'ignore'), "
+                 f"got quantization={quantization!r}"
+             )
+         return quantization_config
+diff --git a/vllm/distributed/device_communicators/cuda_communicator.py b/vllm/distributed/device_communicators/cuda_communicator.py
+index 82fa3723ed1030b01c303412ca594d8ed915e7ec..febdd95c4978af7c3b967eefc6d382b62b0d62a2 100644
+--- a/vllm/distributed/device_communicators/cuda_communicator.py
++++ b/vllm/distributed/device_communicators/cuda_communicator.py
+@@ -662,11 +662,14 @@ class CudaCommunicator(DeviceCommunicatorBase):
+             raise ValueError("No PyNCCL communicator found")
+ 
+     def destroy(self):
++        if self.ca_comm is not None:
++            # SparkInfer close is coordinated across ranks and must run before
++            # its NCCL exchange group is destroyed.
++            self.ca_comm.close()
++            self.ca_comm = None
+         if self.pynccl_comm is not None:
+             self.pynccl_comm.destroy()
+             self.pynccl_comm = None
+-        if self.ca_comm is not None:
+-            self.ca_comm = None
+         if self.aiter_ar_comm is not None:
+             self.aiter_ar_comm.close()
+             self.aiter_ar_comm = None
+diff --git a/vllm/distributed/device_communicators/cuda_wrapper.py b/vllm/distributed/device_communicators/cuda_wrapper.py
+index a5026163e9342506c0f04af18a652cc133034beb..188a86a401ac300363bfdd00ef67eff2e33621d2 100644
+--- a/vllm/distributed/device_communicators/cuda_wrapper.py
++++ b/vllm/distributed/device_communicators/cuda_wrapper.py
+@@ -48,6 +48,8 @@ class CudaRTLibrary:
+         Function("cudaDeviceReset", cudaError_t, []),
+         # const char* 	cudaGetErrorString ( cudaError_t error )
+         Function("cudaGetErrorString", ctypes.c_char_p, [cudaError_t]),
++        # cudaError_t cudaGetLastError ( void )
++        Function("cudaGetLastError", cudaError_t, []),
+         # ​cudaError_t 	cudaMalloc ( void** devPtr, size_t size )
+         Function(
+             "cudaMalloc",
+@@ -86,6 +88,7 @@ class CudaRTLibrary:
+         "cudaDeviceSynchronize": "hipDeviceSynchronize",
+         "cudaDeviceReset": "hipDeviceReset",
+         "cudaGetErrorString": "hipGetErrorString",
++        "cudaGetLastError": "hipGetLastError",
+         "cudaMalloc": "hipMalloc",
+         "cudaFree": "hipFree",
+         "cudaMemset": "hipMemset",
+@@ -142,6 +145,14 @@ class CudaRTLibrary:
+     def cudaGetErrorString(self, error: cudaError_t) -> str:
+         return self.funcs["cudaGetErrorString"](error).decode("utf-8")
+ 
++    def cudaGetLastError(self) -> int:
++        """Return and clear the calling thread's pending runtime error.
++
++        Returns:
++            The CUDA or HIP runtime error code that was cleared.
++        """
++        return int(self.funcs["cudaGetLastError"]())
++
+     def cudaSetDevice(self, device: int) -> None:
+         self.CUDART_CHECK(self.funcs["cudaSetDevice"](device))
+ 
+diff --git a/vllm/distributed/device_communicators/custom_all_reduce.py b/vllm/distributed/device_communicators/custom_all_reduce.py
+index 1b4b4f0cfcc229ca7bd522298059ed32b1afab0e..9a252b34e60d9b72588cbb85c128207aadf36b90 100644
+--- a/vllm/distributed/device_communicators/custom_all_reduce.py
++++ b/vllm/distributed/device_communicators/custom_all_reduce.py
+@@ -31,6 +31,12 @@ except Exception:
+ 
+ logger = init_logger(__name__)
+ 
++# The eager scheduler has one stable all-reduce stream owner.  Never derive
++# this identity from a process-local CUDA stream handle; SparkInfer deliberately
++# fails closed if the same logical owner is rebound to a second eager stream.
++_B12X_PCIE_EAGER_CHANNEL_ID = "vllm:eager:allreduce"
++_B12X_PCIE_MAX_CONCURRENT_CHANNELS = 2
++
+ 
+ def _get_pcie_allreduce_backend() -> str:
+     backend = envs.VLLM_PCIE_ALLREDUCE_BACKEND.lower()
+@@ -488,8 +494,15 @@ class CustomAllreduce:
+                     eager_buffer_bytes=pcie_oneshot_buffer_size,
+                     max_size=pcie_oneshot_buffer_size,
+                     single_channel=pcie_single_channel,
++                    max_concurrent_channels=_B12X_PCIE_MAX_CONCURRENT_CHANNELS,
++                )
++                if not pcie_single_channel:
++                    pcie_runtime.prepare_channels((_B12X_PCIE_EAGER_CHANNEL_ID,))
++                pcie_runtime.for_stream(
++                    channel_id=(
++                        None if pcie_single_channel else _B12X_PCIE_EAGER_CHANNEL_ID
++                    )
+                 )
+-                pcie_runtime.for_stream()
+             except Exception as exc:
+                 pcie_init_error = exc
+ 
+@@ -655,12 +668,26 @@ class CustomAllreduce:
+         ops.register_buffer(self._ptr, self.buffer_ptrs)
+ 
+     @contextmanager
+-    def capture(self, stream: torch.cuda.Stream | None = None):
++    def capture(
++        self,
++        stream: torch.cuda.Stream | None = None,
++        *,
++        channel_id: str | None = None,
++    ):
+         """Bind communicator resources to the enclosing CUDA graph capture.
+ 
+         Legacy custom all-reduce registers graph buffers on exit. SparkInfer
+         PCIe channels are instead created on the graph's owning stream and
+         remain valid for the graph lifetime.
++
++        Args:
++            stream: CUDA stream owned by the enclosing graph capture.
++            channel_id: Stable identity shared by every rank for this graph
++                owner. Required when the SparkInfer PCIe runtime is active.
++
++        Raises:
++            RuntimeError: If the PCIe runtime is active and ``channel_id`` is
++                ``None``.
+         """
+         old_pcie_capture_stream = self._pcie_capture_stream
+         try:
+@@ -668,8 +695,16 @@ class CustomAllreduce:
+             if self._pcie_runtime is None:
+                 yield
+             else:
++                if channel_id is None:
++                    raise RuntimeError(
++                        "distributed PCIe graph capture requires an explicit "
++                        "semantic channel_id"
++                    )
+                 self._pcie_capture_stream = stream
+-                with self._pcie_runtime.capture(stream=stream):
++                with self._pcie_runtime.capture(
++                    stream=stream,
++                    channel_id=channel_id,
++                ):
+                     yield
+         finally:
+             self._pcie_capture_stream = old_pcie_capture_stream
+@@ -727,7 +762,8 @@ class CustomAllreduce:
+     def register_graph_buffers(self):
+         if self._pcie_runtime is not None:
+             self._pcie_runtime.for_stream(
+-                self._pcie_runtime_stream()
++                self._pcie_runtime_stream(),
++                channel_id=_B12X_PCIE_EAGER_CHANNEL_ID,
+             ).register_graph_buffers()
+             return
+         handle, offset = ops.get_graph_buffer_ipc_meta(self._ptr)
+@@ -757,7 +793,8 @@ class CustomAllreduce:
+                 self._pcie_allreduce_max_size is not None
+                 and inp_size <= self._pcie_allreduce_max_size
+                 and self._pcie_runtime.for_stream(
+-                    self._pcie_runtime_stream()
++                    self._pcie_runtime_stream(),
++                    channel_id=_B12X_PCIE_EAGER_CHANNEL_ID,
+                 ).should_allreduce(inp)
+             )
+             if (
+@@ -836,7 +873,10 @@ class CustomAllreduce:
+                     self._pcie_runtime_stream() is not None,
+                 )
+             return self._pcie_runtime.all_reduce(
+-                inp, out=out, stream=self._pcie_runtime_stream()
++                inp,
++                out=out,
++                stream=self._pcie_runtime_stream(),
++                channel_id=_B12X_PCIE_EAGER_CHANNEL_ID,
+             )
+         if out is None:
+             out = torch.empty_like(inp)
+@@ -878,7 +918,8 @@ class CustomAllreduce:
+             return False
+         assert self._pcie_runtime is not None
+         if not self._pcie_runtime.for_stream(
+-            self._pcie_runtime_stream()
++            self._pcie_runtime_stream(),
++            channel_id=_B12X_PCIE_EAGER_CHANNEL_ID,
+         ).should_allreduce(inp):
+             return False
+         if (
+@@ -905,6 +946,7 @@ class CustomAllreduce:
+             out=inp,
+             residual_out=residual,
+             stream=self._pcie_runtime_stream(),
++            channel_id=_B12X_PCIE_EAGER_CHANNEL_ID,
+         )
+         return True
+ 
+@@ -932,12 +974,12 @@ class CustomAllreduce:
+             return self.all_reduce(input, registered=False)
+ 
+     def close(self):
+-        if self._pcie_dma is not None:
+-            self._pcie_dma.close()
+-            self._pcie_dma = None
+         if self._pcie_runtime is not None:
+             self._pcie_runtime.close()
+             self._pcie_runtime = None
++        if self._pcie_dma is not None:
++            self._pcie_dma.close()
++            self._pcie_dma = None
+         if not self.disabled and self._ptr:
+             if ops is not None:
+                 ops.dispose(self._ptr)
+@@ -945,7 +987,16 @@ class CustomAllreduce:
+             self.free_shared_buffer(self.meta_ptrs, rank=self.rank)
+             self.free_shared_buffer(self.buffer_ptrs, rank=self.rank)
+ 
+-    def __del__(self):
++    def __del__(self) -> None:
++        # A finalizer cannot collectively close SparkInfer after another rank
++        # has exited or vLLM has destroyed the process group. The backend owns
++        # abnormal resource finalization; explicit close() is coordinated by
++        # CudaCommunicator.destroy() while both process groups are still live.
++        if (
++            getattr(self, "_pcie_runtime", None) is not None
++            or getattr(self, "_pcie_dma", None) is not None
++        ):
++            return
+         self.close()
+ 
+     @staticmethod
+diff --git a/vllm/distributed/kv_transfer/kv_connector/v1/offloading/scheduler.py b/vllm/distributed/kv_transfer/kv_connector/v1/offloading/scheduler.py
+index 0d15ec22fdf9fd5cb41245495b073b0b6388f9d2..dfc5cc6a2a952056e33371fb2bc4def61c424f75 100644
+--- a/vllm/distributed/kv_transfer/kv_connector/v1/offloading/scheduler.py
++++ b/vllm/distributed/kv_transfer/kv_connector/v1/offloading/scheduler.py
+@@ -6,6 +6,7 @@ from dataclasses import dataclass, field
+ from itertools import chain, islice
+ from typing import Any, NamedTuple
+ 
++import vllm.envs as envs
+ from vllm.config import VllmConfig
+ from vllm.distributed.kv_events import KVCacheEvent
+ from vllm.distributed.kv_transfer.kv_connector.utils import yield_req_data
+@@ -84,10 +85,11 @@ class GroupOffloadConfig(NamedTuple):
+     kv_event_group_spec: OffloadingEventGroupSpec
+     # None below means full attention
+     sliding_window_size_in_chunks: int | None
+-    # Number of this group's offloaded chunks per full-attention alignment
+-    # segment. Used to skip storing SWA chunks that can never serve a load
+-    # hit (e.g. DeepSeek V4 where SWA groups have much smaller block sizes
+-    # than the MLA full-attention group).
++    # Number of this group's offloaded chunks per sparsity segment (the
++    # full-attention alignment size, or VLLM_PREFIX_CACHE_RETENTION_INTERVAL
++    # when sparse retention is configured). Used to skip storing SWA chunks
++    # that can never serve a load hit (e.g. DeepSeek V4 where SWA groups have
++    # much smaller block sizes than the MLA full-attention group).
+     # None for full-attention groups or when the optimization doesn't apply.
+     alignment_chunk_count: int | None = None
+     # True for EAGLE/MTP draft-model attention groups. The trailing chunk
+@@ -136,6 +138,11 @@ class SchedulerOffloadConfig(NamedTuple):
+     blocks_per_chunk: int
+     num_workers: int
+     offload_prompt_only: bool
++    # Token alignment of the per-request "replay boundary" tail (see
++    # OffloadingConnectorScheduler._replay_tail_end_chunk). Set to the
++    # full-attention alignment size when sparse retention
++    # (VLLM_PREFIX_CACHE_RETENTION_INTERVAL) is enabled, else None.
++    replay_alignment_tokens: int | None = None
+ 
+     @classmethod
+     def from_spec(
+@@ -164,16 +171,34 @@ class SchedulerOffloadConfig(NamedTuple):
+         if len(full_attn_tokens_per_chunk) == 1:
+             alignment_tokens = full_attn_tokens_per_chunk.pop()
+ 
++        # Mirror SlidingWindowManager.reachable_block_mask's segment-size
++        # choice: with sparse retention (VLLM_PREFIX_CACHE_RETENTION_INTERVAL)
++        # the local GPU prefix cache keeps SWA tails once per retention
++        # segment rather than at every full-attention block boundary. Use the
++        # same granularity so stored tails sit exactly where lookups converge.
++        # An interval of 0 (latest-boundary-only retention) disables the
++        # store-side skip entirely (conservative: store all chunks).
++        retention_interval = envs.VLLM_PREFIX_CACHE_RETENTION_INTERVAL
++        segment_tokens: int | None = (
++            alignment_tokens
++            if retention_interval is None
++            else (None if retention_interval == 0 else retention_interval)
++        )
++
+         def _alignment_chunk_count(
+             tokens_per_chunk: int,
+             sliding_window_size_in_chunks: int | None,
++            is_eagle_group: bool,
+         ) -> int | None:
+-            if alignment_tokens is None or sliding_window_size_in_chunks is None:
++            if segment_tokens is None or sliding_window_size_in_chunks is None:
+                 return None
+-            if alignment_tokens <= tokens_per_chunk:
++            if segment_tokens <= tokens_per_chunk:
+                 return None
+-            per_segment = alignment_tokens // tokens_per_chunk
+-            if sliding_window_size_in_chunks >= per_segment:
++            per_segment = segment_tokens // tokens_per_chunk
++            # Contiguous chunks a hit needs at a segment boundary, including
++            # the "+1 peek" chunk for EAGLE/MTP groups (see _lookup).
++            need = sliding_window_size_in_chunks + (1 if is_eagle_group else 0)
++            if need >= per_segment:
+                 return None
+             return per_segment
+ 
+@@ -216,7 +241,9 @@ class SchedulerOffloadConfig(NamedTuple):
+                         )
+                     ),
+                     alignment_chunk_count=_alignment_chunk_count(
+-                        tokens_per_block * spec.blocks_per_chunk, sw
++                        tokens_per_block * spec.blocks_per_chunk,
++                        sw,
++                        idx in eagle_groups,
+                     ),
+                     kv_event_group_spec=get_offloading_event_group_spec(
+                         kv_cache_config.kv_cache_groups[idx]
+@@ -227,6 +254,9 @@ class SchedulerOffloadConfig(NamedTuple):
+             ),
+             blocks_per_chunk=spec.blocks_per_chunk,
+             offload_prompt_only=spec.offload_prompt_only,
++            replay_alignment_tokens=(
++                alignment_tokens if retention_interval is not None else None
++            ),
+         )
+ 
+ 
+@@ -413,6 +443,20 @@ class OffloadingConnectorScheduler:
+             spec, kv_cache_config
+         )
+ 
++        # Tokens that must remain past a replay boundary for it to be
++        # servable: the last prompt token is always recomputed (hence the
++        # default of 1), and each EAGLE/MTP group must be able to match one
++        # complete chunk past the boundary (its "+1 peek", dropped after
++        # verification in _lookup).
++        self._replay_reserve_tokens: int = max(
++            (
++                group_config.tokens_per_chunk
++                for group_config in self.config.kv_group_configs
++                if group_config.is_eagle_group
++            ),
++            default=1,
++        )
++
+         self._req_status: dict[ReqId, RequestOffloadState] = {}
+         self._current_batch_load_jobs: dict[int, TransferJob] = {}
+         self._current_batch_jobs_to_flush: set[int] = set()
+@@ -943,6 +987,37 @@ class OffloadingConnectorScheduler:
+                         ):
+                             group_state.block_ids[j] = 0
+ 
++    def _reachable_tail_end_chunks(
++        self, group_config: GroupOffloadConfig, req: Request, shift: int
++    ) -> tuple[int, ...]:
++        """End chunk indices (exclusive) of serviceable boundary tails.
++
++        Mirrors the replay-boundary handling of
++        SlidingWindowManager.reachable_block_mask: with sparse retention,
++        segment tails exist only once per retention interval. Retain tails at
++        the request replay boundary and at a detected shared-prefix junction.
++        Clamp each boundary to the latest point that every group can service,
++        including a complete EAGLE/MTP peek chunk.
++        """
++        alignment_tokens = self.config.replay_alignment_tokens
++        if alignment_tokens is None:
++            return ()
++
++        latest_serviceable = req.num_prompt_tokens - self._replay_reserve_tokens
++        boundaries = [latest_serviceable]
++        if req.shared_prefix_boundary:
++            boundaries.append(min(req.shared_prefix_boundary, latest_serviceable))
++
++        ends: list[int] = []
++        for boundary in boundaries:
++            aligned = boundary // alignment_tokens * alignment_tokens
++            if aligned <= 0 or aligned % group_config.tokens_per_chunk != 0:
++                continue
++            end = aligned // group_config.tokens_per_chunk + shift
++            if end not in ends:
++                ends.append(end)
++        return tuple(ends)
++
+     def _build_store_jobs(
+         self,
+         scheduler_output: SchedulerOutput,
+@@ -995,22 +1070,45 @@ class OffloadingConnectorScheduler:
+ 
+                 alignment_chunk_count = group_config.alignment_chunk_count
+                 tail = group_config.sliding_window_size_in_chunks
++                # Chunks reachable by _sliding_window_lookup, mirroring
++                # SlidingWindowManager.reachable_block_mask: a hit needs
++                # `need` contiguous chunks ending at a segment boundary. For
++                # EAGLE/MTP groups the run includes the "+1 peek" chunk and
++                # is shifted one chunk past the boundary, so that after
++                # _lookup drops the peek the hit lands exactly on it.
++                need = shift = 0
++                reachable_end_chunks: tuple[int, ...] = ()
++                if alignment_chunk_count is not None:
++                    assert tail is not None
++                    shift = 1 if group_config.is_eagle_group else 0
++                    need = tail + shift
++                    reachable_end_chunks = self._reachable_tail_end_chunks(
++                        group_config, req, shift
++                    )
+ 
+                 for key_idx, (offload_key, block_id) in enumerate(
+                     zip(offload_keys, offload_block_ids)
+                 ):
+                     if block_id == 0:
+                         continue
+-                    # Skip SWA chunks that can never serve a load hit:
+-                    # within each full-attention alignment segment, only the
+-                    # trailing `tail` chunks are reachable by
++                    # Skip SWA chunks that can never serve a load hit: only
++                    # the trailing `need` chunks of each alignment segment
++                    # (plus the replay-boundary tail) are reachable by
+                     # _sliding_window_lookup. For DeepSeek V4 with 100K
+                     # tokens this reduces SWA stores by ~78%.
+                     if alignment_chunk_count is not None:
+-                        assert tail is not None
+                         abs_chunk_idx = start_chunk_idx + key_idx
+-                        pos_in_segment = abs_chunk_idx % alignment_chunk_count
+-                        if pos_in_segment < alignment_chunk_count - tail:
++                        reachable = (
++                            abs_chunk_idx >= shift
++                            and (abs_chunk_idx - shift) % alignment_chunk_count
++                            >= alignment_chunk_count - need
++                        )
++                        if not reachable:
++                            reachable = any(
++                                end - need <= abs_chunk_idx < end
++                                for end in reachable_end_chunks
++                            )
++                        if not reachable:
+                             continue
+                     new_offload_keys.append(offload_key)
+ 
+diff --git a/vllm/distributed/parallel_state.py b/vllm/distributed/parallel_state.py
+index 0364580062f895a5e726137c0624caa76a30ec96..fc86a31038e022b7fd38de56d4d12a87cdaf9208 100644
+--- a/vllm/distributed/parallel_state.py
++++ b/vllm/distributed/parallel_state.py
+@@ -65,6 +65,7 @@ if TYPE_CHECKING:
+ @dataclass
+ class GraphCaptureContext:
+     stream: torch.cuda.Stream
++    channel_id: str | None = None
+ 
+ 
+ TensorMetadata = namedtuple("TensorMetadata", ["device", "dtype", "size"])
+@@ -620,7 +621,10 @@ class GroupCoordinator:
+             )
+             ca_comm = self.device_communicator.ca_comm
+             if ca_comm is not None:
+-                maybe_ca_context = ca_comm.capture(stream=stream)  # type: ignore
++                maybe_ca_context = ca_comm.capture(  # type: ignore
++                    stream=stream,
++                    channel_id=graph_capture_context.channel_id,
++                )
+ 
+             from vllm._aiter_ops import rocm_aiter_ops
+ 
+@@ -1261,14 +1265,14 @@ class GroupCoordinator:
+         return self.device_communicator.recv(size, dtype, src)
+ 
+     def destroy(self):
++        if self.device_communicator is not None:
++            self.device_communicator.destroy()
+         if hasattr(self, "device_group"):
+             torch.distributed.destroy_process_group(self.device_group)
+             del self.device_group
+         if hasattr(self, "cpu_group"):
+             torch.distributed.destroy_process_group(self.cpu_group)
+             del self.cpu_group
+-        if self.device_communicator is not None:
+-            self.device_communicator.destroy()
+         if self.mq_broadcaster is not None:
+             self.mq_broadcaster = None
+ 
+@@ -1643,14 +1647,15 @@ def get_pcp_group() -> GroupCoordinator:
+ def graph_capture(
+     device: torch.device,
+     graph_capture_context: GraphCaptureContext | None = None,
++    channel_id: str | None = None,
+ ):
+     """
+     `graph_capture` is a context manager which should surround the code that
+     is capturing the CUDA graph. Its main purpose is to ensure that some
+     operations will be run after the graph is captured, before the graph
+     is replayed. It returns a `GraphCaptureContext` object which contains the
+-    necessary data for the graph capture. Currently, it only contains the
+-    stream that the graph capture is running on. This stream is set to the
++    necessary data for the graph capture: its stream and an optional semantic
++    channel identity for distributed capture resources. The stream is set to the
+     current CUDA stream when the context manager is entered and reset to the
+     default stream when the context manager is exited. This is to ensure that
+     the graph capture is running on a separate stream from the default stream,
+@@ -1659,22 +1664,47 @@ def graph_capture(
+ 
+     A caller may pass an explicit ``graph_capture_context`` to control the
+     stream used (e.g. to capture on the default stream).
++
++    Args:
++        device: Device that owns a newly created capture stream.
++        graph_capture_context: Existing capture context to reuse.
++        channel_id: Stable distributed identity for this graph owner.
++
++    Raises:
++        ValueError: If ``channel_id`` conflicts with the identity stored on
++            ``graph_capture_context``.
+     """
+-    context = graph_capture_context or GraphCaptureContext(
+-        torch.cuda.Stream(device=device)
+-    )
++    if graph_capture_context is None:
++        context = GraphCaptureContext(
++            torch.cuda.Stream(device=device),
++            channel_id=channel_id,
++        )
++    else:
++        context = graph_capture_context
++        if channel_id is not None:
++            if context.channel_id is not None and context.channel_id != channel_id:
++                raise ValueError(
++                    "graph capture channel_id conflicts with GraphCaptureContext"
++                )
++            if context.channel_id is None:
++                context = GraphCaptureContext(context.stream, channel_id=channel_id)
+     maybe_dcp_capture = (
+         get_dcp_group().graph_capture(context)
+         if _DCP is not None and get_dcp_group().world_size > 1
+         else nullcontext()
+     )
++    maybe_b12x_dcp_capture: contextlib.AbstractContextManager[Any]
+     if _DCP is not None and get_dcp_group().world_size > 1:
+         # Import locally to avoid making distributed initialization depend on
+         # attention modules. The helper is a no-op until DCP warmup creates a
+         # SparkInfer pool for this process group.
+         from vllm.v1.attention.ops.dcp_alltoall import capture_b12x_dcp_a2a
+ 
+-        maybe_b12x_dcp_capture = capture_b12x_dcp_a2a(get_dcp_group(), context.stream)
++        maybe_b12x_dcp_capture = capture_b12x_dcp_a2a(
++            get_dcp_group(),
++            context.stream,
++            channel_id=context.channel_id,
++        )
+     else:
+         maybe_b12x_dcp_capture = nullcontext()
+     with (
+diff --git a/vllm/envs.py b/vllm/envs.py
+index 3167a840af0635f4222e3a7467397c1502ccf084..7398bdb33dadee29f7d99937f54393a01b3a3ee0 100755
+--- a/vllm/envs.py
++++ b/vllm/envs.py
+@@ -2287,12 +2287,26 @@ environment_variables: dict[str, Callable[[], Any]] = {
+     "VLLM_EXL3_TRELLIS_MAX_M": lambda: os.getenv("VLLM_EXL3_TRELLIS_MAX_M"),
+     "VLLM_EXL3_TRELLIS_BLOCK_M": lambda: os.getenv("VLLM_EXL3_TRELLIS_BLOCK_M"),
+     "VLLM_EXL3_PREFILL_CHUNK": lambda: os.getenv("VLLM_EXL3_PREFILL_CHUNK"),
++    "VLLM_EXL3_PREFILL_CAPACITY": lambda: os.getenv("VLLM_EXL3_PREFILL_CAPACITY"),
+     "VLLM_EXL3_PREFILL_TRELLIS": lambda: os.getenv("VLLM_EXL3_PREFILL_TRELLIS"),
+     "VLLM_EXL3_PREFILL_BLOCK_M": lambda: os.getenv("VLLM_EXL3_PREFILL_BLOCK_M"),
++    # Deterministic online EXL3 encoding and its persistent rank-local cache.
++    "VLLM_EXL3_ONLINE_TRELLIS_BITS": lambda: os.getenv(
++        "VLLM_EXL3_ONLINE_TRELLIS_BITS"
++    ),
++    "VLLM_EXL3_ENCODER_SOURCE": lambda: os.getenv("VLLM_EXL3_ENCODER_SOURCE"),
++    "VLLM_EXL3_ENCODER_REVISION": lambda: os.getenv(
++        "VLLM_EXL3_ENCODER_REVISION"
++    ),
++    "VLLM_EXL3_ONLINE_CACHE_DIR": lambda: os.getenv(
++        "VLLM_EXL3_ONLINE_CACHE_DIR"
++    ),
++    "VLLM_EXL3_ONLINE_CACHE_MODE": lambda: os.getenv(
++        "VLLM_EXL3_ONLINE_CACHE_MODE"
++    ),
+     # Prebuilt exllamav3 extension location and torch-ABI compatibility shim.
+     "VLLM_EXL3_EXT_PATH": lambda: os.getenv("VLLM_EXL3_EXT_PATH"),
+     "VLLM_EXL3_ABI_SHIM": lambda: os.getenv("VLLM_EXL3_ABI_SHIM"),
+-
+ }
+ 
+ 
+diff --git a/vllm/model_executor/kernels/mhc/tilelang.py b/vllm/model_executor/kernels/mhc/tilelang.py
+index 885ec74f91e3957f32efda5b083257d735d498a8..639f6e059766f943b98615796b8ad8242770842d 100644
+--- a/vllm/model_executor/kernels/mhc/tilelang.py
++++ b/vllm/model_executor/kernels/mhc/tilelang.py
+@@ -407,6 +407,67 @@ def mhc_pre_broadcast_tilelang(
+     )
+ 
+ 
++def _mhc_pre_broadcast_tilelang_fake(
++    residual: torch.Tensor,
++    fn: torch.Tensor,
++    hc_scale: torch.Tensor,
++    hc_base: torch.Tensor,
++    rms_eps: float,
++    hc_pre_eps: float,
++    hc_sinkhorn_eps: float,
++    hc_post_mult_value: float,
++    sinkhorn_repeat: int,
++    n_splits: int = 1,
++    norm_weight: torch.Tensor | None = None,
++    norm_eps: float = 1e-6,
++    fn_broadcast: torch.Tensor | None = None,
++) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor, torch.Tensor]:
++    del (
++        hc_scale,
++        hc_base,
++        rms_eps,
++        hc_pre_eps,
++        hc_sinkhorn_eps,
++        hc_post_mult_value,
++        sinkhorn_repeat,
++        n_splits,
++        norm_weight,
++        norm_eps,
++        fn_broadcast,
++    )
++    num_tokens, hidden_size = residual.shape
++    hc_mult = fn.shape[1] // hidden_size
++    return (
++        torch.empty(
++            num_tokens,
++            hc_mult,
++            hidden_size,
++            dtype=torch.bfloat16,
++            device=residual.device,
++        ),
++        torch.empty(
++            num_tokens,
++            hc_mult,
++            1,
++            dtype=torch.float32,
++            device=residual.device,
++        ),
++        torch.empty(
++            num_tokens,
++            hc_mult,
++            hc_mult,
++            dtype=torch.float32,
++            device=residual.device,
++        ),
++        torch.empty(
++            num_tokens,
++            hidden_size,
++            dtype=torch.bfloat16,
++            device=residual.device,
++        ),
++    )
++
++
+ def mhc_post_tilelang(
+     x: torch.Tensor,
+     residual: torch.Tensor,
+@@ -782,6 +843,7 @@ def _hc_head_fused_kernel_tilelang_fake(
+ 
+ 
+ _mhc_pre_tilelang_impl = mhc_pre_tilelang
++_mhc_pre_broadcast_tilelang_impl = mhc_pre_broadcast_tilelang
+ _mhc_post_tilelang_impl = mhc_post_tilelang
+ _mhc_fused_post_pre_tilelang_impl = mhc_fused_post_pre_tilelang
+ 
+@@ -791,6 +853,12 @@ direct_register_custom_op(
+     mutates_args=[],
+     fake_impl=_mhc_pre_tilelang_fake,
+ )
++direct_register_custom_op(
++    op_name="mhc_pre_broadcast_tilelang",
++    op_func=_mhc_pre_broadcast_tilelang_impl,
++    mutates_args=[],
++    fake_impl=_mhc_pre_broadcast_tilelang_fake,
++)
+ direct_register_custom_op(
+     op_name="mhc_post_tilelang",
+     op_func=_mhc_post_tilelang_impl,
+@@ -816,6 +884,17 @@ def mhc_pre_tilelang(*args, **kwargs):
+     return torch.ops.vllm.mhc_pre_tilelang(*args, **kwargs)
+ 
+ 
++def mhc_pre_broadcast_tilelang(*args, **kwargs):
++    """Call broadcast MHC pre through the registered custom op.
++
++    The implementation invokes DeepGEMM through a pybind extension, which
++    cannot be traced by Dynamo. Keeping that call behind a custom-op boundary
++    lets full-graph compilation represent the operation without entering its
++    Python implementation.
++    """
++    return torch.ops.vllm.mhc_pre_broadcast_tilelang(*args, **kwargs)
++
++
+ def mhc_post_tilelang(*args, **kwargs):
+     """Call MHC post through the registered custom op."""
+     return torch.ops.vllm.mhc_post_tilelang(*args, **kwargs)
+@@ -825,6 +904,7 @@ def mhc_fused_post_pre_tilelang(*args, **kwargs):
+     """Call fused MHC post/pre through the registered custom op."""
+     return torch.ops.vllm.mhc_fused_post_pre_tilelang(*args, **kwargs)
+ 
++
+ direct_register_custom_op(
+     op_name="hc_head_fused_kernel_tilelang",
+     op_func=_hc_head_fused_kernel_tilelang,
+diff --git a/vllm/model_executor/layers/quantization/exl3.py b/vllm/model_executor/layers/quantization/exl3.py
+index a625a000728d4d812eca4a32710bb7f553cb6060..175268fe30ca336cd10dcaeec53bfb0ca773df07 100644
+--- a/vllm/model_executor/layers/quantization/exl3.py
++++ b/vllm/model_executor/layers/quantization/exl3.py
+@@ -24,13 +24,16 @@ import importlib
+ import os
+ import re
+ import sys
+-from types import SimpleNamespace
++import zlib
++from pathlib import Path
++from types import ModuleType, SimpleNamespace
+ from typing import TYPE_CHECKING, Any
+ 
+ import torch
+ from transformers import PretrainedConfig
+ 
+ from vllm.config import get_current_vllm_config_or_none
++from vllm.config.quantization import QuantizationConfigArgs
+ from vllm.distributed import (
+     get_tensor_model_parallel_rank,
+     get_tensor_model_parallel_world_size,
+@@ -53,7 +56,24 @@ from vllm.model_executor.layers.quantization.base_config import (
+     QuantizationConfig,
+     QuantizeMethodBase,
+ )
++from vllm.model_executor.layers.quantization.compressed_tensors.utils import (
++    should_ignore_layer,
++)
++from vllm.model_executor.layers.quantization.exl3_online_cache import (
++    Exl3OnlineCacheKey,
++    cache_mode,
++    load_or_quantize,
++    resolve_encoder_identity,
++    resolve_model_identity,
++)
++from vllm.model_executor.layers.quantization.online.fp8 import _Fp8OnlineLinearBase
++from vllm.model_executor.layers.quantization.online.mxfp8 import (
++    Mxfp8OnlineLinearMethod,
++    is_shared_expert_projection,
++)
++from vllm.model_executor.layers.quantization.utils.quant_utils import kMxfp8Dynamic
+ from vllm.model_executor.parameter import BasevLLMParameter
++from vllm.model_executor.utils import replace_parameter
+ from vllm.transformers_utils.repo_utils import get_hf_file_to_dict
+ 
+ if TYPE_CHECKING:
+@@ -70,10 +90,54 @@ _HADAMARD_BLOCK = 128
+ _EXL3_EXT: Any | None = None
+ _SPARKINFER_FUSED_MOE_API: Any | None = None
+ _SPARKINFER_MIXED_TRELLIS_API: Any | None = None
++_SPARKINFER_TRELLIS_LINEAR_API: Any | None = None
++_EXL3_ONLINE_QUANTIZER: Any | None = None
++_EXL3_ONLINE_WARMED_SIGNATURES: set[tuple[int, int, int, int]] = set()
++_SPARKINFER_TRELLIS_WARMED_DEVICES: set[int] = set()
++# The dense W4A16 kernel caps its temporary accumulation arena at
++# SMs * 4 * block_m * 256 fp32 elements.  SM120/SM121 devices supported by
++# this path have at most 192 SMs, and block_m never exceeds 64.  Keeping this
++# architecture bound here lets Inductor own and reuse the temporary across
++# layers instead of allocating inside CUDA graph capture.
++_SPARKINFER_TRELLIS_C_TMP_CAP = 192 * 4 * 64 * 256
+ _RANK_SLICED_RUNTIMES: dict[tuple[Any, ...], dict[str, Any]] = {}
+ _MIXED_TRELLIS_RUNTIMES: dict[tuple[Any, ...], dict[str, Any]] = {}
+ _NEXT_RUNTIME_SCOPE_ID = 0
+ _MIXED_TRELLIS_ROUTE_BLOCK_SIZE = 8
++_GLM52_MIXED_TRELLIS_PREFILL_BLOCK_SIZE = 32
++
++
++def _resolve_mixed_trellis_prefill_block_m(
++    *,
++    configured_block_m: int,
++    explicit_override: bool,
++    hidden_size: int,
++    intermediate_size: int,
++    tier_signature: tuple[tuple[int, int], ...],
++    topk: int,
++    device_major: int,
++    prefill_tile_config: tuple[int, int, int, int],
++) -> int:
++    """Select the qualified GLM-5.2 mixed-K prefill route block.
++
++    SparkInfer's paired-M8 FC2 schedule makes block-32 numerically equivalent
++    to the established block-64 path while reducing scratch and improving the
++    dominant large-prefill kernel on SM12x. Explicit operator tuning and every
++    other model geometry retain the configured value.
++    """
++
++    qualified = (
++        not explicit_override
++        and int(device_major) == 12
++        and int(hidden_size) == 6144
++        and int(intermediate_size) == 512
++        and tier_signature == ((3, 192), (4, 64))
++        and int(topk) == 8
++        and tuple(int(value) for value in prefill_tile_config) == (128, 128, 32, 512)
++    )
++    if qualified:
++        return _GLM52_MIXED_TRELLIS_PREFILL_BLOCK_SIZE
++    return int(configured_block_m)
+ 
+ 
+ # Smallest m the Trellis kernel path can service, and therefore the smallest
+@@ -88,6 +152,75 @@ MIN_CAPTURABLE_TRELLIS_M = 1
+ _DEFAULT_TRELLIS_MIN_M = MIN_CAPTURABLE_TRELLIS_M
+ 
+ 
++def _online_trellis_bits() -> int | None:
++    raw = os.environ.get("VLLM_EXL3_ONLINE_TRELLIS_BITS")
++    if raw is None or not raw.strip():
++        return None
++    try:
++        bits = int(raw)
++    except ValueError:
++        raise ValueError(
++            f"VLLM_EXL3_ONLINE_TRELLIS_BITS must be an integer from 3 to 8, got {raw!r}"
++        ) from None
++    if bits not in range(3, 9):
++        raise ValueError(
++            f"VLLM_EXL3_ONLINE_TRELLIS_BITS must be from 3 to 8, got {bits}"
++        )
++    return bits
++
++
++def _online_trellis_shape_supported(input_size: int, output_size: int) -> bool:
++    return input_size % _HADAMARD_BLOCK == 0 and output_size % _HADAMARD_BLOCK == 0
++
++
++def _load_exl3_online_quantizer() -> Any:
++    """Load the encoder without importing ExLlamaV3's serving front end."""
++
++    global _EXL3_ONLINE_QUANTIZER
++    if _EXL3_ONLINE_QUANTIZER is not None:
++        return _EXL3_ONLINE_QUANTIZER
++
++    raw_root = os.environ.get("VLLM_EXL3_ENCODER_SOURCE")
++    if raw_root is None or not raw_root.strip():
++        raise RuntimeError(
++            "online EXL3 Trellis requires VLLM_EXL3_ENCODER_SOURCE to point "
++            "to the exllamav3 Python package directory"
++        )
++    package_root = Path(raw_root).resolve()
++    quantizer_path = package_root / "modules" / "quant" / "exl3_lib"
++    if not (quantizer_path / "quantize.py").is_file():
++        raise RuntimeError(
++            "VLLM_EXL3_ENCODER_SOURCE does not contain the ExLlamaV3 encoder: "
++            f"{package_root}"
++        )
++
++    package_name = "_vllm_exl3_encoder"
++    packages = {
++        package_name: package_root,
++        f"{package_name}.modules": package_root / "modules",
++        f"{package_name}.modules.quant": package_root / "modules" / "quant",
++        f"{package_name}.modules.quant.exl3_lib": quantizer_path,
++    }
++    for name, path in packages.items():
++        if name in sys.modules:
++            continue
++        module = ModuleType(name)
++        module.__path__ = [str(path)]
++        module.__package__ = name
++        sys.modules[name] = module
++
++    quantize = importlib.import_module(
++        f"{package_name}.modules.quant.exl3_lib.quantize"
++    )
++    if not hasattr(quantize, "quantize_exl3"):
++        raise RuntimeError(
++            "VLLM_EXL3_ENCODER_SOURCE points to an incompatible ExLlamaV3 "
++            "encoder: modules.quant.exl3_lib.quantize has no quantize_exl3"
++        )
++    _EXL3_ONLINE_QUANTIZER = quantize.quantize_exl3
++    return _EXL3_ONLINE_QUANTIZER
++
++
+ def _is_draft_layer(layer: Any) -> bool:
+     """True for a rank-sliced MTP/nextn/eagle draft MoE layer.
+ 
+@@ -154,10 +287,23 @@ def _runtime_scope_id(quant_config: Any) -> int:
+ 
+ 
+ _RANK_SLICED_FORMAT = "exl3-trellis"
++_PER_EXPERT_ROTATION_LAYOUT = "per_expert_v1"
++_SHARED_H_ROTATION_LAYOUT = "shared_h_v1"
++_SHARED_H_TENSOR_SCHEMA = (
++    "model.layers.{L}.mlp.experts.shared_h.{proj}.rank{r}.{suh|svh}"
++)
+ _RANK_SLICED_WEIGHT_RE = re.compile(
+     r"^(?P<prefix>.+)\.rank(?P<rank>\d+)\."
+     r"(?P<field>trellis|suh|svh|mcg|mul1)$"
+ )
++_SHARED_H_WEIGHT_RE = re.compile(
++    r"^(?P<experts_prefix>.+\.experts)\.shared_h\."
++    r"(?P<projection>gate_proj|up_proj|down_proj)\.rank(?P<rank>\d+)\."
++    r"(?P<field>suh|svh)$"
++)
++_EXPERT_PROJECTION_RE = re.compile(
++    r"^.+\.experts\.\d+\.(?P<projection>gate_proj|up_proj|down_proj)$"
++)
+ 
+ ShardId = str | int | tuple[int, ...] | None
+ 
+@@ -247,6 +393,23 @@ def _load_sparkinfer_mixed_trellis() -> Any:
+     return api
+ 
+ 
++def _load_sparkinfer_trellis_linear() -> Any:
++    """Resolve the native dense Trellis API lazily."""
++
++    global _SPARKINFER_TRELLIS_LINEAR_API
++    if _SPARKINFER_TRELLIS_LINEAR_API is not None:
++        return _SPARKINFER_TRELLIS_LINEAR_API
++    try:
++        from sparkinfer.gemm import trellis_linear
++    except Exception as exc:
++        raise RuntimeError(
++            "Online EXL3 prefill requires sparkinfer.gemm.trellis_linear. "
++            "Install a matching SparkInfer build."
++        ) from exc
++    _SPARKINFER_TRELLIS_LINEAR_API = trellis_linear
++    return trellis_linear
++
++
+ def _unique_tensor_storage_bytes(*buffers: Any) -> int:
+     """Count unique tensor storage while ignoring buffer metadata fields."""
+ 
+@@ -264,6 +427,15 @@ def _unique_tensor_storage_bytes(*buffers: Any) -> int:
+     return total
+ 
+ 
++def _scratch_view(backing: torch.Tensor, spec: Any) -> torch.Tensor:
++    """Return a typed plan-scratch view over a shared byte arena."""
++
++    nbytes = int(spec.dtype.itemsize)
++    for dim in spec.shape:
++        nbytes *= int(dim)
++    return backing.narrow(0, 0, nbytes).view(spec.dtype).view(tuple(spec.shape))
++
++
+ def _positive_env_int(name: str, default: int) -> int:
+     # An env var that is present but blank means "unset". Compose and Kubernetes
+     # both render an unset variable as the empty string, so int("") would abort
+@@ -284,6 +456,21 @@ def _positive_env_int(name: str, default: int) -> int:
+     return value
+ 
+ 
++def _resolve_prefill_capacity(max_batched_tokens: int) -> int:
++    """Resolve the optional EXL3 arena bound within the scheduler contract."""
++
++    prefill_capacity = _positive_env_int(
++        "VLLM_EXL3_PREFILL_CAPACITY", max_batched_tokens
++    )
++    if prefill_capacity > max_batched_tokens:
++        raise ValueError(
++            "VLLM_EXL3_PREFILL_CAPACITY cannot exceed "
++            "max_num_batched_tokens: "
++            f"capacity={prefill_capacity}, max={max_batched_tokens}"
++        )
++    return prefill_capacity
++
++
+ @torch.library.custom_op(
+     "vllm::exl3_gemm",
+     mutates_args=(),
+@@ -338,6 +525,166 @@ def _exl3_gemm_fake(
+     )
+ 
+ 
++def _sparkinfer_trellis_weight(
++    trellis: torch.Tensor,
++    suh: torch.Tensor,
++    svh: torch.Tensor,
++    dtype: torch.dtype,
++) -> Any:
++    """Prepare each online weight before capture and retain its native views."""
++
++    api = _load_sparkinfer_trellis_linear()
++    # Keep prepared views on the owning tensor. A process-global pointer-keyed
++    # cache can alias after allocator address reuse and retains released models
++    # forever. This small reference cycle is collected with the tensor.
++    cache = getattr(trellis, "_vllm_sparkinfer_prepared_weights", None)
++    if cache is None:
++        cache = {}
++        trellis._vllm_sparkinfer_prepared_weights = cache
++    key = (id(suh), id(svh), dtype)
++    weight = cache.get(key)
++    if weight is None:
++        weight = api.prepare_weight(
++            trellis,
++            suh,
++            svh,
++            codebook="mcg",
++            params_dtype=dtype,
++        )
++        cache[key] = weight
++    return weight
++
++
++def _sparkinfer_trellis_k6_supported(
++    trellis: torch.Tensor,
++    *,
++    has_mcg: bool,
++    has_mul1: bool,
++) -> bool:
++    """Gate the native path to the exact K6/MCG contract it implements."""
++
++    return bool(
++        has_mcg
++        and not has_mul1
++        and trellis.dtype == torch.int16
++        and trellis.ndim == 3
++        and int(trellis.shape[2]) == 96
++        and int(trellis.shape[0]) % 8 == 0
++        and int(trellis.shape[1]) % 8 == 0
++    )
++
++
++def _warm_sparkinfer_trellis_device(
++    trellis: torch.Tensor,
++    suh: torch.Tensor,
++    svh: torch.Tensor,
++) -> None:
++    """Build the runtime extension before any CUDA graph starts capturing."""
++
++    device_index = trellis.device.index
++    if device_index is None:
++        device_index = torch.cuda.current_device()
++    if device_index in _SPARKINFER_TRELLIS_WARMED_DEVICES:
++        return
++    source = torch.zeros(
++        (1, int(trellis.shape[0]) * 16),
++        dtype=torch.float16,
++        device=trellis.device,
++    )
++    _sparkinfer_trellis_linear(source, trellis, suh, svh)
++    torch.cuda.synchronize(trellis.device)
++    _SPARKINFER_TRELLIS_WARMED_DEVICES.add(device_index)
++
++
++def _sparkinfer_trellis_c_tmp_elements(rows: int, columns: int) -> int:
++    """Return graph-safe dense-W4A16 scratch capacity for one static shape."""
++
++    rows = int(rows)
++    columns = int(columns)
++    if rows <= 128:
++        # The cooperative K6 small-M kernel does not consume W4A16 scratch.
++        return 1
++    padded_rows = max(
++        ((rows + 47) // 48) * 48,
++        ((rows + 63) // 64) * 64,
++    )
++    return min(columns * padded_rows, _SPARKINFER_TRELLIS_C_TMP_CAP)
++
++
++@torch.library.custom_op(
++    "vllm::sparkinfer_trellis_linear_out",
++    mutates_args=("output", "gemm_output", "c_tmp", "rotated_f16"),
++    device_types="cuda",
++)
++def _sparkinfer_trellis_linear_out(
++    x: torch.Tensor,
++    trellis: torch.Tensor,
++    suh: torch.Tensor,
++    svh: torch.Tensor,
++    output: torch.Tensor,
++    gemm_output: torch.Tensor,
++    c_tmp: torch.Tensor,
++    rotated_f16: torch.Tensor,
++) -> None:
++    """Execute dense Trellis into graph-owned output and scratch tensors."""
++
++    api = _load_sparkinfer_trellis_linear()
++    weight = _sparkinfer_trellis_weight(trellis, suh, svh, x.dtype)
++    api.run(
++        x,
++        weight,
++        output=output,
++        gemm_output=gemm_output,
++        c_tmp=c_tmp,
++        rotated_f16=rotated_f16,
++    )
++
++
++@_sparkinfer_trellis_linear_out.register_fake
++def _sparkinfer_trellis_linear_out_fake(
++    x: torch.Tensor,
++    trellis: torch.Tensor,
++    suh: torch.Tensor,
++    svh: torch.Tensor,
++    output: torch.Tensor,
++    gemm_output: torch.Tensor,
++    c_tmp: torch.Tensor,
++    rotated_f16: torch.Tensor,
++) -> None:
++    del x, trellis, suh, svh, output, gemm_output, c_tmp, rotated_f16
++
++
++def _sparkinfer_trellis_linear(
++    x: torch.Tensor,
++    trellis: torch.Tensor,
++    suh: torch.Tensor,
++    svh: torch.Tensor,
++) -> torch.Tensor:
++    """Run every online-K6 batch through SparkInfer with explicit storage."""
++
++    output = torch.empty(
++        (x.shape[0], trellis.shape[1] * 16), dtype=x.dtype, device=x.device
++    )
++    gemm_output = torch.empty_like(output)
++    c_tmp = torch.empty(
++        (_sparkinfer_trellis_c_tmp_elements(x.shape[0], output.shape[1]),),
++        dtype=torch.float32,
++        device=x.device,
++    )
++    rotated_f16 = torch.empty_like(x)
++    _sparkinfer_trellis_linear_out(
++        x,
++        trellis,
++        suh,
++        svh,
++        output,
++        gemm_output,
++        c_tmp,
++        rotated_f16,
++    )
++    return output
++
++
+ class Exl3Config(QuantizationConfig):
+     """Configuration for modern and legacy EXL3 trellis checkpoints."""
+ 
+@@ -357,8 +704,11 @@ class Exl3Config(QuantizationConfig):
+         self.tensor_storage = tensor_storage or {}
+         self._eager_checked = False
+         self.rank_sliced_metadata: dict[str, Any] | None = None
++        self.rank_sliced_rotation_layout = _PER_EXPERT_ROTATION_LAYOUT
+         self.rank_sliced_k_values: tuple[int, ...] | None = None
+         self.rank_sliced_bits_by_layer: dict[int, tuple[int, ...]] = {}
++        self._online_model_identity: str | None = None
++        self._online_encoder_identity: str | None = None
+ 
+     def get_name(self) -> str:
+         return "exl3"
+@@ -407,6 +757,12 @@ class Exl3Config(QuantizationConfig):
+         hf_config: PretrainedConfig | None = None,
+         revision: str | None = None,
+     ) -> None:
++        if _online_trellis_bits() is not None:
++            self._configure_online_cache_identity(
++                model_name,
++                hf_config=hf_config,
++                revision=revision,
++            )
+         rank_sliced = getattr(hf_config, "hybrid_tr3_tail", None)
+         if (
+             isinstance(rank_sliced, dict)
+@@ -449,6 +805,36 @@ class Exl3Config(QuantizationConfig):
+         self._validate_storage_metadata()
+         self._force_independent_lm_head(hf_config)
+ 
++    def _configure_online_cache_identity(
++        self,
++        model_name: str,
++        *,
++        hf_config: PretrainedConfig | None,
++        revision: str | None,
++    ) -> None:
++        if self._online_model_identity is not None:
++            return
++        encoder_source = os.getenv("VLLM_EXL3_ENCODER_SOURCE")
++        if encoder_source is None or not encoder_source.strip():
++            raise ValueError(
++                "VLLM_EXL3_ENCODER_SOURCE is required when "
++                "VLLM_EXL3_ONLINE_TRELLIS_BITS is enabled"
++            )
++        if cache_mode() == "off":
++            self._online_model_identity = "cache-disabled"
++            self._online_encoder_identity = "cache-disabled"
++            return
++        resolved_revision = revision or getattr(hf_config, "_commit_hash", None)
++        self._online_model_identity = resolve_model_identity(
++            model_name,
++            revision=resolved_revision,
++            hf_config=hf_config,
++        )
++        self._online_encoder_identity = resolve_encoder_identity(
++            encoder_source,
++            revision=os.getenv("VLLM_EXL3_ENCODER_REVISION"),
++        )
++
+     def _configure_rank_sliced(self, metadata: dict[str, Any]) -> None:
+         required = {
+             "bits",
+@@ -484,7 +870,30 @@ class Exl3Config(QuantizationConfig):
+                 "unsupported rank-sliced EXL3 tensor schema: "
+                 f"{metadata['tensor_schema']!r}"
+             )
++        rotation_layout = str(
++            metadata.get("rotation_layout", _PER_EXPERT_ROTATION_LAYOUT)
++        )
++        if rotation_layout not in {
++            _PER_EXPERT_ROTATION_LAYOUT,
++            _SHARED_H_ROTATION_LAYOUT,
++        }:
++            raise ValueError(
++                f"unsupported rank-sliced EXL3 rotation_layout: {rotation_layout!r}"
++            )
++        shared_schema = metadata.get("shared_h_tensor_schema")
++        if rotation_layout == _SHARED_H_ROTATION_LAYOUT:
++            if shared_schema != _SHARED_H_TENSOR_SCHEMA:
++                raise ValueError(
++                    "shared_h_v1 rank-sliced EXL3 requires "
++                    f"shared_h_tensor_schema={_SHARED_H_TENSOR_SCHEMA!r}"
++                )
++        elif shared_schema is not None:
++            raise ValueError(
++                "shared_h_tensor_schema is only valid with "
++                "rotation_layout='shared_h_v1'"
++            )
+         self.rank_sliced_metadata = dict(metadata)
++        self.rank_sliced_rotation_layout = rotation_layout
+         bits_field = metadata["bits"]
+         if isinstance(bits_field, str) and bits_field.strip().lower() == "mixed":
+             k_values = tuple(
+@@ -658,15 +1067,105 @@ class Exl3Config(QuantizationConfig):
+         if is_lm_head and not prefix:
+             prefix = "lm_head"
+         if isinstance(layer, LinearBase) or is_lm_head:
+-            if not self._linear_prefix_is_exl3(prefix):
+-                return UnquantizedLinearMethod()
+-            return Exl3LinearMethod(self)
++            if self._linear_prefix_is_exl3(prefix):
++                return Exl3LinearMethod(self)
++            if not is_lm_head and (
++                method := self._get_bf16_online_linear_method(layer, prefix)
++            ):
++                return method
++            return UnquantizedLinearMethod()
+         if isinstance(layer, RoutedExperts):
+             if not self._moe_prefix_is_exl3(prefix, layer):
+                 return None
+             return Exl3MoEMethod(self, layer.moe_config)
+         return None
+ 
++    def _get_bf16_online_linear_method(
++        self, layer: torch.nn.Module, prefix: str
++    ) -> QuantizeMethodBase | None:
++        """Overlay online quantization on linears absent from EXL3 storage.
++
++        EXL3-owned dense matrices are selected before this method and routed
++        experts never enter it. Shared-expert projections have an independent
++        spec so a broad ``linear`` overlay cannot quantize them accidentally.
++        When ``VLLM_EXL3_ONLINE_TRELLIS_BITS`` is set, eligible projections use
++        online EXL3 Trellis encoding instead of MXFP8.
++
++        Args:
++            layer: Candidate module for the online overlay.
++            prefix: Fully qualified checkpoint module name.
++
++        Returns:
++            An online Trellis or MXFP8 method for an eligible BF16 projection,
++            otherwise ``None``.
++
++        Raises:
++            ValueError: If the EXL3 overlay requests an unsupported weight or
++                activation format.
++        """
++        if not isinstance(layer, LinearBase):
++            return None
++
++        vllm_config = get_current_vllm_config_or_none()
++        if vllm_config is None:
++            return None
++        args = vllm_config.model_config.quantization_config
++        if not isinstance(args, QuantizationConfigArgs):
++            return None
++
++        shared_expert = is_shared_expert_projection(prefix)
++        spec = args.shared_experts if shared_expert else args.linear
++        if spec is None:
++            return None
++        if (
++            not shared_expert
++            and args.ignore
++            and should_ignore_layer(
++                prefix,
++                ignore=args.ignore,
++                fused_mapping=self.packed_modules_mapping,
++            )
++        ):
++            return None
++        if spec.weight != kMxfp8Dynamic or spec.activation is not None:
++            raise ValueError(
++                "EXL3 BF16 online overlay only supports weight='mxfp8' "
++                "with no activation override."
++            )
++
++        if (bits := _online_trellis_bits()) is not None:
++            if self._online_model_identity is None:
++                model_config = vllm_config.model_config
++                self._configure_online_cache_identity(
++                    model_config.model,
++                    hf_config=model_config.hf_config,
++                    revision=model_config.revision,
++                )
++            assert self._online_model_identity is not None
++            assert self._online_encoder_identity is not None
++            logger.warning_once(
++                "EXL3 BF16 online Trellis: encoding eligible non-EXL3 "
++                "linear weights at K=%d; 128-unaligned matrices retain the "
++                "configured MXFP8 path (module example: %s).",
++                bits,
++                prefix,
++            )
++            return Exl3OnlineLinearMethod(
++                bits=bits,
++                prefix=prefix,
++                model_identity=self._online_model_identity,
++                encoder_identity=self._online_encoder_identity,
++            )
++
++        logger.info_once(
++            "EXL3 BF16 online overlay: quantizing non-EXL3 %s projections "
++            "to MXFP8 at load time (module example: %s).",
++            "shared-expert" if shared_expert else "dense-linear",
++            prefix,
++        )
++        logger.debug("EXL3 BF16 MXFP8 overlay applied to %s", prefix)
++        return Mxfp8OnlineLinearMethod()
++
+     def _storage_entry(self, prefix: str) -> dict[str, Any] | None:
+         candidates = [prefix]
+         if prefix.startswith("model."):
+@@ -706,10 +1205,17 @@ class Exl3Config(QuantizationConfig):
+         if not source_leaves:
+             return False
+         base = prefix.rsplit(".", 1)[0] if "." in prefix else ""
+-        return all(
++        source_is_exl3 = [
+             self._is_exl3_prefix(f"{base}.{source}" if base else source)
+             for source in source_leaves
+-        )
++        ]
++        if any(source_is_exl3) and not all(source_is_exl3):
++            raise ValueError(
++                f"Packed EXL3 projection {prefix!r} mixes EXL3 and BF16 "
++                "source shards; a fused module must use one quantization "
++                "scheme."
++            )
++        return all(source_is_exl3)
+ 
+     def _moe_prefix_is_exl3(
+         self, prefix: str, layer: torch.nn.Module | None = None
+@@ -765,9 +1271,40 @@ class Exl3Config(QuantizationConfig):
+         """Drop non-local TP payloads and remove the serialized rank segment."""
+         if self.rank_sliced_metadata is None:
+             return name
++        shared_match = _SHARED_H_WEIGHT_RE.match(name)
++        if shared_match is not None:
++            if self.rank_sliced_rotation_layout != _SHARED_H_ROTATION_LAYOUT:
++                raise ValueError(
++                    "rank-sliced EXL3 contains shared-H tensors but metadata "
++                    "does not declare rotation_layout='shared_h_v1'"
++                )
++            projection = shared_match.group("projection")
++            field = shared_match.group("field")
++            expected_field = "svh" if projection == "down_proj" else "suh"
++            if field != expected_field:
++                raise ValueError(
++                    "invalid shared-H EXL3 tensor: "
++                    f"projection={projection!r} requires {expected_field}, got {field}"
++                )
++            if int(shared_match.group("rank")) != get_tensor_model_parallel_rank():
++                return None
++            return f"{shared_match.group('experts_prefix')}.0.{projection}.{field}"
+         match = _RANK_SLICED_WEIGHT_RE.match(name)
+         if match is None:
+             return name
++        if self.rank_sliced_rotation_layout == _SHARED_H_ROTATION_LAYOUT:
++            projection_match = _EXPERT_PROJECTION_RE.match(match.group("prefix"))
++            if projection_match is not None:
++                projection = projection_match.group("projection")
++                field = match.group("field")
++                is_h_side = (
++                    projection in {"gate_proj", "up_proj"} and field == "suh"
++                ) or (projection == "down_proj" and field == "svh")
++                if is_h_side:
++                    raise ValueError(
++                        "shared_h_v1 must store H-side rotations under "
++                        "experts.shared_h, not under an expert id"
++                    )
+         if int(match.group("rank")) != get_tensor_model_parallel_rank():
+             return None
+         return f"{match.group('prefix')}.{match.group('field')}"
+@@ -800,6 +1337,218 @@ def _exl3_weight_loader(
+     param.load_exl3_weight(loaded_weight, loaded_shard_id)
+ 
+ 
++class Exl3OnlineLinearMethod(_Fp8OnlineLinearBase):
++    """Encode eligible BF16 linear shards to cached dense EXL3 weights."""
++
++    def __init__(
++        self,
++        *,
++        bits: int,
++        prefix: str,
++        model_identity: str,
++        encoder_identity: str,
++    ) -> None:
++        super().__init__()
++        self.bits = bits
++        self.prefix = prefix
++        self.model_identity = model_identity
++        self.encoder_identity = encoder_identity
++        self.fallback: Mxfp8OnlineLinearMethod | None = None
++
++    def create_weights(
++        self,
++        layer: torch.nn.Module,
++        input_size_per_partition: int,
++        output_partition_sizes: list[int],
++        input_size: int,
++        output_size: int,
++        params_dtype: torch.dtype,
++        **extra_weight_attrs,
++    ) -> None:
++        output_size_per_partition = sum(output_partition_sizes)
++        layer.exl3_online_trellis = _online_trellis_shape_supported(
++            input_size_per_partition, output_size_per_partition
++        )
++        if not layer.exl3_online_trellis:
++            self.fallback = Mxfp8OnlineLinearMethod()
++            self.fallback.create_weights(
++                layer,
++                input_size_per_partition,
++                output_partition_sizes,
++                input_size,
++                output_size,
++                params_dtype,
++                **extra_weight_attrs,
++            )
++            logger.info_once(
++                "EXL3 online Trellis retains MXFP8 for 128-unaligned shards "
++                "(example %s: K=%d, N=%d).",
++                self.prefix,
++                input_size_per_partition,
++                output_size_per_partition,
++            )
++            return
++
++        super().create_weights(
++            layer,
++            input_size_per_partition,
++            output_partition_sizes,
++            input_size,
++            output_size,
++            params_dtype,
++            **extra_weight_attrs,
++        )
++        layer.exl3_online_input_size = input_size_per_partition
++        layer.exl3_online_output_size = output_size_per_partition
++
++    @staticmethod
++    def _h_data(input_size: int, device: torch.device) -> dict[str, Any]:
++        return {
++            "H": torch.zeros(
++                input_size, input_size, dtype=torch.float32, device="meta"
++            ),
++            "first_key": "vllm-online",
++            "count": 0,
++            "finalized": False,
++            "num_total": 0,
++            "inf_nan": torch.zeros(2, dtype=torch.long, device=device),
++            "device": device,
++        }
++
++    def _warm_decode_shapes(self, layer: torch.nn.Module) -> None:
++        device = layer.exl3_online_trellis_weight.device
++        _sparkinfer_trellis_weight(
++            layer.exl3_online_trellis_weight,
++            layer.exl3_online_suh,
++            layer.exl3_online_svh,
++            torch.float16,
++        )
++        device_index = device.index
++        if device_index is None:
++            device_index = torch.cuda.current_device()
++        signature = (
++            device_index,
++            layer.exl3_online_input_size,
++            layer.exl3_online_output_size,
++            self.bits,
++        )
++        if signature in _EXL3_ONLINE_WARMED_SIGNATURES:
++            return
++        for rows in range(1, 7):
++            source = torch.zeros(
++                (rows, layer.exl3_online_input_size),
++                dtype=torch.float16,
++                device=device,
++            )
++            _sparkinfer_trellis_linear(
++                source,
++                layer.exl3_online_trellis_weight,
++                layer.exl3_online_suh,
++                layer.exl3_online_svh,
++            )
++        torch.cuda.synchronize(device)
++        _EXL3_ONLINE_WARMED_SIGNATURES.add(signature)
++
++    def process_weights_after_loading(self, layer: torch.nn.Module) -> None:
++        if self.fallback is not None:
++            self.fallback.process_weights_after_loading(layer)
++            return
++        if getattr(layer, "_already_called_process_weights_after_loading", False):
++            return
++
++        device = layer.weight.device
++        seed = zlib.crc32(self.prefix.encode("utf-8")) & 0x7FFFFFFF
++        cache_key = Exl3OnlineCacheKey(
++            model_identity=self.model_identity,
++            encoder_identity=self.encoder_identity,
++            prefix=self.prefix,
++            bits=self.bits,
++            seed=seed,
++            tp_world_size=get_tensor_model_parallel_world_size(),
++            tp_rank=get_tensor_model_parallel_rank(),
++            input_size=layer.exl3_online_input_size,
++            output_size=layer.exl3_online_output_size,
++        )
++
++        def encode() -> tuple[dict[str, torch.Tensor], float]:
++            source = layer.weight.detach().t().float().contiguous()
++            quant_args = {
++                "K": self.bits,
++                "seed": seed,
++                "devices": [device],
++                "apply_out_scales": True,
++                "mcg": True,
++            }
++            quantize_exl3 = _load_exl3_online_quantizer()
++            _, proxy_error, tensors = quantize_exl3(
++                source,
++                self._h_data(layer.exl3_online_input_size, device),
++                quant_args,
++                return_weight_q=False,
++                verbose=False,
++            )
++            if not quant_args.get("q_fallback", False):
++                raise RuntimeError(
++                    "online EXL3 Trellis unexpectedly used calibrated LDLQ"
++                )
++            return {name: tensors[name] for name in ("trellis", "suh", "svh")}, float(
++                proxy_error
++            )
++
++        result = load_or_quantize(cache_key, device=device, quantize=encode)
++
++        layer.register_buffer(
++            "exl3_online_trellis_weight",
++            result.tensors["trellis"],
++            persistent=False,
++        )
++        layer.register_buffer(
++            "exl3_online_suh", result.tensors["suh"], persistent=False
++        )
++        layer.register_buffer(
++            "exl3_online_svh", result.tensors["svh"], persistent=False
++        )
++        replace_parameter(
++            layer,
++            "weight",
++            torch.empty(0, dtype=torch.uint8, device=device),
++        )
++        layer._already_called_process_weights_after_loading = True
++        self._warm_decode_shapes(layer)
++        logger.info(
++            "Online EXL3 K%d %s %s%s",
++            self.bits,
++            "cache hit for" if result.hit else "encoded",
++            self.prefix,
++            ""
++            if result.proxy_error is None
++            else f" (fallback proxy error {result.proxy_error:.8f})",
++        )
++
++    def apply(
++        self,
++        layer: torch.nn.Module,
++        x: torch.Tensor,
++        bias: torch.Tensor | None = None,
++    ) -> torch.Tensor:
++        if self.fallback is not None:
++            return self.fallback.apply(layer, x, bias)
++
++        original_shape = x.shape[:-1]
++        original_dtype = x.dtype
++        x_2d = x.reshape(-1, x.shape[-1]).to(torch.float16).contiguous()
++        output = _sparkinfer_trellis_linear(
++            x_2d,
++            layer.exl3_online_trellis_weight,
++            layer.exl3_online_suh,
++            layer.exl3_online_svh,
++        )
++        if bias is not None:
++            output = output + bias.to(dtype=output.dtype)
++        output = output.reshape(*original_shape, layer.exl3_online_output_size)
++        return output if output.dtype == original_dtype else output.to(original_dtype)
++
++
+ class Exl3LinearMethod(LinearMethodBase):
+     def __init__(self, quant_config: Exl3Config) -> None:
+         self.quant_config = quant_config
+@@ -905,6 +1654,24 @@ class Exl3LinearMethod(LinearMethodBase):
+                     device=device, non_blocking=True
+                 ).contiguous()
+ 
++        for shard_id in layer.exl3_shard_ids:
++            trellis = layer.trellis.exl3_tensors[shard_id]
++            if not _sparkinfer_trellis_k6_supported(
++                trellis,
++                has_mcg=shard_id in layer.mcg.exl3_tensors,
++                has_mul1=shard_id in layer.mul1.exl3_tensors,
++            ):
++                continue
++            suh = layer.suh.exl3_tensors[shard_id]
++            svh = layer.svh.exl3_tensors[shard_id]
++            _sparkinfer_trellis_weight(
++                trellis,
++                suh,
++                svh,
++                torch.float16,
++            )
++            _warm_sparkinfer_trellis_device(trellis, suh, svh)
++
+     def apply(
+         self,
+         layer: torch.nn.Module,
+@@ -1158,14 +1925,28 @@ class Exl3LinearMethod(LinearMethodBase):
+             )
+         if x.shape[-1] < packed_k:
+             x = torch.nn.functional.pad(x, (0, packed_k - x.shape[-1]))
+-        output = _exl3_gemm(
+-            x,
++        has_mcg = shard_id in layer.mcg.exl3_tensors
++        has_mul1 = shard_id in layer.mul1.exl3_tensors
++        if _sparkinfer_trellis_k6_supported(
+             trellis,
+-            layer.suh.exl3_tensors[shard_id],
+-            layer.svh.exl3_tensors[shard_id],
+-            shard_id in layer.mcg.exl3_tensors,
+-            shard_id in layer.mul1.exl3_tensors,
+-        )
++            has_mcg=has_mcg,
++            has_mul1=has_mul1,
++        ):
++            output = _sparkinfer_trellis_linear(
++                x,
++                trellis,
++                layer.suh.exl3_tensors[shard_id],
++                layer.svh.exl3_tensors[shard_id],
++            )
++        else:
++            output = _exl3_gemm(
++                x,
++                trellis,
++                layer.suh.exl3_tensors[shard_id],
++                layer.svh.exl3_tensors[shard_id],
++                has_mcg,
++                has_mul1,
++            )
+         logical_n = Exl3LinearMethod._output_shard_size(layer, shard_id)
+         if output.shape[-1] < logical_n:
+             raise ValueError(
+@@ -1308,6 +2089,12 @@ class Exl3MoEMethod(FusedMoEMethodBase):
+         layer.exl3_intermediate_size_per_partition = intermediate_size_per_partition
+         layer.exl3_params_dtype = params_dtype
+         rank_sliced = self.quant_config.rank_sliced_metadata is not None
++        shared_h = (
++            rank_sliced
++            and self.quant_config.rank_sliced_rotation_layout
++            == _SHARED_H_ROTATION_LAYOUT
++        )
++        layer.exl3_shared_h_rotations = shared_h
+         if rank_sliced:
+             checkpoint_tp = int(self.quant_config.rank_sliced_metadata["tp"])
+             if checkpoint_tp != layer.exl3_tp_size:
+@@ -1360,11 +2147,15 @@ class Exl3MoEMethod(FusedMoEMethodBase):
+             layer.exl3_mixed_bitrate = len(set(layer.exl3_layer_bitrates)) > 1
+         for prefix, shard_ids in (("w13", ("w1", "w3")), ("w2", ("w2",))):
+             for suffix in ("suh", "svh", "trellis", "mcg", "mul1"):
++                shared_parameter = shared_h and (
++                    (prefix == "w13" and suffix == "suh")
++                    or (prefix == "w2" and suffix == "svh")
++                )
+                 layer.register_parameter(
+                     f"{prefix}_{suffix}",
+                     Exl3MoEParameter(
+                         weight_loader=_exl3_moe_weight_loader,
+-                        num_experts=num_experts,
++                        num_experts=1 if shared_parameter else num_experts,
+                         shard_ids=shard_ids,
+                         preallocate=rank_sliced
+                         and suffix
+@@ -1382,7 +2173,16 @@ class Exl3MoEMethod(FusedMoEMethodBase):
+         for prefix, shard_ids in required.items():
+             for attr in ("suh", "svh", "trellis"):
+                 tensors = getattr(layer, f"{prefix}_{attr}").exl3_tensors
+-                for expert_id in range(layer.local_num_experts):
++                shared_parameter = getattr(
++                    layer, "exl3_shared_h_rotations", False
++                ) and (
++                    (prefix == "w13" and attr == "suh")
++                    or (prefix == "w2" and attr == "svh")
++                )
++                expert_ids = (
++                    (0,) if shared_parameter else range(layer.local_num_experts)
++                )
++                for expert_id in expert_ids:
+                     for shard_id in shard_ids:
+                         if (expert_id, shard_id) not in tensors:
+                             missing.append(f"{prefix}_{attr}[{expert_id},{shard_id}]")
+@@ -1484,8 +2284,20 @@ class Exl3MoEMethod(FusedMoEMethodBase):
+                 for shard_id in shard_ids:
+                     key = (expert_id, shard_id)
+                     trellis = getattr(layer, f"{group}_trellis").exl3_tensors[key]
+-                    suh = getattr(layer, f"{group}_suh").exl3_tensors[key]
+-                    svh = getattr(layer, f"{group}_svh").exl3_tensors[key]
++                    suh_key = (
++                        (0, shard_id)
++                        if getattr(layer, "exl3_shared_h_rotations", False)
++                        and group == "w13"
++                        else key
++                    )
++                    svh_key = (
++                        (0, shard_id)
++                        if getattr(layer, "exl3_shared_h_rotations", False)
++                        and group == "w2"
++                        else key
++                    )
++                    suh = getattr(layer, f"{group}_suh").exl3_tensors[suh_key]
++                    svh = getattr(layer, f"{group}_svh").exl3_tensors[svh_key]
+                     if (
+                         trellis.dtype != torch.int16
+                         or trellis.ndim != 3
+@@ -1531,17 +2343,40 @@ class Exl3MoEMethod(FusedMoEMethodBase):
+         return backing
+ 
+     @staticmethod
+-    def _pointer_table(slab: torch.Tensor) -> torch.Tensor:
++    def _pointer_table(
++        slab: torch.Tensor,
++        *,
++        num_experts: int | None = None,
++    ) -> torch.Tensor:
+         if slab.ndim < 2 or not slab[0].is_contiguous():
+             raise RuntimeError("EXL3 pointer-table rows must be contiguous")
++        rows = int(slab.shape[0])
++        entries = rows if num_experts is None else int(num_experts)
++        if rows not in {1, entries}:
++            raise RuntimeError(
++                "EXL3 pointer-table rows must be per-expert or broadcast: "
++                f"rows={rows}, experts={entries}"
++            )
+         step = slab.stride(0) * slab.element_size()
+         base = slab.data_ptr()
+         return torch.tensor(
+-            [base + expert_id * step for expert_id in range(slab.shape[0])],
++            [
++                base + (0 if rows == 1 else expert_id) * step
++                for expert_id in range(entries)
++            ],
+             dtype=torch.int64,
+             device=slab.device,
+         )
+ 
++    @staticmethod
++    def _select_rotation_rows(
++        rotations: torch.Tensor,
++        expert_ids: torch.Tensor,
++    ) -> torch.Tensor:
++        if int(rotations.shape[0]) == 1:
++            return rotations
++        return rotations.index_select(0, expert_ids).contiguous()
++
+     @staticmethod
+     def _trellis_tile_config(hidden_size: int, intermediate_size: int):
+         if hidden_size % 128 or intermediate_size % 128:
+@@ -1569,8 +2404,16 @@ class Exl3MoEMethod(FusedMoEMethodBase):
+             return (128, 128, 64, 256)
+         return (128, 128, 128, 128)
+ 
++    @staticmethod
++    def _mixed_trellis_prefill_tile_config(hidden_size: int, intermediate_size: int):
++        # Route packing stays block-64, while SparkInfer's mixed-kernel ABI v2
++        # executes FC2 as arithmetic-equivalent 8-row subtiles.  Reuse the
++        # checkpoint's original one-grid tile geometry so prefill has the same
++        # reduction order as the stock-r16 quality reference.
++        return Exl3MoEMethod._mixed_trellis_tile_config(hidden_size, intermediate_size)
++
+     def _prepare_mixed_rank_sliced_weights(self, layer: RoutedExperts) -> None:
+-        api = _load_sparkinfer_mixed_trellis()
++        mixed_api = _load_sparkinfer_mixed_trellis()
+         num_experts = int(layer.local_num_experts)
+         hidden_size = int(layer.exl3_hidden_size)
+         intermediate_size = int(layer.exl3_intermediate_size_per_partition)
+@@ -1609,9 +2452,37 @@ class Exl3MoEMethod(FusedMoEMethodBase):
+         down_suh = self._rank_sliced_backing(layer, "w2_suh")
+         down_svh = self._rank_sliced_backing(layer, "w2_svh")
+         device = gate_suh.device
+-        tile_config = self._mixed_trellis_tile_config(hidden_size, intermediate_size)
++        mixed_tile_config = self._mixed_trellis_tile_config(
++            hidden_size, intermediate_size
++        )
++        prefill_tile_config = self._mixed_trellis_prefill_tile_config(
++            hidden_size, intermediate_size
++        )
++        tier_order = tuple(
++            expert_id for expert_ids in tiers.values() for expert_id in expert_ids
++        )
++        tier_index = torch.tensor(tier_order, dtype=torch.long, device=device)
++        combined_gate_suh = self._select_rotation_rows(gate_suh, tier_index)
++        combined_up_suh = self._select_rotation_rows(up_suh, tier_index)
++        combined_intermediate_rotations = torch.cat(
++            (
++                gate_svh.index_select(0, tier_index),
++                up_svh.index_select(0, tier_index),
++                down_suh.index_select(0, tier_index),
++            ),
++            dim=1,
++        ).contiguous()
++        combined_down_svh = self._select_rotation_rows(down_svh, tier_index)
++        combined_rotations = SimpleNamespace(
++            intermediate=combined_intermediate_rotations,
++            gate_suh=combined_gate_suh,
++            up_suh=combined_up_suh,
++            down_svh=combined_down_svh,
++        )
+         prepared_tiers = []
++        prefill_tiers = []
+         tier_ids = []
++        tier_offset = 0
+         for bits, expert_ids in tiers.items():
+             expected_last = 16 * bits
+             w13 = torch.stack(
+@@ -1650,25 +2521,42 @@ class Exl3MoEMethod(FusedMoEMethodBase):
+                     f"expected={expected_w13}/{expected_w2}"
+                 )
+ 
+-            index = torch.tensor(expert_ids, dtype=torch.long, device=device)
+-            tier_gate_suh = gate_suh.index_select(0, index).contiguous()
+-            tier_up_suh = up_suh.index_select(0, index).contiguous()
+-            intermediate_rotations = torch.cat(
+-                (
+-                    gate_svh.index_select(0, index),
+-                    up_svh.index_select(0, index),
+-                    down_suh.index_select(0, index),
+-                ),
+-                dim=1,
+-            ).contiguous()
+-            tier_down_svh = down_svh.index_select(0, index).contiguous()
+-            prepared_tiers.append(
+-                api.prepare_weights(
++            tier_slice = slice(tier_offset, tier_offset + len(expert_ids))
++            tier_gate_suh = (
++                combined_gate_suh
++                if int(combined_gate_suh.shape[0]) == 1
++                else combined_gate_suh[tier_slice]
++            )
++            tier_up_suh = (
++                combined_up_suh
++                if int(combined_up_suh.shape[0]) == 1
++                else combined_up_suh[tier_slice]
++            )
++            intermediate_rotations = combined_intermediate_rotations[tier_slice]
++            tier_down_svh = (
++                combined_down_svh
++                if int(combined_down_svh.shape[0]) == 1
++                else combined_down_svh[tier_slice]
++            )
++
++            def prepare_tier(
++                tile_config: tuple[int, int, int, int],
++                *,
++                w13: torch.Tensor = w13,
++                w2: torch.Tensor = w2,
++                expert_count: int = len(expert_ids),
++                bits: int = bits,
++                tier_gate_suh: torch.Tensor = tier_gate_suh,
++                tier_up_suh: torch.Tensor = tier_up_suh,
++                intermediate_rotations: torch.Tensor = intermediate_rotations,
++                tier_down_svh: torch.Tensor = tier_down_svh,
++            ):
++                return mixed_api.prepare_weights(
+                     w13=w13,
+                     w2=w2,
+                     hidden_size=hidden_size,
+                     intermediate_size=intermediate_size,
+-                    num_experts=len(expert_ids),
++                    num_experts=expert_count,
+                     activation=layer.activation.value,
+                     fc1_tile_n=tile_config[1],
+                     fc2_tile_n=tile_config[3],
+@@ -1683,22 +2571,27 @@ class Exl3MoEMethod(FusedMoEMethodBase):
+                     tile_config=tile_config,
+                     workspace=w13.view(torch.int32).reshape(-1)[:1],
+                 )
+-            )
++
++            prepared_tiers.append(prepare_tier(mixed_tile_config))
++            prefill_tiers.append(prepare_tier(prefill_tile_config))
+             tier_ids.append(expert_ids)
++            tier_offset += len(expert_ids)
+ 
+-        global_to_combined, descriptor_map = api.build_tiered_maps(
++        global_to_combined, descriptor_map = mixed_api.build_tiered_maps(
+             tier_ids[0], tier_ids[1], device=device
+         )
+         layer.exl3_mixed_trellis = {
+             "tiers": tuple(prepared_tiers),
++            "prefill_tiers": tuple(prefill_tiers),
+             "tier_ids": tuple(tier_ids),
+             "tier_bits": tuple(tiers),
+             "global_to_combined": global_to_combined,
+             "descriptor_map": descriptor_map,
+-            "rotations": api.combine_trellis_rotations(*prepared_tiers),
+-            "tile_config": tile_config,
++            "rotations": combined_rotations,
++            "tile_config": mixed_tile_config,
++            "prefill_tile_config": prefill_tile_config,
+         }
+-        layer.exl3_trellis_tile_config = tile_config
++        layer.exl3_trellis_tile_config = mixed_tile_config
+ 
+         # The prepared tier objects own compact, tier-ordered copies. Release
+         # per-expert source tensors and the original rotation slabs now rather
+@@ -1807,13 +2700,22 @@ class Exl3MoEMethod(FusedMoEMethodBase):
+             down_suh,
+             down_svh,
+         )
+-        layer.exl3_pointer_tables = tuple(self._pointer_table(slab) for slab in slabs)
++        layer.exl3_pointer_tables = tuple(
++            self._pointer_table(slab, num_experts=num_experts) for slab in slabs
++        )
+         layer.exl3_expert_map = torch.arange(
+             num_experts,
+             dtype=torch.int64,
+             device=w13.device,
+         )
+         layer.exl3_trellis_tile_config = tile_config
++        if getattr(layer, "exl3_shared_h_rotations", False):
++            saved_bytes = (num_experts - 1) * 3 * hidden_size * 2
++            logger.info_once(
++                "EXL3 shared-H rotation layout active; saving %.2f MiB per "
++                "routed-expert layer and TP rank",
++                saved_bytes / (1024 * 1024),
++            )
+ 
+     def get_fused_moe_quant_config(
+         self, layer: RoutedExperts
+@@ -1832,15 +2734,71 @@ class Exl3MoEMethod(FusedMoEMethodBase):
+         topk_ids: torch.Tensor,
+     ) -> dict[str, Any]:
+         mixed = layer.exl3_mixed_trellis
+-        max_decode_m = _positive_env_int("VLLM_EXL3_TRELLIS_MAX_M", 32)
+-        max_batched_tokens = int(layer.exl3_max_num_batched_tokens)
+-        if max_decode_m > max_batched_tokens:
+-            max_decode_m = max_batched_tokens
+         topk = int(topk_ids.shape[1])
+-        tier_signature = tuple(
+-            (int(bits), len(ids))
+-            for bits, ids in zip(mixed["tier_bits"], mixed["tier_ids"], strict=True)
+-        )
++        policy = mixed.get("runtime_policy")
++        if policy is None:
++            max_decode_m = _positive_env_int("VLLM_EXL3_TRELLIS_MAX_M", 32)
++            max_batched_tokens = int(layer.exl3_max_num_batched_tokens)
++            prefill_capacity = _resolve_prefill_capacity(max_batched_tokens)
++            prefill_block_raw = os.environ.get("VLLM_EXL3_PREFILL_BLOCK_M")
++            configured_block_m = _positive_env_int("VLLM_EXL3_PREFILL_BLOCK_M", 64)
++            max_decode_m = min(max_decode_m, max_batched_tokens)
++            tier_signature = tuple(
++                (int(bits), len(ids))
++                for bits, ids in zip(mixed["tier_bits"], mixed["tier_ids"], strict=True)
++            )
++            props = torch.cuda.get_device_properties(x.device)
++            explicit_block_m = bool(
++                prefill_block_raw is not None and prefill_block_raw.strip()
++            )
++            prefill_block_m = _resolve_mixed_trellis_prefill_block_m(
++                configured_block_m=configured_block_m,
++                explicit_override=explicit_block_m,
++                hidden_size=int(layer.exl3_hidden_size),
++                intermediate_size=int(layer.exl3_intermediate_size_per_partition),
++                tier_signature=tier_signature,
++                topk=topk,
++                device_major=int(getattr(props, "major", 0)),
++                prefill_tile_config=mixed["prefill_tile_config"],
++            )
++            policy = {
++                "device_index": x.device.index,
++                "topk": topk,
++                "max_decode_m": max_decode_m,
++                "max_batched_tokens": max_batched_tokens,
++                "prefill_capacity": prefill_capacity,
++                "prefill_block_m": prefill_block_m,
++                "tier_signature": tier_signature,
++                "sms": int(props.multi_processor_count),
++                "max_shared_mem": int(props.shared_memory_per_block_optin),
++            }
++            mixed["runtime_policy"] = policy
++            logger.info_once(
++                "EXL3 mixed Trellis prefill block policy: selected=%d "
++                "configured=%d explicit=%s shape=%dx%d tiers=%s topk=%d "
++                "sm=%d tile=%s",
++                prefill_block_m,
++                configured_block_m,
++                explicit_block_m,
++                int(layer.exl3_hidden_size),
++                int(layer.exl3_intermediate_size_per_partition),
++                tier_signature,
++                topk,
++                int(getattr(props, "major", 0)),
++                mixed["prefill_tile_config"],
++            )
++        elif policy["device_index"] != x.device.index or policy["topk"] != topk:
++            raise RuntimeError(
++                "mixed-bitrate EXL3 runtime geometry changed after planning: "
++                f"device/topk={x.device.index}/{topk}, expected "
++                f"{policy['device_index']}/{policy['topk']}"
++            )
++
++        max_decode_m = policy["max_decode_m"]
++        max_batched_tokens = policy["max_batched_tokens"]
++        prefill_capacity = policy["prefill_capacity"]
++        prefill_block_m = policy["prefill_block_m"]
++        tier_signature = policy["tier_signature"]
+         key = (
+             _runtime_owner_token(self.quant_config, layer),
+             x.device.index,
+@@ -1852,7 +2810,10 @@ class Exl3MoEMethod(FusedMoEMethodBase):
+             topk,
+             max_decode_m,
+             max_batched_tokens,
++            prefill_capacity,
+             mixed["tile_config"],
++            mixed["prefill_tile_config"],
++            prefill_block_m,
+         )
+         runtime = _MIXED_TRELLIS_RUNTIMES.get(key)
+         if runtime is not None:
+@@ -1868,18 +2829,21 @@ class Exl3MoEMethod(FusedMoEMethodBase):
+                 f"{topk_ids.dtype}"
+             )
+ 
+-        api = _load_sparkinfer_mixed_trellis()
++        mixed_api = _load_sparkinfer_mixed_trellis()
+         device = x.device
+-        props = torch.cuda.get_device_properties(device)
+         total_experts = sum(experts for _, experts in tier_signature)
+ 
+-        def make_state(capacity: int) -> dict[str, Any]:
+-            route_slots = api.max_packed_route_slots(
++        def make_state(
++            capacity: int,
++            block_size_m: int,
++            tile_config: tuple[int, int, int, int],
++        ) -> dict[str, Any]:
++            route_slots = mixed_api.max_packed_route_slots(
+                 capacity * topk,
+-                _MIXED_TRELLIS_ROUTE_BLOCK_SIZE,
++                block_size_m,
+                 total_experts,
+             )
+-            launch = api.compile_mixed_trellis(
++            launch = mixed_api.compile_mixed_trellis(
+                 size_m=capacity,
+                 hidden_size=int(layer.exl3_hidden_size),
+                 intermediate_size=int(layer.exl3_intermediate_size_per_partition),
+@@ -1888,49 +2852,61 @@ class Exl3MoEMethod(FusedMoEMethodBase):
+                 tier0_bits=tier_signature[0][0],
+                 tier1_bits=tier_signature[1][0],
+                 top_k=topk,
+-                max_m_blocks=(route_slots + _MIXED_TRELLIS_ROUTE_BLOCK_SIZE - 1)
+-                // _MIXED_TRELLIS_ROUTE_BLOCK_SIZE,
+-                moe_block_size=_MIXED_TRELLIS_ROUTE_BLOCK_SIZE,
+-                sms=int(props.multi_processor_count),
+-                max_shared_mem=int(props.shared_memory_per_block_optin),
+-                force_tile_config=mixed["tile_config"],
++                max_m_blocks=(route_slots + block_size_m - 1) // block_size_m,
++                moe_block_size=block_size_m,
++                sms=policy["sms"],
++                max_shared_mem=policy["max_shared_mem"],
++                force_tile_config=tile_config,
+                 rotation_input_dtype=("bf16" if x.dtype == torch.bfloat16 else "fp16"),
+                 route_ids_dtype=topk_ids.dtype,
+             )
+             return {
+                 "capacity": capacity,
+                 "launch": launch,
+-                "buffers": api.make_mixed_trellis_buffers(
++                "buffers": mixed_api.make_mixed_trellis_buffers(
+                     launch,
+                     device=device,
+-                    sms=int(props.multi_processor_count),
++                    sms=policy["sms"],
+                 ),
+             }
+ 
+-        decode = make_state(max_decode_m)
+-        prefill = (
+-            make_state(max_batched_tokens)
+-            if max_batched_tokens > max_decode_m
+-            else decode
++        decode = make_state(
++            max_decode_m,
++            _MIXED_TRELLIS_ROUTE_BLOCK_SIZE,
++            mixed["tile_config"],
+         )
++        prefill = None
++        if max_batched_tokens > max_decode_m:
++            if os.environ.get("VLLM_EXL3_PREFILL_TRELLIS", "1") != "1":
++                raise ValueError("mixed-K EXL3 requires VLLM_EXL3_PREFILL_TRELLIS=1")
++            prefill = make_state(
++                prefill_capacity,
++                prefill_block_m,
++                mixed["prefill_tile_config"],
++            )
+         runtime = {
+-            "api": api,
++            "mixed_api": mixed_api,
+             "decode": decode,
+             "prefill": prefill,
+             "max_decode_m": max_decode_m,
+             "max_batched_tokens": max_batched_tokens,
++            "prefill_capacity": prefill_capacity,
+         }
+         _MIXED_TRELLIS_RUNTIMES[key] = runtime
+-        buffer_bytes = _unique_tensor_storage_bytes(
+-            decode["buffers"], prefill["buffers"]
++        decode_bytes = _unique_tensor_storage_bytes(decode["buffers"])
++        prefill_bytes = (
++            0 if prefill is None else _unique_tensor_storage_bytes(prefill["buffers"])
+         )
+         logger.info_once(
+-            "EXL3 mixed Trellis runtime planned: tiers=%s decode_capacity=%d "
+-            "prefill_capacity=%d buffers=%.1f MiB",
++            "EXL3 mixed Trellis runtime planned: tiers=%s one-grid decode=%d "
++            "one-grid prefill=%d/%d block_m=%d buffers=%.1f+%.1f MiB",
+             tier_signature,
+             max_decode_m,
++            prefill_capacity,
+             max_batched_tokens,
+-            buffer_bytes / (1 << 20),
++            prefill_block_m,
++            decode_bytes / (1 << 20),
++            prefill_bytes / (1 << 20),
+         )
+         return runtime
+ 
+@@ -1948,23 +2924,65 @@ class Exl3MoEMethod(FusedMoEMethodBase):
+                 "mixed-bitrate EXL3 batch exceeds planned capacity: "
+                 f"m={m}, capacity={runtime['max_batched_tokens']}"
+             )
+-        state = (
+-            runtime["decode"] if m <= runtime["max_decode_m"] else runtime["prefill"]
+-        )
+         mixed = layer.exl3_mixed_trellis
+-        output = runtime["api"].run_mixed_trellis(
+-            x,
+-            mixed["tiers"][0],
+-            mixed["tiers"][1],
+-            topk_weights,
+-            topk_ids,
+-            mixed["global_to_combined"],
+-            mixed["descriptor_map"],
+-            mixed["rotations"],
+-            state["launch"],
+-            state["buffers"],
+-        )
+-        return output.to(x.dtype)
++
++        def run_state(
++            slice_x: torch.Tensor,
++            slice_weights: torch.Tensor,
++            slice_ids: torch.Tensor,
++            state: dict[str, Any],
++            tiers: tuple[Any, Any],
++        ) -> torch.Tensor:
++            return (
++                runtime["mixed_api"]
++                .run_mixed_trellis(
++                    slice_x,
++                    tiers[0],
++                    tiers[1],
++                    slice_weights,
++                    slice_ids,
++                    mixed["global_to_combined"],
++                    mixed["descriptor_map"],
++                    mixed["rotations"],
++                    state["launch"],
++                    state["buffers"],
++                )
++                .to(slice_x.dtype)
++            )
++
++        if m <= runtime["max_decode_m"]:
++            return run_state(
++                x,
++                topk_weights,
++                topk_ids,
++                runtime["decode"],
++                mixed["tiers"],
++            )
++
++        if runtime["prefill"] is None:
++            raise RuntimeError("mixed-K EXL3 one-grid prefill plan is unavailable")
++        prefill_capacity = int(runtime["prefill_capacity"])
++        if m <= prefill_capacity:
++            return run_state(
++                x,
++                topk_weights,
++                topk_ids,
++                runtime["prefill"],
++                mixed["prefill_tiers"],
++            )
++
++        output = torch.empty_like(x)
++        for start in range(0, m, prefill_capacity):
++            stop = min(start + prefill_capacity, m)
++            slice_output = run_state(
++                x[start:stop],
++                topk_weights[start:stop],
++                topk_ids[start:stop],
++                runtime["prefill"],
++                mixed["prefill_tiers"],
++            )
++            output[start:stop].copy_(slice_output)
++        return output
+ 
+     def _rank_sliced_runtime(
+         self,
+@@ -1996,12 +3014,11 @@ class Exl3MoEMethod(FusedMoEMethodBase):
+             raise ValueError(
+                 "VLLM_EXL3_TRELLIS_MIN_M cannot exceed VLLM_EXL3_TRELLIS_MAX_M"
+             )
+-        # Batch-INVARIANT capacity. Including x.shape[0] here made the runtime
+-        # cache key depend on the live batch, so any m above the planned capacity
+-        # produced a cache MISS -- silently planning a fresh ~1 GiB arena mid-serve
+-        # and making the capacity guard in _apply_rank_sliced unreachable. The
+-        # planned capacity is a property of the layer, not of one forward pass.
++        # Both capacities are batch-invariant runtime properties. The scheduler
++        # bound remains fail-closed while a smaller opt-in Trellis capacity is
++        # handled by slicing at dispatch.
+         max_batched_tokens = int(layer.exl3_max_num_batched_tokens)
++        prefill_capacity = _resolve_prefill_capacity(max_batched_tokens)
+         prefill_plan_enabled = prefill_trellis and max_batched_tokens > max_trellis_m
+         parity_rows = (
+             min(chunk, max_batched_tokens)
+@@ -2036,6 +3053,7 @@ class Exl3MoEMethod(FusedMoEMethodBase):
+             prefill_trellis,
+             prefill_block_m,
+             layer.exl3_trellis_tile_config,
++            prefill_capacity,
+         )
+         runtime = _RANK_SLICED_RUNTIMES.get(key)
+         if runtime is not None:
+@@ -2079,7 +3097,7 @@ class Exl3MoEMethod(FusedMoEMethodBase):
+         prefill_scratch = None
+         if prefill_plan_enabled:
+             prefill_plan, prefill_scratch = _plan_with_scratch(
+-                max_batched_tokens, prefill_block_m
++                prefill_capacity, prefill_block_m
+             )
+ 
+         ext = _load_exl3_ext()
+@@ -2110,6 +3128,7 @@ class Exl3MoEMethod(FusedMoEMethodBase):
+             "min_trellis_m": min_trellis_m,
+             "max_trellis_m": max_trellis_m,
+             "max_batched_tokens": max_batched_tokens,
++            "prefill_capacity": prefill_capacity,
+             "parity_rows": parity_rows,
+             "topk": topk,
+             "chunk": chunk,
+@@ -2182,12 +3201,13 @@ class Exl3MoEMethod(FusedMoEMethodBase):
+         )
+         logger.info_once(
+             "EXL3 rank-sliced runtime planned: Trellis m=%d..%d block_m=%d, "
+-            "prefill %s capacity=%d chunk=%d topk=%d",
++            "prefill %s scheduler_capacity=%d chunk=%d topk=%d",
+             min_trellis_m,
+             max_trellis_m,
+             block_m,
+             (
+-                f"trellis block_m={prefill_block_m} arena={prefill_arena_mib:.1f}MiB"
++                f"trellis block_m={prefill_block_m} "
++                f"capacity={prefill_capacity} arena={prefill_arena_mib:.1f}MiB"
+                 if prefill_plan is not None
+                 else "parity"
+             ),
+@@ -2231,16 +3251,33 @@ class Exl3MoEMethod(FusedMoEMethodBase):
+                     "EXL3 batch exceeds its planned capacity: "
+                     f"m={m}, capacity={runtime['max_batched_tokens']}"
+                 )
+-            binding = runtime["api"].bind(
+-                runtime["prefill_plan"],
+-                scratch=runtime["prefill_scratch"],
+-                a=x,
+-                experts=layer.exl3_trellis_weights,
+-                topk_weights=topk_weights,
+-                topk_ids=topk_ids,
+-            )
+-            output = runtime["api"].run(binding=binding)
+-            return output.to(x.dtype)
++            prefill_capacity = int(runtime["prefill_capacity"])
++            if m <= prefill_capacity:
++                binding = runtime["api"].bind(
++                    runtime["prefill_plan"],
++                    scratch=runtime["prefill_scratch"],
++                    a=x,
++                    experts=layer.exl3_trellis_weights,
++                    topk_weights=topk_weights,
++                    topk_ids=topk_ids,
++                )
++                output = runtime["api"].run(binding=binding)
++                return output.to(x.dtype)
++
++            output = torch.empty_like(x)
++            for start in range(0, m, prefill_capacity):
++                stop = min(start + prefill_capacity, m)
++                binding = runtime["api"].bind(
++                    runtime["prefill_plan"],
++                    scratch=runtime["prefill_scratch"],
++                    a=x[start:stop],
++                    experts=layer.exl3_trellis_weights,
++                    topk_weights=topk_weights[start:stop],
++                    topk_ids=topk_ids[start:stop],
++                )
++                slice_output = runtime["api"].run(binding=binding)
++                output[start:stop].copy_(slice_output)
++            return output
+ 
+         if torch.cuda.is_current_stream_capturing():
+             raise RuntimeError(
+diff --git a/vllm/model_executor/layers/quantization/exl3_online_cache.py b/vllm/model_executor/layers/quantization/exl3_online_cache.py
+new file mode 100644
+index 0000000000000000000000000000000000000000..2855f2b1a43fb6b6d7eeed5a933e042cdc76b80d
+--- /dev/null
++++ b/vllm/model_executor/layers/quantization/exl3_online_cache.py
+@@ -0,0 +1,339 @@
++# SPDX-License-Identifier: Apache-2.0
++# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
++
++"""Persistent cache for deterministic online EXL3 weight encoding."""
++
++from __future__ import annotations
++
++import hashlib
++import json
++import os
++import tempfile
++from collections.abc import Callable, Mapping
++from dataclasses import asdict, dataclass
++from pathlib import Path
++from typing import Any, Literal
++
++import filelock
++import torch
++from safetensors import safe_open
++from safetensors.torch import save_file
++
++from vllm.logger import init_logger
++
++logger = init_logger(__name__)
++
++_CACHE_SCHEMA = 1
++_CACHE_TENSORS = frozenset({"trellis", "suh", "svh"})
++CacheMode = Literal["off", "readonly", "readwrite"]
++QuantizeFn = Callable[[], tuple[Mapping[str, torch.Tensor], float | None]]
++
++
++@dataclass(frozen=True)
++class Exl3OnlineCacheKey:
++    """All inputs that can change one rank-local online EXL3 payload."""
++
++    model_identity: str
++    encoder_identity: str
++    prefix: str
++    bits: int
++    seed: int
++    tp_world_size: int
++    tp_rank: int
++    input_size: int
++    output_size: int
++    codebook: str = "mcg"
++    apply_out_scales: bool = True
++    schema: int = _CACHE_SCHEMA
++
++    def canonical_json(self) -> str:
++        return json.dumps(asdict(self), sort_keys=True, separators=(",", ":"))
++
++    def digest(self) -> str:
++        return hashlib.sha256(self.canonical_json().encode()).hexdigest()
++
++
++@dataclass(frozen=True)
++class Exl3OnlineCacheResult:
++    tensors: dict[str, torch.Tensor]
++    proxy_error: float | None
++    hit: bool
++    path: Path | None
++
++
++def _sha256_file(path: Path) -> str:
++    digest = hashlib.sha256()
++    with path.open("rb") as source:
++        while chunk := source.read(1024 * 1024):
++            digest.update(chunk)
++    return digest.hexdigest()
++
++
++def resolve_model_identity(
++    model_name: str,
++    *,
++    revision: str | None = None,
++    hf_config: Any | None = None,
++) -> str:
++    """Fingerprint a Hub revision or a local checkpoint without reading weights."""
++
++    resolved_revision = getattr(hf_config, "_commit_hash", None) or revision
++    model_path = Path(model_name).expanduser()
++    if not model_path.exists():
++        if not resolved_revision:
++            raise ValueError(
++                "online EXL3 caching requires a resolved revision for Hub "
++                f"checkpoint {model_name!r}; pass --revision or set "
++                "VLLM_EXL3_ONLINE_CACHE_MODE=off"
++            )
++        payload = {
++            "kind": "hub",
++            "model": model_name,
++            "revision": resolved_revision,
++        }
++        return hashlib.sha256(json.dumps(payload, sort_keys=True).encode()).hexdigest()
++
++    model_path = model_path.resolve()
++    if model_path.is_file():
++        stat = model_path.stat()
++        payload = {
++            "kind": "file",
++            "path": str(model_path),
++            "size": stat.st_size,
++            "mtime_ns": stat.st_mtime_ns,
++        }
++        if stat.st_size <= 16 * 1024 * 1024:
++            payload["sha256"] = _sha256_file(model_path)
++        return hashlib.sha256(json.dumps(payload, sort_keys=True).encode()).hexdigest()
++
++    markers: list[tuple[str, str]] = []
++    for name in (
++        "config.json",
++        "quantization_config.json",
++        "model.safetensors.index.json",
++        "pytorch_model.bin.index.json",
++        "tier_bitmap.json",
++    ):
++        path = model_path / name
++        if path.is_file():
++            markers.append((name, _sha256_file(path)))
++
++    shards: list[tuple[str, str, int, int]] = []
++    for pattern in ("*.safetensors", "*.bin", "*.gguf"):
++        for path in sorted(model_path.glob(pattern)):
++            resolved = path.resolve()
++            stat = resolved.stat()
++            shards.append(
++                (
++                    path.name,
++                    str(resolved),
++                    stat.st_size,
++                    stat.st_mtime_ns,
++                )
++            )
++    payload = {
++        "kind": "directory",
++        "path": str(model_path),
++        "revision": resolved_revision,
++        "markers": markers,
++        "shards": shards,
++    }
++    return hashlib.sha256(
++        json.dumps(payload, sort_keys=True, separators=(",", ":")).encode()
++    ).hexdigest()
++
++
++def resolve_encoder_identity(
++    package_root: str | Path,
++    *,
++    revision: str | None = None,
++) -> str:
++    """Identify the encoder implementation used to produce cached tensors."""
++
++    root = Path(package_root).expanduser().resolve()
++    if revision and revision.strip():
++        payload = {"root": str(root), "revision": revision.strip()}
++    else:
++        files = [
++            (str(path.relative_to(root)), _sha256_file(path))
++            for path in sorted(root.rglob("*.py"))
++            if path.is_file()
++        ]
++        if not files:
++            raise ValueError(f"EXL3 encoder source contains no Python files: {root}")
++        payload = {"root": str(root), "files": files}
++    return hashlib.sha256(
++        json.dumps(payload, sort_keys=True, separators=(",", ":")).encode()
++    ).hexdigest()
++
++
++def cache_mode() -> CacheMode:
++    raw = os.getenv("VLLM_EXL3_ONLINE_CACHE_MODE", "readwrite").strip().lower()
++    aliases = {"read-only": "readonly", "rw": "readwrite", "none": "off"}
++    raw = aliases.get(raw, raw)
++    if raw not in {"off", "readonly", "readwrite"}:
++        raise ValueError(
++            "VLLM_EXL3_ONLINE_CACHE_MODE must be off, readonly, or readwrite; "
++            f"got {raw!r}"
++        )
++    return raw  # type: ignore[return-value]
++
++
++def cache_root() -> Path:
++    """Return the trusted online-weight cache directory.
++
++    Cached payloads become model weights after schema validation. The directory
++    must therefore be writable only by the serving user and trusted to the same
++    degree as the source checkpoint.
++    """
++
++    configured = os.getenv("VLLM_EXL3_ONLINE_CACHE_DIR")
++    if configured and configured.strip():
++        return Path(configured).expanduser()
++    vllm_root = Path(os.getenv("VLLM_CACHE_ROOT", "~/.cache/vllm")).expanduser()
++    return vllm_root / "exl3_online"
++
++
++def cache_path(key: Exl3OnlineCacheKey) -> Path:
++    digest = key.digest()
++    model_dir = key.model_identity[:20]
++    rank_dir = f"tp{key.tp_world_size}-rank{key.tp_rank}"
++    return (
++        cache_root()
++        / f"v{_CACHE_SCHEMA}"
++        / model_dir
++        / rank_dir
++        / f"{digest}.safetensors"
++    )
++
++
++def _validate_tensors(
++    tensors: Mapping[str, torch.Tensor], key: Exl3OnlineCacheKey
++) -> None:
++    if set(tensors) != _CACHE_TENSORS:
++        raise ValueError(
++            f"online EXL3 cache tensor set is {sorted(tensors)}, "
++            f"expected {sorted(_CACHE_TENSORS)}"
++        )
++    expected = {
++        "trellis": (
++            torch.int16,
++            (key.input_size // 16, key.output_size // 16, key.bits * 16),
++        ),
++        "suh": (torch.float16, (key.input_size,)),
++        "svh": (torch.float16, (key.output_size,)),
++    }
++    for name, (dtype, shape) in expected.items():
++        tensor = tensors[name]
++        if tensor.dtype != dtype or tuple(tensor.shape) != shape:
++            raise ValueError(
++                f"online EXL3 cache {name} has {tensor.dtype}/{tuple(tensor.shape)}, "
++                f"expected {dtype}/{shape}"
++            )
++        if not tensor.is_contiguous():
++            raise ValueError(f"online EXL3 cache {name} must be contiguous")
++
++
++def _load(path: Path, key: Exl3OnlineCacheKey) -> Exl3OnlineCacheResult:
++    with safe_open(path, framework="pt", device="cpu") as handle:
++        metadata = handle.metadata() or {}
++        if metadata.get("cache_key") != key.canonical_json():
++            raise ValueError("online EXL3 cache key metadata does not match")
++        # ``safe_open`` exposes ``keys()`` but is not itself iterable.
++        tensors = {name: handle.get_tensor(name) for name in handle.keys()}  # noqa: SIM118
++    _validate_tensors(tensors, key)
++    raw_error = metadata.get("proxy_error")
++    proxy_error = None if raw_error in (None, "") else float(raw_error)
++    return Exl3OnlineCacheResult(dict(tensors), proxy_error, True, path)
++
++
++def _to_device(
++    result: Exl3OnlineCacheResult, device: torch.device
++) -> Exl3OnlineCacheResult:
++    tensors = {
++        name: tensor.to(device=device, non_blocking=False).contiguous()
++        for name, tensor in result.tensors.items()
++    }
++    return Exl3OnlineCacheResult(tensors, result.proxy_error, result.hit, result.path)
++
++
++def _quantize(
++    key: Exl3OnlineCacheKey,
++    quantize: QuantizeFn,
++    *,
++    path: Path | None,
++) -> Exl3OnlineCacheResult:
++    tensors, proxy_error = quantize()
++    tensors = {name: tensor.contiguous() for name, tensor in tensors.items()}
++    _validate_tensors(tensors, key)
++    return Exl3OnlineCacheResult(tensors, proxy_error, False, path)
++
++
++def _save(path: Path, key: Exl3OnlineCacheKey, result: Exl3OnlineCacheResult) -> None:
++    path.parent.mkdir(parents=True, exist_ok=True)
++    cpu_tensors = {
++        name: tensor.detach().to(device="cpu").contiguous()
++        for name, tensor in result.tensors.items()
++    }
++    metadata = {
++        "cache_key": key.canonical_json(),
++        "proxy_error": "" if result.proxy_error is None else repr(result.proxy_error),
++    }
++    fd, temporary_name = tempfile.mkstemp(
++        prefix=f".{path.name}.", suffix=".tmp", dir=path.parent
++    )
++    os.close(fd)
++    temporary = Path(temporary_name)
++    try:
++        save_file(cpu_tensors, temporary, metadata=metadata)
++        with temporary.open("rb") as output:
++            os.fsync(output.fileno())
++        os.replace(temporary, path)
++    finally:
++        temporary.unlink(missing_ok=True)
++
++
++def load_or_quantize(
++    key: Exl3OnlineCacheKey,
++    *,
++    device: torch.device,
++    quantize: QuantizeFn,
++) -> Exl3OnlineCacheResult:
++    """Load one rank-local payload or encode and atomically publish it."""
++
++    mode = cache_mode()
++    if mode == "off":
++        return _quantize(key, quantize, path=None)
++
++    path = cache_path(key)
++    if path.is_file():
++        try:
++            return _to_device(_load(path, key), device)
++        except Exception as exc:
++            logger.warning("Ignoring invalid online EXL3 cache %s: %s", path, exc)
++
++    if mode == "readonly":
++        return _quantize(key, quantize, path=None)
++
++    try:
++        path.parent.mkdir(parents=True, exist_ok=True)
++        lock = filelock.FileLock(f"{path}.lock")
++        with lock:
++            if path.is_file():
++                try:
++                    return _to_device(_load(path, key), device)
++                except Exception as exc:
++                    logger.warning(
++                        "Replacing invalid online EXL3 cache %s: %s", path, exc
++                    )
++                    path.unlink(missing_ok=True)
++            result = _quantize(key, quantize, path=path)
++            _save(path, key, result)
++            return result
++    except OSError as exc:
++        logger.warning(
++            "Online EXL3 cache is unavailable at %s; encoding without cache: %s",
++            path,
++            exc,
++        )
++        return _quantize(key, quantize, path=None)
+diff --git a/vllm/model_executor/warmup/kernel_warmup.py b/vllm/model_executor/warmup/kernel_warmup.py
+index 36a17fa8aa263009adc60acc5bf8ca172fa49645..95408d971f86597a245000d3337c47ff79bbd489 100644
+--- a/vllm/model_executor/warmup/kernel_warmup.py
++++ b/vllm/model_executor/warmup/kernel_warmup.py
+@@ -442,6 +442,28 @@ def _flashinfer_autotune_skip_ops(runner: "GPUModelRunner") -> set[str] | None:
+     return None
+ 
+ 
++def _flashinfer_autotune_dummy_run_kwargs(
++    runner: "GPUModelRunner",
++) -> dict[str, object]:
++    kwargs = dict(
++        num_tokens=runner.scheduler_config.max_num_batched_tokens,
++        skip_eplb=True,
++        is_profile=True,
++    )
++
++    # V2 initializes attention backends and block tables only after the initial
++    # memory profile.  Kernel autotuning runs during that profile, so execute
++    # the model kernels without attention until those tables exist.  Attention
++    # backends have their own warmup after KV-cache initialization.
++    if (
++        getattr(runner.vllm_config, "use_v2_model_runner", False)
++        and not hasattr(runner, "block_tables")
++    ):
++        kwargs["skip_attn"] = True
++
++    return kwargs
++
++
+ def flashinfer_autotune(runner: "GPUModelRunner") -> None:
+     """
+     Autotune FlashInfer operations.
+@@ -475,11 +497,7 @@ def flashinfer_autotune(runner: "GPUModelRunner") -> None:
+ 
+     if not use_persistent_cache:
+         with torch.inference_mode(), fi_utils.autotune(**autotune_kwargs):
+-            runner._dummy_run(
+-                num_tokens=runner.scheduler_config.max_num_batched_tokens,
+-                skip_eplb=True,
+-                is_profile=True,
+-            )
++            runner._dummy_run(**_flashinfer_autotune_dummy_run_kwargs(runner))
+         get_world_group().barrier()
+         return
+ 
+@@ -494,11 +512,7 @@ def flashinfer_autotune(runner: "GPUModelRunner") -> None:
+     # When autotuning with number of tokens m, flashinfer will autotune
+     # operations for all number of tokens up to m, so we only need to
+     # run with the max number of tokens.
+-    dummy_run_kwargs = dict(
+-        num_tokens=runner.scheduler_config.max_num_batched_tokens,
+-        skip_eplb=True,
+-        is_profile=True,
+-    )
++    dummy_run_kwargs = _flashinfer_autotune_dummy_run_kwargs(runner)
+ 
+     with torch.inference_mode():
+         if is_leader:
+diff --git a/vllm/models/deepseek_v4/nvidia/b12x.py b/vllm/models/deepseek_v4/nvidia/b12x.py
+index 9b26bd1ab599a7bbd45f285b6d55300b30f04a6c..4d244c087ae752177f9f8561d2ec42b8f9f159fc 100644
+--- a/vllm/models/deepseek_v4/nvidia/b12x.py
++++ b/vllm/models/deepseek_v4/nvidia/b12x.py
+@@ -30,6 +30,12 @@ from vllm.models.deepseek_v4.nvidia.flashmla import (
+     DeepseekV4FlashMLABackend,
+ )
+ from vllm.models.deepseek_v4.sparse_mla import DeepseekV4FlashMLAMetadata
++from vllm.v1.attention.backends.mla.compressor_utils import (
++    get_c128a_topk_width,
++    get_compressed_mla_max_q_chunks,
++    get_compressed_mla_split_cap,
++    get_dspark_swa_index_width,
++)
+ from vllm.v1.attention.ops.common import cp_lse_ag_out_rs
+ from vllm.v1.attention.ops.dcp_alltoall import (
+     dcp_a2a_lse_reduce,
+@@ -44,9 +50,6 @@ if TYPE_CHECKING:
+ _DSV4_HEAD_DIM = 512
+ _DSV4_V_HEAD_DIM = 512
+ _DSV4_CACHE_BYTES_PER_TOKEN = 584
+-_DSV4_CACHE_PAD_ALIGNMENT_BYTES = 576
+-_DECODE_SPLIT_TILE = 64
+-_C128A_TOPK_ALIGNMENT = 128
+ _VALIDATE_DCP_INDICES_ENV = "VLLM_DSV4_DCP_VALIDATE_INDICES"
+ 
+ 
+@@ -55,11 +58,20 @@ def _cdiv(x: int, y: int) -> int:
+ 
+ 
+ def _dsv4_b12x_page_nbytes(page_size: int) -> int:
+-    payload_nbytes = int(page_size) * _DSV4_CACHE_BYTES_PER_TOKEN
+-    return (
+-        _cdiv(payload_nbytes, _DSV4_CACHE_PAD_ALIGNMENT_BYTES)
+-        * _DSV4_CACHE_PAD_ALIGNMENT_BYTES
+-    )
++    """Return the logical DSV4 payload bytes in one cache page.
++
++    vLLM may place padding between physical pages, but the padding is not part
++    of the compressed-MLA payload.  Keeping it out of the exported view also
++    supports standalone contiguous allocations, whose physical page stride is
++    exactly ``page_size * 584`` bytes.
++
++    Args:
++        page_size: Number of tokens stored in one cache page.
++
++    Returns:
++        The logical compressed-MLA payload size in bytes.
++    """
++    return int(page_size) * _DSV4_CACHE_BYTES_PER_TOKEN
+ 
+ 
+ def _b12x_cache_page_view(
+@@ -67,7 +79,25 @@ def _b12x_cache_page_view(
+     page_size: int,
+     name: str,
+ ) -> torch.Tensor:
+-    """Return a uint8 ``[pages, padded_page_bytes]`` view for b12x kernels."""
++    """Return a uint8 ``[pages, payload_bytes]`` view for SparkInfer kernels.
++
++    Preserve the physical page stride so both padded packed allocations and
++    contiguous per-layer allocations follow the same runtime contract.
++
++    Args:
++        cache: Source paged cache tensor.
++        page_size: Number of tokens stored in one cache page.
++        name: Cache name used in validation errors.
++
++    Returns:
++        A logical byte view that preserves the source physical page stride.
++
++    Raises:
++        ValueError: If ``page_size`` is not positive.
++        RuntimeError: If the cache is not paged, a page cannot contain the
++            logical payload, pages overlap, or the payload within a page is
++            not contiguous.
++    """
+     page_nbytes = _dsv4_b12x_page_nbytes(page_size)
+     if page_nbytes <= 0:
+         raise ValueError(f"{name} page_size must be positive, got {page_size}")
+@@ -77,11 +107,19 @@ def _b12x_cache_page_view(
+         if int(byte_cache.shape[1]) < page_nbytes:
+             raise RuntimeError(
+                 f"{name} page width {int(byte_cache.shape[1])} is smaller than "
+-                f"DSV4 padded page width {page_nbytes}"
++                f"DSV4 payload width {page_nbytes}"
+             )
+-        if not byte_cache.is_contiguous():
+-            raise RuntimeError(f"{name} page cache must be contiguous")
+-        return byte_cache
++        if int(byte_cache.stride(1)) != 1:
++            raise RuntimeError(
++                f"{name} page payload must be contiguous, got stride "
++                f"{tuple(byte_cache.stride())}"
++            )
++        if int(byte_cache.stride(0)) < page_nbytes:
++            raise RuntimeError(
++                f"{name} page stride {int(byte_cache.stride(0))} is smaller than "
++                f"DSV4 page payload {page_nbytes}"
++            )
++        return byte_cache[:, :page_nbytes]
+ 
+     if byte_cache.ndim < 2:
+         raise RuntimeError(
+@@ -93,13 +131,22 @@ def _b12x_cache_page_view(
+     if page_stride_nbytes < page_nbytes:
+         raise RuntimeError(
+             f"{name} page stride {page_stride_nbytes} is smaller than DSV4 page "
+-            f"width {page_nbytes}"
++            f"payload {page_nbytes}"
+         )
+ 
++    expected_stride = 1
++    for dim in range(byte_cache.ndim - 1, 0, -1):
++        if int(byte_cache.stride(dim)) != expected_stride:
++            raise RuntimeError(
++                f"{name} page payload must be contiguous, got stride "
++                f"{tuple(byte_cache.stride())}"
++            )
++        expected_stride *= int(byte_cache.shape[dim])
++
+     # Packed DS4 KV cache views have a storage offset for this layer and a
+-    # larger per-block stride for the whole packed block. Expose only this
+-    # layer's page payload while preserving stride(0), so B12X can use the
+-    # packed block stride without materializing/copying.
++    # larger per-block stride for the whole packed block. Expose only the
++    # logical payload while preserving stride(0), so SparkInfer can use the
++    # physical block stride without materializing/copying.
+     page_view = torch.as_strided(
+         byte_cache,
+         size=(pages, page_nbytes),
+@@ -287,7 +334,7 @@ def _run_compressed_mla(
+     width = int(swa_indices.shape[-1])
+     if indexed_indices is not None:
+         width += int(indexed_indices.shape[-1])
+-    decode_split_cap = max(1, _cdiv(width, _DECODE_SPLIT_TILE))
++    decode_split_cap = get_compressed_mla_split_cap(width)
+     # Keep the legacy 64-wide split cap for decode, but let the b12x contract
+     # select the smaller batched-prefill split count when rows > decode max.
+     num_splits_cap = compressed_mla_split_chunks_for_contract(
+@@ -493,28 +540,53 @@ class DeepseekV4B12xMLAAttention(DeepseekV4FlashMLAAttention):
+             elif self.indexer is not None:
+                 indexed_width = int(self.indexer.topk_tokens)
+         elif self.compress_ratio > 1:
+-            indexed_width = _cdiv(self.max_model_len, self.compress_ratio)
+-            indexed_width = _cdiv(indexed_width, _C128A_TOPK_ALIGNMENT)
+-            indexed_width *= _C128A_TOPK_ALIGNMENT
++            indexed_width = get_c128a_topk_width(
++                self.max_model_len,
++                self.compress_ratio,
++            )
++
++        swa_width = int(self.window_size)
++        speculative_config = self.vllm_config.speculative_config
++        if speculative_config is not None and speculative_config.use_dspark():
++            swa_width = max(
++                swa_width,
++                get_dspark_swa_index_width(
++                    swa_width,
++                    speculative_config.num_speculative_tokens or 0,
++                ),
++            )
+ 
+-        width = max(int(self.window_size) + indexed_width, 1)
++        width = max(swa_width + indexed_width, 1)
+         rows = max(int(self.max_num_batched_tokens), 1)
+-        decode_split_cap = max(1, _cdiv(width, _DECODE_SPLIT_TILE))
++        decode_split_cap = get_compressed_mla_split_cap(width)
+         num_splits_cap = compressed_mla_split_chunks_for_contract(
+             rows=rows,
+             width=width,
+             max_chunks=decode_split_cap,
+         )
++        max_q_chunks = get_compressed_mla_max_q_chunks(
++            rows,
++            width,
++            decode_split_cap,
++            compressed_mla_split_chunks_for_contract,
++        )
++        dcp_world_size = max(
++            int(self.vllm_config.parallel_config.decode_context_parallel_size),
++            1,
++        )
++        # max_q_rows covers final row-sized buffers; max_q_chunks covers split
++        # intermediates whose peak can occur below max_q_rows.
+         plan = plan_compressed_mla_scratch(
+             B12XCompressedMLAScratchCaps(
+                 device=q.device,
+-                num_q_heads=int(q.shape[1]),
++                num_q_heads=int(q.shape[1]) * dcp_world_size,
+                 max_q_rows=rows,
+                 max_width=width,
+                 head_dim=_DSV4_HEAD_DIM,
+                 v_head_dim=_DSV4_V_HEAD_DIM,
+                 page_size=int(self.swa_cache_layer.block_size),
+                 max_chunks_per_row=num_splits_cap,
++                max_q_chunks=max_q_chunks,
+             )
+         )
+         current_workspace_manager().get_simultaneous(*plan.shapes_and_dtypes())
+@@ -549,6 +621,7 @@ class DeepseekV4B12xMLAAttention(DeepseekV4FlashMLAAttention):
+         if attn_metadata is None:
+             # Warmup dummy run: no metadata, so reserve the largest compressed
+             # MLA scratch this layer can request before vLLM locks workspace.
++            # Its config-derived geometry is identical on later dummy calls.
+             output.zero_()
+             self._reserve_dummy_compressed_mla_scratch(q)
+             return
+diff --git a/vllm/models/deepseek_v4/sparse_mla.py b/vllm/models/deepseek_v4/sparse_mla.py
+index 623bff0828d59ff275e39fb738ef66368c4d3987..d53b732b1ef9e122137eac343cf588f792b9ae01 100644
+--- a/vllm/models/deepseek_v4/sparse_mla.py
++++ b/vllm/models/deepseek_v4/sparse_mla.py
+@@ -11,7 +11,6 @@ from vllm.config import VllmConfig
+ from vllm.config.cache import CacheDType
+ from vllm.platforms.interface import DeviceCapability
+ from vllm.triton_utils import tl, triton
+-from vllm.utils.math_utils import cdiv
+ from vllm.v1.attention.backend import (
+     AttentionBackend,
+     AttentionCGSupport,
+@@ -20,17 +19,13 @@ from vllm.v1.attention.backend import (
+     CommonAttentionMetadata,
+     MultipleOf,
+ )
+-from vllm.v1.attention.backends.mla.compressor_utils import get_compressed_slot_mapping
++from vllm.v1.attention.backends.mla.compressor_utils import (
++    get_c128a_topk_width,
++    get_compressed_slot_mapping,
++)
+ from vllm.v1.attention.backends.utils import split_decodes_and_prefills
+ from vllm.v1.kv_cache_interface import AttentionSpec
+ 
+-# Pad C128A topk width to this alignment. 128 covers both h_q=64 (B_TOPK=64) and
+-# h_q=128 (B_TOPK=128). FlashMLA decode asserts extra_topk % B_TOPK == 0;
+-# unaligned widths (e.g. 17 = ceil(2136/128)) crash the sm100 head64 kernel.
+-# Padded slots stay -1 and decode_lens caps them via topk_length, so the pad is a
+-# no-op at kernel level. Mirrors _SPARSE_PREFILL_TOPK_ALIGNMENT in cache_utils.py.
+-_C128A_TOPK_ALIGNMENT = 128
+-
+ 
+ class DeepseekV4FlashMLABackend(AttentionBackend):
+     """DeepSeek-V4 sparse-MLA backend.
+@@ -191,12 +186,9 @@ class DeepseekV4FlashMLAMetadataBuilder(
+ 
+         # Pre-allocate C128A topk buffers for CUDA graph address stability.
+         if self.compress_ratio == 128:
+-            c128a_max_compressed = cdiv(
+-                self.model_config.max_model_len, self.compress_ratio
+-            )
+-            c128a_max_compressed = (
+-                cdiv(c128a_max_compressed, _C128A_TOPK_ALIGNMENT)
+-                * _C128A_TOPK_ALIGNMENT
++            c128a_max_compressed = get_c128a_topk_width(
++                self.model_config.max_model_len,
++                self.compress_ratio,
+             )
+             # Stored so _build_c128a_metadata passes it as the kernel's
+             # max_compressed_tokens, matching the buffer stride. Otherwise the
+diff --git a/vllm/v1/attention/backends/mla/compressor_utils.py b/vllm/v1/attention/backends/mla/compressor_utils.py
+index 9ec2085e8d180b0d40dd06f692db7d29916cbb54..7f140a8dfe239255731413533e517571f8d54dbb 100644
+--- a/vllm/v1/attention/backends/mla/compressor_utils.py
++++ b/vllm/v1/attention/backends/mla/compressor_utils.py
+@@ -1,8 +1,91 @@
+ # SPDX-License-Identifier: Apache-2.0
+ # SPDX-FileCopyrightText: Copyright contributors to the vLLM project
++from collections.abc import Callable
++from functools import cache
++
+ import torch
+ 
+ from vllm.triton_utils import tl, triton
++from vllm.utils.math_utils import cdiv
++
++_C128A_TOPK_ALIGNMENT = 128
++_COMPRESSED_MLA_SPLIT_ALIGNMENT = 64
++_DSPARK_SWA_INDEX_ALIGNMENT = 512
++
++
++def get_c128a_topk_width(max_model_len: int, compress_ratio: int) -> int:
++    """Return C128 indexed width padded for FlashMLA B_TOPK divisibility.
++
++    Args:
++        max_model_len: Maximum model context length in tokens.
++        compress_ratio: Ratio used to compress the indexed KV cache.
++
++    Returns:
++        The aligned compressed top-k width.
++    """
++    compressed_width = cdiv(max_model_len, compress_ratio)
++    return cdiv(compressed_width, _C128A_TOPK_ALIGNMENT) * _C128A_TOPK_ALIGNMENT
++
++
++def get_dspark_swa_index_width(
++    window_size: int,
++    num_speculative_tokens: int,
++) -> int:
++    """Return the padded width of non-causal DSpark SWA indices.
++
++    Args:
++        window_size: Sliding-window attention width.
++        num_speculative_tokens: Number of DSpark draft tokens.
++
++    Returns:
++        The aligned non-causal index width.
++    """
++    width = max(int(window_size), 0) + max(int(num_speculative_tokens), 0)
++    return cdiv(width, _DSPARK_SWA_INDEX_ALIGNMENT) * _DSPARK_SWA_INDEX_ALIGNMENT
++
++
++def get_compressed_mla_split_cap(width: int) -> int:
++    """Return the maximum compressed-MLA split count for ``width``.
++
++    Args:
++        width: Combined SWA and indexed width.
++
++    Returns:
++        The split count capped by the kernel tile width.
++    """
++    return max(1, cdiv(max(int(width), 1), _COMPRESSED_MLA_SPLIT_ALIGNMENT))
++
++
++@cache
++def get_compressed_mla_max_q_chunks(
++    max_rows: int,
++    width: int,
++    max_chunks: int,
++    split_chunks_for_contract: Callable[..., int],
++) -> int:
++    """Return the q-chunk cap over every reachable row count.
++
++    Args:
++        max_rows: Maximum number of query rows in one scheduler step.
++        width: Combined SWA and indexed width.
++        max_chunks: Maximum chunks allowed for each row.
++        split_chunks_for_contract: Kernel contract split-count function.
++
++    Returns:
++        The largest reachable product of rows and chunks per row.
++    """
++    max_rows = max(int(max_rows), 1)
++    width = max(int(width), 1)
++    max_chunks = max(int(max_chunks), 1)
++    return max(
++        rows
++        * split_chunks_for_contract(
++            rows=rows,
++            width=width,
++            max_chunks=max_chunks,
++        )
++        for rows in range(1, max_rows + 1)
++    )
+ 
+ 
+ @triton.jit
+@@ -48,15 +131,12 @@ def _compressed_slot_mapping_kernel(
+         else:
+             virtual_block_size = block_size * DCP_WORLD_SIZE
+             block_ids = pos_after_compress // virtual_block_size
+-            virtual_block_offsets = (
+-                pos_after_compress - block_ids * virtual_block_size
+-            )
++            virtual_block_offsets = pos_after_compress - block_ids * virtual_block_size
+             is_local = (
+                 virtual_block_offsets // CP_KV_CACHE_INTERLEAVE_SIZE
+             ) % DCP_WORLD_SIZE == DCP_RANK
+             block_offsets = (
+-                virtual_block_offsets
+-                // (DCP_WORLD_SIZE * CP_KV_CACHE_INTERLEAVE_SIZE)
++                virtual_block_offsets // (DCP_WORLD_SIZE * CP_KV_CACHE_INTERLEAVE_SIZE)
+             ) * CP_KV_CACHE_INTERLEAVE_SIZE + (
+                 virtual_block_offsets % CP_KV_CACHE_INTERLEAVE_SIZE
+             )
+diff --git a/vllm/v1/attention/backends/mla/sparse_swa.py b/vllm/v1/attention/backends/mla/sparse_swa.py
+index 5c23e98d3bb136b3776b1302649e6d3c24897f11..45bdf5d2e6964127e570aacec849c193bb1f34c9 100644
+--- a/vllm/v1/attention/backends/mla/sparse_swa.py
++++ b/vllm/v1/attention/backends/mla/sparse_swa.py
+@@ -17,6 +17,9 @@ from vllm.v1.attention.backend import (
+     CommonAttentionMetadata,
+     MultipleOf,
+ )
++from vllm.v1.attention.backends.mla.compressor_utils import (
++    get_dspark_swa_index_width,
++)
+ from vllm.v1.attention.ops.flashmla import FlashMLASchedMeta, get_mla_metadata
+ from vllm.v1.kv_cache_interface import (
+     KVCacheSpec,
+@@ -416,7 +419,10 @@ class DeepseekSparseSWAMetadataBuilder(AttentionMetadataBuilder):
+         # width. decode_swa_lens keeps the padding out of the attention result.
+         self.is_dspark = spec_config is not None and spec_config.use_dspark()
+         self.noncausal_index_width = (
+-            cdiv(self.window_size + self.num_speculative_tokens, 512) * 512
++            get_dspark_swa_index_width(
++                self.window_size,
++                self.num_speculative_tokens,
++            )
+             if self.is_dspark
+             else 0
+         )
+diff --git a/vllm/v1/attention/ops/dcp_alltoall.py b/vllm/v1/attention/ops/dcp_alltoall.py
+index e908a7262d1a85aedec4d4e73f1879b59f13ebb6..da0dce93e14e08d49d6caadcc93f8babcd923316 100644
+--- a/vllm/v1/attention/ops/dcp_alltoall.py
++++ b/vllm/v1/attention/ops/dcp_alltoall.py
+@@ -41,6 +41,10 @@ logger = init_logger(__name__)
+ 
+ _B12X_DCP_A2A_POOLS: dict[tuple[int, int, int, int, int, int], Any] = {}
+ _B12X_DCP_A2A_DISABLED: set[tuple[int, int, int, int, int, int]] = set()
++# DCP likewise has one stable eager scheduler owner.  Graph target/draft/encoder
++# identities are supplied separately by their GraphCaptureContext.
++_B12X_DCP_EAGER_CHANNEL_ID = "vllm:eager:dcp"
++_B12X_DCP_MAX_CONCURRENT_CHANNELS = 2
+ _DCP_A2A_GRAPH_BUFFERS: dict[
+     tuple[tuple[int, ...], torch.device, torch.dtype],
+     tuple[torch.Tensor, torch.Tensor],
+@@ -53,9 +57,7 @@ def _is_supported_bhd_layout(tensor: torch.Tensor) -> bool:
+         return False
+     batch, heads, head_dim = (int(value) for value in tensor.shape)
+     stride_batch, stride_head, _ = (int(value) for value in tensor.stride())
+-    packed_token_major = (
+-        stride_batch == heads * head_dim and stride_head == head_dim
+-    )
++    packed_token_major = stride_batch == heads * head_dim and stride_head == head_dim
+     capacity_strided_head_major = (
+         stride_batch == head_dim and stride_head >= batch * head_dim
+     )
+@@ -130,8 +132,10 @@ def _get_b12x_dcp_a2a_pool(
+             head_dim=head_dim,
+             query_head_dim=query_head_dim,
+             single_channel=False,
++            max_concurrent_channels=_B12X_DCP_MAX_CONCURRENT_CHANNELS,
+         )
+-        pool.for_stream()
++        pool.prepare_channels((_B12X_DCP_EAGER_CHANNEL_ID,))
++        pool.for_stream(channel_id=_B12X_DCP_EAGER_CHANNEL_ID)
+     except Exception as exc:
+         init_error = exc
+ 
+@@ -171,6 +175,8 @@ def _get_b12x_dcp_a2a_pool(
+ def capture_b12x_dcp_a2a(
+     cp_group: GroupCoordinator,
+     stream: torch.cuda.Stream | None = None,
++    *,
++    channel_id: str | None = None,
+ ):
+     """Bind registered SparkInfer DCP pools to the graph's owning stream.
+ 
+@@ -180,6 +186,7 @@ def capture_b12x_dcp_a2a(
+     Args:
+         cp_group: DCP group whose registered pools should enter capture.
+         stream: CUDA stream owned by the enclosing graph capture.
++        channel_id: Stable identity shared by every rank for this graph owner.
+     """
+     group_id = id(cp_group.device_group)
+     matching_pools = sorted(
+@@ -190,9 +197,14 @@ def capture_b12x_dcp_a2a(
+         ),
+         key=lambda item: item[0][1:],
+     )
++    if matching_pools and channel_id is None:
++        raise RuntimeError(
++            "distributed PCIe DCP graph capture requires an explicit semantic "
++            "channel_id"
++        )
+     with ExitStack() as stack:
+         for _, pool in matching_pools:
+-            stack.enter_context(pool.capture(stream=stream))
++            stack.enter_context(pool.capture(stream=stream, channel_id=channel_id))
+         yield
+ 
+ 
+@@ -313,6 +325,7 @@ def _try_b12x_dcp_lse_reduce(
+         cp_attn_lse,
+         out=reduced,
+         is_lse_base_on_e=is_lse_base_on_e,
++        channel_id=_B12X_DCP_EAGER_CHANNEL_ID,
+     )
+ 
+ 
+@@ -363,7 +376,10 @@ def _try_b12x_dcp_all_gather_heads(
+     )
+     if pool is None:
+         return None
+-    return pool.all_gather_heads(local_input)
++    return pool.all_gather_heads(
++        local_input,
++        channel_id=_B12X_DCP_EAGER_CHANNEL_ID,
++    )
+ 
+ 
+ def dcp_b12x_all_gather_heads(
+diff --git a/vllm/v1/kv_offload/cpu/gpu_worker.py b/vllm/v1/kv_offload/cpu/gpu_worker.py
+index baf9a66719a05c4d69969406ccf3e64e87bb9693..94448857963e21225c4bd97888e0dc46618c5917 100644
+--- a/vllm/v1/kv_offload/cpu/gpu_worker.py
++++ b/vllm/v1/kv_offload/cpu/gpu_worker.py
+@@ -4,6 +4,7 @@ import functools
+ import time
+ from collections import deque
+ from dataclasses import dataclass
++from math import lcm
+ 
+ import numpy as np
+ import torch
+@@ -23,6 +24,10 @@ from vllm.v1.kv_offload.base import (
+     OffloadingWorker,
+     TransferResult,
+ )
++from vllm.v1.kv_offload.cpu.host_mem_ops import (
++    register_host_memory,
++    unregister_host_memory,
++)
+ from vllm.v1.kv_offload.cpu.shared_offload_region import SharedOffloadRegion
+ from vllm.v1.kv_offload.cpu.swap_blocks_triton import (
+     THRESHOLD_BYTES,
+@@ -31,6 +36,75 @@ from vllm.v1.kv_offload.cpu.swap_blocks_triton import (
+ 
+ logger = init_logger(__name__)
+ 
++HOST_REGISTER_SEGMENT_BYTES = 256 << 20
++HOST_REGISTER_ALIGNMENT_BYTES = 64 << 10
++
++
++def _split_copy_descriptors_at_host_boundaries(
++    src: np.ndarray,
++    dst: np.ndarray,
++    sizes: np.ndarray,
++    count: int,
++    *,
++    host_is_src: bool,
++    host_base: int,
++    segment_bytes: int,
++) -> int:
++    """Split raw copies that cross separately registered host segments.
++
++    ``cuMemcpyBatchAsync`` rejects a single descriptor spanning two adjacent
++    ``cudaHostRegister`` regions. Expand only those descriptors in place;
++    processing backwards keeps unread inputs intact.
++    """
++    assert segment_bytes > 0
++    host_ptrs = src if host_is_src else dst
++    host_offsets = host_ptrs[:count] - host_base
++    copy_sizes = sizes[:count]
++    assert np.all(host_offsets >= 0) and np.all(copy_sizes > 0)
++    part_counts = np.floor_divide(
++        np.remainder(host_offsets, segment_bytes) + copy_sizes + segment_bytes - 1,
++        segment_bytes,
++    )
++    expanded_count = int(part_counts.sum())
++
++    if expanded_count == count:
++        return count
++
++    assert expanded_count <= len(src)
++    write_idx = expanded_count
++    for read_idx in range(count - 1, -1, -1):
++        src_ptr = int(src[read_idx])
++        dst_ptr = int(dst[read_idx])
++        size = int(sizes[read_idx])
++        host_ptr = src_ptr if host_is_src else dst_ptr
++        part_count = int(part_counts[read_idx])
++        if part_count == 1:
++            write_idx -= 1
++            src[write_idx] = src_ptr
++            dst[write_idx] = dst_ptr
++            sizes[write_idx] = size
++            continue
++
++        parts: list[tuple[int, int]] = []
++        copied = 0
++        while copied < size:
++            host_offset = host_ptr + copied - host_base
++            bytes_to_boundary = segment_bytes - host_offset % segment_bytes
++            part_size = min(size - copied, bytes_to_boundary)
++            parts.append((copied, part_size))
++            copied += part_size
++
++        assert len(parts) == part_count
++        write_idx -= len(parts)
++        for part_idx, (offset, part_size) in enumerate(parts):
++            out_idx = write_idx + part_idx
++            src[out_idx] = src_ptr + offset
++            dst[out_idx] = dst_ptr + offset
++            sizes[out_idx] = part_size
++
++    assert write_idx == 0
++    return expanded_count
++
+ 
+ def _select_swap_blocks_fn(
+     kv_cache_groups_data_refs: list[list[CanonicalKVCacheRef]],
+@@ -121,7 +195,12 @@ def compute_sub_block_ptrs(
+ 
+ 
+ def pin_mmap_region(region: SharedOffloadRegion) -> None:
+-    """Register the entire mmap as CUDA pinned memory via cudaHostRegister."""
++    """Register the mmap as CUDA pinned memory.
++
++    Large virtual mappings can be rejected by ``cudaHostRegister`` even when
++    enough host memory is available. Preserve the single-registration fast
++    path, then retry large mappings as bounded, non-overlapping segments.
++    """
+     if not current_platform.is_cuda_alike():
+         logger.info(
+             "Skipping mmap host registration on %s; cudaHostRegister is only "
+@@ -133,21 +212,83 @@ def pin_mmap_region(region: SharedOffloadRegion) -> None:
+     rank = region.rank
+ 
+     base_ptr = region._base.data_ptr()
+-    result = torch.cuda.cudart().cudaHostRegister(base_ptr, region.total_size_bytes, 0)
+-    if result.value != 0:
+-        logger.warning(
+-            "cudaHostRegister failed for rank=%d (code=%d) — "
+-            "transfers will still work but may be slower (unpinned DMA)",
+-            rank,
+-            result,
++    region._registered_host_ptrs.clear()
++    region._host_register_segment_bytes = None
++    result = register_host_memory(base_ptr, region.total_size_bytes)
++    if result != 0:
++        if region.total_size_bytes <= HOST_REGISTER_SEGMENT_BYTES:
++            logger.warning(
++                "cudaHostRegister failed for rank=%d (code=%d); "
++                "transfers will continue with unpinned memory",
++                rank,
++                result,
++            )
++            return
++
++        # Keep every canonical KV row inside one registration. CUDA's batched
++        # memcpy API rejects a descriptor spanning two adjacent registrations.
++        row_stride = region._row_stride
++        # CUDA 13 rejects adjacent registrations when their split offset does
++        # not preserve its 64 KiB host-registration granularity. Align to both
++        # that boundary and a full KV row so neither registration ranges nor
++        # batch-copy descriptors straddle a split.
++        segment_alignment = lcm(row_stride, HOST_REGISTER_ALIGNMENT_BYTES)
++        alignments_per_segment = max(
++            1, HOST_REGISTER_SEGMENT_BYTES // segment_alignment
+         )
+-    else:
+-        logger.debug(
+-            "cudaHostRegister rank=%d %.2f GB",
++        segment_bytes = alignments_per_segment * segment_alignment
++        registered_ptrs: list[int] = []
++        for offset in range(0, region.total_size_bytes, segment_bytes):
++            ptr = base_ptr + offset
++            size = min(
++                segment_bytes,
++                region.total_size_bytes - offset,
++            )
++            segment_result = register_host_memory(ptr, size)
++            if segment_result == 0:
++                registered_ptrs.append(ptr)
++                continue
++
++            for registered_ptr in reversed(registered_ptrs):
++                unregister_result = unregister_host_memory(registered_ptr)
++                if unregister_result != 0:
++                    logger.warning(
++                        "cudaHostUnregister rollback failed for rank=%d "
++                        "ptr=%#x (code=%d)",
++                        rank,
++                        registered_ptr,
++                        unregister_result,
++                    )
++            logger.warning(
++                "Segmented cudaHostRegister failed for rank=%d offset=%d "
++                "size=%d (code=%d); transfers will continue with unpinned memory",
++                rank,
++                offset,
++                size,
++                segment_result,
++            )
++            return
++
++        region._registered_host_ptrs.extend(registered_ptrs)
++        region._host_register_segment_bytes = segment_bytes
++        region.is_pinned = True
++        logger.info(
++            "Registered rank=%d mmap as %d row-aligned host-memory segments "
++            "(segment=%d bytes, total=%.2f GB)",
+             rank,
++            len(registered_ptrs),
++            segment_bytes,
+             region.total_size_bytes / 1e9,
+         )
+-        region.is_pinned = True
++        return
++
++    region._registered_host_ptrs.append(base_ptr)
++    region.is_pinned = True
++    logger.debug(
++        "cudaHostRegister rank=%d %.2f GB",
++        rank,
++        region.total_size_bytes / 1e9,
++    )
+ 
+ 
+ def _new_descriptor_buffers(
+@@ -179,6 +320,8 @@ class SingleDirectionOffloadingHandler:
+         kv_cache_groups_data_refs: list[list[CanonicalKVCacheRef]],
+         gpu_to_cpu: bool,
+         mmap_region: SharedOffloadRegion | None = None,
++        segmented_host_base: int | None = None,
++        segmented_host_bytes: int | None = None,
+     ):
+         """
+         Initialize a SingleDirectionOffloadingHandler.
+@@ -218,6 +361,21 @@ class SingleDirectionOffloadingHandler:
+         self._swap_blocks_batch = _select_swap_blocks_fn(
+             kv_cache_groups_data_refs, gpu_to_cpu
+         )
++        self._segmented_host_base = segmented_host_base
++        self._segmented_host_bytes = segmented_host_bytes
++        assert (segmented_host_base is None) == (segmented_host_bytes is None)
++        page_sizes = [
++            data_ref.page_size_bytes
++            for group in kv_cache_groups_data_refs
++            for data_ref in group
++        ]
++        self._descriptor_capacity_multiplier = 1
++        if segmented_host_base is not None and page_sizes:
++            assert segmented_host_bytes is not None
++            max_page_size = max(page_sizes)
++            self._descriptor_capacity_multiplier = 1 + cdiv(
++                max_page_size - 1, segmented_host_bytes
++            )
+ 
+         # GPU blocks may be smaller
+         # cpu_page_size = gpu_page_size * blocks_per_chunk.
+@@ -287,13 +445,16 @@ class SingleDirectionOffloadingHandler:
+             num_copy_ops += group_size * len(group_data_refs)
+ 
+         # reuse a pooled buffer set, growing it if this transfer needs more room
++        descriptor_capacity = num_copy_ops * self._descriptor_capacity_multiplier
+         batch_src, batch_dst, batch_sizes = (
+             self._buffer_pool.pop()
+             if self._buffer_pool
+-            else _new_descriptor_buffers(num_copy_ops)
++            else _new_descriptor_buffers(descriptor_capacity)
+         )
+-        if batch_src.numel() < num_copy_ops:
+-            batch_src, batch_dst, batch_sizes = _new_descriptor_buffers(num_copy_ops)
++        if batch_src.numel() < descriptor_capacity:
++            batch_src, batch_dst, batch_sizes = _new_descriptor_buffers(
++                descriptor_capacity
++            )
+ 
+         src = batch_src[:num_copy_ops]
+         dst = batch_dst[:num_copy_ops]
+@@ -359,6 +520,21 @@ class SingleDirectionOffloadingHandler:
+         assert dst_offset == num_dst_blocks
+         assert op_idx == num_copy_ops
+ 
++        if self._segmented_host_base is not None and num_copy_ops > 0:
++            assert self._segmented_host_bytes is not None
++            num_copy_ops = _split_copy_descriptors_at_host_boundaries(
++                batch_src.numpy(),
++                batch_dst.numpy(),
++                batch_sizes.numpy(),
++                num_copy_ops,
++                host_is_src=not self.gpu_to_cpu,
++                host_base=self._segmented_host_base,
++                segment_bytes=self._segmented_host_bytes,
++            )
++            src = batch_src[:num_copy_ops]
++            dst = batch_dst[:num_copy_ops]
++            sizes = batch_sizes[:num_copy_ops]
++
+         stream = (
+             self._stream_pool.pop() if self._stream_pool else current_platform.Stream()
+         )
+@@ -480,6 +656,8 @@ class CPUOffloadingWorker(OffloadingWorker):
+         logger.info("Allocating %d CPU tensors...", len(kv_caches.tensors))
+         if mmap_region is not None and pin_memory:
+             pin_mmap_region(mmap_region)
++        segmented_host_base = None
++        segmented_host_bytes = None
+ 
+         gpu_tensors: list[torch.Tensor] = []
+         cpu_tensors: list[torch.Tensor] = []
+@@ -511,6 +689,15 @@ class CPUOffloadingWorker(OffloadingWorker):
+             gpu_tensors.append(gpu_tensor)
+             cpu_tensors.append(cpu_tensor)
+ 
++        if mmap_region is not None and len(mmap_region._registered_host_ptrs) > 1:
++            registration_bytes = mmap_region._host_register_segment_bytes
++            assert registration_bytes is not None
++            # Row-aligned registrations are the zero-overhead fast path. Keep
++            # the descriptor splitter only for alternate layouts.
++            if any(registration_bytes % tensor.stride(0) for tensor in cpu_tensors):
++                segmented_host_base = mmap_region._base.data_ptr()
++                segmented_host_bytes = registration_bytes
++
+         self._store_handler = SingleDirectionOffloadingHandler(
+             gpu_tensors=gpu_tensors,
+             cpu_tensors=cpu_tensors,
+@@ -518,6 +705,8 @@ class CPUOffloadingWorker(OffloadingWorker):
+             kv_cache_groups_data_refs=kv_caches.group_data_refs,
+             gpu_to_cpu=True,
+             mmap_region=mmap_region,
++            segmented_host_base=segmented_host_base,
++            segmented_host_bytes=segmented_host_bytes,
+         )
+ 
+         self._load_handler = SingleDirectionOffloadingHandler(
+@@ -526,6 +715,8 @@ class CPUOffloadingWorker(OffloadingWorker):
+             blocks_per_chunk=blocks_per_chunk,
+             kv_cache_groups_data_refs=kv_caches.group_data_refs,
+             gpu_to_cpu=False,
++            segmented_host_base=segmented_host_base,
++            segmented_host_bytes=segmented_host_bytes,
+         )
+ 
+     def submit_store(
+diff --git a/vllm/v1/kv_offload/cpu/host_mem_ops.py b/vllm/v1/kv_offload/cpu/host_mem_ops.py
+new file mode 100644
+index 0000000000000000000000000000000000000000..a6e6d4f59b89d16161d5fb2e66415f794e69a862
+--- /dev/null
++++ b/vllm/v1/kv_offload/cpu/host_mem_ops.py
+@@ -0,0 +1,65 @@
++# SPDX-License-Identifier: Apache-2.0
++# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
++"""Low-level host-memory registration helpers for CPU KV offload."""
++
++import torch
++
++from vllm.distributed.device_communicators.cuda_wrapper import CudaRTLibrary
++from vllm.platforms import current_platform
++
++
++def _get_cuda_driver():
++    from cuda.bindings import driver
++
++    return driver
++
++
++def register_host_memory(ptr: int, size: int) -> int:
++    """Register host memory and return a CUDA/HIP error code.
++
++    CUDA uses the driver API deliberately. A failed runtime
++    ``cudaHostRegister`` updates the calling thread's last-error state, which
++    can make a later unrelated PyTorch operation fail even when offload falls
++    back to pageable memory. Driver API failures are returned directly and do
++    not contaminate that runtime state.
++
++    Args:
++        ptr: Base address of the host-memory region.
++        size: Region size in bytes.
++
++    Returns:
++        The CUDA or HIP registration error code.
++    """
++    if current_platform.is_cuda():
++        (result,) = _get_cuda_driver().cuMemHostRegister(ptr, size, 0)
++        return int(result.value)
++
++    cudart = torch.cuda.cudart()
++    result = cudart.cudaHostRegister(ptr, size, 0)
++    code = int(result.value)
++    if code != 0:
++        # HIP uses the runtime API, so consume its expected registration error
++        # before the caller continues with pageable memory.
++        CudaRTLibrary().cudaGetLastError()
++    return code
++
++
++def unregister_host_memory(ptr: int) -> int:
++    """Unregister host memory and return a CUDA/HIP error code.
++
++    Args:
++        ptr: Base address passed to :func:`register_host_memory`.
++
++    Returns:
++        The CUDA or HIP unregistration error code.
++    """
++    if current_platform.is_cuda():
++        (result,) = _get_cuda_driver().cuMemHostUnregister(ptr)
++        return int(result.value)
++
++    cudart = torch.cuda.cudart()
++    result = cudart.cudaHostUnregister(ptr)
++    code = int(result.value)
++    if code != 0:
++        CudaRTLibrary().cudaGetLastError()
++    return code
+diff --git a/vllm/v1/kv_offload/cpu/shared_offload_region.py b/vllm/v1/kv_offload/cpu/shared_offload_region.py
+index 290c0d5107d4d7298b0bea86f35608da527f25b1..419707282cb54d27db035a9d6514180b67c8deaf 100644
+--- a/vllm/v1/kv_offload/cpu/shared_offload_region.py
++++ b/vllm/v1/kv_offload/cpu/shared_offload_region.py
+@@ -1,5 +1,6 @@
+ # SPDX-License-Identifier: Apache-2.0
+ # SPDX-FileCopyrightText: Copyright contributors to the vLLM project
++import contextlib
+ import mmap
+ import os
+ import time
+@@ -8,6 +9,7 @@ import torch
+ 
+ from vllm.logger import init_logger
+ from vllm.platforms import current_platform
++from vllm.v1.kv_offload.cpu.host_mem_ops import unregister_host_memory
+ 
+ logger = init_logger(__name__)
+ 
+@@ -45,15 +47,27 @@ class SharedOffloadRegion:
+         rank: int | None,
+         kv_bytes_per_block: int,
+         cpu_page_size: int,
++        *,
++        unlink_after_workers_map: bool = False,
++        num_workers: int | None = None,
+     ) -> None:
+         self.page_size = mmap.PAGESIZE
+         assert kv_bytes_per_block % self.page_size == 0
++        if unlink_after_workers_map:
++            if num_workers is None or num_workers <= 0:
++                raise ValueError(
++                    "num_workers must be positive when "
++                    "unlink_after_workers_map is enabled"
++                )
++            if rank is not None and not 0 <= rank < num_workers:
++                raise ValueError(f"rank {rank} is outside num_workers={num_workers}")
+ 
+         self.num_blocks = num_blocks
+         self._row_stride = kv_bytes_per_block
+         self.total_size_bytes = self.num_blocks * self._row_stride
+ 
+         self.mmap_path = f"/dev/shm/vllm_offload_{engine_id}.mmap"
++        self._mapping_marker: str | None = None
+         self._creator = False  # set True only if this worker creates the file
+         self.rank = rank
+         if rank is not None:
+@@ -85,6 +99,10 @@ class SharedOffloadRegion:
+             prot=mmap.PROT_READ | mmap.PROT_WRITE,
+         )
+ 
++        if unlink_after_workers_map and rank is not None:
++            assert num_workers is not None
++            self._unlink_after_worker_mappings(num_workers)
++
+         # MADV_POPULATE_WRITE was added in Linux 5.14 (value 23).
+         _MADV_POPULATE_WRITE = getattr(mmap, "MADV_POPULATE_WRITE", 23)
+         if rank is not None:
+@@ -115,8 +133,59 @@ class SharedOffloadRegion:
+ 
+         self._base = torch.frombuffer(memoryview(self.mmap_obj), dtype=torch.int8)
+         self._views: list[torch.Tensor] = []
++        self._registered_host_ptrs: list[int] = []
++        self._host_register_segment_bytes: int | None = None
+         self.is_pinned: bool = False
+ 
++    def _unlink_after_worker_mappings(
++        self, num_workers: int, timeout: float = 30.0
++    ) -> None:
++        """Make the mmap anonymous after every worker has mapped the file.
++
++        The pathname is needed only while workers rendezvous during startup.
++        Once every rank owns a mapping, unlinking is safe: POSIX keeps the
++        pages alive until the last mapping closes and releases them even when
++        a worker is terminated before Python cleanup runs.
++        """
++        assert self.rank is not None
++        marker_prefix = f"{self.mmap_path}.mapped."
++        marker_path = f"{marker_prefix}{self.rank}"
++        marker_fd = os.open(marker_path, os.O_CREAT | os.O_EXCL | os.O_WRONLY, 0o600)
++        os.close(marker_fd)
++        self._mapping_marker = marker_path
++
++        # Rank 0 is the coordinator, independent of which rank created the
++        # backing file. Other ranks can continue as soon as their mapping is
++        # established; rank 0 keeps the pathname available until all markers
++        # are visible.
++        if self.rank != 0:
++            return
++
++        marker_paths = [f"{marker_prefix}{rank}" for rank in range(num_workers)]
++        deadline = time.monotonic() + timeout
++        while not all(os.path.exists(path) for path in marker_paths):
++            if time.monotonic() > deadline:
++                missing = [path for path in marker_paths if not os.path.exists(path)]
++                raise TimeoutError(
++                    "Timed out waiting for worker mmap markers: " + ", ".join(missing)
++                )
++            time.sleep(0.005)
++
++        try:
++            os.unlink(self.mmap_path)
++            logger.info(
++                "Unlinked mmap file %s after %d workers mapped it",
++                self.mmap_path,
++                num_workers,
++            )
++        except FileNotFoundError:
++            pass
++        finally:
++            for path in marker_paths:
++                with contextlib.suppress(FileNotFoundError):
++                    os.unlink(path)
++            self._mapping_marker = None
++
+     def create_next_view(self, tensor_page_size: int) -> torch.Tensor:
+         """Allocate a strided int8 view for this worker, one canonical tensor.
+ 
+@@ -173,14 +242,18 @@ class SharedOffloadRegion:
+     def cleanup(self) -> None:
+         if self.is_pinned and self._base is not None:
+             if current_platform.is_cuda_alike():
+-                base_ptr = self._base.data_ptr()
+-                result = torch.cuda.cudart().cudaHostUnregister(base_ptr)
+-                if result.value != 0:
+-                    logger.warning(
+-                        "cudaHostUnregister failed for rank=%d (code=%d)",
+-                        self.rank,
+-                        result,
+-                    )
++                registered_ptrs = self._registered_host_ptrs or [self._base.data_ptr()]
++                for ptr in reversed(registered_ptrs):
++                    result = unregister_host_memory(ptr)
++                    if result != 0:
++                        logger.warning(
++                            "cudaHostUnregister failed for rank=%d ptr=%#x (code=%d)",
++                            self.rank,
++                            ptr,
++                            result,
++                        )
++            self._registered_host_ptrs.clear()
++            self._host_register_segment_bytes = None
+             self.is_pinned = False
+         # Release views before _base: each view holds a _base reference and a
+         # direct StorageImpl reference.  Freeing views first lets both refcounts
+@@ -201,10 +274,16 @@ class SharedOffloadRegion:
+             except Exception:
+                 logger.warning("Failed to close fd %s", self.fd, exc_info=True)
+             self.fd = None
++        if self._mapping_marker is not None:
++            with contextlib.suppress(FileNotFoundError):
++                os.unlink(self._mapping_marker)
++            self._mapping_marker = None
+         if self._creator and getattr(self, "mmap_path", None):
+             try:
+                 os.unlink(self.mmap_path)
+                 logger.info("Removed mmap file %s", self.mmap_path)
++            except FileNotFoundError:
++                pass
+             except Exception:
+                 logger.warning(
+                     "Failed to unlink path %s", self.mmap_path, exc_info=True
+diff --git a/vllm/v1/kv_offload/cpu/spec.py b/vllm/v1/kv_offload/cpu/spec.py
+index f6d1c29aff930bf485354a45478040261fa68205..cbd857670faa5770764ce690044c1f831df0fd1a 100644
+--- a/vllm/v1/kv_offload/cpu/spec.py
++++ b/vllm/v1/kv_offload/cpu/spec.py
+@@ -2,6 +2,7 @@
+ # SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+ from typing import Any
+ 
++import torch
+ from typing_extensions import override
+ 
+ from vllm.platforms import current_platform
+@@ -20,10 +21,11 @@ from vllm.v1.kv_offload.config import OffloadingConfig
+ from vllm.v1.kv_offload.cpu.common import CPUOffloadingMetrics
+ from vllm.v1.kv_offload.cpu.gpu_worker import CPUOffloadingWorker
+ from vllm.v1.kv_offload.cpu.manager import CPUOffloadingManager
++from vllm.v1.kv_offload.cpu.shared_offload_region import SharedOffloadRegion
+ 
+ 
+ class CPUOffloadingSpec(OffloadingSpec):
+-    BLOCK_SIZE_ALIGNMENT = 1
++    BLOCK_SIZE_ALIGNMENT = SharedOffloadRegion.BLOCK_SIZE_ALIGNMENT
+ 
+     @classmethod
+     def build_metric_definitions(
+@@ -133,10 +135,24 @@ class CPUOffloadingSpec(OffloadingSpec):
+         return self._manager
+ 
+     def create_worker(self, kv_caches: CanonicalKVCaches) -> CPUOffloadingWorker:
++        mmap_region: SharedOffloadRegion | None = None
++        if current_platform.is_cuda_alike() and self.num_blocks > 0:
++            world_size = self.config.parallel.world_size
++            rank = torch.accelerator.current_device_index() % world_size
++            mmap_region = SharedOffloadRegion(
++                engine_id=self.config.engine_id,
++                num_blocks=self.num_blocks,
++                rank=rank,
++                kv_bytes_per_block=self.kv_bytes_per_chunk,
++                cpu_page_size=self.cpu_page_size_per_worker,
++                unlink_after_workers_map=True,
++                num_workers=world_size,
++            )
+         return CPUOffloadingWorker(
+             kv_caches=kv_caches,
+             blocks_per_chunk=self.blocks_per_chunk,
+             num_cpu_blocks=self.num_blocks,
++            mmap_region=mmap_region,
+         )
+ 
+     @override
+diff --git a/vllm/v1/kv_offload/tiering/spec.py b/vllm/v1/kv_offload/tiering/spec.py
+index 964699968c9b7630fd8375e15dbb7bd4dc1e2253..46e89377369fa37c3a6cf4b7d9fceaee0aa691ca 100644
+--- a/vllm/v1/kv_offload/tiering/spec.py
++++ b/vllm/v1/kv_offload/tiering/spec.py
+@@ -179,6 +179,8 @@ class TieringOffloadingSpec(CPUOffloadingSpec):
+                 rank=None,
+                 kv_bytes_per_block=self.kv_bytes_per_chunk,
+                 cpu_page_size=self.cpu_page_size_per_worker,
++                unlink_after_workers_map=True,
++                num_workers=self.config.parallel.world_size,
+             )
+             self._scheduler_mmap = scheduler_mmap
+ 
+@@ -247,6 +249,8 @@ class TieringOffloadingSpec(CPUOffloadingSpec):
+             rank=rank,
+             kv_bytes_per_block=self.kv_bytes_per_chunk,
+             cpu_page_size=self.cpu_page_size_per_worker,
++            unlink_after_workers_map=True,
++            num_workers=world_size,
+         )
+         return CPUOffloadingWorker(
+             kv_caches=kv_caches,
+diff --git a/vllm/v1/worker/gpu/cudagraph_utils.py b/vllm/v1/worker/gpu/cudagraph_utils.py
+index 7b2991bf6c4d13a0ddb21dfdec9c77ea4e018467..1f4cc19e3b4fbf70c26a88f6a9ff5aed7f1d6bfa 100644
+--- a/vllm/v1/worker/gpu/cudagraph_utils.py
++++ b/vllm/v1/worker/gpu/cudagraph_utils.py
+@@ -446,6 +446,8 @@ class CudaGraphManager:
+     def capture(
+         self,
+         create_forward_fn: CreateForwardFn,
++        *,
++        channel_id: str,
+         progress_bar_desc: str = "Capturing CUDA graphs",
+     ) -> None:
+         """Capture CUDA graphs.
+@@ -456,12 +458,16 @@ class CudaGraphManager:
+                 it is invoked once with warmup=True and again with warmup=False
+                 because attention backends may mutate or lazily initialize
+                 metadata during warmup.
++            channel_id: Stable distributed identity for this graph owner.
+         """
+         # Keep event handles created by descriptor warmups alive together with
+         # the graph artifacts captured below. Some multi-stream custom ops run
+         # on joined auxiliary streams where CUDA's per-current-stream capture
+         # query is false even though later graph nodes retain those handles.
+-        with graph_capture(device=self.device), vllm_cudagraph_capture_scope():
++        with (
++            graph_capture(device=self.device, channel_id=channel_id),
++            vllm_cudagraph_capture_scope(),
++        ):
+             # Capture in order: PIECEWISE first, then FULL. PIECEWISE has larger
+             # activations so FULL activations should fit in already allocated
+             # buffers in the graph pool.
+@@ -638,6 +644,8 @@ class ModelCudaGraphManager(CudaGraphManager):
+         has_lora: bool = False,
+         use_aux_hidden_state_outputs: bool = False,
+         lora_capture_hook: Callable[[int, int, int], None] | None = None,
++        *,
++        channel_id: str,
+         progress_bar_desc: str = "Capturing CUDA graphs",
+     ) -> None:
+         """Capture CUDA graphs for model forward pass."""
+@@ -752,7 +760,11 @@ class ModelCudaGraphManager(CudaGraphManager):
+ 
+             return forward_fn
+ 
+-        super().capture(create_forward_fn, progress_bar_desc)
++        super().capture(
++            create_forward_fn,
++            channel_id=channel_id,
++            progress_bar_desc=progress_bar_desc,
++        )
+ 
+     def clear(self) -> None:
+         super().clear()
+diff --git a/vllm/v1/worker/gpu/model_runner.py b/vllm/v1/worker/gpu/model_runner.py
+index 596b1c2b5be77a318371ca2ccf0bf30c514a5a87..1ba33888a05b3b1d2bede735ea3ea326cb21b60a 100644
+--- a/vllm/v1/worker/gpu/model_runner.py
++++ b/vllm/v1/worker/gpu/model_runner.py
+@@ -967,11 +967,12 @@ class GPUModelRunner(LoRAModelRunnerMixin):
+                     has_lora=self.lora_config is not None,
+                     use_aux_hidden_state_outputs=self.use_aux_hidden_state_outputs,
+                     lora_capture_hook=create_lora_capture_hook(self.lora_config, self),
++                    channel_id="vllm:target:profile",
+                     progress_bar_desc="Profiling CUDA graph memory",
+                 )
+                 if self.speculator is not None:
+                     with use_workspace_lane(1):
+-                        self.speculator.capture()
++                        self.speculator.capture(capture_phase="profile")
+                 self._zero_cudagraph_capture_kv_blocks()
+             end_free_gpu_memory = torch.accelerator.get_memory_info()[0]
+             gross_cuda_graph_size = max(start_free_gpu_memory - end_free_gpu_memory, 0)
+@@ -1050,10 +1051,11 @@ class GPUModelRunner(LoRAModelRunnerMixin):
+                     has_lora=self.lora_config is not None,
+                     use_aux_hidden_state_outputs=self.use_aux_hidden_state_outputs,
+                     lora_capture_hook=create_lora_capture_hook(self.lora_config, self),
++                    channel_id="vllm:target:production",
+                 )
+                 if self.speculator is not None:
+                     with use_workspace_lane(1):
+-                        self.speculator.capture()
++                        self.speculator.capture(capture_phase="production")
+                 self._zero_cudagraph_capture_kv_blocks()
+         finally:
+             self._release_cudagraph_pool_anchor()
+diff --git a/vllm/v1/worker/gpu/spec_decode/autoregressive/cudagraph_utils.py b/vllm/v1/worker/gpu/spec_decode/autoregressive/cudagraph_utils.py
+index 19919043c831574b73c8617615a352e885c648f8..c625d91aee8496d3f518361fff2d234ecdf8329a 100644
+--- a/vllm/v1/worker/gpu/spec_decode/autoregressive/cudagraph_utils.py
++++ b/vllm/v1/worker/gpu/spec_decode/autoregressive/cudagraph_utils.py
+@@ -35,6 +35,8 @@ class SpeculatorCudaGraphManager(CudaGraphManager):
+         block_tables: BlockTables,
+         attn_groups: list[list[AttentionGroup]],
+         kv_cache_config: KVCacheConfig,
++        *,
++        channel_id: str,
+         progress_bar_desc: str = "Capturing CUDA graphs",
+     ) -> None:
+         def create_forward_fn(
+@@ -71,4 +73,8 @@ class SpeculatorCudaGraphManager(CudaGraphManager):
+                 cg_mode,
+             )
+ 
+-        super().capture(create_forward_fn, progress_bar_desc)
++        super().capture(
++            create_forward_fn,
++            channel_id=channel_id,
++            progress_bar_desc=progress_bar_desc,
++        )
+diff --git a/vllm/v1/worker/gpu/spec_decode/autoregressive/speculator.py b/vllm/v1/worker/gpu/spec_decode/autoregressive/speculator.py
+index 9633feaa0103d51d638621b9a90a089e9f9d1d12..d9ab74a28fb9bd1d0f288829f35a5446c5185255 100644
+--- a/vllm/v1/worker/gpu/spec_decode/autoregressive/speculator.py
++++ b/vllm/v1/worker/gpu/spec_decode/autoregressive/speculator.py
+@@ -21,7 +21,10 @@ from vllm.v1.worker.gpu.input_batch import InputBatch, InputBuffers
+ from vllm.v1.worker.gpu.spec_decode.autoregressive.cudagraph_utils import (
+     SpeculatorCudaGraphManager,
+ )
+-from vllm.v1.worker.gpu.spec_decode.speculator import DraftModelSpeculator
++from vllm.v1.worker.gpu.spec_decode.speculator import (
++    CUDAGraphCapturePhase,
++    DraftModelSpeculator,
++)
+ 
+ logger = init_logger(__name__)
+ 
+@@ -87,7 +90,7 @@ class AutoRegressiveSpeculator(DraftModelSpeculator):
+             decode_query_len=1,
+         )
+ 
+-    def capture(self) -> None:
++    def capture(self, *, capture_phase: CUDAGraphCapturePhase) -> None:
+         logger.info("Capturing model for speculator...")
+         # Reset indices to zeros to prevent stale values from prior
+         # dummy runs to cause out-of-bounds indexing during capture.
+@@ -111,6 +114,7 @@ class AutoRegressiveSpeculator(DraftModelSpeculator):
+             self.block_tables,
+             self.target_attn_groups,
+             self.kv_cache_config,
++            channel_id=f"vllm:draft:prefill:{capture_phase}",
+             progress_bar_desc="Capturing prefill CUDA graphs",
+         )
+ 
+@@ -128,6 +132,7 @@ class AutoRegressiveSpeculator(DraftModelSpeculator):
+             self.block_tables,
+             self.attn_groups,
+             self.kv_cache_config,
++            channel_id=f"vllm:draft:decode:{capture_phase}",
+             progress_bar_desc="Capturing decode CUDA graphs",
+         )
+ 
+diff --git a/vllm/v1/worker/gpu/spec_decode/dflash/cudagraph.py b/vllm/v1/worker/gpu/spec_decode/dflash/cudagraph.py
+index 5b36fee76eb227cd735648b9e31ac97ff1aabbec..fb0f0f2b6014f5ac3810ea4394bbf27255485d6b 100644
+--- a/vllm/v1/worker/gpu/spec_decode/dflash/cudagraph.py
++++ b/vllm/v1/worker/gpu/spec_decode/dflash/cudagraph.py
+@@ -72,6 +72,8 @@ class DFlashCudaGraphManager(CudaGraphManager):
+         kv_cache_config: KVCacheConfig,
+         max_model_len: int,
+         causal: bool | Mapping[int, bool],
++        *,
++        channel_id: str,
+         progress_bar_desc: str = "Capturing CUDA graphs",
+     ) -> None:
+         def create_forward_fn(
+@@ -108,4 +110,8 @@ class DFlashCudaGraphManager(CudaGraphManager):
+                 num_query_per_req=desc.uniform_token_count,
+             )
+ 
+-        super().capture(create_forward_fn, progress_bar_desc)
++        super().capture(
++            create_forward_fn,
++            channel_id=channel_id,
++            progress_bar_desc=progress_bar_desc,
++        )
+diff --git a/vllm/v1/worker/gpu/spec_decode/dflash/speculator.py b/vllm/v1/worker/gpu/spec_decode/dflash/speculator.py
+index 4859d74bcb150019a010b3173e885d3e135ef8b4..8af47efab18f3e263373e91740dcf536bc2b1815 100644
+--- a/vllm/v1/worker/gpu/spec_decode/dflash/speculator.py
++++ b/vllm/v1/worker/gpu/spec_decode/dflash/speculator.py
+@@ -35,7 +35,10 @@ from vllm.v1.worker.gpu.spec_decode.dflash.utils import (
+     load_dflash_model,
+     maybe_load_mask_embedding,
+ )
+-from vllm.v1.worker.gpu.spec_decode.speculator import DraftModelSpeculator
++from vllm.v1.worker.gpu.spec_decode.speculator import (
++    CUDAGraphCapturePhase,
++    DraftModelSpeculator,
++)
+ from vllm.v1.worker.gpu.spec_decode.utils import get_parallel_drafting_token_id
+ from vllm.v1.worker.utils import AttentionGroup
+ 
+@@ -184,7 +187,7 @@ class DFlashSpeculator(DraftModelSpeculator):
+             decode_query_len=self.num_query_per_req,
+         )
+ 
+-    def capture(self) -> None:
++    def capture(self, *, capture_phase: CUDAGraphCapturePhase) -> None:
+         logger.info("Capturing model for %s speculator...", self._speculator_name)
+         # Reset sampling indices to prevent stale values from prior dummy runs
+         # from being baked into the captured graph. Mapping rows stay inert.
+@@ -200,6 +203,7 @@ class DFlashSpeculator(DraftModelSpeculator):
+             self.kv_cache_config,
+             self.max_model_len,
+             causal=self._group_causal,
++            channel_id=f"vllm:draft:dflash:{capture_phase}",
+             progress_bar_desc=f"Capturing {self._speculator_name.lower()} CUDA graphs",
+         )
+ 
+diff --git a/vllm/v1/worker/gpu/spec_decode/speculator.py b/vllm/v1/worker/gpu/spec_decode/speculator.py
+index 0784f580ac0106849ec5f56aa6750d3784979695..a59cd1270bdd030f2beed072d5f1f4b726d6d916 100644
+--- a/vllm/v1/worker/gpu/spec_decode/speculator.py
++++ b/vllm/v1/worker/gpu/spec_decode/speculator.py
+@@ -2,7 +2,7 @@
+ # SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+ from abc import ABC, abstractmethod
+ from collections.abc import Mapping
+-from typing import TYPE_CHECKING, Any
++from typing import TYPE_CHECKING, Any, Literal
+ 
+ import torch
+ import torch.nn as nn
+@@ -32,6 +32,8 @@ if TYPE_CHECKING:
+ 
+ logger = init_logger(__name__)
+ 
++CUDAGraphCapturePhase = Literal["profile", "production"]
++
+ 
+ class BaseSpeculator(ABC):
+     # Draft-token capacity surface, implemented by speculators with a
+@@ -51,7 +53,7 @@ class BaseSpeculator(ABC):
+         pass
+ 
+     @abstractmethod
+-    def capture(self) -> None:
++    def capture(self, *, capture_phase: CUDAGraphCapturePhase) -> None:
+         pass
+ 
+     def get_cudagraph_managers(self) -> tuple["CudaGraphManager", ...]:
+diff --git a/vllm/v1/worker/gpu_model_runner.py b/vllm/v1/worker/gpu_model_runner.py
+index 5a066f77c195d6daf9c35820b29dc9f3646833ef..7d1216710fd4a4e7e6ac5c13b17934d04aa273ab 100644
+--- a/vllm/v1/worker/gpu_model_runner.py
++++ b/vllm/v1/worker/gpu_model_runner.py
+@@ -44,12 +44,14 @@ from vllm.distributed.kv_transfer import get_kv_transfer_group, has_kv_transfer_
+ from vllm.distributed.kv_transfer.kv_connector.utils import copy_kv_blocks
+ from vllm.distributed.parallel_state import (
+     GraphCaptureContext,
++    checkpoint_b12x_graph_channels,
+     get_dcp_group,
+     get_pp_group,
+     get_tp_group,
+     graph_capture,
+     is_global_first_rank,
+     prepare_communication_buffer_for_model,
++    rollback_b12x_graph_channels,
+ )
+ from vllm.forward_context import (
+     BatchDescriptor,
+@@ -4643,11 +4645,7 @@ class GPUModelRunner(
+             )
+             # Whether the drafter runs a GPU model forward (and thus carries
+             # TP/EP/DP collectives), independent of padded-batch timing.
+-            drafter_runs_model_forward = (
+-                spec_config.use_eagle()
+-                or spec_config.uses_draft_model()
+-                or spec_config.uses_extract_hidden_states()
+-            )
++            drafter_runs_model_forward = self._drafter_runs_model_forward()
+             use_gpu_toks = (
+                 drafter_runs_model_forward
+                 and not spec_config.disable_padded_drafter_batch
+@@ -5845,6 +5843,7 @@ class GPUModelRunner(
+         profile_seq_lens: int | None = None,
+         include_mm_inputs: bool = True,
+         single_request_prefill: bool = False,
++        run_drafter: bool = True,
+     ) -> tuple[torch.Tensor, torch.Tensor]:
+         """
+         Run a dummy forward pass to warm up/profile run or capture the
+@@ -5878,6 +5877,7 @@ class GPUModelRunner(
+             single_request_prefill: If True, create one prefill request with
+                 `num_tokens` tokens. This covers text-only single-request
+                 prefill kernels without keying warmup on a live prompt length.
++            run_drafter: Whether to execute the draft-model portion of the run.
+         """
+         mm_config = self.vllm_config.model_config.multimodal_config
+         if mm_config and mm_config.mm_encoder_only:
+@@ -6177,11 +6177,7 @@ class GPUModelRunner(
+             else:
+                 hidden_states = outputs
+ 
+-            if self.speculative_config and (
+-                self.speculative_config.use_eagle()
+-                or self.speculative_config.uses_draft_model()
+-                or self.speculative_config.uses_extract_hidden_states()
+-            ):
++            if run_drafter and self._drafter_runs_model_forward():
+                 assert isinstance(
+                     self.drafter,
+                     EagleProposer
+@@ -6672,7 +6668,7 @@ class GPUModelRunner(
+ 
+         saved_num_cudagraph_captured = compilation_counter.num_cudagraph_captured
+ 
+-        capture_descs = self.cudagraph_dispatcher.get_capture_descs()
++        capture_descs = list(self.cudagraph_dispatcher.get_capture_descs())
+         # Use a temporary manager for memory profiling. The persistent manager
+         # is initialized later so it does not keep profiling-only graph state.
+         encoder_cudagraph_manager = self._create_encoder_cudagraph_manager()
+@@ -6715,81 +6711,117 @@ class GPUModelRunner(
+             original_pools[id(instance)] = instance.graph_pool
+             instance.graph_pool = profiling_pool
+ 
+-        shared_memory_estimate = {}
+-        per_graph_estimate = {}
++        shared_memory_estimate: dict[CUDAGraphMode, int] = {}
++        per_graph_estimate: dict[CUDAGraphMode, int] = {}
+         encoder_memory_estimate = 0
+ 
+-        # On ROCm, capture these throwaway profiling graphs on vLLM's dedicated
+-        # compute stream instead of the fresh side stream graph_capture()
+-        # allocates by default. torch's allocator pools free blocks per stream,
+-        # so a side-stream forward strands a persistent aiter scratch buffer in
+-        # a separate pool, shifting the physical placement of the real KV cache
+-        # allocated afterward and slowing bandwidth-bound decode ~20%. The
+-        # graphs are discarded, so a side stream is unnecessary here.
+-        # Use current_stream(), not torch.cuda.current_stream(): before vLLM
+-        # initializes its dedicated stream, torch returns the per-thread default
+-        # stream (cuda_stream=0), which cannot be used for cudagraph capture.
+-        # cap_ctx=None keeps the side-stream path on CUDA.
+-        cap_ctx = (
+-            GraphCaptureContext(current_stream())
+-            if current_platform.is_rocm()
+-            else None
+-        )
+-
+         # Cleanup-only guard: CUDA graph capture errors should still propagate
+         # because encoder graph capture is opt-in.
++        graph_channel_checkpoints: tuple[tuple[Callable[[Any], None], Any], ...] = ()
+         try:
++            graph_channel_checkpoints = checkpoint_b12x_graph_channels()
+             set_cudagraph_capturing_enabled(True)
+-            with (
+-                self._freeze_gc(),
+-                graph_capture(device=self.device, graph_capture_context=cap_ctx),
+-            ):
+-                torch.accelerator.synchronize()
+-                torch.accelerator.empty_cache()
+-
+-                for mode, descs in capture_descs:
+-                    profile_descs = descs[:2]
+-                    mem_samples: list[int] = []
+-
+-                    for i, desc in enumerate(profile_descs):
+-                        mem_before = torch.accelerator.get_memory_info()[0]
+-                        self._warmup_and_capture(
+-                            desc,
+-                            cudagraph_runtime_mode=mode,
+-                            profile_seq_lens=(
+-                                min(
+-                                    self.max_model_len,
+-                                    self.max_num_tokens // desc.num_tokens,
+-                                )
+-                                if mode == CUDAGraphMode.FULL and i == 0
+-                                else None
+-                            ),
++            with self._freeze_gc():
++                for component, channel_id in (
++                    ("target", "vllm:target:profile"),
++                    ("draft", "vllm:draft:profile"),
++                ):
++                    component_descs = [
++                        (mode, descs)
++                        for mode, descs in capture_descs
++                        if descs
++                        and (
++                            component == "target"
++                            or self._captures_independent_drafter_graphs(mode)
+                         )
+-                        torch.accelerator.synchronize()
+-                        free_after = torch.accelerator.get_memory_info()[0]
+-                        mem_samples.append(mem_before - free_after)
++                    ]
++                    if not component_descs:
++                        continue
+ 
+-                    first_capture = mem_samples[0]
+-                    # Use at least 1 MiB per graph for driver overhead
+-                    per_graph = max(
+-                        mem_samples[1] if len(mem_samples) > 1 else 0, 1 << 20
++                    # ROCm profiles on vLLM's dedicated compute stream to avoid
++                    # stranding allocator pages in a disposable side stream.
++                    cap_ctx = (
++                        GraphCaptureContext(current_stream(), channel_id=channel_id)
++                        if current_platform.is_rocm()
++                        else None
+                     )
++                    with graph_capture(
++                        device=self.device,
++                        graph_capture_context=cap_ctx,
++                        channel_id=channel_id,
++                    ):
++                        torch.accelerator.synchronize()
++                        torch.accelerator.empty_cache()
+ 
+-                    shared_memory_estimate[mode] = first_capture
+-                    per_graph_estimate[mode] = per_graph * (len(descs) - 1)
++                        for mode, descs in component_descs:
++                            profile_descs = descs[:2]
++                            mem_samples: list[int] = []
++                            captures_drafter = (
++                                self._captures_independent_drafter_graphs(mode)
++                            )
+ 
+-                    logger.debug(
+-                        "Estimated %s CUDA graph memory: "
+-                        "%.2f MiB first-capture + (%d-1) × %.2f MiB per-graph",
+-                        mode.name,
+-                        first_capture / (1 << 20),
+-                        len(descs),
+-                        per_graph / (1 << 20),
+-                    )
++                            for i, desc in enumerate(profile_descs):
++                                mem_before = torch.accelerator.get_memory_info()[0]
++                                self._warmup_and_capture(
++                                    desc,
++                                    cudagraph_runtime_mode=mode,
++                                    profile_seq_lens=(
++                                        min(
++                                            self.max_model_len,
++                                            self.max_num_tokens // desc.num_tokens,
++                                        )
++                                        if mode == CUDAGraphMode.FULL and i == 0
++                                        else None
++                                    ),
++                                    run_drafter=(
++                                        component == "draft" or not captures_drafter
++                                    ),
++                                )
++                                torch.accelerator.synchronize()
++                                free_after = torch.accelerator.get_memory_info()[0]
++                                mem_samples.append(max(mem_before - free_after, 0))
++
++                            first_capture = mem_samples[0]
++                            # Use at least 1 MiB per graph for driver overhead.
++                            per_graph = max(
++                                mem_samples[1] if len(mem_samples) > 1 else 0,
++                                1 << 20,
++                            )
++
++                            shared_memory_estimate[mode] = (
++                                shared_memory_estimate.get(mode, 0) + first_capture
++                            )
++                            per_graph_estimate[mode] = per_graph_estimate.get(
++                                mode, 0
++                            ) + per_graph * (len(descs) - 1)
++
++                            logger.debug(
++                                "Estimated %s %s CUDA graph memory: "
++                                "%.2f MiB first-capture + (%d-1) x %.2f MiB "
++                                "per-graph",
++                                component,
++                                mode.name,
++                                first_capture / (1 << 20),
++                                len(descs),
++                                per_graph / (1 << 20),
++                            )
+ 
+                 if encoder_cudagraph_manager is not None:
++                    channel_id = "vllm:encoder:profile"
++                    cap_ctx = (
++                        GraphCaptureContext(current_stream(), channel_id=channel_id)
++                        if current_platform.is_rocm()
++                        else None
++                    )
+                     mem_before = torch.accelerator.get_memory_info()[0]
+-                    encoder_cudagraph_manager.capture(graph_pool=encoder_profiling_pool)
++                    with graph_capture(
++                        device=self.device,
++                        graph_capture_context=cap_ctx,
++                        channel_id=channel_id,
++                    ):
++                        encoder_cudagraph_manager.capture(
++                            graph_pool=encoder_profiling_pool
++                        )
+                     torch.accelerator.synchronize()
+                     free_after = torch.accelerator.get_memory_info()[0]
+                     encoder_memory_estimate = max(mem_before - free_after, 0)
+@@ -6800,23 +6832,26 @@ class GPUModelRunner(
+                         encoder_graphs,
+                     )
+         finally:
+-            set_cudagraph_capturing_enabled(False)
+-            CUDAGraphWrapper.clear_all_graphs()
+-            BreakableCUDAGraphWrapper.clear_all_graphs()
+-            if encoder_cudagraph_manager is not None:
+-                encoder_cudagraph_manager.clear()
+-            all_wrappers = list(CUDAGraphWrapper._all_instances) + list(
+-                BreakableCUDAGraphWrapper._all_instances
+-            )
+-            for instance in all_wrappers:
+-                if id(instance) in original_pools:
+-                    instance.graph_pool = original_pools[id(instance)]
+-            for key_set in self.cudagraph_dispatcher.cudagraph_keys.values():
+-                key_set.clear()
+-            self.cudagraph_dispatcher.keys_initialized = False
+-            self.maybe_remove_all_loras(self.lora_config)
+-            self._cleanup_profiling_kv_cache()
+-            compilation_counter.num_cudagraph_captured = saved_num_cudagraph_captured
++            try:
++                try:
++                    set_cudagraph_capturing_enabled(False)
++                    CUDAGraphWrapper.clear_all_graphs()
++                    BreakableCUDAGraphWrapper.clear_all_graphs()
++                    if encoder_cudagraph_manager is not None:
++                        encoder_cudagraph_manager.clear()
++                finally:
++                    for instance in all_wrappers:
++                        instance.graph_pool = original_pools[id(instance)]
++                for key_set in self.cudagraph_dispatcher.cudagraph_keys.values():
++                    key_set.clear()
++                self.cudagraph_dispatcher.keys_initialized = False
++                self.maybe_remove_all_loras(self.lora_config)
++                self._cleanup_profiling_kv_cache()
++                compilation_counter.num_cudagraph_captured = (
++                    saved_num_cudagraph_captured
++                )
++            finally:
++                rollback_b12x_graph_channels(graph_channel_checkpoints)
+ 
+         # FULL and PIECEWISE graphs share the global pool at runtime and are
+         # never replayed concurrently, so the pool overlays their memory.
+@@ -6853,36 +6888,58 @@ class GPUModelRunner(
+         # Trigger CUDA graph capture for specific shapes.
+         # Capture the large shapes first so that the smaller shapes
+         # can reuse the memory pool allocated for the large shapes.
++        capture_descs = list(self.cudagraph_dispatcher.get_capture_descs())
+         set_cudagraph_capturing_enabled(True)
+-        with self._freeze_gc(), graph_capture(device=self.device):
+-            torch.accelerator.synchronize()
+-            torch.accelerator.empty_cache()
+-            start_free_gpu_memory = torch.accelerator.get_memory_info()[0]
+-
+-            for (
+-                runtime_mode,
+-                batch_descs,
+-            ) in self.cudagraph_dispatcher.get_capture_descs():
+-                self._capture_cudagraphs(
+-                    batch_descriptors=batch_descs,
+-                    cudagraph_runtime_mode=runtime_mode,
+-                )
++        try:
++            with self._freeze_gc():
+                 torch.accelerator.synchronize()
++                torch.accelerator.empty_cache()
++                start_free_gpu_memory = torch.accelerator.get_memory_info()[0]
+ 
+-            # Capture encoder CUDA graphs if enabled
+-            if self.encoder_cudagraph_manager is not None:
+-                encoder_graph_pool = current_platform.graph_pool_handle()
+-                self.encoder_cudagraph_manager.capture(graph_pool=encoder_graph_pool)
++                for component, channel_id in (
++                    ("target", "vllm:target:production"),
++                    ("draft", "vllm:draft:production"),
++                ):
++                    component_descs = [
++                        (mode, descs)
++                        for mode, descs in capture_descs
++                        if descs
++                        and (
++                            component == "target"
++                            or self._captures_independent_drafter_graphs(mode)
++                        )
++                    ]
++                    if not component_descs:
++                        continue
++                    with graph_capture(device=self.device, channel_id=channel_id):
++                        for runtime_mode, batch_descs in component_descs:
++                            captures_drafter = (
++                                self._captures_independent_drafter_graphs(runtime_mode)
++                            )
++                            self._capture_cudagraphs(
++                                batch_descriptors=batch_descs,
++                                cudagraph_runtime_mode=runtime_mode,
++                                run_drafter=(
++                                    component == "draft" or not captures_drafter
++                                ),
++                            )
++                            torch.accelerator.synchronize()
+ 
+-            torch.accelerator.synchronize()
+-            end_free_gpu_memory = torch.accelerator.get_memory_info()[0]
++                if self.encoder_cudagraph_manager is not None:
++                    encoder_graph_pool = current_platform.graph_pool_handle()
++                    with graph_capture(
++                        device=self.device,
++                        channel_id="vllm:encoder:production",
++                    ):
++                        self.encoder_cudagraph_manager.capture(
++                            graph_pool=encoder_graph_pool
++                        )
+ 
+-        # Disable cudagraph capturing globally, so any unexpected cudagraph
+-        # capturing will be detected and raise an error after here.
+-        # Note: We don't put it into graph_capture context manager because
+-        # we may do lazy capturing in future that still allows capturing
+-        # after here.
+-        set_cudagraph_capturing_enabled(False)
++                torch.accelerator.synchronize()
++                end_free_gpu_memory = torch.accelerator.get_memory_info()[0]
++        finally:
++            # Leave capture mode disabled even when one graph owner fails.
++            set_cudagraph_capturing_enabled(False)
+ 
+         torch.accelerator.synchronize()
+         torch.accelerator.empty_cache()
+@@ -6902,6 +6959,35 @@ class GPUModelRunner(
+         )
+         return cuda_graph_size
+ 
++    def _captures_independent_drafter_graphs(
++        self,
++        cudagraph_runtime_mode: CUDAGraphMode,
++    ) -> bool:
++        """Return whether PIECEWISE capture needs a separate drafter pass.
++
++        Args:
++            cudagraph_runtime_mode: CUDA graph mode being captured.
++
++        Returns:
++            Whether the mode owns independently replayable drafter graphs.
++        """
++        spec_config = self.speculative_config
++        return (
++            cudagraph_runtime_mode == CUDAGraphMode.PIECEWISE
++            and spec_config is not None
++            and not spec_config.enforce_eager
++            and self._drafter_runs_model_forward()
++        )
++
++    def _drafter_runs_model_forward(self) -> bool:
++        """Return whether the configured drafter executes a model forward."""
++        spec_config = self.speculative_config
++        return spec_config is not None and (
++            spec_config.use_eagle()
++            or spec_config.uses_draft_model()
++            or spec_config.uses_extract_hidden_states()
++        )
++
+     def _warmup_and_capture(
+         self,
+         desc: BatchDescriptor,
+@@ -6909,6 +6995,7 @@ class GPUModelRunner(
+         profile_seq_lens: int | None = None,
+         allow_microbatching: bool = False,
+         num_warmups: int | None = None,
++        run_drafter: bool = True,
+     ):
+         if num_warmups is None:
+             num_warmups = self.compilation_config.cudagraph_num_of_warmups
+@@ -6924,6 +7011,7 @@ class GPUModelRunner(
+                 remove_lora=False,
+                 num_active_loras=desc.num_active_loras,
+                 profile_seq_lens=profile_seq_lens,
++                run_drafter=run_drafter,
+             )
+         self._dummy_run(
+             desc.num_tokens,
+@@ -6935,12 +7023,15 @@ class GPUModelRunner(
+             num_active_loras=desc.num_active_loras,
+             is_graph_capturing=True,
+             profile_seq_lens=profile_seq_lens,
++            run_drafter=run_drafter,
+         )
+ 
+     def _capture_cudagraphs(
+         self,
+         batch_descriptors: list[BatchDescriptor],
+         cudagraph_runtime_mode: CUDAGraphMode,
++        *,
++        run_drafter: bool = True,
+     ):
+         assert (
+             cudagraph_runtime_mode != CUDAGraphMode.NONE
+@@ -6983,6 +7074,7 @@ class GPUModelRunner(
+                 batch_desc,
+                 cudagraph_runtime_mode=cudagraph_runtime_mode,
+                 allow_microbatching=allow_microbatching,
++                run_drafter=run_drafter,
+             )
+             torch.accelerator.synchronize()
+         self.maybe_remove_all_loras(self.lora_config)

--- a/tests/test-gilded-gnosis-release-composition.sh
+++ b/tests/test-gilded-gnosis-release-composition.sh
@@ -337,6 +337,42 @@ grep -Fxq 'lmcache_version=0.5.2+glm52dcp.4' <<<"${output_r18}"
 grep -Fxq 'xgrammar_ref=v0.2.5' <<<"${output_r18}"
 grep -Fxq 'xgrammar_transformers5_compat=1' <<<"${output_r18}"
 
+output_r24="$(
+  cd "${repo_root}"
+  PRINT_RELEASE_CONFIG=1 VLLM_RELEASE_COMPOSITION=reproduce-r24 \
+    ./build-gilded-gnosis-v20-final-cu132.sh
+)"
+
+grep -Fxq 'composition=reproduce-r24' <<<"${output_r24}"
+grep -Fxq \
+  'image=voipmonitor/vllm:gilded-gnosis-v20-vllmf5981f1-si2b9bf2a-fi801d57a-cu132-20260803-r24' \
+  <<<"${output_r24}"
+grep -Fxq \
+  'version=0.11.2.dev280+gilded.gnosis.v20.vllmf5981f1.si2b9bf2a.fi801d57a.cu132.20260803.r24' \
+  <<<"${output_r24}"
+grep -Fxq \
+  'vllm_tree=f5981f14b4d39979bc0d799c020d42002b707257' \
+  <<<"${output_r24}"
+grep -Fxq \
+  'sparkinfer_tree=2b9bf2a4d15770c0c23e19cc13a75843f2f0a995' \
+  <<<"${output_r24}"
+grep -Fxq \
+  'launcher_ref=76b1cf0350709910208e61285adc955e34655136' \
+  <<<"${output_r24}"
+grep -Fxq \
+  'lmcache_tree=9a05c8818bae48d15b79c7e876418bb813c08cd0' \
+  <<<"${output_r24}"
+grep -Fxq \
+  'lmcache_patch=releases/gilded-gnosis-v20-r24/lmcache/integration.patch' \
+  <<<"${output_r24}"
+grep -Fxq 'xgrammar_ref=v0.2.5' <<<"${output_r24}"
+grep -Fxq \
+  'instanttensor_repo=https://github.com/voipmonitor/InstantTensor.git' \
+  <<<"${output_r24}"
+grep -Fxq \
+  'instanttensor_commit=25b3f268ea95b76bd03c825a1681872c9b615428' \
+  <<<"${output_r24}"
+
 output_r20="$(
   cd "${repo_root}"
   PRINT_RELEASE_CONFIG=1 VLLM_RELEASE_COMPOSITION=reproduce-r20 \

--- a/tests/test-gilded-gnosis-release-composition.sh
+++ b/tests/test-gilded-gnosis-release-composition.sh
@@ -373,6 +373,23 @@ grep -Fxq \
   'instanttensor_commit=25b3f268ea95b76bd03c825a1681872c9b615428' \
   <<<"${output_r24}"
 
+output_clean="$(
+  cd "${repo_root}"
+  PRINT_RELEASE_CONFIG=1 VLLM_RELEASE_COMPOSITION=clean \
+    ./build-gilded-gnosis-v20-final-cu132.sh
+)"
+
+grep -Fxq 'composition=clean' <<<"${output_clean}"
+grep -Fxq \
+  'instanttensor_repo=https://github.com/voipmonitor/InstantTensor.git' \
+  <<<"${output_clean}"
+grep -Fxq \
+  'instanttensor_ref=25b3f268ea95b76bd03c825a1681872c9b615428' \
+  <<<"${output_clean}"
+grep -Fxq \
+  'instanttensor_commit=25b3f268ea95b76bd03c825a1681872c9b615428' \
+  <<<"${output_clean}"
+
 output_r20="$(
   cd "${repo_root}"
   PRINT_RELEASE_CONFIG=1 VLLM_RELEASE_COMPOSITION=reproduce-r20 \

--- a/tests/test-gilded-gnosis-release-composition.sh
+++ b/tests/test-gilded-gnosis-release-composition.sh
@@ -371,6 +371,12 @@ grep -Fxq \
 grep -Fxq 'lmcache_version=0.5.2+glm52dcp.4' <<<"${output_r20}"
 grep -Fxq 'xgrammar_ref=v0.2.5' <<<"${output_r20}"
 grep -Fxq 'xgrammar_transformers5_compat=1' <<<"${output_r20}"
+grep -Fxq \
+  'instanttensor_repo=https://github.com/scitix/InstantTensor.git' \
+  <<<"${output_r20}"
+grep -Fxq \
+  'instanttensor_commit=85e7c5f5539d9c006ee0c26bc1b5233c65251b6b' \
+  <<<"${output_r20}"
 
 output_r19="$(
   cd "${repo_root}"


### PR DESCRIPTION
## Summary

Publish the reproducible **Gilded Gnosis r24** DS4 runtime release for
`deepseek-ai/DeepSeek-V4-Flash-0731`.

This supersedes the earlier r21 candidate description. The branch now contains
the exact source archive, composition locks, release manifest, helper policy,
Compose recipe, provenance checks, and test coverage for the published r24
image. It does **not** merge any canonical vLLM or SparkInfer branch.

## Published image

```text
voipmonitor/vllm:gilded-gnosis-v20-vllmf5981f1-si2b9bf2a-fi801d57a-cu132-20260803-r24
manifest: sha256:64b94299abdd3bcf5bb5050ca91b378f9ee4e0b0eff4748375b95352371d7cb2
local image: sha256:dc0bc459b8c1d59f84e945a4b77f65ea474778b58f4a95d3e3d1c97632daeb1d
```

## Runtime changes since DS4 r16

- vLLM #229 derives compressed-MLA workspace capacity from the physical cache
  contract, fixing TP2/K5 long-concurrency under-reservation.
- vLLM #217 adds a shared native-offload mmap, decimal sizing,
  unlink-after-map lifetime, isolated registration failures, and row-stride
  plus 64-KiB-aligned segmented host registration.
- vLLM #218 preserves SWA, MTP/EAGLE tails, replay boundaries, retention
  intervals, and shared-prefix tails during native offload.
- vLLM #216 and SparkInfer #113 isolate semantic PCIe graph channels and
  harden replay/CUDA-IPC graph-state lifetime.
- vLLM #230 keeps broadcast mHC preprocessing behind the compile boundary.
- SparkInfer #106 makes compressed MLA kernels honor the physical cache-page
  stride.
- InstantTensor #19 retains whole-region registration as the fast path, with
  bounded segmented registration fallback for large BUFFERED loads.
- Current LMCache capacity/durability stack and XGrammar 0.2.5.
- Fixed K5 remains the default. K7 and dynamic depth remain explicit
  experiments.

## Reproduction

```bash
VLLM_RELEASE_COMPOSITION=reproduce-r24 \
  ./build-gilded-gnosis-v20-final-cu132.sh
```

The immutable archive verifies every base commit, PR head, resulting tree, and
patch hash. The deployment recipe is
`examples/docker-compose-ds4-v20-r24.yml`.

## Source trees

| Component | Ref |
|---|---|
| GG base | `30038602b71395f481ef4a6edfe4fcf8551d9c15` |
| composed vLLM | `f5981f14b4d39979bc0d799c020d42002b707257` |
| SparkInfer base | `59216fa25f3d5fc9d4df2d052e02d05f763906e9` |
| composed SparkInfer | `2b9bf2a4d15770c0c23e19cc13a75843f2f0a995` |
| composed LMCache | `9a05c8818bae48d15b79c7e876418bb813c08cd0` |
| InstantTensor | `25b3f268ea95b76bd03c825a1681872c9b615428` |
| FlashInfer | `801d57a08958c13d375ddbb6be3be4808f48a708` |

## Validation

- release composition and fail-fast manifest checks passed;
- clean-mode and reproducible-mode provenance checks passed;
- build/helper test suites passed;
- focused native-offload tests: **8 passed**;
- integrated LMCache suite: **222 passed, 131 skipped**;
- TP2/DCP1/fixed-K5/B12X-A8/InstantTensor-BUFFERED startup and chat sanity
  passed;
- native offload E2E: six concurrent uncached prompts of 119,957-119,963 input
  tokens, **6/6 HTTP success in 62.153 s**;
- the server remained healthy and sustained approximately **55-56 GB/s**
  host-store intervals;
- TP4/DCP1/fixed-K5/Lucifer-CUTLASS startup passed, selected
  `FLASHINFER_CUTLASS_MXFP4_MXFP8`, provisioned 771,031 GPU-KV tokens, and
  returned the expected chat result;
- exact final image runtime imports and embedded version were verified.

## Deliberately unresolved

- K7 long-context BOS/tool/output pollution is not closed; use fixed K5.
- LMCache storage/capacity failures are addressed, but DS4 long-context output
  correctness is not certified. Native CPU KV offload is the qualified
  host-cache path.
- Tool/reasoning anomalies beyond roughly 200k context are still under
  investigation.
- Native L2 NIXL/S3 currently has a measured prefill penalty relative to POSIX.

Runbook:
https://github.com/local-inference-lab/rtx6kpro/blob/master/models/ds4dspark-v20.md