### PR TITLE
fix(calibration): fail fast or self-heal when the container hostname does not resolve

### DIFF
--- a/launchers/glm52-pcie-calibration.py
+++ b/launchers/glm52-pcie-calibration.py
@@ -25,6 +25,7 @@ from pathlib import Path
 import platform
 import signal
 import subprocess
+import socket
 import sys
 import tempfile
 import time
@@ -356,7 +357,44 @@ def _terminate_process_group(process: subprocess.Popen[str]) -> str:
     return _output_text(stdout)
 
 
+def _ensure_local_hostname_resolves() -> None:
+    """Fail fast (or self-heal) when the container cannot resolve itself.
+
+    torchrun's elastic agent advertises ``socket.gethostname()`` to its
+    workers for the worker TCPStore, independent of the ``--standalone``
+    rendezvous endpoint. Under ``network_mode: host`` the container usually
+    inherits the host's hostname without an ``/etc/hosts`` entry for it, so
+    every worker retries DNS until the calibration timeout expires and the
+    launcher silently falls back to the conservative topology policy.
+
+    Repair ``/etc/hosts`` when the container allows it; otherwise raise one
+    clean, actionable failure immediately instead of burning the timeout.
+    """
+    hostname = socket.gethostname()
+    try:
+        socket.gethostbyname(hostname)
+        return
+    except OSError:
+        pass
+    try:
+        with open("/etc/hosts", "a", encoding="utf-8") as hosts:
+            hosts.write(f"127.0.0.1\t{hostname}\n")
+        socket.gethostbyname(hostname)
+        return
+    except OSError:
+        pass
+    raise CalibrationFailure(
+        f"hostname {hostname!r} does not resolve inside this container, so "
+        "torchrun workers would retry DNS until the calibration timeout. "
+        f"Add `--add-host={hostname}:127.0.0.1` (docker run) or an "
+        f"`extra_hosts: [\"{hostname}:127.0.0.1\"]` entry (compose), or run "
+        "with a resolvable hostname.",
+        "",
+    )
+
+
 def _run_probe(args: argparse.Namespace, output: Path) -> dict[str, Any]:
+    _ensure_local_hostname_resolves()
     command = [
         sys.executable,
         "-m",


### PR DESCRIPTION
## Problem

`glm52-pcie-calibration.py` launches its probe via `torch.distributed.run --standalone`. The elastic agent advertises `socket.gethostname()` to workers for the worker TCPStore, independent of the standalone rendezvous endpoint. Under `network_mode: host`, the container usually inherits the host's hostname with no `/etc/hosts` entry for it — so every worker retries DNS (`gai error -2`) until the full `PCIE_CALIBRATION_TIMEOUT` (600 s) expires. The launcher then falls back to the conservative topology policy **silently**: the server still comes up healthy, just slower.

Observed on a 4x RTX PRO 6000 Blackwell Workstation host (quad, Gen5 x16, TP4/DCP4): the cold probe burned its entire 600 s budget on `c10d::TCPStore` DNS retries against `<hostname>:34563`, fell back to `DMA-min=6MB`, and cost 5–11% prefill versus the measured policy. Rerunning with `--add-host <hostname>:127.0.0.1` let the probe complete and measure `DMA-min=25165824` on the same topology — byte-identical to the value we had previously hand-tuned, so the calibrator itself is excellent; it just never got to run. Failure log available on request.

## Fix

Before launching torchrun, check that the local hostname resolves:

1. If it does — proceed (zero behavior change for healthy setups).
2. If not — best-effort append `127.0.0.1\t<hostname>` to `/etc/hosts` (containers running as root under host networking allow this) and re-check.
3. Otherwise raise a single clean `CalibrationFailure` naming the exact `--add-host` / `extra_hosts` remedy — consistent with the script's no-traceback, one-status-line philosophy — instead of a ten-minute silent degradation.

## Notes

- A one-line `extra_hosts` example in the wiki compose template would complement this, but the script-level guard covers `docker run` users and every preset.
- No change to the calibration math, fingerprinting, or cache handling; `ast.parse` clean.

Found during the v20 r17–r26 validation campaign on our quad-Workstation host (same campaign as the DCP2 long-context report).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Added a preflight check to verify that the machine’s hostname resolves before PCIe calibration begins.
  * Automatically attempts to configure a local loopback hosts entry when resolution is unavailable.
  * Provides clear remediation guidance when hostname resolution cannot be restored.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->