### PR TITLE
build(gg): release r33 Trellis and topology contracts

### DIFF
--- a/README.md
+++ b/README.md
@@ -661,6 +661,47 @@ The immutable source and live qualification receipt is
 `fa13d334a2962756f9f7e9b562deb85387359f42` and
 `acee6e504209068bd0cbb01cb2b98966bddcf042`.
 
+The r33 release keeps the qualified r31 vLLM tree and adds four isolated B12X
+changes. PR #133 adds topology-scoped fused all-reduce paths: TP8 owner
+reduction is automatic, while TP2/TP4 remote push remains opt-in because
+matched end-to-end runs showed gains and losses rather than a consistent win.
+PR #135 preserves the dense GEMM API contract for block-FP8 callers. PR #136
+restores capture-safe K6 small-M dispatch with an explicit SM120 capability
+gate. PR #137 realigns mixed-Trellis execution with the QSRT ABI.
+
+Reproduce the exact source composition with:
+
+```bash
+VLLM_RELEASE_COMPOSITION=reproduce-r33 \
+  ./build-gilded-gnosis-v20-final-cu132.sh
+```
+
+Validated r33 image:
+
+```text
+voipmonitor/vllm:gilded-gnosis-v20-vllmfa13d33-b12x06db0f4-fi1ac6942-cu132-20260809-r33
+Local validated image ID: sha256:60944a4ea1fbb2d1f35d7972f685d8fb0b91e77dd5aeca1dcafa3bcc29846d12
+```
+
+Validation used only GPUs 4-7 on `192.168.0.69`. The GLM row used
+`willfalco/GLM-5.2-EXL3-TR3-3.36bpw`, TP4/DCP1/MTP3, online EXL3 K6, and
+NVFP4 DS-MLA KV. The standard `llm_decode_bench` prompt produced 116.2 and
+112.0 tok/s, for a two-run median of 114.1 tok/s versus the historical 113.4
+tok/s result. A separate synthetic MTP-friendly prompt reached about 144
+tok/s; that number is not used as the standard headline or regression gate.
+
+| DS4 fixed probabilistic K5 | C1 tok/s | C4 tok/s | C8 tok/s | Prefill 8k tok/s |
+|---|---:|---:|---:|---:|
+| TP2, FlashInfer PCIe IPC auto | 180.6 | 397.1 | 580.7 | 12,849 |
+| TP4, B12X auto | 247.0 | 541.9 | 804.5 | not repeated |
+
+Both DS4 rows used the pinned `DeepSeek-V4-Flash-0731` revision, B12X W4A8,
+FP8 DS-MLA KV, InstantTensor BUFFERED, and FULL+PIECEWISE CUDA graphs. The TP2
+correctness request returned exactly `42`. The immutable validation receipt is
+`validation/gilded-gnosis-v20-r33-remote-gpu.json`; its vLLM and B12X trees are
+`fa13d334a2962756f9f7e9b562deb85387359f42` and
+`06db0f4b27dbd19eb934da0da27eff7a7c49d8c4`.
+
 The current unified image installs
 `/usr/local/bin/serve-fathomless-firmament.sh`, which dispatches to the GLM or
 DS4 helper through `MODEL_FAMILY`. Start either model with a minimal

--- a/build-gilded-gnosis-v20-final-cu132.sh
+++ b/build-gilded-gnosis-v20-final-cu132.sh
@@ -413,7 +413,10 @@ else
 fi
 
 export LAUNCHER_REPO="${LAUNCHER_REPO:-https://github.com/local-inference-lab/blackwell-llm-docker.git}"
-if [[ "${composition_mode}" == "clean" || "${composition_mode}" == "reproduce-r33" || "${composition_mode}" == "reproduce-r32" ]]; then
+if [[ "${composition_mode}" == "clean" || "${composition_mode}" == "reproduce-r33" ]]; then
+  export LAUNCHER_REF="${LAUNCHER_REF:-47ac813334e094090d5fd85b317d13b2e932ef09}"
+  export LAUNCHER_COMMIT="${LAUNCHER_COMMIT:-47ac813334e094090d5fd85b317d13b2e932ef09}"
+elif [[ "${composition_mode}" == "reproduce-r32" ]]; then
   export LAUNCHER_REF="${LAUNCHER_REF:-6b3456a6485d55898534b87a4a07353e434b23b3}"
   export LAUNCHER_COMMIT="${LAUNCHER_COMMIT:-6b3456a6485d55898534b87a4a07353e434b23b3}"
 elif [[ "${composition_mode}" == "reproduce-r31" ]]; then

--- a/build-gilded-gnosis-v20-final-cu132.sh
+++ b/build-gilded-gnosis-v20-final-cu132.sh
@@ -105,8 +105,18 @@ if [[ "${composition_mode}" == "clean" ]]; then
     --output-dir "${lmcache_composition_dir}" >/dev/null
   configure_lmcache_composition "${lmcache_composition_dir}" 1
 
-  export IMAGE="${IMAGE:-voipmonitor/vllm:gilded-gnosis-v20-vllm${VLLM_INTEGRATION_TREE:0:7}-b12x${B12X_INTEGRATION_TREE:0:7}-fi1ac6942-cu132-${release_date}-r32}"
-  export VLLM_BUILD_VERSION="${VLLM_BUILD_VERSION:-0.11.2.dev280+gilded.gnosis.v20.vllm${VLLM_INTEGRATION_TREE:0:7}.b12x${B12X_INTEGRATION_TREE:0:7}.fi1ac6942.cu132.${release_date}.r32}"
+  export IMAGE="${IMAGE:-voipmonitor/vllm:gilded-gnosis-v20-vllm${VLLM_INTEGRATION_TREE:0:7}-b12x${B12X_INTEGRATION_TREE:0:7}-fi1ac6942-cu132-${release_date}-r33}"
+  export VLLM_BUILD_VERSION="${VLLM_BUILD_VERSION:-0.11.2.dev280+gilded.gnosis.v20.vllm${VLLM_INTEGRATION_TREE:0:7}.b12x${B12X_INTEGRATION_TREE:0:7}.fi1ac6942.cu132.${release_date}.r33}"
+elif [[ "${composition_mode}" == "reproduce-r33" ]]; then
+  configure_vllm_composition \
+    "patches/releases/gilded-gnosis-v20-r33/vllm" 0
+  configure_b12x_composition \
+    "patches/releases/gilded-gnosis-v20-r33/b12x" 0
+  configure_lmcache_composition \
+    "patches/releases/gilded-gnosis-v20-r33/lmcache" 0
+
+  export IMAGE="${IMAGE:-voipmonitor/vllm:gilded-gnosis-v20-vllmfa13d33-b12x06db0f4-fi1ac6942-cu132-20260809-r33}"
+  export VLLM_BUILD_VERSION="${VLLM_BUILD_VERSION:-0.11.2.dev280+gilded.gnosis.v20.vllmfa13d33.b12x06db0f4.fi1ac6942.cu132.20260809.r33}"
 elif [[ "${composition_mode}" == "reproduce-r32" ]]; then
   configure_vllm_composition \
     "patches/releases/gilded-gnosis-v20-r32/vllm" 0
@@ -394,7 +404,7 @@ export EXLLAMAV3_COMMIT="${EXLLAMAV3_COMMIT:-704aefd743b390af4bd0fb429d1906f9b96
 
 export VLLM_PATCH_URL=
 
-if [[ "${composition_mode}" == "clean" || "${composition_mode}" == "reproduce-r32" || "${composition_mode}" == "reproduce-r31" || "${composition_mode}" == "reproduce-r30" || "${composition_mode}" == "reproduce-r29" ]]; then
+if [[ "${composition_mode}" == "clean" || "${composition_mode}" == "reproduce-r33" || "${composition_mode}" == "reproduce-r32" || "${composition_mode}" == "reproduce-r31" || "${composition_mode}" == "reproduce-r30" || "${composition_mode}" == "reproduce-r29" ]]; then
   export B12X_VERSION="${B12X_VERSION:-1.1.0}"
   export EXPECTED_B12X_PACKAGE="${EXPECTED_B12X_PACKAGE:-b12x}"
 else
@@ -403,7 +413,7 @@ else
 fi
 
 export LAUNCHER_REPO="${LAUNCHER_REPO:-https://github.com/local-inference-lab/blackwell-llm-docker.git}"
-if [[ "${composition_mode}" == "clean" || "${composition_mode}" == "reproduce-r32" ]]; then
+if [[ "${composition_mode}" == "clean" || "${composition_mode}" == "reproduce-r33" || "${composition_mode}" == "reproduce-r32" ]]; then
   export LAUNCHER_REF="${LAUNCHER_REF:-6b3456a6485d55898534b87a4a07353e434b23b3}"
   export LAUNCHER_COMMIT="${LAUNCHER_COMMIT:-6b3456a6485d55898534b87a4a07353e434b23b3}"
 elif [[ "${composition_mode}" == "reproduce-r31" ]]; then
@@ -440,7 +450,7 @@ export TRITON_KERNELS_REF=
 export TRITON_KERNELS_COMMIT=
 
 export XGRAMMAR_REPO="${XGRAMMAR_REPO:-https://github.com/mlc-ai/xgrammar.git}"
-if [[ "${composition_mode}" == "clean" || "${composition_mode}" == "reproduce-r8" || "${composition_mode}" == "reproduce-r9" || "${composition_mode}" == "reproduce-r11" || "${composition_mode}" == "reproduce-r12" || "${composition_mode}" == "reproduce-r13" || "${composition_mode}" == "reproduce-r14" || "${composition_mode}" == "reproduce-r15" || "${composition_mode}" == "reproduce-r16" || "${composition_mode}" == "reproduce-r17" || "${composition_mode}" == "reproduce-r18" || "${composition_mode}" == "reproduce-r19" || "${composition_mode}" == "reproduce-r20" || "${composition_mode}" == "reproduce-r24" || "${composition_mode}" == "reproduce-r25" || "${composition_mode}" == "reproduce-r26" || "${composition_mode}" == "reproduce-r27" || "${composition_mode}" == "reproduce-r28" || "${composition_mode}" == "reproduce-r29" || "${composition_mode}" == "reproduce-r30" || "${composition_mode}" == "reproduce-r31" || "${composition_mode}" == "reproduce-r32" ]]; then
+if [[ "${composition_mode}" == "clean" || "${composition_mode}" == "reproduce-r8" || "${composition_mode}" == "reproduce-r9" || "${composition_mode}" == "reproduce-r11" || "${composition_mode}" == "reproduce-r12" || "${composition_mode}" == "reproduce-r13" || "${composition_mode}" == "reproduce-r14" || "${composition_mode}" == "reproduce-r15" || "${composition_mode}" == "reproduce-r16" || "${composition_mode}" == "reproduce-r17" || "${composition_mode}" == "reproduce-r18" || "${composition_mode}" == "reproduce-r19" || "${composition_mode}" == "reproduce-r20" || "${composition_mode}" == "reproduce-r24" || "${composition_mode}" == "reproduce-r25" || "${composition_mode}" == "reproduce-r26" || "${composition_mode}" == "reproduce-r27" || "${composition_mode}" == "reproduce-r28" || "${composition_mode}" == "reproduce-r29" || "${composition_mode}" == "reproduce-r30" || "${composition_mode}" == "reproduce-r31" || "${composition_mode}" == "reproduce-r32" || "${composition_mode}" == "reproduce-r33" ]]; then
   export XGRAMMAR_REF="${XGRAMMAR_REF:-v0.2.5}"
   export XGRAMMAR_COMMIT="${XGRAMMAR_COMMIT:-2ea71da4ccb997a06928c9fb69b99f330da56697}"
   export XGRAMMAR_VERSION="${XGRAMMAR_VERSION:-0.2.5}"
@@ -454,7 +464,7 @@ else
   export XGRAMMAR_TRANSFORMERS5_COMPAT="${XGRAMMAR_TRANSFORMERS5_COMPAT:-0}"
 fi
 
-if [[ "${composition_mode}" == "clean" || "${composition_mode}" == "reproduce-r32" || "${composition_mode}" == "reproduce-r31" || "${composition_mode}" == "reproduce-r30" || "${composition_mode}" == "reproduce-r29" || "${composition_mode}" == "reproduce-r28" || "${composition_mode}" == "reproduce-r27" ]]; then
+if [[ "${composition_mode}" == "clean" || "${composition_mode}" == "reproduce-r33" || "${composition_mode}" == "reproduce-r32" || "${composition_mode}" == "reproduce-r31" || "${composition_mode}" == "reproduce-r30" || "${composition_mode}" == "reproduce-r29" || "${composition_mode}" == "reproduce-r28" || "${composition_mode}" == "reproduce-r27" ]]; then
   export INSTANTTENSOR_REPO="${INSTANTTENSOR_REPO:-https://github.com/voipmonitor/InstantTensor.git}"
   export INSTANTTENSOR_REF="${INSTANTTENSOR_REF:-49b4010afc1cae0441e71fe0b0bffc24fa05e932}"
   export INSTANTTENSOR_COMMIT="${INSTANTTENSOR_COMMIT:-49b4010afc1cae0441e71fe0b0bffc24fa05e932}"
@@ -467,7 +477,7 @@ else
   export INSTANTTENSOR_REF="${INSTANTTENSOR_REF:-85e7c5f5539d9c006ee0c26bc1b5233c65251b6b}"
   export INSTANTTENSOR_COMMIT="${INSTANTTENSOR_COMMIT:-85e7c5f5539d9c006ee0c26bc1b5233c65251b6b}"
 fi
-if [[ "${composition_mode}" == "clean" || "${composition_mode}" == "reproduce-r11" || "${composition_mode}" == "reproduce-r12" || "${composition_mode}" == "reproduce-r13" || "${composition_mode}" == "reproduce-r14" || "${composition_mode}" == "reproduce-r15" || "${composition_mode}" == "reproduce-r16" || "${composition_mode}" == "reproduce-r17" || "${composition_mode}" == "reproduce-r18" || "${composition_mode}" == "reproduce-r19" || "${composition_mode}" == "reproduce-r20" || "${composition_mode}" == "reproduce-r24" || "${composition_mode}" == "reproduce-r25" || "${composition_mode}" == "reproduce-r26" || "${composition_mode}" == "reproduce-r27" || "${composition_mode}" == "reproduce-r28" || "${composition_mode}" == "reproduce-r29" || "${composition_mode}" == "reproduce-r30" || "${composition_mode}" == "reproduce-r31" || "${composition_mode}" == "reproduce-r32" ]]; then
+if [[ "${composition_mode}" == "clean" || "${composition_mode}" == "reproduce-r11" || "${composition_mode}" == "reproduce-r12" || "${composition_mode}" == "reproduce-r13" || "${composition_mode}" == "reproduce-r14" || "${composition_mode}" == "reproduce-r15" || "${composition_mode}" == "reproduce-r16" || "${composition_mode}" == "reproduce-r17" || "${composition_mode}" == "reproduce-r18" || "${composition_mode}" == "reproduce-r19" || "${composition_mode}" == "reproduce-r20" || "${composition_mode}" == "reproduce-r24" || "${composition_mode}" == "reproduce-r25" || "${composition_mode}" == "reproduce-r26" || "${composition_mode}" == "reproduce-r27" || "${composition_mode}" == "reproduce-r28" || "${composition_mode}" == "reproduce-r29" || "${composition_mode}" == "reproduce-r30" || "${composition_mode}" == "reproduce-r31" || "${composition_mode}" == "reproduce-r32" || "${composition_mode}" == "reproduce-r33" ]]; then
   export LMCACHE_BUILD_VERSION="${LMCACHE_BUILD_VERSION:-0.5.2+glm52dcp.4}"
 elif [[ "${composition_mode}" == "reproduce-r6" ]]; then
   export LMCACHE_REPO="${LMCACHE_REPO:-https://github.com/LMCache/LMCache.git}"
@@ -576,7 +586,7 @@ jq -e --arg value "${LMCACHE_PATCH_SHA256}" '."local-inference.lmcache.patch_sha
 jq -e --arg value "${LMCACHE_BUILD_VERSION}" '."local-inference.lmcache.version" == $value' <<<"${labels}" >/dev/null
 jq -e --arg value "${INSTANTTENSOR_REPO}" '."local-inference.instanttensor.repo" == $value' <<<"${labels}" >/dev/null
 jq -e --arg value "${INSTANTTENSOR_COMMIT}" '."local-inference.instanttensor.commit" == $value' <<<"${labels}" >/dev/null
-if [[ "${composition_mode}" == "clean" || "${composition_mode}" == "reproduce-r11" || "${composition_mode}" == "reproduce-r12" || "${composition_mode}" == "reproduce-r13" || "${composition_mode}" == "reproduce-r14" || "${composition_mode}" == "reproduce-r15" || "${composition_mode}" == "reproduce-r16" || "${composition_mode}" == "reproduce-r17" || "${composition_mode}" == "reproduce-r18" || "${composition_mode}" == "reproduce-r19" || "${composition_mode}" == "reproduce-r20" || "${composition_mode}" == "reproduce-r24" || "${composition_mode}" == "reproduce-r25" || "${composition_mode}" == "reproduce-r26" || "${composition_mode}" == "reproduce-r27" || "${composition_mode}" == "reproduce-r28" || "${composition_mode}" == "reproduce-r29" || "${composition_mode}" == "reproduce-r30" || "${composition_mode}" == "reproduce-r31" || "${composition_mode}" == "reproduce-r32" ]]; then
+if [[ "${composition_mode}" == "clean" || "${composition_mode}" == "reproduce-r11" || "${composition_mode}" == "reproduce-r12" || "${composition_mode}" == "reproduce-r13" || "${composition_mode}" == "reproduce-r14" || "${composition_mode}" == "reproduce-r15" || "${composition_mode}" == "reproduce-r16" || "${composition_mode}" == "reproduce-r17" || "${composition_mode}" == "reproduce-r18" || "${composition_mode}" == "reproduce-r19" || "${composition_mode}" == "reproduce-r20" || "${composition_mode}" == "reproduce-r24" || "${composition_mode}" == "reproduce-r25" || "${composition_mode}" == "reproduce-r26" || "${composition_mode}" == "reproduce-r27" || "${composition_mode}" == "reproduce-r28" || "${composition_mode}" == "reproduce-r29" || "${composition_mode}" == "reproduce-r30" || "${composition_mode}" == "reproduce-r31" || "${composition_mode}" == "reproduce-r32" || "${composition_mode}" == "reproduce-r33" ]]; then
   jq -e --arg value "${LMCACHE_INTEGRATION_TREE}" '."local-inference.lmcache.integration.tree" == $value' <<<"${labels}" >/dev/null
   jq -e --arg value "${LMCACHE_INTEGRATION_PRS}" '."local-inference.lmcache.integration.prs" == $value' <<<"${labels}" >/dev/null
   jq -e --arg value "${LMCACHE_INTEGRATION_LOCK_SHA256}" '."local-inference.lmcache.integration.lock_sha256" == $value' <<<"${labels}" >/dev/null

--- a/build-gilded-gnosis-v20-final-cu132.sh
+++ b/build-gilded-gnosis-v20-final-cu132.sh
@@ -404,8 +404,8 @@ fi
 
 export LAUNCHER_REPO="${LAUNCHER_REPO:-https://github.com/local-inference-lab/blackwell-llm-docker.git}"
 if [[ "${composition_mode}" == "clean" || "${composition_mode}" == "reproduce-r32" ]]; then
-  export LAUNCHER_REF="${LAUNCHER_REF:-306d4d25185ca069721400545b40aa2a309477e5}"
-  export LAUNCHER_COMMIT="${LAUNCHER_COMMIT:-306d4d25185ca069721400545b40aa2a309477e5}"
+  export LAUNCHER_REF="${LAUNCHER_REF:-6b3456a6485d55898534b87a4a07353e434b23b3}"
+  export LAUNCHER_COMMIT="${LAUNCHER_COMMIT:-6b3456a6485d55898534b87a4a07353e434b23b3}"
 elif [[ "${composition_mode}" == "reproduce-r31" ]]; then
   export LAUNCHER_REF="${LAUNCHER_REF:-3d3b94a7f2493c50aa677fdf6d799cc224db5785}"
   export LAUNCHER_COMMIT="${LAUNCHER_COMMIT:-3d3b94a7f2493c50aa677fdf6d799cc224db5785}"

--- a/build-gilded-gnosis-v20-final-cu132.sh
+++ b/build-gilded-gnosis-v20-final-cu132.sh
@@ -115,8 +115,8 @@ elif [[ "${composition_mode}" == "reproduce-r32" ]]; then
   configure_lmcache_composition \
     "patches/releases/gilded-gnosis-v20-r32/lmcache" 0
 
-  export IMAGE="${IMAGE:-voipmonitor/vllm:gilded-gnosis-v20-vllmfa13d33-b12xe90b8af-fi1ac6942-cu132-20260809-r32}"
-  export VLLM_BUILD_VERSION="${VLLM_BUILD_VERSION:-0.11.2.dev280+gilded.gnosis.v20.vllmfa13d33.b12xe90b8af.fi1ac6942.cu132.20260809.r32}"
+  export IMAGE="${IMAGE:-voipmonitor/vllm:gilded-gnosis-v20-vllmfa13d33-b12x817fb3d-fi1ac6942-cu132-20260809-r32}"
+  export VLLM_BUILD_VERSION="${VLLM_BUILD_VERSION:-0.11.2.dev280+gilded.gnosis.v20.vllmfa13d33.b12x817fb3d.fi1ac6942.cu132.20260809.r32}"
 elif [[ "${composition_mode}" == "reproduce-r31" ]]; then
   configure_vllm_composition \
     "patches/releases/gilded-gnosis-v20-r31/vllm" 0

--- a/build-gilded-gnosis-v20-final-cu132.sh
+++ b/build-gilded-gnosis-v20-final-cu132.sh
@@ -85,6 +85,8 @@ configure_lmcache_composition() {
 if [[ "${composition_mode}" == "clean" ]]; then
   python3 scripts/audit_release_prs.py \
     manifests/vllm/gilded-gnosis-v20.json
+  python3 scripts/audit_release_prs.py \
+    manifests/b12x/gilded-gnosis-v20.json
   composition_dir="patches/generated/gilded-gnosis-v20/vllm"
   python3 scripts/compose_vllm_release.py \
     manifests/vllm/gilded-gnosis-v20.json \
@@ -103,8 +105,18 @@ if [[ "${composition_mode}" == "clean" ]]; then
     --output-dir "${lmcache_composition_dir}" >/dev/null
   configure_lmcache_composition "${lmcache_composition_dir}" 1
 
-  export IMAGE="${IMAGE:-voipmonitor/vllm:gilded-gnosis-v20-vllm${VLLM_INTEGRATION_TREE:0:7}-b12x${B12X_INTEGRATION_TREE:0:7}-fi1ac6942-cu132-${release_date}-r31}"
-  export VLLM_BUILD_VERSION="${VLLM_BUILD_VERSION:-0.11.2.dev280+gilded.gnosis.v20.vllm${VLLM_INTEGRATION_TREE:0:7}.b12x${B12X_INTEGRATION_TREE:0:7}.fi1ac6942.cu132.${release_date}.r31}"
+  export IMAGE="${IMAGE:-voipmonitor/vllm:gilded-gnosis-v20-vllm${VLLM_INTEGRATION_TREE:0:7}-b12x${B12X_INTEGRATION_TREE:0:7}-fi1ac6942-cu132-${release_date}-r32}"
+  export VLLM_BUILD_VERSION="${VLLM_BUILD_VERSION:-0.11.2.dev280+gilded.gnosis.v20.vllm${VLLM_INTEGRATION_TREE:0:7}.b12x${B12X_INTEGRATION_TREE:0:7}.fi1ac6942.cu132.${release_date}.r32}"
+elif [[ "${composition_mode}" == "reproduce-r32" ]]; then
+  configure_vllm_composition \
+    "patches/releases/gilded-gnosis-v20-r32/vllm" 0
+  configure_b12x_composition \
+    "patches/releases/gilded-gnosis-v20-r32/b12x" 0
+  configure_lmcache_composition \
+    "patches/releases/gilded-gnosis-v20-r32/lmcache" 0
+
+  export IMAGE="${IMAGE:-voipmonitor/vllm:gilded-gnosis-v20-vllmfa13d33-b12xe90b8af-fi1ac6942-cu132-20260809-r32}"
+  export VLLM_BUILD_VERSION="${VLLM_BUILD_VERSION:-0.11.2.dev280+gilded.gnosis.v20.vllmfa13d33.b12xe90b8af.fi1ac6942.cu132.20260809.r32}"
 elif [[ "${composition_mode}" == "reproduce-r31" ]]; then
   configure_vllm_composition \
     "patches/releases/gilded-gnosis-v20-r31/vllm" 0
@@ -382,7 +394,7 @@ export EXLLAMAV3_COMMIT="${EXLLAMAV3_COMMIT:-704aefd743b390af4bd0fb429d1906f9b96
 
 export VLLM_PATCH_URL=
 
-if [[ "${composition_mode}" == "clean" || "${composition_mode}" == "reproduce-r31" || "${composition_mode}" == "reproduce-r30" || "${composition_mode}" == "reproduce-r29" ]]; then
+if [[ "${composition_mode}" == "clean" || "${composition_mode}" == "reproduce-r32" || "${composition_mode}" == "reproduce-r31" || "${composition_mode}" == "reproduce-r30" || "${composition_mode}" == "reproduce-r29" ]]; then
   export B12X_VERSION="${B12X_VERSION:-1.1.0}"
   export EXPECTED_B12X_PACKAGE="${EXPECTED_B12X_PACKAGE:-b12x}"
 else
@@ -391,7 +403,7 @@ else
 fi
 
 export LAUNCHER_REPO="${LAUNCHER_REPO:-https://github.com/local-inference-lab/blackwell-llm-docker.git}"
-if [[ "${composition_mode}" == "clean" || "${composition_mode}" == "reproduce-r31" ]]; then
+if [[ "${composition_mode}" == "clean" || "${composition_mode}" == "reproduce-r32" || "${composition_mode}" == "reproduce-r31" ]]; then
   export LAUNCHER_REF="${LAUNCHER_REF:-3d3b94a7f2493c50aa677fdf6d799cc224db5785}"
   export LAUNCHER_COMMIT="${LAUNCHER_COMMIT:-3d3b94a7f2493c50aa677fdf6d799cc224db5785}"
 elif [[ "${composition_mode}" == "reproduce-r30" || "${composition_mode}" == "reproduce-r29" ]]; then
@@ -425,7 +437,7 @@ export TRITON_KERNELS_REF=
 export TRITON_KERNELS_COMMIT=
 
 export XGRAMMAR_REPO="${XGRAMMAR_REPO:-https://github.com/mlc-ai/xgrammar.git}"
-if [[ "${composition_mode}" == "clean" || "${composition_mode}" == "reproduce-r8" || "${composition_mode}" == "reproduce-r9" || "${composition_mode}" == "reproduce-r11" || "${composition_mode}" == "reproduce-r12" || "${composition_mode}" == "reproduce-r13" || "${composition_mode}" == "reproduce-r14" || "${composition_mode}" == "reproduce-r15" || "${composition_mode}" == "reproduce-r16" || "${composition_mode}" == "reproduce-r17" || "${composition_mode}" == "reproduce-r18" || "${composition_mode}" == "reproduce-r19" || "${composition_mode}" == "reproduce-r20" || "${composition_mode}" == "reproduce-r24" || "${composition_mode}" == "reproduce-r25" || "${composition_mode}" == "reproduce-r26" || "${composition_mode}" == "reproduce-r27" || "${composition_mode}" == "reproduce-r28" || "${composition_mode}" == "reproduce-r29" || "${composition_mode}" == "reproduce-r30" || "${composition_mode}" == "reproduce-r31" ]]; then
+if [[ "${composition_mode}" == "clean" || "${composition_mode}" == "reproduce-r8" || "${composition_mode}" == "reproduce-r9" || "${composition_mode}" == "reproduce-r11" || "${composition_mode}" == "reproduce-r12" || "${composition_mode}" == "reproduce-r13" || "${composition_mode}" == "reproduce-r14" || "${composition_mode}" == "reproduce-r15" || "${composition_mode}" == "reproduce-r16" || "${composition_mode}" == "reproduce-r17" || "${composition_mode}" == "reproduce-r18" || "${composition_mode}" == "reproduce-r19" || "${composition_mode}" == "reproduce-r20" || "${composition_mode}" == "reproduce-r24" || "${composition_mode}" == "reproduce-r25" || "${composition_mode}" == "reproduce-r26" || "${composition_mode}" == "reproduce-r27" || "${composition_mode}" == "reproduce-r28" || "${composition_mode}" == "reproduce-r29" || "${composition_mode}" == "reproduce-r30" || "${composition_mode}" == "reproduce-r31" || "${composition_mode}" == "reproduce-r32" ]]; then
   export XGRAMMAR_REF="${XGRAMMAR_REF:-v0.2.5}"
   export XGRAMMAR_COMMIT="${XGRAMMAR_COMMIT:-2ea71da4ccb997a06928c9fb69b99f330da56697}"
   export XGRAMMAR_VERSION="${XGRAMMAR_VERSION:-0.2.5}"
@@ -439,7 +451,7 @@ else
   export XGRAMMAR_TRANSFORMERS5_COMPAT="${XGRAMMAR_TRANSFORMERS5_COMPAT:-0}"
 fi
 
-if [[ "${composition_mode}" == "clean" || "${composition_mode}" == "reproduce-r31" || "${composition_mode}" == "reproduce-r30" || "${composition_mode}" == "reproduce-r29" || "${composition_mode}" == "reproduce-r28" || "${composition_mode}" == "reproduce-r27" ]]; then
+if [[ "${composition_mode}" == "clean" || "${composition_mode}" == "reproduce-r32" || "${composition_mode}" == "reproduce-r31" || "${composition_mode}" == "reproduce-r30" || "${composition_mode}" == "reproduce-r29" || "${composition_mode}" == "reproduce-r28" || "${composition_mode}" == "reproduce-r27" ]]; then
   export INSTANTTENSOR_REPO="${INSTANTTENSOR_REPO:-https://github.com/voipmonitor/InstantTensor.git}"
   export INSTANTTENSOR_REF="${INSTANTTENSOR_REF:-49b4010afc1cae0441e71fe0b0bffc24fa05e932}"
   export INSTANTTENSOR_COMMIT="${INSTANTTENSOR_COMMIT:-49b4010afc1cae0441e71fe0b0bffc24fa05e932}"
@@ -452,7 +464,7 @@ else
   export INSTANTTENSOR_REF="${INSTANTTENSOR_REF:-85e7c5f5539d9c006ee0c26bc1b5233c65251b6b}"
   export INSTANTTENSOR_COMMIT="${INSTANTTENSOR_COMMIT:-85e7c5f5539d9c006ee0c26bc1b5233c65251b6b}"
 fi
-if [[ "${composition_mode}" == "clean" || "${composition_mode}" == "reproduce-r11" || "${composition_mode}" == "reproduce-r12" || "${composition_mode}" == "reproduce-r13" || "${composition_mode}" == "reproduce-r14" || "${composition_mode}" == "reproduce-r15" || "${composition_mode}" == "reproduce-r16" || "${composition_mode}" == "reproduce-r17" || "${composition_mode}" == "reproduce-r18" || "${composition_mode}" == "reproduce-r19" || "${composition_mode}" == "reproduce-r20" || "${composition_mode}" == "reproduce-r24" || "${composition_mode}" == "reproduce-r25" || "${composition_mode}" == "reproduce-r26" || "${composition_mode}" == "reproduce-r27" || "${composition_mode}" == "reproduce-r28" || "${composition_mode}" == "reproduce-r29" || "${composition_mode}" == "reproduce-r30" || "${composition_mode}" == "reproduce-r31" ]]; then
+if [[ "${composition_mode}" == "clean" || "${composition_mode}" == "reproduce-r11" || "${composition_mode}" == "reproduce-r12" || "${composition_mode}" == "reproduce-r13" || "${composition_mode}" == "reproduce-r14" || "${composition_mode}" == "reproduce-r15" || "${composition_mode}" == "reproduce-r16" || "${composition_mode}" == "reproduce-r17" || "${composition_mode}" == "reproduce-r18" || "${composition_mode}" == "reproduce-r19" || "${composition_mode}" == "reproduce-r20" || "${composition_mode}" == "reproduce-r24" || "${composition_mode}" == "reproduce-r25" || "${composition_mode}" == "reproduce-r26" || "${composition_mode}" == "reproduce-r27" || "${composition_mode}" == "reproduce-r28" || "${composition_mode}" == "reproduce-r29" || "${composition_mode}" == "reproduce-r30" || "${composition_mode}" == "reproduce-r31" || "${composition_mode}" == "reproduce-r32" ]]; then
   export LMCACHE_BUILD_VERSION="${LMCACHE_BUILD_VERSION:-0.5.2+glm52dcp.4}"
 elif [[ "${composition_mode}" == "reproduce-r6" ]]; then
   export LMCACHE_REPO="${LMCACHE_REPO:-https://github.com/LMCache/LMCache.git}"
@@ -561,7 +573,7 @@ jq -e --arg value "${LMCACHE_PATCH_SHA256}" '."local-inference.lmcache.patch_sha
 jq -e --arg value "${LMCACHE_BUILD_VERSION}" '."local-inference.lmcache.version" == $value' <<<"${labels}" >/dev/null
 jq -e --arg value "${INSTANTTENSOR_REPO}" '."local-inference.instanttensor.repo" == $value' <<<"${labels}" >/dev/null
 jq -e --arg value "${INSTANTTENSOR_COMMIT}" '."local-inference.instanttensor.commit" == $value' <<<"${labels}" >/dev/null
-if [[ "${composition_mode}" == "clean" || "${composition_mode}" == "reproduce-r11" || "${composition_mode}" == "reproduce-r12" || "${composition_mode}" == "reproduce-r13" || "${composition_mode}" == "reproduce-r14" || "${composition_mode}" == "reproduce-r15" || "${composition_mode}" == "reproduce-r16" || "${composition_mode}" == "reproduce-r17" || "${composition_mode}" == "reproduce-r18" || "${composition_mode}" == "reproduce-r19" || "${composition_mode}" == "reproduce-r20" || "${composition_mode}" == "reproduce-r24" || "${composition_mode}" == "reproduce-r25" || "${composition_mode}" == "reproduce-r26" || "${composition_mode}" == "reproduce-r27" || "${composition_mode}" == "reproduce-r28" || "${composition_mode}" == "reproduce-r29" || "${composition_mode}" == "reproduce-r30" || "${composition_mode}" == "reproduce-r31" ]]; then
+if [[ "${composition_mode}" == "clean" || "${composition_mode}" == "reproduce-r11" || "${composition_mode}" == "reproduce-r12" || "${composition_mode}" == "reproduce-r13" || "${composition_mode}" == "reproduce-r14" || "${composition_mode}" == "reproduce-r15" || "${composition_mode}" == "reproduce-r16" || "${composition_mode}" == "reproduce-r17" || "${composition_mode}" == "reproduce-r18" || "${composition_mode}" == "reproduce-r19" || "${composition_mode}" == "reproduce-r20" || "${composition_mode}" == "reproduce-r24" || "${composition_mode}" == "reproduce-r25" || "${composition_mode}" == "reproduce-r26" || "${composition_mode}" == "reproduce-r27" || "${composition_mode}" == "reproduce-r28" || "${composition_mode}" == "reproduce-r29" || "${composition_mode}" == "reproduce-r30" || "${composition_mode}" == "reproduce-r31" || "${composition_mode}" == "reproduce-r32" ]]; then
   jq -e --arg value "${LMCACHE_INTEGRATION_TREE}" '."local-inference.lmcache.integration.tree" == $value' <<<"${labels}" >/dev/null
   jq -e --arg value "${LMCACHE_INTEGRATION_PRS}" '."local-inference.lmcache.integration.prs" == $value' <<<"${labels}" >/dev/null
   jq -e --arg value "${LMCACHE_INTEGRATION_LOCK_SHA256}" '."local-inference.lmcache.integration.lock_sha256" == $value' <<<"${labels}" >/dev/null
@@ -674,6 +686,9 @@ tiled_topk = importlib.import_module(
 )
 pcie = importlib.import_module(f"{kernel_package}.comm.pcie")
 pcie_dma = importlib.import_module(f"{kernel_package}.comm.pcie.pcie_dma")
+pcie_oneshot = importlib.import_module(
+    f"{kernel_package}.comm.pcie.pcie_oneshot"
+)
 gemm = importlib.import_module(f"{kernel_package}.gemm")
 trellis_k6_small = importlib.import_module(
     f"{kernel_package}.gemm.trellis_linear._small_m"
@@ -772,6 +787,14 @@ emit_source = inspect.getsource(tiled_topk._emit_global_index_virtual)
 assert "Int64(row_idx) * Int64(output_page_table_row_stride)" in emit_source
 assert callable(DcpTopKOwnerExchange)
 assert callable(bmm) and callable(can_implement_bmm) and callable(prewarm_bmm)
+topology_mode_source = inspect.getsource(
+    pcie_oneshot._CuTeOneshotBackend._fused_topology_mode
+)
+assert "stage_tp8_owner" in topology_mode_source
+assert "stage_remote_push" in topology_mode_source
+assert pcie_oneshot._tp8_owner_reduce_enabled()
+assert not pcie_oneshot._tp4_remote_push_enabled()
+assert not pcie_oneshot._tp2_remote_push_enabled()
 assert "per_token_scale" in inspect.signature(
     concat_and_cache_nvfp4_mla_fp8_rope
 ).parameters

--- a/build-gilded-gnosis-v20-final-cu132.sh
+++ b/build-gilded-gnosis-v20-final-cu132.sh
@@ -403,7 +403,10 @@ else
 fi
 
 export LAUNCHER_REPO="${LAUNCHER_REPO:-https://github.com/local-inference-lab/blackwell-llm-docker.git}"
-if [[ "${composition_mode}" == "clean" || "${composition_mode}" == "reproduce-r32" || "${composition_mode}" == "reproduce-r31" ]]; then
+if [[ "${composition_mode}" == "clean" || "${composition_mode}" == "reproduce-r32" ]]; then
+  export LAUNCHER_REF="${LAUNCHER_REF:-306d4d25185ca069721400545b40aa2a309477e5}"
+  export LAUNCHER_COMMIT="${LAUNCHER_COMMIT:-306d4d25185ca069721400545b40aa2a309477e5}"
+elif [[ "${composition_mode}" == "reproduce-r31" ]]; then
   export LAUNCHER_REF="${LAUNCHER_REF:-3d3b94a7f2493c50aa677fdf6d799cc224db5785}"
   export LAUNCHER_COMMIT="${LAUNCHER_COMMIT:-3d3b94a7f2493c50aa677fdf6d799cc224db5785}"
 elif [[ "${composition_mode}" == "reproduce-r30" || "${composition_mode}" == "reproduce-r29" ]]; then

--- a/examples/docker-compose-ds4-v20-r32.yml
+++ b/examples/docker-compose-ds4-v20-r32.yml
@@ -18,7 +18,7 @@
 # mixed-workload default.
 services:
   ds4:
-    image: ${IMAGE:-voipmonitor/vllm:gilded-gnosis-v20-vllmfa13d33-b12xe90b8af-fi1ac6942-cu132-20260809-r32}
+    image: ${IMAGE:-voipmonitor/vllm:gilded-gnosis-v20-vllmfa13d33-b12x817fb3d-fi1ac6942-cu132-20260809-r32}
     container_name: ${NAME:-ds4-0731-r32}
     entrypoint: ["/usr/local/bin/serve-ds4-flash.sh"]
     network_mode: host

--- a/examples/docker-compose-ds4-v20-r32.yml
+++ b/examples/docker-compose-ds4-v20-r32.yml
@@ -1,0 +1,68 @@
+# DeepSeek-V4-Flash-0731 DSpark r32 release profile.
+#
+# Default: TP2/DCP1, B12X W4A8, fixed K5. r32 adds B12X's qualified
+# topology-scoped fused all-reduce. TP8 owner reduction is enabled by default.
+# TP2 and TP4 remote-push variants remain explicit experiments because matched
+# end-to-end testing did not establish a stable gain.
+#
+# ALLREDUCE_MODE=auto still selects FlashInfer PCIe IPC at TP2 and B12X at TP4
+# or larger. To test the B12X TP2 variant, set both ALLREDUCE_MODE=b12x and
+# B12X_PCIE_TP2_REMOTE_PUSH=1. At TP4, set B12X_PCIE_TP4_REMOTE_PUSH=1.
+# Disable the default TP8 owner path with B12X_PCIE_TP8_OWNER_REDUCE=0.
+#
+# Target, DSpark proposal, and DFlash context-KV execution use separate FULL
+# CUDA graph families. Prefill remains PIECEWISE, and unsupported shapes retain
+# the existing fallback.
+#
+# K7 remains available with DSPARK_TOKENS=7 for predictable code. K5 is the
+# mixed-workload default.
+services:
+  ds4:
+    image: ${IMAGE:-voipmonitor/vllm:gilded-gnosis-v20-vllmfa13d33-b12xe90b8af-fi1ac6942-cu132-20260809-r32}
+    container_name: ${NAME:-ds4-0731-r32}
+    entrypoint: ["/usr/local/bin/serve-ds4-flash.sh"]
+    network_mode: host
+    ipc: host
+    init: true
+    shm_size: ${SHM_SIZE:-32gb}
+    gpus: all
+    restart: unless-stopped
+    ulimits:
+      memlock:
+        soft: -1
+        hard: -1
+      nofile:
+        soft: 1048576
+        hard: 1048576
+      stack: 67108864
+    environment:
+      CUDA_VISIBLE_DEVICES: ${GPUS:-0,1}
+      PORT: ${PORT:-8000}
+      MODE: ${MODE:-dspark}
+      BACKEND: ${BACKEND:-b12x-a8}
+      TP_SIZE: ${TP_SIZE:-2}
+      DCP_SIZE: ${DCP_SIZE:-1}
+      ALLREDUCE_MODE: ${ALLREDUCE_MODE:-auto}
+      B12X_PCIE_TP2_REMOTE_PUSH: ${B12X_PCIE_TP2_REMOTE_PUSH:-0}
+      B12X_PCIE_TP4_REMOTE_PUSH: ${B12X_PCIE_TP4_REMOTE_PUSH:-0}
+      B12X_PCIE_TP8_OWNER_REDUCE: ${B12X_PCIE_TP8_OWNER_REDUCE:-1}
+      DSPARK_DEPTH_MODE: ${DSPARK_DEPTH_MODE:-fixed}
+      DSPARK_TOKENS: ${DSPARK_TOKENS:-5}
+      MAX_NUM_SEQS: ${MAX_NUM_SEQS:-16}
+      GRAPH: ${GRAPH:-auto}
+      MAX_MODEL_LEN: ${MAX_MODEL_LEN:-131072}
+      MAX_NUM_BATCHED_TOKENS: ${MAX_NUM_BATCHED_TOKENS:-8192}
+      GPU_MEMORY_UTILIZATION: ${GPU_MEMORY_UTILIZATION:-0.975}
+      LOAD_FORMAT: ${LOAD_FORMAT:-instanttensor}
+      INSTANTTENSOR_BACKEND: ${INSTANTTENSOR_BACKEND:-BUFFERED}
+      PYTHONHASHSEED: ${PYTHONHASHSEED:-0}
+      KV_OFFLOADING_SIZE: ${KV_OFFLOADING_SIZE:-0}
+      NATIVE_L2_PATH: ${NATIVE_L2_PATH:-}
+      NATIVE_L2_GB: ${NATIVE_L2_GB:-}
+      EXTRA_VLLM_ARGS: ${EXTRA_VLLM_ARGS:-}
+    volumes:
+      - ${HF_CACHE:-/root/.cache/huggingface}:/root/.cache/huggingface
+      - ${MODEL_ROOT:-/root/models}:/root/models:ro
+      - ${JIT_CACHE:-./cache/ds4-v20-r32}:/cache
+      - ${CONTAINER_TMP:-./cache/ds4-v20-r32/tmp}:/container-tmp
+      - ${NATIVE_L2_HOST_PATH:-./cache/ds4-v20-r32/native-l2}:/native-l2

--- a/examples/docker-compose-ds4-v20-r33.yml
+++ b/examples/docker-compose-ds4-v20-r33.yml
@@ -1,0 +1,68 @@
+# DeepSeek-V4-Flash-0731 DSpark r33 release profile.
+#
+# Default: TP2/DCP1, B12X W4A8, fixed K5. The DS4 policy is unchanged from
+# r32. r33 additionally restores the capture-safe EXL3 K6 small-M path and
+# realigns mixed-Trellis execution with B12X's current QSRT ABI for GLM.
+#
+# ALLREDUCE_MODE=auto selects FlashInfer PCIe IPC at TP2 and B12X at TP4 or
+# larger. TP8 owner reduction is enabled by default. To test the opt-in B12X
+# remote-push paths, set ALLREDUCE_MODE=b12x plus
+# B12X_PCIE_TP2_REMOTE_PUSH=1 or B12X_PCIE_TP4_REMOTE_PUSH=1 respectively.
+# Disable the default TP8 owner path with B12X_PCIE_TP8_OWNER_REDUCE=0.
+#
+# Target, DSpark proposal, and DFlash context-KV execution use separate FULL
+# CUDA graph families. Prefill remains PIECEWISE, and unsupported shapes retain
+# the existing fallback.
+#
+# K7 remains available with DSPARK_TOKENS=7 for predictable code. K5 is the
+# mixed-workload default.
+services:
+  ds4:
+    image: ${IMAGE:-voipmonitor/vllm:gilded-gnosis-v20-vllmfa13d33-b12x06db0f4-fi1ac6942-cu132-20260809-r33}
+    container_name: ${NAME:-ds4-0731-r33}
+    entrypoint: ["/usr/local/bin/serve-ds4-flash.sh"]
+    network_mode: host
+    ipc: host
+    init: true
+    shm_size: ${SHM_SIZE:-32gb}
+    gpus: all
+    restart: unless-stopped
+    ulimits:
+      memlock:
+        soft: -1
+        hard: -1
+      nofile:
+        soft: 1048576
+        hard: 1048576
+      stack: 67108864
+    environment:
+      CUDA_VISIBLE_DEVICES: ${GPUS:-0,1}
+      PORT: ${PORT:-8000}
+      MODE: ${MODE:-dspark}
+      BACKEND: ${BACKEND:-b12x-a8}
+      TP_SIZE: ${TP_SIZE:-2}
+      DCP_SIZE: ${DCP_SIZE:-1}
+      ALLREDUCE_MODE: ${ALLREDUCE_MODE:-auto}
+      B12X_PCIE_TP2_REMOTE_PUSH: ${B12X_PCIE_TP2_REMOTE_PUSH:-0}
+      B12X_PCIE_TP4_REMOTE_PUSH: ${B12X_PCIE_TP4_REMOTE_PUSH:-0}
+      B12X_PCIE_TP8_OWNER_REDUCE: ${B12X_PCIE_TP8_OWNER_REDUCE:-1}
+      DSPARK_DEPTH_MODE: ${DSPARK_DEPTH_MODE:-fixed}
+      DSPARK_TOKENS: ${DSPARK_TOKENS:-5}
+      MAX_NUM_SEQS: ${MAX_NUM_SEQS:-16}
+      GRAPH: ${GRAPH:-auto}
+      MAX_MODEL_LEN: ${MAX_MODEL_LEN:-131072}
+      MAX_NUM_BATCHED_TOKENS: ${MAX_NUM_BATCHED_TOKENS:-8192}
+      GPU_MEMORY_UTILIZATION: ${GPU_MEMORY_UTILIZATION:-0.975}
+      LOAD_FORMAT: ${LOAD_FORMAT:-instanttensor}
+      INSTANTTENSOR_BACKEND: ${INSTANTTENSOR_BACKEND:-BUFFERED}
+      PYTHONHASHSEED: ${PYTHONHASHSEED:-0}
+      KV_OFFLOADING_SIZE: ${KV_OFFLOADING_SIZE:-0}
+      NATIVE_L2_PATH: ${NATIVE_L2_PATH:-}
+      NATIVE_L2_GB: ${NATIVE_L2_GB:-}
+      EXTRA_VLLM_ARGS: ${EXTRA_VLLM_ARGS:-}
+    volumes:
+      - ${HF_CACHE:-/root/.cache/huggingface}:/root/.cache/huggingface
+      - ${MODEL_ROOT:-/root/models}:/root/models:ro
+      - ${JIT_CACHE:-./cache/ds4-v20-r33}:/cache
+      - ${CONTAINER_TMP:-./cache/ds4-v20-r33/tmp}:/container-tmp
+      - ${NATIVE_L2_HOST_PATH:-./cache/ds4-v20-r33/native-l2}:/native-l2

--- a/manifests/b12x/gilded-gnosis-v20.json
+++ b/manifests/b12x/gilded-gnosis-v20.json
@@ -23,6 +23,16 @@
       "number": 135,
       "head": "0b44e769caa3c38d99d346a3a343a47df68d2e3b",
       "title": "Preserve dense GEMM API contracts with block FP8"
+    },
+    {
+      "number": 136,
+      "head": "b3f572da20b7167bdcdf866419dc414d56945ad6",
+      "title": "Restore capture-safe K6 small-M dispatch"
+    },
+    {
+      "number": 137,
+      "head": "850bc0d0c48c626f236b0ee7e8ea41cc44d75d6d",
+      "title": "Realign mixed Trellis with the QSRT ABI"
     }
   ],
   "reviewed_exclusions": [

--- a/manifests/b12x/gilded-gnosis-v20.json
+++ b/manifests/b12x/gilded-gnosis-v20.json
@@ -13,6 +13,61 @@
       "number": 126,
       "head": "6022e6e7c7ea1199a06a27cf5a777c2804b13cfb",
       "title": "Prewarm target and native-MTP route packing"
+    },
+    {
+      "number": 133,
+      "head": "287fec1c8e6457a5d687f0b7a96a4e1579c1b791",
+      "title": "Add topology-scoped fused all-reduce paths"
+    }
+  ],
+  "reviewed_exclusions": [
+    {
+      "number": 130,
+      "head": "9ead9eaa188c2d36f091c8e5225e196896545721",
+      "disposition": "experimental",
+      "reason": "Draft persistent-Trellis layout work is not GPU-qualified for this release."
+    },
+    {
+      "number": 129,
+      "head": "56d5a9063e7726d6799c87760e2070c38e479677",
+      "disposition": "out_of_scope",
+      "reason": "Fruit QSRT atoms are unrelated to the qualified GLM-5.2 and DeepSeek-V4 runtime paths."
+    },
+    {
+      "number": 124,
+      "head": "9d4f2d7e296b91ece4932070032520e8601f3b99",
+      "disposition": "out_of_scope",
+      "reason": "Kimi-K3 DCP16 support is outside this release's GLM-5.2 and DeepSeek-V4 validation matrix."
+    },
+    {
+      "number": 66,
+      "head": "680082928e27d68dcd7acee2dc09b8affba3476f",
+      "disposition": "experimental",
+      "reason": "Disposable selected-record profiling channels remain draft research and have no production E2E qualification."
+    },
+    {
+      "number": 65,
+      "head": "d5c198086037cabd7280183e11ebd8020c6b0a60",
+      "disposition": "experimental",
+      "reason": "Copy-engine selected-record exchange did not establish a qualified production E2E gain."
+    },
+    {
+      "number": 64,
+      "head": "c70e98b6da1d429bcd57fac1e88f2736a1aab0de",
+      "disposition": "experimental",
+      "reason": "Selected-record PCIe exchange remains a research alternative to the qualified full-CKV path."
+    },
+    {
+      "number": 46,
+      "head": "1bc4f1bf7c54e2b4a30e73ad01632d81729f0b39",
+      "disposition": "experimental",
+      "reason": "Lossy block-INT8 wire modes remain explicit experiments and are not part of the default exact transport release."
+    },
+    {
+      "number": 39,
+      "head": "adcc6aabcd7e330ee0a7a7d12926ba8de2fd3b91",
+      "disposition": "out_of_scope",
+      "reason": "The ultra-wide W4A16 FC2 re-pin path is not used by the qualified release profiles."
     }
   ]
 }

--- a/manifests/b12x/gilded-gnosis-v20.json
+++ b/manifests/b12x/gilded-gnosis-v20.json
@@ -18,6 +18,11 @@
       "number": 133,
       "head": "287fec1c8e6457a5d687f0b7a96a4e1579c1b791",
       "title": "Add topology-scoped fused all-reduce paths"
+    },
+    {
+      "number": 135,
+      "head": "0b44e769caa3c38d99d346a3a343a47df68d2e3b",
+      "title": "Preserve dense GEMM API contracts with block FP8"
     }
   ],
   "reviewed_exclusions": [

--- a/manifests/vllm/gilded-gnosis-v20.json
+++ b/manifests/vllm/gilded-gnosis-v20.json
@@ -172,6 +172,36 @@
       "head": "e15f0fedcd7baa8df2764df374aff66bb43e2558",
       "disposition": "out_of_scope",
       "reason": "Heterogeneous expert-width checkpoints are not in the qualified GLM-5.2/DS4 release matrix."
+    },
+    {
+      "number": 258,
+      "head": "63b77c8031e02d23a2c464627196cd5663f7116f",
+      "disposition": "experimental",
+      "reason": "Prompt-logprobs memory accounting still lacks its planned TP2/TP4 GPU qualification."
+    },
+    {
+      "number": 265,
+      "head": "e371d81ff147d13becd2bf12c34f46c00455a234",
+      "disposition": "out_of_scope",
+      "reason": "EXL3 extension-path hardening is orthogonal to this topology transport release and has not been qualified in the release matrix."
+    },
+    {
+      "number": 266,
+      "head": "0c3c5877f74874ed8bc34059075a2f303d0d76d3",
+      "disposition": "out_of_scope",
+      "reason": "Prompt-logprobs API validation is orthogonal to the model and collective paths qualified for this release."
+    },
+    {
+      "number": 268,
+      "head": "a2e09ba01dbdd235996676020777d1826c91d995",
+      "disposition": "out_of_scope",
+      "reason": "Configured NCCL path validation is orthogonal to this performance release and has not been qualified in its runtime matrix."
+    },
+    {
+      "number": 271,
+      "head": "310c3ac9718f8d28a6d2c6e009ca4376e54f4457",
+      "disposition": "experimental",
+      "reason": "Full-CKV prewarm is still a draft with GPU qualification in progress."
     }
   ]
 }

--- a/patches/releases/gilded-gnosis-v20-r32/b12x/integration.lock.json
+++ b/patches/releases/gilded-gnosis-v20-r32/b12x/integration.lock.json
@@ -1,0 +1,40 @@
+{
+  "base": {
+    "commit": "9bbae67841e4818e7472e1edcdca8ebcbda68611",
+    "ref": "refs/heads/master",
+    "repository": "https://github.com/local-inference-lab/b12x.git"
+  },
+  "manifest": {
+    "sha256": "3b0270cd3b4a0e627f7565090df0ebbfe9ad367f6f3ff32b3dea3a43a7cc1757"
+  },
+  "name": "gilded-gnosis-v20-b12x",
+  "pull_requests": [
+    {
+      "disposition": "merged",
+      "head": "282d61a483c908eaa440a19ba0d70a557c73197f",
+      "number": 125,
+      "ref": "refs/pull/125/head",
+      "title": "Declare compressed MLA decode row capacity"
+    },
+    {
+      "disposition": "merged",
+      "head": "6022e6e7c7ea1199a06a27cf5a777c2804b13cfb",
+      "number": 126,
+      "ref": "refs/pull/126/head",
+      "title": "Prewarm target and native-MTP route packing"
+    },
+    {
+      "disposition": "merged",
+      "head": "287fec1c8e6457a5d687f0b7a96a4e1579c1b791",
+      "number": 133,
+      "ref": "refs/pull/133/head",
+      "title": "Add topology-scoped fused all-reduce paths"
+    }
+  ],
+  "result": {
+    "patch": "integration.patch",
+    "patch_sha256": "da68a395fc6131b3c775472fac0f0295f92c351ebec24f86b4569fd8bbfb78ce",
+    "tree": "e90b8af95d906ff21764814633ac5259d1c0cb4f"
+  },
+  "schema_version": 1
+}

--- a/patches/releases/gilded-gnosis-v20-r32/b12x/integration.lock.json
+++ b/patches/releases/gilded-gnosis-v20-r32/b12x/integration.lock.json
@@ -5,7 +5,7 @@
     "repository": "https://github.com/local-inference-lab/b12x.git"
   },
   "manifest": {
-    "sha256": "3b0270cd3b4a0e627f7565090df0ebbfe9ad367f6f3ff32b3dea3a43a7cc1757"
+    "sha256": "b549a8709b4fc1c8bd0da3d048e4b1efb5d64f425516410c75a44d157e074043"
   },
   "name": "gilded-gnosis-v20-b12x",
   "pull_requests": [
@@ -29,12 +29,19 @@
       "number": 133,
       "ref": "refs/pull/133/head",
       "title": "Add topology-scoped fused all-reduce paths"
+    },
+    {
+      "disposition": "merged",
+      "head": "0b44e769caa3c38d99d346a3a343a47df68d2e3b",
+      "number": 135,
+      "ref": "refs/pull/135/head",
+      "title": "Preserve dense GEMM API contracts with block FP8"
     }
   ],
   "result": {
     "patch": "integration.patch",
-    "patch_sha256": "da68a395fc6131b3c775472fac0f0295f92c351ebec24f86b4569fd8bbfb78ce",
-    "tree": "e90b8af95d906ff21764814633ac5259d1c0cb4f"
+    "patch_sha256": "e11221efec54f125a6ab3f5e1e52f63edf5529186c7a61df47eaaae1678c04fb",
+    "tree": "817fb3da19a4592a54e79571128e83b702be9e0a"
   },
   "schema_version": 1
 }

--- a/patches/releases/gilded-gnosis-v20-r32/b12x/integration.patch
+++ b/patches/releases/gilded-gnosis-v20-r32/b12x/integration.patch
@@ -1,3 +1,68 @@
+diff --git a/b12x/_lib/dense_gemm.py b/b12x/_lib/dense_gemm.py
+index 1c72c8cbd9017784ab359034595aa01cbd16ea68..818e37b22cfdf9627f98aa0f3a2394380ad91ca8 100644
+--- a/b12x/_lib/dense_gemm.py
++++ b/b12x/_lib/dense_gemm.py
+@@ -630,6 +630,7 @@ class DenseGemmKernel:
+         mxfp6_fmt_b: Optional[str] = None,
+         b_packed: bool = False,
+         plain_fp8: bool = False,
++        fused_quant_bf16: Optional[bool] = None,
+         block_fp8: bool = False,
+     ):
+         # When set, A/B operands are MX codes carried in Float8E4M3FN
+@@ -1884,10 +1885,12 @@ class DenseGemmKernel:
+         accumulators = cute.make_rmem_tensor(acc_shape, self.acc_dtype)
+         if cutlass.const_expr(self.block_fp8):
+             stage_accumulators = cute.make_rmem_tensor(acc_shape, self.acc_dtype)
+-            c_identity = cute.make_identity_tensor(
++            block_c_identity = cute.make_identity_tensor(
+                 cute.slice_(self.tile_shape_mnk, (None, None, 0))
+             )
+-            coord_mn = _reshape_acc_to_mn(thr_mma.partition_C(c_identity))
++            block_coord_mn = _reshape_acc_to_mn(
++                thr_mma.partition_C(block_c_identity)
++            )
+ 
+         # Cluster/thread sync
+         if cute.size(self.cluster_shape_mnk) > 1:
+@@ -2340,7 +2343,7 @@ class DenseGemmKernel:
+                                 self._accumulate_block_fp8_stage(
+                                     accumulators,
+                                     stage_accumulators,
+-                                    coord_mn,
++                                    block_coord_mn,
+                                     directSFA_mkl,
+                                     directSFB_nkl,
+                                     tile_coord_mnl,
+@@ -2485,7 +2488,7 @@ class DenseGemmKernel:
+                             self._accumulate_block_fp8_stage(
+                                 accumulators,
+                                 stage_accumulators,
+-                                coord_mn,
++                                block_coord_mn,
+                                 directSFA_mkl,
+                                 directSFB_nkl,
+                                 tile_coord_mnl,
+@@ -7094,6 +7097,7 @@ def dense_gemm(
+     x_bf16: Optional[torch.Tensor] = None,
+     w_gscale: Optional[torch.Tensor] = None,
+     plain_fp8: bool = False,
++    row_scale: Optional[torch.Tensor] = None,
+     block_fp8: bool = False,
+ ) -> torch.Tensor:
+     """Execute dense block-scaled GEMM for one expert-major batch stack.
+@@ -7134,6 +7138,11 @@ def dense_gemm(
+     SM12x dense pipeline. The scalar ``alpha`` carries the combined activation
+     and weight dequantization scale.
+ 
++    ``row_scale``: optional contiguous ``(M,)`` tensor in the C dtype, applied
++    per output row in the epilogue. It replaces a separate ``out.mul_(v)``
++    launch and reproduces that multiply bit-for-bit, including its second
++    rounding to the C dtype. MX-FP6 only.
++
+     ``block_fp8``: accumulate ordinary E4M3 MMA over each K128 block, then
+     apply compact FP32 activation ``[M,K/128]`` and weight
+     ``[N/128,K/128]`` scales before adding it to the final accumulator.
 diff --git a/b12x/attention/_shared/mla/compressed_config.py b/b12x/attention/_shared/mla/compressed_config.py
 index 3d333ba382f7a762d812018a4adf636c4aeb0a20..ac1fb708058a5667a64767b8096b31df1a3508e9 100644
 --- a/b12x/attention/_shared/mla/compressed_config.py
@@ -2610,6 +2675,38 @@ index 8159ba77b76f81b11779e2fd1cddaff2e0339018..9ed9199c607a2e39d75c204cd5f4c0e5
          torch.cuda.synchronize(device)
      finally:
          pool.close()
+diff --git a/tests/gemm/test_fp6_packed_b.py b/tests/gemm/test_fp6_packed_b.py
+index 466efd0c6ab52869b1f530defde2742d1c4aa801..231bb22792773d32b6fc1d19f52ecd0524c024f3 100644
+--- a/tests/gemm/test_fp6_packed_b.py
++++ b/tests/gemm/test_fp6_packed_b.py
+@@ -7,6 +7,8 @@ streaming format differs.
+ """
+ from __future__ import annotations
+ 
++import inspect
++
+ import pytest
+ import torch
+ 
+@@ -15,6 +17,18 @@ cuda_required = pytest.mark.skipif(
+ )
+ 
+ 
++def test_dense_gemm_preserves_fp6_api_contracts():
++    """Keep the FP6 caller and dense GEMM implementation contracts in sync."""
++    from b12x._lib.dense_gemm import DenseGemmKernel, dense_gemm
++
++    parameter = inspect.signature(dense_gemm).parameters["row_scale"]
++    assert parameter.default is None
++    kernel_parameter = inspect.signature(DenseGemmKernel).parameters[
++        "fused_quant_bf16"
++    ]
++    assert kernel_parameter.default is None
++
++
+ def _gemm_operands(m: int, n: int, k: int, source_format: str):
+     """Quantized operands for one case, mirroring ``dense_fp6_linear_expanded``."""
+     from b12x._lib.fp6 import SF_VEC_SIZE_FP6, as_grouped_mxfp6_scale_view
 diff --git a/tests/moe/test_w4a16_route_pack_warmup.py b/tests/moe/test_w4a16_route_pack_warmup.py
 new file mode 100644
 index 0000000000000000000000000000000000000000..6c7288b314ebc2785418085ce323881960fe192e

--- a/patches/releases/gilded-gnosis-v20-r32/b12x/integration.patch
+++ b/patches/releases/gilded-gnosis-v20-r32/b12x/integration.patch
@@ -1,0 +1,2672 @@
+diff --git a/b12x/attention/_shared/mla/compressed_config.py b/b12x/attention/_shared/mla/compressed_config.py
+index 3d333ba382f7a762d812018a4adf636c4aeb0a20..ac1fb708058a5667a64767b8096b31df1a3508e9 100644
+--- a/b12x/attention/_shared/mla/compressed_config.py
++++ b/b12x/attention/_shared/mla/compressed_config.py
+@@ -22,9 +22,18 @@ def compressed_mla_split_config_for_contract(
+     rows: int,
+     width: int,
+     max_chunks: int | None = None,
++    decode_row_capacity: int | None = None,
+ ) -> SparseMLASplitDecodeConfig:
+     rows = max(int(rows), 1)
+     width = max(int(width), 1)
++    decode_split_max_rows = _COMPRESSED_MLA_DECODE_SPLIT_MAX_ROWS
++    if decode_row_capacity is not None:
++        decode_row_capacity = int(decode_row_capacity)
++        if decode_row_capacity <= 0:
++            raise ValueError(
++                f"decode_row_capacity must be positive, got {decode_row_capacity}"
++            )
++        decode_split_max_rows = max(decode_split_max_rows, decode_row_capacity)
+     chunk_limit = _COMPRESSED_MLA_SPLIT_MAX_CHUNKS
+     if max_chunks is not None:
+         chunk_limit = max(1, min(int(max_chunks), chunk_limit))
+@@ -32,7 +41,7 @@ def compressed_mla_split_config_for_contract(
+     decode_chunks = (
+         width + _COMPRESSED_MLA_DECODE_SPLIT_CHUNK_SIZE - 1
+     ) // _COMPRESSED_MLA_DECODE_SPLIT_CHUNK_SIZE
+-    if rows <= _COMPRESSED_MLA_DECODE_SPLIT_MAX_ROWS and decode_chunks <= chunk_limit:
++    if rows <= decode_split_max_rows and decode_chunks <= chunk_limit:
+         return SparseMLASplitDecodeConfig(
+             chunk_size=_COMPRESSED_MLA_DECODE_SPLIT_CHUNK_SIZE,
+             num_chunks=decode_chunks,
+@@ -41,10 +50,7 @@ def compressed_mla_split_config_for_contract(
+     wide_decode_chunks = (
+         width + _COMPRESSED_MLA_DECODE_WIDE_CHUNK_SIZE - 1
+     ) // _COMPRESSED_MLA_DECODE_WIDE_CHUNK_SIZE
+-    if (
+-        rows <= _COMPRESSED_MLA_DECODE_SPLIT_MAX_ROWS
+-        and wide_decode_chunks <= chunk_limit
+-    ):
++    if rows <= decode_split_max_rows and wide_decode_chunks <= chunk_limit:
+         return SparseMLASplitDecodeConfig(
+             chunk_size=_COMPRESSED_MLA_DECODE_WIDE_CHUNK_SIZE,
+             num_chunks=wide_decode_chunks,
+@@ -68,11 +74,13 @@ def compressed_mla_split_chunks_for_contract(
+     rows: int,
+     width: int,
+     max_chunks: int | None = None,
++    decode_row_capacity: int | None = None,
+ ) -> int:
+     return compressed_mla_split_config_for_contract(
+         rows=rows,
+         width=width,
+         max_chunks=max_chunks,
++        decode_row_capacity=decode_row_capacity,
+     ).num_chunks
+ 
+ 
+diff --git a/b12x/attention/compressed_mla/_scratch.py b/b12x/attention/compressed_mla/_scratch.py
+index b462b0ec0ddb7c456a6cec54cc00dc585a8e771f..ec9244ebc6fa4f94c8778f79117cf33f1db4e0c5 100644
+--- a/b12x/attention/compressed_mla/_scratch.py
++++ b/b12x/attention/compressed_mla/_scratch.py
+@@ -46,6 +46,7 @@ class B12XCompressedMLAScratchCaps:
+     max_kv_rows: int = 0
+     max_chunks_per_row: int = 64
+     max_q_chunks: int | None = None
++    decode_row_capacity: int | None = None
+     page_size: int = 64
+ 
+     def __post_init__(self) -> None:
+@@ -74,6 +75,13 @@ class B12XCompressedMLAScratchCaps:
+         )
+         if self.max_q_chunks is not None:
+             object.__setattr__(self, "max_q_chunks", max(int(self.max_q_chunks), 1))
++        if self.decode_row_capacity is not None:
++            decode_row_capacity = int(self.decode_row_capacity)
++            if decode_row_capacity <= 0:
++                raise ValueError(
++                    f"decode_row_capacity must be positive, got {decode_row_capacity}"
++                )
++            object.__setattr__(self, "decode_row_capacity", decode_row_capacity)
+         object.__setattr__(self, "page_size", max(int(self.page_size), 1))
+ 
+ 
+@@ -376,6 +384,7 @@ def _materialize_compressed_mla_scratch(
+         rows=caps.max_q_rows,
+         width=caps.max_width,
+         max_chunks=caps.max_chunks_per_row,
++        decode_row_capacity=caps.decode_row_capacity,
+     )
+     scratch.set_split_chunk_config(
+         kv_chunk_size=split_cfg.chunk_size,
+diff --git a/b12x/comm/pcie/_cute_intrinsics.py b/b12x/comm/pcie/_cute_intrinsics.py
+index 36d10cd2130930e18898d4109b795daf2e547df2..6f2daab78ea857079cdbc74cec904b54aa0688a2 100644
+--- a/b12x/comm/pcie/_cute_intrinsics.py
++++ b/b12x/comm/pcie/_cute_intrinsics.py
+@@ -17,6 +17,25 @@ from cutlass._mlir.dialects import llvm
+ from cutlass.cutlass_dsl import T, dsl_user_op
+ 
+ 
++@dsl_user_op
++def f32_as_u32(value: Float32, *, loc=None, ip=None) -> Uint32:
++    """Bitcast float32 to uint32 without numeric conversion."""
++
++    return Uint32(
++        llvm.inline_asm(
++            T.i32(),
++            [Float32(value).ir_value(loc=loc, ip=ip)],
++            "mov.b32 $0, $1;",
++            "=r,f",
++            has_side_effects=False,
++            is_align_stack=False,
++            asm_dialect=llvm.AsmDialect.AD_ATT,
++            loc=loc,
++            ip=ip,
++        )
++    )
++
++
+ @dsl_user_op
+ def ld_global_u64(addr: Int64, *, loc=None, ip=None) -> Uint64:
+     return Uint64(
+@@ -195,9 +214,7 @@ def unpack_bf16x2(value: Uint32, *, loc=None, ip=None) -> Tuple[Float32, Float32
+ 
+ 
+ @dsl_user_op
+-def pack_f32x2_to_f16x2(
+-    lo: Float32, hi: Float32, *, loc=None, ip=None
+-) -> Uint32:
++def pack_f32x2_to_f16x2(lo: Float32, hi: Float32, *, loc=None, ip=None) -> Uint32:
+     return Uint32(
+         llvm.inline_asm(
+             T.i32(),
+@@ -217,9 +234,7 @@ def pack_f32x2_to_f16x2(
+ 
+ 
+ @dsl_user_op
+-def pack_f32x2_to_bf16x2(
+-    lo: Float32, hi: Float32, *, loc=None, ip=None
+-) -> Uint32:
++def pack_f32x2_to_bf16x2(lo: Float32, hi: Float32, *, loc=None, ip=None) -> Uint32:
+     """Match two scalar ``__float2bfloat16`` conversions without saturation."""
+     return Uint32(
+         llvm.inline_asm(
+@@ -313,9 +328,7 @@ def ld_relaxed_gpu_u32(addr: Int64, *, loc=None, ip=None) -> Uint32:
+ 
+ 
+ @dsl_user_op
+-def atomic_add_global_u32(
+-    addr: Int64, value: Uint32, *, loc=None, ip=None
+-) -> Uint32:
++def atomic_add_global_u32(addr: Int64, value: Uint32, *, loc=None, ip=None) -> Uint32:
+     return Uint32(
+         llvm.inline_asm(
+             T.i32(),
+diff --git a/b12x/comm/pcie/_oneshot_cute.py b/b12x/comm/pcie/_oneshot_cute.py
+index 7a846996dfa12c1f8e0650dc340bb1aca3f19cb5..d0b5ca091d1ef824df4ccf207fa6b68b144853c4 100644
+--- a/b12x/comm/pcie/_oneshot_cute.py
++++ b/b12x/comm/pcie/_oneshot_cute.py
+@@ -30,6 +30,7 @@ from b12x._lib.utils import current_cuda_stream, make_ptr
+ 
+ from ._cute_intrinsics import (
+     atomic_add_global_u32,
++    f32_as_u32,
+     graph_epoch_arrive,
+     ld_global_f32,
+     ld_relaxed_gpu_u32,
+@@ -108,9 +109,7 @@ class _PackedMath:
+                     accumulator[lane + 1] = accumulator[lane + 1] + hi
+ 
+     @cute.jit
+-    def _store_accumulator(
+-        self, address: Int64, accumulator: cute.Tensor
+-    ) -> None:
++    def _store_accumulator(self, address: Int64, accumulator: cute.Tensor) -> None:
+         if cutlass.const_expr(self._dtype_name == "float32"):
+             st_global_v4_f32(
+                 address,
+@@ -131,16 +130,12 @@ class _PackedMath:
+                     packed[word] = pack_f32x2_to_bf16x2(
+                         accumulator[lane], accumulator[lane + 1]
+                     )
+-            st_global_v4_u32(
+-                address, packed[0], packed[1], packed[2], packed[3]
+-            )
++            st_global_v4_u32(address, packed[0], packed[1], packed[2], packed[3])
+ 
+     @cute.jit
+     def _copy_pack(self, source: Int64, destination: Int64) -> None:
+         words = ld_global_v4_u32(source)
+-        st_global_v4_u32(
+-            destination, words[0], words[1], words[2], words[3]
+-        )
++        st_global_v4_u32(destination, words[0], words[1], words[2], words[3])
+ 
+     @cute.jit
+     def _warp_reduce_down(self, value: Float32) -> Float32:
+@@ -204,14 +199,24 @@ class _OneshotLaunch(_PackedMath):
+             self_counter = self_signal + (
+                 Int64(bidx) * Int64(_MAX_RANKS) + Int64(tidx)
+             ) * Int64(4)
+-            peer_slot0 = peer_signal + Int64(_SELF_COUNTER_BYTES) + (
+-                Int64(bidx) * Int64(_MAX_RANKS * _FLAG_STRIDE)
+-                + Int64(self._rank * _FLAG_STRIDE)
+-            ) * Int64(4)
+-            wait_slot0 = self_signal + Int64(_SELF_COUNTER_BYTES) + (
+-                Int64(bidx) * Int64(_MAX_RANKS * _FLAG_STRIDE)
+-                + Int64(tidx) * Int64(_FLAG_STRIDE)
+-            ) * Int64(4)
++            peer_slot0 = (
++                peer_signal
++                + Int64(_SELF_COUNTER_BYTES)
++                + (
++                    Int64(bidx) * Int64(_MAX_RANKS * _FLAG_STRIDE)
++                    + Int64(self._rank * _FLAG_STRIDE)
++                )
++                * Int64(4)
++            )
++            wait_slot0 = (
++                self_signal
++                + Int64(_SELF_COUNTER_BYTES)
++                + (
++                    Int64(bidx) * Int64(_MAX_RANKS * _FLAG_STRIDE)
++                    + Int64(tidx) * Int64(_FLAG_STRIDE)
++                )
++                * Int64(4)
++            )
+             pcie_arrive_and_wait(
+                 self_counter,
+                 peer_slot0,
+@@ -258,9 +263,7 @@ class _OneshotLaunch(_PackedMath):
+         self._multi_gpu_barrier(signal_ptrs)
+ 
+         while index < size_packs:
+-            accumulator = cute.make_rmem_tensor(
+-                (self._pack_elems,), cutlass.Float32
+-            )
++            accumulator = cute.make_rmem_tensor((self._pack_elems,), cutlass.Float32)
+             for peer_index in cutlass.range_constexpr(self._world_size):
+                 peer_rank = (self._rank + peer_index) % self._world_size
+                 peer_base = Int64(peer_ptrs[peer_rank])
+@@ -269,9 +272,7 @@ class _OneshotLaunch(_PackedMath):
+                     peer_base + Int64(index) * Int64(16),
+                     peer_index == 0,
+                 )
+-            self._store_accumulator(
+-                output_base + Int64(index) * Int64(16), accumulator
+-            )
++            self._store_accumulator(output_base + Int64(index) * Int64(16), accumulator)
+             index += stride
+ 
+         if cutlass.const_expr(self._device_slot_selection):
+@@ -298,8 +299,23 @@ class _FusedOneshotLaunch(_PackedMath):
+         threads: int,
+     ) -> None:
+         super().__init__(dtype_name)
+-        if mode not in ("registered", "stage_pull", "stage_push"):
++        if mode not in (
++            "registered",
++            "stage_pull",
++            "stage_push",
++            "stage_remote_push",
++            "stage_tp8_owner",
++        ):
+             raise ValueError(f"invalid fused oneshot mode {mode!r}")
++        if mode == "stage_remote_push" and world_size not in (2, 4):
++            raise ValueError("fused remote push requires TP2 or TP4")
++        if mode == "stage_tp8_owner" and world_size != 8:
++            raise ValueError("fused owner transport requires TP8")
++        if mode == "stage_tp8_owner" and dtype_name not in (
++            "float16",
++            "bfloat16",
++        ):
++            raise ValueError("fused TP8 owner transport requires float16 or bfloat16")
+         self._world_size = int(world_size)
+         self._rank = int(rank)
+         self._mode = mode
+@@ -308,6 +324,10 @@ class _FusedOneshotLaunch(_PackedMath):
+         self._device_slot_selection = bool(device_slot_selection)
+         self._slot_bias = int(slot_bias) & 1
+         self._threads = int(threads)
++        # C1 uses the ordinary staged protocol while C2-C8 use three scoped
++        # phases. Keep their reusable barrier generations in separate rank
++        # slots when one graph-owned channel alternates between those shapes.
++        self._barrier_rank_offset = 8 if mode == "stage_tp8_owner" else 0
+ 
+     @cute.jit
+     def __call__(
+@@ -347,32 +367,80 @@ class _FusedOneshotLaunch(_PackedMath):
+             stream=stream,
+         )
+ 
++    @cute.jit
++    def _pair_arrive_and_wait(
++        self,
++        signal_ptrs: cute.Pointer,
++        peer_rank: Int32,
++    ) -> None:
++        bidx, _, _ = cute.arch.block_idx()
++        barrier_peer = peer_rank + Int32(self._barrier_rank_offset)
++        self_signal = Int64(signal_ptrs[self._rank])
++        peer_signal = Int64(signal_ptrs[peer_rank])
++        self_counter = self_signal + (
++            Int64(bidx) * Int64(_MAX_RANKS) + Int64(barrier_peer)
++        ) * Int64(4)
++        peer_slot0 = (
++            peer_signal
++            + Int64(_SELF_COUNTER_BYTES)
++            + (
++                Int64(bidx) * Int64(_MAX_RANKS * _FLAG_STRIDE)
++                + Int64((self._rank + self._barrier_rank_offset) * _FLAG_STRIDE)
++            )
++            * Int64(4)
++        )
++        wait_slot0 = (
++            self_signal
++            + Int64(_SELF_COUNTER_BYTES)
++            + (
++                Int64(bidx) * Int64(_MAX_RANKS * _FLAG_STRIDE)
++                + Int64(barrier_peer) * Int64(_FLAG_STRIDE)
++            )
++            * Int64(4)
++        )
++        pcie_arrive_and_wait(
++            self_counter,
++            peer_slot0,
++            wait_slot0,
++            Int64(_PEER_SLOT_BYTES),
++        )
++
+     @cute.jit
+     def _multi_gpu_barrier(self, signal_ptrs: cute.Pointer) -> None:
+         tidx, _, _ = cute.arch.thread_idx()
+-        bidx, _, _ = cute.arch.block_idx()
+         if cutlass.const_expr(self._mode != "registered"):
+             cute.arch.sync_threads()
+         if tidx < Int32(self._world_size):
+-            self_signal = Int64(signal_ptrs[self._rank])
+-            peer_signal = Int64(signal_ptrs[tidx])
+-            self_counter = self_signal + (
+-                Int64(bidx) * Int64(_MAX_RANKS) + Int64(tidx)
+-            ) * Int64(4)
+-            peer_slot0 = peer_signal + Int64(_SELF_COUNTER_BYTES) + (
+-                Int64(bidx) * Int64(_MAX_RANKS * _FLAG_STRIDE)
+-                + Int64(self._rank * _FLAG_STRIDE)
+-            ) * Int64(4)
+-            wait_slot0 = self_signal + Int64(_SELF_COUNTER_BYTES) + (
+-                Int64(bidx) * Int64(_MAX_RANKS * _FLAG_STRIDE)
+-                + Int64(tidx) * Int64(_FLAG_STRIDE)
+-            ) * Int64(4)
+-            pcie_arrive_and_wait(
+-                self_counter,
+-                peer_slot0,
+-                wait_slot0,
+-                Int64(_PEER_SLOT_BYTES),
+-            )
++            self._pair_arrive_and_wait(signal_ptrs, Int32(tidx))
++        cute.arch.sync_threads()
++
++    @cute.jit
++    def _tp8_island_barrier(self, signal_ptrs: cute.Pointer) -> None:
++        """Publish and acquire payloads within one four-rank island."""
++
++        tidx, _, _ = cute.arch.thread_idx()
++        island_base = Int32(0 if self._rank < 4 else 4)
++        cute.arch.sync_threads()
++        if tidx < Int32(4):
++            peer_rank = island_base + Int32(tidx)
++            if peer_rank != Int32(self._rank):
++                self._pair_arrive_and_wait(signal_ptrs, peer_rank)
++        cute.arch.sync_threads()
++
++    @cute.jit
++    def _tp8_owner_pair_barrier(self, signal_ptrs: cute.Pointer) -> None:
++        """Publish and acquire one FP32 partial between paired owners.
++
++        This barrier must remain mutual so paired owners can skew by at most
++        one invocation. Eager slots alternate between invocations, making
++        that bounded skew use different storage. Both properties are safety
++        requirements for local-partial publication and final consumption.
++        """
++
++        tidx, _, _ = cute.arch.thread_idx()
++        cute.arch.sync_threads()
++        if Int32(tidx) == Int32(0):
++            self._pair_arrive_and_wait(signal_ptrs, Int32(self._rank ^ 4))
+         cute.arch.sync_threads()
+ 
+     @cute.jit
+@@ -381,6 +449,7 @@ class _FusedOneshotLaunch(_PackedMath):
+         peer_ptrs: cute.Pointer,
+         input_base: Int64,
+         index: Int64,
++        total_packs: Int64,
+         shard_packs: Int64,
+     ) -> None:
+         if cutlass.const_expr(self._mode == "stage_pull"):
+@@ -388,7 +457,9 @@ class _FusedOneshotLaunch(_PackedMath):
+                 input_base + index * Int64(16),
+                 Int64(peer_ptrs[self._rank]) + index * Int64(16),
+             )
+-        elif cutlass.const_expr(self._mode == "stage_push"):
++        elif cutlass.const_expr(
++            self._mode == "stage_push" or self._mode == "stage_remote_push"
++        ):
+             source = input_base + index * Int64(16)
+             words = ld_global_v4_u32(source)
+             for peer_index in cutlass.range_constexpr(1, self._world_size):
+@@ -396,8 +467,135 @@ class _FusedOneshotLaunch(_PackedMath):
+                 destination = Int64(peer_ptrs[destination_rank]) + (
+                     Int64(self._rank) * shard_packs + index
+                 ) * Int64(16)
++                st_global_v4_u32(destination, words[0], words[1], words[2], words[3])
++        elif cutlass.const_expr(self._mode == "stage_tp8_owner"):
++            part = total_packs // Int64(4)
++            chunk = index // part
++            if chunk > Int64(3):
++                chunk = Int64(3)
++            island_base = Int64(0 if self._rank < 4 else 4)
++            owner_rank = island_base + chunk
++            destination = Int64(peer_ptrs[owner_rank]) + (
++                Int64(self._rank) * shard_packs + index
++            ) * Int64(16)
++            words = ld_global_v4_u32(input_base + index * Int64(16))
++            st_global_v4_u32(destination, words[0], words[1], words[2], words[3])
++
++    @cute.jit
++    def _tp8_publish_local_partial(
++        self,
++        peer_ptrs: cute.Pointer,
++        index: Int64,
++        total_packs: Int64,
++        shard_packs: Int64,
++    ) -> None:
++        part = total_packs // Int64(4)
++        chunk = index // part
++        if chunk > Int64(3):
++            chunk = Int64(3)
++        island_base = 0 if self._rank < 4 else 4
++        owner_rank = Int32(island_base) + Int32(chunk)
++        if Int32(self._rank) == owner_rank:
++            local_stage = Int64(peer_ptrs[self._rank])
++            local_sum = cute.make_rmem_tensor((self._pack_elems,), cutlass.Float32)
++            for peer_local in cutlass.range_constexpr(4):
++                source_rank = island_base + peer_local
++                self._load_accumulate(
++                    local_sum,
++                    local_stage
++                    + (Int64(source_rank) * shard_packs + index) * Int64(16),
++                    peer_local == 0,
++                )
++
++            low = (
++                f32_as_u32(local_sum[0]),
++                f32_as_u32(local_sum[1]),
++                f32_as_u32(local_sum[2]),
++                f32_as_u32(local_sum[3]),
++            )
++            high = (
++                f32_as_u32(local_sum[4]),
++                f32_as_u32(local_sum[5]),
++                f32_as_u32(local_sum[6]),
++                f32_as_u32(local_sum[7]),
++            )
++            cross_owner = self._rank ^ 4
++            for destination_rank in (self._rank, cross_owner):
++                destination_stage = Int64(peer_ptrs[destination_rank])
++                st_global_v4_u32(
++                    destination_stage
++                    + (Int64(self._rank) * shard_packs + index) * Int64(16),
++                    low[0],
++                    low[1],
++                    low[2],
++                    low[3],
++                )
+                 st_global_v4_u32(
+-                    destination, words[0], words[1], words[2], words[3]
++                    destination_stage
++                    + (Int64(self._rank ^ 1) * shard_packs + index) * Int64(16),
++                    high[0],
++                    high[1],
++                    high[2],
++                    high[3],
++                )
++
++    @cute.jit
++    def _tp8_publish_final(
++        self,
++        peer_ptrs: cute.Pointer,
++        index: Int64,
++        total_packs: Int64,
++        shard_packs: Int64,
++    ) -> None:
++        part = total_packs // Int64(4)
++        chunk = index // part
++        if chunk > Int64(3):
++            chunk = Int64(3)
++        island_base = 0 if self._rank < 4 else 4
++        owner_rank = Int32(island_base) + Int32(chunk)
++        if Int32(self._rank) == owner_rank:
++            local_stage = Int64(peer_ptrs[self._rank])
++            cross_owner = self._rank ^ 4
++            local_low = ld_global_v4_u32(
++                local_stage + (Int64(self._rank) * shard_packs + index) * Int64(16)
++            )
++            local_high = ld_global_v4_u32(
++                local_stage + (Int64(self._rank ^ 1) * shard_packs + index) * Int64(16)
++            )
++            cross_low = ld_global_v4_u32(
++                local_stage + (Int64(cross_owner) * shard_packs + index) * Int64(16)
++            )
++            cross_high = ld_global_v4_u32(
++                local_stage + (Int64(cross_owner ^ 1) * shard_packs + index) * Int64(16)
++            )
++            final_low = cute.make_rmem_tensor((4,), cutlass.Uint32)
++            final_high = cute.make_rmem_tensor((4,), cutlass.Uint32)
++            for lane in cutlass.range_constexpr(4):
++                final_low[lane] = f32_as_u32(
++                    u32_as_f32(local_low[lane]) + u32_as_f32(cross_low[lane])
++                )
++                final_high[lane] = f32_as_u32(
++                    u32_as_f32(local_high[lane]) + u32_as_f32(cross_high[lane])
++                )
++
++            for peer_local in cutlass.range_constexpr(4):
++                destination_rank = island_base + peer_local
++                destination_stage = Int64(peer_ptrs[destination_rank])
++                st_global_v4_u32(
++                    destination_stage
++                    + (Int64(self._rank) * shard_packs + index) * Int64(16),
++                    final_low[0],
++                    final_low[1],
++                    final_low[2],
++                    final_low[3],
++                )
++                st_global_v4_u32(
++                    destination_stage
++                    + (Int64(self._rank ^ 1) * shard_packs + index) * Int64(16),
++                    final_high[0],
++                    final_high[1],
++                    final_high[2],
++                    final_high[3],
+                 )
+ 
+     @cute.jit
+@@ -407,10 +605,44 @@ class _FusedOneshotLaunch(_PackedMath):
+         input_base: Int64,
+         residual_base: Int64,
+         index: Int64,
++        total_packs: Int64,
+         shard_packs: Int64,
+         accumulator: cute.Tensor,
+     ) -> None:
+-        if cutlass.const_expr(self._mode == "stage_push"):
++        if cutlass.const_expr(self._mode == "stage_tp8_owner"):
++            part = total_packs // Int64(4)
++            chunk = index // part
++            if chunk > Int64(3):
++                chunk = Int64(3)
++            island_base = Int64(0 if self._rank < 4 else 4)
++            owner_rank = island_base + chunk
++            local_stage = Int64(peer_ptrs[self._rank])
++            low = ld_global_v4_u32(
++                local_stage + (owner_rank * shard_packs + index) * Int64(16)
++            )
++            high = ld_global_v4_u32(
++                local_stage
++                + ((owner_rank ^ Int64(1)) * shard_packs + index) * Int64(16)
++            )
++            for lane in cutlass.range_constexpr(4):
++                accumulator[lane] = u32_as_f32(low[lane])
++                accumulator[lane + 4] = u32_as_f32(high[lane])
++        elif cutlass.const_expr(self._mode == "stage_remote_push"):
++            self._load_accumulate(
++                accumulator,
++                input_base + index * Int64(16),
++                True,
++            )
++            local_stage = Int64(peer_ptrs[self._rank])
++            for peer_index in cutlass.range_constexpr(1, self._world_size):
++                source_rank = (self._rank + peer_index) % self._world_size
++                self._load_accumulate(
++                    accumulator,
++                    local_stage
++                    + (Int64(source_rank) * shard_packs + index) * Int64(16),
++                    False,
++                )
++        elif cutlass.const_expr(self._mode == "stage_push"):
+             self._load_accumulate(
+                 accumulator,
+                 input_base + index * Int64(16),
+@@ -423,10 +655,7 @@ class _FusedOneshotLaunch(_PackedMath):
+                     self._load_accumulate(
+                         accumulator,
+                         local_stage
+-                        + (
+-                            Int64(source_rank) * shard_packs + index
+-                        )
+-                        * Int64(16),
++                        + (Int64(source_rank) * shard_packs + index) * Int64(16),
+                         not initialized,
+                     )
+                     initialized = True
+@@ -480,7 +709,6 @@ class _FusedOneshotLaunch(_PackedMath):
+         shard_packs: Int64,
+         epsilon: Float32,
+     ) -> None:
+-        del rows
+         tidx, _, _ = cute.arch.thread_idx()
+         bidx, _, _ = cute.arch.block_idx()
+         gdim, _, _ = cute.arch.grid_dim()
+@@ -494,6 +722,7 @@ class _FusedOneshotLaunch(_PackedMath):
+             col_stride = ctas_per_row * Int32(self._threads)
+         col0 = row_cta * Int32(self._threads) + Int32(tidx)
+         row_offset = Int64(row) * Int64(hidden_packs)
++        total_packs = Int64(rows) * Int64(hidden_packs)
+ 
+         input_base = Int64(input_ptr.toint())
+         residual_base = Int64(residual_ptr.toint())
+@@ -502,9 +731,7 @@ class _FusedOneshotLaunch(_PackedMath):
+         residual_output_base = Int64(residual_output_ptr.toint())
+         self_signal = Int64(signal_ptrs[self._rank])
+         if cutlass.const_expr(self._device_slot_selection):
+-            generation = ld_relaxed_gpu_u32(
+-                self_signal + Int64(_GRAPH_EPOCH_OFFSET)
+-            )
++            generation = ld_relaxed_gpu_u32(self_signal + Int64(_GRAPH_EPOCH_OFFSET))
+             slot = (generation + Uint32(self._slot_bias)) % Uint32(2)
+             peer_ptrs = peer_ptrs + Int64(slot) * Int64(_MAX_RANKS)
+ 
+@@ -535,6 +762,7 @@ class _FusedOneshotLaunch(_PackedMath):
+                         peer_ptrs,
+                         input_base,
+                         row_offset + Int64(col),
++                        total_packs,
+                         shard_packs,
+                     )
+         elif cutlass.const_expr(self._mode != "registered"):
+@@ -544,16 +772,39 @@ class _FusedOneshotLaunch(_PackedMath):
+                     peer_ptrs,
+                     input_base,
+                     row_offset + Int64(col),
++                    total_packs,
+                     shard_packs,
+                 )
+                 col += col_stride
+ 
+-        self._multi_gpu_barrier(signal_ptrs)
++        if cutlass.const_expr(self._mode == "stage_tp8_owner"):
++            self._tp8_island_barrier(signal_ptrs)
++            col = col0
++            while col < hidden_packs:
++                self._tp8_publish_local_partial(
++                    peer_ptrs,
++                    row_offset + Int64(col),
++                    total_packs,
++                    shard_packs,
++                )
++                col += col_stride
++            self._tp8_owner_pair_barrier(signal_ptrs)
++
++            col = col0
++            while col < hidden_packs:
++                self._tp8_publish_final(
++                    peer_ptrs,
++                    row_offset + Int64(col),
++                    total_packs,
++                    shard_packs,
++                )
++                col += col_stride
++            self._tp8_island_barrier(signal_ptrs)
++        else:
++            self._multi_gpu_barrier(signal_ptrs)
+ 
+         square_sum = Float32(0.0)
+-        values = cute.make_rmem_tensor(
+-            (_REG_PACKS, self._pack_elems), cutlass.Float32
+-        )
++        values = cute.make_rmem_tensor((_REG_PACKS, self._pack_elems), cutlass.Float32)
+         if cutlass.const_expr(self._register_normalize):
+             for pack_number in cutlass.range_constexpr(_REG_PACKS):
+                 col = col0 + Int32(pack_number) * col_stride
+@@ -567,6 +818,7 @@ class _FusedOneshotLaunch(_PackedMath):
+                         input_base,
+                         residual_base,
+                         index,
++                        total_packs,
+                         shard_packs,
+                         accumulator,
+                     )
+@@ -589,6 +841,7 @@ class _FusedOneshotLaunch(_PackedMath):
+                     input_base,
+                     residual_base,
+                     index,
++                    total_packs,
+                     shard_packs,
+                     accumulator,
+                 )
+@@ -604,38 +857,28 @@ class _FusedOneshotLaunch(_PackedMath):
+         hidden_size_f = Float32(hidden_packs * Int32(self._pack_elems))
+         if cutlass.const_expr(self._single_cta):
+             if Int32(tidx) == Int32(0):
+-                inv_rms_smem[0] = rsqrt_approx_f32(
+-                    square_sum / hidden_size_f + epsilon
+-                )
++                inv_rms_smem[0] = rsqrt_approx_f32(square_sum / hidden_size_f + epsilon)
+         else:
+             if Int32(tidx) == Int32(0):
+                 st_global_f32(
+-                    self_signal
+-                    + Int64(_RMS_PARTIAL_OFFSET)
+-                    + Int64(bidx) * Int64(4),
++                    self_signal + Int64(_RMS_PARTIAL_OFFSET) + Int64(bidx) * Int64(4),
+                     square_sum,
+                 )
+                 threadfence_gpu()
+                 arrive_address = (
+-                    self_signal
+-                    + Int64(_RMS_ARRIVE_OFFSET)
+-                    + Int64(row) * Int64(4)
++                    self_signal + Int64(_RMS_ARRIVE_OFFSET) + Int64(row) * Int64(4)
+                 )
+                 prior = atomic_add_global_u32(arrive_address, Uint32(1))
+                 if prior == Uint32(ctas_per_row - Int32(1)):
+                     st_global_u32(arrive_address, Uint32(0))
+                     threadfence_gpu()
+                     atomic_add_global_u32(
+-                        self_signal
+-                        + Int64(_RMS_GEN_OFFSET)
+-                        + Int64(row) * Int64(4),
++                        self_signal + Int64(_RMS_GEN_OFFSET) + Int64(row) * Int64(4),
+                         Uint32(1),
+                     )
+                 else:
+                     spin_until_changed_acquire_gpu(
+-                        self_signal
+-                        + Int64(_RMS_GEN_OFFSET)
+-                        + Int64(row) * Int64(4),
++                        self_signal + Int64(_RMS_GEN_OFFSET) + Int64(row) * Int64(4),
+                         row_generation,
+                     )
+             cute.arch.sync_threads()
+@@ -646,10 +889,7 @@ class _FusedOneshotLaunch(_PackedMath):
+                     partial = partial + ld_global_f32(
+                         self_signal
+                         + Int64(_RMS_PARTIAL_OFFSET)
+-                        + (
+-                            Int64(row) * Int64(ctas_per_row)
+-                            + Int64(partial_index)
+-                        )
++                        + (Int64(row) * Int64(ctas_per_row) + Int64(partial_index))
+                         * Int64(4)
+                     )
+                     partial_index += Int32(32)
+@@ -665,9 +905,7 @@ class _FusedOneshotLaunch(_PackedMath):
+             for pack_number in cutlass.range_constexpr(_REG_PACKS):
+                 col = col0 + Int32(pack_number) * col_stride
+                 if col < hidden_packs:
+-                    scale = cute.make_rmem_tensor(
+-                        (self._pack_elems,), cutlass.Float32
+-                    )
++                    scale = cute.make_rmem_tensor((self._pack_elems,), cutlass.Float32)
+                     self._load_accumulate(
+                         scale, weight_base + Int64(col) * Int64(16), True
+                     )
+@@ -675,38 +913,28 @@ class _FusedOneshotLaunch(_PackedMath):
+                         (self._pack_elems,), cutlass.Float32
+                     )
+                     for lane in cutlass.range_constexpr(self._pack_elems):
+-                        normalized[lane] = (
+-                            values[pack_number, lane]
+-                            * (inv_rms * scale[lane])
++                        normalized[lane] = values[pack_number, lane] * (
++                            inv_rms * scale[lane]
+                         )
+                     self._store_accumulator(
+-                        output_base
+-                        + (row_offset + Int64(col)) * Int64(16),
++                        output_base + (row_offset + Int64(col)) * Int64(16),
+                         normalized,
+                     )
+         else:
+             col = col0
+             while col < hidden_packs:
+                 index = row_offset + Int64(col)
+-                value = cute.make_rmem_tensor(
+-                    (self._pack_elems,), cutlass.Float32
+-                )
+-                scale = cute.make_rmem_tensor(
+-                    (self._pack_elems,), cutlass.Float32
+-                )
++                value = cute.make_rmem_tensor((self._pack_elems,), cutlass.Float32)
++                scale = cute.make_rmem_tensor((self._pack_elems,), cutlass.Float32)
+                 self._load_accumulate(
+                     value,
+                     residual_output_base + index * Int64(16),
+                     True,
+                 )
+-                self._load_accumulate(
+-                    scale, weight_base + Int64(col) * Int64(16), True
+-                )
++                self._load_accumulate(scale, weight_base + Int64(col) * Int64(16), True)
+                 for lane in cutlass.range_constexpr(self._pack_elems):
+                     value[lane] = value[lane] * (inv_rms * scale[lane])
+-                self._store_accumulator(
+-                    output_base + index * Int64(16), value
+-                )
++                self._store_accumulator(output_base + index * Int64(16), value)
+                 col += col_stride
+ 
+         if cutlass.const_expr(self._device_slot_selection):
+@@ -719,9 +947,7 @@ class _FusedOneshotLaunch(_PackedMath):
+ 
+ 
+ def _dummy(dtype, alignment: int):
+-    return make_ptr(
+-        dtype, 16, cute.AddressSpace.gmem, assumed_align=alignment
+-    )
++    return make_ptr(dtype, 16, cute.AddressSpace.gmem, assumed_align=alignment)
+ 
+ 
+ def _oneshot_process_key(
+@@ -758,16 +984,19 @@ def is_oneshot_launcher_prepared(
+ ) -> bool:
+     """Return whether this exact process-local launcher is already loaded."""
+ 
+-    return _oneshot_process_key(
+-        dtype_name,
+-        world_size,
+-        rank,
+-        stage_input,
+-        device_slot_selection,
+-        slot_bias,
+-        threads,
+-        device_index,
+-    ) in _PREPARED_ONESHOT_LAUNCHERS
++    return (
++        _oneshot_process_key(
++            dtype_name,
++            world_size,
++            rank,
++            stage_input,
++            device_slot_selection,
++            slot_bias,
++            threads,
++            device_index,
++        )
++        in _PREPARED_ONESHOT_LAUNCHERS
++    )
+ 
+ 
+ @functools.cache
+@@ -823,9 +1052,7 @@ def get_oneshot_launcher(
+         1,
+         1,
+         current_cuda_stream(),
+-        compile_spec=KernelCompileSpec.from_key(
+-            "comm.pcie.oneshot", 1, cache_key
+-        ),
++        compile_spec=KernelCompileSpec.from_key("comm.pcie.oneshot", 1, cache_key),
+     )
+ 
+     def run(
+@@ -910,18 +1137,21 @@ def is_fused_oneshot_launcher_prepared(
+ ) -> bool:
+     """Return whether this exact fused graph launcher is already loaded."""
+ 
+-    return _fused_oneshot_process_key(
+-        dtype_name,
+-        world_size,
+-        rank,
+-        mode,
+-        single_cta,
+-        register_normalize,
+-        device_slot_selection,
+-        slot_bias,
+-        threads,
+-        device_index,
+-    ) in _PREPARED_FUSED_ONESHOT_LAUNCHERS
++    return (
++        _fused_oneshot_process_key(
++            dtype_name,
++            world_size,
++            rank,
++            mode,
++            single_cta,
++            register_normalize,
++            device_slot_selection,
++            slot_bias,
++            threads,
++            device_index,
++        )
++        in _PREPARED_FUSED_ONESHOT_LAUNCHERS
++    )
+ 
+ 
+ @functools.cache
+@@ -1013,13 +1243,39 @@ def get_fused_oneshot_launcher(
+         grid_x: int,
+     ) -> None:
+         raw(
+-            make_ptr(cutlass.Uint64, peer_table_address, cute.AddressSpace.gmem, assumed_align=8),
+-            make_ptr(cutlass.Uint64, signal_table_address, cute.AddressSpace.gmem, assumed_align=8),
+-            make_ptr(cutlass.Uint32, input_address, cute.AddressSpace.gmem, assumed_align=16),
+-            make_ptr(cutlass.Uint32, residual_address, cute.AddressSpace.gmem, assumed_align=16),
+-            make_ptr(cutlass.Uint32, weight_address, cute.AddressSpace.gmem, assumed_align=16),
+-            make_ptr(cutlass.Uint32, output_address, cute.AddressSpace.gmem, assumed_align=16),
+-            make_ptr(cutlass.Uint32, residual_output_address, cute.AddressSpace.gmem, assumed_align=16),
++            make_ptr(
++                cutlass.Uint64,
++                peer_table_address,
++                cute.AddressSpace.gmem,
++                assumed_align=8,
++            ),
++            make_ptr(
++                cutlass.Uint64,
++                signal_table_address,
++                cute.AddressSpace.gmem,
++                assumed_align=8,
++            ),
++            make_ptr(
++                cutlass.Uint32, input_address, cute.AddressSpace.gmem, assumed_align=16
++            ),
++            make_ptr(
++                cutlass.Uint32,
++                residual_address,
++                cute.AddressSpace.gmem,
++                assumed_align=16,
++            ),
++            make_ptr(
++                cutlass.Uint32, weight_address, cute.AddressSpace.gmem, assumed_align=16
++            ),
++            make_ptr(
++                cutlass.Uint32, output_address, cute.AddressSpace.gmem, assumed_align=16
++            ),
++            make_ptr(
++                cutlass.Uint32,
++                residual_output_address,
++                cute.AddressSpace.gmem,
++                assumed_align=16,
++            ),
+             int(hidden_packs),
+             int(rows),
+             int(ctas_per_row),
+diff --git a/b12x/comm/pcie/pcie_oneshot.py b/b12x/comm/pcie/pcie_oneshot.py
+index 614266b4b705566dd29340a87bd0aa5ea5415b8e..6dcc3c8df2e8ba22617f6e8fd5f67ca990126172 100644
+--- a/b12x/comm/pcie/pcie_oneshot.py
++++ b/b12x/comm/pcie/pcie_oneshot.py
+@@ -114,6 +114,51 @@ def _push_mode_enabled() -> bool:
+     return os.getenv("B12X_PCIE_ONESHOT_PUSH", "0") not in ("", "0")
+ 
+ 
++def _tp2_remote_push_enabled() -> bool:
++    """Enable the qualified fused TP2 remote-write transport."""
++
++    return os.getenv("B12X_PCIE_TP2_REMOTE_PUSH", "0") not in ("", "0")
++
++
++def _tp4_remote_push_enabled() -> bool:
++    """Enable the qualified fused TP4 remote-write transport."""
++
++    return os.getenv("B12X_PCIE_TP4_REMOTE_PUSH", "0") not in ("", "0")
++
++
++def _tp8_owner_reduce_enabled() -> bool:
++    """Enable the qualified topology-scoped fused TP8 transport by default."""
++
++    return os.getenv("B12X_PCIE_TP8_OWNER_REDUCE", "1") not in ("", "0")
++
++
++def _uses_sharded_eager_storage(
++    world_size: int,
++    transport_policy: Optional[tuple[bool, bool, bool, bool]] = None,
++) -> bool:
++    """Return whether staged fused transport needs one shard per source."""
++
++    push, tp2_remote, tp4_remote, tp8_owner = (
++        _transport_policy_contract() if transport_policy is None else transport_policy
++    )
++    return push or (
++        (world_size == 2 and tp2_remote)
++        or (world_size == 4 and tp4_remote)
++        or (world_size == 8 and tp8_owner)
++    )
++
++
++def _transport_policy_contract() -> tuple[bool, bool, bool, bool]:
++    """Values that must agree across ranks before IPC storage is allocated."""
++
++    return (
++        _push_mode_enabled(),
++        _tp2_remote_push_enabled(),
++        _tp4_remote_push_enabled(),
++        _tp8_owner_reduce_enabled(),
++    )
++
++
+ def _is_weak_contiguous(inp: torch.Tensor) -> bool:
+     if inp.is_contiguous():
+         return True
+@@ -569,9 +614,7 @@ def _require_full_grid_residency(
+         visible_sms = int(
+             torch.cuda.get_device_properties(device).multi_processor_count
+         )
+-        test_visible_sms = int(
+-            os.getenv("B12X_PCIE_TEST_VISIBLE_SM_COUNT", "0") or "0"
+-        )
++        test_visible_sms = int(os.getenv("B12X_PCIE_TEST_VISIBLE_SM_COUNT", "0") or "0")
+         if test_visible_sms > 0:
+             visible_sms = min(visible_sms, test_visible_sms)
+         if visible_sms < required_sms:
+@@ -1206,6 +1249,9 @@ class _CuTeOneshotState:
+     registered_tables: dict[int, int]
+     eager_tables: Optional[tuple[int, int]] = None
+     eager_ptrs: Optional[tuple[tuple[int, ...], tuple[int, ...]]] = None
++    eager_buffer_bytes: Optional[int] = None
++    transport_policy: tuple[bool, bool, bool, bool] = (False, False, False, False)
++    sharded_eager_storage: bool = False
+     eager_slot: int = 0
+     device_slot_selection: bool = False
+     slot_bias: int = 0
+@@ -1236,6 +1282,8 @@ class _CuTeOneshotBackend:
+         self._next_handle = 1
+         self._states: dict[int, _CuTeOneshotState] = {}
+ 
++    supports_eager_storage_contract = True
++
+     @staticmethod
+     def meta_size() -> int:
+         return _SIGNAL_BYTES
+@@ -1315,6 +1363,8 @@ class _CuTeOneshotBackend:
+         handle: int,
+         pointers0: Sequence[int],
+         pointers1: Sequence[int],
++        eager_buffer_bytes: Optional[int] = None,
++        transport_policy: Optional[tuple[bool, bool, bool, bool]] = None,
+     ) -> None:
+         state = self._state(handle)
+         ptrs0 = tuple(int(pointer) for pointer in pointers0)
+@@ -1323,6 +1373,18 @@ class _CuTeOneshotBackend:
+         table1 = self._write_table(state, ptrs1)
+         state.eager_tables = (table0, table1)
+         state.eager_ptrs = (ptrs0, ptrs1)
++        state.eager_buffer_bytes = (
++            None if eager_buffer_bytes is None else int(eager_buffer_bytes)
++        )
++        state.transport_policy = (
++            _transport_policy_contract()
++            if transport_policy is None
++            else tuple(bool(value) for value in transport_policy)
++        )
++        state.sharded_eager_storage = _uses_sharded_eager_storage(
++            state.world_size,
++            state.transport_policy,
++        )
+         state.registered_tables[ptrs0[state.rank]] = table0
+         state.registered_tables[ptrs1[state.rank]] = table1
+         state.eager_slot = 0
+@@ -1331,9 +1393,7 @@ class _CuTeOneshotBackend:
+     def _launch_geometry(size_packs: int) -> tuple[int, int]:
+         threads = int(os.getenv("B12X_PCIE_ONESHOT_THREADS", "256"))
+         threads = min(512, max(64, (threads // 32) * 32))
+-        block_limit = int(
+-            os.getenv("B12X_PCIE_ONESHOT_BLOCK_LIMIT", "8")
+-        )
++        block_limit = int(os.getenv("B12X_PCIE_ONESHOT_BLOCK_LIMIT", "8"))
+         if block_limit <= 0 or block_limit > _MAX_BLOCKS:
+             raise ValueError(
+                 f"B12X_PCIE_ONESHOT_BLOCK_LIMIT must be in [1, {_MAX_BLOCKS}]"
+@@ -1346,6 +1406,43 @@ class _CuTeOneshotBackend:
+         threads = int(os.getenv("B12X_PCIE_FUSED_THREADS", "256"))
+         return min(512, max(64, (threads // 32) * 32))
+ 
++    @staticmethod
++    def _fused_topology_mode(
++        state: _CuTeOneshotState,
++        inp: torch.Tensor,
++    ) -> Optional[str]:
++        """Select only topology transports with a qualified shape contract."""
++
++        if (
++            state.eager_tables is None
++            or state.eager_buffer_bytes is None
++            or inp.dtype not in (torch.float16, torch.bfloat16)
++            or inp.ndim == 0
++        ):
++            return None
++        hidden = int(inp.shape[-1])
++        if hidden <= 0 or inp.numel() % hidden != 0:
++            return None
++        rows = inp.numel() // hidden
++        _, tp2_remote, tp4_remote, tp8_owner = state.transport_policy
++        if (
++            state.world_size == 8
++            and tp8_owner
++            and hidden in (4096, 6144)
++            and 2 <= rows <= 8
++        ):
++            return "stage_tp8_owner"
++        if (
++            state.world_size == 4
++            and tp4_remote
++            and hidden in (4096, 6144)
++            and 1 <= rows <= 32
++        ):
++            return "stage_remote_push"
++        if state.world_size == 2 and tp2_remote and hidden == 4096 and 1 <= rows <= 32:
++            return "stage_remote_push"
++        return None
++
+     @classmethod
+     def _fused_launch_config(
+         cls,
+@@ -1360,17 +1457,20 @@ class _CuTeOneshotBackend:
+         if override > 0:
+             ctas_per_row = override
+         else:
+-            min_ctas = (
+-                hidden_packs + threads * _REG_PACKS - 1
+-            ) // (threads * _REG_PACKS)
++            min_ctas = (hidden_packs + threads * _REG_PACKS - 1) // (
++                threads * _REG_PACKS
++            )
+             ctas_per_row = max(max(1, 3 // rows), min_ctas)
+         ctas_per_row = max(1, min(ctas_per_row, _MAX_BLOCKS // rows))
+-        register_normalize = (
+-            hidden_packs + ctas_per_row * threads - 1
+-        ) // (ctas_per_row * threads) <= _REG_PACKS
+-        if state.eager_tables is None:
++        register_normalize = (hidden_packs + ctas_per_row * threads - 1) // (
++            ctas_per_row * threads
++        ) <= _REG_PACKS
++        topology_mode = cls._fused_topology_mode(state, inp)
++        if topology_mode is not None:
++            mode = topology_mode
++        elif state.eager_tables is None:
+             mode = "registered"
+-        elif _push_mode_enabled():
++        elif state.transport_policy[0]:
+             mode = "stage_push"
+         else:
+             mode = "stage_pull"
+@@ -1378,11 +1478,7 @@ class _CuTeOneshotBackend:
+ 
+     @staticmethod
+     def _device_index(device: torch.device) -> int:
+-        return (
+-            device.index
+-            if device.index is not None
+-            else torch.cuda.current_device()
+-        )
++        return device.index if device.index is not None else torch.cuda.current_device()
+ 
+     def prepare_all_reduce(self, handle: int, inp: torch.Tensor) -> None:
+         """Compile/load every graph slot variant without launching a kernel."""
+@@ -1412,7 +1508,10 @@ class _CuTeOneshotBackend:
+         """Compile/load fused graph variants without launching a kernel."""
+ 
+         state = self._state(handle)
+-        if state.eager_tables is None and int(inp.data_ptr()) not in state.registered_tables:
++        if (
++            state.eager_tables is None
++            and int(inp.data_ptr()) not in state.registered_tables
++        ):
+             raise RuntimeError("input buffer is not registered")
+         mode, single_cta, register_normalize, threads = self._fused_launch_config(
+             state, inp
+@@ -1421,9 +1520,7 @@ class _CuTeOneshotBackend:
+ 
+         device_index = self._device_index(inp.device)
+         variants = (
+-            ((True, 0), (True, 1))
+-            if state.eager_tables is not None
+-            else ((False, 0),)
++            ((True, 0), (True, 1)) if state.eager_tables is not None else ((False, 0),)
+         )
+         for device_slot_selection, slot_bias in variants:
+             get_fused_oneshot_launcher(
+@@ -1440,9 +1537,7 @@ class _CuTeOneshotBackend:
+             )
+ 
+     @staticmethod
+-    def _select_table(
+-        state: _CuTeOneshotState, input_pointer: int
+-    ) -> tuple[int, bool]:
++    def _select_table(state: _CuTeOneshotState, input_pointer: int) -> tuple[int, bool]:
+         if state.eager_tables is not None:
+             if state.device_slot_selection:
+                 # The two 16-entry tables are adjacent in rank_data.  A
+@@ -1477,9 +1572,7 @@ class _CuTeOneshotBackend:
+             capturing and state.eager_tables is not None
+         )
+         prospective_slot_bias = (
+-            state.slot_bias
+-            if state.device_slot_selection
+-            else state.eager_slot & 1
++            state.slot_bias if state.device_slot_selection else state.eager_slot & 1
+         )
+         if capturing:
+             from ._oneshot_cute import is_oneshot_launcher_prepared
+@@ -1498,7 +1591,11 @@ class _CuTeOneshotBackend:
+                     "cold PCIe oneshot CUDA graph capture is not allowed; "
+                     "call prepare_graph_all_reduce() before capture"
+                 )
+-        if capturing and state.eager_tables is not None and not state.device_slot_selection:
++        if (
++            capturing
++            and state.eager_tables is not None
++            and not state.device_slot_selection
++        ):
+             # The graph epoch begins at zero.  Bias it to the host slot that
+             # would have been selected for this invocation, then keep both
+             # values fixed in the captured specialization.
+@@ -1563,9 +1660,7 @@ class _CuTeOneshotBackend:
+             capturing and state.eager_tables is not None
+         )
+         prospective_slot_bias = (
+-            state.slot_bias
+-            if state.device_slot_selection
+-            else state.eager_slot & 1
++            state.slot_bias if state.device_slot_selection else state.eager_slot & 1
+         )
+         if capturing:
+             from ._oneshot_cute import is_fused_oneshot_launcher_prepared
+@@ -1602,9 +1697,9 @@ class _CuTeOneshotBackend:
+         if override > 0:
+             ctas_per_row = override
+         else:
+-            min_ctas = (
+-                hidden_packs + threads * _REG_PACKS - 1
+-            ) // (threads * _REG_PACKS)
++            min_ctas = (hidden_packs + threads * _REG_PACKS - 1) // (
++                threads * _REG_PACKS
++            )
+             ctas_per_row = max(max(1, 3 // rows), min_ctas)
+         ctas_per_row = max(1, min(ctas_per_row, _MAX_BLOCKS // rows))
+         assert single_cta_check == (ctas_per_row == 1)
+@@ -1650,7 +1745,7 @@ class _CuTeOneshotBackend:
+                 hidden_packs,
+                 rows,
+                 ctas_per_row,
+-                inp.numel() // pack_elems,
++                int(state.eager_buffer_bytes or inp.numel() * inp.element_size()) // 16,
+                 float(epsilon),
+                 blocks,
+             )
+@@ -1664,9 +1759,7 @@ class _CuTeOneshotBackend:
+     def register_graph_buffers(self, handle: int, handles, offsets) -> None:
+         self._state(handle)
+         if any(handles) or any(offsets):
+-            raise RuntimeError(
+-                "CuTe oneshot graph capture requires eager IPC buffers"
+-            )
++            raise RuntimeError("CuTe oneshot graph capture requires eager IPC buffers")
+ 
+     def dispose(self, handle: int) -> None:
+         with self._lock:
+@@ -1766,6 +1859,7 @@ class PCIeOneshotAllReduce:
+             normalized_eager_bytes = (
+                 None if eager_buffer_bytes is None else int(eager_buffer_bytes)
+             )
++            normalized_transport_policy = _transport_policy_contract()
+             if normalized_world_size not in SUPPORTED_WORLD_SIZES:
+                 raise ValueError(f"unsupported world size {normalized_world_size}")
+             if not 0 <= normalized_rank < normalized_world_size:
+@@ -1832,6 +1926,7 @@ class PCIeOneshotAllReduce:
+                 normalized_eager0,
+                 normalized_eager1,
+                 normalized_eager_bytes,
++                normalized_transport_policy,
+                 normalized_max_size,
+                 normalized_rank_data_bytes,
+             )
+@@ -1853,6 +1948,7 @@ class PCIeOneshotAllReduce:
+             normalized_eager0,
+             normalized_eager1,
+             normalized_eager_bytes,
++            normalized_transport_policy,
+             normalized_max_size,
+             normalized_rank_data_bytes,
+         ) = normalized
+@@ -1865,6 +1961,7 @@ class PCIeOneshotAllReduce:
+             eager_buffer_ptrs0=normalized_eager0,
+             eager_buffer_ptrs1=normalized_eager1,
+             eager_buffer_bytes=normalized_eager_bytes,
++            transport_policy=normalized_transport_policy,
+             exchange_group=resolved_group,
+             ipc=ipc,
+             owned_buffers=owned_buffers,
+@@ -1911,6 +2008,7 @@ class PCIeOneshotAllReduce:
+                     self.rank_data_bytes,
+                     self.eager_buffer_bytes,
+                     self._pending_eager_ptrs is not None,
++                    self._transport_policy,
+                 ),
+             )
+ 
+@@ -1941,6 +2039,7 @@ class PCIeOneshotAllReduce:
+         eager_buffer_ptrs0: Optional[Sequence[int]],
+         eager_buffer_ptrs1: Optional[Sequence[int]],
+         eager_buffer_bytes: Optional[int],
++        transport_policy: tuple[bool, bool, bool, bool],
+         exchange_group: Optional[ProcessGroup],
+         ipc: Optional[CudaRTLibrary],
+         owned_buffers: Optional[Sequence[_OwnedSharedBuffer]],
+@@ -1959,6 +2058,11 @@ class PCIeOneshotAllReduce:
+         self.eager_buffer_bytes = (
+             None if eager_buffer_bytes is None else int(eager_buffer_bytes)
+         )
++        self._transport_policy = tuple(bool(value) for value in transport_policy)
++        self._sharded_eager_storage = _uses_sharded_eager_storage(
++            self.world_size,
++            self._transport_policy,
++        )
+         self._ipc = ipc
+         self._ext = ext_module
+         self._signal_ptrs = tuple(int(ptr) for ptr in signal_ptrs)
+@@ -1993,11 +2097,24 @@ class PCIeOneshotAllReduce:
+             )
+             if self._pending_eager_ptrs is not None:
+                 self._eager_ptrs = self._pending_eager_ptrs
+-                self._ext.register_pcie_buffers(
+-                    self._ptr,
+-                    list(self._eager_ptrs[0]),
+-                    list(self._eager_ptrs[1]),
+-                )
++                if getattr(
++                    self._ext,
++                    "supports_eager_storage_contract",
++                    False,
++                ):
++                    self._ext.register_pcie_buffers(
++                        self._ptr,
++                        list(self._eager_ptrs[0]),
++                        list(self._eager_ptrs[1]),
++                        self.eager_buffer_bytes,
++                        self._transport_policy,
++                    )
++                else:
++                    self._ext.register_pcie_buffers(
++                        self._ptr,
++                        list(self._eager_ptrs[0]),
++                        list(self._eager_ptrs[1]),
++                    )
+         except Exception as exc:
+             init_error = exc
+         finally:
+@@ -2068,6 +2185,7 @@ class PCIeOneshotAllReduce:
+             normalized_eager_bytes = int(eager_buffer_bytes)
+             normalized_max_size = int(max_size)
+             normalized_rank_data_bytes = int(rank_data_bytes)
++            normalized_transport_policy = _transport_policy_contract()
+             if world_size not in SUPPORTED_WORLD_SIZES:
+                 raise ValueError(f"unsupported world size {world_size}")
+             if device_obj.type != "cuda":
+@@ -2085,14 +2203,19 @@ class PCIeOneshotAllReduce:
+                 normalized_eager_bytes,
+                 normalized_max_size,
+                 normalized_rank_data_bytes,
++                normalized_transport_policy,
+             )
+ 
+-        device_obj, eager_buffer_bytes, max_size, rank_data_bytes = (
+-            _run_collective_preallocation_setup(
+-                owner="PCIe oneshot argument validation",
+-                exchange_group=exchange_group,
+-                setup=validate_factory_arguments,
+-            )
++        (
++            device_obj,
++            eager_buffer_bytes,
++            max_size,
++            rank_data_bytes,
++            transport_policy,
++        ) = _run_collective_preallocation_setup(
++            owner="PCIe oneshot argument validation",
++            exchange_group=exchange_group,
++            setup=validate_factory_arguments,
+         )
+ 
+         _require_full_grid_residency(
+@@ -2121,7 +2244,7 @@ class PCIeOneshotAllReduce:
+                 eager_buffer_bytes,
+                 max_size,
+                 rank_data_bytes,
+-                _push_mode_enabled(),
++                transport_policy,
+             ),
+         )
+ 
+@@ -2129,6 +2252,10 @@ class PCIeOneshotAllReduce:
+             exchange_group,
+             signal_bytes=signal_bytes,
+             eager_buffer_bytes=eager_buffer_bytes,
++            sharded_eager_storage=_uses_sharded_eager_storage(
++                world_size,
++                transport_policy,
++            ),
+             ipc=ipc,
+         )
+         owned_buffers = [channel_buffers.owned_buffer]
+@@ -2140,6 +2267,7 @@ class PCIeOneshotAllReduce:
+             eager_buffer_ptrs0=channel_buffers.eager0_ptrs,
+             eager_buffer_ptrs1=channel_buffers.eager1_ptrs,
+             eager_buffer_bytes=eager_buffer_bytes,
++            transport_policy=transport_policy,
+             exchange_group=exchange_group,
+             ipc=ipc,
+             owned_buffers=owned_buffers,
+@@ -2399,6 +2527,7 @@ class PCIeOneshotAllReduce:
+         *,
+         signal_bytes: int,
+         eager_buffer_bytes: int,
++        sharded_eager_storage: bool,
+         ipc: CudaRTLibrary,
+     ) -> _ChannelSharedBuffers:
+         signal_bytes = int(signal_bytes)
+@@ -2407,7 +2536,7 @@ class PCIeOneshotAllReduce:
+             raise ValueError("signal_bytes must be positive")
+         if eager_buffer_bytes <= 0:
+             raise ValueError("eager_buffer_bytes must be positive")
+-        if _push_mode_enabled():
++        if sharded_eager_storage:
+             eager_buffer_bytes *= dist.get_world_size(group=exchange_group)
+ 
+         signal_offset = 0
+@@ -2523,7 +2652,9 @@ class PCIeOneshotAllReduce:
+         if not self.should_allreduce(inp) or inp.ndim == 0:
+             raise ValueError("input does not satisfy fused PCIe oneshot requirements")
+         if inp.shape[-1] * inp.element_size() % 16 != 0:
+-            raise ValueError("the last input dimension must occupy a multiple of 16 bytes")
++            raise ValueError(
++                "the last input dimension must occupy a multiple of 16 bytes"
++            )
+         self._check_stream()
+         self._prepare_input(inp, peer_input_ptrs)
+         self._ext.prepare_fused_all_reduce(self._ptr, inp)
+@@ -3030,6 +3161,7 @@ class PCIeOneshotAllReducePool:
+             normalized_rank_data_bytes = int(rank_data_bytes)
+             normalized_single_channel = bool(single_channel)
+             normalized_max_concurrent_channels = int(max_concurrent_channels)
++            normalized_transport_policy = _transport_policy_contract()
+             if normalized_world_size not in SUPPORTED_WORLD_SIZES:
+                 raise ValueError(f"unsupported world size {normalized_world_size}")
+             if not 0 <= normalized_rank < normalized_world_size:
+@@ -3075,6 +3207,7 @@ class PCIeOneshotAllReducePool:
+                 normalized_rank_data_bytes,
+                 normalized_single_channel,
+                 normalized_max_concurrent_channels,
++                normalized_transport_policy,
+             )
+ 
+         if channel_factory is None and resolved_group is not None:
+@@ -3095,7 +3228,12 @@ class PCIeOneshotAllReducePool:
+             self.rank_data_bytes,
+             self.single_channel,
+             self.max_concurrent_channels,
++            self._transport_policy,
+         ) = normalized
++        self._sharded_eager_storage = _uses_sharded_eager_storage(
++            self.world_size,
++            self._transport_policy,
++        )
+         self.exchange_group = resolved_group
+         self.process_group = self.exchange_group
+         self._channel_factory = channel_factory
+@@ -3145,7 +3283,7 @@ class PCIeOneshotAllReducePool:
+                     self.rank_data_bytes,
+                     self.single_channel,
+                     self.max_concurrent_channels,
+-                    _push_mode_enabled(),
++                    self._transport_policy,
+                 ),
+             )
+             # A genuine single-channel pool has no independent eager/graph
+@@ -3223,6 +3361,7 @@ class PCIeOneshotAllReducePool:
+             self.exchange_group,
+             signal_bytes=self._signal_bytes,
+             eager_buffer_bytes=self.eager_buffer_bytes,
++            sharded_eager_storage=self._sharded_eager_storage,
+             ipc=self._ipc,
+         )
+         owned_buffers = [channel_buffers.owned_buffer]
+@@ -3234,6 +3373,7 @@ class PCIeOneshotAllReducePool:
+             eager_buffer_ptrs0=channel_buffers.eager0_ptrs,
+             eager_buffer_ptrs1=channel_buffers.eager1_ptrs,
+             eager_buffer_bytes=self.eager_buffer_bytes,
++            transport_policy=self._transport_policy,
+             exchange_group=self.exchange_group,
+             ipc=self._ipc,
+             owned_buffers=owned_buffers,
+@@ -3486,9 +3626,7 @@ class PCIeOneshotAllReducePool:
+                         inp, peer_input_ptrs=peer_input_ptrs
+                     )
+             else:
+-                channel.prepare_graph_all_reduce(
+-                    inp, peer_input_ptrs=peer_input_ptrs
+-                )
++                channel.prepare_graph_all_reduce(inp, peer_input_ptrs=peer_input_ptrs)
+ 
+     def prepare_graph_fused_add_rms_norm(
+         self,
+diff --git a/b12x/moe/_shared/kernels/w4a16/host.py b/b12x/moe/_shared/kernels/w4a16/host.py
+index 6517d2883880bd41438ac6b85c8272488593ddd3..868ef398adef1332d677e5cbc4386431ea9b8501 100644
+--- a/b12x/moe/_shared/kernels/w4a16/host.py
++++ b/b12x/moe/_shared/kernels/w4a16/host.py
+@@ -190,6 +190,32 @@ def route_pack_token_capacity(tokens: int, topk: int) -> int:
+     return 1 << (max(int(tokens), 1) - 1).bit_length()
+ 
+ 
++def route_pack_warmup_token_counts(capacity: int) -> tuple[int, ...]:
++    """Return live row counts covering capacity and scalar specializations.
++
++    Triton specializes the runtime ``live_numel`` scalar on alignment as well
++    as the constexpr route-capacity bucket. For a power-of-two bucket, the
++    bucket maximum and its first live member cover both alignment classes
++    reached by the GLM top-k route counts (for example 8 and 5 rows in the
++    8-row bucket). Warming only bucket maxima leaves the less-aligned variant
++    to compile on the first odd-sized request.
++    """
++    capacity = int(capacity)
++    if capacity < 1:
++        raise ValueError(f"route-pack warmup capacity must be positive, got {capacity}")
++    counts: list[int] = []
++    bucket = 1
++    while True:
++        first_in_bucket = 1 if bucket == 1 else bucket // 2 + 1
++        if first_in_bucket > capacity:
++            break
++        for count in (first_in_bucket, min(bucket, capacity)):
++            if not counts or counts[-1] != count:
++                counts.append(count)
++        bucket *= 2
++    return tuple(counts)
++
++
+ def route_pack_capacity(
+     numel: int,
+     block_size: int,
+@@ -405,6 +431,7 @@ __all__ = [
+     "route_pack_numel_capacity",
+     "route_pack_capacity",
+     "route_pack_token_capacity",
++    "route_pack_warmup_token_counts",
+     "select_route_block_size_m",
+     "unswizzle_block_scale",
+     "unswizzle_expert_scales",
+diff --git a/b12x/moe/_shared/kernels/w4a16/mixed_trellis.py b/b12x/moe/_shared/kernels/w4a16/mixed_trellis.py
+index a97ee2e62b57463012fd2aaa64edb59cbdd452ab..76a17f77048c648d6e84782212ff41884fcb74bd 100644
+--- a/b12x/moe/_shared/kernels/w4a16/mixed_trellis.py
++++ b/b12x/moe/_shared/kernels/w4a16/mixed_trellis.py
+@@ -27,7 +27,11 @@ from b12x._lib.intrinsics import shared_ptr_to_u32
+ from b12x._lib.runtime_control import raise_if_kernel_resolution_frozen
+ from b12x._lib.utils import current_cuda_stream, make_ptr
+ 
+-from .host import max_packed_route_slots, packed_gemm_scratch_elements
++from .host import (
++    max_packed_route_slots,
++    packed_gemm_scratch_elements,
++    route_pack_warmup_token_counts,
++)
+ from .kernel import (
+     W4A16FusedMoeKernel,
+     _cutlass_element_dtype,
+@@ -774,6 +778,67 @@ class W4A16MixedTrellisKernel:
+ 
+ 
+ _CACHE: dict[tuple[object, ...], MixedTrellisCompileResult] = {}
++_ROUTE_PACK_WARMED: set[tuple[object, ...]] = set()
++
++
++def warmup_mixed_trellis_route_pack(
++    launch: MixedTrellisCompileResult,
++    buffers: MixedTrellisBuffers,
++    *,
++    expert_map: torch.Tensor,
++) -> int:
++    """Materialize every route-pack specialization reachable by ``launch``.
++
++    Route packing buckets token capacity to powers of two. A profile pass at
++    the maximum batch therefore does not cover smaller decode, speculative,
++    or final-prefill-chunk buckets. Load those CUDA modules eagerly while the
++    serving framework is still profiling persistent memory, so KV sizing sees
++    their real driver footprint instead of discovering it under live traffic.
++    """
++    device = buffers.packed_route_indices.device
++    if device.type != "cuda":
++        raise RuntimeError("mixed Trellis route-pack warmup requires CUDA buffers")
++    if torch.cuda.is_current_stream_capturing():
++        raise RuntimeError("mixed Trellis route-pack warmup cannot run during capture")
++
++    total_experts = int(launch.tier0_num_experts) + int(launch.tier1_num_experts)
++    warmed = 0
++    pending_keys: list[tuple[object, ...]] = []
++    with torch.cuda.device(device):
++        device_index = int(torch.cuda.current_device())
++        for token_count in route_pack_warmup_token_counts(launch.size_m):
++            key = (
++                device_index,
++                str(launch.route_ids_dtype),
++                int(token_count),
++                int(launch.top_k),
++                total_experts,
++                int(launch.moe_block_size),
++                True,
++            )
++            if key in _ROUTE_PACK_WARMED:
++                continue
++            dummy_topk_ids = torch.zeros(
++                (token_count, launch.top_k),
++                dtype=launch.route_ids_dtype,
++                device=device,
++            )
++            pack_topk_routes_by_expert(
++                dummy_topk_ids,
++                launch.moe_block_size,
++                total_experts,
++                expert_map=expert_map,
++                packed_route_indices=buffers.packed_route_indices,
++                block_expert_ids=buffers.block_expert_ids,
++                packed_route_count=buffers.packed_route_count,
++                expert_offsets=buffers.expert_offsets,
++                expert_counts=buffers.expert_counts,
++            )
++            pending_keys.append(key)
++            warmed += 1
++        torch.cuda.current_stream(device).synchronize()
++        _ROUTE_PACK_WARMED.update(pending_keys)
++    return warmed
+ 
+ 
+ def compile_mixed_trellis(
+@@ -1521,4 +1586,5 @@ __all__ = [
+     "compile_mixed_trellis",
+     "make_mixed_trellis_buffers",
+     "run_mixed_trellis",
++    "warmup_mixed_trellis_route_pack",
+ ]
+diff --git a/b12x/moe/fused_moe/_impl.py b/b12x/moe/fused_moe/_impl.py
+index 47b08f478ccb030d333b94467f30cf036ddb3572..7f7b0fbd5babb6b3c5b0d02e2876162038cdbab8 100644
+--- a/b12x/moe/fused_moe/_impl.py
++++ b/b12x/moe/fused_moe/_impl.py
+@@ -6527,7 +6527,10 @@ def _plan_full_rotation_w4a16_launches(
+     if torch.cuda.is_current_stream_capturing():
+         raise RuntimeError("Trellis launch planning cannot run during capture")
+ 
+-    from b12x.moe._shared.kernels.w4a16.host import route_pack_capacity
++    from b12x.moe._shared.kernels.w4a16.host import (
++        route_pack_capacity,
++        route_pack_warmup_token_counts,
++    )
+     from b12x.moe._shared.kernels.w4a16.kernel import (
+         _DEFAULT_MAX_SHARED_MEM,
+         compile_w4a16_fused_moe,
+@@ -6637,68 +6640,80 @@ def _plan_full_rotation_w4a16_launches(
+             for ids_dtype in (torch.int32, torch.int64)
+             for mapped in (False, True)
+         )
+-        for mapped in (False, True):
+-            route_pack_key = (
+-                core_plan.device.type,
+-                int(torch.cuda.current_device()),
+-                capacity_tokens * core_plan.num_topk,
+-                int(block_size_m),
+-                int(core_plan.route_E),
+-                mapped,
+-            )
+-            if route_pack_key in _W4A16_ROUTE_PACK_PREWARMED:
+-                continue
++        packed_route_indices = torch.empty(
++            capacity_route_slots,
++            dtype=torch.int32,
++            device=core_plan.device,
++        )
++        block_expert_ids = torch.empty(
++            capacity_m_blocks,
++            dtype=torch.int32,
++            device=core_plan.device,
++        )
++        packed_route_count = torch.empty(
++            1,
++            dtype=torch.int32,
++            device=core_plan.device,
++        )
++        expert_offsets = torch.empty(
++            core_plan.route_E + 1,
++            dtype=torch.int32,
++            device=core_plan.device,
++        )
++        expert_counts = torch.empty(
++            core_plan.route_E,
++            dtype=torch.int32,
++            device=core_plan.device,
++        )
++        pending_route_pack_keys: list[tuple[object, ...]] = []
++        for route_ids_dtype in (torch.int32, torch.int64):
+             dummy_topk_ids = torch.zeros(
+                 capacity_tokens,
+                 core_plan.num_topk,
+-                dtype=torch.int32,
+-                device=core_plan.device,
+-            )
+-            packed_route_indices = torch.empty(
+-                capacity_route_slots,
+-                dtype=torch.int32,
+-                device=core_plan.device,
+-            )
+-            block_expert_ids = torch.empty(
+-                capacity_m_blocks,
+-                dtype=torch.int32,
+-                device=core_plan.device,
+-            )
+-            packed_route_count = torch.empty(
+-                1,
+-                dtype=torch.int32,
+-                device=core_plan.device,
+-            )
+-            expert_offsets = torch.empty(
+-                core_plan.route_E + 1,
+-                dtype=torch.int32,
+-                device=core_plan.device,
+-            )
+-            expert_counts = torch.empty(
+-                core_plan.route_E,
+-                dtype=torch.int32,
++                dtype=route_ids_dtype,
+                 device=core_plan.device,
+             )
+-            expert_map = None
+-            if mapped:
+-                expert_map = torch.arange(
+-                    core_plan.route_E,
+-                    dtype=torch.int32,
+-                    device=core_plan.device,
+-                )
+-            pack_topk_routes_by_expert(
+-                dummy_topk_ids,
+-                block_size_m,
+-                core_plan.route_E,
+-                expert_map=expert_map,
+-                packed_route_indices=packed_route_indices,
+-                block_expert_ids=block_expert_ids,
+-                packed_route_count=packed_route_count,
+-                expert_offsets=expert_offsets,
+-                expert_counts=expert_counts,
++            for mapped in (False, True):
++                expert_map = None
++                if mapped:
++                    expert_map = torch.arange(
++                        core_plan.route_E,
++                        dtype=torch.int32,
++                        device=core_plan.device,
++                    )
++                for token_count in route_pack_warmup_token_counts(capacity_tokens):
++                    route_pack_key = (
++                        core_plan.device.type,
++                        int(torch.cuda.current_device()),
++                        str(route_ids_dtype),
++                        token_count * core_plan.num_topk,
++                        int(block_size_m),
++                        int(core_plan.route_E),
++                        mapped,
++                    )
++                    if route_pack_key in _W4A16_ROUTE_PACK_PREWARMED:
++                        continue
++                    pack_topk_routes_by_expert(
++                        dummy_topk_ids[:token_count],
++                        block_size_m,
++                        core_plan.route_E,
++                        expert_map=expert_map,
++                        packed_route_indices=packed_route_indices,
++                        block_expert_ids=block_expert_ids,
++                        packed_route_count=packed_route_count,
++                        expert_offsets=expert_offsets,
++                        expert_counts=expert_counts,
++                    )
++                    pending_route_pack_keys.append(route_pack_key)
++        torch.cuda.current_stream(core_plan.device).synchronize()
++        _W4A16_ROUTE_PACK_PREWARMED.update(pending_route_pack_keys)
++        if pending_route_pack_keys:
++            logger.info(
++                "Prewarmed %d full-rotation W4A16 route-pack variant(s) "
++                "for token capacity %d.",
++                len(pending_route_pack_keys),
++                capacity_tokens,
+             )
+-            torch.cuda.current_stream(core_plan.device).synchronize()
+-            _W4A16_ROUTE_PACK_PREWARMED.add(route_pack_key)
+     return fused_launches, topk_sum_launches
+ 
+ 
+@@ -7031,6 +7046,7 @@ def _prewarm_w4a16_planned_launches(
+             route_pack_key = (
+                 workspace.device.type,
+                 int(torch.cuda.current_device()),
++                str(torch.int32),
+                 int(token_count) * int(workspace.num_topk),
+                 int(block_size_m),
+                 int(workspace.route_E),
+diff --git a/tests/attention/test_attention_mla_compressed.py b/tests/attention/test_attention_mla_compressed.py
+index d16f936d42d32bfa33114fd73fb9b3016fc51aa4..bdb70f9cac99e551bb1c5a8b97903055bb9151ba 100644
+--- a/tests/attention/test_attention_mla_compressed.py
++++ b/tests/attention/test_attention_mla_compressed.py
+@@ -23,17 +23,20 @@ from b12x.attention._shared.mla.compressed_reference import (
+     gather_compressed_mla_kv_cache_reference,
+     pack_compressed_mla_kv_cache_reference,
+ )
++from b12x.attention._shared.mla.api import clear_mla_caches
+ from b12x.attention._shared.mla.compressed_api import (
+     _should_use_sm121_single_pass_decode,
++    compressed_mla_decode_forward,
+ )
+-from b12x.attention._shared.mla.kernel import _dsv4_h16_auto
+ from b12x.attention._shared.mla.compressed_config import (
++    compressed_mla_split_chunks_for_contract,
+     compressed_mla_split_config_for_contract,
+ )
+-from b12x.attention._shared.mla.api import clear_mla_caches
+-from b12x.attention._shared.mla.compressed_api import compressed_mla_decode_forward
+-from b12x.attention._shared.mla.compressed_config import compressed_mla_split_chunks_for_contract
+-from b12x.attention.compressed_mla._scratch import B12XCompressedMLAScratchCaps, plan_compressed_mla_scratch
++from b12x.attention._shared.mla.kernel import _dsv4_h16_auto
++from b12x.attention.compressed_mla._scratch import (
++    B12XCompressedMLAScratchCaps,
++    plan_compressed_mla_scratch,
++)
+ from b12x._lib.compiler import clear_compile_cache, compile_cache_info
+ 
+ from tests._reference.helpers import require_b12x
+@@ -218,6 +221,7 @@ def _make_compressed_binding(
+     v_head_dim: int = _COMPRESSED_HEAD_DIM,
+     max_chunks_per_row: int = 64,
+     max_page_table_width: int | None = None,
++    decode_row_capacity: int | None = None,
+ ):
+     plan = plan_compressed_mla_scratch(
+         B12XCompressedMLAScratchCaps(
+@@ -233,6 +237,7 @@ def _make_compressed_binding(
+             max_batch=rows,
+             max_kv_rows=max_kv_rows,
+             max_chunks_per_row=max_chunks_per_row,
++            decode_row_capacity=decode_row_capacity,
+         )
+     )
+     (spec,) = plan.scratch_specs()
+@@ -324,6 +329,160 @@ def test_compressed_mla_mtp_graph_rows_keep_decode_split_contract() -> None:
+     assert larger_prefill_cfg.num_chunks == 1
+ 
+ 
++@pytest.mark.parametrize(
++    ("decode_row_capacity", "last_decode_row"),
++    [
++        pytest.param(144, 256, id="legacy-floor"),
++        pytest.param(384, 384, id="mns64-k5"),
++        pytest.param(512, 512, id="mns64-k7"),
++        pytest.param(768, 768, id="mns128-k5"),
++    ],
++)
++def test_compressed_mla_declared_decode_row_capacity_extends_contract(
++    decode_row_capacity: int,
++    last_decode_row: int,
++) -> None:
++    decode_cfg = compressed_mla_split_config_for_contract(
++        rows=last_decode_row,
++        width=384,
++        max_chunks=6,
++        decode_row_capacity=decode_row_capacity,
++    )
++    next_cfg = compressed_mla_split_config_for_contract(
++        rows=last_decode_row + 1,
++        width=384,
++        max_chunks=6,
++        decode_row_capacity=decode_row_capacity,
++    )
++
++    assert decode_cfg.chunk_size == 64
++    assert decode_cfg.num_chunks == 6
++    assert next_cfg.chunk_size == 1024
++    assert next_cfg.num_chunks == 1
++
++
++def test_compressed_mla_declared_decode_row_capacity_rejects_nonpositive() -> None:
++    with pytest.raises(ValueError, match="decode_row_capacity must be positive"):
++        compressed_mla_split_config_for_contract(
++            rows=1,
++            width=384,
++            max_chunks=6,
++            decode_row_capacity=0,
++        )
++
++
++@pytest.mark.parametrize("rows", [1, 24, 65, 144, 192, 256])
++@pytest.mark.parametrize("width", [128, 384, 2176, 4608])
++@pytest.mark.parametrize("decode_row_capacity", [144, 384, 768])
++def test_declared_capacity_preserves_legacy_plans_through_256_rows(
++    rows: int,
++    width: int,
++    decode_row_capacity: int,
++) -> None:
++    legacy = compressed_mla_split_config_for_contract(
++        rows=rows,
++        width=width,
++    )
++    declared = compressed_mla_split_config_for_contract(
++        rows=rows,
++        width=width,
++        decode_row_capacity=decode_row_capacity,
++    )
++
++    assert declared == legacy
++
++
++@pytest.mark.parametrize("rows", [384, 512, 768])
++@torch.inference_mode()
++def test_declared_decode_capacity_matches_reference_under_graph_replay(
++    rows: int,
++) -> None:
++    device = require_b12x()
++    clear_mla_caches()
++    width = 384
++    live_width = 32
++    q = _make_q(rows=rows, seed=6130 + rows, device=device)
++    swa_cache_bytes = _make_cache(
++        tokens=64,
++        page_size=COMPRESSED_MLA_DSV4_PAGE_SIZE,
++        seed=6131 + rows,
++        device=device,
++    )
++    swa_cache = swa_cache_bytes.view(torch.float8_e4m3fn)
++    base_indices = torch.arange(live_width, dtype=torch.int32, device=device)
++    swa_indices = torch.full(
++        (rows, width),
++        -1,
++        dtype=torch.int32,
++        device=device,
++    )
++    swa_indices[:, :live_width] = base_indices
++    swa_lengths = torch.full(
++        (rows,),
++        live_width,
++        dtype=torch.int32,
++        device=device,
++    )
++    attn_sink = torch.linspace(
++        -0.1,
++        0.1,
++        _LOCAL_Q_HEADS,
++        dtype=torch.float32,
++        device=device,
++    )
++    split_cap = math.ceil(width / 64)
++    binding = _make_compressed_binding(
++        device=device,
++        rows=rows,
++        topk=width,
++        max_kv_rows=rows * width,
++        q=q,
++        swa_indices=swa_indices,
++        swa_lengths=swa_lengths,
++        use_cuda_graph=True,
++        max_chunks_per_row=split_cap,
++        decode_row_capacity=rows,
++    )
++
++    captured_out: torch.Tensor | None = None
++
++    def run() -> torch.Tensor:
++        nonlocal captured_out
++        captured_out = compressed_mla_decode_forward(
++            swa_k_cache=swa_cache,
++            binding=binding,
++            attn_sink=attn_sink,
++            sm_scale=_SM_SCALE,
++        )
++        return captured_out
++
++    run()
++    torch.cuda.synchronize(device)
++    graph = torch.cuda.CUDAGraph()
++    with torch.cuda.graph(graph):
++        run()
++    graph.replay()
++    torch.cuda.synchronize(device)
++    assert captured_out is not None
++
++    expected = compressed_sparse_mla_reference(
++        q,
++        swa_cache_bytes,
++        swa_indices,
++        swa_lengths,
++        attn_sink=attn_sink,
++        sm_scale=_SM_SCALE,
++    )
++    max_abs = (captured_out.float() - expected.float()).abs().max().item()
++    cosine = torch.nn.functional.cosine_similarity(
++        captured_out.float().reshape(-1),
++        expected.float().reshape(-1),
++        dim=0,
++    )
++    assert max_abs <= 0.10
++    assert cosine.item() >= 0.9995
++
++
+ def test_compressed_mla_arena_scratch_uses_contract_q_chunks() -> None:
+     device = require_b12x()
+     selected_widths = (128, 640, 2880)
+@@ -397,6 +556,7 @@ def test_compressed_mla_arena_scratch_uses_contract_q_chunks() -> None:
+     assert legacy_ragged > capped * 3
+     assert capped < int(2.25 * (1 << 30))
+ 
++
+ def test_compressed_mla_reference_pack_gathers_across_padded_pages() -> None:
+     device = require_b12x()
+     gen = torch.Generator(device=device)
+@@ -490,15 +650,18 @@ def test_compressed_mla_fixed_workspace_split_plan_uses_contract_not_live_shape(
+         max_page_table_width=page_table_width,
+     )
+ 
+-    with torch.inference_mode(), torch.no_grad():
+-        with pytest.raises(ValueError, match="mapped indexed_page_table"):
+-            compressed_api_impl.compressed_mla_decode_forward(
+-                swa_k_cache=swa_cache.view(torch.float8_e4m3fn),
+-                binding=binding,
+-                indexed_k_cache=indexed_cache,
+-                indexed_page_size=COMPRESSED_MLA_C4_PAGE_SIZE,
+-                sm_scale=_SM_SCALE,
+-            )
++    with (
++        torch.inference_mode(),
++        torch.no_grad(),
++        pytest.raises(ValueError, match="mapped indexed_page_table"),
++    ):
++        compressed_api_impl.compressed_mla_decode_forward(
++            swa_k_cache=swa_cache.view(torch.float8_e4m3fn),
++            binding=binding,
++            indexed_k_cache=indexed_cache,
++            indexed_page_size=COMPRESSED_MLA_C4_PAGE_SIZE,
++            sm_scale=_SM_SCALE,
++        )
+ 
+ 
+ @torch.inference_mode()
+@@ -910,7 +1073,9 @@ def test_compressed_mla_mapped_page_table_is_rejected() -> None:
+         swa_lengths=swa_lengths,
+         indexed_indices=torch.arange(8, dtype=torch.int32, device=device).unsqueeze(0),
+         indexed_lengths=indexed_lengths,
+-        indexed_page_table=torch.arange(2, dtype=torch.int32, device=device).unsqueeze(0),
++        indexed_page_table=torch.arange(2, dtype=torch.int32, device=device).unsqueeze(
++            0
++        ),
+         use_cuda_graph=True,
+     )
+ 
+@@ -1164,8 +1329,7 @@ def test_compressed_mla_prefill_is_run_to_run_deterministic() -> None:
+     for row in range(rows):
+         length = min(width, row + 1)
+         swa_indices[row, :length] = (
+-            torch.arange(row, row - length, -1, dtype=torch.int32, device=device)
+-            % 64
++            torch.arange(row, row - length, -1, dtype=torch.int32, device=device) % 64
+         )
+         swa_lengths[row] = length
+     attn_sink = torch.linspace(
+diff --git a/tests/comm/test_pcie_oneshot.py b/tests/comm/test_pcie_oneshot.py
+index ffb61ba0d7e7657381aef79840fc49f526961f77..898b48f65544ef5086fb957726f0ad4be9b477d8 100644
+--- a/tests/comm/test_pcie_oneshot.py
++++ b/tests/comm/test_pcie_oneshot.py
+@@ -20,10 +20,14 @@ from b12x.comm.pcie.pcie_oneshot import (
+     _require_full_grid_residency,
+     _ABANDONED_PCIE_RUNTIME_QUARANTINE,
+     _RETAINED_FAILED_IPC_EXPORTS,
++    _CuTeOneshotBackend,
+     _CuTeOneshotState,
+     _enable_device_slot_selection,
++    _transport_policy_contract,
++    _uses_sharded_eager_storage,
+     parse_pcie_oneshot_max_size,
+ )
++from b12x.comm.pcie._oneshot_cute import _FusedOneshotLaunch
+ 
+ 
+ @pytest.fixture(autouse=True)
+@@ -252,6 +256,178 @@ def test_graph_slot_bias_preserves_the_next_host_slot() -> None:
+     assert state.slot_bias == 1
+ 
+ 
++def _make_cute_state(world_size: int, *, eager: bool = True) -> _CuTeOneshotState:
++    transport_policy = _transport_policy_contract()
++    return _CuTeOneshotState(
++        rank=0,
++        world_size=world_size,
++        signal_ptrs=tuple(range(100, 100 + world_size)),
++        rank_data=torch.empty(256, dtype=torch.uint8),
++        signal_table_address=0,
++        next_table_offset=128,
++        registered_tables={},
++        eager_tables=(300, 400) if eager else None,
++        eager_buffer_bytes=128 * 1024 if eager else None,
++        transport_policy=transport_policy,
++        sharded_eager_storage=_uses_sharded_eager_storage(
++            world_size,
++            transport_policy,
++        ),
++    )
++
++
++def test_tp8_owner_launcher_rejects_float32() -> None:
++    with pytest.raises(ValueError, match="requires float16 or bfloat16"):
++        _FusedOneshotLaunch(
++            "float32",
++            world_size=8,
++            rank=0,
++            mode="stage_tp8_owner",
++            single_cta=True,
++            register_normalize=True,
++            device_slot_selection=False,
++            slot_bias=0,
++            threads=256,
++        )
++
++
++@pytest.mark.parametrize(
++    ("rows", "hidden", "dtype", "expected"),
++    (
++        (1, 6144, torch.bfloat16, "stage_pull"),
++        (2, 4096, torch.float16, "stage_tp8_owner"),
++        (4, 6144, torch.bfloat16, "stage_tp8_owner"),
++        (8, 6144, torch.bfloat16, "stage_tp8_owner"),
++        (9, 6144, torch.bfloat16, "stage_pull"),
++        (4, 8192, torch.bfloat16, "stage_pull"),
++        (4, 6144, torch.float32, "stage_pull"),
++    ),
++)
++def test_tp8_owner_reduce_default_has_a_bounded_shape_contract(
++    monkeypatch,
++    rows: int,
++    hidden: int,
++    dtype: torch.dtype,
++    expected: str,
++) -> None:
++    monkeypatch.delenv("B12X_PCIE_ONESHOT_PUSH", raising=False)
++    monkeypatch.delenv("B12X_PCIE_TP8_OWNER_REDUCE", raising=False)
++    mode, _, _, _ = _CuTeOneshotBackend._fused_launch_config(
++        _make_cute_state(8), torch.empty((rows, hidden), dtype=dtype)
++    )
++    assert mode == expected
++
++
++def test_tp8_owner_reduce_can_be_disabled(monkeypatch) -> None:
++    monkeypatch.delenv("B12X_PCIE_ONESHOT_PUSH", raising=False)
++    monkeypatch.setenv("B12X_PCIE_TP8_OWNER_REDUCE", "0")
++    mode, _, _, _ = _CuTeOneshotBackend._fused_launch_config(
++        _make_cute_state(8), torch.empty((4, 6144), dtype=torch.bfloat16)
++    )
++    assert mode == "stage_pull"
++
++
++@pytest.mark.parametrize(
++    ("world_size", "env_name", "shape", "expected_when_enabled"),
++    (
++        (2, "B12X_PCIE_TP2_REMOTE_PUSH", (4, 4096), "stage_remote_push"),
++        (4, "B12X_PCIE_TP4_REMOTE_PUSH", (32, 6144), "stage_remote_push"),
++    ),
++)
++def test_tp2_tp4_remote_push_is_opt_in(
++    monkeypatch,
++    world_size: int,
++    env_name: str,
++    shape: tuple[int, int],
++    expected_when_enabled: str,
++) -> None:
++    monkeypatch.delenv("B12X_PCIE_ONESHOT_PUSH", raising=False)
++    monkeypatch.delenv(env_name, raising=False)
++    inp = torch.empty(shape, dtype=torch.bfloat16)
++    mode, _, _, _ = _CuTeOneshotBackend._fused_launch_config(
++        _make_cute_state(world_size), inp
++    )
++    assert mode == "stage_pull"
++
++    monkeypatch.setenv(env_name, "1")
++    mode, _, _, _ = _CuTeOneshotBackend._fused_launch_config(
++        _make_cute_state(world_size), inp
++    )
++    assert mode == expected_when_enabled
++
++
++def test_topology_policy_is_immutable_after_channel_setup(monkeypatch) -> None:
++    monkeypatch.delenv("B12X_PCIE_ONESHOT_PUSH", raising=False)
++    monkeypatch.setenv("B12X_PCIE_TP4_REMOTE_PUSH", "1")
++    state = _make_cute_state(4)
++
++    monkeypatch.setenv("B12X_PCIE_TP4_REMOTE_PUSH", "0")
++    mode, _, _, _ = _CuTeOneshotBackend._fused_launch_config(
++        state,
++        torch.empty((4, 6144), dtype=torch.bfloat16),
++    )
++
++    assert mode == "stage_remote_push"
++
++
++@pytest.mark.parametrize(
++    ("world_size", "env_name", "shape"),
++    (
++        (2, "B12X_PCIE_TP2_REMOTE_PUSH", (4, 6144)),
++        (2, "B12X_PCIE_TP2_REMOTE_PUSH", (33, 4096)),
++        (4, "B12X_PCIE_TP4_REMOTE_PUSH", (33, 6144)),
++        (4, "B12X_PCIE_TP4_REMOTE_PUSH", (4, 8192)),
++    ),
++)
++def test_tp2_tp4_remote_push_falls_back_outside_qualified_shapes(
++    monkeypatch,
++    world_size: int,
++    env_name: str,
++    shape: tuple[int, int],
++) -> None:
++    monkeypatch.delenv("B12X_PCIE_ONESHOT_PUSH", raising=False)
++    monkeypatch.setenv(env_name, "1")
++    mode, _, _, _ = _CuTeOneshotBackend._fused_launch_config(
++        _make_cute_state(world_size),
++        torch.empty(shape, dtype=torch.bfloat16),
++    )
++    assert mode == "stage_pull"
++
++
++def test_registered_fused_input_never_selects_topology_transport(
++    monkeypatch,
++) -> None:
++    monkeypatch.setenv("B12X_PCIE_TP4_REMOTE_PUSH", "1")
++    mode, _, _, _ = _CuTeOneshotBackend._fused_launch_config(
++        _make_cute_state(4, eager=False),
++        torch.empty((4, 6144), dtype=torch.bfloat16),
++    )
++    assert mode == "registered"
++
++
++def test_topology_transport_storage_policy_matches_opt_in_defaults(
++    monkeypatch,
++) -> None:
++    for name in (
++        "B12X_PCIE_ONESHOT_PUSH",
++        "B12X_PCIE_TP2_REMOTE_PUSH",
++        "B12X_PCIE_TP4_REMOTE_PUSH",
++        "B12X_PCIE_TP8_OWNER_REDUCE",
++    ):
++        monkeypatch.delenv(name, raising=False)
++
++    assert not _uses_sharded_eager_storage(2)
++    assert not _uses_sharded_eager_storage(4)
++    assert _uses_sharded_eager_storage(8)
++    assert _transport_policy_contract() == (False, False, False, True)
++
++    monkeypatch.setenv("B12X_PCIE_TP8_OWNER_REDUCE", "0")
++    monkeypatch.setenv("B12X_PCIE_TP4_REMOTE_PUSH", "1")
++    assert _uses_sharded_eager_storage(4)
++    assert not _uses_sharded_eager_storage(8)
++    assert _transport_policy_contract() == (False, False, True, False)
++
++
+ def test_register_buffer_is_idempotent_for_same_mapping():
+     runtime = _make_runtime()
+     ext = runtime._ext
+@@ -1218,6 +1394,7 @@ def test_eager_channel_buffers_use_single_ipc_slab(monkeypatch):
+         exchange_group,
+         signal_bytes=signal_bytes,
+         eager_buffer_bytes=eager_bytes,
++        sharded_eager_storage=False,
+         ipc=ipc,
+     )
+ 
+@@ -1281,6 +1458,7 @@ def test_eager_channel_buffers_cleanup_when_slab_zero_fails(monkeypatch):
+             object(),
+             signal_bytes=300,
+             eager_buffer_bytes=128,
++            sharded_eager_storage=False,
+             ipc=ipc,
+         )
+ 
+@@ -1486,9 +1664,7 @@ def test_collective_logical_channel_mismatch_rejects_before_allocation(monkeypat
+         _requested, existing = local_state
+         return [local_state, (("other",), existing)]
+ 
+-    monkeypatch.setattr(
+-        "b12x.comm.pcie.pcie_oneshot._broadcast_gather_object", gather
+-    )
++    monkeypatch.setattr("b12x.comm.pcie.pcie_oneshot._broadcast_gather_object", gather)
+ 
+     with pytest.raises(RuntimeError, match="differs across ranks"):
+         pool.prepare_channels(("target",))
+@@ -1535,9 +1711,7 @@ def test_empty_logical_channel_set_still_enters_collective_contract(monkeypatch)
+         _, existing = local_state
+         return [local_state, (("peer-channel",), existing)]
+ 
+-    monkeypatch.setattr(
+-        "b12x.comm.pcie.pcie_oneshot._broadcast_gather_object", gather
+-    )
++    monkeypatch.setattr("b12x.comm.pcie.pcie_oneshot._broadcast_gather_object", gather)
+ 
+     with pytest.raises(RuntimeError, match="differs across ranks"):
+         pool.prepare_channels(())
+@@ -1599,9 +1773,7 @@ def test_collective_capture_allows_opposite_order_from_agreed_catalog(monkeypatc
+         assert requested == "graph:target"
+         return [local_state, ("graph:draft", catalog)]
+ 
+-    monkeypatch.setattr(
+-        "b12x.comm.pcie.pcie_oneshot._broadcast_gather_object", gather
+-    )
++    monkeypatch.setattr("b12x.comm.pcie.pcie_oneshot._broadcast_gather_object", gather)
+ 
+     with pool.capture(7, channel_id="graph:target") as channel:
+         assert channel is target
+@@ -1631,9 +1803,7 @@ def test_collective_capture_rejects_divergent_catalog_before_allocation(monkeypa
+             return [(), ()]
+         return [local_state, ("graph:target", ())]
+ 
+-    monkeypatch.setattr(
+-        "b12x.comm.pcie.pcie_oneshot._broadcast_gather_object", gather
+-    )
++    monkeypatch.setattr("b12x.comm.pcie.pcie_oneshot._broadcast_gather_object", gather)
+ 
+     with (
+         pytest.raises(RuntimeError, match="prepared channel catalog differs"),
+@@ -1665,9 +1835,7 @@ def test_collective_capture_rejects_differing_unprepared_ids(monkeypatch):
+         _, catalog = local_state
+         return [local_state, ("graph:unknown", catalog)]
+ 
+-    monkeypatch.setattr(
+-        "b12x.comm.pcie.pcie_oneshot._broadcast_gather_object", gather
+-    )
++    monkeypatch.setattr("b12x.comm.pcie.pcie_oneshot._broadcast_gather_object", gather)
+ 
+     with (
+         pytest.raises(RuntimeError, match="unprepared logical channels"),
+diff --git a/tests/comm/test_pcie_oneshot_fused_rmsnorm_gpu.py b/tests/comm/test_pcie_oneshot_fused_rmsnorm_gpu.py
+index 8159ba77b76f81b11779e2fd1cddaff2e0339018..9ed9199c607a2e39d75c204cd5f4c0e588fd3593 100644
+--- a/tests/comm/test_pcie_oneshot_fused_rmsnorm_gpu.py
++++ b/tests/comm/test_pcie_oneshot_fused_rmsnorm_gpu.py
+@@ -12,7 +12,10 @@ import torch.distributed as dist
+ import torch.multiprocessing as mp
+ from cuda.bindings import runtime as cudart
+ 
+-from b12x.comm.pcie.pcie_oneshot import PCIeOneshotAllReducePool
++from b12x.comm.pcie.pcie_oneshot import (
++    PCIeOneshotAllReducePool,
++    _CuTeOneshotBackend,
++)
+ 
+ 
+ pytestmark = pytest.mark.skipif(
+@@ -22,9 +25,7 @@ pytestmark = pytest.mark.skipif(
+         "RMSNorm GPU tests"
+     ),
+ )
+-TEST_TIMEOUT_SECONDS = float(
+-    os.getenv("B12X_PCIE_ONESHOT_RMS_TIMEOUT_SECONDS", "300")
+-)
++TEST_TIMEOUT_SECONDS = float(os.getenv("B12X_PCIE_ONESHOT_RMS_TIMEOUT_SECONDS", "300"))
+ 
+ 
+ def _free_port() -> int:
+@@ -145,10 +146,15 @@ def _run_eager(
+     rank: int,
+ ) -> None:
+     epsilon = 1e-6
+-    for dtype in (torch.float16, torch.bfloat16, torch.float32):
++    cases = [
++        (dtype, rows, hidden_size)
++        for dtype in (torch.float16, torch.bfloat16, torch.float32)
+         for rows, hidden_size in (
+             (1, 6144),
+             (1, 8192),
++            (2, 4096),
++            (4, 4096),
++            (8, 4096),
+             (2, 6144),
+             (3, 6144),
+             (4, 6144),
+@@ -156,40 +162,47 @@ def _run_eager(
+             (6, 6144),
+             (8, 6144),
+             (3, 128),
+-        ):
+-            if rows * hidden_size * dtype.itemsize > 128 * 1024:
+-                continue
+-            inp, residual, weight = _make_inputs(
+-                rows,
+-                hidden_size,
+-                dtype,
+-                device,
+-                rank,
+-            )
+-            expected_out, expected_residual = _reference(
+-                inp,
+-                residual,
+-                weight,
+-                epsilon,
+-            )
+-            torch.cuda.synchronize(device)
+-            wrong_device = (rank + 1) % dist.get_world_size()
+-            exercise_device_guard = dtype == torch.float16 and rows == 1 and hidden_size == 6144
+-            if exercise_device_guard:
+-                torch.cuda.set_device(wrong_device)
+-            out, residual_out = pool.all_reduce_fused_add_rms_norm(
+-                inp,
+-                residual,
+-                weight,
+-                epsilon,
+-                channel_id="eager:fused-rmsnorm",
+-            )
+-            if exercise_device_guard:
+-                assert torch.cuda.current_device() == wrong_device
+-                torch.cuda.set_device(rank)
+-            torch.cuda.synchronize(device)
+-            _assert_close(out, expected_out, dtype)
+-            _assert_close(residual_out, expected_residual, dtype)
++        )
++        if rows * hidden_size * dtype.itemsize <= 128 * 1024
++    ]
++    if os.getenv("B12X_PCIE_ONESHOT_RMS_TOPOLOGY_ONLY", "0") not in ("", "0"):
++        hidden_size = 4096 if dist.get_world_size() == 2 else 6144
++        cases = [(torch.bfloat16, rows, hidden_size) for rows in (1, 2, 4, 8)]
++
++    for dtype, rows, hidden_size in cases:
++        inp, residual, weight = _make_inputs(
++            rows,
++            hidden_size,
++            dtype,
++            device,
++            rank,
++        )
++        expected_out, expected_residual = _reference(
++            inp,
++            residual,
++            weight,
++            epsilon,
++        )
++        torch.cuda.synchronize(device)
++        wrong_device = (rank + 1) % dist.get_world_size()
++        exercise_device_guard = (
++            dtype == torch.float16 and rows == 1 and hidden_size == 6144
++        )
++        if exercise_device_guard:
++            torch.cuda.set_device(wrong_device)
++        out, residual_out = pool.all_reduce_fused_add_rms_norm(
++            inp,
++            residual,
++            weight,
++            epsilon,
++            channel_id="eager:fused-rmsnorm",
++        )
++        if exercise_device_guard:
++            assert torch.cuda.current_device() == wrong_device
++            torch.cuda.set_device(rank)
++        torch.cuda.synchronize(device)
++        _assert_close(out, expected_out, dtype)
++        _assert_close(residual_out, expected_residual, dtype)
+ 
+ 
+ def _run_graph(
+@@ -197,8 +210,8 @@ def _run_graph(
+     device: torch.device,
+     rank: int,
+ ) -> None:
+-    rows = 4
+-    hidden_size = 6144
++    rows = int(os.getenv("B12X_PCIE_ONESHOT_RMS_GRAPH_ROWS", "4"))
++    hidden_size = int(os.getenv("B12X_PCIE_ONESHOT_RMS_GRAPH_HIDDEN", "6144"))
+     epsilon = 1e-6
+     dtype = torch.bfloat16
+     inp, residual, weight = _make_inputs(
+@@ -227,10 +240,30 @@ def _run_graph(
+     # preserves the one-kernel production topology.
+     _cuda_graph_kernel_chain(graph)
+     stream = torch.cuda.current_stream(device)
++    world_size = dist.get_world_size()
++    topology_remote = (
++        (
++            world_size == 2
++            and os.getenv("B12X_PCIE_TP2_REMOTE_PUSH", "0") not in ("", "0")
++        )
++        or (
++            world_size == 4
++            and os.getenv("B12X_PCIE_TP4_REMOTE_PUSH", "0") not in ("", "0")
++        )
++        or (
++            world_size == 8
++            and os.getenv("B12X_PCIE_TP8_OWNER_REDUCE", "1") not in ("", "0")
++        )
++    )
+     offset = 0
+-    if os.getenv("B12X_PCIE_ONESHOT_PUSH", "0") not in ("", "0"):
+-        remote_source = (rank + 1) % dist.get_world_size()
+-        offset = remote_source * inp.numel() * inp.element_size()
++    if os.getenv("B12X_PCIE_ONESHOT_PUSH", "0") not in ("", "0") or topology_remote:
++        if world_size == 8 and topology_remote:
++            # TP8 owner mode publishes owner data into each rank's staging
++            # slot, so probe the island owner rather than a neighboring rank.
++            remote_source = 0 if rank < 4 else 4
++        else:
++            remote_source = (rank + 1) % world_size
++        offset = remote_source * channel.eager_buffer_bytes
+     snapshots = [_local_eager_words(channel, stream, offset=offset)]
+ 
+     for iteration in range(3):
+@@ -273,6 +306,87 @@ def _run_graph(
+     )
+ 
+ 
++def _run_tp8_graph_mode_transition(
++    pool: PCIeOneshotAllReducePool,
++    device: torch.device,
++    rank: int,
++) -> None:
++    """Replay C1 fallback followed by C4 owner reduction on one channel."""
++
++    if dist.get_world_size() != 8 or os.getenv("B12X_PCIE_TP8_OWNER_REDUCE", "1") in (
++        "",
++        "0",
++    ):
++        return
++
++    hidden_size = 6144
++    epsilon = 1e-6
++    dtype = torch.bfloat16
++    stream = torch.cuda.Stream(device=device)
++    channel_id = "graph:fused-transition"
++    channel = pool.for_stream(stream, channel_id=channel_id)
++
++    calls = []
++    modes = []
++    state = channel._ext._state(channel._ptr)
++    for rows, iteration in ((1, 41), (4, 43)):
++        inp, residual, weight = _make_inputs(
++            rows,
++            hidden_size,
++            dtype,
++            device,
++            rank,
++            iteration=iteration,
++        )
++        out = torch.empty_like(inp)
++        calls.append((inp, residual, weight, out))
++        modes.append(_CuTeOneshotBackend._fused_launch_config(state, inp)[0])
++        with torch.cuda.stream(stream):
++            channel.prepare_graph_fused_add_rms_norm(inp)
++    assert modes == ["stage_pull", "stage_tp8_owner"]
++
++    graph = torch.cuda.CUDAGraph(keep_graph=True)
++    with (
++        pool.capture(stream=stream, channel_id=channel_id),
++        torch.cuda.graph(graph, stream=stream),
++    ):
++        for inp, residual, weight, out in calls:
++            pool.all_reduce_fused_add_rms_norm(
++                inp,
++                residual,
++                weight,
++                epsilon,
++                out=out,
++                residual_out=residual,
++                stream=stream,
++                channel_id=channel_id,
++            )
++
++    for replay in range(3):
++        expected = []
++        for rows, (inp, residual, weight, _out) in zip((1, 4), calls, strict=True):
++            next_inp, next_residual, _ = _make_inputs(
++                rows,
++                hidden_size,
++                dtype,
++                device,
++                rank,
++                iteration=47 + replay,
++            )
++            inp.copy_(next_inp)
++            residual.copy_(next_residual)
++            expected.append(_reference(inp, residual, weight, epsilon))
++
++        graph.replay()
++        stream.synchronize()
++        for (_inp, residual, _weight, out), (
++            expected_out,
++            expected_residual,
++        ) in zip(calls, expected, strict=True):
++            _assert_close(out, expected_out, dtype)
++            _assert_close(residual, expected_residual, dtype)
++
++
+ def _worker(rank: int, world_size: int, port: int) -> None:
+     torch.cuda.set_device(rank)
+     device = torch.device(f"cuda:{rank}")
+@@ -291,11 +405,19 @@ def _worker(rank: int, world_size: int, port: int) -> None:
+         max_concurrent_channels=2,
+     )
+     try:
+-        pool.prepare_channels(("eager:fused-rmsnorm", "graph:fused-rmsnorm"))
++        pool.prepare_channels(
++            (
++                "eager:fused-rmsnorm",
++                "graph:fused-rmsnorm",
++                "graph:fused-transition",
++            )
++        )
+         pool.for_stream(channel_id="eager:fused-rmsnorm")
+         _run_eager(pool, device, rank)
+         dist.barrier()
+         _run_graph(pool, device, rank)
++        dist.barrier()
++        _run_tp8_graph_mode_transition(pool, device, rank)
+         torch.cuda.synchronize(device)
+     finally:
+         pool.close()
+diff --git a/tests/moe/test_w4a16_route_pack_warmup.py b/tests/moe/test_w4a16_route_pack_warmup.py
+new file mode 100644
+index 0000000000000000000000000000000000000000..6c7288b314ebc2785418085ce323881960fe192e
+--- /dev/null
++++ b/tests/moe/test_w4a16_route_pack_warmup.py
+@@ -0,0 +1,54 @@
++import pytest
++
++from b12x.moe._shared.kernels.w4a16.host import (
++    route_pack_warmup_token_counts,
++)
++
++
++@pytest.mark.parametrize(
++    ("capacity", "expected"),
++    [
++        (1, (1,)),
++        (5, (1, 2, 3, 4, 5)),
++        (6, (1, 2, 3, 4, 5, 6)),
++        (32, (1, 2, 3, 4, 5, 8, 9, 16, 17, 32)),
++        (
++            3072,
++            (
++                1,
++                2,
++                3,
++                4,
++                5,
++                8,
++                9,
++                16,
++                17,
++                32,
++                33,
++                64,
++                65,
++                128,
++                129,
++                256,
++                257,
++                512,
++                513,
++                1024,
++                1025,
++                2048,
++                2049,
++                3072,
++            ),
++        ),
++    ],
++)
++def test_route_pack_warmup_covers_capacity_buckets(
++    capacity: int, expected: tuple[int, ...]
++) -> None:
++    assert route_pack_warmup_token_counts(capacity) == expected
++
++
++def test_route_pack_warmup_rejects_empty_capacity() -> None:
++    with pytest.raises(ValueError, match="capacity must be positive"):
++        route_pack_warmup_token_counts(0)

--- a/patches/releases/gilded-gnosis-v20-r32/lmcache/integration.lock.json
+++ b/patches/releases/gilded-gnosis-v20-r32/lmcache/integration.lock.json
@@ -1,0 +1,96 @@
+{
+  "base": {
+    "commit": "9cebd405d0caf4bebe01d694b5a8bf4e3e354314",
+    "ref": "refs/heads/release/v0.5.2-glm52-dcp-base",
+    "repository": "https://github.com/local-inference-lab/LMCache.git"
+  },
+  "manifest": {
+    "sha256": "7cce6c13a12987da499b1adb3e52c25447604aecfa2ec5d90d0dbbb6f76d570c"
+  },
+  "name": "gilded-gnosis-v20-lmcache",
+  "pull_requests": [
+    {
+      "disposition": "merged",
+      "head": "7b7583aef55e98ba05a6c199e71601d78552e794",
+      "number": 7,
+      "ref": "refs/pull/7/head",
+      "title": "Return bounded LMCache MP RPC handler errors"
+    },
+    {
+      "disposition": "merged",
+      "head": "31c4175d2134518e5b43fe8f4a7d072df6043a13",
+      "number": 8,
+      "ref": "refs/pull/8/head",
+      "title": "Recover failed MP retrieves by recomputing invalid blocks"
+    },
+    {
+      "disposition": "merged",
+      "head": "c3b73de74d855f6263deea8b6c6c4dde87e6e5b9",
+      "number": 9,
+      "ref": "refs/pull/9/head",
+      "title": "Restore the largest exact L1 prefix after allocation failure"
+    },
+    {
+      "disposition": "merged",
+      "head": "59186798bb5859b7add7bcac81dff9f2fd4037ab",
+      "number": 10,
+      "ref": "refs/pull/10/head",
+      "title": "Protect native lookup keys from concurrent deletion"
+    },
+    {
+      "disposition": "merged",
+      "head": "2cee5a2c1ef7e80028e94b1bc4bfbfc02e2c2a8d",
+      "number": 11,
+      "ref": "refs/pull/11/head",
+      "title": "Log bounded prefetch failure key samples"
+    },
+    {
+      "disposition": "merged",
+      "head": "baf1345106ebe568a116a35fdcee36bfec73da57",
+      "number": 12,
+      "ref": "refs/pull/12/head",
+      "title": "Return native per-key store results"
+    },
+    {
+      "disposition": "merged",
+      "head": "d4dce69bf90362953cf9ac9a86cccc186b3219dc",
+      "number": 13,
+      "ref": "refs/pull/13/head",
+      "title": "Enforce native filesystem O_DIRECT alignment"
+    },
+    {
+      "disposition": "merged",
+      "head": "502b3c60f2e61625d6e32a31d0d725eedc620792",
+      "number": 14,
+      "ref": "refs/pull/14/head",
+      "title": "Support current and legacy native filesystem object-group keys"
+    },
+    {
+      "disposition": "merged",
+      "head": "7729a9c75f2c29f14a27ea1e84ee6970950197ce",
+      "number": 15,
+      "ref": "refs/pull/15/head",
+      "title": "Make native stores durable and capacity-bounded"
+    },
+    {
+      "disposition": "merged",
+      "head": "e6c2708fe8ae8a96d3c66e83bf4b548c734fbb13",
+      "number": 16,
+      "ref": "refs/pull/16/head",
+      "title": "Restore native filesystem capacity accounting after restart"
+    },
+    {
+      "disposition": "merged",
+      "head": "f9639e2094f70955a1145bfd7219b6fdd39ee143",
+      "number": 17,
+      "ref": "refs/pull/17/head",
+      "title": "Add bounded L1 writeback to durable storage"
+    }
+  ],
+  "result": {
+    "patch": "integration.patch",
+    "patch_sha256": "e9f5369ee134cbc697e77d9fd9d77219aceea5fabf2fe90e3b74542bbeb200ca",
+    "tree": "9a05c8818bae48d15b79c7e876418bb813c08cd0"
+  },
+  "schema_version": 1
+}

--- a/patches/releases/gilded-gnosis-v20-r32/lmcache/integration.patch
+++ b/patches/releases/gilded-gnosis-v20-r32/lmcache/integration.patch
@@ -1,0 +1,4262 @@
+diff --git a/csrc/storage_backends/connector_base.h b/csrc/storage_backends/connector_base.h
+index c2cd35a174a1225c467d1479ea347b0d6e5ebd0e..0df7677cef0d0172a7cb60f7c9f3599cb189b555 100644
+--- a/csrc/storage_backends/connector_base.h
++++ b/csrc/storage_backends/connector_base.h
+@@ -111,6 +111,9 @@ class ConnectorBase : public IStorageConnector {
+     auto [batch_future_id, batch_state, num_tiles, tile_size] =
+         prepare_batch_operation(num_items, Op::BATCH_TILE_SET);
+ 
++    // pre-allocate per-key results so partial store failures are visible
++    batch_state->per_key_results.assign(num_items, 0);
++
+     // fan out work to threads
+     for (size_t tile_idx = 0; tile_idx < num_tiles; ++tile_idx) {
+       auto tile_req = create_tile_request(
+@@ -326,10 +329,30 @@ class ConnectorBase : public IStorageConnector {
+       }
+     }
+   }
++  // Records a per-key result for every key in the tile (continuing past
++  // failures instead of aborting the tile), then rethrows so batch-level
++  // ok=false semantics are preserved for consumers that ignore per-key
++  // results.
+   virtual void do_batch_set(ConnectionType& conn, const Request& req) {
++    bool any_failed = false;
++    std::string first_error;
+     for (size_t i = 0; i < req.keys.size(); ++i) {
+-      do_single_set(conn, req.keys[i], req.buf_ptrs[i], req.buf_lens[i],
+-                    req.batch_chunk_num_bytes);
++      try {
++        do_single_set(conn, req.keys[i], req.buf_ptrs[i], req.buf_lens[i],
++                      req.batch_chunk_num_bytes);
++        req.batch->per_key_results[req.start_idx + i] = 1;
++      } catch (const std::exception& e) {
++        req.batch->per_key_results[req.start_idx + i] = 0;
++        if (!any_failed) {
++          any_failed = true;
++          first_error = e.what();
++        }
++        fprintf(stderr, "[LMCache SET] key %s failed: %s\n",
++                req.keys[i].c_str(), e.what());
++      }
++    }
++    if (any_failed) {
++      throw std::runtime_error("batch set partially failed: " + first_error);
+     }
+   }
+   virtual void do_batch_exists(ConnectionType& conn, const Request& req) {
+@@ -612,9 +635,10 @@ class ConnectorBase : public IStorageConnector {
+         std::lock_guard<std::mutex> lk(req.batch->err_mu);
+         batch_comp.error = req.batch->first_error;
+       }
+-      // for batch exists and batch get, move per-key results
++      // move per-key results for every op that records them
+       if (req.batch->batch_op == Op::BATCH_TILE_EXISTS ||
+           req.batch->batch_op == Op::BATCH_TILE_GET ||
++          req.batch->batch_op == Op::BATCH_TILE_SET ||
+           req.batch->batch_op == Op::BATCH_TILE_DELETE) {
+         batch_comp.result_bytes = std::move(req.batch->per_key_results);
+       }
+diff --git a/csrc/storage_backends/fs/connector.cpp b/csrc/storage_backends/fs/connector.cpp
+index e54d98f54f5428afad363cf1c5f5f380cdd8fffb..727ed016f10ae0b0c6e863c4234439dbaac0e7f8 100644
+--- a/csrc/storage_backends/fs/connector.cpp
++++ b/csrc/storage_backends/fs/connector.cpp
+@@ -2,10 +2,22 @@
+ 
+ #include "connector.h"
+ #include <cerrno>
++#include <cstdint>
+ #include <cstdio>
+ #include <stdexcept>
+ #include <string>
+ 
++namespace {
++// O_DIRECT requires the buffer ADDRESS to be block-aligned as well as the
++// length; a misaligned address fails the read/write with EINVAL. Buffers
++// come from Python and carry no alignment guarantee, so fall back to
++// buffered I/O whenever either constraint is unmet.
++bool odirect_eligible(const void* buf, size_t len, size_t disk_block_size) {
++  return disk_block_size > 0 && len % disk_block_size == 0 &&
++         reinterpret_cast<uintptr_t>(buf) % disk_block_size == 0;
++}
++}  // namespace
++
+ namespace lmcache {
+ namespace connector {
+ 
+@@ -27,22 +39,23 @@ std::string FSConnector::replace_all(const std::string& str,
+ 
+ std::string FSConnector::key_to_filename(const std::string& key) {
+   // Input key format (from _object_key_to_string):
+-  //   Unsalted: <model_name>@<kv_rank_hex>@<chunk_hash_hex>
+-  //   Salted  : <model_name>@<kv_rank_hex>@<chunk_hash_hex>@<cache_salt>
++  //   Legacy unsalted: <model_name>@<kv_rank_hex>@<chunk_hash_hex>
++  //   Legacy salted  : <model_name>@<kv_rank_hex>@<chunk_hash_hex>@<cache_salt>
++  //   Current unsalted:
++  //     <model_name>@<kv_rank_hex>@<object_group_id_hex>@<chunk_hash_hex>
++  //   Current salted appends @<cache_salt> to the current unsalted shape.
+   //
+   // Output filename (matching fs_l2_adapter.py._object_key_to_filename):
+   //   Unsalted: <model_name_safe>@0x<kv_rank_hex>@<chunk_hash_hex>.data
+   //   Salted  :
+   //   <model_name_safe>@0x<kv_rank_hex>@<chunk_hash_hex>@<cache_salt>.data
+   //
+-  // The unsalted 3-field shape is bit-identical to the pre-cache_salt
+-  // format, so existing cache directories remain valid.
+-  //
+-  // NOTE: both model_name and cache_salt are forbidden from containing
+-  // '@' (invariant enforced on the Python side), so splitting on '@'
+-  // is unambiguous — no marker, no rsplit.
++  // Four fields are intentionally not interpreted: that shape can mean a
++  // legacy salted key or a current unsalted key, and both map correctly by
++  // preserving every field after kv_rank verbatim.
+ 
+-  // Split on '@' — must yield 3 (unsalted) or 4 (salted) fields.
++  // Split on '@'. Current ObjectKey serialization has four or five fields;
++  // three-field legacy keys remain readable for cache compatibility.
+   std::vector<std::string> parts;
+   size_t start = 0;
+   for (size_t pos = 0; pos <= key.size(); ++pos) {
+@@ -51,34 +64,28 @@ std::string FSConnector::key_to_filename(const std::string& key) {
+       start = pos + 1;
+     }
+   }
+-  if (parts.size() != 3 && parts.size() != 4) {
++  if (parts.size() < 3 || parts.size() > 5) {
+     throw std::runtime_error(
+-        "FSConnector: malformed key (expected 3 or 4 '@'-separated fields): " +
++        "FSConnector: malformed key (expected 3 to 5 '@'-separated fields): " +
+         key);
+   }
+ 
+   const std::string& model_name = parts[0];
+   const std::string& kv_rank_hex = parts[1];
+-  const std::string& chunk_hash = parts[2];
+-  const std::string cache_salt = parts.size() == 4 ? parts[3] : std::string();
+ 
+   // Replace '/' with '-SEP-' for filesystem safety
+   std::string safe_model = replace_all(model_name, "/", PATH_SLASH_REPLACEMENT);
+ 
+-  // Emit filename. Salt is appended at the tail so the unsalted shape
+-  // matches what older builds wrote to disk.
++  // Emit the model and normalized rank, preserving all remaining fields.
+   std::string result;
+-  result.reserve(safe_model.size() + kv_rank_hex.size() + chunk_hash.size() +
+-                 cache_salt.size() + 32);
++  result.reserve(key.size() + 16);
+   result += safe_model;
+   result += KEY_SEP;
+   result += "0x";
+   result += kv_rank_hex;
+-  result += KEY_SEP;
+-  result += chunk_hash;
+-  if (!cache_salt.empty()) {
++  for (size_t i = 2; i < parts.size(); ++i) {
+     result += KEY_SEP;
+-    result += cache_salt;
++    result += parts[i];
+   }
+   result += FILE_EXT;
+   return result;
+@@ -174,8 +181,11 @@ void FSConnector::do_single_get(WorkerFSConn& conn, const std::string& key,
+   int flags = O_RDONLY;
+   bool do_odirect = conn.use_odirect;
+   if (do_odirect) {
+-    bool aligned = conn.disk_block_size > 0 && len % conn.disk_block_size == 0;
+-    if (aligned) {
++    const bool split_aligned = conn.disk_block_size > 0 &&
++                               (conn.read_ahead_size == 0 ||
++                                len <= conn.read_ahead_size ||
++                                conn.read_ahead_size % conn.disk_block_size == 0);
++    if (odirect_eligible(buf, len, conn.disk_block_size) && split_aligned) {
+ #ifdef O_DIRECT
+       flags |= O_DIRECT;
+ #endif
+@@ -243,8 +253,7 @@ void FSConnector::do_single_set(WorkerFSConn& conn, const std::string& key,
+   int flags = O_CREAT | O_WRONLY | O_TRUNC;
+   bool do_odirect = conn.use_odirect;
+   if (do_odirect) {
+-    bool aligned = conn.disk_block_size > 0 && len % conn.disk_block_size == 0;
+-    if (aligned) {
++    if (odirect_eligible(buf, len, conn.disk_block_size)) {
+ #ifdef O_DIRECT
+       flags |= O_DIRECT;
+ #endif
+diff --git a/csrc/storage_backends/fs/connector.h b/csrc/storage_backends/fs/connector.h
+index 03b7b9cc5e0a2cac7ab9e39404d80c760b4e9018..7b9010947c18de36684317ed7c2628c3d2be0161 100644
+--- a/csrc/storage_backends/fs/connector.h
++++ b/csrc/storage_backends/fs/connector.h
+@@ -21,7 +21,9 @@ static constexpr const char* FILE_EXT = ".data";
+ static constexpr const char* TMP_EXT = ".tmp";
+ 
+ // Per-worker connection state for the FS connector.
+-// Each worker maintains its own I/O buffer for O_DIRECT.
++// O_DIRECT engages per request only when both the transfer length and the
++// caller's buffer address are multiples of the disk block size; anything
++// else falls back to buffered I/O.
+ struct WorkerFSConn {
+   std::filesystem::path base_path;
+   std::filesystem::path tmp_dir;  // empty if not configured
+@@ -52,17 +54,20 @@ class FSConnector : public ConnectorBase<WorkerFSConn> {
+   // Build the filesystem-safe filename from a serialized key string.
+   //
+   // Input key (from NativeConnectorL2Adapter._object_key_to_string):
+-  //   Unsalted: "{model}@{kv_rank:08x}@{hash.hex()}"
+-  //   Salted  : "{model}@{kv_rank:08x}@{hash.hex()}@{cache_salt}"
++  //   Current unsalted:
++  //     "{model}@{kv_rank:08x}@{object_group:x}@{hash.hex()}"
++  //   Current salted appends "@{cache_salt}". Legacy three/four-field keys
++  //   without object_group_id remain supported.
+   //
+   // Output filename (matching fs_l2_adapter.py._object_key_to_filename):
+-  //   Unsalted: "{safe_model}@{kv_rank:#010x}@{hash.hex()}.data"
+-  //   Salted  : "{safe_model}@{kv_rank:#010x}@{hash.hex()}@{cache_salt}.data"
++  //   Current unsalted:
++  //     "{safe_model}@{kv_rank:#010x}@{object_group:x}@{hash.hex()}.data"
++  //   Current salted appends "@{cache_salt}" before ".data".
+   //
+   // Differences from the input: '/' in model becomes '-SEP-', kv_rank
+-  // gains a '0x' prefix, and '.data' is appended. Both model_name and
+-  // cache_salt are forbidden from containing '@' (enforced on the
+-  // Python side), so the parse is unambiguous.
++  // gains a '0x' prefix, and '.data' is appended. All fields after kv_rank
++  // are preserved because four fields can represent either a legacy salted
++  // key or a current unsalted key.
+   static std::string key_to_filename(const std::string& key);
+ 
+   static std::string replace_all(const std::string& str,
+diff --git a/csrc/storage_backends/mooncake/connector.cpp b/csrc/storage_backends/mooncake/connector.cpp
+index 685fa4165b188b517a5c0de50753e5ae2e596d6f..0d5109e0dbb5595476806071d62c6dedd6f2bf98 100644
+--- a/csrc/storage_backends/mooncake/connector.cpp
++++ b/csrc/storage_backends/mooncake/connector.cpp
+@@ -173,12 +173,23 @@ void MooncakeConnector::do_batch_set(WorkerMooncakeConn& conn,
+       conn.client->batch_put_from(req.keys, req.buf_ptrs, req.buf_lens);
+   ensure_batch_result_size(results, req.keys.size(), "batch_put_from");
+ 
++  // Record per-key results before failing the tile so partial store
++  // failures stay visible to consumers that honor them.
++  size_t first_failed = results.size();
+   for (size_t i = 0; i < results.size(); ++i) {
+-    if (results[i] != 0) {
+-      throw std::runtime_error("Mooncake batch_put_from failed for key: " +
+-                               req.keys[i]);
++    if (results[i] == 0) {
++      req.batch->per_key_results[req.start_idx + i] = 1;
++    } else {
++      req.batch->per_key_results[req.start_idx + i] = 0;
++      if (first_failed == results.size()) {
++        first_failed = i;
++      }
+     }
+   }
++  if (first_failed != results.size()) {
++    throw std::runtime_error("Mooncake batch_put_from failed for key: " +
++                             req.keys[first_failed]);
++  }
+ }
+ 
+ void MooncakeConnector::do_batch_exists(WorkerMooncakeConn& conn,
+diff --git a/lmcache/integration/vllm/lmcache_mp_connector.py b/lmcache/integration/vllm/lmcache_mp_connector.py
+index d268070c3c0daa534a616c88312f8da7b5c665de..21af3747ede9f78c608841a692acc9c25e0bbc29 100644
+--- a/lmcache/integration/vllm/lmcache_mp_connector.py
++++ b/lmcache/integration/vllm/lmcache_mp_connector.py
+@@ -464,6 +464,42 @@ class LMCacheMPRequestMetadata:
+             "number of LMCache hit tokens. "
+         )
+         if end_token_idx > start_token_idx:
++            # allocated_block_ids must cover [start_token_idx, end_token_idx)
++            # in every engine group. slice_block_ids_per_group() validates
++            # chunk alignment only; its plain Python slice truncates
++            # silently, so a tracker primed with LMCache hit counts on a
++            # scheduling pass whose allocation never materialised would emit
++            # a retrieve op with too few block ids. The MP server fails
++            # closed on the short list, wasting a doomed round-trip and
++            # relying on the failure being surfaced at all. Suppress the op
++            # instead so the request recomputes cleanly. Never clamp
++            # end_token_idx: a clamped retrieve completes a load vLLM does
++            # not expect and re-creates the desync downstream.
++            # One allocated id of group g covers group_tokens_per_block[g]
++            # global token positions (KV-spec block_size, DCP-scaled), the
++            # same arithmetic GetStoreMetadata uses to bound its
++            # allocated_tokens.
++            for group_idx, tokens_per_block in enumerate(group_tokens_per_block):
++                allocated = len(tracker.allocated_block_ids.get(group_idx, []))
++                if allocated * tokens_per_block < end_token_idx:
++                    logger.warning(
++                        "LMCache retrieve suppressed for request_id=%s: "
++                        "engine group %d has %d allocated block(s) x %d "
++                        "tokens/block = %d tokens < end_token_idx=%d "
++                        "(start_token_idx=%d, vllm_hit_tokens=%d, "
++                        "lmcache_hit_tokens=%d) -- tracker/allocation "
++                        "desync; falling back to recompute.",
++                        tracker.request_id,
++                        group_idx,
++                        allocated,
++                        tokens_per_block,
++                        allocated * tokens_per_block,
++                        end_token_idx,
++                        start_token_idx,
++                        tracker.num_vllm_hit_tokens,
++                        tracker.num_lmcache_hit_tokens,
++                    )
++                    return None
+             block_ids = slice_block_ids_per_group(
+                 tracker.allocated_block_ids,
+                 group_tokens_per_block,
+diff --git a/lmcache/integration/vllm/vllm_multi_process_adapter.py b/lmcache/integration/vllm/vllm_multi_process_adapter.py
+index d74fe3af02cbefc7755c8446434a36034c681ef3..dd5aa0e6033292eaad06dd8f0b7961d58cf6b2f1 100644
+--- a/lmcache/integration/vllm/vllm_multi_process_adapter.py
++++ b/lmcache/integration/vllm/vllm_multi_process_adapter.py
+@@ -1173,8 +1173,11 @@ class LMCacheMPWorkerAdapter:
+         self.store_events: dict[str, list[_IpcEvent]] = {}
+         self.retrieve_events: dict[str, _IpcEvent] = {}
+ 
+-        # Block IDs that failed due to retrieve timeout
++        # Block IDs of failed retrieves (timeout, server-reported failure,
++        # or raising future), consumed by get_block_ids_with_load_errors().
+         self.error_block_ids: set[int] = set()
++        # Total failed retrieves on this worker, for log-based diagnostics.
++        self.retrieve_failure_count: int = 0
+ 
+         # Retrieve request ids dropped by the unhealthy early-return of
+         # submit_retrieve_request. get_finished must still report each id
+@@ -1657,6 +1660,9 @@ class LMCacheMPWorkerAdapter:
+             - The second set contains the finished retrieve request ids,
+                 including retrieves dropped at submit time while unhealthy
+                 (reported exactly once; blocks already in error_block_ids).
++                A failed retrieve (server result False or a raising future)
++                is reported finished with its block ids recorded in
++                error_block_ids so the scheduler recomputes them.
+ 
+         Notes:
+             When enabling async scheduling in vLLM, the same request ID may appear
+@@ -1701,19 +1707,45 @@ class LMCacheMPWorkerAdapter:
+ 
+         finished_stores = self._poll_store_futures()
+         finished_retrieves = set()
+-        for request_id, (r_future, _) in self.retrieve_futures.items():
++        for request_id, (r_future, r_block_ids) in self.retrieve_futures.items():
+             if not r_future.query():
+                 continue
+ 
+-            r_result = r_future.result()
++            try:
++                r_result = r_future.result()
++            except Exception as exc:
++                # A raising future must not propagate out of get_finished
++                # (that would kill the engine step); contain it as a failed
++                # retrieve on the standard failure path.
++                logger.error(
++                    "LMCache retrieve future raised for request_id=%s: %r "
++                    "-- treating as failed retrieve.",
++                    request_id,
++                    exc,
++                )
++                r_result = False
+             finished_retrieves.add(request_id)
+ 
+             if not r_result:
++                # Surface the failure to the scheduler. Reporting the
++                # request finished without recording the failed span would
++                # ACK the load as successful: the request then decodes over
++                # never-written GPU blocks and the phantom blocks enter the
++                # shared prefix cache. error_block_ids feeds
++                # get_block_ids_with_load_errors() ->
++                # kv_connector_output.invalid_block_ids -> scheduler
++                # recompute. The MP server collapses per-key results into
++                # one bool, so marking the op's whole span is
++                # conservative-correct for partial failures too.
++                self.error_block_ids.update(r_block_ids)
++                self.retrieve_failure_count += 1
+                 logger.error(
+-                    "Something went wrong when processing the "
+-                    "retrieve request for request_id=%s, result=%s",
++                    "LMCache retrieve failed for request_id=%s: %d block(s) "
++                    "marked invalid for scheduler recompute "
++                    "(total retrieve failures this worker: %d)",
+                     request_id,
+-                    r_result,
++                    len(r_block_ids),
++                    self.retrieve_failure_count,
+                 )
+ 
+         # Store futures and events are removed together by _poll_store_futures.
+@@ -1758,8 +1790,8 @@ class LMCacheMPWorkerAdapter:
+ 
+     def get_block_ids_with_load_errors(self) -> set[int]:
+         """
+-        Returns the block IDs that failed due to retrieve timeout,
+-        then clears the internal set.
++        Returns the block IDs of failed retrieves (timeout, server-reported
++        failure, or raising future), then clears the internal set.
+         """
+         errors = self.error_block_ids.copy()
+         self.error_block_ids.clear()
+diff --git a/lmcache/v1/distributed/config.py b/lmcache/v1/distributed/config.py
+index de36535a57df7ceb8ca8bbb97276c4733e568270..ac11158668fdbfd00f36512cc08a90b7f42860b4 100644
+--- a/lmcache/v1/distributed/config.py
++++ b/lmcache/v1/distributed/config.py
+@@ -226,6 +226,21 @@ class EvictionConfig:
+     extra_logging_interval: float = field(default=10.0)
+     """ Seconds between L1 memory usage log lines when extra logging is enabled. """
+ 
++    write_back_on_evict: bool = field(default=False)
++    """ Flush evicted L1 objects to L2 synchronously and delete them from L1
++    only once every key in the batch is durable; without this, eviction
++    discards the objects. Requires an L2 adapter with store_objects_sync(). """
++
++    periodic_flush_interval: float = field(default=0.0)
++    """ Seconds between periodic L1-to-L2 backup flush scans while below the
++    eviction watermark (0 disables). Backup keeps the L1 copy; only L2 gains
++    a copy, so a restart or session expiry no longer costs a cold prefill. """
++
++    emergency_evict_for_prefetch: bool = field(default=False)
++    """ Allow the prefetch controller to synchronously evict LRU L1 keys to
++    make room for large L2-to-L1 restores. Effective only together with
++    write_back_on_evict, so victims are persisted before deletion. """
++
+ 
+ @dataclass
+ class StorageManagerConfig:
+@@ -296,6 +311,12 @@ def validate_storage_manager_config(config: StorageManagerConfig) -> None:
+         ValueError: If mutually exclusive L1 tiers are both configured, or
+             hybrid L1 is paired with incompatible L2 adapters.
+     """
++    eviction = config.eviction_config
++    if eviction.periodic_flush_interval < 0:
++        raise ValueError("periodic_flush_interval must be >= 0")
++    if eviction.emergency_evict_for_prefetch and not eviction.write_back_on_evict:
++        raise ValueError("emergency_evict_for_prefetch requires write_back_on_evict")
++
+     if (
+         config.l1_manager_config.gds_l1_config is not None
+         and config.l1_manager_config.memory_config.devdax_path
+@@ -471,6 +492,28 @@ def add_storage_manager_args(
+         help="The fraction of memory to evict when triggered (0.0 to 1.0). "
+         "Default is 0.2.",
+     )
++    eviction_group.add_argument(
++        "--write-back-on-evict",
++        action="store_true",
++        help="Flush evicted L1 objects to L2 synchronously and delete them "
++        "from L1 only once every key in the batch is durable. Requires an "
++        "L2 adapter with a synchronous store path.",
++    )
++    eviction_group.add_argument(
++        "--periodic-flush-interval",
++        type=float,
++        default=0.0,
++        help="Seconds between periodic L1-to-L2 backup flush scans while "
++        "below the eviction watermark (0 disables). The backup keeps the "
++        "L1 copy; only L2 gains a copy.",
++    )
++    eviction_group.add_argument(
++        "--emergency-evict-for-prefetch",
++        action="store_true",
++        help="Allow the prefetch controller to synchronously evict LRU L1 "
++        "keys to make room for large L2-to-L1 restores. Effective only "
++        "together with --write-back-on-evict.",
++    )
+ 
+     # L2 Policies
+     # Import here to break circular dependency:
+@@ -596,6 +639,11 @@ def parse_args_to_config(
+         eviction_ratio=args.eviction_ratio,
+         extra_logging_enabled=getattr(args, "enable_extra_logging", False),
+         extra_logging_interval=getattr(args, "extra_logging_interval", 10.0),
++        write_back_on_evict=getattr(args, "write_back_on_evict", False),
++        periodic_flush_interval=getattr(args, "periodic_flush_interval", 0.0),
++        emergency_evict_for_prefetch=getattr(
++            args, "emergency_evict_for_prefetch", False
++        ),
+     )
+ 
+     l2_adapter_config = parse_args_to_l2_adapters_config(args)
+diff --git a/lmcache/v1/distributed/l1_manager.py b/lmcache/v1/distributed/l1_manager.py
+index 44cf55f615f2bf491bdf72784ac152a7ee422457..4a2be000b86a576759cb3d5579acbc45181b14e7 100644
+--- a/lmcache/v1/distributed/l1_manager.py
++++ b/lmcache/v1/distributed/l1_manager.py
+@@ -5,6 +5,7 @@ Managing objects and memory for L1 cache
+ 
+ # Standard
+ from dataclasses import dataclass
++from itertools import chain, islice
+ from typing import Literal
+ import threading
+ 
+@@ -462,6 +463,11 @@ class L1Manager:
+         Errors:
+             KEY_NOT_WRITABLE: The key exists but is not writable.
+             OUT_OF_MEMORY: Not enough memory to allocate for the object.
++
++        Note:
++            When the full batch does not fit, the longest prefix of the
++            to-be-allocated keys that fits is allocated and the remaining
++            keys report OUT_OF_MEMORY.
+         """
+         need_to_allocate: list[tuple[ObjectKey, bool]] = []
+         ret: dict[ObjectKey, L1OperationResult] = {}
+@@ -499,6 +505,26 @@ class L1Manager:
+             layout_desc, len(need_to_allocate)
+         )
+ 
++        # A full-batch allocation failure would fail every key even when
++        # most of the batch fits, collapsing large L2->L1 restores to zero
++        # prefix hits and forcing full re-prefills upstream. Fall back to
++        # allocating the longest prefix that fits; callers already handle
++        # per-key OOM (prefetch trims to the contiguous prefix, the store
++        # path skips failed keys).
++        if err != L1Error.SUCCESS and len(need_to_allocate) > 1:
++            if allocated_objs:
++                self._memory_manager.free(allocated_objs)
++                allocated_objs = []
++            err, allocated_objs = self._allocate_largest_prefix(
++                layout_desc, len(need_to_allocate)
++            )
++            if err == L1Error.SUCCESS:
++                logger.warning(
++                    "Partial L1 allocation: %d/%d objects (prefix) allocated",
++                    len(allocated_objs),
++                    len(need_to_allocate),
++                )
++
+         if err != L1Error.SUCCESS:
+             for key, _ in need_to_allocate:
+                 ret[key] = (L1Error.OUT_OF_MEMORY, None)
+@@ -508,6 +534,10 @@ class L1Manager:
+                 self._memory_manager.free(allocated_objs)
+ 
+         else:
++            # Mark any unallocated tail as OOM so every requested key keeps
++            # an explicit per-key result.
++            for key, _ in need_to_allocate[len(allocated_objs) :]:
++                ret[key] = (L1Error.OUT_OF_MEMORY, None)
+             for (key, is_temp), mem_obj in zip(
+                 need_to_allocate, allocated_objs, strict=False
+             ):
+@@ -531,6 +561,41 @@ class L1Manager:
+         )
+         return ret
+ 
++    def _allocate_largest_prefix(
++        self, layout_desc: MemoryLayoutDesc, want: int
++    ) -> tuple[L1Error, list[MemoryObj]]:
++        """Allocate the largest prefix below an already-failed full batch.
++
++        L1 allocators have an all-or-nothing batch contract. While holding the
++        L1 manager lock, allocation feasibility is therefore monotonic: if a
++        batch of size ``n`` fits, every smaller batch also fits. Binary search
++        finds the maximum without relying on byte estimates that can be wrong
++        for alignment or fragmented free lists. Successful probes are freed
++        before the final allocation.
++
++        This recovery path runs only after the ``want`` allocation failed, so
++        normal reservations still perform exactly one allocation.
++        """
++        low = 1
++        high = want - 1
++        largest = 0
++
++        while low <= high:
++            candidate = (low + high) // 2
++            err, objects = self._memory_manager.allocate(layout_desc, candidate)
++            if err == L1Error.SUCCESS:
++                largest = candidate
++                self._memory_manager.free(objects)
++                low = candidate + 1
++            else:
++                if objects:
++                    self._memory_manager.free(objects)
++                high = candidate - 1
++
++        if largest == 0:
++            return L1Error.OUT_OF_MEMORY, []
++        return self._memory_manager.allocate(layout_desc, largest)
++
+     @l1_mgr_synchronized
+     def finish_write(
+         self,
+@@ -793,6 +858,59 @@ class L1Manager:
+             locked_count,
+         )
+ 
++    @l1_mgr_synchronized
++    def get_evictable_keys(
++        self,
++        limit: int,
++        cursor: int = 0,
++        scan_limit: int | None = None,
++    ) -> tuple[list[ObjectKey], int]:
++        """Return a bounded, rotating batch of evictable keys.
++
++        ``cursor`` is an insertion-order offset returned by the previous call.
++        The scan wraps once and inspects at most ``scan_limit`` entries, so a
++        periodic backup cannot materialize the complete L1 keyspace while the
++        manager lock is held. Concurrent insertions or removals may shift the
++        offset, but every returned key is revalidated by ``reserve_read``.
++
++        Args:
++            limit: Maximum number of keys to return.
++            cursor: Insertion-order offset at which to resume scanning.
++            scan_limit: Maximum entries to inspect. Defaults to four batches.
++
++        Returns:
++            A pair of the eligible keys and the cursor for the next call.
++        """
++        if limit <= 0 or not self._objects:
++            return [], 0
++
++        object_count = len(self._objects)
++        start = cursor % object_count
++        max_scan = min(
++            object_count,
++            max(limit, scan_limit if scan_limit is not None else limit * 4),
++        )
++        ordered_keys = chain(
++            islice(self._objects, start, None),
++            islice(self._objects, 0, start),
++        )
++        keys: list[ObjectKey] = []
++        scanned = 0
++        for key in ordered_keys:
++            scanned += 1
++            if self.is_key_evictable(key):
++                keys.append(key)
++                if len(keys) >= limit:
++                    break
++            if scanned >= max_scan:
++                break
++        return keys, (start + scanned) % object_count
++
++    @l1_mgr_synchronized
++    def num_objects(self) -> int:
++        """Return the number of objects currently tracked in L1."""
++        return len(self._objects)
++
+     def is_key_evictable(self, key: ObjectKey) -> bool:
+         """Check if a key is eligible for eviction (not locked).
+ 
+diff --git a/lmcache/v1/distributed/l2_adapters/base.py b/lmcache/v1/distributed/l2_adapters/base.py
+index 1838553e285ce0f2c7a0b3d9a3180b6ad57ed499..dcc71deaa4c5097911fc810a6e80e80225baa384 100644
+--- a/lmcache/v1/distributed/l2_adapters/base.py
++++ b/lmcache/v1/distributed/l2_adapters/base.py
+@@ -135,6 +135,7 @@ class L2AdapterInterface(ABC):
+         # every adapter exposes the same shape via ``get_usage()``.
+         self._max_capacity_bytes: int = max_capacity_bytes
+         self._total_bytes_used: int = 0
++        self._reserved_store_bytes: int = 0
+         self._bytes_by_cache_salt: dict[str, int] = {}
+         self._usage_lock = threading.Lock()
+ 
+@@ -354,13 +355,8 @@ class L2AdapterInterface(ABC):
+         """Register a listener to receive L2 adapter events."""
+         self._listeners.append(listener)
+ 
+-    def _notify_keys_stored(self, keys: list[ObjectKey], sizes: list[int]) -> None:
+-        """Update byte accounting and notify listeners that ``keys`` were
+-        stored. ``sizes[i]`` is the byte size of ``keys[i]``.
+-
+-        Accounting is held under ``_usage_lock``; listener callbacks fire
+-        outside the lock so a slow listener cannot stall further notifies.
+-        """
++    def _account_keys_stored(self, keys: list[ObjectKey], sizes: list[int]) -> None:
++        """Apply stored-key byte accounting without invoking listeners."""
+         # Aggregate per-salt deltas before touching
+         # ``_bytes_by_cache_salt`` — one dict read/write per unique
+         # salt instead of one per key. This matters when the registry is
+@@ -377,9 +373,90 @@ class L2AdapterInterface(ABC):
+                 self._bytes_by_cache_salt[salt] = (
+                     self._bytes_by_cache_salt.get(salt, 0) + d
+                 )
++
++    def _try_reserve_store_bytes(self, size: int) -> bool:
++        """Reserve capacity before an asynchronous L2 store is submitted.
++
++        The reservation covers transient backend storage as well as the final
++        object. This keeps a burst of in-flight writes from exceeding a hard
++        adapter capacity before completion accounting becomes visible.
++        """
++        if size < 0:
++            raise ValueError("store reservation size must be non-negative")
++        with self._usage_lock:
++            projected = self._total_bytes_used + self._reserved_store_bytes + size
++            if self._max_capacity_bytes > 0 and projected > self._max_capacity_bytes:
++                return False
++            self._reserved_store_bytes += size
++            return True
++
++    def _settle_store_reservation(
++        self,
++        reserved_bytes: int,
++        keys: list[ObjectKey],
++        sizes: list[int],
++    ) -> None:
++        """Atomically release a store reservation and account durable keys."""
++        if reserved_bytes < 0:
++            raise ValueError("reserved_bytes must be non-negative")
++
++        delta: dict[str, int] = {}
++        total_delta = 0
++        for key, size in zip(keys, sizes, strict=True):
++            delta[key.cache_salt] = delta.get(key.cache_salt, 0) + size
++            total_delta += size
++
++        with self._usage_lock:
++            if reserved_bytes > self._reserved_store_bytes:
++                raise RuntimeError(
++                    "store reservation accounting underflow: "
++                    f"settling {reserved_bytes} bytes with only "
++                    f"{self._reserved_store_bytes} reserved"
++                )
++            self._reserved_store_bytes -= reserved_bytes
++            self._total_bytes_used += total_delta
++            for salt, d in delta.items():
++                self._bytes_by_cache_salt[salt] = (
++                    self._bytes_by_cache_salt.get(salt, 0) + d
++                )
++
++    def _release_store_reservation(self, reserved_bytes: int) -> None:
++        """Release capacity for a store that will not produce a completion."""
++        if reserved_bytes < 0:
++            raise ValueError("reserved_bytes must be non-negative")
++        with self._usage_lock:
++            if reserved_bytes > self._reserved_store_bytes:
++                raise RuntimeError(
++                    "store reservation accounting underflow: "
++                    f"releasing {reserved_bytes} bytes with only "
++                    f"{self._reserved_store_bytes} reserved"
++                )
++            self._reserved_store_bytes -= reserved_bytes
++
++    def get_reserved_store_bytes(self) -> int:
++        """Return bytes reserved by submitted stores awaiting completion."""
++        with self._usage_lock:
++            return self._reserved_store_bytes
++
++    def _notify_keys_stored_listeners(
++        self,
++        keys: list[ObjectKey],
++        sizes: list[int],
++    ) -> None:
++        """Notify stored-key observers after accounting is committed."""
+         for listener in self._listeners:
+             listener.on_l2_keys_stored(keys, sizes)
+ 
++    def _notify_keys_stored(self, keys: list[ObjectKey], sizes: list[int]) -> None:
++        """Update byte accounting and notify listeners that ``keys`` were
++        stored. ``sizes[i]`` is the byte size of ``keys[i]``.
++
++        Accounting is held under ``_usage_lock``; listener callbacks fire
++        outside the lock so a slow listener cannot stall further notifies.
++        """
++        self._account_keys_stored(keys, sizes)
++        self._notify_keys_stored_listeners(keys, sizes)
++
+     def _notify_keys_accessed(self, keys: list[ObjectKey]) -> None:
+         # ``_notify_keys_accessed`` carries no byte impact — only LRU
+         # bookkeeping cares about it, so no accounting is needed here.
+diff --git a/lmcache/v1/distributed/l2_adapters/fs_native_l2_adapter.py b/lmcache/v1/distributed/l2_adapters/fs_native_l2_adapter.py
+index 2d703499d20c5aa1c0ecc8e1f0667f2bf857c6a2..dacdead73b3eb1a34bec530fe14c535759607b2a 100644
+--- a/lmcache/v1/distributed/l2_adapters/fs_native_l2_adapter.py
++++ b/lmcache/v1/distributed/l2_adapters/fs_native_l2_adapter.py
+@@ -10,9 +10,11 @@ Backed by the native C++ filesystem connector wrapped with
+ from __future__ import annotations
+ 
+ # Standard
++from pathlib import Path
+ from typing import TYPE_CHECKING, Optional
+ 
+ if TYPE_CHECKING:
++    from lmcache.v1.distributed.api import ObjectKey
+     from lmcache.v1.distributed.internal_api import (
+         L1MemoryDesc,
+     )
+@@ -158,7 +160,7 @@ def _create_fs_native_l2_adapter(
+         config.use_odirect,
+         config.read_ahead_size,
+     )
+-    return NativeConnectorL2Adapter(
++    adapter = NativeConnectorL2Adapter(
+         native_client,
+         max_capacity_gb=config.max_capacity_gb,
+         type_name="FSNativeL2Adapter",
+@@ -169,6 +171,53 @@ def _create_fs_native_l2_adapter(
+             "read_ahead_size": config.read_ahead_size,
+         },
+     )
++    try:
++        keys, sizes = _scan_existing_fs_native_files(config.base_path)
++        adapter.prime_existing_keys(keys, sizes)
++    except Exception:
++        adapter.close()
++        raise
++    return adapter
++
++
++def _scan_existing_fs_native_files(
++    base_path: str,
++) -> tuple[list["ObjectKey"], list[int]]:
++    """Recover durable keys and sizes, ordered from oldest to newest."""
++    # First Party
++    from lmcache.v1.distributed.l2_adapters.fs_l2_adapter import (
++        _filename_to_object_key,
++    )
++
++    root = Path(base_path)
++    if not root.is_dir():
++        return [], []
++
++    entries: list[tuple[int, str, ObjectKey, int]] = []
++    for path in root.glob("*.data"):
++        try:
++            if not path.is_file():
++                continue
++            key = _filename_to_object_key(path.name)
++            if key is None:
++                logger.warning("Ignoring unrecognized cache file: %s", path)
++                continue
++            stat = path.stat()
++            if stat.st_size <= 0:
++                logger.warning("Ignoring empty cache file: %s", path)
++                continue
++            entries.append((stat.st_mtime_ns, path.name, key, stat.st_size))
++        except OSError as exc:
++            # Silently omitting a durable object would under-report usage and
++            # seed an incomplete eviction index. Fail adapter construction so
++            # the operator can repair the directory or retry the startup scan.
++            raise RuntimeError(f"Could not inspect cache file {path}: {exc}") from exc
++
++    entries.sort(key=lambda entry: (entry[0], entry[1]))
++    return (
++        [entry[2] for entry in entries],
++        [entry[3] for entry in entries],
++    )
+ 
+ 
+ register_l2_adapter_type("fs_native", FSNativeL2AdapterConfig)
+diff --git a/lmcache/v1/distributed/l2_adapters/native_connector_l2_adapter.py b/lmcache/v1/distributed/l2_adapters/native_connector_l2_adapter.py
+index c10d3802dfbdba50b6a49e4d764ebf10a567a0df..97518b74a161dd995548a7894eb0e13a3fed0df2 100644
+--- a/lmcache/v1/distributed/l2_adapters/native_connector_l2_adapter.py
++++ b/lmcache/v1/distributed/l2_adapters/native_connector_l2_adapter.py
+@@ -30,7 +30,7 @@ import threading
+ from lmcache.logging import init_logger
+ from lmcache.native_storage_ops import Bitmap
+ from lmcache.v1.distributed.api import MemoryLayoutDesc, ObjectKey
+-from lmcache.v1.distributed.internal_api import L2StoreResult
++from lmcache.v1.distributed.internal_api import L2AdapterListener, L2StoreResult
+ from lmcache.v1.distributed.l2_adapters.base import (
+     L2AdapterInterface,
+     L2TaskId,
+@@ -98,6 +98,7 @@ class NativeConnectorL2Adapter(L2AdapterInterface):
+ 
+     # Operation type tags for the pending-ops map
+     _OP_STORE = "store"
++    _OP_SYNC_STORE = "sync_store"
+     _OP_LOOKUP = "lookup"
+     _OP_LOAD = "load"
+     _OP_DELETE = "delete"
+@@ -144,15 +145,30 @@ class NativeConnectorL2Adapter(L2AdapterInterface):
+         # Pending delete events for synchronous delete() calls
+         self._pending_delete_events: dict[L2TaskId, threading.Event] = {}
+ 
++        # Synchronous stores use private completions so StoreController cannot
++        # consume another thread's result from _completed_stores.
++        self._pending_sync_store_events: dict[
++            L2TaskId, tuple[threading.Event, dict[str, Any]]
++        ] = {}
++
+         # Per-key size tracking. ``_key_sizes`` lets us look up byte sizes
+         # at delete time (the native completion only carries booleans, not
+         # sizes) so we can pass them to ``_notify_keys_deleted``. Aggregate
+         # and per-user totals live in the base class — see ``get_usage``.
+         self._key_sizes: dict[ObjectKey, int] = {}
+-        # Pending store sizes: native future_id -> (keys, per_key_sizes).
++        # Pending store sizes:
++        #   native future_id -> (keys, per_key_sizes, reserved_bytes).
+         # Bridges the async store submit → demux completion gap so the
+         # demux thread can fire ``_notify_keys_stored(keys, sizes)``.
+-        self._pending_store_sizes: dict[int, tuple[list[ObjectKey], list[int]]] = {}
++        self._pending_store_sizes: dict[
++            int, tuple[list[ObjectKey], list[int], int]
++        ] = {}
++
++        # A filesystem factory may prime durable objects before the eviction
++        # listener exists. Keep one temporary startup snapshot for that first
++        # listener; _key_sizes remains the sole long-lived key index.
++        self._startup_primed = False
++        self._startup_replay: tuple[list[ObjectKey], list[int]] | None = None
+ 
+         # Task ID counter
+         self._next_task_id: L2TaskId = 0
+@@ -194,20 +210,39 @@ class NativeConnectorL2Adapter(L2AdapterInterface):
+         key_strings = [_object_key_to_string(k) for k in keys]
+         memviews = [_obj_to_memoryview(obj) for obj in objects]
+         per_key_sizes = [obj.get_size() for obj in objects]
++        reserved_bytes = sum(per_key_sizes)
+ 
+         # Register pending op BEFORE submit to avoid race
+         # with demux thread. The native submit is
+         # non-blocking so holding the lock is brief.
+         with self._lock:
+             task_id = self._get_next_task_id()
+-            future_id = int(self._client.submit_batch_set(key_strings, memviews))
++            if not self._try_reserve_store_bytes(reserved_bytes):
++                self._completed_stores[task_id] = L2StoreResult(False, 0)
++                self._store_efd.notify()
++                logger.warning(
++                    "Rejected native L2 store of %d bytes: capacity would "
++                    "exceed %d bytes",
++                    reserved_bytes,
++                    self._max_capacity_bytes,
++                )
++                return task_id
++            try:
++                future_id = int(self._client.submit_batch_set(key_strings, memviews))
++            except Exception:
++                self._release_store_reservation(reserved_bytes)
++                raise
+             self._pending_ops[future_id] = (
+                 self._OP_STORE,
+                 task_id,
+                 len(keys),
+                 None,
+             )
+-            self._pending_store_sizes[future_id] = (list(keys), per_key_sizes)
++            self._pending_store_sizes[future_id] = (
++                list(keys),
++                per_key_sizes,
++                reserved_bytes,
++            )
+ 
+         return task_id
+ 
+@@ -219,6 +254,83 @@ class NativeConnectorL2Adapter(L2AdapterInterface):
+             self._completed_stores = {}
+         return completed
+ 
++    def store_objects_sync(
++        self,
++        keys: list[ObjectKey],
++        objects: list[MemoryObj],
++        timeout: float | None = None,
++    ) -> tuple[bool, int, int]:
++        """Persist objects and wait for their native backend completion.
++
++        Returns ``(success, persisted_count, bytes_written)``. ``success`` is
++        true only when every key persisted, while the other fields account
++        for successful keys in a partially failed batch.
++        """
++        if len(keys) != len(objects):
++            raise ValueError("keys and objects length mismatch")
++        if not keys:
++            return True, 0, 0
++        if timeout is not None and timeout <= 0:
++            raise ValueError("timeout must be positive")
++
++        key_strings = [_object_key_to_string(key) for key in keys]
++        memviews = [_obj_to_memoryview(obj) for obj in objects]
++        per_key_sizes = [obj.get_size() for obj in objects]
++        reserved_bytes = sum(per_key_sizes)
++        done_event = threading.Event()
++        result: dict[str, Any] = {
++            "ok": False,
++            "persisted_count": 0,
++            "bytes_written": 0,
++        }
++
++        with self._lock:
++            task_id = self._get_next_task_id()
++            if not self._try_reserve_store_bytes(reserved_bytes):
++                logger.warning(
++                    "Rejected synchronous native L2 store of %d bytes: "
++                    "capacity would exceed %d bytes",
++                    reserved_bytes,
++                    self._max_capacity_bytes,
++                )
++                return False, 0, 0
++            try:
++                future_id = int(self._client.submit_batch_set(key_strings, memviews))
++            except Exception:
++                self._release_store_reservation(reserved_bytes)
++                raise
++            self._pending_ops[future_id] = (
++                self._OP_SYNC_STORE,
++                task_id,
++                len(keys),
++                None,
++            )
++            self._pending_store_sizes[future_id] = (
++                list(keys),
++                per_key_sizes,
++                reserved_bytes,
++            )
++            self._pending_sync_store_events[task_id] = (done_event, result)
++
++        wait_timeout = (
++            timeout if timeout is not None else max(30.0, min(300.0, len(keys) * 5.0))
++        )
++        if not done_event.wait(timeout=wait_timeout):
++            with self._lock:
++                self._pending_sync_store_events.pop(task_id, None)
++            logger.warning(
++                "store_objects_sync() timed out after %.1fs for %d keys",
++                wait_timeout,
++                len(keys),
++            )
++            return False, 0, 0
++
++        return (
++            bool(result["ok"]),
++            int(result["persisted_count"]),
++            int(result["bytes_written"]),
++        )
++
+     # ---------------------------------------------------------------
+     # Lookup and Lock Interface
+     # ---------------------------------------------------------------
+@@ -297,22 +409,46 @@ class NativeConnectorL2Adapter(L2AdapterInterface):
+         tracking stays in sync.
+ 
+         No-op if the connector does not expose ``submit_batch_delete``
+-        or if the key list is empty.
++        or if the key list is empty. Keys currently lookup-locked by an
++        in-flight prefetch are skipped: the load task would race the
++        unlink and fail with a phantom not_found.
+         """
+         if not keys or not self._has_delete:
+             return
+ 
+-        key_strings = [_object_key_to_string(k) for k in keys]
+         done_event = threading.Event()
+ 
+         with self._lock:
++            # A key becomes lookup-locked only when the native EXISTS
++            # completion is demultiplexed. Protect pending lookup keys as
++            # well, otherwise eviction can delete a key between lookup
++            # submission and lock acquisition. Filtering and delete submit
++            # stay in one critical section so a new lookup cannot enter that
++            # same gap.
++            protected_keys = set(self._locked_keys)
++            for op_type, _task_id, _num_keys, op_keys in self._pending_ops.values():
++                if op_type == self._OP_LOOKUP and op_keys is not None:
++                    protected_keys.update(op_keys)
++
++            delete_keys = [key for key in keys if key not in protected_keys]
++            skipped_count = len(keys) - len(delete_keys)
++            if skipped_count:
++                logger.info(
++                    "delete(): skipping %d lookup-pending or locked keys; %d remain",
++                    skipped_count,
++                    len(delete_keys),
++                )
++            if not delete_keys:
++                return
++
++            key_strings = [_object_key_to_string(k) for k in delete_keys]
+             task_id = self._get_next_task_id()
+             future_id = int(self._client.submit_batch_delete(key_strings))
+             self._pending_ops[future_id] = (
+                 self._OP_DELETE,
+                 task_id,
+-                len(keys),
+-                list(keys),
++                len(delete_keys),
++                delete_keys,
+             )
+             self._pending_delete_events[task_id] = done_event
+ 
+@@ -328,7 +464,7 @@ class NativeConnectorL2Adapter(L2AdapterInterface):
+                         break
+             logger.warning(
+                 "delete() timed out after 30s for %d keys",
+-                len(keys),
++                len(delete_keys),
+             )
+             return
+ 
+@@ -345,6 +481,52 @@ class NativeConnectorL2Adapter(L2AdapterInterface):
+     # Status Interface
+     # ---------------------------------------------------------------
+ 
++    def prime_existing_keys(
++        self,
++        keys: list[ObjectKey],
++        sizes: list[int],
++    ) -> None:
++        """Account durable objects discovered before adapter registration."""
++        if len(keys) != len(sizes):
++            raise ValueError("keys and sizes length mismatch")
++
++        unique: dict[ObjectKey, int] = {}
++        for key, size in zip(keys, sizes, strict=True):
++            if size <= 0:
++                raise ValueError("existing object sizes must be positive")
++            unique.setdefault(key, int(size))
++
++        primed_keys = list(unique)
++        primed_sizes = list(unique.values())
++        with self._lock:
++            if self._startup_primed:
++                raise RuntimeError("existing keys were already primed")
++            if self._listeners:
++                raise RuntimeError("existing keys must be primed before listeners")
++            self._startup_primed = True
++            self._key_sizes.update(unique)
++            self._startup_replay = (primed_keys, primed_sizes)
++
++        # No listener is registered during factory construction. This uses
++        # the common accounting implementation without retaining a second
++        # byte-accounting path in this adapter.
++        if primed_keys:
++            self._notify_keys_stored(primed_keys, primed_sizes)
++            logger.info(
++                "Startup scan primed %.2f GB in %d existing objects",
++                sum(primed_sizes) / 1e9,
++                len(primed_keys),
++            )
++
++    def register_listener(self, listener: L2AdapterListener) -> None:
++        """Register a listener and replay the one-time startup snapshot."""
++        with self._lock:
++            replay = self._startup_replay
++            self._startup_replay = None
++        if replay is not None and replay[0]:
++            listener.on_l2_keys_stored(*replay)
++        super().register_listener(listener)
++
+     def report_status(self) -> dict[str, Any]:
+         """Return a status dict for this native-connector L2 adapter.
+ 
+@@ -360,6 +542,7 @@ class NativeConnectorL2Adapter(L2AdapterInterface):
+         status: dict[str, Any] = {
+             "is_healthy": (self._demux_thread.is_alive() and not self._stop.is_set()),
+             "type": self._type_name,
++            "reserved_store_bytes": self.get_reserved_store_bytes(),
+         }
+         status.update(self._extra_status)
+         return status
+@@ -372,6 +555,22 @@ class NativeConnectorL2Adapter(L2AdapterInterface):
+         self._stop.set()
+         self._demux_thread.join(timeout=5)
+ 
++        with self._lock:
++            sync_events = [
++                event for event, _result in self._pending_sync_store_events.values()
++            ]
++            self._pending_sync_store_events.clear()
++            abandoned_reservations = sum(
++                reserved_bytes
++                for _keys, _sizes, reserved_bytes in self._pending_store_sizes.values()
++            )
++            self._pending_store_sizes.clear()
++            self._pending_ops.clear()
++        if abandoned_reservations:
++            self._release_store_reservation(abandoned_reservations)
++        for event in sync_events:
++            event.set()
++
+         self._client.close()
+ 
+         self._store_efd.close()
+@@ -420,11 +619,13 @@ class NativeConnectorL2Adapter(L2AdapterInterface):
+             keys_accessed: list[ObjectKey] = []
+             keys_deleted: list[ObjectKey] = []
+             sizes_deleted: list[int] = []
++            settled_store_reservations = 0
+             # Events for synchronous ``delete()`` callers. We set these
+             # AFTER firing ``_notify_keys_deleted`` below so that when
+             # the caller unblocks and calls ``get_usage()``, the base
+             # class's byte counters already reflect the deletion.
+             delete_done_events: list[threading.Event] = []
++            sync_store_done_events: list[threading.Event] = []
+ 
+             with self._lock:
+                 for (
+@@ -449,12 +650,31 @@ class NativeConnectorL2Adapter(L2AdapterInterface):
+                         lookup_keys,
+                     ) = entry
+ 
+-                    if op_type == self._OP_STORE:
++                    if op_type in (self._OP_STORE, self._OP_SYNC_STORE):
+                         store_info = self._pending_store_sizes.pop(fid, None)
+                         task_bytes = 0
+-                        if ok and store_info is not None:
+-                            store_keys, sizes = store_info
+-                            for key, size in zip(store_keys, sizes, strict=True):
++                        persisted_count = 0
++                        completion_ok = False
++                        if store_info is not None:
++                            store_keys, sizes, reserved_bytes = store_info
++                            settled_store_reservations += reserved_bytes
++                            if result_bools is None:
++                                stored_flags = [bool(ok)] * len(store_keys)
++                            else:
++                                stored_flags = [bool(value) for value in result_bools]
++                                if len(stored_flags) < len(store_keys):
++                                    stored_flags.extend(
++                                        [False] * (len(store_keys) - len(stored_flags))
++                                    )
++                                elif len(stored_flags) > len(store_keys):
++                                    stored_flags = stored_flags[: len(store_keys)]
++                            completion_ok = bool(ok) and all(stored_flags)
++                            for key, size, stored in zip(
++                                store_keys, sizes, stored_flags, strict=True
++                            ):
++                                if not stored:
++                                    continue
++                                persisted_count += 1
+                                 # First-store wins for byte accounting:
+                                 # a re-store of an existing key adds 0
+                                 # bytes (the backend already holds it).
+@@ -470,8 +690,21 @@ class NativeConnectorL2Adapter(L2AdapterInterface):
+                                 else:
+                                     keys_stored.append(key)
+                                     sizes_stored.append(0)
+-                        self._completed_stores[task_id] = L2StoreResult(ok, task_bytes)
+-                        self._store_efd.notify()
++                        if op_type == self._OP_STORE:
++                            self._completed_stores[task_id] = L2StoreResult(
++                                completion_ok, task_bytes
++                            )
++                            self._store_efd.notify()
++                        else:
++                            sync_entry = self._pending_sync_store_events.pop(
++                                task_id, None
++                            )
++                            if sync_entry is not None:
++                                sync_event, sync_result = sync_entry
++                                sync_result["ok"] = completion_ok
++                                sync_result["persisted_count"] = persisted_count
++                                sync_result["bytes_written"] = task_bytes
++                                sync_store_done_events.append(sync_event)
+ 
+                     elif op_type == self._OP_LOOKUP:
+                         bitmap = Bitmap(num_keys)
+@@ -519,10 +752,22 @@ class NativeConnectorL2Adapter(L2AdapterInterface):
+                         if evt is not None:
+                             delete_done_events.append(evt)
+ 
+-            # Fire listener notifications outside the lock so a slow
+-            # listener cannot stall further demux iterations.
++            # Release in-flight reservations and commit durable-byte
++            # accounting in one critical section before waking callers.
++            if settled_store_reservations or keys_stored:
++                self._settle_store_reservation(
++                    settled_store_reservations,
++                    keys_stored,
++                    sizes_stored,
++                )
++            for evt in sync_store_done_events:
++                evt.set()
++
++            # Observer callbacks remain outside the lock and after synchronous
++            # durability completion. A slow observer must not defeat a caller's
++            # store timeout after persistence and accounting have committed.
+             if keys_stored:
+-                self._notify_keys_stored(keys_stored, sizes_stored)
++                self._notify_keys_stored_listeners(keys_stored, sizes_stored)
+             if keys_accessed:
+                 self._notify_keys_accessed(keys_accessed)
+             if keys_deleted:
+diff --git a/lmcache/v1/distributed/storage_controllers/eviction_controller.py b/lmcache/v1/distributed/storage_controllers/eviction_controller.py
+index 8624207de385ab334a102852b6d1b7c19d3182b0..899d8bf2166c2451fde6605dc839fa912e0e22f5 100644
+--- a/lmcache/v1/distributed/storage_controllers/eviction_controller.py
++++ b/lmcache/v1/distributed/storage_controllers/eviction_controller.py
+@@ -6,7 +6,10 @@ from __future__ import annotations
+ # Standard
+ from abc import abstractmethod
+ from collections import Counter
++from enum import Enum, auto
+ from typing import TYPE_CHECKING
++import inspect
++import math
+ import threading
+ import time
+ 
+@@ -16,6 +19,7 @@ from lmcache.v1.distributed.api import ObjectKey
+ from lmcache.v1.distributed.config import EvictionConfig
+ from lmcache.v1.distributed.eviction import L1EvictionPolicy, L2EvictionPolicy
+ from lmcache.v1.distributed.eviction_policy import CreateEvictionPolicy
++from lmcache.v1.distributed.error import L1Error
+ from lmcache.v1.distributed.internal_api import (
+     EvictionAction,
+     EvictionDestination,
+@@ -33,6 +37,12 @@ if TYPE_CHECKING:
+ logger = init_logger(__name__)
+ 
+ 
++class _SyncFlushResult(Enum):
++    SUCCESS = auto()
++    FAILURE = auto()
++    DEADLINE_EXHAUSTED = auto()
++
++
+ class EvictionController(StorageControllerInterface):
+     """
+     Abstract base class for eviction controllers.
+@@ -92,12 +102,33 @@ class L1EvictionController(EvictionController):
+     Uses an L1EvictionPolicy bridge to keep the eviction policy up-to-date
+     with L1 manager events, and periodically triggers eviction based on
+     L1 memory usage.
++
++    With ``EvictionConfig.write_back_on_evict`` enabled and L2 adapters
++    injected via ``set_l2_adapters``, eviction actions target
++    ``EvictionDestination.L2_CACHE``: readable objects are synchronously
++    persisted to L2 in bounded batches and deleted from L1 only once every
++    key in the batch is durable. Repeated flush failures open a circuit
++    breaker that pauses write-back instead of retrying every second.
++
++    ``EvictionConfig.periodic_flush_interval`` additionally enables a
++    below-watermark backup flush that copies evictable L1 keys to L2
++    without deleting them from L1.
+     """
+ 
++    # Bounded batches keep each blocking sync-store call short.
++    _SYNC_FLUSH_BATCH_SIZE = 128
++    # Keys per periodic backup flush cycle.
++    _BACKUP_FLUSH_BATCH_SIZE = 128
++    # A prefetch request must not stall the controller indefinitely on L2.
++    _EMERGENCY_FLUSH_TIMEOUT_SECONDS = 1.0
++    # Periodic backup runs under the flush lock and must remain stoppable.
++    _PERIODIC_FLUSH_TIMEOUT_SECONDS = 5.0
++
+     def __init__(
+         self,
+         l1_manager: L1Manager,
+         eviction_config: EvictionConfig,
++        l2_adapters: dict[int, L2AdapterInterface] | None = None,
+     ):
+         super().__init__()
+         self._eviction_config = eviction_config
+@@ -108,13 +139,101 @@ class L1EvictionController(EvictionController):
+         self._event_bus = get_event_bus()
+         self._last_extra_log = time.monotonic()
+ 
++        self._write_back_enabled = bool(eviction_config.write_back_on_evict)
++        self._l2_adapters: dict[int, L2AdapterInterface] = {}
++        self._l2_adapter_supports_timeout: dict[int, bool] = {}
++        self._l2_adapters_lock = threading.Lock()
++        # Serializes all synchronous L2 flushes and adapter-set replacement.
++        # StorageManager can therefore remove an adapter only after any L1
++        # writeback currently using it has finished.
++        self._flush_lock = threading.Lock()
++        # Sync-flush circuit breaker: a dead L2 must not cause a
++        # multi-thousand-key synchronous retry and warning storm every
++        # second.
++        self._sync_flush_failures: int = 0
++        self._sync_flush_backoff_until: float = 0.0
++        self._last_backup_flush = time.monotonic()
++        self._backup_flush_cursor: int = 0
++        # Serializes emergency evictions from concurrent callers.
++        self._emergency_evict_lock = threading.Lock()
++        if self._write_back_enabled:
++            # Writeback must fail closed. Register the L2 destination even
++            # before a compatible adapter exists so policy never falls back
++            # to DISCARD when persistence is unavailable.
++            self._eviction_policy.register_eviction_destination(
++                EvictionDestination.L2_CACHE
++            )
++        if l2_adapters:
++            self.set_l2_adapters(l2_adapters)
++
++    def set_l2_adapters(self, l2_adapters: dict[int, L2AdapterInterface]) -> None:
++        """Late-inject L2 adapters after StorageManager creates them.
++
++        Only adapters with an explicit synchronous durability contract are
++        eligible. The L2 eviction destination itself is registered at
++        construction so enabled writeback always fails closed.
++        """
++        compatible: dict[int, L2AdapterInterface] = {}
++        supports_timeout: dict[int, bool] = {}
++        for adapter_id, adapter in l2_adapters.items():
++            sync_store = getattr(adapter, "store_objects_sync", None)
++            if not callable(sync_store):
++                continue
++            compatible[adapter_id] = adapter
++            try:
++                supports_timeout[adapter_id] = (
++                    "timeout" in inspect.signature(sync_store).parameters
++                )
++            except (TypeError, ValueError):
++                supports_timeout[adapter_id] = False
++        ignored = sorted(set(l2_adapters) - set(compatible))
++        if ignored:
++            logger.warning(
++                "L1 writeback ignored adapters without store_objects_sync: %s",
++                ignored,
++            )
++        with self._flush_lock:
++            with self._l2_adapters_lock:
++                self._l2_adapters = compatible
++                self._l2_adapter_supports_timeout = supports_timeout
++
++    def has_l2_flush_adapter(self) -> bool:
++        """Return whether a synchronous durability backend is available."""
++        return bool(self._snapshot_l2_adapters())
++
++    def _snapshot_l2_adapters(self) -> list[tuple[int, L2AdapterInterface]]:
++        with self._l2_adapters_lock:
++            return list(self._l2_adapters.items())
++
++    def _snapshot_l2_flush_adapters(
++        self,
++    ) -> list[tuple[int, L2AdapterInterface, bool]]:
++        with self._l2_adapters_lock:
++            return [
++                (
++                    adapter_id,
++                    adapter,
++                    self._l2_adapter_supports_timeout.get(adapter_id, False),
++                )
++                for adapter_id, adapter in self._l2_adapters.items()
++            ]
++
+     def report_status(self) -> dict:
++        adapters = self._snapshot_l2_adapters()
+         return {
+             "is_healthy": self._thread.is_alive(),
+             "thread_alive": self._thread.is_alive(),
+             "eviction_policy": self._eviction_config.eviction_policy,
+             "trigger_watermark": self._eviction_config.trigger_watermark,
+             "eviction_ratio": self._eviction_config.eviction_ratio,
++            "write_back_enabled": self._write_back_enabled,
++            "l2_flush_enabled": bool(adapters),
++            "l2_flush_adapter_ids": [adapter_id for adapter_id, _ in adapters],
++            "periodic_flush_interval": (self._eviction_config.periodic_flush_interval),
++            "sync_flush_failures": self._sync_flush_failures,
++            "sync_flush_backoff_seconds": max(
++                0.0, self._sync_flush_backoff_until - time.monotonic()
++            ),
+         }
+ 
+     def _publish_skipped(self, usage: float, watermark: float) -> None:
+@@ -160,6 +279,7 @@ class L1EvictionController(EvictionController):
+     def eviction_loop(self):
+         watermark = self._eviction_config.trigger_watermark
+         eviction_ratio = self._eviction_config.eviction_ratio
++        backup_interval = self._eviction_config.periodic_flush_interval
+ 
+         while not self._stop_flag.is_set():
+             time.sleep(1)
+@@ -168,6 +288,13 @@ class L1EvictionController(EvictionController):
+                 self._maybe_log_memory_usage(used_bytes, total_bytes)
+             usage = 0 if total_bytes == 0 else used_bytes / total_bytes
+             if usage < watermark:
++                if (
++                    backup_interval > 0
++                    and self._snapshot_l2_adapters()
++                    and time.monotonic() - self._last_backup_flush >= backup_interval
++                ):
++                    self._last_backup_flush = time.monotonic()
++                    self._backup_to_l2_no_delete(self._BACKUP_FLUSH_BATCH_SIZE)
+                 logger.debug(
+                     "L1 memory usage %.2f below watermark %.2f; skipping eviction.",
+                     usage,
+@@ -176,6 +303,13 @@ class L1EvictionController(EvictionController):
+                 self._publish_skipped(usage, watermark)
+                 continue
+ 
++            if (
++                self._write_back_enabled
++                and time.monotonic() < self._sync_flush_backoff_until
++            ):
++                self._publish_skipped(usage, watermark)
++                continue
++
+             logger.info(
+                 "L1 memory usage %.2f above watermark %.2f; triggering eviction.",
+                 usage,
+@@ -190,13 +324,340 @@ class L1EvictionController(EvictionController):
+             self._publish_triggered(usage, watermark)
+ 
+     def execute_eviction_action(self, action: EvictionAction):
+-        if action.destination == EvictionDestination.DISCARD:
++        if action.destination == EvictionDestination.L2_CACHE:
++            self._flush_to_l2_then_delete(action.keys)
++        elif action.destination == EvictionDestination.DISCARD:
+             self._l1_manager.delete(action.keys)
+         else:
+             logger.error("Unsupported eviction destination: %s", action.destination)
+             logger.error("Treating it as DISCARD.")
+             self._l1_manager.delete(action.keys)
+ 
++    def emergency_evict_bytes(self, target_free_bytes: int, requester: str = "") -> int:
++        """Synchronously evict LRU L1 keys until at least
++        ``target_free_bytes`` bytes are free.
++
++        Victims take the normal eviction path, so with write-back enabled
++        they are flushed to L2 before deletion. Intended for the prefetch
++        controller when a large L2-to-L1 restore cannot reserve L1 buffers.
++
++        Args:
++            target_free_bytes: The free-space goal in bytes.
++            requester: Optional label for logging.
++
++        Returns:
++            The free byte count after eviction.
++        """
++        deadline = time.monotonic() + self._EMERGENCY_FLUSH_TIMEOUT_SECONDS
++        if not self._emergency_evict_lock.acquire(
++            timeout=self._EMERGENCY_FLUSH_TIMEOUT_SECONDS
++        ):
++            used, total = self._l1_manager.get_memory_usage()
++            return max(0, total - used)
++        try:
++            used, total = self._l1_manager.get_memory_usage()
++            free = max(0, total - used)
++            if free >= target_free_bytes:
++                return free
++            deficit = target_free_bytes - free
++            num_objects = self._l1_manager.num_objects()
++            if num_objects <= 0:
++                return free
++            if self._write_back_enabled and (
++                time.monotonic() < self._sync_flush_backoff_until
++                or not self.has_l2_flush_adapter()
++            ):
++                return free
++            per_key = max(1, used // num_objects)
++            need_keys = math.ceil(deficit / per_key)
++            need_keys += max(1, math.ceil(need_keys / 8))
++            tracked = num_objects
++            get_tracked = getattr(self._eviction_policy, "get_num_tracked_keys", None)
++            if callable(get_tracked):
++                tracked = max(1, int(get_tracked()))
++            ratio = min(1.0, need_keys / max(tracked, 1))
++            start = time.monotonic()
++            actions = self._eviction_policy.get_eviction_actions(
++                ratio,
++                key_eligible_filter=self._l1_manager.is_key_evictable,
++            )
++            evicted_keys = 0
++            for action in actions:
++                evicted_keys += len(action.keys)
++                if action.destination == EvictionDestination.L2_CACHE:
++                    self._flush_to_l2_then_delete(action.keys, deadline=deadline)
++                else:
++                    self.execute_eviction_action(action)
++                if time.monotonic() >= deadline:
++                    break
++            used_after, total_after = self._l1_manager.get_memory_usage()
++            free_after = max(0, total_after - used_after)
++            logger.info(
++                "Emergency L1 eviction%s: wanted %.0f MB free, evicted %d "
++                "keys in %.0f ms; free %.0f MB -> %.0f MB",
++                (" for " + requester) if requester else "",
++                target_free_bytes / 1e6,
++                evicted_keys,
++                (time.monotonic() - start) * 1000.0,
++                free / 1e6,
++                free_after / 1e6,
++            )
++            return free_after
++        finally:
++            self._emergency_evict_lock.release()
++
++    def _flush_to_l2_then_delete(
++        self,
++        keys: list[ObjectKey],
++        deadline: float | None = None,
++    ) -> None:
++        """Persist bounded batches to L2 and delete only fully durable
++        batches from L1.
++
++        The native adapter reports a store successful only when every key
++        persisted, so this method conservatively retains the whole readable
++        batch on any partial failure. Repeated failures open the circuit
++        breaker with exponential backoff.
++        """
++        if deadline is None:
++            self._flush_lock.acquire()
++        else:
++            remaining = deadline - time.monotonic()
++            if remaining <= 0 or not self._flush_lock.acquire(timeout=remaining):
++                return
++        try:
++            if not keys:
++                return
++            if time.monotonic() < self._sync_flush_backoff_until:
++                return
++
++            all_ok = True
++            deadline_exhausted = False
++            for start in range(0, len(keys), self._SYNC_FLUSH_BATCH_SIZE):
++                if deadline is not None and time.monotonic() >= deadline:
++                    deadline_exhausted = True
++                    break
++                batch = keys[start : start + self._SYNC_FLUSH_BATCH_SIZE]
++                result = self._flush_one_l2_batch_then_delete(batch, deadline=deadline)
++                if result == _SyncFlushResult.DEADLINE_EXHAUSTED:
++                    deadline_exhausted = True
++                    break
++                if result == _SyncFlushResult.FAILURE:
++                    all_ok = False
++                    break
++
++            if deadline_exhausted:
++                logger.debug(
++                    "L1-to-L2 emergency flush exhausted its time budget; "
++                    "remaining L1 keys preserved"
++                )
++            elif all_ok:
++                self._sync_flush_failures = 0
++                self._sync_flush_backoff_until = 0.0
++            else:
++                self._sync_flush_failures += 1
++                delay = min(60.0, float(2 ** min(self._sync_flush_failures, 6)))
++                self._sync_flush_backoff_until = time.monotonic() + delay
++                logger.warning(
++                    "L1-to-L2 flush circuit breaker: failure=%d, retry in %.0fs; "
++                    "remaining L1 keys preserved",
++                    self._sync_flush_failures,
++                    delay,
++                )
++        finally:
++            self._flush_lock.release()
++
++    def _flush_one_l2_batch_then_delete(
++        self,
++        keys: list[ObjectKey],
++        deadline: float | None = None,
++    ) -> _SyncFlushResult:
++        """Flush one batch to L2; delete from L1 only when fully durable.
++
++        Returns:
++            SUCCESS when every readable key was persisted (or none were
++            readable), FAILURE for an actual persistence failure, and
++            DEADLINE_EXHAUSTED when an emergency flush consumed its budget.
++        """
++        if not keys:
++            return _SyncFlushResult.SUCCESS
++
++        read_result = self._l1_manager.reserve_read(keys)
++        readable_keys: list[ObjectKey] = []
++        readable_objs = []
++        for key in keys:
++            entry = read_result.get(key)
++            if (
++                entry is not None
++                and entry[0] == L1Error.SUCCESS
++                and entry[1] is not None
++            ):
++                readable_keys.append(key)
++                readable_objs.append(entry[1])
++
++        flushed = not readable_keys
++        deadline_exhausted = False
++        if readable_keys:
++            try:
++                for (
++                    idx,
++                    adapter,
++                    supports_timeout,
++                ) in self._snapshot_l2_flush_adapters():
++                    sync_store = adapter.store_objects_sync
++                    try:
++                        if deadline is None:
++                            result = sync_store(readable_keys, readable_objs)
++                        else:
++                            remaining = deadline - time.monotonic()
++                            if remaining <= 0:
++                                deadline_exhausted = True
++                                break
++                            if not supports_timeout:
++                                logger.warning(
++                                    "Emergency L1 writeback skipped adapter %d: "
++                                    "store_objects_sync has no timeout contract",
++                                    idx,
++                                )
++                                continue
++                            result = sync_store(
++                                readable_keys,
++                                readable_objs,
++                                timeout=remaining,
++                            )
++                        ok, persisted_count, bytes_written = result
++                    except Exception:
++                        if deadline is not None and time.monotonic() >= deadline:
++                            deadline_exhausted = True
++                            break
++                        logger.exception(
++                            "L1-to-L2 flush: sync store failed on adapter %d", idx
++                        )
++                        continue
++                    if not ok and deadline is not None and time.monotonic() >= deadline:
++                        deadline_exhausted = True
++                        break
++                    # Never delete unless every readable key is durable.
++                    if ok and persisted_count == len(readable_keys):
++                        flushed = True
++                        logger.info(
++                            "L1-to-L2 flush: sync persisted %d/%d keys "
++                            "(%d bytes) via adapter %d",
++                            persisted_count,
++                            len(readable_keys),
++                            bytes_written,
++                            idx,
++                        )
++                        break
++                    logger.warning(
++                        "L1-to-L2 flush: adapter %d partial/failed persist "
++                        "(%d/%d keys, %d bytes)",
++                        idx,
++                        persisted_count,
++                        len(readable_keys),
++                        bytes_written,
++                    )
++            finally:
++                self._l1_manager.finish_read(readable_keys)
++
++        # Only keys we read and then fully persisted may be deleted. A key
++        # that failed reserve_read can have become locked after candidate
++        # selection and must never be treated as absent.
++        keys_to_delete = list(readable_keys) if flushed else []
++        if not flushed and readable_keys:
++            logger.warning(
++                "L1-to-L2 flush: preserving %d readable keys after failed persist",
++                len(readable_keys),
++            )
++
++        if keys_to_delete:
++            result = self._l1_manager.delete(keys_to_delete)
++            not_deleted = [k for k, err in result.items() if err != L1Error.SUCCESS]
++            if not_deleted:
++                logger.debug(
++                    "L1-to-L2 flush: %d keys not deleted, likely still locked",
++                    len(not_deleted),
++                )
++        if deadline_exhausted:
++            return _SyncFlushResult.DEADLINE_EXHAUSTED
++        if flushed:
++            return _SyncFlushResult.SUCCESS
++        return _SyncFlushResult.FAILURE
++
++    def _backup_to_l2_no_delete(self, batch_limit: int) -> None:
++        """Flush evictable L1 keys to L2 without deleting them from L1.
++
++        A backup, not an eviction: keys remain in L1 for fast access while
++        L2 gains a copy, so losing L1 (session expiry, restart) no longer
++        costs a cold prefill. A rotating cursor spreads repeated scans over
++        the whole L1 keyspace instead of hammering the first ``batch_limit``
++        insertion-ordered keys forever. Adapters skip keys they already
++        hold, so the flush is idempotent.
++        """
++        with self._flush_lock:
++            self._backup_to_l2_no_delete_locked(batch_limit)
++
++    def _backup_to_l2_no_delete_locked(self, batch_limit: int) -> None:
++        """Implementation of periodic backup under ``_flush_lock``."""
++        batch, self._backup_flush_cursor = self._l1_manager.get_evictable_keys(
++            limit=batch_limit,
++            cursor=self._backup_flush_cursor,
++        )
++        if not batch:
++            return
++
++        read_result = self._l1_manager.reserve_read(batch)
++        readable_keys: list[ObjectKey] = []
++        readable_objs = []
++        for key in batch:
++            entry = read_result.get(key)
++            if (
++                entry is not None
++                and entry[0] == L1Error.SUCCESS
++                and entry[1] is not None
++            ):
++                readable_keys.append(key)
++                readable_objs.append(entry[1])
++
++        if not readable_keys:
++            return
++
++        persisted_keys = 0
++        persisted_bytes = 0
++        try:
++            for idx, adapter, supports_timeout in self._snapshot_l2_flush_adapters():
++                if not supports_timeout:
++                    logger.warning(
++                        "Periodic L2 backup skipped adapter %d: "
++                        "store_objects_sync has no timeout contract",
++                        idx,
++                    )
++                    continue
++                sync_store = adapter.store_objects_sync
++                try:
++                    ok, persisted, written = sync_store(
++                        readable_keys,
++                        readable_objs,
++                        timeout=self._PERIODIC_FLUSH_TIMEOUT_SECONDS,
++                    )
++                    if ok and persisted == len(readable_keys):
++                        persisted_keys = persisted
++                        persisted_bytes = written
++                        break
++                except Exception:
++                    logger.exception("Periodic L2 backup: sync store failed on %d", idx)
++        finally:
++            self._l1_manager.finish_read(readable_keys)
++
++        if persisted_bytes > 0:
++            logger.info(
++                "Periodic L2 backup: persisted %d keys (%d new bytes, "
++                "%d evictable in L1, none deleted)",
++                persisted_keys,
++                persisted_bytes,
++                len(batch),
++            )
++
+ 
+ class L2AdapterEvictionState:
+     """Per-adapter eviction state: its own policy, listener, and config."""
+diff --git a/lmcache/v1/distributed/storage_controllers/prefetch_controller.py b/lmcache/v1/distributed/storage_controllers/prefetch_controller.py
+index 2138a33aa01ce95d7926bd4f6bcda79ae7d1955a..46239e518abaee70412223ec76eaa89f934a4bbe 100644
+--- a/lmcache/v1/distributed/storage_controllers/prefetch_controller.py
++++ b/lmcache/v1/distributed/storage_controllers/prefetch_controller.py
+@@ -55,6 +55,9 @@ from lmcache.v1.platform import (
+ 
+ if TYPE_CHECKING:
+     # First Party
++    from lmcache.v1.distributed.storage_controllers.eviction_controller import (
++        L1EvictionController,
++    )
+     from lmcache.v1.memory_management import MemoryObj
+ 
+ logger = init_logger(__name__)
+@@ -121,6 +124,17 @@ def trim_load_plan_with_mask(
+     return trimmed_plan
+ 
+ 
++def _layout_nbytes(layout_desc: MemoryLayoutDesc) -> int:
++    """Return the byte size of one object with the given layout."""
++    total = 0
++    for shape, dtype in zip(layout_desc.shapes, layout_desc.dtypes, strict=True):
++        numel = 1
++        for dim in shape:
++            numel *= int(dim)
++        total += numel * dtype.itemsize
++    return total
++
++
+ # Poll timeout in milliseconds for the prefetch loop
+ PREFETCH_LOOP_POLL_TIMEOUT_MS = 500
+ 
+@@ -227,6 +241,11 @@ class PrefetchController(StorageControllerInterface):
+         self._policy = policy
+         self._max_in_flight = max_in_flight
+ 
++        # Optional L1 eviction controller for emergency make-room before
++        # large restores; injected by StorageManager when
++        # EvictionConfig.emergency_evict_for_prefetch is enabled.
++        self._l1_eviction_controller: "L1EvictionController | None" = None
++
+         # Adapters that are being drained and will be removed after all
+         # the in-flight operations are done.
+         self._draining: dict[int, threading.Event] = {}
+@@ -847,6 +866,25 @@ class PrefetchController(StorageControllerInterface):
+     # =========================================================================
+     # Load phase
+     # =========================================================================
++    def _select_l1_retentions(
++        self,
++        request_id: int,
++        keys: list[ObjectKey],
++    ) -> list[bool]:
++        """Return one retention decision per key, degrading safely on a
++        malformed policy result."""
++        retentions = self._policy.select_l1_retentions(keys)
++        if len(retentions) != len(keys):
++            logger.error(
++                "Prefetch request %d: policy returned %d retentions for "
++                "%d keys; defaulting to temporary entries",
++                request_id,
++                len(retentions),
++                len(keys),
++            )
++            return [False] * len(keys)
++        return retentions
++
+     def _transition_to_load_phase(self, request: InFlightPrefetchRequest) -> None:
+         """Compute load plan, reserve L1 buffers, and submit load tasks."""
+         request.phase = PrefetchPhase.PLAN_AND_LOAD
+@@ -899,15 +937,23 @@ class PrefetchController(StorageControllerInterface):
+         if request.mode is PrefetchMode.WARM:
+             retentions = [True] * len(keys_to_reserve)
+         else:
+-            retentions = self._policy.select_l1_retentions(
++            retentions = self._select_l1_retentions(
++                request.request_id,
+                 keys_to_reserve,
+             )
++            # Non-WARM only: a WARM warm-up must never trigger emergency
++            # eviction of other sessions' chunks.
++            self._make_room_for_restore(request, keys_to_reserve)
+         write_results = l1_mgr.reserve_write(
+             keys=keys_to_reserve,
+             is_temporary=[not r for r in retentions],
+             layout_desc=request.layout_desc,
+             mode="new",
+         )
++        if request.mode is not PrefetchMode.WARM:
++            write_results = self._retry_oom_reservations(
++                request, keys_to_reserve, retentions, write_results
++            )
+ 
+         # Step 4: filter to successfully reserved keys
+         reserved_key_set: set[ObjectKey] = set()
+@@ -1038,6 +1084,123 @@ class PrefetchController(StorageControllerInterface):
+             len(reserved_key_set),
+         )
+ 
++    def set_l1_eviction_controller(
++        self,
++        controller: "L1EvictionController | None",
++    ) -> None:
++        """Enable emergency L1 eviction for large restores.
++
++        With a controller injected, a non-WARM restore that would not fit
++        in free L1 space synchronously evicts LRU keys (write-back first)
++        before reserving, and retries OOM reservations once. Pass ``None``
++        after the last synchronous L2 adapter is removed to disable this path.
++        """
++        self._l1_eviction_controller = controller
++
++    # Never let a single restore claim more than this fraction of L1: a
++    # huge context must not wipe every hot chunk of the running sessions.
++    _EMERGENCY_EVICT_MAX_L1_FRACTION = 0.6
++    # Headroom per object for alignment and allocator bookkeeping.
++    _PER_OBJECT_HEADROOM_BYTES = 8192
++
++    def _make_room_for_restore(
++        self,
++        request: InFlightPrefetchRequest,
++        keys_to_reserve: list[ObjectKey],
++    ) -> None:
++        """Pre-evict LRU L1 chunks so the upcoming reserve_write for this
++        restore can succeed. No-op unless an eviction controller was
++        injected via ``set_l1_eviction_controller``."""
++        evictor = self._l1_eviction_controller
++        if evictor is None or not keys_to_reserve:
++            return
++        per_obj = _layout_nbytes(request.layout_desc)
++        if per_obj <= 0:
++            return
++        used, total = self._l1_manager.get_memory_usage()
++        need = (per_obj + self._PER_OBJECT_HEADROOM_BYTES) * len(keys_to_reserve)
++        need = min(need, int(total * self._EMERGENCY_EVICT_MAX_L1_FRACTION))
++        free = max(0, total - used)
++        if free >= need:
++            return
++        try:
++            evictor.emergency_evict_bytes(
++                need, requester=f"prefetch_request={request.request_id}"
++            )
++        except Exception:
++            logger.exception(
++                "Emergency eviction failed for prefetch request %d",
++                request.request_id,
++            )
++
++    def _retry_oom_reservations(
++        self,
++        request: InFlightPrefetchRequest,
++        keys_to_reserve: list[ObjectKey],
++        retentions: list[bool],
++        write_results: dict[ObjectKey, tuple[L1Error, "MemoryObj | None"]],
++    ) -> dict[ObjectKey, tuple[L1Error, "MemoryObj | None"]]:
++        """One retry round for keys whose reservation failed with
++        OUT_OF_MEMORY: evict the missing amount, reserve just those keys
++        again, and merge the results. No-op unless an eviction controller
++        was injected."""
++        evictor = self._l1_eviction_controller
++        if evictor is None:
++            return write_results
++        oom_keys: list[ObjectKey] = []
++        retention_by_key = dict(zip(keys_to_reserve, retentions, strict=True))
++        for key in keys_to_reserve:
++            entry = write_results.get(key)
++            if entry is None:
++                oom_keys.append(key)
++                continue
++            err, mem_obj = entry
++            if err == L1Error.OUT_OF_MEMORY or (
++                err == L1Error.SUCCESS and mem_obj is None
++            ):
++                oom_keys.append(key)
++        if not oom_keys:
++            return write_results
++        per_obj = _layout_nbytes(request.layout_desc)
++        if per_obj <= 0:
++            return write_results
++        _, total = self._l1_manager.get_memory_usage()
++        need = (per_obj + self._PER_OBJECT_HEADROOM_BYTES) * len(oom_keys)
++        need = min(need, int(total * self._EMERGENCY_EVICT_MAX_L1_FRACTION))
++        try:
++            evictor.emergency_evict_bytes(
++                need, requester=f"prefetch_request={request.request_id}/retry"
++            )
++        except Exception:
++            logger.exception(
++                "Emergency eviction retry failed for prefetch request %d",
++                request.request_id,
++            )
++            return write_results
++        retry_results = self._l1_manager.reserve_write(
++            keys=oom_keys,
++            is_temporary=[not retention_by_key[k] for k in oom_keys],
++            layout_desc=request.layout_desc,
++            mode="new",
++        )
++        recovered = sum(
++            1
++            for k in oom_keys
++            if retry_results.get(k)
++            and retry_results[k][0] == L1Error.SUCCESS
++            and retry_results[k][1] is not None
++        )
++        if recovered:
++            logger.info(
++                "Retry recovered %d/%d OOM reservations for prefetch request %d",
++                recovered,
++                len(oom_keys),
++                request.request_id,
++            )
++        merged = dict(write_results)
++        merged.update(retry_results)
++        return merged
++
+     def _update_lookup_results(
+         self, request_id: PrefetchRequestId, prefix_hit_count: int
+     ) -> None:
+@@ -1181,6 +1344,17 @@ class PrefetchController(StorageControllerInterface):
+         # added once the serde PR lands and adapters can distinguish
+         # deserialization errors from missing objects.
+         if failed_keys:
++            # These keys were reported present by the L2 lookup but the load
++            # returned no data. Sample a few so the on-disk state can be
++            # inspected post hoc.
++            logger.warning(
++                "Prefetch request %d: %d/%d plan keys failed to load from "
++                "L2 (lookup hit, load empty); sample: %s",
++                request.request_id,
++                len(failed_keys),
++                len(request.write_reserved_keys),
++                [str(k)[:160] for k in failed_keys[:3]],
++            )
+             self._event_bus.publish(
+                 Event(
+                     event_type=EventType.L2_PREFETCH_FAILED,
+diff --git a/lmcache/v1/distributed/storage_manager.py b/lmcache/v1/distributed/storage_manager.py
+index 3054e2441c5c7d98d817ca7a1f9ac30b4a7e92d7..a7da312a475264ddd1c829ad73937fc103cbf1a8 100644
+--- a/lmcache/v1/distributed/storage_manager.py
++++ b/lmcache/v1/distributed/storage_manager.py
+@@ -66,6 +66,7 @@ logger = init_logger(__name__)
+ 
+ class StorageManager:
+     def __init__(self, config: StorageManagerConfig):
++        self._eviction_config = config.eviction_config
+         self._l1_manager = L1Manager(config.l1_manager_config)
+         self._event_bus = get_event_bus()
+ 
+@@ -154,6 +155,31 @@ class StorageManager:
+         )
+         self._prefetch_controller.start()
+ 
++        # Opt-in L1 write-back tier: wire L2 adapters into the L1 eviction
++        # controller so evicted or periodically backed-up chunks are flushed
++        # to L2, and optionally let the prefetch controller trigger
++        # emergency eviction to make room for large restores.
++        eviction_config = config.eviction_config
++        wants_l1_write_back = (
++            eviction_config.write_back_on_evict
++            or eviction_config.periodic_flush_interval > 0
++        )
++        if wants_l1_write_back:
++            self._sync_l1_writeback_adapters()
++            if not self._eviction_controller.has_l2_flush_adapter():
++                logger.warning(
++                    "write_back_on_evict / periodic_flush_interval is set but "
++                    "no L2 adapter exposes store_objects_sync"
++                )
++        if (
++            eviction_config.emergency_evict_for_prefetch
++            and not self._eviction_controller.has_l2_flush_adapter()
++        ):
++            logger.warning(
++                "emergency_evict_for_prefetch has no synchronous L2 "
++                "adapter; inactive until one is added"
++            )
++
+         # L2 usage gauge — one observation per adapter, tagged by
+         # ``l2_name``.  Parallel to L1Manager's ``l1_memory_usage_bytes``.
+         register_gauge(
+@@ -904,6 +930,7 @@ class StorageManager:
+             with self._adapters_lock:
+                 self._l2_adapters[adapter_id] = adapter
+                 self._adapter_descriptors[adapter_id] = descriptor
++            self._sync_l1_writeback_adapters()
+             self._store_controller.add_adapter(adapter_id, adapter, descriptor)
+             self._prefetch_controller.add_adapter(adapter_id, adapter, descriptor)
+             if self._should_enable_l2_eviction(adapter, config.eviction_config):
+@@ -956,6 +983,9 @@ class StorageManager:
+             with self._adapters_lock:
+                 adapter = self._l2_adapters.pop(adapter_id)
+                 self._adapter_descriptors.pop(adapter_id, None)
++            # Waits for any synchronous L1 flush using the removed adapter
++            # before adapter.close() releases its native resources.
++            self._sync_l1_writeback_adapters()
+             adapter.close()
+             logger.info("Deleted L2 adapter %d", adapter_id)
+ 
+@@ -1121,6 +1151,21 @@ class StorageManager:
+             return False
+         return True
+ 
++    def _sync_l1_writeback_adapters(self) -> None:
++        """Publish the current adapter set to the optional L1 writeback tier."""
++        config = self._eviction_config
++        if not (config.write_back_on_evict or config.periodic_flush_interval > 0):
++            return
++        with self._adapters_lock:
++            adapters = dict(self._l2_adapters)
++        self._eviction_controller.set_l2_adapters(adapters)
++        if config.emergency_evict_for_prefetch:
++            self._prefetch_controller.set_l1_eviction_controller(
++                self._eviction_controller
++                if self._eviction_controller.has_l2_flush_adapter()
++                else None
++            )
++
+     def _unwrap_reconfigurable_l2_adapter(
+         self,
+         adapter: L2AdapterInterface,
+diff --git a/lmcache/v1/multiprocess/futures.py b/lmcache/v1/multiprocess/futures.py
+index beadae5505e4062d95b3e5f083d8e72b6bdf06d1..ab5195eec56aa3fcd9b52550aac52dc6133680b4 100644
+--- a/lmcache/v1/multiprocess/futures.py
++++ b/lmcache/v1/multiprocess/futures.py
+@@ -14,6 +14,7 @@ class MessagingFuture(Generic[T]):
+     def __init__(self):
+         self.is_done_ = threading.Event()
+         self.result_ = None
++        self.exception_: BaseException | None = None
+ 
+     def query(self) -> bool:
+         """
+@@ -54,6 +55,8 @@ class MessagingFuture(Generic[T]):
+         flag = self.wait(timeout)
+         if not flag:
+             raise LMCacheTimeoutError("Future result not available within timeout")
++        if self.exception_ is not None:
++            raise self.exception_
+         return self.result_
+ 
+     def set_result(self, result: T) -> None:
+@@ -68,6 +71,13 @@ class MessagingFuture(Generic[T]):
+         self.result_ = result
+         self.is_done_.set()
+ 
++    def set_exception(self, exception: BaseException) -> None:
++        """Complete the future with an exception from the messaging system."""
++        if not isinstance(exception, BaseException):
++            raise TypeError("exception must derive from BaseException")
++        self.exception_ = exception
++        self.is_done_.set()
++
+     def to_cuda_future(
+         self,
+         device: Any | None = None,
+diff --git a/lmcache/v1/multiprocess/mq.py b/lmcache/v1/multiprocess/mq.py
+index 271ff93b2a933f6c0f70f95a95d6f2249e7636c1..a5d0d0cf7322a523a9a8b89a0c5af2e2466109b1 100644
+--- a/lmcache/v1/multiprocess/mq.py
++++ b/lmcache/v1/multiprocess/mq.py
+@@ -40,6 +40,26 @@ T = TypeVar("T")
+ # Internal type used for the client-server communication
+ RequestUID = int
+ 
++_ERROR_RESPONSE_MARKER = b"LMCACHE_RPC_ERROR_V1"
++_MAX_REMOTE_ERROR_MESSAGE_BYTES = 4096
++
++
++class RemoteHandlerError(RuntimeError):
++    """A request handler failed in the remote LMCache process."""
++
++    def __init__(
++        self, request_type: RequestType, error_type: str, message: str
++    ) -> None:
++        self.request_type = request_type
++        self.error_type = error_type
++        self.remote_message = message
++        super().__init__(f"{request_type.name} handler failed: {error_type}: {message}")
++
++
++class _RemoteErrorPayload(msgspec.Struct, frozen=True):
++    error_type: str
++    message: str
++
+ 
+ # Helper functions
+ def encode_request_uid(uid: RequestUID) -> bytes:
+@@ -346,7 +366,28 @@ class MessageQueueClient:
+ 
+         if request_uid in self.pending_futures:
+             future = self.pending_futures.pop(request_uid)
+-            if b_response:
++            if b_response and b_response[0] == _ERROR_RESPONSE_MARKER:
++                if len(b_response) != 2:
++                    future.set_exception(
++                        RuntimeError("Malformed LMCache RPC error response")
++                    )
++                    return
++                try:
++                    error = msgspec_decode(b_response[1], cls=_RemoteErrorPayload)
++                except Exception:
++                    future.set_exception(
++                        RuntimeError("Failed to decode LMCache RPC error response")
++                    )
++                    logger.exception("Failed to decode RPC error response")
++                    return
++                future.set_exception(
++                    RemoteHandlerError(
++                        request_type=request_type,
++                        error_type=error.error_type,
++                        message=error.message,
++                    )
++                )
++            elif b_response:
+                 response = msgspec_decode(b_response[0], cls=response_cls)
+                 future.set_result(response)
+             else:
+@@ -516,6 +557,24 @@ class MessageQueueServer:
+         # Thread pools assigned via add_normal_thread_pool / add_affinity_thread_pool
+         self.extra_pools: list[ThreadPoolExecutor | AffinityThreadPool] = []
+ 
++    def _queue_error_response(
++        self, prefix_frames: list[bytes], exception: BaseException
++    ) -> None:
++        """Return a bounded error response without touching ZMQ off-thread."""
++        message = str(exception).encode("utf-8")[:_MAX_REMOTE_ERROR_MESSAGE_BYTES]
++        payload = _RemoteErrorPayload(
++            error_type=type(exception).__name__,
++            message=message.decode("utf-8", errors="replace"),
++        )
++        self.output_queue.put(
++            prefix_frames
++            + [
++                _ERROR_RESPONSE_MARKER,
++                msgspec_encode(payload, cls=_RemoteErrorPayload),
++            ]
++        )
++        self._output_efd.notify()
++
+     def _call_sync_handler(
+         self,
+         handler_entry: SyncRequestHandler[Any],
+@@ -571,8 +630,9 @@ class MessageQueueServer:
+                 self.output_queue.put(frames_to_send)
+                 self._output_efd.notify()
+ 
+-            except Exception:
++            except Exception as exc:
+                 logger.exception("Error in blocking handler")
++                self._queue_error_response(prefix_frames, exc)
+ 
+         future.add_done_callback(_notify_response)
+ 
+@@ -619,13 +679,23 @@ class MessageQueueServer:
+                             payloads=payloads,
+                             prefix_frames=[identity, b_request_uid, b_request_type],
+                         )
+-                    except Exception:
++                    except Exception as exc:
+                         logger.exception("Error handling request %s", request_type)
++                        self._queue_error_response(
++                            [identity, b_request_uid, b_request_type], exc
++                        )
+                 else:
+                     logger.error(
+                         "No handler registered for request type %s", request_type
+                     )
+                     logger.error("Available handlers: %s", list(self.handlers.keys()))
++                    self._queue_error_response(
++                        [identity, b_request_uid, b_request_type],
++                        RuntimeError(
++                            "No handler registered for request type "
++                            f"{request_type.name}"
++                        ),
++                    )
+ 
+             # Send the responses
+             if outbound_state and outbound_state & zmq.POLLIN:
+diff --git a/tests/v1/distributed/test_fs_native_startup_scan.py b/tests/v1/distributed/test_fs_native_startup_scan.py
+new file mode 100644
+index 0000000000000000000000000000000000000000..796c27e183c9ff0bc923b4d5fbe7e7dfdb6957bc
+--- /dev/null
++++ b/tests/v1/distributed/test_fs_native_startup_scan.py
+@@ -0,0 +1,78 @@
++# SPDX-License-Identifier: Apache-2.0
++"""Restart accounting for the native filesystem L2 adapter."""
++
++# Standard
++import os
++
++# Third Party
++import pytest
++
++# First Party
++from lmcache.v1.distributed.api import ObjectKey
++from lmcache.v1.distributed.l2_adapters.fs_l2_adapter import (
++    _object_key_to_filename,
++)
++from lmcache.v1.distributed.l2_adapters.fs_native_l2_adapter import (
++    _scan_existing_fs_native_files,
++)
++
++
++def _key(chunk_id: int) -> ObjectKey:
++    return ObjectKey(
++        chunk_hash=ObjectKey.IntHash2Bytes(chunk_id),
++        model_name="test-model",
++        kv_rank=0,
++    )
++
++
++def _write(root, key: ObjectKey, size: int, mtime_ns: int) -> None:
++    path = root / _object_key_to_filename(key)
++    path.write_bytes(b"x" * size)
++    os.utime(path, ns=(mtime_ns, mtime_ns))
++
++
++def test_scan_returns_oldest_to_newest_keys_and_sizes(tmp_path):
++    newer = _key(2)
++    older = _key(1)
++    _write(tmp_path, newer, 200, 2_000_000_000)
++    _write(tmp_path, older, 100, 1_000_000_000)
++
++    keys, sizes = _scan_existing_fs_native_files(str(tmp_path))
++
++    assert keys == [older, newer]
++    assert sizes == [100, 200]
++
++
++def test_scan_skips_foreign_empty_and_temporary_files(tmp_path):
++    valid = _key(1)
++    _write(tmp_path, valid, 100, 1_000_000_000)
++    (tmp_path / "not-a-cache-file.data").write_bytes(b"x")
++    (tmp_path / _object_key_to_filename(_key(2))).write_bytes(b"")
++    (tmp_path / "pending.tmp").write_bytes(b"x")
++
++    keys, sizes = _scan_existing_fs_native_files(str(tmp_path))
++
++    assert keys == [valid]
++    assert sizes == [100]
++
++
++def test_scan_missing_directory_returns_empty(tmp_path):
++    assert _scan_existing_fs_native_files(str(tmp_path / "missing")) == ([], [])
++
++
++def test_scan_fails_closed_when_existing_file_cannot_be_inspected(
++    tmp_path, monkeypatch
++):
++    path = tmp_path / "broken.data"
++    path.write_bytes(b"x")
++    original_stat = type(path).stat
++
++    def fail_data_stat(self, *args, **kwargs):
++        if self == path:
++            raise OSError("injected stat failure")
++        return original_stat(self, *args, **kwargs)
++
++    monkeypatch.setattr(type(path), "stat", fail_data_stat)
++
++    with pytest.raises(RuntimeError, match="Could not inspect cache file"):
++        _scan_existing_fs_native_files(str(tmp_path))
+diff --git a/tests/v1/distributed/test_l1_manager.py b/tests/v1/distributed/test_l1_manager.py
+index fea845f903879a84856058ac107589a4b21e0fc7..5b0fb89bc77f4b274f8a27bc48c876aa3c7b54bb 100644
+--- a/tests/v1/distributed/test_l1_manager.py
++++ b/tests/v1/distributed/test_l1_manager.py
+@@ -132,18 +132,6 @@ def basic_layout():
+     )
+ 
+ 
+-@pytest.fixture
+-def large_layout():
+-    """Create a large MemoryLayoutDesc that will exhaust small memory.
+-
+-    Each allocation is 8MB (2M elements * 4 bytes).
+-    """
+-    return MemoryLayoutDesc(
+-        shapes=[torch.Size([2048, 1024])],  # 2M elements * 4 bytes = 8MB
+-        dtypes=[torch.float32],
+-    )
+-
+-
+ def make_object_key(chunk_hash: int, model_name: str = "test_model", kv_rank: int = 0):
+     """Helper to create ObjectKey instances."""
+     hash_bytes = ObjectKey.IntHash2Bytes(chunk_hash)
+@@ -879,14 +867,23 @@ class TestReserveWrite:
+ 
+         manager.close()
+ 
+-    def test_reserve_write_out_of_memory(self, small_l1_config, large_layout):
+-        """Test that reserve_write returns OUT_OF_MEMORY when allocation fails."""
++    def test_reserve_write_out_of_memory(self, small_l1_config):
++        """Test that reserve_write returns OUT_OF_MEMORY when allocation fails.
++
++        Uses an object larger than the whole pool; a batch that partially
++        fits allocates the longest prefix instead (see
++        tests/v1/distributed/test_l1_manager_partial_alloc.py).
++        """
+         manager = L1Manager(small_l1_config)
+         keys = [make_object_key(i) for i in range(10)]
+         is_temporary = [False] * 10
+ 
+-        # Request more memory than available (8MB * 10 = 80MB > 64MB)
+-        result = manager.reserve_write(keys, is_temporary, large_layout)
++        # A single object (128MB) exceeds the 64MB pool.
++        oversized_layout = MemoryLayoutDesc(
++            shapes=[torch.Size([2048 * 16, 1024])],
++            dtypes=[torch.float32],
++        )
++        result = manager.reserve_write(keys, is_temporary, oversized_layout)
+ 
+         # All keys should return OUT_OF_MEMORY
+         for key in keys:
+diff --git a/tests/v1/distributed/test_l1_manager_partial_alloc.py b/tests/v1/distributed/test_l1_manager_partial_alloc.py
+new file mode 100644
+index 0000000000000000000000000000000000000000..30ddc3fba0ce10c957ad6375874fac7df9cc8585
+--- /dev/null
++++ b/tests/v1/distributed/test_l1_manager_partial_alloc.py
+@@ -0,0 +1,151 @@
++# SPDX-License-Identifier: Apache-2.0
++"""Partial-prefix allocation behavior of ``L1Manager.reserve_write``.
++
++A batch whose full allocation does not fit must not fail every key
++(all-or-nothing would collapse large L2->L1 restores to zero prefix hits):
++the longest prefix that fits is allocated and only the tail reports
++OUT_OF_MEMORY. Uses the CPU shared-memory allocator, no GPU required.
++"""
++
++# Standard
++from collections.abc import Iterator
++from types import SimpleNamespace
++
++# Third Party
++import pytest
++import torch
++
++# First Party
++from lmcache.v1.distributed.api import MemoryLayoutDesc, ObjectKey
++from lmcache.v1.distributed.config import (
++    L1ManagerConfig,
++    L1MemoryManagerConfig,
++)
++from lmcache.v1.distributed.error import L1Error
++from lmcache.v1.distributed.l1_manager import L1Manager
++
++POOL_BYTES = 64 * 1024 * 1024
++
++# 8MB per object: ten of them cannot fit in the 64MB pool, most can.
++OBJECT_LAYOUT = MemoryLayoutDesc(
++    shapes=[torch.Size([2048, 1024])],
++    dtypes=[torch.float32],
++)
++
++# A single 128MB object exceeds the whole pool.
++OVERSIZED_LAYOUT = MemoryLayoutDesc(
++    shapes=[torch.Size([2048 * 16, 1024])],
++    dtypes=[torch.float32],
++)
++
++
++@pytest.fixture
++def manager() -> Iterator[L1Manager]:
++    config = L1ManagerConfig(
++        memory_config=L1MemoryManagerConfig(
++            size_in_bytes=POOL_BYTES,
++            use_lazy=False,
++            init_size_in_bytes=POOL_BYTES,
++            align_bytes=0x1000,
++        ),
++        write_ttl_seconds=600,
++        read_ttl_seconds=300,
++    )
++    manager = L1Manager(config)
++    yield manager
++    manager.close()
++
++
++def _make_keys(count: int) -> list[ObjectKey]:
++    return [
++        ObjectKey(
++            chunk_hash=ObjectKey.IntHash2Bytes(i),
++            model_name="test_model",
++            kv_rank=0,
++        )
++        for i in range(count)
++    ]
++
++
++def test_reserve_write_allocates_longest_prefix_on_oom(manager: L1Manager) -> None:
++    """When the full batch does not fit, a non-empty prefix succeeds and
++    only the tail reports OUT_OF_MEMORY; every requested key keeps an
++    explicit per-key result."""
++    keys = _make_keys(10)
++    result = manager.reserve_write(keys, [False] * 10, OBJECT_LAYOUT)
++
++    assert set(result) == set(keys)
++    statuses = [result[key][0] for key in keys]
++    num_success = statuses.count(L1Error.SUCCESS)
++    assert 0 < num_success < 10
++
++    # The successful keys form a prefix in request order.
++    assert statuses == [L1Error.SUCCESS] * num_success + [L1Error.OUT_OF_MEMORY] * (
++        10 - num_success
++    )
++    for key in keys[:num_success]:
++        assert result[key][1] is not None
++    for key in keys[num_success:]:
++        assert result[key][1] is None
++
++
++def test_partial_prefix_is_committable(manager: L1Manager) -> None:
++    """The allocated prefix stays usable: finish_write succeeds for it."""
++    keys = _make_keys(10)
++    result = manager.reserve_write(keys, [False] * 10, OBJECT_LAYOUT)
++    successful = [key for key in keys if result[key][0] == L1Error.SUCCESS]
++    assert successful
++
++    finish_result = manager.finish_write(successful)
++    for key in successful:
++        assert finish_result[key] == L1Error.SUCCESS
++
++
++def test_reserve_write_all_oom_when_nothing_fits(manager: L1Manager) -> None:
++    """An object larger than the pool still fails every key."""
++    keys = _make_keys(3)
++    result = manager.reserve_write(keys, [False] * 3, OVERSIZED_LAYOUT)
++
++    for key in keys:
++        assert result[key][0] == L1Error.OUT_OF_MEMORY
++        assert result[key][1] is None
++
++
++def test_single_key_batch_keeps_all_or_nothing(manager: L1Manager) -> None:
++    """A one-key batch has no prefix to fall back to; it simply fails."""
++    keys = _make_keys(1)
++    result = manager.reserve_write(keys, [False], OVERSIZED_LAYOUT)
++
++    assert result[keys[0]] == (L1Error.OUT_OF_MEMORY, None)
++
++
++def test_largest_prefix_search_does_not_stop_at_a_smaller_fit() -> None:
++    """The OOM fallback finds the maximum, rather than accepting a midpoint."""
++
++    class BoundedMemoryManager:
++        def __init__(self, capacity: int) -> None:
++            self.capacity = capacity
++            self.allocate_counts: list[int] = []
++
++        def allocate(self, _layout: MemoryLayoutDesc, count: int):
++            self.allocate_counts.append(count)
++            if count > self.capacity:
++                return L1Error.OUT_OF_MEMORY, []
++            return L1Error.SUCCESS, [object() for _ in range(count)]
++
++        def free(self, _objects: list[object]) -> L1Error:
++            return L1Error.SUCCESS
++
++    memory_manager = BoundedMemoryManager(capacity=7)
++    manager = SimpleNamespace(_memory_manager=memory_manager)
++
++    err, objects = L1Manager._allocate_largest_prefix(
++        manager,
++        OBJECT_LAYOUT,
++        10,  # type: ignore[arg-type]
++    )
++
++    assert err == L1Error.SUCCESS
++    assert len(objects) == 7
++    assert memory_manager.allocate_counts[-1] == 7
++    assert 8 in memory_manager.allocate_counts
+diff --git a/tests/v1/distributed/test_l1_write_back_eviction.py b/tests/v1/distributed/test_l1_write_back_eviction.py
+new file mode 100644
+index 0000000000000000000000000000000000000000..b677516e37c31959421ea88f777a734d7f61bd0d
+--- /dev/null
++++ b/tests/v1/distributed/test_l1_write_back_eviction.py
+@@ -0,0 +1,609 @@
++# SPDX-License-Identifier: Apache-2.0
++"""Opt-in L1 write-back tier.
++
++With ``EvictionConfig.write_back_on_evict`` enabled, L1 eviction flushes
++readable objects to L2 synchronously and deletes them from L1 only once
++every key in the batch is durable. ``periodic_flush_interval`` adds a
++below-watermark backup flush that keeps the L1 copy.
++``emergency_evict_for_prefetch`` lets the prefetch controller make room
++for large restores through the same write-back path.
++
++Uses the CPU shared-memory allocator; no GPU required.
++"""
++
++# Standard
++from collections.abc import Iterator
++import argparse
++import threading
++import time
++
++# Third Party
++import pytest
++import torch
++
++# First Party
++from lmcache.v1.distributed.api import MemoryLayoutDesc, ObjectKey
++from lmcache.v1.distributed.config import (
++    EvictionConfig,
++    L1ManagerConfig,
++    L1MemoryManagerConfig,
++    StorageManagerConfig,
++    add_storage_manager_args,
++    parse_args_to_config,
++)
++from lmcache.v1.distributed.error import L1Error
++from lmcache.v1.distributed.internal_api import (
++    EvictionAction,
++    EvictionDestination,
++)
++from lmcache.v1.distributed.l1_manager import L1Manager
++from lmcache.v1.distributed.storage_controllers.eviction_controller import (
++    L1EvictionController,
++)
++from lmcache.v1.distributed.storage_controllers.prefetch_controller import (
++    InFlightPrefetchRequest,
++    PrefetchController,
++    PrefetchPhase,
++)
++from lmcache.v1.distributed.storage_controllers.prefetch_policy import (
++    DefaultPrefetchPolicy,
++)
++from lmcache.v1.mp_observability.config import add_observability_args
++
++POOL_BYTES = 8 * 1024 * 1024
++
++# 1MB per object so a handful of objects create real memory pressure.
++OBJECT_LAYOUT = MemoryLayoutDesc(
++    shapes=[torch.Size([256, 1024])],
++    dtypes=[torch.float32],
++)
++
++
++class FakeSyncStoreAdapter:
++    """L2 adapter double exposing only the synchronous store path.
++
++    ``result`` overrides the returned tuple; by default every key is
++    reported durable.
++    """
++
++    def __init__(self) -> None:
++        self.stored_batches: list[list[ObjectKey]] = []
++        self.result: tuple[bool, int, int] | None = None
++
++    def store_objects_sync(
++        self,
++        keys: list[ObjectKey],
++        objects: list,
++        timeout: float | None = None,
++    ) -> tuple[bool, int, int]:
++        self.stored_batches.append(list(keys))
++        if self.result is not None:
++            return self.result
++        return True, len(keys), sum(obj.get_size() for obj in objects)
++
++
++class BlockingSyncStoreAdapter(FakeSyncStoreAdapter):
++    def __init__(self) -> None:
++        super().__init__()
++        self.entered = threading.Event()
++        self.release = threading.Event()
++
++    def store_objects_sync(self, keys, objects, timeout=None):
++        self.entered.set()
++        if not self.release.wait(timeout=timeout or 5.0):
++            return False, 0, 0
++        return super().store_objects_sync(keys, objects, timeout=timeout)
++
++
++@pytest.fixture
++def l1_manager() -> Iterator[L1Manager]:
++    config = L1ManagerConfig(
++        memory_config=L1MemoryManagerConfig(
++            size_in_bytes=POOL_BYTES,
++            use_lazy=False,
++            init_size_in_bytes=POOL_BYTES,
++            align_bytes=0x1000,
++        ),
++        write_ttl_seconds=600,
++        read_ttl_seconds=300,
++    )
++    manager = L1Manager(config)
++    yield manager
++    manager.close()
++
++
++def _make_controller(
++    l1_manager: L1Manager,
++    adapter: FakeSyncStoreAdapter,
++    **config_kwargs,
++) -> L1EvictionController:
++    config = EvictionConfig(eviction_policy="LRU", **config_kwargs)
++    return L1EvictionController(
++        l1_manager=l1_manager,
++        eviction_config=config,
++        l2_adapters={0: adapter},
++    )
++
++
++def _make_keys(count: int) -> list[ObjectKey]:
++    return [
++        ObjectKey(
++            chunk_hash=ObjectKey.IntHash2Bytes(i),
++            model_name="test_model",
++            kv_rank=0,
++        )
++        for i in range(count)
++    ]
++
++
++def _store_keys(l1_manager: L1Manager, keys: list[ObjectKey]) -> None:
++    result = l1_manager.reserve_write(keys, [False] * len(keys), OBJECT_LAYOUT)
++    for key in keys:
++        assert result[key][0] == L1Error.SUCCESS
++    l1_manager.finish_write(keys)
++
++
++def _readable_keys(l1_manager: L1Manager, keys: list[ObjectKey]) -> list[ObjectKey]:
++    result = l1_manager.reserve_read(keys)
++    readable = [
++        key
++        for key in keys
++        if result.get(key) is not None and result[key][0] == L1Error.SUCCESS
++    ]
++    if readable:
++        l1_manager.finish_read(readable)
++    return readable
++
++
++class TestWriteBackOnEvict:
++    def test_flush_then_delete(self, l1_manager):
++        """A durable flush deletes the batch from L1."""
++        adapter = FakeSyncStoreAdapter()
++        controller = _make_controller(l1_manager, adapter, write_back_on_evict=True)
++        keys = _make_keys(3)
++        _store_keys(l1_manager, keys)
++
++        controller.execute_eviction_action(
++            EvictionAction(keys=keys, destination=EvictionDestination.L2_CACHE)
++        )
++
++        assert adapter.stored_batches == [keys]
++        assert _readable_keys(l1_manager, keys) == []
++
++    def test_failed_flush_preserves_l1(self, l1_manager):
++        """A failed flush keeps every readable key in L1 and opens the
++        circuit breaker."""
++        adapter = FakeSyncStoreAdapter()
++        adapter.result = (False, 0, 0)
++        controller = _make_controller(l1_manager, adapter, write_back_on_evict=True)
++        keys = _make_keys(3)
++        _store_keys(l1_manager, keys)
++
++        controller.execute_eviction_action(
++            EvictionAction(keys=keys, destination=EvictionDestination.L2_CACHE)
++        )
++
++        assert _readable_keys(l1_manager, keys) == keys
++        status = controller.report_status()
++        assert status["sync_flush_failures"] == 1
++        assert status["sync_flush_backoff_seconds"] > 0.0
++
++    def test_partial_flush_preserves_l1(self, l1_manager):
++        """A partial persist is not durable; the batch stays in L1."""
++        adapter = FakeSyncStoreAdapter()
++        adapter.result = (False, 2, 1024)
++        controller = _make_controller(l1_manager, adapter, write_back_on_evict=True)
++        keys = _make_keys(3)
++        _store_keys(l1_manager, keys)
++
++        controller.execute_eviction_action(
++            EvictionAction(keys=keys, destination=EvictionDestination.L2_CACHE)
++        )
++
++        assert _readable_keys(l1_manager, keys) == keys
++
++    def test_missing_sync_adapter_fails_closed(self, l1_manager):
++        config = EvictionConfig(eviction_policy="LRU", write_back_on_evict=True)
++        controller = L1EvictionController(
++            l1_manager=l1_manager,
++            eviction_config=config,
++            l2_adapters={0: object()},
++        )
++        keys = _make_keys(2)
++        _store_keys(l1_manager, keys)
++
++        controller.execute_eviction_action(
++            EvictionAction(keys=keys, destination=EvictionDestination.L2_CACHE)
++        )
++
++        assert controller.has_l2_flush_adapter() is False
++        assert _readable_keys(l1_manager, keys) == keys
++
++    def test_reserve_read_failure_is_not_deleted(self, l1_manager, monkeypatch):
++        adapter = FakeSyncStoreAdapter()
++        controller = _make_controller(l1_manager, adapter, write_back_on_evict=True)
++        keys = _make_keys(1)
++        _store_keys(l1_manager, keys)
++        monkeypatch.setattr(
++            l1_manager,
++            "reserve_read",
++            lambda _keys: {keys[0]: (L1Error.KEY_IS_LOCKED, None)},
++        )
++
++        controller.execute_eviction_action(
++            EvictionAction(keys=keys, destination=EvictionDestination.L2_CACHE)
++        )
++
++        monkeypatch.undo()
++        assert adapter.stored_batches == []
++        assert _readable_keys(l1_manager, keys) == keys
++
++    def test_adapter_replacement_waits_for_active_flush(self, l1_manager):
++        adapter = BlockingSyncStoreAdapter()
++        controller = _make_controller(l1_manager, adapter, write_back_on_evict=True)
++        keys = _make_keys(1)
++        _store_keys(l1_manager, keys)
++        flush = threading.Thread(
++            target=lambda: controller.execute_eviction_action(
++                EvictionAction(keys=keys, destination=EvictionDestination.L2_CACHE)
++            )
++        )
++        replaced = threading.Event()
++        replace = threading.Thread(
++            target=lambda: (
++                controller.set_l2_adapters({}),
++                replaced.set(),
++            )
++        )
++
++        flush.start()
++        assert adapter.entered.wait(timeout=5.0)
++        replace.start()
++        time.sleep(0.05)
++        assert not replaced.is_set()
++
++        adapter.release.set()
++        flush.join(timeout=5.0)
++        replace.join(timeout=5.0)
++
++        assert replaced.is_set()
++        assert not flush.is_alive()
++        assert not replace.is_alive()
++
++
++class TestEmergencyEvict:
++    def test_emergency_evict_frees_bytes_via_write_back(self, l1_manager):
++        """emergency_evict_bytes flushes LRU victims to L2 and frees L1."""
++        adapter = FakeSyncStoreAdapter()
++        controller = _make_controller(l1_manager, adapter, write_back_on_evict=True)
++        keys = _make_keys(6)
++        _store_keys(l1_manager, keys)
++
++        used_before, total = l1_manager.get_memory_usage()
++        free_before = total - used_before
++
++        free_after = controller.emergency_evict_bytes(
++            free_before + 2 * 1024 * 1024, requester="test"
++        )
++
++        assert free_after > free_before
++        assert adapter.stored_batches
++        evicted = [k for batch in adapter.stored_batches for k in batch]
++        assert set(evicted) <= set(keys)
++        assert len(evicted) < len(keys)
++        # Evicted keys are gone from L1.
++        assert not set(evicted) & set(_readable_keys(l1_manager, keys))
++
++    def test_emergency_evict_noop_when_enough_free(self, l1_manager):
++        adapter = FakeSyncStoreAdapter()
++        controller = _make_controller(l1_manager, adapter, write_back_on_evict=True)
++        keys = _make_keys(2)
++        _store_keys(l1_manager, keys)
++
++        controller.emergency_evict_bytes(1024, requester="test")
++
++        assert adapter.stored_batches == []
++        assert _readable_keys(l1_manager, keys) == keys
++
++    def test_emergency_evict_skips_scan_during_backoff(self, l1_manager, monkeypatch):
++        adapter = FakeSyncStoreAdapter()
++        controller = _make_controller(l1_manager, adapter, write_back_on_evict=True)
++        keys = _make_keys(6)
++        _store_keys(l1_manager, keys)
++        controller._sync_flush_backoff_until = time.monotonic() + 60
++        monkeypatch.setattr(
++            controller._eviction_policy,
++            "get_eviction_actions",
++            lambda *args, **kwargs: pytest.fail("eviction scan should be skipped"),
++        )
++
++        used, total = l1_manager.get_memory_usage()
++        free = total - used
++        assert controller.emergency_evict_bytes(free + 1024) == free
++
++    def test_emergency_evict_has_bounded_store_wait(self, l1_manager):
++        adapter = BlockingSyncStoreAdapter()
++        controller = _make_controller(l1_manager, adapter, write_back_on_evict=True)
++        controller._EMERGENCY_FLUSH_TIMEOUT_SECONDS = 0.05
++        keys = _make_keys(6)
++        _store_keys(l1_manager, keys)
++        used, total = l1_manager.get_memory_usage()
++
++        start = time.monotonic()
++        free_after = controller.emergency_evict_bytes(total - used + 1024)
++        elapsed = time.monotonic() - start
++
++        assert adapter.entered.is_set()
++        assert elapsed < 0.5
++        assert free_after == total - used
++        assert _readable_keys(l1_manager, keys) == keys
++        status = controller.report_status()
++        assert status["sync_flush_failures"] == 0
++        assert status["sync_flush_backoff_seconds"] == 0.0
++
++
++class TestPeriodicBackupFlush:
++    def test_backup_flush_keeps_l1_copy(self, l1_manager):
++        """The periodic backup flush copies keys to L2 without deleting
++        them from L1."""
++        adapter = FakeSyncStoreAdapter()
++        controller = _make_controller(l1_manager, adapter, periodic_flush_interval=0.1)
++        keys = _make_keys(3)
++        _store_keys(l1_manager, keys)
++
++        controller.start()
++        try:
++            deadline = time.monotonic() + 5.0
++            while not adapter.stored_batches and time.monotonic() < deadline:
++                time.sleep(0.1)
++        finally:
++            controller.stop()
++
++        assert adapter.stored_batches
++        flushed = {k for batch in adapter.stored_batches for k in batch}
++        assert flushed <= set(keys)
++        assert _readable_keys(l1_manager, keys) == keys
++
++    def test_backup_batches_rotate_without_full_snapshot(self, l1_manager):
++        adapter = FakeSyncStoreAdapter()
++        controller = _make_controller(l1_manager, adapter)
++        keys = _make_keys(6)
++        _store_keys(l1_manager, keys)
++
++        for _ in range(3):
++            controller._backup_to_l2_no_delete(batch_limit=2)
++
++        assert [len(batch) for batch in adapter.stored_batches] == [2, 2, 2]
++        assert {key for batch in adapter.stored_batches for key in batch} == set(keys)
++
++    def test_backup_flush_has_bounded_store_wait(self, l1_manager):
++        adapter = BlockingSyncStoreAdapter()
++        controller = _make_controller(l1_manager, adapter)
++        controller._PERIODIC_FLUSH_TIMEOUT_SECONDS = 0.05
++        keys = _make_keys(2)
++        _store_keys(l1_manager, keys)
++
++        start = time.monotonic()
++        controller._backup_to_l2_no_delete(batch_limit=2)
++        elapsed = time.monotonic() - start
++
++        assert adapter.entered.is_set()
++        assert elapsed < 0.5
++        assert _readable_keys(l1_manager, keys) == keys
++
++    def test_evictable_batch_scan_wraps_and_is_bounded(self, l1_manager):
++        keys = _make_keys(5)
++        _store_keys(l1_manager, keys)
++        assert l1_manager.reserve_read([keys[0]])[keys[0]][0] == L1Error.SUCCESS
++        try:
++            first, cursor = l1_manager.get_evictable_keys(
++                limit=2,
++                cursor=0,
++                scan_limit=2,
++            )
++            second, cursor = l1_manager.get_evictable_keys(
++                limit=2,
++                cursor=cursor,
++                scan_limit=2,
++            )
++            third, _ = l1_manager.get_evictable_keys(
++                limit=2,
++                cursor=cursor,
++                scan_limit=2,
++            )
++        finally:
++            l1_manager.finish_read([keys[0]])
++
++        assert first == [keys[1]]
++        assert second == keys[2:4]
++        assert third == [keys[4]]
++
++
++class _RecordingEvictor:
++    """Eviction-controller double recording emergency_evict_bytes calls."""
++
++    def __init__(self) -> None:
++        self.calls: list[tuple[int, str]] = []
++
++    def emergency_evict_bytes(self, target_free_bytes: int, requester: str = "") -> int:
++        self.calls.append((target_free_bytes, requester))
++        return target_free_bytes
++
++
++@pytest.fixture
++def prefetch_controller(l1_manager: L1Manager) -> Iterator[PrefetchController]:
++    controller = PrefetchController(
++        l1_manager=l1_manager,
++        l2_adapters=[],
++        adapter_descriptors=[],
++        policy=DefaultPrefetchPolicy(),
++    )
++    yield controller
++    # The loop thread was never started, so stop() cannot join it.
++    controller._submission_efd.close()
++    controller._adapter_ctrl_efd.close()
++
++
++def _make_request(keys: list[ObjectKey]) -> InFlightPrefetchRequest:
++    return InFlightPrefetchRequest(
++        request_id=7,
++        keys=keys,
++        layout_desc=OBJECT_LAYOUT,
++        phase=PrefetchPhase.PLAN_AND_LOAD,
++    )
++
++
++class TestPrefetchMakeRoom:
++    def test_make_room_asks_evictor_when_short(self, l1_manager, prefetch_controller):
++        """A restore that does not fit in free L1 asks for eviction."""
++        controller = prefetch_controller
++        evictor = _RecordingEvictor()
++        controller.set_l1_eviction_controller(evictor)
++        resident = _make_keys(6)
++        _store_keys(l1_manager, resident)
++
++        restore_keys = [
++            ObjectKey(
++                chunk_hash=ObjectKey.IntHash2Bytes(100 + i),
++                model_name="test_model",
++                kv_rank=0,
++            )
++            for i in range(4)
++        ]
++        controller._make_room_for_restore(_make_request(restore_keys), restore_keys)
++
++        assert len(evictor.calls) == 1
++        target, requester = evictor.calls[0]
++        assert target > 0
++        assert "prefetch_request=7" in requester
++
++    def test_make_room_noop_when_space_available(self, l1_manager, prefetch_controller):
++        controller = prefetch_controller
++        evictor = _RecordingEvictor()
++        controller.set_l1_eviction_controller(evictor)
++
++        keys = _make_keys(2)
++        controller._make_room_for_restore(_make_request(keys), keys)
++
++        assert evictor.calls == []
++
++    def test_make_room_noop_without_evictor(self, l1_manager, prefetch_controller):
++        controller = prefetch_controller
++        keys = _make_keys(2)
++
++        controller._make_room_for_restore(_make_request(keys), keys)
++
++    def test_eviction_controller_can_be_disconnected(self, prefetch_controller):
++        evictor = _RecordingEvictor()
++        prefetch_controller.set_l1_eviction_controller(evictor)
++        prefetch_controller.set_l1_eviction_controller(None)
++
++        assert prefetch_controller._l1_eviction_controller is None
++
++    def test_short_retention_policy_degrades_to_temporary(
++        self, prefetch_controller, monkeypatch
++    ):
++        keys = _make_keys(3)
++        monkeypatch.setattr(
++            prefetch_controller._policy,
++            "select_l1_retentions",
++            lambda _keys: [True],
++        )
++
++        assert prefetch_controller._select_l1_retentions(7, keys) == [
++            False,
++            False,
++            False,
++        ]
++
++    def test_retry_recovers_oom_reservations(self, l1_manager, prefetch_controller):
++        """OOM reservations are retried once after emergency eviction."""
++        controller = prefetch_controller
++        evictor = _RecordingEvictor()
++        controller.set_l1_eviction_controller(evictor)
++        keys = _make_keys(2)
++        write_results = {key: (L1Error.OUT_OF_MEMORY, None) for key in keys}
++
++        merged = controller._retry_oom_reservations(
++            _make_request(keys), keys, [True, True], write_results
++        )
++
++        assert len(evictor.calls) == 1
++        for key in keys:
++            err, mem_obj = merged[key]
++            assert err == L1Error.SUCCESS
++            assert mem_obj is not None
++        l1_manager.finish_write(keys)
++
++    def test_retry_noop_when_all_reserved(self, l1_manager, prefetch_controller):
++        controller = prefetch_controller
++        evictor = _RecordingEvictor()
++        controller.set_l1_eviction_controller(evictor)
++        keys = _make_keys(2)
++        result = l1_manager.reserve_write(keys, [False, False], OBJECT_LAYOUT)
++
++        merged = controller._retry_oom_reservations(
++            _make_request(keys), keys, [True, True], result
++        )
++
++        assert evictor.calls == []
++        assert merged is result
++        l1_manager.finish_write(keys)
++
++
++class TestConfigPlumbing:
++    def test_parser_populates_write_back_fields(self):
++        parser = argparse.ArgumentParser()
++        add_storage_manager_args(parser)
++        add_observability_args(parser)
++        args = parser.parse_args(
++            [
++                "--l1-size-gb",
++                "1",
++                "--eviction-policy",
++                "LRU",
++                "--write-back-on-evict",
++                "--periodic-flush-interval",
++                "30.0",
++                "--emergency-evict-for-prefetch",
++            ]
++        )
++        config = parse_args_to_config(args)
++        assert config.eviction_config.write_back_on_evict is True
++        assert config.eviction_config.periodic_flush_interval == 30.0
++        assert config.eviction_config.emergency_evict_for_prefetch is True
++
++    def test_defaults_are_disabled(self):
++        parser = argparse.ArgumentParser()
++        add_storage_manager_args(parser)
++        add_observability_args(parser)
++        args = parser.parse_args(["--l1-size-gb", "1", "--eviction-policy", "LRU"])
++        config = parse_args_to_config(args)
++        assert config.eviction_config.write_back_on_evict is False
++        assert config.eviction_config.periodic_flush_interval == 0.0
++        assert config.eviction_config.emergency_evict_for_prefetch is False
++
++    @pytest.mark.parametrize(
++        "eviction_config",
++        [
++            EvictionConfig(
++                eviction_policy="LRU",
++                periodic_flush_interval=-1.0,
++            ),
++            EvictionConfig(
++                eviction_policy="LRU",
++                emergency_evict_for_prefetch=True,
++            ),
++        ],
++    )
++    def test_invalid_writeback_config_is_rejected(self, eviction_config):
++        with pytest.raises(ValueError):
++            StorageManagerConfig(
++                l1_manager_config=L1ManagerConfig(
++                    memory_config=L1MemoryManagerConfig(
++                        size_in_bytes=POOL_BYTES,
++                        use_lazy=False,
++                    )
++                ),
++                eviction_config=eviction_config,
++            )
+diff --git a/tests/v1/distributed/test_native_connector_l2_adapter.py b/tests/v1/distributed/test_native_connector_l2_adapter.py
+index dc16cdd1ae0161bf2306759cd2b72614a93c83fc..1f4348ad5e223aed6a96d25017a41c2b017a1126 100644
+--- a/tests/v1/distributed/test_native_connector_l2_adapter.py
++++ b/tests/v1/distributed/test_native_connector_l2_adapter.py
+@@ -10,6 +10,7 @@ C++ IStorageConnector interface, so no Redis or C++ build is needed.
+ import ctypes
+ import select
+ import threading
++import time
+ 
+ # Third Party
+ import pytest
+@@ -56,6 +57,9 @@ class MockNativeConnector:
+         self._completions: list[tuple[int, bool, str, list[bool] | None]] = []
+         self._lock = threading.Lock()
+         self._closed = False
++        self.report_set_per_key_results = True
++        self.fail_set_keys: set[str] = set()
++        self.suppress_set_completion = False
+ 
+     def event_fd(self) -> int:
+         return self._efd.fileno()
+@@ -66,9 +70,21 @@ class MockNativeConnector:
+             self._next_id += 1
+ 
+         try:
++            results = []
+             for key, mv in zip(keys, memoryviews, strict=False):
++                if key in self.fail_set_keys:
++                    results.append(False)
++                    continue
+                 self._store[key] = bytes(mv)
+-            self._push_completion(fid, True, "", None)
++                results.append(True)
++            ok = all(results)
++            if not self.suppress_set_completion:
++                self._push_completion(
++                    fid,
++                    ok,
++                    "" if ok else "injected set failure",
++                    results if self.report_set_per_key_results else None,
++                )
+         except Exception as e:
+             self._push_completion(fid, False, str(e), None)
+ 
+@@ -155,6 +171,27 @@ class MockNativeConnector:
+             pass
+ 
+ 
++class DeferredExistsConnector(MockNativeConnector):
++    """Hold EXISTS completion to expose the submit-to-lock race window."""
++
++    def __init__(self):
++        super().__init__()
++        self.pending_exists: tuple[int, list[str]] | None = None
++
++    def submit_batch_exists(self, keys: list[str]) -> int:
++        with self._lock:
++            fid = self._next_id
++            self._next_id += 1
++        self.pending_exists = (fid, list(keys))
++        return fid
++
++    def complete_exists(self) -> None:
++        assert self.pending_exists is not None
++        fid, keys = self.pending_exists
++        self.pending_exists = None
++        self._push_completion(fid, True, "", [key in self._store for key in keys])
++
++
+ # =============================================================================
+ # Test Fixtures
+ # =============================================================================
+@@ -203,6 +240,14 @@ def adapter():
+     adp.close()
+ 
+ 
++@pytest.fixture
++def adapter_and_mock():
++    mock_client = MockNativeConnector()
++    adp = NativeConnectorL2Adapter(mock_client)
++    yield adp, mock_client
++    adp.close()
++
++
+ # =============================================================================
+ # ObjectKey Serialization Tests
+ # =============================================================================
+@@ -1182,6 +1227,91 @@ class TestDeleteInterface:
+     def test_delete_empty_keys(self, adapter):
+         adapter.delete([])  # should not raise
+ 
++    def test_delete_skips_lookup_locked_keys(self, adapter):
++        """Keys lookup-locked by an in-flight prefetch survive delete();
++        unlocked keys in the same batch are still deleted, and the locked
++        key becomes deletable again after unlock."""
++        keys = [create_object_key(i) for i in range(2)]
++        objs = [create_memory_obj(fill_value=float(i)) for i in range(2)]
++        store_fd = adapter.get_store_event_fd()
++        lookup_fd = adapter.get_lookup_and_lock_event_fd()
++
++        adapter.submit_store_task(keys, objs)
++        wait_for_event_fd(store_fd, timeout=5.0)
++        adapter.pop_completed_store_tasks()
++
++        # An in-flight prefetch holds a lookup lock on keys[0].
++        task_id = adapter.submit_lookup_and_lock_task([keys[0]], _EMPTY_LAYOUT)
++        wait_for_event_fd(lookup_fd, timeout=5.0)
++        bitmap = adapter.query_lookup_and_lock_result(task_id)
++        assert bitmap.test(0) is True
++
++        adapter.delete(keys)
++
++        # keys[0] survived, keys[1] is gone. This lookup takes another
++        # lock on keys[0].
++        task_id = adapter.submit_lookup_and_lock_task(keys, _EMPTY_LAYOUT)
++        wait_for_event_fd(lookup_fd, timeout=5.0)
++        bitmap = adapter.query_lookup_and_lock_result(task_id)
++        assert bitmap.test(0) is True
++        assert bitmap.test(1) is False
++
++        # Release both locks; the key is deletable again.
++        adapter.submit_unlock([keys[0]])
++        adapter.submit_unlock([keys[0]])
++        adapter.delete([keys[0]])
++
++        task_id = adapter.submit_lookup_and_lock_task([keys[0]], _EMPTY_LAYOUT)
++        wait_for_event_fd(lookup_fd, timeout=5.0)
++        bitmap = adapter.query_lookup_and_lock_result(task_id)
++        assert bitmap.test(0) is False
++
++    def test_delete_all_keys_locked_is_noop(self, adapter):
++        """delete() returns without submitting when every key is locked."""
++        key = create_object_key(1)
++        obj = create_memory_obj()
++        store_fd = adapter.get_store_event_fd()
++        lookup_fd = adapter.get_lookup_and_lock_event_fd()
++
++        adapter.submit_store_task([key], [obj])
++        wait_for_event_fd(store_fd, timeout=5.0)
++        adapter.pop_completed_store_tasks()
++
++        task_id = adapter.submit_lookup_and_lock_task([key], _EMPTY_LAYOUT)
++        wait_for_event_fd(lookup_fd, timeout=5.0)
++        assert adapter.query_lookup_and_lock_result(task_id).test(0) is True
++
++        adapter.delete([key])
++
++        task_id = adapter.submit_lookup_and_lock_task([key], _EMPTY_LAYOUT)
++        wait_for_event_fd(lookup_fd, timeout=5.0)
++        assert adapter.query_lookup_and_lock_result(task_id).test(0) is True
++        adapter.submit_unlock([key])
++        adapter.submit_unlock([key])
++
++    def test_delete_skips_lookup_that_has_not_completed(self):
++        """Eviction cannot enter between lookup submission and lock acquire."""
++        client = DeferredExistsConnector()
++        adapter = NativeConnectorL2Adapter(client)
++        key = create_object_key(1)
++        obj = create_memory_obj()
++
++        try:
++            adapter.submit_store_task([key], [obj])
++            wait_for_event_fd(adapter.get_store_event_fd(), timeout=5.0)
++            adapter.pop_completed_store_tasks()
++
++            task_id = adapter.submit_lookup_and_lock_task([key], _EMPTY_LAYOUT)
++            adapter.delete([key])
++            assert _object_key_to_string(key) in client._store
++
++            client.complete_exists()
++            wait_for_event_fd(adapter.get_lookup_and_lock_event_fd(), timeout=5.0)
++            assert adapter.query_lookup_and_lock_result(task_id).test(0) is True
++            adapter.submit_unlock([key])
++        finally:
++            adapter.close()
++
+     def test_delete_batch(self, adapter):
+         keys = [create_object_key(i) for i in range(5)]
+         objs = [create_memory_obj(fill_value=float(i)) for i in range(5)]
+@@ -1294,7 +1424,6 @@ class TestUsageTracking:
+         # 400 bytes / 2000 bytes = 0.2
+         assert usage.usage_fraction == pytest.approx(0.2)
+         assert usage.total_bytes_used == 400
+-
+     def test_get_usage_after_delete(self, adapter_with_capacity):
+         adp = adapter_with_capacity
+         store_fd = adp.get_store_event_fd()
+@@ -1358,3 +1487,208 @@ class TestUsageTracking:
+         usage = adp.get_usage()
+         assert usage.usage_fraction == pytest.approx(0.2)
+         assert usage.total_bytes_used == 400
++
++    def test_inflight_stores_cannot_exceed_capacity(self):
++        mock_client = MockNativeConnector()
++        mock_client.suppress_set_completion = True
++        capacity = 800
++        adp = NativeConnectorL2Adapter(
++            mock_client,
++            max_capacity_gb=capacity / (1024**3),
++        )
++        try:
++            obj = create_memory_obj(size=100)  # 400 bytes
++            first = adp.submit_store_task([create_object_key(1)], [obj])
++            second = adp.submit_store_task([create_object_key(2)], [obj])
++            rejected = adp.submit_store_task([create_object_key(3)], [obj])
++
++            assert first != second != rejected
++            assert sum(len(value) for value in mock_client._store.values()) == capacity
++            assert adp.get_reserved_store_bytes() == capacity
++            assert wait_for_event_fd(adp.get_store_event_fd(), timeout=1.0)
++            result = adp.pop_completed_store_tasks()[rejected]
++            assert result.is_successful() is False
++            assert result.bytes_transferred() == 0
++        finally:
++            adp.close()
++
++    def test_failed_store_releases_capacity_reservation(self):
++        mock_client = MockNativeConnector()
++        capacity = 400
++        adp = NativeConnectorL2Adapter(
++            mock_client,
++            max_capacity_gb=capacity / (1024**3),
++        )
++        try:
++            first_key = create_object_key(1)
++            mock_client.fail_set_keys = {_object_key_to_string(first_key)}
++            first = adp.submit_store_task([first_key], [create_memory_obj(size=100)])
++            assert wait_for_event_fd(adp.get_store_event_fd(), timeout=1.0)
++            assert adp.pop_completed_store_tasks()[first].is_successful() is False
++            assert adp.get_reserved_store_bytes() == 0
++
++            mock_client.fail_set_keys.clear()
++            second = adp.submit_store_task(
++                [create_object_key(2)], [create_memory_obj(size=100)]
++            )
++            assert wait_for_event_fd(adp.get_store_event_fd(), timeout=1.0)
++            assert adp.pop_completed_store_tasks()[second].is_successful() is True
++            assert adp.get_usage().total_bytes_used == capacity
++        finally:
++            adp.close()
++
++    def test_synchronous_store_respects_capacity(self):
++        mock_client = MockNativeConnector()
++        capacity = 400
++        adp = NativeConnectorL2Adapter(
++            mock_client,
++            max_capacity_gb=capacity / (1024**3),
++        )
++        try:
++            first = adp.store_objects_sync(
++                [create_object_key(1)], [create_memory_obj(size=100)]
++            )
++            rejected = adp.store_objects_sync(
++                [create_object_key(2)], [create_memory_obj(size=100)]
++            )
++
++            assert first == (True, 1, capacity)
++            assert rejected == (False, 0, 0)
++            assert len(mock_client._store) == 1
++            assert adp.get_usage().total_bytes_used == capacity
++        finally:
++            adp.close()
++
++
++# =============================================================================
++# Durable Store Tests
++# =============================================================================
++
++
++class _BlockingStoreListener:
++    def __init__(self):
++        self.entered = threading.Event()
++        self.release = threading.Event()
++
++    def on_l2_keys_stored(self, keys, sizes) -> None:
++        self.entered.set()
++        assert self.release.wait(timeout=5.0)
++
++
++class TestStoreObjectsSync:
++    def test_success_uses_private_completion(self, adapter):
++        keys = [create_object_key(i) for i in range(2)]
++        objs = [create_memory_obj(fill_value=float(i)) for i in range(2)]
++
++        ok, persisted, bytes_written = adapter.store_objects_sync(keys, objs)
++
++        assert ok is True
++        assert persisted == 2
++        assert bytes_written == sum(obj.get_size() for obj in objs)
++        assert adapter.get_usage().total_bytes_used == bytes_written
++        assert adapter.pop_completed_store_tasks() == {}
++
++    def test_partial_failure_accounts_only_persisted_keys(self, adapter_and_mock):
++        adapter, mock_client = adapter_and_mock
++        keys = [create_object_key(i) for i in range(2)]
++        objs = [create_memory_obj(fill_value=float(i)) for i in range(2)]
++        mock_client.fail_set_keys = {_object_key_to_string(keys[1])}
++
++        ok, persisted, bytes_written = adapter.store_objects_sync(keys, objs)
++
++        assert ok is False
++        assert persisted == 1
++        assert bytes_written == objs[0].get_size()
++        assert adapter.get_usage().total_bytes_used == objs[0].get_size()
++
++    def test_async_partial_failure_uses_per_key_results(self, adapter_and_mock):
++        adapter, mock_client = adapter_and_mock
++        keys = [create_object_key(i) for i in range(2)]
++        objs = [create_memory_obj(fill_value=float(i)) for i in range(2)]
++        mock_client.fail_set_keys = {_object_key_to_string(keys[1])}
++
++        task_id = adapter.submit_store_task(keys, objs)
++        assert wait_for_event_fd(adapter.get_store_event_fd(), timeout=5.0)
++
++        result = adapter.pop_completed_store_tasks()[task_id]
++        assert result.is_successful() is False
++        assert adapter.get_usage().total_bytes_used == objs[0].get_size()
++
++    def test_batch_fallback_without_per_key_results(self, adapter_and_mock):
++        adapter, mock_client = adapter_and_mock
++        mock_client.report_set_per_key_results = False
++        keys = [create_object_key(i) for i in range(2)]
++        objs = [create_memory_obj(fill_value=float(i)) for i in range(2)]
++
++        ok, persisted, bytes_written = adapter.store_objects_sync(keys, objs)
++
++        assert ok is True
++        assert persisted == 2
++        assert bytes_written == sum(obj.get_size() for obj in objs)
++
++    def test_validates_inputs(self, adapter):
++        with pytest.raises(ValueError, match="length mismatch"):
++            adapter.store_objects_sync([create_object_key(1)], [])
++        with pytest.raises(ValueError, match="timeout must be positive"):
++            adapter.store_objects_sync(
++                [create_object_key(1)], [create_memory_obj()], timeout=0
++            )
++        assert adapter.store_objects_sync([], []) == (True, 0, 0)
++
++    def test_real_timeout_keeps_pending_operation_reserved(self, adapter_and_mock):
++        adapter, mock_client = adapter_and_mock
++        mock_client.suppress_set_completion = True
++
++        result = adapter.store_objects_sync(
++            [create_object_key(1)], [create_memory_obj()], timeout=0.05
++        )
++
++        assert result == (False, 0, 0)
++        assert adapter._pending_sync_store_events == {}
++        assert len(adapter._pending_ops) == 1
++        assert adapter.get_reserved_store_bytes() == create_memory_obj().get_size()
++
++    def test_completion_at_timeout_does_not_wait_for_observer(self, adapter):
++        listener = _BlockingStoreListener()
++        adapter.register_listener(listener)
++        result = []
++        worker = threading.Thread(
++            target=lambda: result.append(
++                adapter.store_objects_sync(
++                    [create_object_key(1)],
++                    [create_memory_obj()],
++                    timeout=0.05,
++                )
++            )
++        )
++        worker.start()
++        assert listener.entered.wait(timeout=5.0)
++        time.sleep(0.1)
++        assert not worker.is_alive()
++        assert result[0][0] is True
++        assert adapter.get_usage().total_bytes_used == result[0][2]
++
++        listener.release.set()
++        worker.join(timeout=5.0)
++
++        assert not worker.is_alive()
++
++    def test_close_unblocks_waiter(self, adapter_and_mock):
++        adapter, mock_client = adapter_and_mock
++        mock_client.suppress_set_completion = True
++        result = []
++        worker = threading.Thread(
++            target=lambda: result.append(
++                adapter.store_objects_sync(
++                    [create_object_key(1)], [create_memory_obj()], timeout=10.0
++                )
++            )
++        )
++        worker.start()
++        time.sleep(0.05)
++
++        adapter.close()
++        worker.join(timeout=5.0)
++
++        assert not worker.is_alive()
++        assert result == [(False, 0, 0)]
+diff --git a/tests/v1/distributed/test_native_connector_restart_accounting.py b/tests/v1/distributed/test_native_connector_restart_accounting.py
+new file mode 100644
+index 0000000000000000000000000000000000000000..dc5d6c68c3fcb236bafd2bfdf9a2b8c9582e00d8
+--- /dev/null
++++ b/tests/v1/distributed/test_native_connector_restart_accounting.py
+@@ -0,0 +1,66 @@
++# SPDX-License-Identifier: Apache-2.0
++"""Restart accounting behavior shared by native L2 connectors."""
++
++# Third Party
++import pytest
++
++# First Party
++from tests.v1.distributed.test_native_connector_l2_adapter import (
++    adapter,
++    create_object_key,
++)
++
++
++class _RecordingL2Listener:
++    def __init__(self):
++        self.stored = []
++
++    def on_l2_keys_stored(self, keys, sizes) -> None:
++        self.stored.append((list(keys), list(sizes)))
++
++
++class TestPrimeExistingKeys:
++    def test_priming_accounts_deduplicated_usage(self, adapter):
++        key = create_object_key(1)
++
++        adapter.prime_existing_keys([key, key], [100, 999])
++
++        assert adapter.get_usage().total_bytes_used == 100
++        assert adapter._key_sizes == {key: 100}
++
++    def test_first_listener_receives_startup_snapshot_once(self, adapter):
++        keys = [create_object_key(1), create_object_key(2)]
++        adapter.prime_existing_keys(keys, [100, 200])
++        first = _RecordingL2Listener()
++        second = _RecordingL2Listener()
++
++        adapter.register_listener(first)
++        adapter.register_listener(second)
++
++        assert first.stored == [(keys, [100, 200])]
++        assert second.stored == []
++        assert adapter.get_usage().total_bytes_used == 300
++
++    def test_empty_snapshot_is_consumed_without_callback(self, adapter):
++        adapter.prime_existing_keys([], [])
++        listener = _RecordingL2Listener()
++
++        adapter.register_listener(listener)
++
++        assert listener.stored == []
++
++    def test_rejects_invalid_or_repeated_priming(self, adapter):
++        with pytest.raises(ValueError, match="length mismatch"):
++            adapter.prime_existing_keys([create_object_key(1)], [1, 2])
++        with pytest.raises(ValueError, match="must be positive"):
++            adapter.prime_existing_keys([create_object_key(1)], [0])
++
++        adapter.prime_existing_keys([], [])
++        with pytest.raises(RuntimeError, match="already primed"):
++            adapter.prime_existing_keys([], [])
++
++    def test_rejects_priming_after_listener_registration(self, adapter):
++        adapter.register_listener(_RecordingL2Listener())
++
++        with pytest.raises(RuntimeError, match="before listeners"):
++            adapter.prime_existing_keys([], [])
+diff --git a/tests/v1/distributed/test_native_fs_connector_results.py b/tests/v1/distributed/test_native_fs_connector_results.py
+new file mode 100644
+index 0000000000000000000000000000000000000000..458fcf0edfcf8a04ab13a4431248640e557cb8c3
+--- /dev/null
++++ b/tests/v1/distributed/test_native_fs_connector_results.py
+@@ -0,0 +1,54 @@
++# SPDX-License-Identifier: Apache-2.0
++"""Native FS connector completion semantics.
++
++These tests exercise the compiled extension. They are skipped when the
++optional native FS module is not part of the test environment.
++"""
++
++# Standard
++import select
++import time
++
++# Third Party
++import pytest
++
++lmcache_fs = pytest.importorskip("lmcache.lmcache_fs")
++
++
++def _wait_for_completion(client, timeout: float = 5.0):
++    poller = select.poll()
++    poller.register(client.event_fd(), select.POLLIN)
++    deadline = time.monotonic() + timeout
++    while time.monotonic() < deadline:
++        if poller.poll(50):
++            completions = client.drain_completions()
++            if completions:
++                return completions
++    raise AssertionError("native connector completion timed out")
++
++
++def test_batch_set_reports_partial_results_and_continues(tmp_path):
++    client = lmcache_fs.LMCacheFSClient(str(tmp_path), 1)
++    try:
++        buffers = [bytearray(b"first"), bytearray(b"bad"), bytearray(b"last")]
++        keys = [
++            "model@00000000@01",
++            "malformed-key",
++            "model@00000000@03",
++        ]
++
++        future_id = client.submit_batch_set(
++            keys,
++            [memoryview(buffer) for buffer in buffers],
++        )
++        completions = _wait_for_completion(client)
++
++        assert len(completions) == 1
++        completed_id, ok, error, results = completions[0]
++        assert completed_id == future_id
++        assert ok is False
++        assert "partially failed" in error
++        assert results == [True, False, True]
++        assert len(list(tmp_path.glob("*.data"))) == 2
++    finally:
++        client.close()
+diff --git a/tests/v1/distributed/test_native_fs_key_compatibility.py b/tests/v1/distributed/test_native_fs_key_compatibility.py
+new file mode 100644
+index 0000000000000000000000000000000000000000..d18fba4e8f8c662a3826f1a8182ac681ca9a0584
+--- /dev/null
++++ b/tests/v1/distributed/test_native_fs_key_compatibility.py
+@@ -0,0 +1,55 @@
++# SPDX-License-Identifier: Apache-2.0
++"""ObjectKey compatibility of the compiled native FS connector."""
++
++# Standard
++import select
++import time
++
++# Third Party
++import pytest
++
++lmcache_fs = pytest.importorskip("lmcache.lmcache_fs")
++
++
++def _wait_for_completion(client, timeout: float = 5.0):
++    poller = select.poll()
++    poller.register(client.event_fd(), select.POLLIN)
++    deadline = time.monotonic() + timeout
++    while time.monotonic() < deadline:
++        if poller.poll(50):
++            completions = client.drain_completions()
++            if completions:
++                return completions[0]
++    raise AssertionError("native connector completion timed out")
++
++
++@pytest.mark.parametrize(
++    ("wire_key", "filename"),
++    [
++        ("model@00000000@aabb", "model@0x00000000@aabb.data"),
++        (
++            "model@00000000@aabb@salt",
++            "model@0x00000000@aabb@salt.data",
++        ),
++        (
++            "model@00000000@2@aabb",
++            "model@0x00000000@2@aabb.data",
++        ),
++        (
++            "model@00000000@2@aabb@salt",
++            "model@0x00000000@2@aabb@salt.data",
++        ),
++    ],
++)
++def test_legacy_and_current_key_shapes(wire_key, filename, tmp_path):
++    client = lmcache_fs.LMCacheFSClient(str(tmp_path), 1)
++    try:
++        payload = bytearray(b"payload")
++        future_id = client.submit_batch_set([wire_key], [memoryview(payload)])
++        completed_id, ok, error, _results = _wait_for_completion(client)
++
++        assert completed_id == future_id
++        assert ok, error
++        assert (tmp_path / filename).read_bytes() == payload
++    finally:
++        client.close()
+diff --git a/tests/v1/distributed/test_native_fs_odirect.py b/tests/v1/distributed/test_native_fs_odirect.py
+new file mode 100644
+index 0000000000000000000000000000000000000000..1d5118eca102011208e580b447f3d034cb8afd13
+--- /dev/null
++++ b/tests/v1/distributed/test_native_fs_odirect.py
+@@ -0,0 +1,80 @@
++# SPDX-License-Identifier: Apache-2.0
++"""O_DIRECT behavior of the compiled native FS connector."""
++
++# Standard
++import ctypes
++import select
++import time
++
++# Third Party
++import pytest
++
++lmcache_fs = pytest.importorskip("lmcache.lmcache_fs")
++
++
++def _aligned_view(size: int, alignment: int = 4096):
++    storage = bytearray(size + alignment)
++    address = ctypes.addressof(ctypes.c_char.from_buffer(storage))
++    offset = (-address) % alignment
++    return storage, memoryview(storage)[offset : offset + size]
++
++
++def _wait_for_completion(client, timeout: float = 5.0):
++    poller = select.poll()
++    poller.register(client.event_fd(), select.POLLIN)
++    deadline = time.monotonic() + timeout
++    while time.monotonic() < deadline:
++        if poller.poll(50):
++            completions = client.drain_completions()
++            if completions:
++                return completions[0]
++    raise AssertionError("native connector completion timed out")
++
++
++def test_odirect_falls_back_for_misaligned_buffer_address(tmp_path):
++    client = lmcache_fs.LMCacheFSClient(str(tmp_path), 1, "", True)
++    try:
++        payload_storage = bytearray(4097)
++        payload = memoryview(payload_storage)[1:]
++        payload[:] = b"x" * len(payload)
++        key = "model@00000000@01"
++
++        store_id = client.submit_batch_set([key], [payload])
++        completed_id, ok, error, _results = _wait_for_completion(client)
++        assert completed_id == store_id
++        assert ok, error
++
++        loaded_storage = bytearray(4097)
++        loaded = memoryview(loaded_storage)[1:]
++        load_id = client.submit_batch_get([key], [loaded])
++        completed_id, ok, error, results = _wait_for_completion(client)
++        assert completed_id == load_id
++        assert ok, error
++        assert results == [True]
++        assert loaded == payload
++    finally:
++        client.close()
++
++
++def test_odirect_falls_back_for_misaligned_readahead_split(tmp_path):
++    client = lmcache_fs.LMCacheFSClient(str(tmp_path), 1, "", True, 4095)
++    try:
++        payload_storage, payload = _aligned_view(8192)
++        payload[:] = b"x" * len(payload)
++        key = "model@00000000@02"
++
++        store_id = client.submit_batch_set([key], [payload])
++        completed_id, ok, error, _results = _wait_for_completion(client)
++        assert completed_id == store_id
++        assert ok, error
++
++        loaded_storage, loaded = _aligned_view(8192)
++        load_id = client.submit_batch_get([key], [loaded])
++        completed_id, ok, error, results = _wait_for_completion(client)
++        assert completed_id == load_id
++        assert ok, error
++        assert results == [True]
++        assert loaded == payload
++        del payload_storage, loaded_storage
++    finally:
++        client.close()
+diff --git a/tests/v1/distributed/test_prefetch_controller.py b/tests/v1/distributed/test_prefetch_controller.py
+index 09c06c5819646d20d65485ee446793a1a9a7f9d0..e86ac177a07f19f54bb6417858dea1d4ff116cfd 100644
+--- a/tests/v1/distributed/test_prefetch_controller.py
++++ b/tests/v1/distributed/test_prefetch_controller.py
+@@ -35,6 +35,9 @@ from lmcache.v1.distributed.l2_adapters.mock_l2_adapter import (
+     MockL2Adapter,
+     MockL2AdapterConfig,
+ )
++from lmcache.v1.distributed.storage_controllers import (
++    prefetch_controller as prefetch_controller_module,
++)
+ from lmcache.v1.distributed.storage_controllers.prefetch_controller import (
+     PrefetchController,
+     build_trim_mask,
+@@ -363,7 +366,7 @@ class TestSingleAdapterPrefetch:
+         ctrl.stop()
+         adapter.close()
+ 
+-    def test_fault_inject_load_gap_segmented_vs_prefix(self, l1_manager):
++    def test_fault_inject_load_gap_segmented_vs_prefix(self, l1_manager, monkeypatch):
+         """fault_inject (load fails at index 2) drives the segmented path.
+ 
+         Lookup reports all 5 keys present; the *load* of index 2 fails (the L2
+@@ -371,6 +374,14 @@ class TestSingleAdapterPrefetch:
+         post-gap keys {0,1,3,4}; PREFIX truncates at the hole to {0,1}. Distinct
+         key ranges per policy keep the shared L1 from serving the second pass.
+         """
++        warning_messages: list[str] = []
++
++        def capture_warning(message, *args, **_kwargs):
++            warning_messages.append(message % args)
++
++        monkeypatch.setattr(
++            prefetch_controller_module.logger, "warning", capture_warning
++        )
+         layout = make_layout()
+         for base, trim, expected in (
+             (0, TrimPolicy.SEGMENTED_PREFIX, [0, 1, 3, 4]),
+@@ -402,6 +413,11 @@ class TestSingleAdapterPrefetch:
+             ctrl.stop()
+             fault.close()
+ 
++        assert any(
++            "1/5 plan keys failed to load from L2" in message and "sample:" in message
++            for message in warning_messages
++        )
++
+     def test_key0_missing(self, l1_manager):
+         """L2 has keys {1,2,3} but not 0 → prefix = 0, nothing loaded."""
+         adapter = make_adapter()
+diff --git a/tests/v1/multiprocess/test_futures.py b/tests/v1/multiprocess/test_futures.py
+index 53cf694bc5c29ee852c5511d2753b6a8a676511a..c9086609ec879d9ed6fcceab478da9c5c7117d49 100644
+--- a/tests/v1/multiprocess/test_futures.py
++++ b/tests/v1/multiprocess/test_futures.py
+@@ -173,6 +173,27 @@ def test_messaging_future_complex_type():
+     thread.join()
+ 
+ 
++def test_messaging_future_exception_is_re_raised():
++    """A remote messaging failure completes the future instead of hanging it."""
++    future = MessagingFuture[int]()
++    error = RuntimeError("remote operation failed")
++
++    future.set_exception(error)
++
++    assert future.query()
++    assert future.wait(timeout=0.1)
++    with pytest.raises(RuntimeError, match="remote operation failed") as exc_info:
++        future.result(timeout=0.1)
++    assert exc_info.value is error
++
++
++def test_messaging_future_rejects_non_exception():
++    future = MessagingFuture[int]()
++
++    with pytest.raises(TypeError, match="must derive from BaseException"):
++        future.set_exception("not an exception")  # type: ignore[arg-type]
++
++
+ # ==============================================================================
+ # CUDAMessagingFuture Tests
+ # ==============================================================================
+diff --git a/tests/v1/multiprocess/test_mq.py b/tests/v1/multiprocess/test_mq.py
+index 75ff9cd7a0630391f0515622e36e1f38fe243764..93ef515bfc0c3a66feda76720178b2dd140a7211 100644
+--- a/tests/v1/multiprocess/test_mq.py
++++ b/tests/v1/multiprocess/test_mq.py
+@@ -21,6 +21,7 @@ from lmcache.v1.multiprocess.mq import (
+     BlockingRequestHandler,
+     MessageQueueClient,
+     MessageQueueServer,
++    RemoteHandlerError,
+ )
+ from lmcache.v1.multiprocess.protocol import (
+     RequestType,
+@@ -683,6 +684,58 @@ def test_shared_loop_dispatch():
+         server.close()
+ 
+ 
++def test_sync_handler_failure_completes_future_and_loop_recovers():
++    context = zmq.Context.instance()
++    server = MessageQueueServer("tcp://127.0.0.1:16021", context)
++    add_handler_helper(
++        server, RequestType.NOOP, test_mq_handler_helpers.failing_noop_handler
++    )
++    server.start()
++    client = MessageQueueClient("tcp://127.0.0.1:16021", context)
++
++    try:
++        failed = client.submit_request(RequestType.NOOP, [])
++        with pytest.raises(
++            RemoteHandlerError, match="intentional sync handler failure"
++        ) as exc_info:
++            failed.result(timeout=2)
++        assert exc_info.value.request_type is RequestType.NOOP
++        assert exc_info.value.error_type == "ValueError"
++
++        server.add_sync_handler(
++            RequestType.NOOP, [], test_mq_handler_helpers.noop_handler
++        )
++        assert (
++            client.submit_request(RequestType.NOOP, []).result(timeout=2) == "NOOP_OK"
++        )
++    finally:
++        client.close()
++        server.close()
++
++
++def test_blocking_handler_failure_completes_future():
++    context = zmq.Context.instance()
++    server = MessageQueueServer("tcp://127.0.0.1:16022", context)
++    add_handler_helper(
++        server, RequestType.LOOKUP, test_mq_handler_helpers.failing_lookup_handler
++    )
++    server.add_normal_thread_pool([RequestType.LOOKUP], max_workers=1)
++    server.start()
++    client = MessageQueueClient("tcp://127.0.0.1:16022", context)
++
++    try:
++        future = client.submit_request(RequestType.LOOKUP, [create_cache_key(1), 1])
++        with pytest.raises(
++            RemoteHandlerError, match="intentional blocking handler failure"
++        ) as exc_info:
++            future.result(timeout=2)
++        assert exc_info.value.request_type is RequestType.LOOKUP
++        assert exc_info.value.error_type == "OSError"
++    finally:
++        client.close()
++        server.close()
++
++
+ def test_shared_loop_recreate():
+     """
+     Test that closing all clients and creating new ones starts a fresh loop.
+diff --git a/tests/v1/multiprocess/test_mq_handler_helpers.py b/tests/v1/multiprocess/test_mq_handler_helpers.py
+index b1d65251d3fd0a615bc256fb483cf78a4a8ef16e..9837df531ef7414473af86834bc63afcb7f842c0 100644
+--- a/tests/v1/multiprocess/test_mq_handler_helpers.py
++++ b/tests/v1/multiprocess/test_mq_handler_helpers.py
+@@ -29,6 +29,11 @@ def noop_handler() -> str:
+     return "NOOP_OK"
+ 
+ 
++def failing_noop_handler() -> str:
++    """Raise a deterministic error for RPC error propagation tests."""
++    raise ValueError("intentional sync handler failure")
++
++
+ # ==============================================================================
+ # REGISTER_KV_CACHE Request Handlers
+ # ==============================================================================
+@@ -203,6 +208,12 @@ def lookup_handler(key: KeyType, tp_size: int) -> None:
+     assert isinstance(tp_size, int), f"Expected tp_size to be int, got {type(tp_size)}"
+ 
+ 
++def failing_lookup_handler(key: KeyType, tp_size: int) -> None:
++    """Raise a deterministic error from a blocking request handler."""
++    del key, tp_size
++    raise OSError("intentional blocking handler failure")
++
++
+ # ==============================================================================
+ # FREE_LOOKUP_LOCKS Request Handlers
+ # ==============================================================================
+diff --git a/tests/v1/test_vllm_mp_adapter.py b/tests/v1/test_vllm_mp_adapter.py
+index d64ca9ec7061a0714cba7c9c488e3fb0cef9179a..ddf180a64dd9e6b9d8f4af4114324bc927fbf12f 100644
+--- a/tests/v1/test_vllm_mp_adapter.py
++++ b/tests/v1/test_vllm_mp_adapter.py
+@@ -782,3 +782,65 @@ def test_recover_callback_rebuilds_transfer_ctx_without_closing_previous(
+     assert len(contexts) == 3
+     assert adapter.transfer_ctx is contexts[2]
+     contexts[1].close.assert_not_called()
++
++
++def _finished_retrieve_future(result: object) -> MagicMock:
++    """Build a completed retrieve future; an Exception *result* makes
++    ``result()`` raise it."""
++    future = MagicMock(name="retrieve_future")
++    future.query.return_value = True
++    if isinstance(result, Exception):
++        future.result.side_effect = result
++    else:
++        future.result.return_value = result
++    return future
++
++
++def test_failed_retrieve_marks_blocks_invalid(fake_adapter) -> None:
++    """A retrieve the healthy server answers with ``result=False`` is
++    reported finished AND its block ids are surfaced through
++    ``get_block_ids_with_load_errors`` so the scheduler recomputes them
++    instead of decoding over never-written blocks."""
++    adapter, _send_mock, _ = fake_adapter
++    adapter.retrieve_futures["req-1"] = (
++        _finished_retrieve_future(False),
++        [3, 4, 5],
++    )
++
++    ret_stores, finished_retrieves = adapter.get_finished(set())
++
++    assert ret_stores == set()
++    assert finished_retrieves == {"req-1"}
++    assert adapter.get_block_ids_with_load_errors() == {3, 4, 5}
++    # The error set is consumed on read.
++    assert adapter.get_block_ids_with_load_errors() == set()
++    assert adapter.retrieve_failure_count == 1
++
++
++def test_raising_retrieve_future_contained_as_failure(fake_adapter) -> None:
++    """A retrieve future whose ``result()`` raises must not propagate out
++    of ``get_finished`` (that would kill the engine step); it lands on the
++    same failure path as ``result=False``."""
++    adapter, _send_mock, _ = fake_adapter
++    adapter.retrieve_futures["req-1"] = (
++        _finished_retrieve_future(RuntimeError("ipc receive failed")),
++        [7, 8],
++    )
++
++    _ret_stores, finished_retrieves = adapter.get_finished(set())
++
++    assert finished_retrieves == {"req-1"}
++    assert adapter.get_block_ids_with_load_errors() == {7, 8}
++    assert adapter.retrieve_failure_count == 1
++
++
++def test_successful_retrieve_marks_no_blocks_invalid(fake_adapter) -> None:
++    """A successful retrieve reports no load errors."""
++    adapter, _send_mock, _ = fake_adapter
++    adapter.retrieve_futures["req-1"] = (_finished_retrieve_future(True), [1, 2])
++
++    _ret_stores, finished_retrieves = adapter.get_finished(set())
++
++    assert finished_retrieves == {"req-1"}
++    assert adapter.get_block_ids_with_load_errors() == set()
++    assert adapter.retrieve_failure_count == 0
+diff --git a/tests/v1/test_vllm_mp_connector_metadata.py b/tests/v1/test_vllm_mp_connector_metadata.py
+new file mode 100644
+index 0000000000000000000000000000000000000000..45d427bd561aed4dcc953eda04259e2854008e15
+--- /dev/null
++++ b/tests/v1/test_vllm_mp_connector_metadata.py
+@@ -0,0 +1,133 @@
++# SPDX-License-Identifier: Apache-2.0
++"""Unit tests for ``LMCacheMPRequestMetadata.GetRetrieveMetadata``.
++
++The retrieve op must only be emitted when the tracker's allocated block ids
++actually cover the retrieve token range in every engine group:
++``slice_block_ids_per_group`` validates chunk alignment only, and its plain
++Python slice truncates silently, so an uncovered range would otherwise emit
++an op with too few block ids.
++"""
++
++# Standard
++from types import SimpleNamespace
++
++# Third Party
++import pytest
++
++# First Party
++from lmcache.integration.vllm.lmcache_mp_connector import (
++    LMCacheMPRequestMetadata,
++    LMCacheMPRequestState,
++    LMCacheMPRequestTracker,
++)
++
++CHUNK_TOKENS = 64
++
++
++def _tracker(
++    num_tokens: int,
++    lmcache_hit_tokens: int,
++    vllm_hit_tokens: int,
++    allocated_block_ids: dict[int, list[int]],
++) -> LMCacheMPRequestTracker:
++    """Build a tracker that is ready for retrieving over *num_tokens*."""
++    request = SimpleNamespace(
++        request_id="req-1",
++        cache_salt="",
++        all_token_ids=list(range(num_tokens)),
++    )
++    tracker = LMCacheMPRequestTracker(request)
++    tracker.num_lmcache_hit_tokens = lmcache_hit_tokens
++    tracker.num_vllm_hit_tokens = vllm_hit_tokens
++    tracker.allocated_block_ids = allocated_block_ids
++    tracker.state = LMCacheMPRequestState.WAITING_FOR_LOAD
++    return tracker
++
++
++@pytest.mark.parametrize(
++    ("group_tokens_per_block", "allocated_block_ids", "expected_block_ids"),
++    [
++        # Single group, plain geometry: 64 tokens / 16 tokens per block.
++        ([16], {0: [0, 1, 2, 3]}, [[0, 1, 2, 3]]),
++        # Single group, DCP-scaled: one manager block id covers 64 tokens.
++        ([64], {0: [5]}, [[5]]),
++        # Hybrid geometries: each group sliced by its own tokens-per-block.
++        ([16, 32], {0: [0, 1, 2, 3], 1: [10, 11]}, [[0, 1, 2, 3], [10, 11]]),
++        # Extra allocated blocks beyond the range are fine (and not emitted).
++        ([16], {0: [0, 1, 2, 3, 4, 5]}, [[0, 1, 2, 3]]),
++    ],
++)
++def test_retrieve_metadata_emitted_when_allocation_covers_range(
++    group_tokens_per_block: list[int],
++    allocated_block_ids: dict[int, list[int]],
++    expected_block_ids: list[list[int]],
++) -> None:
++    tracker = _tracker(
++        num_tokens=CHUNK_TOKENS,
++        lmcache_hit_tokens=CHUNK_TOKENS,
++        vllm_hit_tokens=0,
++        allocated_block_ids=allocated_block_ids,
++    )
++
++    metadata = LMCacheMPRequestMetadata.GetRetrieveMetadata(
++        tracker, CHUNK_TOKENS, group_tokens_per_block
++    )
++
++    assert metadata is not None
++    assert metadata.direction == "RETRIEVE"
++    assert metadata.op.start == 0
++    assert metadata.op.end == CHUNK_TOKENS
++    assert metadata.op.block_ids == expected_block_ids
++
++
++@pytest.mark.parametrize(
++    ("group_tokens_per_block", "allocated_block_ids"),
++    [
++        # One block short in the only group.
++        ([16], {0: [0, 1, 2]}),
++        # DCP-scaled group with no allocation at all.
++        ([64], {0: []}),
++        # Group 0 covered, group 1 one block short.
++        ([16, 32], {0: [0, 1, 2, 3], 1: [10]}),
++        # Group key missing entirely (counts as zero blocks).
++        ([16, 16], {0: [0, 1, 2, 3]}),
++    ],
++)
++def test_retrieve_metadata_suppressed_when_allocation_short(
++    group_tokens_per_block: list[int],
++    allocated_block_ids: dict[int, list[int]],
++) -> None:
++    """Any engine group whose allocation does not cover the retrieve range
++    suppresses the op entirely: the request falls back to recompute instead
++    of retrieving over silently truncated block-id lists."""
++    tracker = _tracker(
++        num_tokens=CHUNK_TOKENS,
++        lmcache_hit_tokens=CHUNK_TOKENS,
++        vllm_hit_tokens=0,
++        allocated_block_ids=allocated_block_ids,
++    )
++
++    metadata = LMCacheMPRequestMetadata.GetRetrieveMetadata(
++        tracker, CHUNK_TOKENS, group_tokens_per_block
++    )
++
++    assert metadata is None
++
++
++def test_retrieve_metadata_skip_tokens_preserved_on_emitted_op() -> None:
++    """vLLM-hit tokens inside the first chunk round the start down and are
++    carried as skip_first_n_tokens; coverage is still checked against the
++    chunk-aligned end."""
++    tracker = _tracker(
++        num_tokens=CHUNK_TOKENS,
++        lmcache_hit_tokens=CHUNK_TOKENS,
++        vllm_hit_tokens=16,
++        allocated_block_ids={0: [0, 1, 2, 3]},
++    )
++
++    metadata = LMCacheMPRequestMetadata.GetRetrieveMetadata(tracker, CHUNK_TOKENS, [16])
++
++    assert metadata is not None
++    assert metadata.op.start == 0
++    assert metadata.op.end == CHUNK_TOKENS
++    assert metadata.op.skip_first_n_tokens == 16

--- a/patches/releases/gilded-gnosis-v20-r32/vllm/integration.lock.json
+++ b/patches/releases/gilded-gnosis-v20-r32/vllm/integration.lock.json
@@ -1,0 +1,152 @@
+{
+  "base": {
+    "commit": "e2666d9a65f41fc376607531453cbd57c4c71016",
+    "ref": "refs/heads/dev/gilded-gnosis",
+    "repository": "https://github.com/local-inference-lab/vllm.git"
+  },
+  "manifest": {
+    "sha256": "2f1c3ddc252aec35269247491717f58b5af35c01038fd5dd9cf6648996ac98c1"
+  },
+  "name": "gilded-gnosis-v20",
+  "pull_requests": [
+    {
+      "disposition": "merged",
+      "head": "99bf3f13f13012b72d6d67e49572d686b45b2833",
+      "number": 145,
+      "ref": "refs/pull/145/head",
+      "title": "GLM-5.2 calibrated NVFP4 MLA KV outer scales"
+    },
+    {
+      "disposition": "merged",
+      "head": "48e9d0f75d96db61429cbe7fe4fccb96739c58d6",
+      "number": 256,
+      "ref": "refs/pull/256/head",
+      "title": "Preserve activation dtype for int32-packed MLA weights"
+    },
+    {
+      "disposition": "merged",
+      "head": "aa75b01c476ffb5fc728232546fe5c215e3728ec",
+      "number": 188,
+      "ref": "refs/pull/188/head",
+      "title": "Emit packed UE8M0 scales from compiled QuantFP8"
+    },
+    {
+      "disposition": "merged",
+      "head": "1a2b01f43fbc151239c437e918dfdc27681ce4e7",
+      "number": 229,
+      "ref": "refs/pull/229/head",
+      "title": "Harden compressed MLA cache, workspace, and verifier capacity contracts"
+    },
+    {
+      "disposition": "merged",
+      "head": "5f144274d6e092237f4f4f437b7e9d3aaa427157",
+      "number": 213,
+      "ref": "refs/pull/213/head",
+      "title": "Skip pre-KV V2 attention during FlashInfer autotune"
+    },
+    {
+      "disposition": "merged",
+      "head": "8d989f18c2845e514313e80f65b07087b09d6a67",
+      "number": 214,
+      "ref": "refs/pull/214/head",
+      "title": "Add DeepSeek-V4-Flash-0731 profile and native L1/L2 offload"
+    },
+    {
+      "disposition": "merged",
+      "head": "bde9a133774e38a54511696cef1ac10b16ef700b",
+      "number": 217,
+      "ref": "refs/pull/217/head",
+      "title": "Harden shared regions for native CPU KV offload"
+    },
+    {
+      "disposition": "merged",
+      "head": "3b89c7a113f92522aa07cc3271422c04e458d771",
+      "number": 218,
+      "ref": "refs/pull/218/head",
+      "title": "Align native SWA/MTP retention and shared-prefix tails"
+    },
+    {
+      "disposition": "merged",
+      "head": "5ec935796f0afa19e3d8e41888ecc51a6a637528",
+      "number": 228,
+      "ref": "refs/pull/228/head",
+      "title": "Consolidate EXL3 runtime and prewarm mixed-Trellis route packing"
+    },
+    {
+      "disposition": "merged",
+      "head": "9401f9d8916f3bdf34123d2d493a918b748c8132",
+      "number": 230,
+      "ref": "refs/pull/230/head",
+      "title": "Keep broadcast MHC pre behind the compile boundary"
+    },
+    {
+      "disposition": "merged",
+      "head": "eaf24cc15f313c4b15afabb3f902cfe17f19f28f",
+      "number": 234,
+      "ref": "refs/pull/234/head",
+      "title": "Guard persistent FlashInfer decode wrappers by planned query length"
+    },
+    {
+      "disposition": "merged",
+      "head": "54349f9ce6d32a68c7c736f2ac3ac597afd6e208",
+      "number": 235,
+      "ref": "refs/pull/235/head",
+      "title": "Align DeepSeek-V4-0731 reasoning and tool prompt contract"
+    },
+    {
+      "disposition": "merged",
+      "head": "9dbd6d00b0340da173b61affb961954090632dec",
+      "number": 245,
+      "ref": "refs/pull/245/head",
+      "title": "Build one-shard indexer query-split topology"
+    },
+    {
+      "disposition": "merged",
+      "head": "85bc9770c94394fb070f3f9311d68bcaca6a354d",
+      "number": 248,
+      "ref": "refs/pull/248/head",
+      "title": "Prewarm CuTe PCIe one-shot all-reduce before graph capture"
+    },
+    {
+      "disposition": "merged",
+      "head": "c66ce7327ee586e5b600b9d7e12db30e93e8ec96",
+      "number": 251,
+      "ref": "refs/pull/251/head",
+      "title": "Isolate B12X graph channels and capture DSpark context KV"
+    },
+    {
+      "disposition": "merged",
+      "head": "1772842af39788286634e168ef766e15add83869",
+      "number": 253,
+      "ref": "refs/pull/253/head",
+      "title": "Add FlashInfer PCIe IPC all-reduce backend"
+    },
+    {
+      "disposition": "merged",
+      "head": "e3317de2336fc84396d7541950542c79b62102ae",
+      "number": 252,
+      "ref": "refs/pull/252/head",
+      "title": "Defer native KV-offload finalization until the final store is built"
+    },
+    {
+      "disposition": "merged",
+      "head": "5d961ad9d2efaba40531e8e4542a6c193412898d",
+      "number": 254,
+      "ref": "refs/pull/254/head",
+      "title": "Harden native offload cleanup and bound filesystem storage"
+    },
+    {
+      "disposition": "merged",
+      "head": "d1b7bbeb78da068ab0a505bd09505f6637cddcd9",
+      "number": 255,
+      "ref": "refs/pull/255/head",
+      "title": "Register GG runtime controls consumed directly by backends"
+    }
+  ],
+  "result": {
+    "patch": "integration.patch",
+    "patch_sha256": "c03a83a6cf81c213caa435ec6190f61b6b10c02ab8cc3d5b24fe6d291a121b39",
+    "tree": "fa13d334a2962756f9f7e9b562deb85387359f42"
+  },
+  "schema_version": 1
+}

--- a/patches/releases/gilded-gnosis-v20-r32/vllm/integration.patch
+++ b/patches/releases/gilded-gnosis-v20-r32/vllm/integration.patch
@@ -1,0 +1,14579 @@
+diff --git a/docs/features/quantization/online.md b/docs/features/quantization/online.md
+index bd4db0e0194320db6ea081be349d8f9b764f9162..169d2d01baac036213a13db54675db969be1fa76 100644
+--- a/docs/features/quantization/online.md
++++ b/docs/features/quantization/online.md
+@@ -100,7 +100,7 @@ vllm serve <glm-5.2-modelopt-checkpoint> \
+ Serialized checkpoint-quantized shared experts are preserved; only excluded
+ BF16 projection weights are converted at load time.
+ 
+-### MXFP8 dense linears on ModelOpt checkpoints
++### MXFP8 dense linears on quantized checkpoints
+ 
+ The `linear` field overlays online MXFP8 the same way onto every other
+ BF16 dense linear the ModelOpt checkpoint excludes: attention projections,
+@@ -143,6 +143,22 @@ vllm serve lukealonso/GLM-5.2-NVFP4 \
+   --quantization-config '{"linear":{"weight":"mxfp8"},"ignore":["re:.*kv_b_proj"]}'
+ ```
+ 
++EXL3 checkpoints can use the same overlay for dense and shared-expert
++projections that are absent from the EXL3 tensor metadata. Serialized EXL3
++dense matrices and routed experts always retain their checkpoint format;
++`moe` overlays are rejected. `lm_head` also remains in its checkpoint format
++or BF16. For example:
++
++```bash
++vllm serve <exl3-checkpoint> \
++  --quantization exl3 \
++  --quantization-config '{"linear":{"weight":"mxfp8"},"shared_experts":{"weight":"mxfp8"},"ignore":["re:.*\\.q_a_proj$","re:.*kv_a_proj_with_mqa","lm_head"]}'
++```
++
++As with ModelOpt, `linear` does not select shared experts. Add the
++`shared_experts` field explicitly when those BF16 projections should also be
++converted. Ignore patterns are matched against unfused checkpoint names.
++
+ ### Activation overrides on already-quantized checkpoints
+ 
+ For checkpoint-quantized models, `quantization_config` lets you pick an
+diff --git a/kv-scales/README.md b/kv-scales/README.md
+new file mode 100644
+index 0000000000000000000000000000000000000000..36b37d5aa188027675ec9eaa447e9597b3921e4c
+--- /dev/null
++++ b/kv-scales/README.md
+@@ -0,0 +1,49 @@
++# GLM-5.2 NVFP4 MLA KV outer scales
++
++Per-layer calibration for the `nvfp4_ds_mla` KV cache writer
++(`VLLM_NVFP4_MLA_SCALES_FILE`, format `nvfp4_ds_mla_outer_scale_v1`).
++
++GLM-5.2's post-RMSNorm 512-dim `kv_c` latent spans a ~240x amplitude range
++across layers. With the default outer scale of 1.0, shallow layers quantize
++with E4M3 block scales at or below the subnormal floor, and shallow-layer KV
++error is strongly amplified downstream. `s_l = max_abs(kv_c_normed) / (6*448)`
++re-centers every layer so its largest block scale lands at the top of the
++E4M3 range.
++
++## Files
++
++- `glm52-nvfp4-nf3-hybrid_mla_outer_scales_v1.json` — calibrated on
++  `madeby561/GLM-5.2-MXFP8-NVFP4-NF3-Hybrid` (K64R16), Salesforce/wikitext
++  (wikitext-2-raw-v1, test), 2048-token context, TP4; per-layer envelope with
++  an independent community capture of the same base model for shallow-layer
++  headroom. `max_abs` per layer is included for auditability.
++
++## Usage
++
++```bash
++VLLM_NVFP4_MLA_SCALES_FILE=/path/to/glm52-nvfp4-nf3-hybrid_mla_outer_scales_v1.json \
++  ./serve-glm52.sh   # nvfp4_ds_mla + B12X_MLA_SPARSE only; inert otherwise
++```
++
++## Results (teacher-forced prefill KLD vs BF16 reference, 5 fresh boots each)
++
++| KV config | mean +/- sd | max ctx (4x96GB) |
++|---|---|---|
++| fp8_ds_mla | 0.1263 +/- 0.0030 | 373k |
++| nvfp4_ds_mla + scales, bf16 rope | 0.1345 +/- 0.0035 | 550k |
++| nvfp4_ds_mla + scales, fp8 rope (`KV_FP8_ROPE=1`) | 0.1356 +/- 0.0054 | 600k+ |
++| nvfp4_ds_mla, no scales, bf16 rope | 0.158 | 550k |
++| nvfp4_ds_mla, no scales, fp8 rope | 0.168 | 600k+ |
++
++Protocol: local-inference-lab/rtx6kpro `benchmarks/glm52-kld-evaluation.md`
++(festr2 2026-07-08 reference logits, one fixed 2048-token window, 2047
++positions, full 154,880 vocab, `KL(ref || candidate)`).
++
++## Cache invalidation (required)
++
++CuTeDSL folds the outer-scale multiply out of the kernel when `latent_scale`
++traces at exactly 1.0. b12x builds without the identity/dynamic compile-spec
++fact (see lukealonso/b12x PR "mla: split latent_scale identity/dynamic
++compile-cache entries") replay stale identity cubins from persistent compile
++caches, silently dropping the restore. Clear mounted b12x compile caches once
++when enabling scales on such builds.
+diff --git a/kv-scales/glm52-nvfp4-nf3-hybrid_mla_outer_scales_v1.json b/kv-scales/glm52-nvfp4-nf3-hybrid_mla_outer_scales_v1.json
+new file mode 100644
+index 0000000000000000000000000000000000000000..7ae9d9351c4e8de79f6387b5f64a5fa9618bf155
+--- /dev/null
++++ b/kv-scales/glm52-nvfp4-nf3-hybrid_mla_outer_scales_v1.json
+@@ -0,0 +1,178 @@
++{
++ "format": "nvfp4_ds_mla_outer_scale_v1",
++ "num_layers": 78,
++ "latent_dim": 512,
++ "denominator": 2688.0,
++ "formula": "s_l = max_abs(kv_c_normed) / (6 * 448)",
++ "model": "madeby561/GLM-5.2-MXFP8-NVFP4-NF3-Hybrid (local K64R16 build; own capture)",
++ "dataset": {
++  "name": "Salesforce/wikitext",
++  "config": "wikitext-2-raw-v1",
++  "split": "test",
++  "context_length": 2048,
++  "windows": 1,
++  "note": "the canonical festr2-0708 census window"
++ },
++ "created_utc": "2026-07-20T16:40:43.312260+00:00",
++ "hook": "mla.py kv_a_layernorm output (bind-mount capture patch), per-TP-rank agreement checked",
++ "max_abs": [
++  0.04833984375,
++  0.021728515625,
++  0.03662109375,
++  0.1005859375,
++  0.023681640625,
++  0.03515625,
++  0.046875,
++  0.033203125,
++  0.259765625,
++  0.1474609375,
++  0.7734375,
++  1.0,
++  1.1171875,
++  0.150390625,
++  0.76171875,
++  0.392578125,
++  0.25390625,
++  0.455078125,
++  0.80859375,
++  0.80078125,
++  0.96875,
++  0.78515625,
++  0.58203125,
++  0.330078125,
++  0.89453125,
++  0.73046875,
++  1.0390625,
++  1.578125,
++  1.0078125,
++  0.92578125,
++  1.25,
++  1.5859375,
++  1.234375,
++  1.9140625,
++  1.9453125,
++  1.7578125,
++  1.7890625,
++  2.546875,
++  2.296875,
++  2.4375,
++  1.921875,
++  2.171875,
++  2.875,
++  2.546875,
++  2.765625,
++  3.234375,
++  2.5625,
++  3.390625,
++  2.40625,
++  2.546875,
++  3.09375,
++  2.90625,
++  3.671875,
++  2.46875,
++  2.609375,
++  2.359375,
++  3.078125,
++  3.171875,
++  2.578125,
++  2.359375,
++  3.890625,
++  2.953125,
++  4.09375,
++  4.09375,
++  5.0625,
++  5.1875,
++  2.984375,
++  2.875,
++  2.984375,
++  3.296875,
++  3.828125,
++  2.859375,
++  3.59375,
++  3.734375,
++  4.25,
++  4.1875,
++  4.84375,
++  3.75
++ ],
++ "scales": [
++  1.7983572823660715e-05,
++  8.083525158110119e-06,
++  1.3623918805803572e-05,
++  3.742036365327381e-05,
++  8.810134161086309e-06,
++  1.3078962053571428e-05,
++  1.743861607142857e-05,
++  1.2352353050595238e-05,
++  9.663899739583333e-05,
++  5.485897972470238e-05,
++  0.00028773716517857144,
++  0.0003720238095238095,
++  0.00041562034970238094,
++  5.5948893229166664e-05,
++  0.0002833775111607143,
++  0.00014604840959821428,
++  9.445917038690477e-05,
++  0.00016929989769345238,
++  0.00030081612723214287,
++  0.0002979096912202381,
++  0.0003603980654761905,
++  0.00029209681919642856,
++  0.00021652948288690475,
++  0.0001227969215029762,
++  0.00033278692336309525,
++  0.00027175176711309525,
++  0.0003865559895833333,
++  0.0005871000744047619,
++  0.0003749302455357143,
++  0.0003444126674107143,
++  0.0004650297619047619,
++  0.0005900065104166666,
++  0.0004592168898809524,
++  0.0007120768229166666,
++  0.0007237025669642857,
++  0.0006539481026785714,
++  0.0006655738467261905,
++  0.0009474981398809524,
++  0.0008544921875,
++  0.0009068080357142857,
++  0.0007149832589285714,
++  0.0008079892113095238,
++  0.0010695684523809525,
++  0.0009474981398809524,
++  0.0010288783482142857,
++  0.0012032645089285715,
++  0.0009533110119047619,
++  0.0012613932291666667,
++  0.0008951822916666666,
++  0.0009474981398809524,
++  0.0011509486607142857,
++  0.0010811941964285715,
++  0.001366024925595238,
++  0.0009184337797619048,
++  0.0009707496279761905,
++  0.0008777436755952381,
++  0.0011451357886904762,
++  0.0011800130208333333,
++  0.0009591238839285714,
++  0.0008777436755952381,
++  0.0014474051339285715,
++  0.0010986328125,
++  0.0015229724702380952,
++  0.0015229724702380952,
++  0.0018833705357142857,
++  0.001929873511904762,
++  0.001110258556547619,
++  0.0010695684523809525,
++  0.001110258556547619,
++  0.0012265159970238095,
++  0.0014241536458333333,
++  0.0010637555803571428,
++  0.0013369605654761905,
++  0.0013892764136904762,
++  0.0015811011904761905,
++  0.0015578497023809525,
++  0.0018019903273809525,
++  0.0013950892857142857
++ ]
++}
+\ No newline at end of file
+diff --git a/rust/src/chat/src/renderer/deepseek_v4/encoding.rs b/rust/src/chat/src/renderer/deepseek_v4/encoding.rs
+index 80438b0c4156783ada07acc582bd44af886641b4..c96dcfa9bdeb061432528146b393fe1e63c5829c 100644
+--- a/rust/src/chat/src/renderer/deepseek_v4/encoding.rs
++++ b/rust/src/chat/src/renderer/deepseek_v4/encoding.rs
+@@ -24,11 +24,16 @@ const THINKING_END_TOKEN: &str = "</think>";
+ const DSML_TOKEN: &str = "｜DSML｜";
+ const USER_SP_TOKEN: &str = "<｜User｜>";
+ const ASSISTANT_SP_TOKEN: &str = "<｜Assistant｜>";
+-const REASONING_EFFORT_MAX: &str = concat!(
++const REASONING_EFFORT_HIGH: &str = concat!(
+     "Reasoning Effort: Absolute maximum with no shortcuts permitted.\n",
+     "You MUST be very thorough in your thinking and comprehensively decompose the problem to resolve the root cause, rigorously stress-testing your logic against all potential paths, edge cases, and adversarial scenarios.\n",
+     "Explicitly write out your entire deliberation process, documenting every intermediate step, considered alternative, and rejected hypothesis to ensure absolutely no assumption is left unchecked.\n\n",
+ );
++const REASONING_EFFORT_MAX: &str = concat!(
++    "Reasoning Effort: Beyond maximum — exhaustive, relentless, and uncompromising.\n",
++    "You MUST reason with the utmost depth and rigor, leaving absolutely nothing to chance: exhaustively decompose the problem into its most fundamental components, trace every causal chain to its root, and resolve the underlying cause rather than any surface symptom.\n",
++    "Do not stop reasoning until you have independently verified the solution from multiple angles and are certain that no assumption remains unchecked and no error remains undiscovered.\n\n",
++);
+ 
+ #[derive(Debug, Clone, Copy, PartialEq, Eq)]
+ enum ThinkingMode {
+@@ -47,7 +52,7 @@ struct RenderedToolSchema<'a> {
+ 
+ /// Render one chat request into the final prompt string.
+ pub(super) fn render_request(request: &ChatRequest) -> Result<String> {
+-    let (thinking_mode, max_reasoning_effort) = resolve_thinking_options(request)?;
++    let (thinking_mode, reasoning_effort_prompt) = resolve_thinking_options(request)?;
+     let request_tools = request_tools(request);
+     let synthetic_tool_system = needs_synthetic_tool_system(request, request_tools);
+     let drop_thinking = request.parse_template_bool("drop_thinking")?.unwrap_or(true)
+@@ -55,8 +60,8 @@ pub(super) fn render_request(request: &ChatRequest) -> Result<String> {
+     let last_user_render_index =
+         find_last_user_render_index(request.messages.as_slice(), synthetic_tool_system);
+     let mut out = String::from(BOS_TOKEN);
+-    if thinking_mode == ThinkingMode::Thinking && max_reasoning_effort {
+-        out.push_str(REASONING_EFFORT_MAX);
++    if thinking_mode == ThinkingMode::Thinking {
++        out.push_str(reasoning_effort_prompt);
+     }
+ 
+     let mut request_tools_attached = false;
+@@ -124,20 +129,25 @@ pub(super) fn render_request(request: &ChatRequest) -> Result<String> {
+ /// wrapper, the Rust renderer only consumes the typed top-level
+ /// `reasoning_effort`; the generic template-kwargs map is left for HF
+ /// templates.
+-fn resolve_thinking_options(request: &ChatRequest) -> Result<(ThinkingMode, bool)> {
++fn resolve_thinking_options(request: &ChatRequest) -> Result<(ThinkingMode, &'static str)> {
+     let mut thinking_mode = match request.enable_thinking()?.unwrap_or(false) {
+         true => ThinkingMode::Thinking,
+         false => ThinkingMode::Chat,
+     };
+-    let mut max_reasoning_effort = false;
++    let mut reasoning_effort_prompt = "";
+ 
+     match request.chat_options.reasoning_effort {
+         Some(ReasoningEffort::None) => thinking_mode = ThinkingMode::Chat,
+-        Some(ReasoningEffort::Max | ReasoningEffort::XHigh) => max_reasoning_effort = true,
++        Some(ReasoningEffort::Max | ReasoningEffort::XHigh) => {
++            reasoning_effort_prompt = REASONING_EFFORT_MAX;
++        }
++        Some(ReasoningEffort::Minimal | ReasoningEffort::Medium | ReasoningEffort::High) => {
++            reasoning_effort_prompt = REASONING_EFFORT_HIGH;
++        }
+         Some(_) | None => {}
+     }
+ 
+-    Ok((thinking_mode, max_reasoning_effort))
++    Ok((thinking_mode, reasoning_effort_prompt))
+ }
+ 
+ /// Return request-level tools only when native tool parsing is enabled.
+diff --git a/rust/src/chat/src/renderer/deepseek_v4/tests.rs b/rust/src/chat/src/renderer/deepseek_v4/tests.rs
+index 73380cef260ed6e498698f0208986587e2ba4e5c..46d625588ba3a1517cf86ca9b5327528ae425da4 100644
+--- a/rust/src/chat/src/renderer/deepseek_v4/tests.rs
++++ b/rust/src/chat/src/renderer/deepseek_v4/tests.rs
+@@ -10,7 +10,9 @@ use super::DeepSeekV4ChatRenderer;
+ use crate::ChatRenderer;
+ use crate::event::{AssistantContentBlock, AssistantToolCall};
+ use crate::renderer::test_utils::{FixtureRequestOptions, fixture_chat_request};
+-use crate::request::{ChatMessage, ChatRequest, GenerationPromptMode, ReasoningEffort};
++use crate::request::{
++    ChatMessage, ChatRequest, ChatTool, ChatToolChoice, GenerationPromptMode, ReasoningEffort,
++};
+ 
+ fn render_request(request: &ChatRequest) -> String {
+     DeepSeekV4ChatRenderer::new()
+@@ -75,6 +77,29 @@ fn reasoning_effort_max_adds_prefix_when_thinking_is_enabled() {
+ 
+     let rendered = render_request(&request);
+ 
++    expect![[r#"
++        <｜begin▁of▁sentence｜>Reasoning Effort: Beyond maximum — exhaustive, relentless, and uncompromising.
++        You MUST reason with the utmost depth and rigor, leaving absolutely nothing to chance: exhaustively decompose the problem into its most fundamental components, trace every causal chain to its root, and resolve the underlying cause rather than any surface symptom.
++        Do not stop reasoning until you have independently verified the solution from multiple angles and are certain that no assumption remains unchecked and no error remains undiscovered.
++
++        <｜User｜>solve it<｜Assistant｜><think>"#]]
++    .assert_eq(&rendered);
++}
++
++#[test]
++fn reasoning_effort_high_adds_0731_high_prefix() {
++    let mut request = ChatRequest {
++        messages: vec![ChatMessage::user("solve it")],
++        ..ChatRequest::for_test()
++    };
++    request
++        .chat_options
++        .template_kwargs
++        .insert("thinking".to_string(), Value::Bool(true));
++    request.chat_options.reasoning_effort = Some(ReasoningEffort::High);
++
++    let rendered = render_request(&request);
++
+     expect![[r#"
+         <｜begin▁of▁sentence｜>Reasoning Effort: Absolute maximum with no shortcuts permitted.
+         You MUST be very thorough in your thinking and comprehensively decompose the problem to resolve the root cause, rigorously stress-testing your logic against all potential paths, edge cases, and adversarial scenarios.
+@@ -84,6 +109,57 @@ fn reasoning_effort_max_adds_prefix_when_thinking_is_enabled() {
+     .assert_eq(&rendered);
+ }
+ 
++#[test]
++fn reasoning_effort_low_keeps_the_default_prompt() {
++    let mut request = ChatRequest {
++        messages: vec![ChatMessage::user("solve it")],
++        ..ChatRequest::for_test()
++    };
++    request
++        .chat_options
++        .template_kwargs
++        .insert("thinking".to_string(), Value::Bool(true));
++    request.chat_options.reasoning_effort = Some(ReasoningEffort::Low);
++
++    let rendered = render_request(&request);
++
++    expect!["<｜begin▁of▁sentence｜><｜User｜>solve it<｜Assistant｜><think>"].assert_eq(&rendered);
++}
++
++#[test]
++fn request_tools_follow_existing_system_prompt() {
++    let mut request = ChatRequest {
++        messages: vec![
++            ChatMessage::system("Follow policy."),
++            ChatMessage::user("Find it."),
++        ],
++        tools: vec![ChatTool {
++            name: "lookup".to_string(),
++            description: Some("Look things up".to_string()),
++            parameters: serde_json::json!({
++                "type": "object",
++                "properties": {},
++            }),
++            strict: None,
++        }],
++        tool_choice: ChatToolChoice::Auto,
++        ..ChatRequest::for_test()
++    };
++    request
++        .chat_options
++        .template_kwargs
++        .insert("thinking".to_string(), Value::Bool(true));
++    request.chat_options.reasoning_effort = Some(ReasoningEffort::Max);
++
++    let rendered = render_request(&request);
++
++    let prefix = rendered.find("Reasoning Effort: Beyond maximum").unwrap();
++    let system = rendered.find("Follow policy.").unwrap();
++    let tools = rendered.find("## Tools").unwrap();
++    let user = rendered.find("<｜User｜>Find it.").unwrap();
++    assert!(prefix < system && system < tools && tools < user);
++}
++
+ #[test]
+ fn reasoning_effort_none_disables_thinking() {
+     let mut request = ChatRequest {
+diff --git a/serve-ds4-flash.sh b/serve-ds4-flash.sh
+index f9a640bed07f8e82381274cc027f6723c9ed57d5..ea2e218e3f84d63e0a1098e22a98e4217fd52118 100755
+--- a/serve-ds4-flash.sh
++++ b/serve-ds4-flash.sh
+@@ -40,9 +40,10 @@ case "${mode}" in
+   off|mtp0|standard-mtp0) mode=mtp0 ;;
+   mtp2|standard-mtp2) mode=mtp2 ;;
+   mtp3|standard-mtp3) mode=mtp3 ;;
++  dspark-off|dspark-mtp0) mode=dspark-mtp0 ;;
+   dspark) ;;
+   *)
+-    echo "MODE must be mtp0, mtp2, mtp3, or dspark; got '${mode}'" >&2
++    echo "MODE must be mtp0, mtp2, mtp3, dspark-off, dspark-mtp0, or dspark; got '${mode}'" >&2
+     exit 2
+     ;;
+ esac
+@@ -59,13 +60,13 @@ case "${backend}" in
+ esac
+ 
+ standard_model=${STANDARD_MODEL:-deepseek-ai/DeepSeek-V4-Flash}
+-dspark_model=${DSPARK_MODEL:-deepseek-ai/DeepSeek-V4-Flash-DSpark}
++dspark_model=${DSPARK_MODEL:-deepseek-ai/DeepSeek-V4-Flash-0731}
+ standard_model_revision=${STANDARD_MODEL_REVISION:-60d8d70770c6776ff598c94bb586a859a38244f1}
+-dspark_model_revision=${DSPARK_MODEL_REVISION:-62af8fffb2f7030cac4de2f0169f5b8d1101b646}
+-if [[ "${mode}" == "dspark" ]]; then
++dspark_model_revision=${DSPARK_MODEL_REVISION:-9e165c30e2704aec5d9d593cce3eebd58bbef1cb}
++if [[ "${mode}" == "dspark" || "${mode}" == "dspark-mtp0" ]]; then
+   model=${MODEL_PATH:-${MODEL:-${dspark_model}}}
+   spec_model=${SPEC_MODEL_PATH:-${model}}
+-  served_model_name=${SERVED_MODEL_NAME:-DeepSeek-V4-Flash-DSpark}
++  served_model_name=${SERVED_MODEL_NAME:-DeepSeek-V4-Flash-0731}
+   default_model_revision=${dspark_model_revision}
+ else
+   model=${MODEL_PATH:-${MODEL:-${standard_model}}}
+@@ -88,13 +89,21 @@ fi
+ host=${HOST:-0.0.0.0}
+ port=${PORT:-8000}
+ tp_size=${TP_SIZE:-${TP:-2}}
+-dcp_size=${DCP_SIZE:-1}
+-max_num_seqs=${MAX_NUM_SEQS:-64}
+-max_model_len=${MAX_MODEL_LEN:-262144}
++dcp_size=${DCP_SIZE:-${DCP:-1}}
++if [[ "${mode}" == "dspark" || "${mode}" == "dspark-mtp0" ]]; then
++  max_num_seqs=${MAX_NUM_SEQS:-16}
++  max_model_len=${MAX_MODEL_LEN:-131072}
++else
++  max_num_seqs=${MAX_NUM_SEQS:-64}
++  max_model_len=${MAX_MODEL_LEN:-262144}
++fi
+ max_num_batched_tokens=${MAX_NUM_BATCHED_TOKENS:-8192}
+ gpu_memory_utilization=${GPU_MEMORY_UTILIZATION:-}
+ block_size=${BLOCK_SIZE:-256}
+ load_format=${LOAD_FORMAT:-instanttensor}
++kv_offloading_size=${KV_OFFLOADING_SIZE:-}
++native_l2_path=${NATIVE_L2_PATH:-}
++native_l2_size=${NATIVE_L2_GB:-}
+ prefix_cache=$(bool_value PREFIX_CACHE "${PREFIX_CACHE:-1}")
+ enable_flashinfer_autotune=$(bool_value ENABLE_FLASHINFER_AUTOTUNE "${ENABLE_FLASHINFER_AUTOTUNE:-1}")
+ draft_sample_method=${DRAFT_SAMPLE_METHOD:-probabilistic}
+@@ -105,6 +114,33 @@ require_positive_int DCP_SIZE "${dcp_size}"
+ require_positive_int MAX_NUM_SEQS "${max_num_seqs}"
+ require_positive_int MAX_NUM_BATCHED_TOKENS "${max_num_batched_tokens}"
+ require_positive_int BLOCK_SIZE "${block_size}"
++if [[ -n "${kv_offloading_size}" \
++  && ! "${kv_offloading_size}" =~ ^([0-9]+([.][0-9]*)?|[.][0-9]+)$ ]]; then
++  echo "KV_OFFLOADING_SIZE must be a non-negative GiB value; got '${kv_offloading_size}'" >&2
++  exit 2
++fi
++native_l2_enabled=0
++if [[ -n "${native_l2_path}" || -n "${native_l2_size}" ]]; then
++  if [[ -z "${native_l2_path}" || -z "${native_l2_size}" ]]; then
++    echo "NATIVE_L2_PATH and NATIVE_L2_GB must be set together" >&2
++    exit 2
++  fi
++  if [[ "${native_l2_path}" != /* ]]; then
++    echo "NATIVE_L2_PATH must be an absolute container path" >&2
++    exit 2
++  fi
++  if [[ ! "${native_l2_size}" =~ ^([0-9]+([.][0-9]*)?|[.][0-9]+)$ \
++    || "${native_l2_size}" =~ ^0*([.]0*)?$ ]]; then
++    echo "NATIVE_L2_GB must be a positive GiB value; got '${native_l2_size}'" >&2
++    exit 2
++  fi
++  if [[ -z "${kv_offloading_size}" \
++    || "${kv_offloading_size}" =~ ^0*([.]0*)?$ ]]; then
++    echo "NATIVE_L2 requires a positive KV_OFFLOADING_SIZE for its L1 tier" >&2
++    exit 2
++  fi
++  native_l2_enabled=1
++fi
+ if [[ "${mode}" == "dspark" && "${dcp_size}" != "1" ]]; then
+   echo "DSpark non-causal attention currently requires DCP_SIZE=1" >&2
+   exit 2
+@@ -144,7 +180,14 @@ export VLLM_MEMORY_PROFILER_ESTIMATE_CUDAGRAPHS=${VLLM_MEMORY_PROFILER_ESTIMATE_
+ export VLLM_PREFIX_CACHE_RETENTION_INTERVAL=${VLLM_PREFIX_CACHE_RETENTION_INTERVAL:-4096}
+ export VLLM_MULTI_STREAM_GEMM_TOKEN_THRESHOLD=${VLLM_MULTI_STREAM_GEMM_TOKEN_THRESHOLD:-1024}
+ 
+-allreduce_mode=${ALLREDUCE_MODE:-b12x}
++allreduce_mode=${ALLREDUCE_MODE:-auto}
++if [[ "${allreduce_mode}" == "auto" ]]; then
++  if [[ "${tp_size}" == "2" ]]; then
++    allreduce_mode=flashinfer-ipc
++  else
++    allreduce_mode=b12x
++  fi
++fi
+ b12x_pcie_dma=$(bool_value B12X_PCIE_DMA "${B12X_PCIE_DMA:-0}")
+ export VLLM_USE_B12X_PCIE_DMA=${b12x_pcie_dma}
+ allreduce_args=()
+@@ -156,6 +199,15 @@ case "${allreduce_mode}" in
+     export VLLM_ALLOW_CUSTOM_ALLREDUCE_PCIE=0
+     export PYTORCH_CUDA_ALLOC_CONF=${PYTORCH_CUDA_ALLOC_CONF:-expandable_segments:True}
+     ;;
++  flashinfer-ipc)
++    export VLLM_ENABLE_PCIE_ALLREDUCE=1
++    export VLLM_PCIE_ALLREDUCE_BACKEND=flashinfer-ipc
++    export VLLM_PCIE_ONESHOT_ALLREDUCE_MAX_SIZE=${VLLM_PCIE_ONESHOT_ALLREDUCE_MAX_SIZE:-1MB}
++    export VLLM_PCIE_ONESHOT_FUSED_ADD_RMS_NORM_MAX_SIZE=0
++    export VLLM_PCIE_DMA_MIN_BYTES=off
++    export VLLM_ALLOW_CUSTOM_ALLREDUCE_PCIE=0
++    export PYTORCH_CUDA_ALLOC_CONF=${PYTORCH_CUDA_ALLOC_CONF:-expandable_segments:True}
++    ;;
+   vllm-custom)
+     export VLLM_ENABLE_PCIE_ALLREDUCE=0
+     export VLLM_ALLOW_CUSTOM_ALLREDUCE_PCIE=1
+@@ -177,8 +229,8 @@ case "${allreduce_mode}" in
+     allreduce_args=(--disable-custom-all-reduce)
+     ;;
+   *)
+-    echo "ALLREDUCE_MODE must be b12x, vllm-custom, vllm-custom-2stage," \
+-      "or nccl; got '${allreduce_mode}'" >&2
++    echo "ALLREDUCE_MODE must be auto, b12x, flashinfer-ipc, vllm-custom," \
++      "vllm-custom-2stage, or nccl; got '${allreduce_mode}'" >&2
+     exit 2
+     ;;
+ esac
+@@ -246,6 +298,7 @@ esac
+ spec_args=()
+ spec_tokens=0
+ graph_multiplier=4
++dspark_depth_mode=disabled
+ if [[ "${mode}" == "mtp2" || "${mode}" == "mtp3" ]]; then
+   if [[ "${mode}" == "mtp2" ]]; then spec_tokens=2; else spec_tokens=3; fi
+   mtp_moe_json=
+@@ -259,7 +312,7 @@ if [[ "${mode}" == "mtp2" || "${mode}" == "mtp3" ]]; then
+   spec_args=(--speculative-config "${spec_json}")
+   graph_multiplier=8
+ elif [[ "${mode}" == "dspark" ]]; then
+-  spec_tokens=${DSPARK_TOKENS:-5}
++  spec_tokens=${DSPARK_TOKENS:-${NUM_SPECULATIVE_TOKENS:-7}}
+   require_positive_int DSPARK_TOKENS "${spec_tokens}"
+   # Target verification schedules at most one sampled token plus K drafts per
+   # request. Capturing beyond that physical row count only consumes graph
+@@ -278,9 +331,27 @@ elif [[ "${mode}" == "dspark" ]]; then
+         ;;
+     esac
+     draft_attention_json=$(printf \
+-      ',"draft_attention_backend":"%s"' "${draft_attention_backend}")
++      ',"attention_backend":"%s"' "${draft_attention_backend}")
+   fi
+-  dspark_capacity=$(bool_value DSPARK_CAPACITY "${DSPARK_CAPACITY:-0}")
++  dspark_depth_mode=${DSPARK_DEPTH_MODE:-fixed}
++  case "${dspark_depth_mode}" in
++    fixed)
++      default_dspark_capacity=0
++      default_dynamic_depth=0
++      default_activation_batch_size=0
++      ;;
++    dynamic)
++      default_dspark_capacity=1
++      default_dynamic_depth=1
++      default_activation_batch_size=1
++      ;;
++    *)
++      echo "DSPARK_DEPTH_MODE must be fixed or dynamic" >&2
++      exit 2
++      ;;
++  esac
++  dspark_capacity=$(bool_value DSPARK_CAPACITY \
++    "${DSPARK_CAPACITY:-${default_dspark_capacity}}")
+   capacity_json=
+   if [[ "${dspark_capacity}" == "1" ]]; then
+     capacity_mode=${DSPARK_CAPACITY_VERIFICATION_MODE:-}
+@@ -319,11 +390,14 @@ elif [[ "${mode}" == "dspark" ]]; then
+     "${rejection_sample_method}" "${draft_attention_json}" "${capacity_json}")
+   spec_args=(--speculative-config "${spec_json}")
+   export VLLM_DSPARK_FP8_DRAFT_HEAD=$(bool_value DSPARK_FP8_DRAFT_HEAD "${DSPARK_FP8_DRAFT_HEAD:-0}")
+-  export VLLM_DSPARK_DYNAMIC_DRAFT_DEPTH=$(bool_value DSPARK_DYNAMIC_DRAFT_DEPTH "${DSPARK_DYNAMIC_DRAFT_DEPTH:-0}")
++  dynamic_depth=${DSPARK_DYNAMIC_DRAFT_DEPTH:-${VLLM_DSPARK_DYNAMIC_DRAFT_DEPTH:-${default_dynamic_depth}}}
++  export VLLM_DSPARK_DYNAMIC_DRAFT_DEPTH=$(bool_value \
++    DSPARK_DYNAMIC_DRAFT_DEPTH "${dynamic_depth}")
+   export VLLM_DSPARK_DYNAMIC_DRAFT_DEPTH_WINDOW=${DSPARK_DYNAMIC_DRAFT_DEPTH_WINDOW:-8}
+   require_positive_int DSPARK_DYNAMIC_DRAFT_DEPTH_WINDOW \
+     "${VLLM_DSPARK_DYNAMIC_DRAFT_DEPTH_WINDOW}"
+-  export VLLM_DSPARK_CAPACITY_ACTIVATION_BATCH_SIZE=${DSPARK_CAPACITY_ACTIVATION_BATCH_SIZE:-0}
++  activation_batch_size=${DSPARK_CAPACITY_ACTIVATION_BATCH_SIZE:-${VLLM_DSPARK_CAPACITY_ACTIVATION_BATCH_SIZE:-${default_activation_batch_size}}}
++  export VLLM_DSPARK_CAPACITY_ACTIVATION_BATCH_SIZE=${activation_batch_size}
+   require_nonnegative_int DSPARK_CAPACITY_ACTIVATION_BATCH_SIZE \
+     "${VLLM_DSPARK_CAPACITY_ACTIVATION_BATCH_SIZE}"
+   export VLLM_DSPARK_CAPACITY_LOG_INTERVAL=${DSPARK_CAPACITY_LOG_INTERVAL:-0}
+@@ -358,8 +432,10 @@ if [[ "${sp_async_tp}" == "1" ]]; then
+ fi
+ 
+ if [[ -z "${gpu_memory_utilization}" ]]; then
+-  # The v10 profiler includes attention and FULL-graph allocations. These
+-  # defaults preserve the 262k serving limit used by v9 after that accounting.
++  # The 0731 DSpark draft head is larger than the historical MTP head. Its
++  # B12X TP2 profile needs 0.975 to retain the default 131k serving limit after
++  # attention and FULL-graph allocations are accounted for. At 0.97 the r15
++  # stack exposed 7.11 GiB of KV storage while this profile needs 7.37 GiB.
+   if [[ "${mode}" == "dspark" ]]; then
+     if [[ "${backend}" == "lucifer-default" ]]; then
+       # The default DeepGEMM MoE path retains more model/runtime memory than
+@@ -377,7 +453,7 @@ if [[ -z "${gpu_memory_utilization}" ]]; then
+     elif [[ "${backend}" == lucifer-* ]]; then
+       gpu_memory_utilization=0.9465
+     else
+-      gpu_memory_utilization=0.95
++      gpu_memory_utilization=0.975
+     fi
+   elif [[ "${backend}" == lucifer-* \
+     && ( "${mode}" == "mtp2" || "${mode}" == "mtp3" ) ]]; then
+@@ -398,6 +474,54 @@ if [[ "${enable_flashinfer_autotune}" == "0" ]]; then
+   autotune_args=(--no-enable-flashinfer-autotune)
+ fi
+ 
++offloading_args=()
++if [[ -n "${kv_offloading_size}" \
++  && ! "${kv_offloading_size}" =~ ^0*([.]0*)?$ ]]; then
++  # This is the total host-cache capacity across all TP ranks, matching the
++  # vLLM CLI contract. LMCache remains a separate deployment mode. Native KV
++  # offload pins/registers GPU cache allocations, so PyTorch's remappable VMM
++  # segments must be disabled while preserving any other allocator settings.
++  allocator_config=${PYTORCH_CUDA_ALLOC_CONF:-}
++  if [[ -z "${allocator_config}" ]]; then
++    allocator_config=expandable_segments:False
++  elif [[ "${allocator_config}" =~ (^|,)expandable_segments:True(,|$) ]]; then
++    allocator_config=${allocator_config//expandable_segments:True/expandable_segments:False}
++  fi
++  export PYTORCH_CUDA_ALLOC_CONF=${allocator_config}
++  offloading_args=(
++    --kv-offloading-size "${kv_offloading_size}"
++    --kv-offloading-backend native
++  )
++  if [[ "${native_l2_enabled}" == "1" ]]; then
++    export PYTHONHASHSEED=${PYTHONHASHSEED:-0}
++    native_l2_config=$(python3 - "${native_l2_path}" "${native_l2_size}" <<'PY'
++import json
++import sys
++
++root_dir, max_size_gb = sys.argv[1:]
++config = {
++    "kv_connector": "OffloadingConnector",
++    "kv_role": "kv_both",
++    "kv_connector_extra_config": {
++        "spec_name": "TieringOffloadingSpec",
++        "secondary_tiers": [
++            {
++                "type": "fs",
++                "root_dir": root_dir,
++                "n_read_threads": 32,
++                "n_write_threads": 16,
++                "gc_max_size_gb": float(max_size_gb),
++            }
++        ],
++    },
++}
++print(json.dumps(config, separators=(",", ":")))
++PY
++    )
++    offloading_args+=(--kv-transfer-config "${native_l2_config}")
++  fi
++fi
++
+ capture_args=()
+ capture_sizes=${CUDAGRAPH_CAPTURE_SIZES:-default}
+ if [[ "${capture_sizes}" == "auto" ]]; then
+@@ -465,6 +589,7 @@ command=(
+   "${autotune_args[@]}"
+   "${prefix_args[@]}"
+   "${capture_args[@]}"
++  "${offloading_args[@]}"
+   "${spec_args[@]}"
+   "${backend_args[@]}"
+   "${allreduce_args[@]}"
+@@ -478,10 +603,13 @@ if [[ -n "${EXTRA_VLLM_ARGS:-}" ]]; then
+ fi
+ command+=("$@")
+ 
+-printf 'DS4 launch: mode=%s backend=%s allreduce=%s b12x_dma=%s indexer=%s tp=%s dcp=%s max_seqs=%s graph=%s load_format=%s instanttensor_backend=%s model=%s\n' \
+-  "${mode}" "${backend}" "${allreduce_mode}" "${b12x_pcie_dma}" \
++printf 'DS4 launch: mode=%s depth=%s backend=%s allreduce=%s b12x_dma=%s indexer=%s tp=%s dcp=%s max_seqs=%s graph=%s load_format=%s instanttensor_backend=%s native_l2=%s allocator=%s model=%s\n' \
++  "${mode}" "${dspark_depth_mode}" \
++  "${backend}" "${allreduce_mode}" "${b12x_pcie_dma}" \
+   "${indexer_backend}" "${tp_size}" "${dcp_size}" "${max_num_seqs}" \
+-  "${graph_cap}" "${load_format}" "${INSTANTTENSOR_BACKEND}" "${model}" >&2
++  "${graph_cap}" "${load_format}" "${INSTANTTENSOR_BACKEND}" \
++  "${native_l2_enabled}" \
++  "${PYTORCH_CUDA_ALLOC_CONF:-<unset>}" "${model}" >&2
+ printf 'Command:' >&2
+ printf ' %q' "${command[@]}" >&2
+ printf '\n' >&2
+diff --git a/serve-glm52.sh b/serve-glm52.sh
+index 68f7501b3d618dea5c4ae93047b281cd56efd85d..8933ad62d752aabbc9f2e6a80bc3b17945afef41 100755
+--- a/serve-glm52.sh
++++ b/serve-glm52.sh
+@@ -107,6 +107,8 @@ MOE_BACKEND="${MOE_BACKEND:-b12x}"
+ MOE_SPEC_BACKEND="${MOE_SPEC_BACKEND:-b12x}"
+ ATTENTION_BACKEND="${ATTENTION_BACKEND:-B12X_MLA_SPARSE}"
+ KV_CACHE_DTYPE="${KV_CACHE_DTYPE:-fp8}"
++# Calibrated per-layer outer scales for nvfp4_ds_mla KV (empty = disabled).
++export VLLM_NVFP4_MLA_SCALES_FILE="${VLLM_NVFP4_MLA_SCALES_FILE:-}"
+ GLM51_PROFILE="${GLM51_PROFILE:-0}"
+ GLM52_CAUSAL_CASCADE="${GLM52_CAUSAL_CASCADE:-0}"
+ GLM52_DSPARK="${GLM52_DSPARK:-0}"
+diff --git a/tests/distributed/test_b12x_custom_all_reduce_warmup.py b/tests/distributed/test_b12x_custom_all_reduce_warmup.py
+new file mode 100644
+index 0000000000000000000000000000000000000000..21d1b9411c22d20c65fe2ad1f7b0962b29a8cf29
+--- /dev/null
++++ b/tests/distributed/test_b12x_custom_all_reduce_warmup.py
+@@ -0,0 +1,102 @@
++# SPDX-License-Identifier: Apache-2.0
++# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
++
++from unittest.mock import MagicMock
++
++import pytest
++import torch
++
++from vllm.distributed.device_communicators.custom_all_reduce import CustomAllreduce
++
++
++def _make_custom_allreduce(
++    *, allreduce_max_size: int
++) -> tuple[CustomAllreduce, MagicMock]:
++    """Build a minimal custom all-reduce with a mocked PCIe runtime.
++
++    Args:
++        allreduce_max_size: Largest input eligible for one-shot all-reduce.
++
++    Returns:
++        The custom all-reduce instance and its mocked PCIe runtime.
++    """
++    runtime = MagicMock()
++    runtime.for_stream.return_value.should_allreduce.return_value = True
++
++    custom_allreduce = object.__new__(CustomAllreduce)
++    custom_allreduce.disabled = False
++    custom_allreduce._pcie_runtime = runtime
++    custom_allreduce._pcie_dma = None
++    custom_allreduce._pcie_capture_stream = None
++    custom_allreduce._pcie_allreduce_max_size = allreduce_max_size
++    custom_allreduce._pcie_logged_first_allreduce = False
++    custom_allreduce._IS_CAPTURING = True
++    custom_allreduce._ptr = 0
++    custom_allreduce.max_size = allreduce_max_size
++    return custom_allreduce, runtime
++
++
++def _mock_capture_warmup(
++    monkeypatch: pytest.MonkeyPatch,
++    custom_allreduce: CustomAllreduce,
++) -> object:
++    """Place a custom all-reduce in the non-capturing graph warmup phase.
++
++    Args:
++        monkeypatch: Pytest fixture used to replace capture state helpers.
++        custom_allreduce: Instance whose PCIe stream should be mocked.
++
++    Returns:
++        The mocked PCIe capture stream.
++    """
++    capture_stream = object()
++    monkeypatch.setattr(
++        custom_allreduce,
++        "_pcie_runtime_stream",
++        lambda: capture_stream,
++    )
++    monkeypatch.setattr(torch.cuda, "is_current_stream_capturing", lambda: False)
++    monkeypatch.setattr(
++        "vllm.distributed.device_communicators.custom_all_reduce."
++        "_is_piecewise_cudagraph_runtime",
++        lambda: False,
++    )
++    return capture_stream
++
++
++def test_capture_warmup_prepares_plain_graph_allreduce(
++    monkeypatch: pytest.MonkeyPatch,
++) -> None:
++    """Verify that plain one-shot warmup prepares without communication."""
++    custom_allreduce, runtime = _make_custom_allreduce(allreduce_max_size=64)
++    capture_stream = _mock_capture_warmup(monkeypatch, custom_allreduce)
++    inp = torch.randn(2, 4)
++
++    output = custom_allreduce.custom_all_reduce(inp)
++
++    assert output is not None
++    assert output.shape == inp.shape
++    runtime.prepare_graph_all_reduce.assert_called_once_with(
++        inp,
++        stream=capture_stream,
++    )
++    runtime.all_reduce.assert_not_called()
++
++
++def test_capture_warmup_does_not_prepare_dma_only_input(
++    monkeypatch: pytest.MonkeyPatch,
++) -> None:
++    """Verify that DMA-only warmup keeps the communication-free placeholder."""
++    custom_allreduce, runtime = _make_custom_allreduce(allreduce_max_size=16)
++    custom_allreduce._pcie_dma = MagicMock()
++    custom_allreduce._pcie_dma.should_allreduce.return_value = True
++    _mock_capture_warmup(monkeypatch, custom_allreduce)
++    inp = torch.randn(4, 4)
++
++    output = custom_allreduce.custom_all_reduce(inp)
++
++    assert output is not None
++    assert output.shape == inp.shape
++    runtime.prepare_graph_all_reduce.assert_not_called()
++    runtime.all_reduce.assert_not_called()
++    custom_allreduce._pcie_dma.all_reduce.assert_not_called()
+diff --git a/tests/distributed/test_b12x_fused_all_reduce.py b/tests/distributed/test_b12x_fused_all_reduce.py
+index a79acc3afd09f4a248aa0473e5fb02209c18a4ed..5c7c0e746aa58076bcce42de4710b183d07fd81e 100644
+--- a/tests/distributed/test_b12x_fused_all_reduce.py
++++ b/tests/distributed/test_b12x_fused_all_reduce.py
+@@ -1,6 +1,7 @@
+ # SPDX-License-Identifier: Apache-2.0
+ # SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+ 
++from types import SimpleNamespace
+ from unittest.mock import MagicMock
+ 
+ import pytest
+@@ -25,6 +26,7 @@ from vllm.config import (
+     set_current_vllm_config,
+ )
+ from vllm.distributed import tensor_model_parallel_all_reduce
++from vllm.distributed.device_communicators import custom_all_reduce
+ from vllm.distributed.device_communicators.custom_all_reduce import (
+     CustomAllreduce,
+     _b12x_pcie_dma_min_bytes,
+@@ -107,8 +109,66 @@ def test_b12x_fused_allreduce_uses_independent_cutoff() -> None:
+         out=inp,
+         residual_out=residual,
+         stream=None,
+-        channel_id="eager:vllm-tp-allreduce",
++        channel_id="vllm:eager:allreduce",
+     )
++    runtime.for_stream.assert_called_with(
++        None,
++        channel_id="vllm:eager:allreduce",
++    )
++
++
++def test_b12x_eager_allreduce_forwards_stable_semantic_channel() -> None:
++    custom_allreduce, runtime = make_b12x_custom_allreduce(
++        allreduce_max_size=64,
++        fused_max_size=64,
++    )
++    inp = torch.randn(2, 4)
++    expected = torch.empty_like(inp)
++    runtime.all_reduce.return_value = expected
++
++    actual = custom_allreduce.all_reduce(inp)
++
++    assert actual is expected
++    runtime.all_reduce.assert_called_once_with(
++        inp,
++        out=None,
++        stream=None,
++        channel_id="vllm:eager:allreduce",
++    )
++
++
++def test_b12x_eager_owner_fails_closed_on_second_stream_bind() -> None:
++    custom_allreduce, runtime = make_b12x_custom_allreduce(
++        allreduce_max_size=64,
++        fused_max_size=64,
++    )
++    first_stream = object()
++    second_stream = object()
++    custom_allreduce._pcie_runtime_stream = MagicMock(  # type: ignore[method-assign]
++        side_effect=(first_stream, second_stream)
++    )
++    bound_stream = None
++
++    def for_stream(stream, *, channel_id):
++        nonlocal bound_stream
++        assert channel_id == "vllm:eager:allreduce"
++        if bound_stream is None:
++            bound_stream = stream
++        elif stream is not bound_stream:
++            raise RuntimeError("stream-affine logical owner rebound")
++        channel = MagicMock()
++        channel.should_allreduce.return_value = True
++        return channel
++
++    runtime.for_stream.side_effect = for_stream
++    inp = torch.randn(2, 4)
++
++    assert custom_allreduce.should_custom_ar(inp)
++    with pytest.raises(RuntimeError, match="stream-affine"):
++        custom_allreduce.should_custom_ar(inp)
++    assert [
++        call.kwargs["channel_id"] for call in runtime.for_stream.call_args_list
++    ] == ["vllm:eager:allreduce", "vllm:eager:allreduce"]
+ 
+ 
+ def test_b12x_fused_allreduce_falls_back_above_its_cutoff() -> None:
+@@ -144,6 +204,121 @@ def test_b12x_oneshot_defaults_to_stream_isolation(
+     assert not envs.environment_variables["VLLM_PCIE_ONESHOT_SINGLE_CHANNEL"]()
+ 
+ 
++def test_b12x_pool_prepares_single_stable_eager_owner(
++    monkeypatch: pytest.MonkeyPatch,
++) -> None:
++    captured = {}
++    runtime = MagicMock()
++
++    class FakePool:
++        @classmethod
++        def from_exchange_group(cls, **kwargs):
++            captured.update(kwargs)
++            return runtime
++
++    def fake_all_gather(gather_list, tensor, *, group):
++        for index, slot in enumerate(gather_list):
++            slot.fill_(index)
++
++    fake_config = SimpleNamespace(
++        model_config=SimpleNamespace(get_hidden_size=lambda: 4),
++        scheduler_config=SimpleNamespace(max_num_batched_tokens=8),
++    )
++    monkeypatch.setattr(custom_all_reduce, "custom_ar", True)
++    monkeypatch.setattr(custom_all_reduce.dist, "get_backend", lambda group: "gloo")
++    monkeypatch.setattr(
++        custom_all_reduce,
++        "in_the_same_node_as",
++        lambda group, source_rank=0: [True, True],
++    )
++    monkeypatch.setattr(custom_all_reduce.dist, "get_rank", lambda group=None: 0)
++    monkeypatch.setattr(custom_all_reduce.dist, "get_world_size", lambda group=None: 2)
++    monkeypatch.setattr(custom_all_reduce.dist, "all_gather", fake_all_gather)
++    monkeypatch.setattr(
++        custom_all_reduce.dist, "all_reduce", lambda *args, **kwargs: None
++    )
++    monkeypatch.setattr(
++        custom_all_reduce,
++        "_b12x_pcie_allreduce_requested",
++        lambda: True,
++    )
++    monkeypatch.setattr(custom_all_reduce, "_can_p2p", lambda *args: True)
++    monkeypatch.setattr(
++        custom_all_reduce,
++        "_is_cross_numa_topology",
++        lambda ids: False,
++    )
++    monkeypatch.setattr(
++        custom_all_reduce,
++        "_load_b12x_pcie_oneshot_pool",
++        lambda: FakePool,
++    )
++    monkeypatch.setattr(
++        custom_all_reduce,
++        "_b12x_pcie_dma_min_bytes",
++        lambda: None,
++    )
++    monkeypatch.setattr(
++        custom_all_reduce.current_platform,
++        "get_device_capability",
++        lambda: None,
++    )
++    monkeypatch.setattr(
++        custom_all_reduce.current_platform,
++        "visible_device_id_to_physical_device_id",
++        lambda index: index,
++    )
++    monkeypatch.setattr(
++        custom_all_reduce.current_platform,
++        "is_cuda_alike",
++        lambda: True,
++    )
++    monkeypatch.setattr(
++        custom_all_reduce.current_platform,
++        "is_fully_connected",
++        lambda ids: False,
++        raising=False,
++    )
++    monkeypatch.setattr(
++        custom_all_reduce.current_platform,
++        "is_cuda",
++        lambda: True,
++    )
++    monkeypatch.setattr(
++        custom_all_reduce.current_platform,
++        "is_rocm",
++        lambda: False,
++    )
++    monkeypatch.setattr(
++        "vllm.config.get_current_vllm_config",
++        lambda: fake_config,
++    )
++    monkeypatch.setattr(
++        custom_all_reduce.envs,
++        "VLLM_PCIE_ONESHOT_SINGLE_CHANNEL",
++        False,
++        raising=False,
++    )
++    monkeypatch.setattr(
++        custom_all_reduce.envs,
++        "VLLM_ALLOW_CUSTOM_ALLREDUCE_PCIE",
++        False,
++        raising=False,
++    )
++
++    built = CustomAllreduce(
++        object(),  # type: ignore[arg-type]
++        torch.device("cuda:0"),
++        nccl_group=object(),  # type: ignore[arg-type]
++    )
++
++    assert not built.disabled
++    assert captured["single_channel"] is False
++    assert captured["max_concurrent_channels"] == 2
++    runtime.prepare_channels.assert_called_once_with(("vllm:eager:allreduce",))
++    runtime.for_stream.assert_called_once_with(channel_id="vllm:eager:allreduce")
++
++
+ def test_b12x_channel_checkpoint_delegates_to_runtime() -> None:
+     custom_allreduce, runtime = make_b12x_custom_allreduce(
+         allreduce_max_size=64,
+@@ -159,6 +334,40 @@ def test_b12x_channel_checkpoint_delegates_to_runtime() -> None:
+     runtime.rollback_channels.assert_called_once_with(checkpoint)
+ 
+ 
++def test_b12x_capture_forwards_semantic_channel_id() -> None:
++    custom_allreduce, runtime = make_b12x_custom_allreduce(
++        allreduce_max_size=64,
++        fused_max_size=64,
++    )
++    stream = object()
++
++    with custom_allreduce.capture(  # type: ignore[arg-type]
++        stream,
++        channel_id="vllm:target:profile",
++    ):
++        pass
++
++    runtime.capture.assert_called_once_with(
++        stream=stream,
++        channel_id="vllm:target:profile",
++    )
++
++
++def test_b12x_capture_rejects_missing_semantic_channel_id() -> None:
++    custom_allreduce, runtime = make_b12x_custom_allreduce(
++        allreduce_max_size=64,
++        fused_max_size=64,
++    )
++
++    with (
++        pytest.raises(RuntimeError, match="semantic channel_id"),
++        custom_allreduce.capture(),
++    ):
++        pass
++
++    runtime.capture.assert_not_called()
++
++
+ def test_b12x_oneshot_buffer_tracks_dispatch_limits(
+     monkeypatch: pytest.MonkeyPatch,
+ ) -> None:
+@@ -361,7 +570,7 @@ def _run_b12x_fused_allreduce_gpu(rank: int, port: int) -> None:
+     residual.copy_(original_residual)
+     with graph_capture(
+         device=device,
+-        channel_id="graph:test-b12x-fused-allreduce",
++        channel_id="vllm:test:b12x-fused",
+     ) as capture_context:
+         graph = torch.cuda.CUDAGraph()
+         with torch.cuda.graph(graph, stream=capture_context.stream):
+diff --git a/tests/distributed/test_custom_allreduce_lifecycle.py b/tests/distributed/test_custom_allreduce_lifecycle.py
+new file mode 100644
+index 0000000000000000000000000000000000000000..c5806ccbddeb65c3af7ec2ab38a6dac2d8b79980
+--- /dev/null
++++ b/tests/distributed/test_custom_allreduce_lifecycle.py
+@@ -0,0 +1,144 @@
++# SPDX-License-Identifier: Apache-2.0
++# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
++
++import gc
++import weakref
++from unittest.mock import MagicMock
++
++import pytest
++import torch
++
++from vllm.distributed.device_communicators.cuda_communicator import CudaCommunicator
++from vllm.distributed.device_communicators.custom_all_reduce import CustomAllreduce
++from vllm.distributed.parallel_state import GroupCoordinator
++
++
++def make_b12x_custom_allreduce() -> tuple[CustomAllreduce, MagicMock]:
++    runtime = MagicMock()
++    custom_allreduce = object.__new__(CustomAllreduce)
++    custom_allreduce.disabled = False
++    custom_allreduce._pcie_runtime = runtime
++    custom_allreduce._pcie_dma = None
++    custom_allreduce._ptr = 0
++    return custom_allreduce, runtime
++
++
++def test_b12x_destructor_skips_collective_close_without_retention() -> None:
++    custom_allreduce, runtime = make_b12x_custom_allreduce()
++    dma = MagicMock()
++    custom_allreduce._pcie_dma = dma
++    custom_allreduce_ref = weakref.ref(custom_allreduce)
++
++    del custom_allreduce
++    gc.collect()
++
++    dma.close.assert_not_called()
++    runtime.close.assert_not_called()
++    assert custom_allreduce_ref() is None
++
++
++def test_b12x_explicit_close_remains_coordinated() -> None:
++    custom_allreduce, runtime = make_b12x_custom_allreduce()
++    dma = MagicMock()
++    custom_allreduce._pcie_dma = dma
++    close_order = []
++    runtime.close.side_effect = lambda: close_order.append("runtime")
++    dma.close.side_effect = lambda: close_order.append("dma")
++
++    custom_allreduce.close()
++
++    assert close_order == ["runtime", "dma"]
++    dma.close.assert_called_once_with()
++    runtime.close.assert_called_once_with()
++    assert custom_allreduce._pcie_dma is None
++    assert custom_allreduce._pcie_runtime is None
++
++
++def test_b12x_close_retains_owners_when_runtime_close_fails() -> None:
++    custom_allreduce, runtime = make_b12x_custom_allreduce()
++    dma = MagicMock()
++    runtime.close.side_effect = RuntimeError("close failed")
++    custom_allreduce._pcie_dma = dma
++
++    with pytest.raises(RuntimeError, match="close failed"):
++        custom_allreduce.close()
++
++    assert custom_allreduce._pcie_runtime is runtime
++    assert custom_allreduce._pcie_dma is dma
++    dma.close.assert_not_called()
++
++
++def test_cuda_communicator_closes_custom_allreduce_before_nccl() -> None:
++    communicator = object.__new__(CudaCommunicator)
++    communicator.ca_comm = MagicMock()
++    communicator.pynccl_comm = MagicMock()
++    communicator.aiter_ar_comm = None
++    communicator.fi_ar_comm = None
++    communicator.all2all_manager = None
++    close_order = []
++    communicator.ca_comm.close.side_effect = lambda: close_order.append("custom")
++    communicator.pynccl_comm.destroy.side_effect = lambda: close_order.append("nccl")
++
++    communicator.destroy()
++
++    assert close_order == ["custom", "nccl"]
++    assert communicator.ca_comm is None
++    assert communicator.pynccl_comm is None
++
++
++def test_cuda_communicator_retains_owners_when_custom_close_fails() -> None:
++    communicator = object.__new__(CudaCommunicator)
++    custom_allreduce = MagicMock()
++    custom_allreduce.close.side_effect = RuntimeError("close failed")
++    communicator.ca_comm = custom_allreduce
++    communicator.pynccl_comm = MagicMock()
++    communicator.aiter_ar_comm = None
++    communicator.fi_ar_comm = None
++    communicator.all2all_manager = None
++
++    with pytest.raises(RuntimeError, match="close failed"):
++        communicator.destroy()
++
++    assert communicator.ca_comm is custom_allreduce
++    communicator.pynccl_comm.destroy.assert_not_called()
++
++
++def test_group_destroy_keeps_process_groups_live_for_communicator(
++    monkeypatch: pytest.MonkeyPatch,
++) -> None:
++    coordinator = object.__new__(GroupCoordinator)
++    coordinator.device_group = object()
++    coordinator.cpu_group = object()
++    coordinator.device_communicator = MagicMock()
++    coordinator.mq_broadcaster = None
++    device_group = coordinator.device_group
++    destroy_order = []
++    coordinator.device_communicator.destroy.side_effect = lambda: destroy_order.append(
++        "communicator"
++    )
++    monkeypatch.setattr(
++        torch.distributed,
++        "destroy_process_group",
++        lambda group: destroy_order.append(
++            "device" if group is device_group else "cpu"
++        ),
++    )
++
++    coordinator.destroy()
++
++    assert destroy_order == ["communicator", "device", "cpu"]
++
++
++def test_group_destroy_retains_process_groups_when_communicator_close_fails() -> None:
++    coordinator = object.__new__(GroupCoordinator)
++    coordinator.device_group = object()
++    coordinator.cpu_group = object()
++    coordinator.device_communicator = MagicMock()
++    coordinator.device_communicator.destroy.side_effect = RuntimeError("close failed")
++    coordinator.mq_broadcaster = None
++
++    with pytest.raises(RuntimeError, match="close failed"):
++        coordinator.destroy()
++
++    assert hasattr(coordinator, "device_group")
++    assert hasattr(coordinator, "cpu_group")
+diff --git a/tests/distributed/test_dcp_a2a.py b/tests/distributed/test_dcp_a2a.py
+index 4bf1144c6fc3d3d378752dd4e36d986ec50b91e4..6a1029568a2087a1d4b373ed8080a18c59a0f73e 100644
+--- a/tests/distributed/test_dcp_a2a.py
++++ b/tests/distributed/test_dcp_a2a.py
+@@ -10,7 +10,7 @@ Tests cover:
+ 
+ import importlib.util
+ import math
+-from contextlib import contextmanager
++from contextlib import contextmanager, nullcontext
+ from typing import Any
+ 
+ import multiprocess as mp
+@@ -553,7 +553,7 @@ def test_b12x_pool_uses_independent_stream_channels(
+             return cls()
+ 
+         def prepare_channels(self, channel_ids):
+-            captured["prepared"] = channel_ids
++            captured["prepared"] = tuple(channel_ids)
+ 
+         def for_stream(self, *, channel_id):
+             captured["warmed"] = channel_id
+@@ -580,14 +580,15 @@ def test_b12x_pool_uses_independent_stream_channels(
+ 
+     assert pool is not None
+     assert captured["single_channel"] is False
+-    assert captured["prepared"] == ("eager:vllm-dcp-a2a",)
+-    assert captured["warmed"] == "eager:vllm-dcp-a2a"
++    assert captured["max_concurrent_channels"] == 2
++    assert captured["prepared"] == ("vllm:eager:dcp",)
++    assert captured["warmed"] == "vllm:eager:dcp"
+ 
+ 
+ def test_b12x_dcp_capture_selects_only_current_group_pools(monkeypatch):
+     from vllm.v1.attention.ops import dcp_alltoall
+ 
+-    events = []
++    events: list[Any] = []
+ 
+     class _FakePool:
+         def __init__(self, name):
+@@ -614,25 +615,44 @@ def test_b12x_dcp_capture_selects_only_current_group_pools(monkeypatch):
+     with dcp_alltoall.capture_b12x_dcp_a2a(  # type: ignore[arg-type]
+         group,
+         stream,
+-        channel_id="graph:test",
++        channel_id="vllm:target:profile",
+     ):
+-        events.append(("body", None, stream))
++        events.append(("body", None, stream, "vllm:target:profile"))
+ 
+     assert events == [
+-        ("enter", "output", stream, "graph:test"),
+-        ("enter", "query", stream, "graph:test"),
+-        ("body", None, stream),
+-        ("exit", "query", stream, "graph:test"),
+-        ("exit", "output", stream, "graph:test"),
++        ("enter", "output", stream, "vllm:target:profile"),
++        ("enter", "query", stream, "vllm:target:profile"),
++        ("body", None, stream, "vllm:target:profile"),
++        ("exit", "query", stream, "vllm:target:profile"),
++        ("exit", "output", stream, "vllm:target:profile"),
+     ]
+ 
+ 
++def test_b12x_dcp_capture_rejects_missing_semantic_id(monkeypatch):
++    from vllm.v1.attention.ops import dcp_alltoall
++
++    device_group = object()
++    group = _FakeCPGroup(2, device_group)  # type: ignore[arg-type]
++    key = (id(device_group), 0, 64, 512, 576, 64)
++    monkeypatch.setattr(
++        dcp_alltoall,
++        "_B12X_DCP_A2A_POOLS",
++        {key: object()},
++    )
++
++    with (
++        pytest.raises(RuntimeError, match="semantic channel_id"),
++        dcp_alltoall.capture_b12x_dcp_a2a(group),
++    ):
++        pass
++
++
+ def test_b12x_dcp_channel_rollback_restores_existing_and_closes_new_pools(
+     monkeypatch,
+ ):
+     from vllm.v1.attention.ops import dcp_alltoall
+ 
+-    events = []
++    events: list[Any] = []
+ 
+     class _FakePool:
+         def __init__(self, name):
+@@ -675,7 +695,7 @@ def test_profile_channel_checkpoint_rolls_back_all_b12x_transports(monkeypatch):
+     from vllm.distributed import parallel_state
+     from vllm.v1.attention.ops import dcp_alltoall
+ 
+-    events = []
++    events: list[Any] = []
+ 
+     class _FakeCommunicator:
+         def checkpoint_pcie_channels(self):
+@@ -699,10 +719,15 @@ def test_profile_channel_checkpoint_rolls_back_all_b12x_transports(monkeypatch):
+     monkeypatch.setattr(parallel_state, "_TP", tp_group)
+     monkeypatch.setattr(parallel_state, "_PP", pp_group)
+     monkeypatch.setattr(parallel_state, "_DCP", dcp_group)
++
++    def checkpoint_dcp(group):
++        events.append("checkpoint-dcp")
++        return "dcp-checkpoint"
++
+     monkeypatch.setattr(
+         dcp_alltoall,
+         "checkpoint_b12x_dcp_a2a_channels",
+-        lambda group: events.append("checkpoint-dcp") or "dcp-checkpoint",
++        checkpoint_dcp,
+     )
+     monkeypatch.setattr(
+         dcp_alltoall,
+@@ -725,28 +750,38 @@ def test_global_graph_capture_enters_b12x_dcp_pool(monkeypatch):
+     from vllm.distributed import parallel_state
+     from vllm.v1.attention.ops import dcp_alltoall
+ 
+-    events = []
++    events: list[Any] = []
+ 
+     class _FakeGroup:
+         world_size = 2
+ 
++        def __init__(self, name):
++            self.name = name
++
+         @contextmanager
+         def graph_capture(self, context):
+-            yield context
++            events.append(("enter-group", self.name, context.channel_id))
++            try:
++                yield context
++            finally:
++                events.append(("exit-group", self.name, context.channel_id))
+ 
+-    tp_group = _FakeGroup()
+-    pp_group = _FakeGroup()
+-    dcp_group = _FakeGroup()
++    tp_group = _FakeGroup("tp")
++    pp_group = _FakeGroup("pp")
++    dcp_group = _FakeGroup("dcp")
+     stream = object()
+     context = parallel_state.GraphCaptureContext(  # type: ignore[arg-type]
+         stream,
+-        channel_id="graph:test-global-capture",
++        channel_id="vllm:target:profile",
+     )
+ 
+     @contextmanager
+     def fake_b12x_capture(group, selected_stream, *, channel_id):
+-        events.append((group, selected_stream, channel_id))
+-        yield
++        events.append(("enter-b12x", group, selected_stream, channel_id))
++        try:
++            yield
++        finally:
++            events.append(("exit-b12x", group, selected_stream, channel_id))
+ 
+     monkeypatch.setattr(parallel_state, "_DCP", dcp_group)
+     monkeypatch.setattr(parallel_state, "get_tp_group", lambda: tp_group)
+@@ -757,7 +792,75 @@ def test_global_graph_capture_enters_b12x_dcp_pool(monkeypatch):
+     with parallel_state.graph_capture(torch.device("cpu"), context) as actual:
+         assert actual is context
+ 
+-    assert events == [(dcp_group, stream, "graph:test-global-capture")]
++    assert events == [
++        ("enter-group", "tp", "vllm:target:profile"),
++        ("enter-group", "pp", "vllm:target:profile"),
++        ("enter-group", "dcp", "vllm:target:profile"),
++        (
++            "enter-b12x",
++            dcp_group,
++            stream,
++            "vllm:target:profile",
++        ),
++        (
++            "exit-b12x",
++            dcp_group,
++            stream,
++            "vllm:target:profile",
++        ),
++        ("exit-group", "dcp", "vllm:target:profile"),
++        ("exit-group", "pp", "vllm:target:profile"),
++        ("exit-group", "tp", "vllm:target:profile"),
++    ]
++
++
++def test_group_capture_forwards_semantic_id_to_custom_allreduce(monkeypatch):
++    from vllm._aiter_ops import rocm_aiter_ops
++    from vllm.distributed import parallel_state
++    from vllm.distributed.device_communicators.cuda_communicator import (
++        CudaCommunicator,
++    )
++
++    events: list[Any] = []
++
++    class FakeCustomAllreduce:
++        @contextmanager
++        def capture(self, *, stream, channel_id):
++            events.append(("enter", stream, channel_id))
++            try:
++                yield
++            finally:
++                events.append(("exit", stream, channel_id))
++
++    communicator = object.__new__(CudaCommunicator)
++    communicator.ca_comm = FakeCustomAllreduce()
++    group = object.__new__(parallel_state.GroupCoordinator)
++    group.device_communicator = communicator
++    stream = object()
++    context = parallel_state.GraphCaptureContext(  # type: ignore[arg-type]
++        stream,
++        channel_id="vllm:draft:decode:production",
++    )
++
++    monkeypatch.setattr(rocm_aiter_ops, "is_enabled", lambda: False)
++    monkeypatch.setattr(
++        parallel_state.torch.cuda,
++        "current_stream",
++        lambda: stream,
++    )
++    monkeypatch.setattr(
++        parallel_state.torch.cuda,
++        "stream",
++        lambda selected: nullcontext(),
++    )
++
++    with parallel_state.GroupCoordinator.graph_capture(group, context) as actual:
++        assert actual is context
++
++    assert events == [
++        ("enter", stream, "vllm:draft:decode:production"),
++        ("exit", stream, "vllm:draft:decode:production"),
++    ]
+ 
+ 
+ @pytest.mark.skipif(torch.accelerator.device_count() < 1, reason="CUDA is required.")
+@@ -779,7 +882,7 @@ def test_b12x_lse_reduce_honors_token_cap(monkeypatch: pytest.MonkeyPatch):
+             is_lse_base_on_e,
+             channel_id,
+         ):
+-            assert channel_id == "eager:vllm-dcp-a2a"
++            created["channel_id"] = channel_id
+             return sentinel
+ 
+     def fake_get_pool(
+@@ -805,6 +908,7 @@ def test_b12x_lse_reduce_honors_token_cap(monkeypatch: pytest.MonkeyPatch):
+     # Batch within the cap uses B12X, with the staging pool capped too.
+     assert result is sentinel
+     assert created["max_batch_size"] == 4
++    assert created["channel_id"] == "vllm:eager:dcp"
+ 
+     out_large = torch.zeros(8, 16, 64, dtype=torch.bfloat16, device="cuda")
+     lse_large = torch.zeros(8, 16, dtype=torch.float32, device="cuda")
+@@ -832,7 +936,7 @@ def test_b12x_query_gather_honors_token_cap(monkeypatch: pytest.MonkeyPatch):
+ 
+     class _FakePool:
+         def all_gather_heads(self, local_input, *, channel_id):
+-            assert channel_id == "eager:vllm-dcp-a2a"
++            created["channel_id"] = channel_id
+             return sentinel
+ 
+     def fake_get_pool(
+@@ -853,6 +957,7 @@ def test_b12x_query_gather_honors_token_cap(monkeypatch: pytest.MonkeyPatch):
+     )
+     assert result is sentinel
+     assert created["max_batch_size"] == 4
++    assert created["channel_id"] == "vllm:eager:dcp"
+ 
+     large = torch.zeros(8, 8, 64, dtype=torch.bfloat16, device="cuda")
+     result = dcp_alltoall._try_b12x_dcp_all_gather_heads(
+@@ -919,11 +1024,9 @@ def test_b12x_lse_reduce_preserves_supported_layouts(monkeypatch: pytest.MonkeyP
+     assert received["partial"].is_contiguous()
+     assert received["lse"].is_contiguous()
+     assert received["out"].movedim(0, 1).is_contiguous()
+-    assert received["channel_id"] == "eager:vllm-dcp-a2a"
++    assert received["channel_id"] == "vllm:eager:dcp"
+ 
+-    head_major_storage = torch.zeros(
+-        16, 8, 64, dtype=torch.bfloat16, device="cuda"
+-    )
++    head_major_storage = torch.zeros(16, 8, 64, dtype=torch.bfloat16, device="cuda")
+     head_major = head_major_storage.transpose(0, 1)[:4]
+     result = dcp_alltoall._try_b12x_dcp_lse_reduce(
+         head_major,
+@@ -1298,12 +1401,12 @@ def _distributed_b12x_a2a_worker(env: dict[str, str]) -> None:
+         dcp_alltoall._dcp_a2a_send_recv_buffers = fail_packed_nccl
+         group.all_gather = fail_query_nccl  # type: ignore[attr-defined]
+         graph = torch.cuda.CUDAGraph()
+-        capture_stream = torch.cuda.Stream()
++        capture_stream = torch.cuda.Stream(device=f"cuda:{local_rank}")
+         with (
+             dcp_alltoall.capture_b12x_dcp_a2a(
+                 group,  # type: ignore[arg-type]
+                 capture_stream,
+-                channel_id="graph:test-dcp-a2a",
++                channel_id="test:dcp:graph",
+             ),
+             torch.cuda.graph(graph, stream=capture_stream),
+         ):
+diff --git a/tests/distributed/test_flashinfer_pcie_all_reduce.py b/tests/distributed/test_flashinfer_pcie_all_reduce.py
+new file mode 100644
+index 0000000000000000000000000000000000000000..181baec216cb4b316ebb52c215fa4dab87d4f256
+--- /dev/null
++++ b/tests/distributed/test_flashinfer_pcie_all_reduce.py
+@@ -0,0 +1,224 @@
++# SPDX-License-Identifier: Apache-2.0
++# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
++
++from __future__ import annotations
++
++from types import SimpleNamespace
++from typing import Any
++from unittest.mock import MagicMock
++
++import pytest
++import torch
++
++from vllm.distributed.device_communicators import custom_all_reduce
++from vllm.distributed.device_communicators import flashinfer_pcie_all_reduce as fi_pcie
++
++
++class FakeWorkspace:
++    instances: list[FakeWorkspace] = []
++
++    def __init__(self, **kwargs: Any) -> None:
++        self.kwargs = kwargs
++        self.destroyed = False
++        self.last_input: torch.Tensor | None = None
++        FakeWorkspace.instances.append(self)
++
++    def supports(self, inp: torch.Tensor) -> bool:
++        return inp.numel() <= self.kwargs["max_numel"]
++
++    def all_reduce(
++        self, inp: torch.Tensor, *, out: torch.Tensor | None = None
++    ) -> torch.Tensor:
++        self.last_input = inp
++        if out is None:
++            return inp.clone()
++        out.copy_(inp)
++        return out
++
++    def destroy(self) -> None:
++        self.destroyed = True
++
++
++@pytest.fixture(autouse=True)
++def fake_runtime(monkeypatch: pytest.MonkeyPatch) -> None:
++    FakeWorkspace.instances.clear()
++    monkeypatch.setattr(fi_pcie, "_load_workspace_class", lambda: FakeWorkspace)
++    monkeypatch.setattr(fi_pcie.dist, "get_rank", lambda group=None: 0)
++    monkeypatch.setattr(fi_pcie.dist, "get_world_size", lambda group=None: 2)
++
++    def all_gather_object(gathered, value, *, group):
++        del group
++        gathered[:] = [value, value]
++
++    monkeypatch.setattr(fi_pcie.dist, "all_gather_object", all_gather_object)
++
++
++def make_pool() -> fi_pcie.FlashInferPcieIpcAllReducePool:
++    return fi_pcie.FlashInferPcieIpcAllReducePool(
++        exchange_group=object(),  # type: ignore[arg-type]
++        device="cpu",
++        max_size=64,
++    )
++
++
++def test_each_semantic_channel_gets_an_independent_workspace() -> None:
++    pool = make_pool()
++    assert FakeWorkspace.instances == []
++    checkpoint = pool.checkpoint_channels()
++
++    pool.prepare_channels(("vllm:target:profile",))
++    assert len(FakeWorkspace.instances) == 1
++    assert pool.for_stream(channel_id="vllm:target:profile").should_allreduce(
++        torch.ones(4)
++    )
++
++    profile_workspace = FakeWorkspace.instances[-1]
++    pool.rollback_channels(checkpoint)
++    assert profile_workspace.destroyed
++    assert pool.checkpoint_channels() == ()
++
++    inp = torch.ones(4)
++    assert torch.equal(pool.all_reduce(inp), inp)
++    eager = FakeWorkspace.instances[-1]
++    pool.close()
++    assert eager.destroyed
++
++
++def test_capture_routes_graph_calls_without_reusing_eager_state() -> None:
++    pool = make_pool()
++    inp = torch.arange(4, dtype=torch.float32)
++    out = torch.empty_like(inp)
++
++    with pool.capture(channel_id="vllm:target:production"):
++        pool.prepare_graph_all_reduce(inp)
++        actual = pool.all_reduce(
++            inp,
++            out=out,
++            channel_id="vllm:target:production",
++        )
++
++    assert actual is out
++    assert torch.equal(actual, inp)
++    assert len(FakeWorkspace.instances) == 1
++    assert FakeWorkspace.instances[0].last_input is inp
++    pool.close()
++
++
++def test_channel_creation_fails_closed_when_rank_ids_differ(
++    monkeypatch: pytest.MonkeyPatch,
++) -> None:
++    pool = make_pool()
++
++    def divergent(gathered, value, *, group):
++        del group
++        gathered[:] = [value, "different-channel"]
++
++    monkeypatch.setattr(fi_pcie.dist, "all_gather_object", divergent)
++    with pytest.raises(RuntimeError, match="rank-stable"):
++        pool.prepare_channels(("vllm:target:production",))
++    pool.close()
++
++
++def test_flashinfer_ipc_is_an_explicit_integrated_backend(
++    monkeypatch: pytest.MonkeyPatch,
++) -> None:
++    monkeypatch.setenv("VLLM_ENABLE_PCIE_ALLREDUCE", "1")
++    monkeypatch.setenv("VLLM_PCIE_ALLREDUCE_BACKEND", "flashinfer-ipc")
++
++    assert custom_all_reduce._flashinfer_pcie_allreduce_requested()
++    assert not custom_all_reduce._b12x_pcie_allreduce_requested()
++    assert custom_all_reduce._get_pcie_allreduce_backend() == "flashinfer-ipc"
++
++
++def test_custom_allreduce_constructs_flashinfer_pool(
++    monkeypatch: pytest.MonkeyPatch,
++) -> None:
++    captured: dict[str, Any] = {}
++    runtime = MagicMock()
++
++    class FakePool:
++        @classmethod
++        def from_exchange_group(cls, **kwargs: Any) -> MagicMock:
++            captured.update(kwargs)
++            return runtime
++
++    def fake_all_gather(gather_list, tensor, *, group) -> None:
++        del tensor, group
++        for index, slot in enumerate(gather_list):
++            slot.fill_(index)
++
++    fake_config = SimpleNamespace(
++        model_config=SimpleNamespace(get_hidden_size=lambda: 4096),
++        scheduler_config=SimpleNamespace(max_num_batched_tokens=128),
++    )
++    monkeypatch.setattr(custom_all_reduce, "custom_ar", True)
++    monkeypatch.setattr(custom_all_reduce.dist, "get_backend", lambda group: "gloo")
++    monkeypatch.setattr(
++        custom_all_reduce,
++        "in_the_same_node_as",
++        lambda group, source_rank=0: [True, True],
++    )
++    monkeypatch.setattr(custom_all_reduce.dist, "get_rank", lambda group=None: 0)
++    monkeypatch.setattr(custom_all_reduce.dist, "get_world_size", lambda group=None: 2)
++    monkeypatch.setattr(custom_all_reduce.dist, "all_gather", fake_all_gather)
++    monkeypatch.setattr(
++        custom_all_reduce.dist, "all_reduce", lambda *args, **kwargs: None
++    )
++    monkeypatch.setattr(
++        custom_all_reduce, "_b12x_pcie_allreduce_requested", lambda: False
++    )
++    monkeypatch.setattr(
++        custom_all_reduce, "_flashinfer_pcie_allreduce_requested", lambda: True
++    )
++    monkeypatch.setattr(
++        custom_all_reduce, "_get_pcie_allreduce_backend", lambda: "flashinfer-ipc"
++    )
++    monkeypatch.setattr(custom_all_reduce, "_can_p2p", lambda *args: True)
++    monkeypatch.setattr(custom_all_reduce, "_is_cross_numa_topology", lambda ids: False)
++    monkeypatch.setattr(
++        custom_all_reduce, "_load_flashinfer_pcie_oneshot_pool", lambda: FakePool
++    )
++    monkeypatch.setattr(
++        custom_all_reduce.current_platform, "get_device_capability", lambda: None
++    )
++    monkeypatch.setattr(
++        custom_all_reduce.current_platform,
++        "visible_device_id_to_physical_device_id",
++        lambda index: index,
++    )
++    monkeypatch.setattr(
++        custom_all_reduce.current_platform, "is_cuda_alike", lambda: True
++    )
++    monkeypatch.setattr(
++        custom_all_reduce.current_platform,
++        "is_fully_connected",
++        lambda ids: False,
++        raising=False,
++    )
++    monkeypatch.setattr(custom_all_reduce.current_platform, "is_cuda", lambda: True)
++    monkeypatch.setattr(custom_all_reduce.current_platform, "is_rocm", lambda: False)
++    monkeypatch.setattr("vllm.config.get_current_vllm_config", lambda: fake_config)
++    monkeypatch.setattr(
++        custom_all_reduce.envs,
++        "VLLM_PCIE_ONESHOT_SINGLE_CHANNEL",
++        False,
++        raising=False,
++    )
++    monkeypatch.setattr(
++        custom_all_reduce.envs,
++        "VLLM_ALLOW_CUSTOM_ALLREDUCE_PCIE",
++        False,
++        raising=False,
++    )
++
++    built = custom_all_reduce.CustomAllreduce(
++        object(),  # type: ignore[arg-type]
++        torch.device("cuda:0"),
++        nccl_group=object(),  # type: ignore[arg-type]
++    )
++
++    assert not built.disabled
++    assert built.backend_name() == "FLASHINFER_PCIE_IPC"
++    assert captured["max_size"] > 0
++    runtime.prepare_channels.assert_called_once()
++    runtime.for_stream.assert_called_once()
+diff --git a/tests/distributed/test_indexer_parallel_groups.py b/tests/distributed/test_indexer_parallel_groups.py
+index 8414eb255eeccbdd5af48ccb64f60ea86983d00c..1c65833173363b70ce5e9ecf1258383389fa7ddc 100644
+--- a/tests/distributed/test_indexer_parallel_groups.py
++++ b/tests/distributed/test_indexer_parallel_groups.py
+@@ -8,6 +8,7 @@ import pytest
+ from vllm.distributed import parallel_state
+ from vllm.distributed.parallel_state import (
+     _build_indexer_replica_group_ranks,
++    _needs_indexer_replica_groups,
+     _validate_indexer_shard_count,
+ )
+ 
+@@ -54,6 +55,14 @@ def test_build_indexer_groups_cover_dcp1_partial_and_full(
+     assert query_split_groups == expected_query_split
+ 
+ 
++@pytest.mark.parametrize(
++    ("indexer_shards", "expected"),
++    [(0, False), (1, True), (2, True), (4, True), (8, False)],
++)
++def test_indexer_replica_group_gate_for_dcp8(indexer_shards, expected):
++    assert _needs_indexer_replica_groups(indexer_shards, 8) is expected
++
++
+ def test_build_indexer_replica_groups_stay_inside_each_tp_group():
+     dcp_groups, query_split_groups = _build_indexer_replica_group_ranks(
+         [list(range(8)), list(range(8, 16))], 4
+diff --git a/tests/entrypoints/test_ds4_allreduce_launcher.py b/tests/entrypoints/test_ds4_allreduce_launcher.py
+new file mode 100644
+index 0000000000000000000000000000000000000000..73ec7f630a58f78f07caadfb60e6f9d4b04e547d
+--- /dev/null
++++ b/tests/entrypoints/test_ds4_allreduce_launcher.py
+@@ -0,0 +1,58 @@
++# SPDX-License-Identifier: Apache-2.0
++# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
++
++import os
++import subprocess
++from pathlib import Path
++
++_REPO_ROOT = Path(__file__).parents[2]
++_LAUNCHER = _REPO_ROOT / "serve-ds4-flash.sh"
++
++
++def _dry_run(tmp_path: Path, **overrides: str) -> str:
++    """Run the DS4 launcher without starting a server.
++
++    Args:
++        tmp_path: Isolated home and cache root for the launcher.
++        **overrides: Environment values applied to the launcher defaults.
++
++    Returns:
++        The launcher's diagnostic stderr output.
++    """
++    env = {
++        "PATH": os.environ["PATH"],
++        "HOME": str(tmp_path),
++        "XDG_CACHE_HOME": str(tmp_path / "cache"),
++        "DRY_RUN": "1",
++        "MODE": "mtp0",
++        **overrides,
++    }
++    result = subprocess.run(
++        ["bash", str(_LAUNCHER)],
++        env=env,
++        check=True,
++        capture_output=True,
++        text=True,
++    )
++    return result.stderr
++
++
++def test_ds4_launcher_auto_selects_flashinfer_ipc_for_tp2(tmp_path: Path) -> None:
++    """Verify that automatic selection uses FlashInfer IPC at TP2."""
++    output = _dry_run(tmp_path, TP="2")
++
++    assert "allreduce=flashinfer-ipc" in output
++
++
++def test_ds4_launcher_auto_keeps_b12x_for_tp4(tmp_path: Path) -> None:
++    """Verify that automatic selection retains B12X at TP4."""
++    output = _dry_run(tmp_path, TP="4")
++
++    assert "allreduce=b12x" in output
++
++
++def test_ds4_launcher_explicit_allreduce_overrides_auto(tmp_path: Path) -> None:
++    """Verify that an explicit all-reduce mode overrides automatic selection."""
++    output = _dry_run(tmp_path, TP="2", ALLREDUCE_MODE="b12x")
++
++    assert "allreduce=b12x" in output
+diff --git a/tests/entrypoints/test_ds4_flash_launcher.py b/tests/entrypoints/test_ds4_flash_launcher.py
+new file mode 100644
+index 0000000000000000000000000000000000000000..47bcf54a2fbd4a07aeb4c7abe28f5810b14d639a
+--- /dev/null
++++ b/tests/entrypoints/test_ds4_flash_launcher.py
+@@ -0,0 +1,279 @@
++# SPDX-License-Identifier: Apache-2.0
++# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
++
++import os
++import subprocess
++from pathlib import Path
++
++_REPO_ROOT = Path(__file__).parents[2]
++_LAUNCHER = _REPO_ROOT / "serve-ds4-flash.sh"
++
++
++def _dry_run(tmp_path: Path, **overrides: str) -> str:
++    """Run the DS4 launcher in dry-run mode.
++
++    Args:
++        tmp_path: Temporary home and cache root.
++        **overrides: Environment variables that override launcher defaults.
++
++    Returns:
++        The launcher's standard-error output.
++    """
++    env = {
++        "PATH": os.environ["PATH"],
++        "HOME": str(tmp_path),
++        "XDG_CACHE_HOME": str(tmp_path / "cache"),
++        "DRY_RUN": "1",
++        **overrides,
++    }
++    result = subprocess.run(
++        ["bash", str(_LAUNCHER)],
++        env=env,
++        check=True,
++        capture_output=True,
++        text=True,
++    )
++    return result.stderr
++
++
++def test_ds4_launcher_defaults_to_0731_fixed_k7(tmp_path: Path) -> None:
++    """Verify the default 0731 fixed-K7 launch profile.
++
++    Args:
++        tmp_path: Temporary home and cache root.
++    """
++    output = _dry_run(tmp_path)
++
++    assert "mode=dspark depth=fixed" in output
++    assert "model=deepseek-ai/DeepSeek-V4-Flash-0731" in output
++    assert "9e165c30e2704aec5d9d593cce3eebd58bbef1cb" in output
++    assert 'num_speculative_tokens\\":7' in output
++    assert "max_seqs=16 graph=128" in output
++    assert "--max-model-len 131072" in output
++    assert "--gpu-memory-utilization 0.975" in output
++
++
++def test_ds4_launcher_dynamic_depth_enables_capacity_mode(tmp_path: Path) -> None:
++    """Verify that dynamic depth selects variable-capacity verification.
++
++    Args:
++        tmp_path: Temporary home and cache root.
++    """
++    output = _dry_run(tmp_path, DSPARK_DEPTH_MODE="dynamic")
++
++    assert "mode=dspark depth=dynamic" in output
++    assert 'dspark_capacity_verification_mode\\":\\"varlen' in output
++    assert 'dspark_sps_curve\\":\\"auto' in output
++
++
++def test_ds4_launcher_uses_speculative_attention_backend_field(
++    tmp_path: Path,
++) -> None:
++    """Verify the draft backend uses SpeculativeConfig's canonical field.
++
++    Args:
++        tmp_path: Temporary home and cache root.
++    """
++    output = _dry_run(
++        tmp_path,
++        DSPARK_DRAFT_ATTENTION_BACKEND="FLASHINFER_MLA_SPARSE_DSV4",
++    )
++
++    assert 'attention_backend\\":\\"FLASHINFER_MLA_SPARSE_DSV4' in output
++    assert 'draft_attention_backend\\"' not in output
++
++
++def test_ds4_launcher_accepts_cluster_style_aliases(tmp_path: Path) -> None:
++    """Verify compatibility with cluster-style environment aliases.
++
++    Args:
++        tmp_path: Temporary home and cache root.
++    """
++    output = _dry_run(
++        tmp_path,
++        DCP="1",
++        NUM_SPECULATIVE_TOKENS="5",
++    )
++
++    assert "dcp=1" in output
++    assert 'num_speculative_tokens\\":5' in output
++
++
++def test_ds4_launcher_standard_mtp_uses_standard_checkpoint(tmp_path: Path) -> None:
++    """Verify that standard MTP selects the non-DSpark checkpoint.
++
++    Args:
++        tmp_path: Temporary home and cache root.
++    """
++    output = _dry_run(tmp_path, MODE="mtp2")
++
++    assert "mode=mtp2 depth=disabled" in output
++    assert "model=deepseek-ai/DeepSeek-V4-Flash" in output
++    assert "DeepSeek-V4-Flash-0731" not in output
++    assert 'method\\":\\"mtp' in output
++    assert 'num_speculative_tokens\\":2' in output
++
++
++def test_ds4_launcher_can_disable_dspark_on_0731(tmp_path: Path) -> None:
++    """Verify target-only serving with the 0731 checkpoint.
++
++    Args:
++        tmp_path: Temporary home and cache root.
++    """
++    output = _dry_run(tmp_path, MODE="dspark-mtp0")
++
++    assert "mode=dspark-mtp0 depth=disabled" in output
++    assert "model=deepseek-ai/DeepSeek-V4-Flash-0731" in output
++    assert "--speculative-config" not in output
++
++
++def test_ds4_launcher_enables_native_kv_offload(tmp_path: Path) -> None:
++    """Verify native host-memory KV offload arguments.
++
++    Args:
++        tmp_path: Temporary home and cache root.
++    """
++    output = _dry_run(tmp_path, KV_OFFLOADING_SIZE="5.5")
++
++    assert "--kv-offloading-size 5.5" in output
++    assert "--kv-offloading-backend native" in output
++    assert "allocator=expandable_segments:False" in output
++
++
++def test_ds4_launcher_builds_bounded_native_l2_config(tmp_path: Path) -> None:
++    """Verify bounded filesystem L2 configuration generation.
++
++    Args:
++        tmp_path: Temporary home and cache root.
++    """
++    output = _dry_run(
++        tmp_path,
++        KV_OFFLOADING_SIZE="32",
++        NATIVE_L2_PATH="/cache/native-l2",
++        NATIVE_L2_GB="128",
++    )
++
++    assert "native_l2=1" in output
++    assert "--kv-transfer-config" in output
++    assert "OffloadingConnector" in output
++    assert "TieringOffloadingSpec" in output
++    assert "cache/native-l2" in output
++    assert 'gc_max_size_gb\\":128.0' in output
++
++
++def test_ds4_launcher_native_l2_requires_l1(tmp_path: Path) -> None:
++    """Verify that filesystem L2 requires native host-memory L1.
++
++    Args:
++        tmp_path: Temporary home and cache root.
++    """
++    env = {
++        "PATH": os.environ["PATH"],
++        "HOME": str(tmp_path),
++        "XDG_CACHE_HOME": str(tmp_path / "cache"),
++        "DRY_RUN": "1",
++        "NATIVE_L2_PATH": "/cache/native-l2",
++        "NATIVE_L2_GB": "128",
++    }
++    result = subprocess.run(
++        ["bash", str(_LAUNCHER)],
++        env=env,
++        check=False,
++        capture_output=True,
++        text=True,
++    )
++
++    assert result.returncode == 2
++    assert "NATIVE_L2 requires a positive KV_OFFLOADING_SIZE" in result.stderr
++
++
++def test_ds4_launcher_native_l2_requires_complete_pair(tmp_path: Path) -> None:
++    """Verify that both filesystem L2 settings are required.
++
++    Args:
++        tmp_path: Temporary home and cache root.
++    """
++    env = {
++        "PATH": os.environ["PATH"],
++        "HOME": str(tmp_path),
++        "XDG_CACHE_HOME": str(tmp_path / "cache"),
++        "DRY_RUN": "1",
++        "KV_OFFLOADING_SIZE": "32",
++        "NATIVE_L2_PATH": "/cache/native-l2",
++    }
++    result = subprocess.run(
++        ["bash", str(_LAUNCHER)],
++        env=env,
++        check=False,
++        capture_output=True,
++        text=True,
++    )
++
++    assert result.returncode == 2
++    assert "NATIVE_L2_PATH and NATIVE_L2_GB must be set together" in result.stderr
++
++
++def test_ds4_launcher_native_offload_preserves_other_allocator_settings(
++    tmp_path: Path,
++) -> None:
++    """Verify allocator normalization preserves unrelated settings.
++
++    Args:
++        tmp_path: Temporary home and cache root.
++    """
++    output = _dry_run(
++        tmp_path,
++        KV_OFFLOADING_SIZE="5.5",
++        PYTORCH_CUDA_ALLOC_CONF=("max_split_size_mb:256,expandable_segments:True"),
++    )
++
++    assert "allocator=max_split_size_mb:256,expandable_segments:False" in output
++
++
++def test_ds4_launcher_without_offload_keeps_expandable_segments(
++    tmp_path: Path,
++) -> None:
++    """Verify the default allocator when native offload is disabled.
++
++    Args:
++        tmp_path: Temporary home and cache root.
++    """
++    output = _dry_run(tmp_path)
++
++    assert "allocator=expandable_segments:True" in output
++
++
++def test_ds4_launcher_zero_kv_offload_stays_disabled(tmp_path: Path) -> None:
++    """Verify that a zero offload size does not enable native offload.
++
++    Args:
++        tmp_path: Temporary home and cache root.
++    """
++    output = _dry_run(tmp_path, KV_OFFLOADING_SIZE="0.0")
++
++    assert "--kv-offloading-size" not in output
++
++
++def test_ds4_launcher_rejects_invalid_kv_offload_size(tmp_path: Path) -> None:
++    """Verify rejection of a nonnumeric native-offload size.
++
++    Args:
++        tmp_path: Temporary home and cache root.
++    """
++    env = {
++        "PATH": os.environ["PATH"],
++        "HOME": str(tmp_path),
++        "XDG_CACHE_HOME": str(tmp_path / "cache"),
++        "DRY_RUN": "1",
++        "KV_OFFLOADING_SIZE": "five",
++    }
++    result = subprocess.run(
++        ["bash", str(_LAUNCHER)],
++        env=env,
++        check=False,
++        capture_output=True,
++        text=True,
++    )
++
++    assert result.returncode == 2
++    assert "KV_OFFLOADING_SIZE must be a non-negative GiB value" in result.stderr
+diff --git a/tests/entrypoints/unit_tests/test_chat_utils.py b/tests/entrypoints/unit_tests/test_chat_utils.py
+index 82b262321d6c12f06296a2d36b593622fd456a86..a923256daf3a63aced57f6c0ba6ea715253ab028 100644
+--- a/tests/entrypoints/unit_tests/test_chat_utils.py
++++ b/tests/entrypoints/unit_tests/test_chat_utils.py
+@@ -708,6 +708,30 @@ def test_parse_chat_messages_empty_system(
+     ]
+ 
+ 
++@pytest.mark.parametrize("role", ["system", "developer"])
++def test_parse_chat_messages_preserves_message_level_tools(
++    mistral_model_config,
++    role,
++):
++    # Message-level `tools` (as opposed to the request-level `tools`
++    # parameter) must be preserved on both "system" and "developer" role
++    # messages: chat template/encoders such as DeepSeek-V4 and DeepSeek-V3.2
++    # read message-level tools for either role.
++    tools = [{"type": "function", "function": {"name": "get_weather"}}]
++    conversation, _, _ = parse_chat_messages(
++        [
++            {"role": role, "content": "you have tools", "tools": tools},
++            {
++                "role": "user",
++                "content": [{"type": "text", "text": "Hi"}],
++            },
++        ],
++        mistral_model_config,
++        content_format="string",
++    )
++    assert conversation[0]["tools"] == tools
++
++
+ @pytest.mark.asyncio
+ async def test_parse_chat_messages_single_image_async(
+     phi3v_model_config,
+diff --git a/tests/kernels/attention/test_mla_kv_b_dtype_guard.py b/tests/kernels/attention/test_mla_kv_b_dtype_guard.py
+new file mode 100644
+index 0000000000000000000000000000000000000000..6497e1f6d0277ae05366ab28319b8c58abda64e6
+--- /dev/null
++++ b/tests/kernels/attention/test_mla_kv_b_dtype_guard.py
+@@ -0,0 +1,29 @@
++# SPDX-License-Identifier: Apache-2.0
++# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
++"""Packed-quantized kv_b_proj weights must not drive a kv_c_normed upcast.
++
++NVFP4 packs into uint8 and compressed-tensors int4/int8 packs into int32.
++Both are containers, not real activation dtypes -- casting kv_c_normed to
++either corrupts chunked prefill past ~4K prompts.
++"""
++
++import pytest
++import torch
++
++from vllm.model_executor.layers.attention.mla_attention import (
++    is_packed_quantized_dtype,
++)
++
++
++@pytest.mark.parametrize(
++    "dtype,expected",
++    [
++        (torch.uint8, True),  # NVFP4
++        (torch.int32, True),  # compressed-tensors int4/int8
++        (torch.bfloat16, False),
++        (torch.float16, False),
++        (torch.float8_e4m3fn, False),
++    ],
++)
++def test_is_packed_quantized_dtype(dtype: torch.dtype, expected: bool):
++    assert is_packed_quantized_dtype(dtype) is expected
+diff --git a/tests/kernels/quantization/test_fp8_quant_group.py b/tests/kernels/quantization/test_fp8_quant_group.py
+index 113afb3c102e666be53e50fc1c0c56f88d8fe2ce..39ddea5269269482a0d0e2b013b28b65a7dcf48b 100644
+--- a/tests/kernels/quantization/test_fp8_quant_group.py
++++ b/tests/kernels/quantization/test_fp8_quant_group.py
+@@ -7,6 +7,11 @@ import torch
+ 
+ from vllm.model_executor.layers.quantization.input_quant_fp8 import QuantFP8
+ from vllm.model_executor.layers.quantization.utils.quant_utils import GroupShape
++from vllm.utils.deep_gemm import (
++    DeepGemmQuantScaleFMT,
++    get_tma_aligned_size,
++    is_deep_gemm_supported,
++)
+ from vllm.utils.torch_utils import set_random_seed
+ 
+ 
+@@ -140,6 +145,70 @@ def test_quantfp8_group_multidimensional(
+     assert scales_4d_col.shape == (batch1, batch2, hidden_dim // group_size, batch3)
+ 
+ 
++@pytest.mark.parametrize("batch_size", [16, 17])
++@pytest.mark.parametrize("seed", [42])
++@torch.inference_mode()
++def test_quantfp8_group_packed_ue8m0_native_matches_cuda(
++    default_vllm_config, batch_size: int, seed: int
++) -> None:
++    """forward_native must emit the same scale FORMAT as forward_cuda.
++
++    When the DeepGEMM oracle selects packed UE8M0, scales are four biased e8m0
++    exponent bytes per int32 in a TMA-aligned buffer -- not float32. Since
++    CustomOp.default_on() is False under inductor, forward_native is what a
++    compiled run executes, so a float32 fallback there hands DeepGEMM the wrong
++    format with no error raised.
++
++    batch_size 17 is deliberate: it is not TMA-aligned, so it catches a layout
++    that only holds when mn happens to be a multiple of four.
++    """
++    if not is_deep_gemm_supported():
++        pytest.skip("DeepGEMM not supported on this platform")
++    try:
++        wants_packed = (
++            DeepGemmQuantScaleFMT.from_oracle() == DeepGemmQuantScaleFMT.UE8M0
++        )
++    except AssertionError:
++        pytest.skip("DeepGEMM scale-format oracle not initialized")
++    if not wants_packed:
++        pytest.skip("Oracle does not select packed UE8M0 on this platform")
++
++    set_random_seed(seed)
++
++    hidden_dim, group_size = 1024, 128
++    x = torch.randn((batch_size, hidden_dim), dtype=torch.bfloat16, device="cuda") * 8
++
++    quant_op = QuantFP8(
++        static=False,
++        group_shape=GroupShape(1, group_size),
++        column_major_scales=False,
++        use_ue8m0=True,
++    )
++
++    x_q_native, scales_native = quant_op.forward_native(x.clone())
++    x_q_cuda, scales_cuda = quant_op.forward_cuda(x.clone())
++
++    # Format, not just values: a float32 fallback fails on dtype alone.
++    assert scales_native.dtype == torch.int32
++    assert scales_native.dtype == scales_cuda.dtype
++    assert scales_native.shape == scales_cuda.shape
++    assert scales_native.stride() == scales_cuda.stride()
++
++    # DeepGEMM's layout contract, asserted directly so a refactor that keeps the
++    # values but loses the strides still fails here.
++    assert scales_native.size(-2) == batch_size
++    assert scales_native.stride(-2) == 1
++    assert scales_native.stride(-1) == get_tma_aligned_size(
++        batch_size, scales_native.element_size()
++    )
++
++    # Packed exponent bytes are integers, so they must match exactly.
++    torch.testing.assert_close(scales_native, scales_cuda, rtol=0, atol=0)
++
++    diff_ratio = (x_q_cuda != x_q_native).sum().item() / x_q_cuda.numel()
++    assert diff_ratio < 0.002, f"Too many differences: {diff_ratio:.4%}"
++
++
+ @pytest.mark.parametrize("seed", [42])
+ @torch.inference_mode()
+ def test_quantfp8_group_edge_cases(default_vllm_config, seed: int) -> None:
+diff --git a/tests/kernels/test_compressor_kv_cache.py b/tests/kernels/test_compressor_kv_cache.py
+index b8f1cb8bfa7311ce4de851088d2fbc5534488630..63607455371401445ce46697474b9315e4ee2f1b 100644
+--- a/tests/kernels/test_compressor_kv_cache.py
++++ b/tests/kernels/test_compressor_kv_cache.py
+@@ -21,6 +21,7 @@ from vllm import _custom_ops as ops
+ from vllm.models.deepseek_v4.common.ops import (
+     dequantize_and_gather_k_cache,
+     quantize_and_insert_k_cache,
++    save_partial_states,
+ )
+ from vllm.models.deepseek_v4.common.ops.fused_compress_quant_cache import (
+     _fused_kv_compress_norm_rope_insert_indexer_attn,
+@@ -61,6 +62,77 @@ def _ue8m0_reference(x: torch.Tensor, block_size: int, fp8_max: float):
+ # ── Test A: DeepseekV4 Attention path ──────────────────────────────────────────────
+ 
+ 
++@pytest.mark.parametrize("draft_tokens", [5, 7])
++def test_save_partial_states_writes_every_verifier_row(draft_tokens: int) -> None:
++    """The compressor state write covers all target rows for each request."""
++    device = "cuda"
++    verifier_width = draft_tokens + 1
++    num_reqs = 2
++    num_actual = num_reqs * verifier_width
++    head_size = 16
++    block_size = 16
++    compress_ratio = 4
++
++    kv = (
++        torch.arange(
++            (num_actual + 1) * head_size,
++            dtype=torch.float32,
++            device=device,
++        )
++        .view(num_actual + 1, head_size)
++        .to(torch.bfloat16)
++    )
++    score = (kv + 1000).to(torch.bfloat16)
++    ape = (
++        torch.arange(
++            compress_ratio * head_size,
++            dtype=torch.float32,
++            device=device,
++        )
++        .view(compress_ratio, head_size)
++        .to(torch.bfloat16)
++    )
++    positions = torch.arange(num_actual + 1, dtype=torch.int64, device=device)
++    slot_mapping = torch.cat(
++        (
++            torch.arange(verifier_width, dtype=torch.int64, device=device),
++            torch.arange(
++                block_size,
++                block_size + verifier_width,
++                dtype=torch.int64,
++                device=device,
++            ),
++            torch.tensor([-1], dtype=torch.int64, device=device),
++        )
++    )
++    state_cache = torch.full(
++        (2, block_size, 2 * head_size),
++        fill_value=-1,
++        dtype=torch.bfloat16,
++        device=device,
++    )
++
++    save_partial_states(
++        kv=kv,
++        score=score,
++        ape=ape,
++        positions=positions,
++        state_cache=state_cache,
++        slot_mapping=slot_mapping,
++        block_size=block_size,
++        state_width=head_size,
++        compress_ratio=compress_ratio,
++    )
++    torch.cuda.synchronize()
++
++    actual_slots = slot_mapping[:num_actual]
++    actual = state_cache.view(-1, 2 * head_size)[actual_slots]
++    torch.testing.assert_close(actual[:, :head_size], kv[:num_actual])
++    expected_score = score[:num_actual] + ape[positions[:num_actual] % compress_ratio]
++    torch.testing.assert_close(actual[:, head_size:], expected_score)
++    assert torch.all(state_cache.view(-1, 2 * head_size)[verifier_width] == -1)
++
++
+ @pytest.mark.parametrize("num_tokens", [1, 4, 8, 17])
+ @pytest.mark.parametrize("block_size", [16, 64])
+ def test_deepseek_v4_attention_quant_cache_roundtrip(num_tokens: int, block_size: int):
+diff --git a/tests/kernels/test_mhc_broadcast_compile.py b/tests/kernels/test_mhc_broadcast_compile.py
+new file mode 100644
+index 0000000000000000000000000000000000000000..101c3d50dbde933305e9824447baa6aea23e1fe8
+--- /dev/null
++++ b/tests/kernels/test_mhc_broadcast_compile.py
+@@ -0,0 +1,74 @@
++# SPDX-License-Identifier: Apache-2.0
++# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
++import torch
++
++from vllm.model_executor.kernels.mhc.tilelang import mhc_pre_broadcast_tilelang
++
++
++def _inputs(device: str = "meta") -> tuple[torch.Tensor, ...]:
++    num_tokens = 6
++    hidden_size = 128
++    hc_mult = 4
++    hc_mult3 = 2 * hc_mult + hc_mult * hc_mult
++    return (
++        torch.empty(num_tokens, hidden_size, dtype=torch.bfloat16, device=device),
++        torch.empty(
++            hc_mult3,
++            hc_mult * hidden_size,
++            dtype=torch.float32,
++            device=device,
++        ),
++        torch.empty(3, dtype=torch.float32, device=device),
++        torch.empty(hc_mult3, dtype=torch.float32, device=device),
++        torch.empty(hidden_size, dtype=torch.bfloat16, device=device),
++        torch.empty(
++            hc_mult3,
++            hidden_size,
++            dtype=torch.float32,
++            device=device,
++        ),
++    )
++
++
++def _run_broadcast_mhc(
++    residual: torch.Tensor,
++    fn: torch.Tensor,
++    hc_scale: torch.Tensor,
++    hc_base: torch.Tensor,
++    norm_weight: torch.Tensor,
++    fn_broadcast: torch.Tensor,
++) -> tuple[torch.Tensor, ...]:
++    return mhc_pre_broadcast_tilelang(
++        residual,
++        fn,
++        hc_scale,
++        hc_base,
++        1e-6,
++        1e-6,
++        1e-6,
++        2.0,
++        20,
++        norm_weight=norm_weight,
++        fn_broadcast=fn_broadcast,
++    )
++
++
++def _assert_output_contract(outputs: tuple[torch.Tensor, ...]) -> None:
++    residual, post_mix, res_mix, layer_input = outputs
++    assert residual.shape == (6, 4, 128)
++    assert residual.dtype == torch.bfloat16
++    assert post_mix.shape == (6, 4, 1)
++    assert post_mix.dtype == torch.float32
++    assert res_mix.shape == (6, 4, 4)
++    assert res_mix.dtype == torch.float32
++    assert layer_input.shape == (6, 128)
++    assert layer_input.dtype == torch.bfloat16
++
++
++def test_mhc_pre_broadcast_fake_output_contract() -> None:
++    _assert_output_contract(_run_broadcast_mhc(*_inputs()))
++
++
++def test_mhc_pre_broadcast_is_fullgraph_compile_boundary() -> None:
++    compiled = torch.compile(_run_broadcast_mhc, backend="eager", fullgraph=True)
++    _assert_output_contract(compiled(*_inputs()))
+diff --git a/tests/model_executor/test_flashinfer_autotune_cache.py b/tests/model_executor/test_flashinfer_autotune_cache.py
+index 65b8e8f55d2da000353a80317babdf02885096ac..dc0bf6a13e9b9ca71a332efe8d73e7f39e16ff9e 100644
+--- a/tests/model_executor/test_flashinfer_autotune_cache.py
++++ b/tests/model_executor/test_flashinfer_autotune_cache.py
+@@ -128,6 +128,53 @@ def _patch_flashinfer_autotune_deps(monkeypatch):
+     return calls
+ 
+ 
++def test_flashinfer_autotune_dummy_run_skips_pre_kv_v2_attention() -> None:
++    runner = SimpleNamespace(
++        scheduler_config=SimpleNamespace(max_num_batched_tokens=8192),
++        vllm_config=SimpleNamespace(use_v2_model_runner=True),
++    )
++
++    kwargs = kernel_warmup._flashinfer_autotune_dummy_run_kwargs(runner)
++
++    assert kwargs == {
++        "num_tokens": 8192,
++        "skip_eplb": True,
++        "is_profile": True,
++        "skip_attn": True,
++    }
++
++
++def test_flashinfer_autotune_dummy_run_keeps_attention_after_kv_init() -> None:
++    runner = SimpleNamespace(
++        scheduler_config=SimpleNamespace(max_num_batched_tokens=8192),
++        vllm_config=SimpleNamespace(use_v2_model_runner=True),
++        block_tables=object(),
++    )
++
++    kwargs = kernel_warmup._flashinfer_autotune_dummy_run_kwargs(runner)
++
++    assert kwargs == {
++        "num_tokens": 8192,
++        "skip_eplb": True,
++        "is_profile": True,
++    }
++
++
++def test_flashinfer_autotune_dummy_run_keeps_v1_signature() -> None:
++    runner = SimpleNamespace(
++        scheduler_config=SimpleNamespace(max_num_batched_tokens=8192),
++        vllm_config=SimpleNamespace(use_v2_model_runner=False),
++    )
++
++    kwargs = kernel_warmup._flashinfer_autotune_dummy_run_kwargs(runner)
++
++    assert kwargs == {
++        "num_tokens": 8192,
++        "skip_eplb": True,
++        "is_profile": True,
++    }
++
++
+ def test_b12x_dcp_warmup_finds_generic_mla_attention(monkeypatch) -> None:
+     from vllm.distributed import parallel_state
+     from vllm.model_executor.layers.attention.mla_attention import MLAAttention
+diff --git a/tests/models/deepseek_v4/test_b12x_cache_page_view.py b/tests/models/deepseek_v4/test_b12x_cache_page_view.py
+new file mode 100644
+index 0000000000000000000000000000000000000000..2a626dc73d673f4b3b70ddce3f3aae28d9e40f26
+--- /dev/null
++++ b/tests/models/deepseek_v4/test_b12x_cache_page_view.py
+@@ -0,0 +1,70 @@
++# SPDX-License-Identifier: Apache-2.0
++# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
++
++import pytest
++import torch
++
++from vllm.models.deepseek_v4.nvidia.b12x import _b12x_cache_page_view
++
++_PAGE_SIZE = 64
++_PAYLOAD_BYTES = _PAGE_SIZE * 584
++_PADDED_PAGE_BYTES = 37_440
++
++
++def test_b12x_cache_page_view_accepts_contiguous_payload_pages() -> None:
++    cache = torch.empty((3, _PAGE_SIZE, 584), dtype=torch.uint8)
++
++    view = _b12x_cache_page_view(cache, _PAGE_SIZE, "cache")
++
++    assert view.shape == (3, _PAYLOAD_BYTES)
++    assert view.stride() == (_PAYLOAD_BYTES, 1)
++
++
++def test_b12x_cache_page_view_preserves_padded_physical_stride() -> None:
++    storage = torch.empty(3 * _PADDED_PAGE_BYTES, dtype=torch.uint8)
++    cache = torch.as_strided(
++        storage,
++        size=(3, _PAGE_SIZE, 584),
++        stride=(_PADDED_PAGE_BYTES, 584, 1),
++    )
++
++    view = _b12x_cache_page_view(cache, _PAGE_SIZE, "cache")
++
++    assert view.shape == (3, _PAYLOAD_BYTES)
++    assert view.stride() == (_PADDED_PAGE_BYTES, 1)
++
++
++def test_b12x_cache_page_view_rejects_short_physical_stride() -> None:
++    storage = torch.empty(2 * _PAYLOAD_BYTES, dtype=torch.uint8)
++    cache = torch.as_strided(
++        storage,
++        size=(2, _PAGE_SIZE, 584),
++        stride=(_PAYLOAD_BYTES - 1, 584, 1),
++    )
++
++    with pytest.raises(RuntimeError, match=r"page stride .* is smaller"):
++        _b12x_cache_page_view(cache, _PAGE_SIZE, "cache")
++
++
++def test_b12x_cache_page_view_rejects_overlapping_2d_pages() -> None:
++    storage = torch.empty(2 * _PAYLOAD_BYTES, dtype=torch.uint8)
++    cache = torch.as_strided(
++        storage,
++        size=(2, _PAYLOAD_BYTES),
++        stride=(_PAYLOAD_BYTES - 1, 1),
++    )
++
++    with pytest.raises(RuntimeError, match=r"page stride .* is smaller"):
++        _b12x_cache_page_view(cache, _PAGE_SIZE, "cache")
++
++
++def test_b12x_cache_page_view_rejects_gapped_page_payload() -> None:
++    storage = torch.empty(2 * _PAYLOAD_BYTES + _PAGE_SIZE, dtype=torch.uint8)
++    cache = torch.as_strided(
++        storage,
++        size=(2, _PAGE_SIZE, 584),
++        stride=(_PAYLOAD_BYTES, 585, 1),
++    )
++
++    with pytest.raises(RuntimeError, match=r"page payload must be contiguous"):
++        _b12x_cache_page_view(cache, _PAGE_SIZE, "cache")
+diff --git a/tests/models/deepseek_v4/test_b12x_compressed_mla_workspace.py b/tests/models/deepseek_v4/test_b12x_compressed_mla_workspace.py
+new file mode 100644
+index 0000000000000000000000000000000000000000..f570a5c89a90aed3c3a0aa4935ea2aae4772fcf6
+--- /dev/null
++++ b/tests/models/deepseek_v4/test_b12x_compressed_mla_workspace.py
+@@ -0,0 +1,511 @@
++# SPDX-License-Identifier: Apache-2.0
++# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
++
++import math
++import sys
++import types
++from types import SimpleNamespace
++
++import pytest
++import torch
++
++from vllm.models.deepseek_v4 import compressor as compressor_mod
++from vllm.models.deepseek_v4.nvidia import b12x as b12x_mod
++from vllm.utils.math_utils import round_up
++from vllm.v1.attention.backend import CommonAttentionMetadata
++from vllm.v1.attention.backends.mla.compressor_utils import (
++    get_c128a_topk_width,
++    get_compressed_mla_max_q_chunks,
++    get_compressed_mla_split_cap,
++    get_dspark_swa_index_width,
++)
++
++_MAX_ROWS = 2048
++_LOCAL_HEADS = 32
++_PAGE_SIZE = 64
++_WINDOW_SIZE = 128
++_INDEX_TOPK = 2048
++
++
++class _RecordingWorkspaceManager:
++    def __init__(self) -> None:
++        self.specs: tuple[tuple[tuple[int, ...], torch.dtype], ...] | None = None
++
++    def get_simultaneous(
++        self, *specs: tuple[tuple[int, ...], torch.dtype]
++    ) -> list[torch.Tensor]:
++        self.specs = specs
++        return []
++
++
++def _install_recording_b12x(monkeypatch, caps_calls: list[SimpleNamespace]):
++    b12x = types.ModuleType("b12x")
++    b12x.__path__ = []
++    attention = types.ModuleType("b12x.attention")
++    attention.__path__ = []
++    compressed_mla = types.ModuleType("b12x.attention.compressed_mla")
++
++    def caps(**kwargs) -> SimpleNamespace:
++        return SimpleNamespace(**kwargs)
++
++    def plan(caps_value):
++        caps_calls.append(caps_value)
++        return SimpleNamespace(
++            shapes_and_dtypes=lambda: (((1,), torch.uint8),),
++        )
++
++    def split_chunks_for_contract(
++        *,
++        rows: int,
++        width: int,
++        max_chunks: int,
++        decode_row_capacity: int | None = None,
++    ) -> int:
++        del width
++        decode_split_max_rows = max(256, int(decode_row_capacity or 0))
++        return min(max_chunks, 8 if rows <= decode_split_max_rows else 1)
++
++    compressed_mla.Caps = caps  # type: ignore[attr-defined]
++    compressed_mla.plan = plan  # type: ignore[attr-defined]
++    compressed_mla.split_chunks_for_contract = (  # type: ignore[attr-defined]
++        split_chunks_for_contract
++    )
++    monkeypatch.setitem(sys.modules, "b12x", b12x)
++    monkeypatch.setitem(sys.modules, "b12x.attention", attention)
++    monkeypatch.setitem(
++        sys.modules,
++        "b12x.attention.compressed_mla",
++        compressed_mla,
++    )
++    return split_chunks_for_contract
++
++
++def _make_layer(
++    *,
++    compress_ratio: int,
++    dspark: bool,
++    dcp_world_size: int = 1,
++    max_num_batched_tokens: int = _MAX_ROWS,
++    max_num_seqs: int = 64,
++):
++    layer = object.__new__(b12x_mod.DeepseekV4B12xMLAAttention)
++    torch.nn.Module.__init__(layer)
++    layer.compress_ratio = compress_ratio
++    layer.topk_indices_buffer = (
++        torch.empty((1, _INDEX_TOPK), dtype=torch.int32)
++        if compress_ratio == 4
++        else None
++    )
++    layer.indexer = None
++    layer.max_model_len = 524288
++    layer.window_size = _WINDOW_SIZE
++    layer.max_num_batched_tokens = max_num_batched_tokens
++    layer.swa_cache_layer = SimpleNamespace(block_size=_PAGE_SIZE)
++    speculative_config = (
++        SimpleNamespace(
++            use_dspark=lambda: True,
++            num_speculative_tokens=5,
++        )
++        if dspark
++        else None
++    )
++    layer.vllm_config = SimpleNamespace(
++        speculative_config=speculative_config,
++        scheduler_config=SimpleNamespace(
++            max_num_seqs=max_num_seqs,
++            max_num_batched_tokens=max_num_batched_tokens,
++        ),
++        parallel_config=SimpleNamespace(
++            decode_context_parallel_size=dcp_world_size,
++        ),
++    )
++    return layer
++
++
++@pytest.mark.parametrize(
++    ("compress_ratio", "dspark", "expected_width"),
++    [
++        pytest.param(1, False, 128, id="swa-causal"),
++        pytest.param(1, True, 512, id="swa-dspark"),
++        pytest.param(4, False, 2176, id="c4-causal"),
++        pytest.param(4, True, 2560, id="c4-dspark"),
++        pytest.param(128, False, 4224, id="c128-causal"),
++        pytest.param(128, True, 4608, id="c128-dspark"),
++    ],
++)
++def test_reserve_uses_full_runtime_width(
++    monkeypatch,
++    compress_ratio: int,
++    dspark: bool,
++    expected_width: int,
++) -> None:
++    caps_calls: list[SimpleNamespace] = []
++    split_chunks = _install_recording_b12x(monkeypatch, caps_calls)
++    workspace = _RecordingWorkspaceManager()
++    monkeypatch.setattr(b12x_mod, "current_workspace_manager", lambda: workspace)
++    layer = _make_layer(compress_ratio=compress_ratio, dspark=dspark)
++
++    layer._reserve_dummy_compressed_mla_scratch(
++        torch.empty((1, _LOCAL_HEADS, 512), dtype=torch.bfloat16)
++    )
++
++    caps = caps_calls[-1]
++    split_cap = get_compressed_mla_split_cap(expected_width)
++    decode_row_capacity = 64 * (1 + 5) if dspark else None
++    assert caps.max_width == expected_width
++    assert caps.max_q_rows == _MAX_ROWS
++    assert caps.decode_row_capacity == decode_row_capacity
++    assert caps.max_q_chunks == get_compressed_mla_max_q_chunks(
++        _MAX_ROWS,
++        expected_width,
++        split_cap,
++        split_chunks,
++        decode_row_capacity=decode_row_capacity,
++    )
++    assert workspace.specs is not None
++
++
++def test_reserve_uses_dcp_gathered_heads(monkeypatch) -> None:
++    caps_calls: list[SimpleNamespace] = []
++    _install_recording_b12x(monkeypatch, caps_calls)
++    monkeypatch.setattr(
++        b12x_mod,
++        "current_workspace_manager",
++        lambda: _RecordingWorkspaceManager(),
++    )
++    layer = _make_layer(compress_ratio=128, dspark=False, dcp_world_size=2)
++
++    layer._reserve_dummy_compressed_mla_scratch(
++        torch.empty((1, _LOCAL_HEADS, 512), dtype=torch.bfloat16)
++    )
++
++    assert caps_calls[-1].num_q_heads == _LOCAL_HEADS * 2
++
++
++def test_workspace_width_helpers_match_reporter_geometry() -> None:
++    assert get_c128a_topk_width(524288, 128) == 4096
++    assert get_dspark_swa_index_width(128, 5) == 512
++    assert get_dspark_swa_index_width(512, 5) == 1024
++
++
++@pytest.mark.parametrize(
++    ("max_num_seqs", "num_speculative_tokens", "expected"),
++    [
++        pytest.param(24, 5, 144, id="mns24-k5"),
++        pytest.param(64, 5, 384, id="mns64-k5"),
++        pytest.param(128, 5, 768, id="mns128-k5"),
++        pytest.param(64, 7, 512, id="mns64-k7"),
++    ],
++)
++def test_dspark_decode_row_capacity_comes_from_scheduler_contract(
++    max_num_seqs: int,
++    num_speculative_tokens: int,
++    expected: int,
++) -> None:
++    vllm_config = SimpleNamespace(
++        speculative_config=SimpleNamespace(
++            use_dspark=lambda: True,
++            num_speculative_tokens=num_speculative_tokens,
++        ),
++        scheduler_config=SimpleNamespace(
++            max_num_seqs=max_num_seqs,
++            max_num_batched_tokens=8192,
++        ),
++    )
++    assert b12x_mod._get_dspark_decode_row_capacity(vllm_config) == expected
++
++
++def test_non_dspark_has_no_declared_decode_row_capacity() -> None:
++    vllm_config = SimpleNamespace(
++        speculative_config=SimpleNamespace(use_dspark=lambda: False),
++        scheduler_config=SimpleNamespace(
++            max_num_seqs=128,
++            max_num_batched_tokens=8192,
++        ),
++    )
++    assert b12x_mod._get_dspark_decode_row_capacity(vllm_config) is None
++
++
++def test_dspark_decode_row_capacity_fails_closed() -> None:
++    b12x_mod._validate_compressed_mla_decode_row_capacity(
++        rows=384,
++        mode="decode",
++        decode_row_capacity=384,
++    )
++    b12x_mod._validate_compressed_mla_decode_row_capacity(
++        rows=8192,
++        mode="extend",
++        decode_row_capacity=384,
++    )
++    with pytest.raises(ValueError, match="rows 385 exceed.*capacity 384"):
++        b12x_mod._validate_compressed_mla_decode_row_capacity(
++            rows=385,
++            mode="decode",
++            decode_row_capacity=384,
++        )
++
++
++@pytest.mark.parametrize("draft_tokens", [5, 7])
++def test_compressor_metadata_keeps_every_verifier_row(
++    monkeypatch,
++    draft_tokens: int,
++) -> None:
++    verifier_width = draft_tokens + 1
++    num_reqs = 2
++    num_tokens = num_reqs * verifier_width
++    builder = object.__new__(compressor_mod.CompressorMetadataBuilder)
++    builder.block_size = 16
++    builder.token_to_req_indices = torch.empty(num_tokens, dtype=torch.int32)
++    common = CommonAttentionMetadata(
++        query_start_loc=torch.tensor(
++            [0, verifier_width, num_tokens], dtype=torch.int32
++        ),
++        query_start_loc_cpu=torch.tensor(
++            [0, verifier_width, num_tokens], dtype=torch.int32
++        ),
++        seq_lens=torch.tensor([100, 200], dtype=torch.int32),
++        num_reqs=num_reqs,
++        num_actual_tokens=num_tokens,
++        max_query_len=verifier_width,
++        max_seq_len=200,
++        block_table_tensor=torch.zeros((num_reqs, 1), dtype=torch.int32),
++        slot_mapping=torch.arange(num_tokens, dtype=torch.int64),
++        causal=False,
++    )
++    monkeypatch.setattr(compressor_mod, "_prefer_two_stage_compressor", lambda: False)
++
++    metadata = builder.build(0, common)
++
++    assert metadata.slot_mapping.shape == (num_tokens,)
++    assert metadata.token_to_req_indices is not None
++    torch.testing.assert_close(
++        metadata.token_to_req_indices,
++        torch.repeat_interleave(
++            torch.arange(num_reqs, dtype=torch.int32),
++            verifier_width,
++        ),
++    )
++
++
++def test_q_chunk_envelope_is_cached() -> None:
++    call_count = 0
++
++    def split_chunks_for_contract(**kwargs) -> int:
++        nonlocal call_count
++        call_count += 1
++        return min(kwargs["max_chunks"], 8 if kwargs["rows"] <= 256 else 1)
++
++    get_compressed_mla_max_q_chunks.cache_clear()
++    split_cap = get_compressed_mla_split_cap(4608)
++    for _ in range(2):
++        assert (
++            get_compressed_mla_max_q_chunks(
++                _MAX_ROWS,
++                4608,
++                split_cap,
++                split_chunks_for_contract,
++            )
++            == _MAX_ROWS
++        )
++    assert call_count == _MAX_ROWS
++
++
++def test_production_q_chunk_envelope_only_reserves_declared_capacity() -> None:
++    def split_chunks_for_contract(
++        *,
++        rows: int,
++        width: int,
++        max_chunks: int,
++        decode_row_capacity: int | None = None,
++    ) -> int:
++        decode_split_max_rows = max(256, int(decode_row_capacity or 0))
++        chunk_size = 64 if rows <= decode_split_max_rows else 1024
++        return min(max_chunks, math.ceil(width / chunk_size))
++
++    max_rows = 8192
++    width = 4608
++    split_cap = get_compressed_mla_split_cap(width)
++    get_compressed_mla_max_q_chunks.cache_clear()
++
++    legacy = get_compressed_mla_max_q_chunks(
++        max_rows,
++        width,
++        split_cap,
++        split_chunks_for_contract,
++    )
++    mns24 = get_compressed_mla_max_q_chunks(
++        max_rows,
++        width,
++        split_cap,
++        split_chunks_for_contract,
++        decode_row_capacity=144,
++    )
++    mns64 = get_compressed_mla_max_q_chunks(
++        max_rows,
++        width,
++        split_cap,
++        split_chunks_for_contract,
++        decode_row_capacity=384,
++    )
++    mns128 = get_compressed_mla_max_q_chunks(
++        max_rows,
++        width,
++        split_cap,
++        split_chunks_for_contract,
++        decode_row_capacity=768,
++    )
++
++    assert legacy == 40960
++    assert mns24 == legacy
++    assert mns64 == legacy
++    assert mns128 == 55296
++
++
++def _aligned_nbytes(
++    specs: tuple[tuple[tuple[int, ...], torch.dtype], ...],
++) -> int:
++    return sum(
++        round_up(math.prod(shape) * dtype.itemsize, 256) for shape, dtype in specs
++    )
++
++
++def _runtime_plan_nbytes(compressed_mla, *, rows: int, width: int, heads: int) -> int:
++    split_cap = get_compressed_mla_split_cap(width)
++    splits = compressed_mla.split_chunks_for_contract(
++        rows=rows,
++        width=width,
++        max_chunks=split_cap,
++    )
++    runtime_plan = compressed_mla.plan(
++        compressed_mla.Caps(
++            device="cpu",
++            num_q_heads=heads,
++            max_q_rows=rows,
++            max_width=width,
++            head_dim=512,
++            v_head_dim=512,
++            page_size=_PAGE_SIZE,
++            max_chunks_per_row=splits,
++        )
++    )
++    return _aligned_nbytes(runtime_plan.shapes_and_dtypes())
++
++
++@pytest.mark.parametrize(
++    (
++        "compress_ratio",
++        "dspark",
++        "dcp_world_size",
++        "runtime_widths",
++        "expected_reserve_mib",
++    ),
++    [
++        pytest.param(1, False, 1, (128,), 64.502929688, id="swa-causal"),
++        pytest.param(1, True, 1, (128, 512), 96.627929688, id="swa-dspark"),
++        pytest.param(4, False, 1, (2176,), 273.315429688, id="c4-causal"),
++        pytest.param(
++            4,
++            True,
++            1,
++            (2176, 2560),
++            482.127929688,
++            id="c4-dspark",
++        ),
++        pytest.param(128, False, 1, (4224,), 530.315429688, id="c128-causal"),
++        pytest.param(
++            128,
++            True,
++            1,
++            (4224, 4608),
++            867.627929688,
++            id="c128-dspark",
++        ),
++        pytest.param(128, False, 2, (4224,), 1060.627929688, id="c128-dcp2"),
++    ],
++)
++def test_real_b12x_reserve_dominates_runtime_envelope(
++    monkeypatch,
++    compress_ratio: int,
++    dspark: bool,
++    dcp_world_size: int,
++    runtime_widths: tuple[int, ...],
++    expected_reserve_mib: float,
++) -> None:
++    compressed_mla = pytest.importorskip("b12x.attention.compressed_mla")
++    workspace = _RecordingWorkspaceManager()
++    monkeypatch.setattr(b12x_mod, "current_workspace_manager", lambda: workspace)
++    layer = _make_layer(
++        compress_ratio=compress_ratio,
++        dspark=dspark,
++        dcp_world_size=dcp_world_size,
++    )
++
++    layer._reserve_dummy_compressed_mla_scratch(
++        torch.empty((1, _LOCAL_HEADS, 512), dtype=torch.bfloat16)
++    )
++
++    assert workspace.specs is not None
++    reserve_bytes = _aligned_nbytes(workspace.specs)
++    assert reserve_bytes / (1 << 20) == pytest.approx(expected_reserve_mib)
++    runtime_heads = _LOCAL_HEADS * dcp_world_size
++    runtime_bytes = max(
++        _runtime_plan_nbytes(
++            compressed_mla,
++            rows=rows,
++            width=runtime_width,
++            heads=runtime_heads,
++        )
++        for runtime_width in runtime_widths
++        for rows in range(1, _MAX_ROWS + 1)
++    )
++    assert reserve_bytes >= runtime_bytes
++
++
++def test_mns64_contract_does_not_grow_production_mnb8192_scratch(
++    monkeypatch,
++) -> None:
++    compressed_mla = pytest.importorskip("b12x.attention.compressed_mla")
++    workspace = _RecordingWorkspaceManager()
++    monkeypatch.setattr(b12x_mod, "current_workspace_manager", lambda: workspace)
++    max_rows = 8192
++    layer = _make_layer(
++        compress_ratio=128,
++        dspark=True,
++        max_num_batched_tokens=max_rows,
++        max_num_seqs=64,
++    )
++
++    layer._reserve_dummy_compressed_mla_scratch(
++        torch.empty((1, _LOCAL_HEADS, 512), dtype=torch.bfloat16)
++    )
++
++    assert workspace.specs is not None
++    candidate_bytes = _aligned_nbytes(workspace.specs)
++    width = 4608
++    split_cap = get_compressed_mla_split_cap(width)
++    max_q_chunks = get_compressed_mla_max_q_chunks(
++        max_rows,
++        width,
++        split_cap,
++        compressed_mla.split_chunks_for_contract,
++    )
++    splits = compressed_mla.split_chunks_for_contract(
++        rows=max_rows,
++        width=width,
++        max_chunks=split_cap,
++    )
++    legacy_plan = compressed_mla.plan(
++        compressed_mla.Caps(
++            device="cpu",
++            num_q_heads=_LOCAL_HEADS,
++            max_q_rows=max_rows,
++            max_width=width,
++            head_dim=512,
++            v_head_dim=512,
++            page_size=_PAGE_SIZE,
++            max_chunks_per_row=splits,
++            max_q_chunks=max_q_chunks,
++        )
++    )
++
++    assert candidate_bytes == _aligned_nbytes(legacy_plan.shapes_and_dtypes())
+diff --git a/tests/quantization/test_exl3.py b/tests/quantization/test_exl3.py
+index b25e2d28d95740c1f1bdae69fe2a40164f3e556c..6b5b934d5c8eb4f5d9abdf67cc78e53e5725e6b8 100644
+--- a/tests/quantization/test_exl3.py
++++ b/tests/quantization/test_exl3.py
+@@ -1,20 +1,31 @@
+ # SPDX-License-Identifier: Apache-2.0
+ # SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+ 
++import gc
++import weakref
+ from types import SimpleNamespace
++from unittest.mock import Mock
+ 
+ import pytest
+ import torch
+ 
+ import vllm.model_executor.layers.quantization.exl3 as exl3_module
++import vllm.model_executor.layers.quantization.online.fp8 as fp8_module
+ import vllm.model_executor.parameter as parameter_module
+ from vllm.config import CompilationMode
+-from vllm.model_executor.layers.fused_moe import MoEActivation
++from vllm.config.quantization import QuantizationConfigArgs
++from vllm.model_executor.layers.fused_moe import MoEActivation, RoutedExperts
++from vllm.model_executor.layers.linear import LinearBase, UnquantizedLinearMethod
+ from vllm.model_executor.layers.quantization import get_quantization_config
+ from vllm.model_executor.layers.quantization.exl3 import (
+     Exl3Config,
++    Exl3LinearMethod,
+     Exl3MoEMethod,
+     Exl3MoEParameter,
++    Exl3OnlineLinearMethod,
++)
++from vllm.model_executor.layers.quantization.exl3_online_cache import (
++    Exl3OnlineCacheResult,
+ )
+ from vllm.model_executor.models import glm4_moe
+ 
+@@ -35,6 +46,244 @@ def _rank_sliced_metadata(**overrides):
+     return metadata
+ 
+ 
++def _set_online_overlay(monkeypatch, args: QuantizationConfigArgs) -> object:
++    current = SimpleNamespace(
++        model_config=SimpleNamespace(
++            quantization_config=args,
++            enforce_eager=True,
++        )
++    )
++    sentinel = object()
++    monkeypatch.setattr(exl3_module, "get_current_vllm_config_or_none", lambda: current)
++    monkeypatch.setattr(exl3_module, "Mxfp8OnlineLinearMethod", lambda: sentinel)
++    return sentinel
++
++
++def _mock_linear() -> Mock:
++    return Mock(spec=LinearBase)
++
++
++def test_exl3_online_overlay_quantizes_only_bf16_dense_and_shared(monkeypatch):
++    config = Exl3Config(
++        tensor_storage={"model.layers.3.self_attn.q_b_proj": {"quant_format": "exl3"}}
++    )
++    sentinel = _set_online_overlay(
++        monkeypatch,
++        QuantizationConfigArgs(linear="mxfp8", shared_experts="mxfp8"),
++    )
++
++    serialized = config.get_quant_method(
++        _mock_linear(), "model.layers.3.self_attn.q_b_proj"
++    )
++    dense_bf16 = config.get_quant_method(
++        _mock_linear(), "model.layers.3.self_attn.kv_b_proj"
++    )
++    shared_bf16 = config.get_quant_method(
++        _mock_linear(), "model.layers.3.mlp.shared_experts.down_proj"
++    )
++
++    assert isinstance(serialized, Exl3LinearMethod)
++    assert dense_bf16 is sentinel
++    assert shared_bf16 is sentinel
++
++
++def test_exl3_linear_overlay_does_not_select_shared_experts(monkeypatch):
++    config = Exl3Config()
++    sentinel = _set_online_overlay(monkeypatch, QuantizationConfigArgs(linear="mxfp8"))
++
++    dense = config.get_quant_method(
++        _mock_linear(), "model.layers.3.self_attn.kv_b_proj"
++    )
++    shared = config.get_quant_method(
++        _mock_linear(), "model.layers.3.mlp.shared_experts.down_proj"
++    )
++
++    assert dense is sentinel
++    assert isinstance(shared, UnquantizedLinearMethod)
++
++
++def test_exl3_online_overlay_honors_unfused_ignore_names(monkeypatch):
++    config = Exl3Config()
++    config.packed_modules_mapping = {
++        "fused_qkv_a_proj": ["q_a_proj", "kv_a_proj_with_mqa"]
++    }
++    sentinel = _set_online_overlay(
++        monkeypatch,
++        QuantizationConfigArgs(
++            linear="mxfp8",
++            ignore=["re:.*\\.q_a_proj$", "re:.*kv_a_proj_with_mqa"],
++        ),
++    )
++
++    ignored = config.get_quant_method(
++        _mock_linear(), "model.layers.3.self_attn.fused_qkv_a_proj"
++    )
++    kept = config.get_quant_method(_mock_linear(), "model.layers.3.self_attn.kv_b_proj")
++
++    assert isinstance(ignored, UnquantizedLinearMethod)
++    assert kept is sentinel
++
++
++def test_exl3_online_overlay_rejects_split_packed_quantization(monkeypatch):
++    config = Exl3Config()
++    config.packed_modules_mapping = {
++        "fused_qkv_a_proj": ["q_a_proj", "kv_a_proj_with_mqa"]
++    }
++    _set_online_overlay(
++        monkeypatch,
++        QuantizationConfigArgs(linear="mxfp8", ignore=["re:.*\\.q_a_proj$"]),
++    )
++
++    with pytest.raises(ValueError, match="different quantization schemes"):
++        config.get_quant_method(
++            _mock_linear(), "model.layers.3.self_attn.fused_qkv_a_proj"
++        )
++
++
++def test_exl3_online_overlay_rejects_mixed_packed_storage(monkeypatch):
++    config = Exl3Config(
++        tensor_storage={"model.layers.3.self_attn.q_a_proj": {"quant_format": "exl3"}}
++    )
++    config.packed_modules_mapping = {
++        "fused_qkv_a_proj": ["q_a_proj", "kv_a_proj_with_mqa"]
++    }
++    _set_online_overlay(monkeypatch, QuantizationConfigArgs(linear="mxfp8"))
++
++    with pytest.raises(ValueError, match="mixes EXL3 and BF16 source shards"):
++        config.get_quant_method(
++            _mock_linear(), "model.layers.3.self_attn.fused_qkv_a_proj"
++        )
++
++
++def test_exl3_online_overlay_never_quantizes_bf16_lm_head(monkeypatch):
++    config = Exl3Config()
++    _set_online_overlay(monkeypatch, QuantizationConfigArgs(linear="mxfp8"))
++    lm_head = type("ParallelLMHead", (torch.nn.Module,), {})()
++
++    method = config.get_quant_method(lm_head, "lm_head")
++
++    assert isinstance(method, UnquantizedLinearMethod)
++
++
++def test_exl3_online_overlay_preserves_rank_sliced_routed_experts(monkeypatch):
++    config = Exl3Config()
++    config.rank_sliced_metadata = _rank_sliced_metadata()
++    _set_online_overlay(
++        monkeypatch,
++        QuantizationConfigArgs(linear="mxfp8", shared_experts="mxfp8"),
++    )
++    routed = Mock(spec=RoutedExperts)
++    routed.moe_config = object()
++
++    method = config.get_quant_method(routed, "model.layers.3.mlp.experts")
++
++    assert isinstance(method, Exl3MoEMethod)
++
++
++def test_exl3_online_trellis_selects_cached_k6_method(monkeypatch):
++    config = Exl3Config()
++    config._online_model_identity = "model"  # noqa: SLF001
++    config._online_encoder_identity = "encoder"  # noqa: SLF001
++    _set_online_overlay(monkeypatch, QuantizationConfigArgs(linear="mxfp8"))
++    monkeypatch.setattr(
++        fp8_module,
++        "get_current_vllm_config",
++        lambda: SimpleNamespace(model_config=SimpleNamespace(dtype=torch.bfloat16)),
++    )
++    monkeypatch.setenv("VLLM_EXL3_ONLINE_TRELLIS_BITS", "6")
++
++    method = config.get_quant_method(_mock_linear(), "model.layers.3.self_attn.o_proj")
++
++    assert isinstance(method, Exl3OnlineLinearMethod)
++    assert method.bits == 6
++    assert method.model_identity == "model"
++    assert method.encoder_identity == "encoder"
++
++
++def test_online_trellis_cache_off_does_not_require_hub_commit(tmp_path, monkeypatch):
++    config = Exl3Config()
++    monkeypatch.setenv("VLLM_EXL3_ONLINE_CACHE_MODE", "off")
++    monkeypatch.setenv("VLLM_EXL3_ENCODER_SOURCE", str(tmp_path))
++
++    config._configure_online_cache_identity(  # noqa: SLF001
++        "org/model", hf_config=None, revision=None
++    )
++
++    assert config._online_model_identity == "cache-disabled"  # noqa: SLF001
++    assert config._online_encoder_identity == "cache-disabled"  # noqa: SLF001
++
++
++def test_online_trellis_encoder_requires_quantize_entrypoint(tmp_path, monkeypatch):
++    encoder = tmp_path / "encoder"
++    quantizer = encoder / "modules" / "quant" / "exl3_lib"
++    quantizer.mkdir(parents=True)
++    (quantizer / "quantize.py").write_text("VALUE = 1\n", encoding="utf-8")
++    monkeypatch.setenv("VLLM_EXL3_ENCODER_SOURCE", str(encoder))
++    monkeypatch.setattr(exl3_module, "_EXL3_ONLINE_QUANTIZER", None)
++    monkeypatch.setattr(
++        exl3_module.importlib,
++        "import_module",
++        lambda name: SimpleNamespace(),
++    )
++
++    with pytest.raises(RuntimeError, match="has no quantize_exl3"):
++        exl3_module._load_exl3_online_quantizer()
++    for name in tuple(exl3_module.sys.modules):
++        if name == "_vllm_exl3_encoder" or name.startswith("_vllm_exl3_encoder."):
++            monkeypatch.delitem(exl3_module.sys.modules, name, raising=False)
++
++
++def test_exl3_online_trellis_cache_hit_skips_encoder(monkeypatch):
++    monkeypatch.setattr(
++        fp8_module,
++        "get_current_vllm_config",
++        lambda: SimpleNamespace(model_config=SimpleNamespace(dtype=torch.bfloat16)),
++    )
++    method = Exl3OnlineLinearMethod(
++        bits=6,
++        prefix="model.layers.3.self_attn.o_proj",
++        model_identity="model",
++        encoder_identity="encoder",
++    )
++    layer = torch.nn.Module()
++    layer.register_parameter(
++        "weight",
++        torch.nn.Parameter(torch.zeros((256, 128), dtype=torch.float16)),
++    )
++    layer.exl3_online_input_size = 128
++    layer.exl3_online_output_size = 256
++    tensors = {
++        "trellis": torch.zeros((8, 16, 96), dtype=torch.int16),
++        "suh": torch.ones(128, dtype=torch.float16),
++        "svh": torch.ones(256, dtype=torch.float16),
++    }
++    captured = {}
++
++    def cache_hit(key, *, device, quantize):
++        del quantize
++        captured["key"] = key
++        captured["device"] = device
++        return Exl3OnlineCacheResult(tensors, 0.25, True, None)
++
++    monkeypatch.setattr(exl3_module, "load_or_quantize", cache_hit)
++    monkeypatch.setattr(
++        exl3_module,
++        "_load_exl3_online_quantizer",
++        lambda: pytest.fail("cache hit must not import the encoder"),
++    )
++    monkeypatch.setattr(exl3_module, "get_tensor_model_parallel_world_size", lambda: 4)
++    monkeypatch.setattr(exl3_module, "get_tensor_model_parallel_rank", lambda: 2)
++    monkeypatch.setattr(method, "_warm_decode_shapes", lambda layer: None)
++
++    method.process_weights_after_loading(layer)
++
++    assert captured["key"].tp_world_size == 4
++    assert captured["key"].tp_rank == 2
++    assert captured["device"] == torch.device("cpu")
++    assert layer.weight.numel() == 0
++    assert layer.exl3_online_trellis_weight is tensors["trellis"]
++
++
+ def test_rank_sliced_checkpoint_selects_exl3_override():
+     hf_config = SimpleNamespace(hybrid_tr3_tail=_rank_sliced_metadata())
+ 
+@@ -92,6 +341,8 @@ def test_glm_model_retains_quant_config_for_weight_loading(monkeypatch):
+         ({"codebook": "mul1"}, "MCG codebook"),
+         ({"moe_layers": [77, 3]}, "moe_layers"),
+         ({"tensor_schema": "unsupported"}, "tensor schema"),
++        ({"rotation_layout": "implicit_magic"}, "rotation_layout"),
++        ({"rotation_layout": "shared_h_v1"}, "shared_h_tensor_schema"),
+     ],
+ )
+ def test_rank_sliced_metadata_fails_closed(overrides, message):
+@@ -118,6 +369,28 @@ def test_rank_sliced_metadata_admits_only_declared_moe_layers():
+     )
+ 
+ 
++def test_rank_sliced_shared_h_metadata_is_explicit_and_legacy_defaults_unchanged():
++    legacy = Exl3Config()
++    legacy.maybe_update_config(
++        "unused", SimpleNamespace(hybrid_tr3_tail=_rank_sliced_metadata())
++    )
++    shared = Exl3Config()
++    shared.maybe_update_config(
++        "unused",
++        SimpleNamespace(
++            hybrid_tr3_tail=_rank_sliced_metadata(
++                rotation_layout="shared_h_v1",
++                shared_h_tensor_schema=(
++                    "model.layers.{L}.mlp.experts.shared_h.{proj}.rank{r}.{suh|svh}"
++                ),
++            )
++        ),
++    )
++
++    assert legacy.rank_sliced_rotation_layout == "per_expert_v1"
++    assert shared.rank_sliced_rotation_layout == "shared_h_v1"
++
++
+ def test_mixed_rank_sliced_metadata_hydrates_per_layer_bitrates(monkeypatch):
+     metadata = _rank_sliced_metadata(
+         bits="mixed",
+@@ -179,6 +452,49 @@ def test_rank_sliced_weight_name_keeps_only_local_tp_rank(monkeypatch):
+     )
+ 
+ 
++def test_rank_sliced_shared_h_names_map_once_and_fail_closed(monkeypatch):
++    config = Exl3Config()
++    config.maybe_update_config(
++        "unused",
++        SimpleNamespace(
++            hybrid_tr3_tail=_rank_sliced_metadata(
++                rotation_layout="shared_h_v1",
++                shared_h_tensor_schema=(
++                    "model.layers.{L}.mlp.experts.shared_h.{proj}.rank{r}.{suh|svh}"
++                ),
++            )
++        ),
++    )
++    monkeypatch.setattr(exl3_module, "get_tensor_model_parallel_rank", lambda: 2)
++    prefix = "model.layers.3.mlp.experts"
++
++    assert (
++        config.normalize_rank_sliced_weight_name(
++            f"{prefix}.shared_h.gate_proj.rank2.suh"
++        )
++        == f"{prefix}.0.gate_proj.suh"
++    )
++    assert (
++        config.normalize_rank_sliced_weight_name(
++            f"{prefix}.shared_h.down_proj.rank1.svh"
++        )
++        is None
++    )
++    with pytest.raises(ValueError, match="requires suh"):
++        config.normalize_rank_sliced_weight_name(
++            f"{prefix}.shared_h.gate_proj.rank2.svh"
++        )
++    with pytest.raises(ValueError, match="must store H-side rotations"):
++        config.normalize_rank_sliced_weight_name(f"{prefix}.7.down_proj.rank2.svh")
++
++    legacy = Exl3Config()
++    legacy.maybe_update_config(
++        "unused", SimpleNamespace(hybrid_tr3_tail=_rank_sliced_metadata())
++    )
++    with pytest.raises(ValueError, match="does not declare"):
++        legacy.normalize_rank_sliced_weight_name(f"{prefix}.shared_h.up_proj.rank2.suh")
++
++
+ def test_rank_sliced_parameter_preallocates_projection_major_slab(monkeypatch):
+     monkeypatch.setattr(parameter_module, "get_tensor_model_parallel_rank", lambda: 0)
+     monkeypatch.setattr(
+@@ -208,6 +524,70 @@ def test_rank_sliced_parameter_preallocates_projection_major_slab(monkeypatch):
+     torch.testing.assert_close(param.exl3_tensors[(2, "w3")], w3)
+ 
+ 
++def test_rank_sliced_broadcast_pointer_table_repeats_one_physical_row():
++    slab = torch.ones((1, 128), dtype=torch.float16)
++
++    table = Exl3MoEMethod._pointer_table(slab, num_experts=4)
++
++    assert table.tolist() == [slab.data_ptr()] * 4
++    with pytest.raises(RuntimeError, match="per-expert or broadcast"):
++        Exl3MoEMethod._pointer_table(
++            torch.ones((2, 128), dtype=torch.float16), num_experts=4
++        )
++
++
++def test_rank_sliced_shared_h_create_weights_allocates_one_physical_row(
++    monkeypatch,
++):
++    monkeypatch.setattr(parameter_module, "get_tensor_model_parallel_rank", lambda: 0)
++    monkeypatch.setattr(
++        parameter_module, "get_tensor_model_parallel_world_size", lambda: 4
++    )
++    config = Exl3Config()
++    config.maybe_update_config(
++        "unused",
++        SimpleNamespace(
++            hybrid_tr3_tail=_rank_sliced_metadata(
++                rotation_layout="shared_h_v1",
++                shared_h_tensor_schema=(
++                    "model.layers.{L}.mlp.experts.shared_h.{proj}.rank{r}.{suh|svh}"
++                ),
++            )
++        ),
++    )
++    monkeypatch.setattr(
++        exl3_module,
++        "get_current_vllm_config_or_none",
++        lambda: SimpleNamespace(
++            scheduler_config=SimpleNamespace(max_num_batched_tokens=8192),
++            model_config=SimpleNamespace(runner_type="generate"),
++        ),
++    )
++    layer = torch.nn.Module()
++    layer.layer_name = "model.layers.3.mlp.experts"
++    moe = SimpleNamespace(
++        moe_parallel_config=SimpleNamespace(use_ep=False, tp_rank=0, tp_size=4),
++        has_bias=False,
++    )
++    method = Exl3MoEMethod(config, moe)
++
++    method.create_weights(
++        layer,
++        num_experts=256,
++        hidden_size=6144,
++        intermediate_size_per_partition=512,
++        params_dtype=torch.bfloat16,
++    )
++
++    assert layer.exl3_shared_h_rotations
++    assert layer.w13_suh.exl3_num_experts == 1
++    assert layer.w2_svh.exl3_num_experts == 1
++    assert layer.w13_svh.exl3_num_experts == 256
++    assert layer.w2_suh.exl3_num_experts == 256
++    assert layer.w13_trellis.exl3_num_experts == 256
++    assert layer.w2_trellis.exl3_num_experts == 256
++
++
+ def test_rank_sliced_weights_use_unified_fused_moe_contract(monkeypatch):
+     experts = 2
+     hidden = intermediate = 128
+@@ -278,7 +658,66 @@ def test_rank_sliced_weights_use_unified_fused_moe_contract(monkeypatch):
+     assert api.prepare_kwargs["trellis_mcg"] is marker
+ 
+ 
+-def test_mixed_rank_sliced_weights_are_partitioned_by_declared_bitrate(monkeypatch):
++def test_rank_sliced_weights_pass_shared_h_rows_without_expansion(monkeypatch):
++    experts = 3
++    hidden = intermediate = 128
++    bits = 3
++    slabs = {
++        "w13_trellis": torch.zeros(
++            (2, experts, hidden // 16, intermediate // 16, 16 * bits),
++            dtype=torch.int16,
++        ),
++        "w2_trellis": torch.zeros(
++            (experts, intermediate // 16, hidden // 16, 16 * bits),
++            dtype=torch.int16,
++        ),
++        "w13_suh": torch.ones((2, 1, hidden), dtype=torch.float16),
++        "w13_svh": torch.ones((2, experts, intermediate), dtype=torch.float16),
++        "w2_suh": torch.ones((experts, intermediate), dtype=torch.float16),
++        "w2_svh": torch.ones((1, hidden), dtype=torch.float16),
++    }
++
++    class FakeFusedMoe:
++        @staticmethod
++        def plan_weights(**kwargs):
++            return SimpleNamespace(source_format=kwargs["source_format"])
++
++        @staticmethod
++        def prepare_weights(**kwargs):
++            return SimpleNamespace(**kwargs)
++
++    monkeypatch.setattr(
++        exl3_module, "_load_b12x_fused_moe", lambda: FakeFusedMoe()
++    )
++    method = object.__new__(Exl3MoEMethod)
++    method.quant_config = SimpleNamespace(bits=float(bits))
++    method._rank_sliced_backing = lambda _layer, name: slabs[name]
++    marker = torch.tensor(0xCBAC1FED - (1 << 32), dtype=torch.int32)
++    layer = SimpleNamespace(
++        local_num_experts=experts,
++        exl3_hidden_size=hidden,
++        exl3_intermediate_size_per_partition=intermediate,
++        exl3_params_dtype=torch.float16,
++        exl3_layer_bitrates=(bits,) * experts,
++        exl3_mixed_bitrate=False,
++        exl3_shared_h_rotations=True,
++        activation=MoEActivation.SILU,
++        w13_mcg=SimpleNamespace(exl3_tensors={(0, "w1"): marker}),
++    )
++
++    method._prepare_rank_sliced_weights(layer)
++
++    prepared = layer.exl3_trellis_weights
++    assert tuple(prepared.gate_suh.shape) == (1, hidden)
++    assert tuple(prepared.up_suh.shape) == (1, hidden)
++    assert tuple(prepared.down_svh.shape) == (1, hidden)
++    assert all(tuple(table.shape) == (experts,) for table in layer.exl3_pointer_tables)
++
++
++@pytest.mark.parametrize("shared_h", [False, True])
++def test_mixed_rank_sliced_weights_are_partitioned_by_declared_bitrate(
++    monkeypatch, shared_h
++):
+     experts = 4
+     hidden = intermediate = 128
+     bitrates = (3, 4, 3, 4)
+@@ -304,15 +743,18 @@ def test_mixed_rank_sliced_weights_are_partitioned_by_declared_bitrate(monkeypat
+         )
+ 
+     slabs = {
+-        "w13_suh": torch.ones((2, experts, hidden), dtype=torch.float16),
++        "w13_suh": torch.ones(
++            (2, 1 if shared_h else experts, hidden), dtype=torch.float16
++        ),
+         "w13_svh": torch.ones((2, experts, intermediate), dtype=torch.float16),
+         "w2_suh": torch.ones((experts, intermediate), dtype=torch.float16),
+-        "w2_svh": torch.ones((experts, hidden), dtype=torch.float16),
++        "w2_svh": torch.ones((1 if shared_h else experts, hidden), dtype=torch.float16),
+     }
+     layer = SimpleNamespace(
+         local_num_experts=experts,
+         exl3_hidden_size=hidden,
+         exl3_intermediate_size_per_partition=intermediate,
++        exl3_params_dtype=torch.float16,
+         exl3_layer_bitrates=bitrates,
+         activation=MoEActivation.SILU,
+         layer_name="model.layers.3.mlp.experts",
+@@ -353,8 +795,8 @@ def test_mixed_rank_sliced_weights_are_partitioned_by_declared_bitrate(monkeypat
+ 
+     method._prepare_mixed_rank_sliced_weights(layer)
+ 
+-    assert [entry["trellis_bits"] for entry in api.prepared] == [3, 4]
+-    assert [entry["num_experts"] for entry in api.prepared] == [2, 2]
++    assert [entry["trellis_bits"] for entry in api.prepared] == [3, 3, 4, 4]
++    assert [entry["num_experts"] for entry in api.prepared] == [2] * 4
+     for entry in api.prepared:
+         bits = entry["trellis_bits"]
+         assert tuple(entry["w13"].shape) == (
+@@ -373,9 +815,29 @@ def test_mixed_rank_sliced_weights_are_partitioned_by_declared_bitrate(monkeypat
+     assert [entry["tile_config"] for entry in api.prepared] == [
+         (128, 128, 128, 128),
+         (128, 128, 128, 128),
++        (128, 128, 128, 128),
++        (128, 128, 128, 128),
+     ]
+     assert layer.exl3_mixed_trellis["tier_ids"] == ((0, 2), (1, 3))
+     assert layer.exl3_mixed_trellis["tier_bits"] == (3, 4)
++    assert len(layer.exl3_mixed_trellis["tiers"]) == 2
++    assert len(layer.exl3_mixed_trellis["prefill_tiers"]) == 2
++    rotations = layer.exl3_mixed_trellis["rotations"]
++    expected_h_rows = 1 if shared_h else experts
++    assert rotations.gate_suh.shape[0] == expected_h_rows
++    assert rotations.up_suh.shape[0] == expected_h_rows
++    assert rotations.down_svh.shape[0] == expected_h_rows
++    assert layer.exl3_mixed_trellis["broadcast_suh"] is shared_h
++    assert layer.exl3_mixed_trellis["broadcast_svh"] is shared_h
++    for entry in api.prepared:
++        expected_tier_rows = 1 if shared_h else 2
++        assert entry["gate_suh"].shape[0] == expected_tier_rows
++        assert entry["up_suh"].shape[0] == expected_tier_rows
++        assert entry["down_svh"].shape[0] == expected_tier_rows
++        assert (
++            entry["gate_suh"].untyped_storage().data_ptr()
++            == rotations.gate_suh.untyped_storage().data_ptr()
++        )
+     assert layer.w13_trellis.exl3_tensors == {}
+     assert layer.w2_trellis.exl3_tensors == {}
+     assert layer.w13_suh.exl3_backing is None
+@@ -390,6 +852,150 @@ def test_mixed_trellis_buffer_accounting_ignores_metadata() -> None:
+     assert exl3_module._unique_tensor_storage_bytes(first, second) == 8
+ 
+ 
++def test_prepared_dense_weight_is_owned_by_source_tensor(monkeypatch) -> None:
++    class FakeApi:
++        def __init__(self):
++            self.calls = 0
++
++        def prepare_weight(self, trellis, suh, svh, **kwargs):
++            del kwargs
++            self.calls += 1
++            return SimpleNamespace(trellis=trellis, suh=suh, svh=svh)
++
++    api = FakeApi()
++    monkeypatch.setattr(exl3_module, "_load_b12x_trellis_linear", lambda: api)
++    trellis = torch.empty((8, 8, 96), dtype=torch.int16)
++    suh = torch.empty(128, dtype=torch.float16)
++    svh = torch.empty(128, dtype=torch.float16)
++
++    first = exl3_module._b12x_trellis_weight(trellis, suh, svh, torch.float16)
++    second = exl3_module._b12x_trellis_weight(trellis, suh, svh, torch.float16)
++    assert first is second
++    assert api.calls == 1
++
++    source_ref = weakref.ref(trellis)
++    del first, second, trellis
++    gc.collect()
++    assert source_ref() is None
++
++
++def test_mixed_trellis_dispatches_decode_and_one_grid_prefill(monkeypatch):
++    class FakeMixedApi:
++        def __init__(self):
++            self.calls = []
++
++        def run_mixed_trellis(self, x, *args):
++            launch = args[7]
++            self.calls.append((int(x.shape[0]), args[0], args[1], launch))
++            return torch.full_like(x, launch.value)
++
++    mixed_api = FakeMixedApi()
++    decode_tiers = (object(), object())
++    prefill_tiers = (object(), object())
++    runtime = {
++        "mixed_api": mixed_api,
++        "decode": {
++            "launch": SimpleNamespace(value=1),
++            "buffers": object(),
++        },
++        "prefill": {
++            "launch": SimpleNamespace(value=3),
++            "buffers": object(),
++        },
++        "max_decode_m": 8,
++        "max_batched_tokens": 16,
++        "prefill_capacity": 8,
++    }
++    layer = SimpleNamespace(
++        exl3_mixed_trellis={
++            "tiers": decode_tiers,
++            "prefill_tiers": prefill_tiers,
++            "global_to_combined": object(),
++            "descriptor_map": object(),
++            "rotations": object(),
++        }
++    )
++    method = object.__new__(Exl3MoEMethod)
++    monkeypatch.setattr(
++        method, "_mixed_rank_sliced_runtime", lambda layer, x, ids: runtime
++    )
++    weights = torch.ones((16, 2), dtype=torch.float32)
++    ids = torch.zeros((16, 2), dtype=torch.int64)
++
++    decode = method._apply_mixed_rank_sliced(
++        layer, torch.zeros((4, 4)), weights[:4], ids[:4]
++    )
++    prefill = method._apply_mixed_rank_sliced(layer, torch.zeros((16, 4)), weights, ids)
++
++    torch.testing.assert_close(decode, torch.ones_like(decode))
++    torch.testing.assert_close(prefill, torch.full_like(prefill, 3))
++    assert [call[0] for call in mixed_api.calls] == [4, 8, 8]
++    assert mixed_api.calls[0][1:3] == decode_tiers
++    assert all(call[1:3] == prefill_tiers for call in mixed_api.calls[1:])
++
++
++@pytest.mark.parametrize(
++    "tier_signature",
++    [
++        ((3, 192), (4, 64)),
++        ((3, 206), (4, 50)),
++        ((3, 148), (4, 108)),
++    ],
++)
++def test_mixed_trellis_prefill_block_policy_qualified_partitions(
++    tier_signature,
++) -> None:
++    common = {
++        "configured_block_m": 64,
++        "explicit_override": False,
++        "hidden_size": 6144,
++        "intermediate_size": 512,
++        "tier_signature": tier_signature,
++        "topk": 8,
++        "device_major": 12,
++        "prefill_tile_config": (128, 128, 32, 512),
++    }
++
++    assert exl3_module._resolve_mixed_trellis_prefill_block_m(**common) == 32
++    assert (
++        exl3_module._resolve_mixed_trellis_prefill_block_m(
++            **{**common, "explicit_override": True}
++        )
++        == 64
++    )
++
++
++def test_mixed_trellis_prefill_block_policy_rejects_unqualified_partition() -> None:
++    common = {
++        "configured_block_m": 64,
++        "explicit_override": False,
++        "hidden_size": 6144,
++        "intermediate_size": 512,
++        "tier_signature": ((3, 192), (4, 64)),
++        "topk": 8,
++        "device_major": 12,
++        "prefill_tile_config": (128, 128, 32, 512),
++    }
++    assert (
++        exl3_module._resolve_mixed_trellis_prefill_block_m(
++            **{**common, "tier_signature": ((3, 128), (4, 128))}
++        )
++        == 64
++    )
++    assert (
++        exl3_module._resolve_mixed_trellis_prefill_block_m(
++            **{**common, "tier_signature": ((4, 256),)}
++        )
++        == 64
++    )
++    assert (
++        exl3_module._resolve_mixed_trellis_prefill_block_m(
++            **{**common, "device_major": 11}
++        )
++        == 64
++    )
++
++
+ @pytest.mark.parametrize(
+     ("hidden", "intermediate", "expected"),
+     [
+diff --git a/tests/quantization/test_exl3_online_cache.py b/tests/quantization/test_exl3_online_cache.py
+new file mode 100644
+index 0000000000000000000000000000000000000000..7c02cc5915ed928f87c7f99441a7fe08360a745d
+--- /dev/null
++++ b/tests/quantization/test_exl3_online_cache.py
+@@ -0,0 +1,213 @@
++# SPDX-License-Identifier: Apache-2.0
++# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
++
++from __future__ import annotations
++
++from dataclasses import replace
++
++import pytest
++import torch
++
++from vllm.model_executor.layers.quantization.exl3_online_cache import (
++    Exl3OnlineCacheKey,
++    cache_mode,
++    cache_path,
++    load_or_quantize,
++    resolve_encoder_identity,
++    resolve_model_identity,
++)
++
++
++def _key() -> Exl3OnlineCacheKey:
++    return Exl3OnlineCacheKey(
++        model_identity="model-identity",
++        encoder_identity="encoder-identity",
++        prefix="model.layers.0.self_attn.o_proj",
++        bits=6,
++        seed=123,
++        tp_world_size=4,
++        tp_rank=2,
++        input_size=128,
++        output_size=256,
++    )
++
++
++def _tensors(key: Exl3OnlineCacheKey) -> dict[str, torch.Tensor]:
++    return {
++        "trellis": torch.arange(
++            key.input_size // 16 * key.output_size // 16 * key.bits * 16,
++            dtype=torch.int16,
++        ).reshape(key.input_size // 16, key.output_size // 16, key.bits * 16),
++        "suh": torch.ones(key.input_size, dtype=torch.float16),
++        "svh": torch.full((key.output_size,), 2, dtype=torch.float16),
++    }
++
++
++def test_cache_round_trip_skips_second_quantization(tmp_path, monkeypatch):
++    monkeypatch.setenv("VLLM_EXL3_ONLINE_CACHE_DIR", str(tmp_path))
++    monkeypatch.setenv("VLLM_EXL3_ONLINE_CACHE_MODE", "readwrite")
++    key = _key()
++    calls = 0
++
++    def quantize():
++        nonlocal calls
++        calls += 1
++        return _tensors(key), 0.125
++
++    first = load_or_quantize(key, device=torch.device("cpu"), quantize=quantize)
++    second = load_or_quantize(key, device=torch.device("cpu"), quantize=quantize)
++
++    assert calls == 1
++    assert not first.hit
++    assert second.hit
++    assert second.proxy_error == pytest.approx(0.125)
++    assert second.path == cache_path(key)
++    for name, expected in _tensors(key).items():
++        assert torch.equal(second.tensors[name], expected)
++
++
++def test_corrupt_cache_is_replaced_atomically(tmp_path, monkeypatch):
++    monkeypatch.setenv("VLLM_EXL3_ONLINE_CACHE_DIR", str(tmp_path))
++    monkeypatch.setenv("VLLM_EXL3_ONLINE_CACHE_MODE", "readwrite")
++    key = _key()
++    path = cache_path(key)
++    path.parent.mkdir(parents=True)
++    path.write_bytes(b"not a safetensors file")
++    calls = 0
++
++    def quantize():
++        nonlocal calls
++        calls += 1
++        return _tensors(key), None
++
++    result = load_or_quantize(key, device=torch.device("cpu"), quantize=quantize)
++    reloaded = load_or_quantize(
++        key,
++        device=torch.device("cpu"),
++        quantize=lambda: pytest.fail("valid replacement must be reused"),
++    )
++
++    assert calls == 1
++    assert not result.hit
++    assert reloaded.hit
++
++
++def test_readonly_miss_does_not_publish(tmp_path, monkeypatch):
++    monkeypatch.setenv("VLLM_EXL3_ONLINE_CACHE_DIR", str(tmp_path))
++    monkeypatch.setenv("VLLM_EXL3_ONLINE_CACHE_MODE", "readonly")
++    key = _key()
++
++    result = load_or_quantize(
++        key,
++        device=torch.device("cpu"),
++        quantize=lambda: (_tensors(key), 0.5),
++    )
++
++    assert not result.hit
++    assert result.path is None
++    assert not cache_path(key).exists()
++
++
++@pytest.mark.parametrize(
++    ("raw", "expected"),
++    [
++        ("off", "off"),
++        ("none", "off"),
++        ("readonly", "readonly"),
++        ("read-only", "readonly"),
++        ("readwrite", "readwrite"),
++        ("rw", "readwrite"),
++    ],
++)
++def test_cache_mode_aliases(raw, expected, monkeypatch):
++    monkeypatch.setenv("VLLM_EXL3_ONLINE_CACHE_MODE", raw)
++    assert cache_mode() == expected
++
++
++def test_cache_mode_rejects_unknown_value(monkeypatch):
++    monkeypatch.setenv("VLLM_EXL3_ONLINE_CACHE_MODE", "sometimes")
++    with pytest.raises(ValueError, match="must be off, readonly, or readwrite"):
++        cache_mode()
++
++
++def test_off_mode_neither_reads_nor_writes(tmp_path, monkeypatch):
++    monkeypatch.setenv("VLLM_EXL3_ONLINE_CACHE_DIR", str(tmp_path))
++    monkeypatch.setenv("VLLM_EXL3_ONLINE_CACHE_MODE", "off")
++    key = _key()
++    cache_path(key).parent.mkdir(parents=True)
++    cache_path(key).write_bytes(b"must not be read")
++
++    result = load_or_quantize(
++        key,
++        device=torch.device("cpu"),
++        quantize=lambda: (_tensors(key), 0.5),
++    )
++
++    assert not result.hit
++    assert result.path is None
++    assert cache_path(key).read_bytes() == b"must not be read"
++
++
++def test_cache_key_covers_every_rank_local_encoding_input():
++    key = _key()
++    variants = [
++        replace(key, model_identity="other-model"),
++        replace(key, encoder_identity="other-encoder"),
++        replace(key, prefix="model.layers.1.self_attn.o_proj"),
++        replace(key, bits=5),
++        replace(key, seed=456),
++        replace(key, tp_world_size=8),
++        replace(key, tp_rank=3),
++        replace(key, input_size=256),
++        replace(key, output_size=128),
++    ]
++
++    assert len({key.digest(), *(variant.digest() for variant in variants)}) == 10
++
++
++def test_local_model_identity_tracks_metadata_and_shards(tmp_path):
++    model = tmp_path / "model"
++    model.mkdir()
++    config = model / "config.json"
++    shard = model / "model-00001-of-00001.safetensors"
++    config.write_text('{"model_type":"test"}', encoding="utf-8")
++    shard.write_bytes(b"weight payload")
++
++    before = resolve_model_identity(str(model))
++    config.write_text('{"model_type":"changed"}', encoding="utf-8")
++    after = resolve_model_identity(str(model))
++
++    assert before != after
++
++
++def test_hub_model_identity_tracks_resolved_revision():
++    first = resolve_model_identity("org/model", revision="commit-a")
++    second = resolve_model_identity("org/model", revision="commit-b")
++
++    assert first != second
++
++    resolved = resolve_model_identity(
++        "org/model",
++        revision="main",
++        hf_config=type("Config", (), {"_commit_hash": "commit-a"})(),
++    )
++    assert resolved == first
++
++
++def test_hub_model_identity_rejects_unresolved_revision():
++    with pytest.raises(ValueError, match="requires a resolved revision"):
++        resolve_model_identity("org/model")
++
++
++def test_encoder_identity_tracks_source_without_explicit_revision(tmp_path):
++    package = tmp_path / "exllamav3"
++    package.mkdir()
++    source = package / "quantize.py"
++    source.write_text("VALUE = 1\n", encoding="utf-8")
++    before = resolve_encoder_identity(package)
++    source.write_text("VALUE = 2\n", encoding="utf-8")
++    after = resolve_encoder_identity(package)
++
++    assert before != after
++    explicit = resolve_encoder_identity(package, revision="abc")
++    assert explicit == resolve_encoder_identity(package, revision="abc")
+diff --git a/tests/quantization/test_exl3_prefill_plan.py b/tests/quantization/test_exl3_prefill_plan.py
+index d846ef4b25e0c317ed73c55a032347e5c20bf346..040b02cf0b666d51701a80276f48a30dec641ddb 100644
+--- a/tests/quantization/test_exl3_prefill_plan.py
++++ b/tests/quantization/test_exl3_prefill_plan.py
+@@ -7,7 +7,8 @@ The planned Trellis API and the ExLlamaV3 extension are mocked; these tests
+ prove backend policy only:
+ 
+ * decode window m in [min, max] binds the decode plan;
+-* max < m <= capacity binds the prefill plan (block_size_m=64 by default);
++* max < m <= scheduler capacity binds capacity-bounded prefill slices;
++* the opt-in prefill capacity defaults to the scheduler capacity;
+ * m < min stays on the parity path with chunk-capped staging buffers;
+ * VLLM_EXL3_PREFILL_TRELLIS=0 restores the single-plan parity behavior
+   with full-capacity staging;
+@@ -50,6 +51,7 @@ class _FakeFusedMoeApi:
+     def __init__(self):
+         self.planned = []
+         self.bound = []
++        self.routed = []
+ 
+     def Caps(self, **kwargs):
+         return kwargs
+@@ -59,13 +61,64 @@ class _FakeFusedMoeApi:
+         self.planned.append(caps)
+         return plan
+ 
+-    def bind(self, plan, *, scratch, a, experts, topk_weights, topk_ids):
+-        del scratch, experts, topk_weights, topk_ids
++    def bind(
++        self,
++        plan,
++        *,
++        scratch,
++        a,
++        experts,
++        topk_weights,
++        topk_ids,
++        route_expert_map=None,
++        output_expert_map=None,
++        output=None,
++    ):
++        del scratch, experts
+         self.bound.append((plan, int(a.shape[0])))
+-        return SimpleNamespace(plan=plan, m=int(a.shape[0]))
++        self.routed.append((topk_weights.clone(), topk_ids.clone()))
++        return SimpleNamespace(
++            plan=plan,
++            a=a,
++            route_expert_map=route_expert_map,
++            output_expert_map=output_expert_map,
++            output=output,
++        )
+ 
+     def run(self, *, binding):
+-        return torch.zeros((binding.m, HIDDEN), dtype=torch.float32)
++        if binding.route_expert_map is not None:
++            tier_output = binding.a.to(torch.float32).mul(0.5)
++            if binding.output is not None:
++                binding.output.copy_(tier_output)
++                return binding.output
++            return tier_output
++        return binding.a.to(torch.float32)
++
++
++class _FakeMixedTrellisApi:
++    def __init__(self):
++        self.compiled = []
++        self.routed = []
++        self.calls = []
++
++    def max_packed_route_slots(self, routed_rows, block_size, experts):
++        del block_size, experts
++        return routed_rows
++
++    def compile_mixed_trellis(self, **kwargs):
++        launch = SimpleNamespace(**kwargs)
++        self.compiled.append(launch)
++        return launch
++
++    def make_mixed_trellis_buffers(self, launch, **kwargs):
++        del kwargs
++        return SimpleNamespace(scratch=torch.empty(launch.size_m, dtype=torch.uint8))
++
++    def run_mixed_trellis(self, *args):
++        x, tier0, tier1, topk_weights, topk_ids = args[:5]
++        self.calls.append((int(x.shape[0]), tier0, tier1))
++        self.routed.append((topk_weights.clone(), topk_ids.clone()))
++        return x.to(torch.float32)
+ 
+ 
+ class _FakeExt:
+@@ -96,6 +149,25 @@ def _make_layer():
+     )
+ 
+ 
++def _make_mixed_layer():
++    layer = _make_layer()
++    layer.exl3_mixed_bitrate = True
++    layer.exl3_mixed_trellis = {
++        "tiers": (object(), object()),
++        "prefill_tiers": (object(), object()),
++        "tier_ids": ((0, 1, 2, 3), (4, 5, 6, 7)),
++        "tier_bits": (3, 4),
++        "global_to_combined": object(),
++        "descriptor_map": object(),
++        "rotations": object(),
++        "broadcast_suh": False,
++        "broadcast_svh": False,
++        "tile_config": (64, 128, 64, 128),
++        "prefill_tile_config": (128, 128, 128, 128),
++    }
++    return layer
++
++
+ def _make_method():
+     method = object.__new__(Exl3MoEMethod)
+     method.quant_config = SimpleNamespace(
+@@ -112,6 +184,7 @@ class _Harness:
+         self._saved_capturing = None
+         self.api = _FakeFusedMoeApi()
+         self.ext = _FakeExt()
++        self.mixed_api = _FakeMixedTrellisApi()
+ 
+     def __enter__(self):
+         for name, value in self._env.items():
+@@ -122,30 +195,41 @@ class _Harness:
+                 os.environ[name] = value
+         self._saved_loaders = (
+             exl3_module._load_b12x_fused_moe,
++            exl3_module._load_b12x_mixed_trellis,
+             exl3_module._load_exl3_ext,
+         )
+         exl3_module._load_b12x_fused_moe = lambda: self.api
++        exl3_module._load_b12x_mixed_trellis = lambda: self.mixed_api
+         exl3_module._load_exl3_ext = lambda: self.ext
+         self._saved_capturing = torch.cuda.is_current_stream_capturing
+         torch.cuda.is_current_stream_capturing = lambda: False
+         self._saved_current_device = torch.cuda.current_device
+         torch.cuda.current_device = lambda: 0
++        self._saved_device_properties = torch.cuda.get_device_properties
++        torch.cuda.get_device_properties = lambda device: SimpleNamespace(
++            multi_processor_count=1,
++            shared_memory_per_block_optin=1,
++        )
+         exl3_module._RANK_SLICED_RUNTIMES.clear()
++        exl3_module._MIXED_TRELLIS_RUNTIMES.clear()
+         return self
+ 
+     def __exit__(self, *exc):
+         (
+             exl3_module._load_b12x_fused_moe,
++            exl3_module._load_b12x_mixed_trellis,
+             exl3_module._load_exl3_ext,
+         ) = self._saved_loaders
+         torch.cuda.is_current_stream_capturing = self._saved_capturing
+         torch.cuda.current_device = self._saved_current_device
++        torch.cuda.get_device_properties = self._saved_device_properties
+         for name, value in self._saved_env.items():
+             if value is None:
+                 os.environ.pop(name, None)
+             else:
+                 os.environ[name] = value
+         exl3_module._RANK_SLICED_RUNTIMES.clear()
++        exl3_module._MIXED_TRELLIS_RUNTIMES.clear()
+         return False
+ 
+     def planned_caps(self):
+@@ -159,24 +243,24 @@ def _apply(method, layer, m):
+     return method._apply_rank_sliced(layer, x, weights, ids)
+ 
+ 
+-def test_dual_plan_construction_and_dispatch():
+-    with _Harness() as h:
++def test_opt_in_prefill_capacity_slices_dispatch():
++    with _Harness(env={"VLLM_EXL3_PREFILL_CAPACITY": "128"}) as h:
+         method = _make_method()
+         layer = _make_layer()
+ 
+         out = _apply(method, layer, 16)
+         assert out.dtype == torch.bfloat16 and out.shape == (16, HIDDEN)
+-        # Two plans: decode (32, block 8) then prefill (capacity, block 64).
++        # Two plans: decode (32, block 8), then bounded prefill (block 64).
+         assert [
+             (caps["max_tokens"], caps["w4a16_block_size_m"])
+             for caps in h.planned_caps()
+-        ] == [(32, 8), (MAX_BATCHED, 64)]
++        ] == [(32, 8), (128, 64)]
+         assert all(caps["route_num_experts"] == 0 for caps in h.planned_caps())
+         assert h.api.bound[-1][0].caps["max_tokens"] == 32
+ 
+         _apply(method, layer, 200)
+-        assert h.api.bound[-1][0].caps["max_tokens"] == MAX_BATCHED
+-        assert h.api.bound[-1][1] == 200
++        assert all(bound[0].caps["max_tokens"] == 128 for bound in h.api.bound[-2:])
++        assert [bound[1] for bound in h.api.bound[-2:]] == [128, 72]
+         assert not h.ext.moe_calls
+ 
+         _apply(method, layer, 2)
+@@ -188,6 +272,7 @@ def test_dual_plan_construction_and_dispatch():
+         assert runtime["parity_rows"] == 128
+         assert runtime["xh"].shape[0] == 128
+         assert runtime["token_sorted"].numel() == 128 * TOPK
++        assert runtime["prefill_capacity"] == 128
+ 
+         # Batches above the scheduler contract must fail before allocating a
+         # replacement runtime or a larger Trellis arena during serving.
+@@ -204,6 +289,120 @@ def test_dual_plan_construction_and_dispatch():
+         assert len(h.planned_caps()) == plan_count
+ 
+ 
++@pytest.mark.parametrize(
++    ("rows", "expected_slice_rows"),
++    ((127, [127]), (128, [128]), (129, [128, 1])),
++)
++def test_prefill_capacity_boundaries_preserve_rows_and_routing(
++    rows, expected_slice_rows
++):
++    with _Harness(env={"VLLM_EXL3_PREFILL_CAPACITY": "128"}) as h:
++        method = _make_method()
++        layer = _make_layer()
++        x = torch.arange(rows, dtype=torch.bfloat16).unsqueeze(1).expand(-1, HIDDEN)
++        weights = torch.arange(rows * TOPK, dtype=torch.float32).reshape(rows, TOPK)
++        ids = torch.arange(rows * TOPK, dtype=torch.int64).reshape(rows, TOPK)
++        ids = ids.remainder(EXPERTS)
++
++        out = method._apply_rank_sliced(layer, x, weights, ids)
++
++        assert [bound[1] for bound in h.api.bound] == expected_slice_rows
++        assert torch.equal(out, x)
++        assert torch.equal(torch.cat([route[0] for route in h.api.routed]), weights)
++        assert torch.equal(torch.cat([route[1] for route in h.api.routed]), ids)
++        assert all(bound[0] is h.api.bound[0][0] for bound in h.api.bound)
++
++
++def test_default_prefill_capacity_keeps_single_dispatch():
++    with _Harness() as h:
++        out = _apply(_make_method(), _make_layer(), 200)
++
++        assert h.planned_caps()[-1]["max_tokens"] == MAX_BATCHED
++        assert [bound[1] for bound in h.api.bound] == [200]
++        assert out.shape == (200, HIDDEN)
++
++
++def test_mixed_prefill_capacity_slices_rows_and_routing():
++    with _Harness(env={"VLLM_EXL3_PREFILL_CAPACITY": "128"}) as h:
++        method = _make_method()
++        layer = _make_mixed_layer()
++        rows = 200
++        x = torch.arange(rows, dtype=torch.bfloat16).unsqueeze(1).expand(-1, HIDDEN)
++        weights = torch.arange(rows * TOPK, dtype=torch.float32).reshape(rows, TOPK)
++        ids = torch.arange(rows * TOPK, dtype=torch.int64).reshape(rows, TOPK)
++        ids = ids.remainder(EXPERTS)
++
++        out = method._apply_rank_sliced(layer, x, weights, ids)
++
++        assert [launch.size_m for launch in h.mixed_api.compiled] == [32, 128]
++        assert [launch.moe_block_size for launch in h.mixed_api.compiled] == [8, 64]
++        assert h.mixed_api.compiled[1].force_tile_config == (128, 128, 128, 128)
++        assert not h.planned_caps()
++        assert not h.api.bound
++        assert [call[0] for call in h.mixed_api.calls] == [128, 72]
++        assert all(
++            call[1:] == layer.exl3_mixed_trellis["prefill_tiers"]
++            for call in h.mixed_api.calls
++        )
++        assert torch.equal(out, x)
++        assert torch.equal(
++            torch.cat([route[0] for route in h.mixed_api.routed]), weights
++        )
++        assert torch.equal(torch.cat([route[1] for route in h.mixed_api.routed]), ids)
++
++
++def test_mixed_runtime_policy_is_resolved_once(monkeypatch):
++    calls = 0
++
++    def properties(device):
++        nonlocal calls
++        del device
++        calls += 1
++        return SimpleNamespace(
++            major=12,
++            multi_processor_count=1,
++            shared_memory_per_block_optin=1,
++        )
++
++    with _Harness() as h:
++        monkeypatch.setattr(torch.cuda, "get_device_properties", properties)
++        method = _make_method()
++        layer = _make_mixed_layer()
++        x = torch.zeros((16, HIDDEN), dtype=torch.bfloat16)
++        ids = torch.zeros((16, TOPK), dtype=torch.int64)
++
++        first = method._mixed_rank_sliced_runtime(layer, x, ids)
++        second = method._mixed_rank_sliced_runtime(layer, x, ids)
++
++        assert first is second
++        assert calls == 1
++        assert len(h.mixed_api.compiled) == 2
++
++
++def test_mixed_runtime_forwards_shared_h_broadcast_contract():
++    with _Harness() as h:
++        method = _make_method()
++        layer = _make_mixed_layer()
++        layer.exl3_mixed_trellis["broadcast_suh"] = True
++        layer.exl3_mixed_trellis["broadcast_svh"] = True
++        x = torch.zeros((16, HIDDEN), dtype=torch.bfloat16)
++        ids = torch.zeros((16, TOPK), dtype=torch.int64)
++
++        method._mixed_rank_sliced_runtime(layer, x, ids)
++
++        assert len(h.mixed_api.compiled) == 2
++        assert all(launch.broadcast_suh is True for launch in h.mixed_api.compiled)
++        assert all(launch.broadcast_svh is True for launch in h.mixed_api.compiled)
++
++
++def test_prefill_capacity_cannot_exceed_scheduler_bound():
++    env = {"VLLM_EXL3_PREFILL_CAPACITY": str(MAX_BATCHED + 1)}
++    with _Harness(env=env) as h:
++        with pytest.raises(ValueError, match="cannot exceed max_num_batched_tokens"):
++            _apply(_make_method(), _make_layer(), 16)
++        assert not h.planned_caps()
++
++
+ def test_prefill_trellis_disabled_restores_parity():
+     with _Harness(env={"VLLM_EXL3_PREFILL_TRELLIS": "0"}) as h:
+         method = _make_method()
+@@ -221,16 +420,19 @@ def test_prefill_trellis_disabled_restores_parity():
+         runtime = next(iter(exl3_module._RANK_SLICED_RUNTIMES.values()))
+         assert runtime["prefill_plan"] is None
+         assert runtime["parity_rows"] == MAX_BATCHED
+-        assert runtime["xh"].shape[0] == MAX_BATCHED
+ 
+ 
+ def test_prefill_block_m_env_override():
+-    with _Harness(env={"VLLM_EXL3_PREFILL_BLOCK_M": "48"}) as h:
++    env = {
++        "VLLM_EXL3_PREFILL_BLOCK_M": "48",
++        "VLLM_EXL3_PREFILL_CAPACITY": "128",
++    }
++    with _Harness(env=env) as h:
+         method = _make_method()
+         layer = _make_layer()
+         _apply(method, layer, 40)
+         assert h.planned_caps()[-1]["w4a16_block_size_m"] == 48
+-        assert h.api.bound[-1][0].caps["max_tokens"] == MAX_BATCHED
++        assert h.api.bound[-1][0].caps["max_tokens"] == 128
+ 
+ 
+ def test_parity_window_capacity_is_validated_before_planning():
+@@ -259,7 +461,11 @@ def test_disabled_prefill_plan_keeps_full_parity_capacity():
+ 
+ 
+ def test_explicit_parity_path_guarded_against_capture():
+-    with _Harness(env={"VLLM_EXL3_TRELLIS_MIN_M": "4"}) as h:
++    env = {
++        "VLLM_EXL3_TRELLIS_MIN_M": "4",
++        "VLLM_EXL3_PREFILL_CAPACITY": "128",
++    }
++    with _Harness(env=env) as h:
+         method = _make_method()
+         layer = _make_layer()
+         # Plan eagerly, then flip into "capturing" state.
+@@ -268,18 +474,14 @@ def test_explicit_parity_path_guarded_against_capture():
+         # Both trellis plans stay capture-safe.
+         _apply(method, layer, 16)
+         _apply(method, layer, 200)
+-        assert h.api.bound[-1][1] == 200
++        assert [bound[1] for bound in h.api.bound[-2:]] == [128, 72]
+         # The eager parity path must refuse to be recorded.
+-        try:
++        with pytest.raises(RuntimeError, match="capture"):
+             _apply(method, layer, 2)
+-        except RuntimeError as err:
+-            assert "capture" in str(err)
+-        else:
+-            raise AssertionError("parity path must raise during capture")
+ 
+ 
+ if __name__ == "__main__":
+-    test_dual_plan_construction_and_dispatch()
++    test_opt_in_prefill_capacity_slices_dispatch()
+     test_prefill_trellis_disabled_restores_parity()
+     test_prefill_block_m_env_override()
+     test_explicit_parity_path_guarded_against_capture()
+diff --git a/tests/quantization/test_exl3_warmup.py b/tests/quantization/test_exl3_warmup.py
+new file mode 100644
+index 0000000000000000000000000000000000000000..c9b5a210f03ba8f17cd8a42546f1ffdb4b0deb86
+--- /dev/null
++++ b/tests/quantization/test_exl3_warmup.py
+@@ -0,0 +1,55 @@
++from types import SimpleNamespace
++from unittest.mock import Mock
++
++import pytest
++import torch
++
++from vllm.model_executor.layers.quantization.exl3 import (
++    warmup_exl3_mixed_trellis_route_pack,
++)
++
++
++def _model_with_mixed_trellis(mixed: dict) -> torch.nn.Module:
++    model = torch.nn.Module()
++    holder = torch.nn.Module()
++    holder.routed_experts = SimpleNamespace(
++        exl3_mixed_trellis=mixed,
++        layer_name="model.layers.3.mlp.experts",
++    )
++    model.add_module("holder", holder)
++    return model
++
++
++def test_mixed_trellis_warmup_delegates_each_runtime_state() -> None:
++    warmup = Mock(side_effect=(6, 12))
++    api = SimpleNamespace(warmup_mixed_trellis_route_pack=warmup)
++    decode = {"launch": object(), "buffers": object()}
++    prefill = {"launch": object(), "buffers": object()}
++    expert_map = object()
++    model = _model_with_mixed_trellis(
++        {
++            "runtime": {
++                "mixed_api": api,
++                "decode": decode,
++                "prefill": prefill,
++            },
++            "global_to_combined": expert_map,
++        }
++    )
++
++    assert warmup_exl3_mixed_trellis_route_pack(model) == 18
++    assert warmup.call_args_list == [
++        ((decode["launch"], decode["buffers"]), {"expert_map": expert_map}),
++        ((prefill["launch"], prefill["buffers"]), {"expert_map": expert_map}),
++    ]
++
++
++def test_mixed_trellis_warmup_fails_closed_without_profiled_runtime() -> None:
++    model = _model_with_mixed_trellis({"global_to_combined": object()})
++
++    with pytest.raises(RuntimeError, match="eager profile pass must plan"):
++        warmup_exl3_mixed_trellis_route_pack(model)
++
++
++def test_mixed_trellis_warmup_ignores_unrelated_models() -> None:
++    assert warmup_exl3_mixed_trellis_route_pack(torch.nn.Linear(4, 4)) == 0
+diff --git a/tests/quantization/test_quantization_config_args.py b/tests/quantization/test_quantization_config_args.py
+index 2ec8761fc75de25e7c156375ec67041cb74fcd66..d881f82cbe82a40d587128095cb0ed38d886fe36 100644
+--- a/tests/quantization/test_quantization_config_args.py
++++ b/tests/quantization/test_quantization_config_args.py
+@@ -187,6 +187,35 @@ def test_resolve_rejects_modelopt_moe_override():
+         )
+ 
+ 
++def test_resolve_allows_exl3_bf16_mxfp8_overlay():
++    args = resolve_quantization_config(
++        "exl3",
++        {
++            "linear": {"weight": "mxfp8"},
++            "shared_experts": "mxfp8",
++            "ignore": ["re:.*q_a_proj$", "lm_head"],
++        },
++    )
++
++    assert args.linear == QuantSpec(weight=kMxfp8Dynamic)
++    assert args.shared_experts == QuantSpec(weight=kMxfp8Dynamic)
++    assert args.ignore == ["re:.*q_a_proj$", "lm_head"]
++
++
++@pytest.mark.parametrize(
++    "config",
++    [
++        {"linear": {"weight": "fp8_per_block_static"}},
++        {"linear": {"weight": "mxfp8", "activation": "mxfp8"}},
++        {"linear": {"weight": "mxfp8"}, "moe": "mxfp8"},
++        {"shared_experts": "mxfp8", "ignore": ["lm_head"]},
++    ],
++)
++def test_resolve_rejects_unsupported_exl3_overlay(config):
++    with pytest.raises(ValueError, match="checkpoint online overlay"):
++        resolve_quantization_config("exl3", config)
++
++
+ def test_resolve_rejects_quantization_config_with_non_shorthand_quant():
+     # If --quantization names something other than an online shorthand,
+     # quantization_config is not allowed via this path (checkpoint quant
+diff --git a/tests/test_envs.py b/tests/test_envs.py
+index 56c04dd6f2e2d1005b0f2d4f925099aa88e7e7ca..e864ae549aab703ae3269c4992c1ef8eb756c821 100644
+--- a/tests/test_envs.py
++++ b/tests/test_envs.py
+@@ -48,6 +48,53 @@ def test_p2p_side_channel_defaults_and_override(monkeypatch: pytest.MonkeyPatch)
+     assert envs.VLLM_P2P_SIDE_CHANNEL_PORT == 5799
+ 
+ 
++def _clear_unknown_vllm_envs(monkeypatch: pytest.MonkeyPatch) -> None:
++    """Remove inherited VLLM variables not known by this source tree."""
++    for name in list(os.environ):
++        if name.startswith("VLLM_") and name not in environment_variables:
++            monkeypatch.delenv(name)
++
++
++@pytest.mark.parametrize(
++    ("name", "value", "expected"),
++    [
++        ("VLLM_B12X_MLA_SPEC_DECODE_MAX_Q", "12", 12),
++        ("VLLM_B12X_MLA_SPEC_EXTEND_AS_DECODE", "1", "1"),
++        ("VLLM_PCIE_DMA_FP8", "ring", "ring"),
++        ("VLLM_CPP_AR_1STAGE_NCCL_CUTOFF", "56KB", "56KB"),
++        ("VLLM_CPP_AR_IGNORE_CUTOFF_MAX_ROWS", "4", 4),
++        ("VLLM_USE_B12X_PCIE_DMA", "1", True),
++        ("VLLM_CACHE_DIR", "/cache/vllm", "/cache/vllm"),
++    ],
++)
++def test_gilded_gnosis_runtime_envs_are_registered(
++    monkeypatch: pytest.MonkeyPatch,
++    name: str,
++    value: str,
++    expected: str | int,
++) -> None:
++    """Accept every GG runtime variable consumed outside the env registry."""
++    _clear_unknown_vllm_envs(monkeypatch)
++    monkeypatch.setenv(name, value)
++
++    envs.validate_environ(hard_fail=True)
++    assert environment_variables[name]() == expected
++
++
++def test_gilded_gnosis_env_registration_keeps_unknown_detection(
++    monkeypatch: pytest.MonkeyPatch,
++) -> None:
++    """Continue rejecting misspelled VLLM variables after registration."""
++    _clear_unknown_vllm_envs(monkeypatch)
++    monkeypatch.setenv("VLLM_GILDED_GNOSIS_TYPO", "1")
++
++    with pytest.raises(
++        ValueError,
++        match="Unknown vLLM environment variable detected: VLLM_GILDED_GNOSIS_TYPO",
++    ):
++        envs.validate_environ(hard_fail=True)
++
++
+ def test_getattr_with_cache(monkeypatch: pytest.MonkeyPatch):
+     monkeypatch.setenv("VLLM_HOST_IP", "1.1.1.1")
+     monkeypatch.setenv("VLLM_PORT", "1234")
+diff --git a/tests/tokenizers_/fixtures/deepseek_v4/test_output_1.txt b/tests/tokenizers_/fixtures/deepseek_v4/test_output_1.txt
+index dbd823476c1c34156b5bff79bf493d3074098576..7e3c9bd5a394617f02d76384d613d991e60d48bd 100644
+--- a/tests/tokenizers_/fixtures/deepseek_v4/test_output_1.txt
++++ b/tests/tokenizers_/fixtures/deepseek_v4/test_output_1.txt
+@@ -1,4 +1,4 @@
+-<｜begin▁of▁sentence｜>
++<｜begin▁of▁sentence｜>You are a helpful assistant.
+ 
+ ## Tools
+ 
+@@ -26,7 +26,7 @@ Otherwise, output directly after </think> with tool calls or final response.
+ {"name": "search", "description": "Search the web for information", "parameters": {"type": "object", "properties": {"query": {"type": "string", "description": "Search query"}, "num_results": {"type": "integer", "description": "Number of results to return"}}, "required": ["query"]}}
+ 
+ You MUST strictly follow the above defined tool name and parameter schemas to invoke tool calls.
+-You are a helpful assistant.<｜User｜>What's the weather in Beijing?<｜Assistant｜><think>The user wants to know the weather in Beijing. I should use the get_weather tool.</think>
++<｜User｜>What's the weather in Beijing?<｜Assistant｜><think>The user wants to know the weather in Beijing. I should use the get_weather tool.</think>
+ 
+ <｜DSML｜tool_calls>
+ <｜DSML｜invoke name="get_weather">
+diff --git a/tests/tokenizers_/test_deepseek_v4.py b/tests/tokenizers_/test_deepseek_v4.py
+index 358732eabf40ebafc14c032c10da74dd2149a111..ea82c69c4eb793552a4ee57109ec82ab51f65123 100644
+--- a/tests/tokenizers_/test_deepseek_v4.py
++++ b/tests/tokenizers_/test_deepseek_v4.py
+@@ -126,6 +126,165 @@ def test_deepseek_v4_uses_v4_tool_prompt_from_request_tools():
+     assert prompt.endswith("<｜User｜>Weather?<｜Assistant｜></think>")
+ 
+ 
++def test_deepseek_v4_attaches_request_tools_after_existing_system_prompt():
++    tools = [
++        {
++            "type": "function",
++            "function": {
++                "name": "lookup",
++                "description": "Look things up",
++                "parameters": {"type": "object", "properties": {}},
++            },
++        }
++    ]
++
++    prompt = _tokenizer().apply_chat_template(
++        [
++            {"role": "system", "content": "Follow policy."},
++            {"role": "user", "content": "Find it."},
++        ],
++        tools=tools,
++        tokenize=False,
++        enable_thinking=True,
++        reasoning_effort="max",
++    )
++
++    max_prefix = "Reasoning Effort: Beyond maximum"
++    system = "Follow policy."
++    tool_block = "## Tools"
++    user = "<｜User｜>Find it."
++    assert prompt.index(max_prefix) < prompt.index(system)
++    assert prompt.index(system) < prompt.index(tool_block)
++    assert prompt.index(tool_block) < prompt.index(user)
++
++
++def test_deepseek_v4_attaches_request_tools_to_existing_developer_prompt():
++    tools = [
++        {
++            "type": "function",
++            "function": {
++                "name": "lookup",
++                "description": "Look things up",
++                "parameters": {"type": "object", "properties": {}},
++            },
++        }
++    ]
++
++    prompt = _tokenizer().apply_chat_template(
++        [
++            {"role": "developer", "content": "Follow policy."},
++            {"role": "user", "content": "Find it."},
++        ],
++        tools=tools,
++        tokenize=False,
++    )
++
++    assert prompt.index("Follow policy.") < prompt.index("## Tools")
++    assert prompt.index("## Tools") < prompt.index("<｜User｜>Find it.")
++    assert prompt.count("## Tools") == 1
++
++
++def test_deepseek_v4_merges_message_and_request_tools_into_one_block():
++    message_tools = [
++        {
++            "type": "function",
++            "function": {"name": "old_tool", "parameters": {"type": "object"}},
++        }
++    ]
++    request_tools = [
++        {
++            "type": "function",
++            "function": {"name": "new_tool", "parameters": {"type": "object"}},
++        }
++    ]
++
++    prompt = _tokenizer().apply_chat_template(
++        [
++            {
++                "role": "system",
++                "content": "Follow policy.",
++                "tools": message_tools,
++            },
++            {"role": "user", "content": "Find it."},
++        ],
++        tools=request_tools,
++        tokenize=False,
++    )
++
++    assert prompt.count("## Tools") == 1
++    assert '"name": "new_tool"' in prompt
++    assert '"name": "old_tool"' in prompt
++
++
++def test_deepseek_v4_request_tool_replaces_same_named_message_tool():
++    prompt = _tokenizer().apply_chat_template(
++        [
++            {
++                "role": "system",
++                "content": "Follow policy.",
++                "tools": [
++                    {
++                        "type": "function",
++                        "function": {
++                            "name": "lookup",
++                            "description": "old definition",
++                            "parameters": {"type": "object"},
++                        },
++                    }
++                ],
++            },
++            {"role": "user", "content": "Find it."},
++        ],
++        tools=[
++            {
++                "type": "function",
++                "function": {
++                    "name": "lookup",
++                    "description": "new definition",
++                    "parameters": {"type": "object"},
++                },
++            }
++        ],
++        tokenize=False,
++    )
++
++    assert prompt.count("## Tools") == 1
++    assert prompt.count('"name": "lookup"') == 1
++    assert "new definition" in prompt
++    assert "old definition" not in prompt
++
++
++def test_deepseek_v4_renders_message_level_system_tools():
++    tools = [
++        {
++            "type": "function",
++            "function": {
++                "name": "lookup",
++                "description": "Look things up",
++                "parameters": {"type": "object", "properties": {}},
++            },
++        }
++    ]
++    messages = [
++        {"role": "system", "content": "Follow policy.", "tools": tools},
++        {"role": "user", "content": "Find it."},
++    ]
++    conversation, _, _ = parse_chat_messages(
++        messages,
++        _model_config(),
++        content_format="string",
++    )
++
++    prompt = _tokenizer().apply_chat_template(
++        conversation=conversation,
++        messages=messages,
++        tokenize=False,
++    )
++
++    assert prompt.index("Follow policy.") < prompt.index("## Tools")
++    assert prompt.index("## Tools") < prompt.index("<｜User｜>Find it.")
++
++
+ def test_deepseek_v4_renders_parsed_history_tool_arguments():
+     messages = [
+         {"role": "user", "content": "List the repo"},
+@@ -183,8 +342,56 @@ def test_deepseek_v4_renders_parsed_history_tool_arguments():
+     assert 'parameter name="arguments"' not in prompt
+ 
+ 
+-@pytest.mark.parametrize("reasoning_effort", ["minimal", "low", "medium", "high"])
+-def test_deepseek_v4_accepts_openai_reasoning_effort_values(reasoning_effort):
++@pytest.mark.parametrize(
++    ("arguments", "expected_value", "is_string"),
++    [
++        ("", "", True),
++        ("not json", "not json", True),
++        ('{"unterminated": 1', '{"unterminated": 1', True),
++        (None, "null", False),
++        ([1, 2], "[1, 2]", False),
++        ("[1, 2]", "[1, 2]", False),
++    ],
++)
++def test_deepseek_v4_renders_non_object_history_tool_arguments(
++    arguments,
++    expected_value,
++    is_string,
++):
++    prompt = _tokenizer().apply_chat_template(
++        [
++            {"role": "user", "content": "Run it"},
++            {
++                "role": "assistant",
++                "tool_calls": [
++                    {
++                        "type": "function",
++                        "function": {"name": "run", "arguments": arguments},
++                    }
++                ],
++            },
++        ],
++        tokenize=False,
++    )
++
++    parameter = (
++        f'<｜DSML｜parameter name="arguments" '
++        f'string="{str(is_string).lower()}">{expected_value}'
++    )
++    assert parameter in prompt
++
++
++@pytest.mark.parametrize(
++    ("reasoning_effort", "expected_prefix"),
++    [
++        ("low", "<｜begin▁of▁sentence｜><｜User｜>Hello"),
++        ("high", "<｜begin▁of▁sentence｜>Reasoning Effort: Absolute maximum"),
++        ("max", "<｜begin▁of▁sentence｜>Reasoning Effort: Beyond maximum"),
++    ],
++)
++def test_deepseek_v4_renders_0731_reasoning_effort_prompts(
++    reasoning_effort, expected_prefix
++):
+     prompt = _tokenizer().apply_chat_template(
+         [{"role": "user", "content": "Hello"}],
+         tokenize=False,
+@@ -193,7 +400,7 @@ def test_deepseek_v4_accepts_openai_reasoning_effort_values(reasoning_effort):
+     )
+ 
+     assert prompt.endswith("<｜Assistant｜><think>")
+-    assert "Reasoning Effort: Absolute maximum" not in prompt
++    assert prompt.startswith(expected_prefix)
+ 
+ 
+ def test_deepseek_v4_none_reasoning_effort_disables_thinking():
+@@ -212,7 +419,7 @@ def test_deepseek_v4_none_reasoning_effort_disables_thinking():
+     [
+         ("none", "chat", None),
+         ("minimal", "thinking", "high"),
+-        ("low", "thinking", "high"),
++        ("low", "thinking", "low"),
+         ("medium", "thinking", "high"),
+         ("high", "thinking", "high"),
+         ("xhigh", "thinking", "max"),
+@@ -248,7 +455,7 @@ def test_deepseek_v4_maps_compatible_thinking_reasoning_effort_values(
+     assert captured_kwargs[-1]["reasoning_effort"] == expected_effort
+ 
+ 
+-def test_deepseek_v4_preserves_reference_max_reasoning_effort():
++def test_deepseek_v4_renders_0731_max_reasoning_effort():
+     prompt = _tokenizer().apply_chat_template(
+         [{"role": "user", "content": "Hello"}],
+         tokenize=False,
+@@ -256,12 +463,10 @@ def test_deepseek_v4_preserves_reference_max_reasoning_effort():
+         reasoning_effort="max",
+     )
+ 
+-    assert prompt.startswith(
+-        "<｜begin▁of▁sentence｜>Reasoning Effort: Absolute maximum"
+-    )
++    assert prompt.startswith("<｜begin▁of▁sentence｜>Reasoning Effort: Beyond maximum")
+ 
+ 
+-def test_deepseek_v4_maps_xhigh_to_reference_max_reasoning_effort():
++def test_deepseek_v4_maps_xhigh_to_0731_max_reasoning_effort():
+     prompt = _tokenizer().apply_chat_template(
+         [{"role": "user", "content": "Hello"}],
+         tokenize=False,
+@@ -269,9 +474,7 @@ def test_deepseek_v4_maps_xhigh_to_reference_max_reasoning_effort():
+         reasoning_effort="xhigh",
+     )
+ 
+-    assert prompt.startswith(
+-        "<｜begin▁of▁sentence｜>Reasoning Effort: Absolute maximum"
+-    )
++    assert prompt.startswith("<｜begin▁of▁sentence｜>Reasoning Effort: Beyond maximum")
+ 
+ 
+ @pytest.mark.parametrize(
+diff --git a/tests/v1/attention/test_flashinfer_decode_qlen_guard.py b/tests/v1/attention/test_flashinfer_decode_qlen_guard.py
+new file mode 100644
+index 0000000000000000000000000000000000000000..0f3b7eb681b4075601534cfc8227c2fb3d7f0928
+--- /dev/null
++++ b/tests/v1/attention/test_flashinfer_decode_qlen_guard.py
+@@ -0,0 +1,139 @@
++"""Persistent FlashInfer decode wrappers may only be reused when the runtime
++q_len_per_req equals the value frozen during wrapper planning (1 + K).
++
++The decode-classification ceiling (reorder_batch_threshold = 1 + 2K under
++parallel drafting) deliberately admits reduced-depth lone steps as decodes —
++spec truncation near max_tokens, short chunked-prefill tails fused with the
++spec step. Those steps must take the dynamic wrapper; routing them to a
++captured wrapper raises inside flashinfer's fast_decode_plan ("q_len_per_req
++is part of the frozen cudagraph shape: this wrapper was planned with 6,
++got 8|5") and kills the engine.
++
++These tests pin the invariant and, deliberately, the distinction between the
++classification ceiling (1 + 2K) and the planned shape (1 + K): substituting
++reorder_batch_threshold for the planned length reintroduces the crash.
++"""
++
++from types import SimpleNamespace
++
++import pytest
++import torch
++
++from vllm.v1.attention.backend import AttentionMetadataBuilder
++from vllm.v1.attention.backends.flashinfer import (
++    decode_q_len_from_indptr,
++    persistent_decode_wrapper_eligible,
++)
++from vllm.v1.attention.backends.utils import split_decodes_and_prefills
++
++K = 5
++PLANNED = 1 + K
++CEILING = 1 + 2 * K
++MAX_BS = 96
++
++
++def _threshold_for(parallel_drafting: bool) -> int:
++    stub = SimpleNamespace(
++        vllm_config=SimpleNamespace(
++            speculative_config=SimpleNamespace(
++                num_speculative_tokens=K,
++                parallel_drafting=parallel_drafting,
++            ),
++            parallel_config=SimpleNamespace(decode_context_parallel_size=1),
++        )
++    )
++    AttentionMetadataBuilder._init_reorder_batch_threshold(
++        stub, 1, supports_spec_as_decode=True
++    )
++    return stub.reorder_batch_threshold
++
++
++def _eligible(q_len, *, num_reqs=1, pure_decode=True, max_bs=MAX_BS,
++              planned=PLANNED):
++    return persistent_decode_wrapper_eligible(
++        pure_decode=pure_decode,
++        num_decode_tokens=q_len * num_reqs,
++        decode_cudagraph_max_bs=max_bs,
++        decode_q_len=q_len,
++        planned_decode_q_len=planned,
++    )
++
++
++def test_classification_ceiling_is_not_planned_shape():
++    assert _threshold_for(parallel_drafting=True) == CEILING
++    assert _threshold_for(parallel_drafting=False) == PLANNED
++    assert CEILING != PLANNED
++
++
++def test_planned_shape_selects_persistent_wrapper():
++    assert _eligible(PLANNED)
++    assert _eligible(PLANNED, num_reqs=8)
++
++
++@pytest.mark.parametrize(
++    "q_len", [q for q in range(1, CEILING + 1) if q != PLANNED]
++)
++def test_reduced_or_extended_depth_falls_back_to_dynamic(q_len):
++    # Covers both observed crash signatures: q_len=5 (spec truncation near
++    # max_tokens) and q_len=8 (chunked-prefill tail fused with spec step).
++    assert not _eligible(q_len)
++
++
++def test_above_ceiling_classifies_as_prefill():
++    meta = SimpleNamespace(
++        max_query_len=CEILING + 1,
++        num_reqs=1,
++        num_actual_tokens=CEILING + 1,
++        query_start_loc_cpu=torch.tensor([0, CEILING + 1], dtype=torch.int32),
++    )
++    nd, npf, ndt, npt = split_decodes_and_prefills(
++        meta, decode_threshold=CEILING, require_uniform=True
++    )
++    assert (nd, npf, ndt, npt) == (0, 1, 0, CEILING + 1)
++
++
++def test_other_predicate_terms_still_gate():
++    assert not _eligible(PLANNED, pure_decode=False)
++    assert not _eligible(PLANNED, num_reqs=32)  # over capacity
++
++
++def test_no_spec_planned_length_is_one():
++    assert _eligible(1, planned=1)
++    assert not _eligible(2, planned=1)
++
++
++def _indptr(*lens):
++    out = [0]
++    for n in lens:
++        out.append(out[-1] + n)
++    return torch.tensor(out, dtype=torch.int32)
++
++
++@pytest.mark.parametrize(
++    ("lens", "expected"),
++    [
++        ((PLANNED,), PLANNED),
++        ((PLANNED, 0), PLANNED),          # one active + one padding row
++        ((PLANNED, PLANNED, 0), PLANNED),
++        ((PLANNED,) * 3 + (0,), PLANNED), # total not divisible by num rows
++        ((0, 0), 0),                      # all-padding
++        ((5,), 5),                        # reduced-depth lone step
++    ],
++)
++def test_decode_q_len_ignores_zero_padding(lens, expected):
++    assert decode_q_len_from_indptr(_indptr(*lens), len(lens)) == expected
++
++
++def test_zero_padded_planned_batch_keeps_persistent_wrapper():
++    # Regression: uniform CUDA-graph batches may carry zero-length padding
++    # rows; averaging tokens over rows understated the active q_len and
++    # demoted a planned-shape batch to the dynamic wrapper.
++    lens = (PLANNED, 0)
++    q_len = decode_q_len_from_indptr(_indptr(*lens), len(lens))
++    assert persistent_decode_wrapper_eligible(
++        pure_decode=True,
++        num_decode_tokens=sum(lens),
++        decode_cudagraph_max_bs=MAX_BS,
++        decode_q_len=q_len,
++        planned_decode_q_len=PLANNED,
++    )
+diff --git a/tests/v1/cudagraph/test_breakable_cudagraph.py b/tests/v1/cudagraph/test_breakable_cudagraph.py
+index 72a9a11d3cb81cf388b7a42fc7ba7af68ae9a288..aedc99a1787da628151a439d96f7d175cce94649 100644
+--- a/tests/v1/cudagraph/test_breakable_cudagraph.py
++++ b/tests/v1/cudagraph/test_breakable_cudagraph.py
+@@ -99,6 +99,7 @@ def test_memory_profile_reuses_production_pool_and_destroys_graphs(monkeypatch):
+         def capture(self, *args, **kwargs):
+             assert self.pool is production_pool
+             assert wrapper.graph_pool is production_pool
++            assert kwargs["channel_id"] == "vllm:target:profile"
+             lazy_wrapper = FakeWrapper()
+             lazy_wrapper.graph_pool = self.pool
+             lazy_wrappers.append(lazy_wrapper)
+@@ -112,8 +113,9 @@ def test_memory_profile_reuses_production_pool_and_destroys_graphs(monkeypatch):
+         def get_cudagraph_managers(self):
+             return []
+ 
+-        def capture(self):
++        def capture(self, *, capture_phase):
+             assert workspace_module._workspace_lane.get() == 1
++            assert capture_phase == "profile"
+             events.append("spec_capture")
+ 
+     manager = FakeManager()
+@@ -235,6 +237,7 @@ def test_production_capture_releases_pool_anchor_on_failure(monkeypatch):
+ 
+         @staticmethod
+         def capture(*args, **kwargs):
++            assert kwargs["channel_id"] == "vllm:target:production"
+             events.append("capture")
+             raise RuntimeError("capture failed")
+ 
+@@ -269,6 +272,60 @@ def test_production_capture_releases_pool_anchor_on_failure(monkeypatch):
+     assert events == ["capture", "anchor_reset"]
+ 
+ 
++def test_production_capture_assigns_target_and_draft_phase_ids(monkeypatch):
++    from vllm.v1.worker.gpu import model_runner as model_runner_module
++
++    events = []
++
++    class FakeManager:
++        @staticmethod
++        def needs_capture():
++            return True
++
++        @staticmethod
++        def capture(*args, **kwargs):
++            events.append(("target", kwargs["channel_id"]))
++
++    class FakeSpeculator:
++        @staticmethod
++        def capture(*, capture_phase):
++            events.append(("draft", capture_phase))
++
++    runner = model_runner_module.GPUModelRunner.__new__(
++        model_runner_module.GPUModelRunner
++    )
++    runner.cudagraph_manager = FakeManager()
++    runner._cudagraph_pool_anchor = None
++    runner.lora_config = None
++    runner.model = object()
++    runner.model_state = object()
++    runner.input_buffers = object()
++    runner.intermediate_tensors = object()
++    runner.block_tables = object()
++    runner.attn_groups = object()
++    runner.kv_cache_config = object()
++    runner.use_aux_hidden_state_outputs = False
++    runner.speculator = FakeSpeculator()
++    runner.maybe_setup_dummy_loras = lambda _: nullcontext()
++    runner._zero_cudagraph_capture_kv_blocks = lambda: None
++
++    monkeypatch.setattr(model_runner_module.gc, "collect", lambda: None)
++    monkeypatch.setattr(torch.accelerator, "empty_cache", lambda: None)
++    monkeypatch.setattr(
++        torch.accelerator,
++        "get_memory_info",
++        lambda: (1000, 0),
++    )
++    monkeypatch.setattr(model_runner_module, "lock_workspace", lambda: None)
++
++    runner.capture_model()
++
++    assert events == [
++        ("target", "vllm:target:production"),
++        ("draft", "production"),
++    ]
++
++
+ def test_skipped_production_capture_releases_pool_anchor():
+     from vllm.v1.worker.gpu import model_runner as model_runner_module
+ 
+@@ -372,13 +429,21 @@ def test_piecewise_capture_builds_fresh_metadata_for_both_passes():
+         patch(
+             "vllm.v1.worker.gpu.cudagraph_utils.graph_capture",
+             return_value=nullcontext(),
+-        ),
++        ) as graph_capture_mock,
+         patch(
+             "vllm.v1.worker.gpu.cudagraph_utils.is_global_first_rank",
+             return_value=False,
+         ),
+     ):
+-        manager.capture(create_forward_fn)
++        manager.capture(
++            create_forward_fn,
++            channel_id="vllm:target:profile",
++        )
++
++    graph_capture_mock.assert_called_once_with(
++        device=torch.device("cpu"),
++        channel_id="vllm:target:profile",
++    )
+ 
+     assert [warmup for warmup, _ in create_calls] == [True, False]
+     assert [mode for _, mode, _ in forward_calls] == [
+diff --git a/tests/v1/kv_connector/unit/offloading_connector/test_scheduler.py b/tests/v1/kv_connector/unit/offloading_connector/test_scheduler.py
+index c783957de6717a633d46e78f210735fc6dfacd45..e1a1b4d8288e71bbb545962383a814e6b802296b 100644
+--- a/tests/v1/kv_connector/unit/offloading_connector/test_scheduler.py
++++ b/tests/v1/kv_connector/unit/offloading_connector/test_scheduler.py
+@@ -37,6 +37,10 @@ from vllm.v1.kv_offload.base import (
+     get_offload_block_hash,
+     make_offload_key,
+ )
++from vllm.v1.kv_offload.tiering.manager import (
++    CPUPrimaryTierOffloadingManager,
++    TieringOffloadingManager,
++)
+ from vllm.v1.request import RequestStatus
+ 
+ 
+@@ -53,6 +57,19 @@ def _reduce_kv_connector_stats(runner):
+     return reduced
+ 
+ 
++def test_remove_pending_job_deduplicates_lockstep_mla_block_ids() -> None:
++    """Clean one shared physical block once per transfer job."""
++    scheduler = object.__new__(OffloadingConnectorScheduler)
++    scheduler._block_id_to_pending_jobs = {
++        7: {42, 43},
++        9: {42},
++    }
++
++    scheduler._remove_pending_job(42, [7, 7, 9, 9])
++
++    assert scheduler._block_id_to_pending_jobs == {7: {43}}
++
++
+ def test_scheduler_reports_allocation_failure(request_runner):
+     runner = request_runner(
+         block_size=4,
+@@ -65,7 +82,8 @@ def test_scheduler_reports_allocation_failure(request_runner):
+     runner.run(decoded_tokens=[EOS_TOKEN_ID])
+ 
+     reduced = _reduce_kv_connector_stats(runner)
+-    assert reduced[_ConnectorMetricName.ALLOCATION_FAILURE] == 1
++    # The final scheduler step retries the failed store before finalization.
++    assert reduced[_ConnectorMetricName.ALLOCATION_FAILURE] == 2
+ 
+ 
+ @pytest.mark.parametrize("missing_metadata", ["block_ids", "offload_keys"])
+@@ -166,7 +184,7 @@ def test_abort_queued_request_does_not_build_store_job(
+ def test_last_block_offloaded_at_request_finish(
+     request_runner, async_scheduling: bool, prompt_offset: int
+ ):
+-    """EOS fills the last block at request finish — verify req_status is kept alive.
++    """EOS fills the last block at request finish and stores it before cleanup.
+ 
+     prompt = block_size + prompt_offset tokens → not a full block at schedule time,
+     so _build_store_jobs creates no store job. After EOS, request_finished
+@@ -188,19 +206,50 @@ def test_last_block_offloaded_at_request_finish(
+         generate_store_output(list(keys))
+     )
+ 
+-    # Run with one step (EOS)
+-    runner.run(
+-        decoded_tokens=[EOS_TOKEN_ID],
+-    )
++    if prompt_offset == -1:
++        runner.run(decoded_tokens=[EOS_TOKEN_ID], expected_stored=(0,))
++    else:
++        runner.run(decoded_tokens=[EOS_TOKEN_ID])
+ 
+     cs = runner.connector_scheduler
+-    # Verify req_status is kept alive for _build_store_jobs to process
+-    # regardless of whether there are storable blocks
+-    assert "0" in cs._req_status, (
+-        "req_status was deleted but should be kept alive "
+-        "for _build_store_jobs to process finished_req_ids."
++    assert "0" not in cs._req_status
++
++
++@pytest.mark.parametrize("async_scheduling", [True, False])
++def test_tiering_manager_final_store_precedes_request_finish(
++    request_runner, async_scheduling: bool
++):
++    """Regression for a final-store KeyError in TieringOffloadingManager."""
++    runner = request_runner(
++        block_size=4,
++        num_gpu_blocks=10,
++        async_scheduling=async_scheduling,
+     )
+ 
++    manager_events: list[str] = []
++    primary = MagicMock(spec=CPUPrimaryTierOffloadingManager)
++    primary.lookup.return_value = LookupResult.MISS
++    primary.get_stats.return_value = None
++    primary.take_events.return_value = []
++
++    def prepare_store(keys, req_context):
++        manager_events.append("prepare_store")
++        return generate_store_output(keys)
++
++    primary.prepare_store.side_effect = prepare_store
++    primary.on_request_finished.side_effect = lambda req_context: manager_events.append(
++        "on_request_finished"
++    )
++
++    tiering_manager = TieringOffloadingManager(primary_tier=primary)
++    runner.connector_scheduler.manager = tiering_manager
++
++    runner.new_request(token_ids=[0, 0, 0])
++    runner.run(decoded_tokens=[EOS_TOKEN_ID], expected_stored=(0,))
++
++    assert manager_events == ["prepare_store", "on_request_finished"]
++    assert tiering_manager._req_state == {}
++
+ 
+ def test_scheduler_reports_lookup_sync_delay(request_runner):
+     runner = request_runner(
+@@ -423,10 +472,10 @@ def test_request_preemption(request_runner, async_scheduling: bool):
+ 
+ 
+ @pytest.mark.parametrize("async_scheduling", [True, False])
+-def test_on_request_finished_is_not_deferred_until_store_completion(
++def test_on_request_finished_not_deferred_until_store_completion(
+     request_runner, async_scheduling: bool
+ ):
+-    """on_request_finished fires when no more stores will be submitted.
++    """on_request_finished fires after the last prepare_store is submitted.
+ 
+     A request can finish while its GPU->primary store is still in flight. The
+     manager-level hook should not wait for that completion; complete_store may
+@@ -467,8 +516,8 @@ def test_on_request_finished_is_not_deferred_until_store_completion(
+         complete_transfers=False,
+     )
+ 
+-    # Finish the request while its stores are still in flight. The hook should
+-    # fire immediately even though no complete_store has arrived yet.
++    # The following scheduler step submits the final store and fires the hook,
++    # without waiting for any complete_store callback.
+     runner.run(
+         decoded_tokens=[EOS_TOKEN_ID],
+         complete_transfers=False,
+@@ -685,7 +734,7 @@ def test_two_groups_full_and_sliding_window(request_runner, async_scheduling: bo
+     touch_calls = runner.manager.touch.call_args_list
+     assert len(touch_calls) == 6
+ 
+-    runner.run(decoded_tokens=[EOS_TOKEN_ID])
++    runner.run(decoded_tokens=[EOS_TOKEN_ID], expected_stored=(6,))
+ 
+     runner.scheduler.reset_prefix_cache()
+ 
+@@ -698,19 +747,11 @@ def test_two_groups_full_and_sliding_window(request_runner, async_scheduling: bo
+         # Group 1 (sliding window, window=2): only the last 2 blocks
+         #   are within the window → loads blocks 1,2
+         expected_loaded=((0, 0), (0, 1), (0, 2), (1, 1), (1, 2)),
+-        # The deferred store from the previous request's last block
+-        # completes during this step, and its blocks are flushed because
+-        # they were reallocated to the new request.
+-        # Only block 1 (sliding window group) is stored — block 0's
+-        # deferred store is flushed because it was reallocated.
+-        expected_stored=((0, 1),),
+-        expected_flushed=((0, 1),),
+     )
+ 
+-    # 4 touch calls: 2 from get_num_new_matched_tokens (2 groups)
+-    # + 2 from _get_reqs_to_store (2 groups)
++    # 2 touch calls from get_num_new_matched_tokens (2 groups).
+     touch_calls = runner.manager.touch.call_args_list
+-    assert len(touch_calls) == 4
++    assert len(touch_calls) == 2
+     # full attention group touched all 3 blocks
+     assert len(touch_calls[0].args[0]) == 3
+     # sliding window group touched just the last 2 blocks
+@@ -1553,16 +1594,13 @@ def test_reset_cache_finalizes_finished_request_with_pending_store(
+     assert req_status.transfer_jobs, "expected an in-flight store before finish"
+     assert any(job.is_store for job in cs._jobs.values())
+ 
+-    # Finish the request while its store is still in flight. request_finished
+-    # fires the hook eagerly, but the entry stays tracked so later completions
+-    # can still call complete_store().
++    # Finalization is deferred because the final store decision has not run.
+     req_status.req.status = RequestStatus.FINISHED_STOPPED
+     cs.request_finished(req_status.req)
+-    assert finalized == [req_id]
++    assert finalized == []
+     assert req_id in cs._req_status
+ 
+-    # reset_cache discards the in-flight store and drops the state without a
+-    # duplicate on_request_finished call.
++    # reset_cache discards pending work, signals finalization, and drops state.
+     cs.reset_cache()
+     assert finalized == [req_id]
+     assert req_id not in cs._req_status
+@@ -1783,6 +1821,288 @@ def test_swa_alignment_skip(request_runner, async_scheduling: bool):
+     )
+ 
+ 
++@pytest.mark.parametrize("async_scheduling", [True, False])
++def test_swa_alignment_skip_eagle(request_runner, async_scheduling: bool):
++    """EAGLE/MTP SWA groups store their per-segment tail run shifted one
++    block past the segment boundary.
++
++    _lookup requires sliding_window_size_in_chunks + 1 consecutive stored
++    blocks for eagle groups (the "+1 peek" block, dropped after matching).
++    Mirroring SlidingWindowManager.reachable_block_mask (shift=1), the store
++    path retains a run of tail + 1 blocks ending one block PAST each segment
++    boundary, so the post-drop hit lands exactly on the boundary.
++
++    Setup:
++      - Group 0: full attention, block_size=16
++      - Group 1: SWA + eagle, block_size=4, sliding_window=8
++
++    alignment_chunk_count = 16 / 4 = 4, tail = 2, need = 3 (incl. peek).
++    Reachable block positions: {2, 3, 4} and {6, 7, 8} (shifted by one).
++
++    With a 36-token prompt (2 full full-attn blocks, 9 SWA blocks):
++      - Group 0 stores: blocks 0, 1
++      - Group 1 stores: blocks 2, 3, 4, 6, 7, 8
++
++    A replay then hits exactly 32 tokens (the second segment boundary): the
++    eagle lookup matches the run [6, 7, 8], drops peek block 8, and the
++    load fetches window blocks [6, 7].
++    """
++    full_attn_block_size = 16
++    swa_block_size = 4
++    sliding_window = 8
++    num_gpu_blocks = 200
++
++    kv_cache_groups = [
++        KVCacheGroupSpec(
++            ["layer0"],
++            FullAttentionSpec(
++                block_size=full_attn_block_size,
++                num_kv_heads=1,
++                head_size=1,
++                dtype=torch.float32,
++            ),
++        ),
++        KVCacheGroupSpec(
++            ["layer1"],
++            SlidingWindowSpec(
++                block_size=swa_block_size,
++                num_kv_heads=1,
++                head_size=1,
++                dtype=torch.float32,
++                sliding_window=sliding_window,
++            ),
++            is_eagle_group=True,
++        ),
++    ]
++
++    runner = request_runner(
++        block_size=swa_block_size,
++        num_gpu_blocks=num_gpu_blocks,
++        async_scheduling=async_scheduling,
++        kv_cache_groups=kv_cache_groups,
++    )
++
++    kv_group_configs = runner.connector_scheduler.config.kv_group_configs
++    assert kv_group_configs[1].is_eagle_group
++    assert kv_group_configs[1].alignment_chunk_count == 4
++    assert kv_group_configs[1].sliding_window_size_in_chunks == 2
++    # No sparse retention -> no per-request replay tail.
++    assert runner.connector_scheduler.config.replay_alignment_tokens is None
++
++    # Track stored keys so lookups reflect the actual store-side filtering.
++    stored_keys: set = set()
++
++    def _prepare_store(keys, req_context):
++        keys = list(keys)
++        stored_keys.update(keys)
++        return generate_store_output(keys)
++
++    runner.manager.prepare_store.side_effect = _prepare_store
++    runner.manager.lookup.side_effect = lambda key, req_context: (
++        LookupResult.HIT if key in stored_keys else LookupResult.MISS
++    )
++
++    num_tokens = 36
++    runner.new_request(token_ids=[0] * num_tokens)
++    runner.run(decoded_tokens=[0])
++    runner.run(
++        decoded_tokens=[EOS_TOKEN_ID],
++        expected_stored=(
++            (0, 0),
++            (0, 1),
++            (1, 2),
++            (1, 3),
++            (1, 4),
++            (1, 6),
++            (1, 7),
++            (1, 8),
++        ),
++    )
++
++    # Replay the same prompt; the eagle group must hit exactly at the
++    # 32-token segment boundary via the shifted run [6, 7, 8].
++    runner.scheduler.reset_prefix_cache()
++    # Avoid re-storing the (unloaded) peek block during the replay.
++    runner.manager.prepare_store.side_effect = lambda keys, req_context: (
++        generate_store_output([])
++    )
++    runner.new_request(token_ids=[0] * num_tokens)
++    runner.run(
++        decoded_tokens=[EOS_TOKEN_ID],
++        expected_loaded=(
++            (0, 0),
++            (0, 1),
++            (1, 6),
++            (1, 7),
++        ),
++    )
++
++
++@pytest.mark.parametrize("async_scheduling", [True, False])
++def test_swa_alignment_retention_interval(
++    request_runner, monkeypatch, async_scheduling: bool
++):
++    """VLLM_PREFIX_CACHE_RETENTION_INTERVAL sets the sparsity segment size,
++    and a per-request replay-boundary tail keeps exact replays servable.
++
++    Mirrors SlidingWindowManager.reachable_block_mask: with sparse retention
++    the local GPU cache keeps SWA tails once per retention interval (not at
++    every full-attention block boundary), plus one tail run at the latest
++    full-attention-aligned boundary of the prompt (the "replay boundary") so
++    a replay of the same prompt does not fall back a whole retention segment.
++
++    Setup:
++      - retention interval = 32 tokens
++      - Group 0: full attention, block_size=16
++      - Group 1: SWA, block_size=4, sliding_window=8
++
++    alignment_chunk_count = 32 / 4 = 8 (retention-based, not 16 / 4 = 4).
++
++    With a 56-token prompt (3 full full-attn blocks, 14 SWA blocks):
++      - segment tails: blocks {6, 7} (the second segment is incomplete:
++        blocks 14, 15 never fill)
++      - replay boundary: (56 - 1) // 16 * 16 = 48 -> tail run {10, 11}
++      - Group 1 stores: blocks 6, 7, 10, 11
++
++    A replay of the prompt hits 48 tokens via the replay tail {10, 11};
++    without it, the hit would fall back to 32 (the only segment boundary).
++    """
++    monkeypatch.setenv("VLLM_PREFIX_CACHE_RETENTION_INTERVAL", "32")
++
++    full_attn_block_size = 16
++    swa_block_size = 4
++    sliding_window = 8
++    num_gpu_blocks = 200
++
++    kv_cache_groups = [
++        KVCacheGroupSpec(
++            ["layer0"],
++            FullAttentionSpec(
++                block_size=full_attn_block_size,
++                num_kv_heads=1,
++                head_size=1,
++                dtype=torch.float32,
++            ),
++        ),
++        KVCacheGroupSpec(
++            ["layer1"],
++            SlidingWindowSpec(
++                block_size=swa_block_size,
++                num_kv_heads=1,
++                head_size=1,
++                dtype=torch.float32,
++                sliding_window=sliding_window,
++            ),
++        ),
++    ]
++
++    runner = request_runner(
++        block_size=swa_block_size,
++        num_gpu_blocks=num_gpu_blocks,
++        async_scheduling=async_scheduling,
++        kv_cache_groups=kv_cache_groups,
++    )
++
++    config = runner.connector_scheduler.config
++    # Segment granularity comes from the retention interval.
++    assert config.kv_group_configs[1].alignment_chunk_count == 8
++    assert config.kv_group_configs[1].sliding_window_size_in_chunks == 2
++    # Replay tails align to the full-attention block size.
++    assert config.replay_alignment_tokens == full_attn_block_size
++
++    # Track stored keys so lookups reflect the actual store-side filtering.
++    stored_keys: set = set()
++
++    def _prepare_store(keys, req_context):
++        keys = list(keys)
++        stored_keys.update(keys)
++        return generate_store_output(keys)
++
++    runner.manager.prepare_store.side_effect = _prepare_store
++    runner.manager.lookup.side_effect = lambda key, req_context: (
++        LookupResult.HIT if key in stored_keys else LookupResult.MISS
++    )
++
++    num_tokens = 56
++    runner.new_request(token_ids=[0] * num_tokens)
++    runner.run(decoded_tokens=[0])
++    runner.run(
++        decoded_tokens=[EOS_TOKEN_ID],
++        expected_stored=(
++            (0, 0),
++            (0, 1),
++            (0, 2),
++            (1, 6),
++            (1, 7),
++            (1, 10),
++            (1, 11),
++        ),
++    )
++
++    # Replay the same prompt; the hit must reach the 48-token replay
++    # boundary served by the replay tail run {10, 11}.
++    runner.scheduler.reset_prefix_cache()
++    runner.manager.prepare_store.side_effect = lambda keys, req_context: (
++        generate_store_output([])
++    )
++    runner.new_request(token_ids=[0] * num_tokens)
++    runner.run(
++        decoded_tokens=[EOS_TOKEN_ID],
++        expected_loaded=(
++            (0, 0),
++            (0, 1),
++            (0, 2),
++            (1, 10),
++            (1, 11),
++        ),
++    )
++
++
++def test_swa_alignment_retains_shared_prefix_boundary(request_runner, monkeypatch):
++    """Native offload retains the same sparse shared-prefix tail as APC."""
++    monkeypatch.setenv("VLLM_PREFIX_CACHE_RETENTION_INTERVAL", "64")
++
++    kv_cache_groups = [
++        KVCacheGroupSpec(
++            ["layer0"],
++            FullAttentionSpec(
++                block_size=16,
++                num_kv_heads=1,
++                head_size=1,
++                dtype=torch.float32,
++            ),
++        ),
++        KVCacheGroupSpec(
++            ["layer1"],
++            SlidingWindowSpec(
++                block_size=4,
++                num_kv_heads=1,
++                head_size=1,
++                dtype=torch.float32,
++                sliding_window=8,
++            ),
++        ),
++    ]
++    runner = request_runner(
++        block_size=4,
++        num_gpu_blocks=200,
++        async_scheduling=False,
++        kv_cache_groups=kv_cache_groups,
++    )
++
++    runner.new_request(token_ids=[0] * 56)
++    request = runner.scheduler.requests[str(runner.req_id)]
++    request.shared_prefix_boundary = 32
++
++    group_config = runner.connector_scheduler.config.kv_group_configs[1]
++    assert runner.connector_scheduler._reachable_tail_end_chunks(
++        group_config, request, shift=0
++    ) == (
++        12,  # Latest replay boundary: floor((56 - 1) / 16) * 16 / 4.
++        8,  # Shared-prefix junction: 32 / 4.
++    )
++
++
+ @pytest.mark.parametrize("async_scheduling", [True, False])
+ def test_stale_sliding_window_block_after_prepare_store_failure(
+     request_runner, async_scheduling: bool
+diff --git a/tests/v1/kv_connector/unit/offloading_connector/utils.py b/tests/v1/kv_connector/unit/offloading_connector/utils.py
+index b878e294a6ef07a9fbbace001cbf0b9c76d89fd4..b335c8927971c0d736d903685c44b54f4999dc1f 100644
+--- a/tests/v1/kv_connector/unit/offloading_connector/utils.py
++++ b/tests/v1/kv_connector/unit/offloading_connector/utils.py
+@@ -482,8 +482,13 @@ class RequestRunner:
+             # Strict-always-False frees the request immediately on EOS, but
+             # the worker may still have a deferred store queued. In production
+             # the next request's step drains it; in single-request tests we
+-            # must keep stepping until the scheduler sees no in-flight jobs.
+-            if not self.scheduler.requests and not self.connector_scheduler._jobs:
++            # must keep stepping until the scheduler sees no in-flight jobs
++            # and no finished request awaiting final-store construction.
++            if (
++                not self.scheduler.requests
++                and not self.connector_scheduler._jobs
++                and not self.scheduler.finished_req_ids
++            ):
+                 break
+ 
+             scheduler_output = self.scheduler.schedule()
+@@ -544,19 +549,30 @@ class RequestRunner:
+             if (
+                 prev_token_id == EOS_TOKEN_ID
+                 and prev_token_id != token_id
+-                and (self.scheduler.requests or self.connector_scheduler._jobs)
++                and (
++                    self.scheduler.requests
++                    or self.connector_scheduler._jobs
++                    or self.scheduler.finished_req_ids
++                )
+             ):
+                 # continue for one more step to allow offloading to kick off
+                 continue
+ 
+             if token_id is None:
+                 if self.async_scheduling:
+-                    # sample last token
++                    # Flush the previous step's output.
+                     engine_outputs = self.scheduler.update_from_output(
+                         prev_scheduler_output, prev_model_runner_output
+                     )
+                     self._record_kv_connector_stats(engine_outputs)
+-                break
++                    prev_model_runner_output = None
++                if self.scheduler.requests:
++                    # The request is still running; decoded_tokens is exhausted.
++                    break
++                if not self.scheduler.finished_req_ids and (
++                    not complete_transfers or not self.connector_scheduler._jobs
++                ):
++                    break
+ 
+         self._parse_transfers()
+ 
+diff --git a/tests/v1/kv_offload/cpu/test_gpu_worker.py b/tests/v1/kv_offload/cpu/test_gpu_worker.py
+index 2f1ce67e9c4103a45ccc195683e656e6d38279d7..3dd254128a5777295f6edd806356107800869dfe 100644
+--- a/tests/v1/kv_offload/cpu/test_gpu_worker.py
++++ b/tests/v1/kv_offload/cpu/test_gpu_worker.py
+@@ -3,7 +3,10 @@
+ import random
+ import time
+ import uuid
++from types import SimpleNamespace
++from unittest.mock import MagicMock, call
+ 
++import numpy as np
+ import pytest
+ import torch
+ 
+@@ -16,8 +19,15 @@ from vllm.v1.kv_offload.base import (
+     CanonicalKVCacheTensor,
+     GPULoadStoreSpec,
+ )
++from vllm.v1.kv_offload.cpu import gpu_worker
+ from vllm.v1.kv_offload.cpu.common import CPULoadStoreSpec
+-from vllm.v1.kv_offload.cpu.gpu_worker import CPUOffloadingWorker
++from vllm.v1.kv_offload.cpu.gpu_worker import (
++    HOST_REGISTER_ALIGNMENT_BYTES,
++    HOST_REGISTER_SEGMENT_BYTES,
++    CPUOffloadingWorker,
++    _split_copy_descriptors_at_host_boundaries,
++    pin_mmap_region,
++)
+ from vllm.v1.kv_offload.cpu.shared_offload_region import SharedOffloadRegion
+ 
+ NUM_GPU_BLOCKS = [64]
+@@ -32,6 +42,179 @@ NUM_MAPPINGS = [3]
+ NUM_MAPPINGS_PER_GROUP = [2]
+ 
+ 
++def _mock_mmap_region(
++    total_size_bytes: int = 4096, row_stride: int = 4096
++) -> SimpleNamespace:
++    return SimpleNamespace(
++        rank=2,
++        total_size_bytes=total_size_bytes,
++        _row_stride=row_stride,
++        _base=SimpleNamespace(data_ptr=lambda: 0x1000),
++        _registered_host_ptrs=[],
++        _host_register_segment_bytes=None,
++        is_pinned=False,
++    )
++
++
++def test_pin_mmap_region_falls_back_after_failed_registration(monkeypatch) -> None:
++    region = _mock_mmap_region()
++    register = MagicMock(return_value=1)
++    monkeypatch.setattr(gpu_worker.current_platform, "is_cuda_alike", lambda: True)
++    monkeypatch.setattr(gpu_worker, "register_host_memory", register)
++
++    pin_mmap_region(region)
++
++    register.assert_called_once_with(0x1000, 4096)
++    assert region.is_pinned is False
++
++
++def test_pin_mmap_region_keeps_successful_registration(monkeypatch) -> None:
++    region = _mock_mmap_region()
++    register = MagicMock(return_value=0)
++    monkeypatch.setattr(gpu_worker.current_platform, "is_cuda_alike", lambda: True)
++    monkeypatch.setattr(gpu_worker, "register_host_memory", register)
++
++    pin_mmap_region(region)
++
++    register.assert_called_once_with(0x1000, 4096)
++    assert region.is_pinned is True
++    assert region._registered_host_ptrs == [0x1000]
++
++
++def test_pin_mmap_region_retries_large_mapping_as_segments(monkeypatch) -> None:
++    tail_bytes = 4096
++    total_bytes = 2 * HOST_REGISTER_SEGMENT_BYTES + tail_bytes
++    region = _mock_mmap_region(total_bytes)
++    register = MagicMock(side_effect=[1, 0, 0, 0])
++    monkeypatch.setattr(gpu_worker.current_platform, "is_cuda_alike", lambda: True)
++    monkeypatch.setattr(gpu_worker, "register_host_memory", register)
++
++    pin_mmap_region(region)
++
++    assert register.call_args_list == [
++        call(0x1000, total_bytes),
++        call(0x1000, HOST_REGISTER_SEGMENT_BYTES),
++        call(
++            0x1000 + HOST_REGISTER_SEGMENT_BYTES,
++            HOST_REGISTER_SEGMENT_BYTES,
++        ),
++        call(0x1000 + 2 * HOST_REGISTER_SEGMENT_BYTES, tail_bytes),
++    ]
++    assert region.is_pinned is True
++    assert region._registered_host_ptrs == [
++        0x1000,
++        0x1000 + HOST_REGISTER_SEGMENT_BYTES,
++        0x1000 + 2 * HOST_REGISTER_SEGMENT_BYTES,
++    ]
++    assert region._host_register_segment_bytes == HOST_REGISTER_SEGMENT_BYTES
++
++
++def test_pin_mmap_region_aligns_segments_to_kv_rows(monkeypatch) -> None:
++    row_stride = 3 * 4096
++    segment_alignment = np.lcm(row_stride, HOST_REGISTER_ALIGNMENT_BYTES)
++    segment_bytes = (
++        HOST_REGISTER_SEGMENT_BYTES // segment_alignment
++    ) * segment_alignment
++    total_bytes = 2 * segment_bytes + row_stride
++    region = _mock_mmap_region(total_bytes, row_stride)
++    register = MagicMock(side_effect=[1, 0, 0, 0])
++    monkeypatch.setattr(gpu_worker.current_platform, "is_cuda_alike", lambda: True)
++    monkeypatch.setattr(gpu_worker, "register_host_memory", register)
++
++    pin_mmap_region(region)
++
++    assert register.call_args_list == [
++        call(0x1000, total_bytes),
++        call(0x1000, segment_bytes),
++        call(0x1000 + segment_bytes, segment_bytes),
++        call(0x1000 + 2 * segment_bytes, row_stride),
++    ]
++    assert region.is_pinned is True
++    assert region._host_register_segment_bytes == segment_bytes
++    assert segment_bytes % row_stride == 0
++    assert segment_bytes % HOST_REGISTER_ALIGNMENT_BYTES == 0
++
++
++def test_pin_mmap_region_rolls_back_partial_segment_registration(
++    monkeypatch,
++) -> None:
++    total_bytes = 3 * HOST_REGISTER_SEGMENT_BYTES
++    region = _mock_mmap_region(total_bytes)
++    register = MagicMock(side_effect=[1, 0, 0, 2])
++    unregister = MagicMock(return_value=0)
++    monkeypatch.setattr(gpu_worker.current_platform, "is_cuda_alike", lambda: True)
++    monkeypatch.setattr(gpu_worker, "register_host_memory", register)
++    monkeypatch.setattr(gpu_worker, "unregister_host_memory", unregister)
++
++    pin_mmap_region(region)
++
++    assert unregister.call_args_list == [
++        call(0x1000 + HOST_REGISTER_SEGMENT_BYTES),
++        call(0x1000),
++    ]
++    assert region.is_pinned is False
++    assert region._registered_host_ptrs == []
++
++
++@pytest.mark.parametrize("host_is_src", [False, True])
++def test_split_copy_descriptors_at_host_boundaries(host_is_src: bool) -> None:
++    host_base = 10_000
++    segment_bytes = 100
++    src = np.full(6, -1, dtype=np.int64)
++    dst = np.full(6, -1, dtype=np.int64)
++    sizes = np.full(6, -1, dtype=np.int64)
++
++    host_ptrs = [host_base + 90, host_base + 196]
++    device_ptrs = [20_000, 30_000]
++    if host_is_src:
++        src[:2], dst[:2] = host_ptrs, device_ptrs
++    else:
++        src[:2], dst[:2] = device_ptrs, host_ptrs
++    sizes[:2] = [20, 12]
++
++    count = _split_copy_descriptors_at_host_boundaries(
++        src,
++        dst,
++        sizes,
++        2,
++        host_is_src=host_is_src,
++        host_base=host_base,
++        segment_bytes=segment_bytes,
++    )
++
++    assert count == 4
++    expected_host = [host_base + 90, host_base + 100, host_base + 196, host_base + 200]
++    expected_device = [20_000, 20_010, 30_000, 30_004]
++    if host_is_src:
++        assert src[:count].tolist() == expected_host
++        assert dst[:count].tolist() == expected_device
++    else:
++        assert src[:count].tolist() == expected_device
++        assert dst[:count].tolist() == expected_host
++    assert sizes[:count].tolist() == [10, 10, 4, 8]
++
++
++def test_split_copy_descriptors_keeps_in_segment_copy() -> None:
++    src = np.array([20_000], dtype=np.int64)
++    dst = np.array([10_010], dtype=np.int64)
++    sizes = np.array([20], dtype=np.int64)
++
++    count = _split_copy_descriptors_at_host_boundaries(
++        src,
++        dst,
++        sizes,
++        1,
++        host_is_src=False,
++        host_base=10_000,
++        segment_bytes=100,
++    )
++
++    assert count == 1
++    assert src.tolist() == [20_000]
++    assert dst.tolist() == [10_010]
++    assert sizes.tolist() == [20]
++
++
+ @pytest.mark.parametrize("gpu_to_cpu", [True, False])
+ @pytest.mark.parametrize("num_mappings", NUM_MAPPINGS)
+ @pytest.mark.parametrize("gpu_page_size_bytes", GPU_PAGE_SIZES)
+diff --git a/tests/v1/kv_offload/cpu/test_host_mem_ops.py b/tests/v1/kv_offload/cpu/test_host_mem_ops.py
+new file mode 100644
+index 0000000000000000000000000000000000000000..02d527c9d58ce101d69a861f87c620ab7bfed332
+--- /dev/null
++++ b/tests/v1/kv_offload/cpu/test_host_mem_ops.py
+@@ -0,0 +1,44 @@
++# SPDX-License-Identifier: Apache-2.0
++# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
++from types import SimpleNamespace
++from unittest.mock import MagicMock
++
++import torch
++
++from vllm.v1.kv_offload.cpu import host_mem_ops
++
++
++def _driver_result(code: int) -> tuple[SimpleNamespace]:
++    return (SimpleNamespace(value=code),)
++
++
++def test_cuda_registration_uses_driver_api(monkeypatch) -> None:
++    driver = MagicMock()
++    driver.cuMemHostRegister.return_value = _driver_result(2)
++    driver.cuMemHostUnregister.return_value = _driver_result(0)
++    runtime_factory = MagicMock()
++    monkeypatch.setattr(host_mem_ops.current_platform, "is_cuda", lambda: True)
++    monkeypatch.setattr(host_mem_ops, "_get_cuda_driver", lambda: driver)
++    monkeypatch.setattr(host_mem_ops, "CudaRTLibrary", runtime_factory)
++
++    assert host_mem_ops.register_host_memory(0x1000, 4096) == 2
++    assert host_mem_ops.unregister_host_memory(0x1000) == 0
++
++    driver.cuMemHostRegister.assert_called_once_with(0x1000, 4096, 0)
++    driver.cuMemHostUnregister.assert_called_once_with(0x1000)
++    runtime_factory.assert_not_called()
++
++
++def test_rocm_registration_clears_runtime_failures(monkeypatch) -> None:
++    cudart = MagicMock()
++    cudart.cudaHostRegister.return_value = SimpleNamespace(value=1)
++    cudart.cudaHostUnregister.return_value = SimpleNamespace(value=2)
++    runtime = MagicMock()
++    monkeypatch.setattr(host_mem_ops.current_platform, "is_cuda", lambda: False)
++    monkeypatch.setattr(torch.cuda, "cudart", lambda: cudart)
++    monkeypatch.setattr(host_mem_ops, "CudaRTLibrary", lambda: runtime)
++
++    assert host_mem_ops.register_host_memory(0x2000, 8192) == 1
++    assert host_mem_ops.unregister_host_memory(0x2000) == 2
++
++    assert runtime.cudaGetLastError.call_count == 2
+diff --git a/tests/v1/kv_offload/cpu/test_shared_offload_region.py b/tests/v1/kv_offload/cpu/test_shared_offload_region.py
+index ca7295f1978e1cca51ceb3dfc3fcd7c54e3c90ba..81ad7fce2aebfd852848be3ab817f230934cf8f8 100644
+--- a/tests/v1/kv_offload/cpu/test_shared_offload_region.py
++++ b/tests/v1/kv_offload/cpu/test_shared_offload_region.py
+@@ -8,10 +8,12 @@ import os
+ import threading
+ import time
+ import uuid
++from unittest.mock import MagicMock, call
+ 
+ import pytest
+ 
+ from vllm.utils.system_utils import get_mp_context
++from vllm.v1.kv_offload.cpu import shared_offload_region
+ from vllm.v1.kv_offload.cpu.shared_offload_region import (
+     SharedOffloadRegion,
+     _wait_for_file_size,
+@@ -404,6 +406,169 @@ def test_file_has_correct_size(iid):
+         assert os.path.getsize(r.mmap_path) == 4 * PAGE_SIZE
+ 
+ 
++def test_prefault_can_be_disabled_for_delayed_scheduler(iid, monkeypatch):
++    """A scheduler join must not issue MADV_POPULATE_WRITE for the full region."""
++    monkeypatch.setattr(
++        shared_offload_region.mmap,
++        "MADV_POPULATE_WRITE",
++        2**31 - 1,
++        raising=False,
++    )
++    mmap_path = f"/dev/shm/vllm_offload_{iid}.mmap"
++    region = SharedOffloadRegion(
++        engine_id=iid,
++        num_blocks=4,
++        rank=None,
++        kv_bytes_per_block=PAGE_SIZE,
++        cpu_page_size=PAGE_SIZE,
++        prefault=False,
++    )
++    try:
++        assert region.mmap_obj is not None
++    finally:
++        region.cleanup()
++        _cleanup_file(mmap_path)
++
++
++def test_unlink_after_all_workers_map_keeps_shared_mapping(iid):
++    """The production mode unlinks only after every worker owns its mmap."""
++    num_workers = 2
++    regions: list[SharedOffloadRegion | None] = [None, None]
++    errors: list[BaseException] = []
++    mmap_path = f"/dev/shm/vllm_offload_{iid}.mmap"
++
++    def create_rank0() -> None:
++        try:
++            regions[0] = SharedOffloadRegion(
++                engine_id=iid,
++                num_blocks=4,
++                rank=0,
++                kv_bytes_per_block=num_workers * PAGE_SIZE,
++                cpu_page_size=PAGE_SIZE,
++                unlink_after_workers_map=True,
++                num_workers=num_workers,
++            )
++        except BaseException as exc:
++            errors.append(exc)
++
++    rank0_thread = threading.Thread(target=create_rank0)
++    rank0_thread.start()
++    marker0 = f"{mmap_path}.mapped.0"
++    deadline = time.monotonic() + 5
++    while not os.path.exists(marker0):
++        assert time.monotonic() < deadline, "rank 0 did not publish its mmap marker"
++        time.sleep(0.005)
++
++    assert os.path.exists(mmap_path), "joiners still need the pathname"
++    regions[1] = SharedOffloadRegion(
++        engine_id=iid,
++        num_blocks=4,
++        rank=1,
++        kv_bytes_per_block=num_workers * PAGE_SIZE,
++        cpu_page_size=PAGE_SIZE,
++        unlink_after_workers_map=True,
++        num_workers=num_workers,
++    )
++    rank0_thread.join(timeout=5)
++
++    try:
++        assert not rank0_thread.is_alive()
++        assert not errors
++        assert regions[0] is not None
++        assert regions[1] is not None
++        assert not os.path.exists(mmap_path)
++        assert not os.path.exists(marker0)
++        assert not os.path.exists(f"{mmap_path}.mapped.1")
++
++        regions[0].mmap_obj[0:1] = b"\x2a"
++        assert regions[1].mmap_obj[0:1] == b"\x2a"
++    finally:
++        for region in regions:
++            if region is not None:
++                region.cleanup()
++        _cleanup_file(mmap_path)
++
++
++def test_unlink_after_workers_map_requires_worker_count(iid):
++    with pytest.raises(ValueError, match="num_workers must be positive"):
++        SharedOffloadRegion(
++            engine_id=iid,
++            num_blocks=4,
++            rank=0,
++            kv_bytes_per_block=PAGE_SIZE,
++            cpu_page_size=PAGE_SIZE,
++            unlink_after_workers_map=True,
++        )
++
++
++def test_unlink_rendezvous_timeout_cleans_resources_and_markers(iid, monkeypatch):
++    """A missing worker must not leak the creator mapping or rendezvous files."""
++    mmap_path = f"/dev/shm/vllm_offload_{iid}.mmap"
++    cleanup_state: list[tuple[int | None, mmap.mmap | None]] = []
++    original_cleanup = SharedOffloadRegion.cleanup
++
++    def tracked_cleanup(region: SharedOffloadRegion) -> None:
++        original_cleanup(region)
++        cleanup_state.append((region.fd, region.mmap_obj))
++
++    monotonic = MagicMock(side_effect=[0.0, 31.0])
++    monkeypatch.setattr(shared_offload_region.time, "monotonic", monotonic)
++    monkeypatch.setattr(SharedOffloadRegion, "cleanup", tracked_cleanup)
++
++    with pytest.raises(TimeoutError, match="worker mmap markers"):
++        SharedOffloadRegion(
++            engine_id=iid,
++            num_blocks=4,
++            rank=0,
++            kv_bytes_per_block=2 * PAGE_SIZE,
++            cpu_page_size=PAGE_SIZE,
++            unlink_after_workers_map=True,
++            num_workers=2,
++        )
++
++    assert cleanup_state == [(None, None)]
++    assert not os.path.exists(mmap_path)
++    assert not os.path.exists(f"{mmap_path}.mapped.0")
++    assert not os.path.exists(f"{mmap_path}.mapped.1")
++
++
++def test_delayed_scheduler_joins_worker_backing(iid):
++    """Tiering's delayed scheduler mapping must observe the worker backing."""
++    mmap_path = f"/dev/shm/vllm_offload_{iid}.mmap"
++    regions: list[SharedOffloadRegion] = []
++    try:
++        for rank in range(2):
++            regions.append(
++                SharedOffloadRegion(
++                    engine_id=iid,
++                    num_blocks=4,
++                    rank=rank,
++                    kv_bytes_per_block=2 * PAGE_SIZE,
++                    cpu_page_size=PAGE_SIZE,
++                )
++            )
++
++        assert os.path.exists(mmap_path)
++        scheduler = SharedOffloadRegion(
++            engine_id=iid,
++            num_blocks=4,
++            rank=None,
++            kv_bytes_per_block=2 * PAGE_SIZE,
++            cpu_page_size=PAGE_SIZE,
++            prefault=False,
++        )
++        regions.append(scheduler)
++
++        regions[0].mmap_obj[0:1] = b"\x2a"
++        assert scheduler.mmap_obj[0:1] == b"\x2a"
++        scheduler.mmap_obj[PAGE_SIZE : PAGE_SIZE + 1] = b"\x3b"
++        assert regions[1].mmap_obj[PAGE_SIZE : PAGE_SIZE + 1] == b"\x3b"
++    finally:
++        for region in reversed(regions):
++            region.cleanup()
++        _cleanup_file(mmap_path)
++
++
+ # ---------------------------------------------------------------------------
+ # Multi-worker race — concurrent construction
+ # ---------------------------------------------------------------------------
+@@ -485,26 +650,36 @@ def test_multiprocess_race_construct_and_write(iid):
+     for rank, r in results.items():
+         assert r["error"] is None, f"rank {rank}: {r['error']}"
+ 
+-    # Read the raw file while all workers still hold it open.
+-    mmap_path = f"/dev/shm/vllm_offload_{iid}.mmap"
+-    with open(mmap_path, "rb") as f:
+-        raw = f.read()
+-
+-    for blk in range(num_blocks):
+-        for w in range(num_workers):
+-            slot_start = (blk * num_workers + w) * PAGE_SIZE
+-            slot = raw[slot_start : slot_start + PAGE_SIZE]
+-            expected = w + 1  # fill_value = rank + 1
+-            assert all(b == expected for b in slot), (
+-                f"block {blk}, worker {w}: expected {expected} but got wrong bytes"
+-            )
++    # Attach through the scheduler API only after every worker has mapped and
++    # written the region. This mirrors TieringOffloadingSpec startup ordering.
++    scheduler = SharedOffloadRegion(
++        engine_id=iid,
++        num_blocks=num_blocks,
++        rank=None,
++        kv_bytes_per_block=num_workers * PAGE_SIZE,
++        cpu_page_size=PAGE_SIZE,
++        prefault=False,
++    )
++    try:
++        assert scheduler.mmap_obj is not None
++        raw = bytes(scheduler.mmap_obj)
+ 
+-    # Unblock all workers to clean up.
+-    for _ in range(num_workers):
+-        cleanup_queue.put(True)
+-    for p in procs:
+-        p.join(timeout=10)
+-        assert p.exitcode == 0
++        for blk in range(num_blocks):
++            for w in range(num_workers):
++                slot_start = (blk * num_workers + w) * PAGE_SIZE
++                slot = raw[slot_start : slot_start + PAGE_SIZE]
++                expected = w + 1  # fill_value = rank + 1
++                assert all(b == expected for b in slot), (
++                    f"block {blk}, worker {w}: expected {expected} but got wrong bytes"
++                )
++    finally:
++        scheduler.cleanup()
++        # Unblock all workers to clean up.
++        for _ in range(num_workers):
++            cleanup_queue.put(True)
++        for proc in procs:
++            proc.join(timeout=10)
++            assert proc.exitcode == 0
+ 
+ 
+ # ---------------------------------------------------------------------------
+@@ -568,6 +743,34 @@ def test_cleanup_after_create_next_view_releases_mmap(iid):
+     assert mmap_obj.closed, "mmap should be closed after releasing the tensor"
+ 
+ 
++def test_cleanup_unregisters_tracked_segments_in_reverse(iid, monkeypatch):
++    """cleanup() must unregister the exact segments accepted during pinning."""
++    r = _make_region(iid)
++    unregister = MagicMock(return_value=0)
++    monkeypatch.setattr(
++        shared_offload_region.current_platform,
++        "is_cuda_alike",
++        lambda: True,
++    )
++    monkeypatch.setattr(
++        shared_offload_region,
++        "unregister_host_memory",
++        unregister,
++    )
++    r._registered_host_ptrs = [0x1000, 0x2000, 0x3000]
++    r.is_pinned = True
++
++    r.cleanup()
++
++    assert unregister.call_args_list == [
++        call(0x3000),
++        call(0x2000),
++        call(0x1000),
++    ]
++    assert r._registered_host_ptrs == []
++    assert r.is_pinned is False
++
++
+ # ---------------------------------------------------------------------------
+ # _wait_for_file_size
+ # ---------------------------------------------------------------------------
+diff --git a/tests/v1/kv_offload/test_factory.py b/tests/v1/kv_offload/test_factory.py
+index 98191db57b735fba639f7e809ac85a47645c2482..070b74976782d02589fb0b73bc1440ec4bb04ce6 100644
+--- a/tests/v1/kv_offload/test_factory.py
++++ b/tests/v1/kv_offload/test_factory.py
+@@ -328,7 +328,8 @@ def test_create_cpu_offloading_spec_end_to_end():
+ 
+ @pytest.mark.parametrize("packed", [False, True])
+ def test_cpu_spec_sizing_preserves_tensor_layout(packed: bool):
+-    cpu_bytes_to_use = 1920
++    alignment = SharedOffloadRegion.BLOCK_SIZE_ALIGNMENT
++    cpu_bytes_to_use = alignment * 3
+     config = _make_layout_vllm_config(
+         cpu_bytes_to_use=cpu_bytes_to_use,
+         extra_config={"block_size": 32},
+@@ -340,8 +341,85 @@ def test_cpu_spec_sizing_preserves_tensor_layout(packed: bool):
+ 
+     assert isinstance(spec, CPUOffloadingSpec)
+     assert spec.cpu_page_size_per_worker == 32
+-    assert spec.kv_bytes_per_chunk == 192
+-    assert spec.num_blocks == cpu_bytes_to_use // 192
++    assert spec.kv_bytes_per_chunk == alignment
++    assert spec.num_blocks == 3
++
++
++def test_cpu_spec_create_worker_uses_shared_region_on_cuda(monkeypatch):
++    import vllm.v1.kv_offload.cpu.spec as cpu_spec_module
++
++    alignment = SharedOffloadRegion.BLOCK_SIZE_ALIGNMENT
++    config = _make_layout_vllm_config(
++        cpu_bytes_to_use=alignment * 2,
++        tensor_parallel_size=4,
++    )
++    spec = _create_spec(config, _make_sizing_kv_cache_config(packed=False))
++    assert isinstance(spec, CPUOffloadingSpec)
++
++    region = MagicMock()
++    region_ctor = MagicMock(return_value=region)
++    worker_ctor = MagicMock(return_value=MagicMock())
++    monkeypatch.setattr(cpu_spec_module.current_platform, "is_cuda_alike", lambda: True)
++    monkeypatch.setattr(cpu_spec_module, "SharedOffloadRegion", region_ctor)
++    monkeypatch.setattr(cpu_spec_module, "CPUOffloadingWorker", worker_ctor)
++    monkeypatch.setattr(
++        cpu_spec_module.torch.accelerator, "current_device_index", lambda: 5
++    )
++
++    kv_caches = MagicMock()
++    spec.create_worker(kv_caches)
++
++    region_ctor.assert_called_once_with(
++        engine_id=spec.config.engine_id,
++        num_blocks=spec.num_blocks,
++        rank=1,
++        kv_bytes_per_block=spec.kv_bytes_per_chunk,
++        cpu_page_size=spec.cpu_page_size_per_worker,
++        unlink_after_workers_map=True,
++        num_workers=4,
++    )
++    worker_ctor.assert_called_once_with(
++        kv_caches=kv_caches,
++        blocks_per_chunk=spec.blocks_per_chunk,
++        num_cpu_blocks=spec.num_blocks,
++        mmap_region=region,
++    )
++
++
++@pytest.mark.parametrize("num_blocks", [0, 2])
++def test_cpu_spec_create_worker_keeps_tensor_path_without_cuda_or_blocks(
++    monkeypatch, num_blocks: int
++):
++    import vllm.v1.kv_offload.cpu.spec as cpu_spec_module
++
++    alignment = SharedOffloadRegion.BLOCK_SIZE_ALIGNMENT
++    config = _make_layout_vllm_config(cpu_bytes_to_use=alignment * 2)
++    kv_cache_config = _make_sizing_kv_cache_config(packed=False)
++    if num_blocks == 0:
++        kv_cache_config.num_blocks = 0
++    spec = _create_spec(config, kv_cache_config)
++    assert isinstance(spec, CPUOffloadingSpec)
++
++    region_ctor = MagicMock()
++    worker_ctor = MagicMock(return_value=MagicMock())
++    monkeypatch.setattr(
++        cpu_spec_module.current_platform,
++        "is_cuda_alike",
++        lambda: num_blocks == 0,
++    )
++    monkeypatch.setattr(cpu_spec_module, "SharedOffloadRegion", region_ctor)
++    monkeypatch.setattr(cpu_spec_module, "CPUOffloadingWorker", worker_ctor)
++
++    kv_caches = MagicMock()
++    spec.create_worker(kv_caches)
++
++    region_ctor.assert_not_called()
++    worker_ctor.assert_called_once_with(
++        kv_caches=kv_caches,
++        blocks_per_chunk=spec.blocks_per_chunk,
++        num_cpu_blocks=spec.num_blocks,
++        mmap_region=None,
++    )
+ 
+ 
+ def test_cpu_spec_rejects_partially_packed_tensor_layout():
+@@ -386,6 +464,81 @@ def test_tiering_spec_aligns_row_size():
+     assert spec.num_blocks == cpu_bytes_to_use // alignment
+ 
+ 
++def test_tiering_spec_keeps_region_named_for_delayed_scheduler(monkeypatch):
++    import vllm.v1.kv_offload.tiering.spec as tiering_spec_module
++
++    alignment = SharedOffloadRegion.BLOCK_SIZE_ALIGNMENT
++    config = _make_layout_vllm_config(
++        spec_name="TieringOffloadingSpec",
++        cpu_bytes_to_use=alignment * 2,
++        tensor_parallel_size=2,
++    )
++    spec = _create_spec(config, _make_sizing_kv_cache_config(packed=False))
++    assert isinstance(spec, TieringOffloadingSpec)
++
++    scheduler_region = MagicMock()
++    region_ctor = MagicMock(return_value=scheduler_region)
++    primary_tier = MagicMock()
++    primary_tier.get_kv_memoryview.return_value = memoryview(bytearray(1))
++    primary_ctor = MagicMock(return_value=primary_tier)
++    manager_ctor = MagicMock(return_value=MagicMock())
++    monkeypatch.setattr(tiering_spec_module, "SharedOffloadRegion", region_ctor)
++    monkeypatch.setattr(
++        tiering_spec_module, "CPUPrimaryTierOffloadingManager", primary_ctor
++    )
++    monkeypatch.setattr(tiering_spec_module, "TieringOffloadingManager", manager_ctor)
++
++    spec.get_manager()
++
++    region_ctor.assert_called_once_with(
++        engine_id=spec._engine_id,
++        num_blocks=spec.num_blocks,
++        rank=None,
++        kv_bytes_per_block=spec.kv_bytes_per_chunk,
++        cpu_page_size=spec.cpu_page_size_per_worker,
++        prefault=False,
++    )
++
++
++def test_tiering_worker_keeps_region_named_for_scheduler(monkeypatch):
++    import vllm.v1.kv_offload.tiering.spec as tiering_spec_module
++
++    alignment = SharedOffloadRegion.BLOCK_SIZE_ALIGNMENT
++    config = _make_layout_vllm_config(
++        spec_name="TieringOffloadingSpec",
++        cpu_bytes_to_use=alignment * 2,
++        tensor_parallel_size=2,
++    )
++    spec = _create_spec(config, _make_sizing_kv_cache_config(packed=False))
++    assert isinstance(spec, TieringOffloadingSpec)
++
++    worker_region = MagicMock()
++    region_ctor = MagicMock(return_value=worker_region)
++    worker_ctor = MagicMock(return_value=MagicMock())
++    monkeypatch.setattr(tiering_spec_module, "SharedOffloadRegion", region_ctor)
++    monkeypatch.setattr(tiering_spec_module, "CPUOffloadingWorker", worker_ctor)
++    monkeypatch.setattr(
++        tiering_spec_module.torch.accelerator, "current_device_index", lambda: 3
++    )
++
++    kv_caches = MagicMock()
++    spec.create_worker(kv_caches)
++
++    region_ctor.assert_called_once_with(
++        engine_id=spec._engine_id,
++        num_blocks=spec.num_blocks,
++        rank=1,
++        kv_bytes_per_block=spec.kv_bytes_per_chunk,
++        cpu_page_size=spec.cpu_page_size_per_worker,
++    )
++    worker_ctor.assert_called_once_with(
++        kv_caches=kv_caches,
++        blocks_per_chunk=spec.blocks_per_chunk,
++        num_cpu_blocks=spec.num_blocks,
++        mmap_region=worker_region,
++    )
++
++
+ def test_offloading_spec_resolves_prefill_context_parallel_block_sizes():
+     config = _make_layout_vllm_config(
+         cpu_bytes_to_use=65536,
+diff --git a/tests/v1/kv_offload/tiering/test_fs_gc.py b/tests/v1/kv_offload/tiering/test_fs_gc.py
+new file mode 100644
+index 0000000000000000000000000000000000000000..fc3049c7e7466eaa20b2cc83d4c3219c4f8a9f88
+--- /dev/null
++++ b/tests/v1/kv_offload/tiering/test_fs_gc.py
+@@ -0,0 +1,257 @@
++# SPDX-License-Identifier: Apache-2.0
++# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
++"""
++Unit tests for FsGCManager, the fs secondary tier's capacity bound.
++
++These use real files on disk with explicitly set mtimes, since mtime is the
++GC's single source of truth for recency. The background thread is neutralized
++by giving every manager a very long `interval_s` and driving `sweep()` directly,
++so nothing here depends on timing except the two stamping tests, which poll.
++"""
++
++import hashlib
++import os
++import time
++
++import pytest
++
++from vllm.v1.kv_offload.base import make_offload_key
++from vllm.v1.kv_offload.file_mapper import FileMapper
++from vllm.v1.kv_offload.tiering.fs.gc_manager import FsGCManager
++
++_BLOCK_BYTES = 4096
++
++
++def _make_file_mapper(root_dir: str) -> FileMapper:
++    return FileMapper(
++        root_dir=root_dir,
++        model_name="test/model",
++        tokens_per_hash=16,
++        blocks_per_file=1,
++        tp_size=1,
++        pp_size=1,
++        pcp_size=1,
++        dcp_size=1,
++        rank=0,
++        dtype="float32",
++    )
++
++
++def _key(index: int):
++    return make_offload_key(hashlib.sha256(str(index).encode()).digest()[:16], 0)
++
++
++def _write_block(mapper: FileMapper, index: int, age_s: float) -> str:
++    """Create a block file for `index` whose mtime is `age_s` in the past."""
++    path = mapper.get_file_name(_key(index))
++    os.makedirs(os.path.dirname(path), exist_ok=True)
++    with open(path, "wb") as f:
++        f.write(b"\0" * _BLOCK_BYTES)
++    stamp = time.time() - age_s
++    os.utime(path, (stamp, stamp))
++    return path
++
++
++@pytest.fixture
++def mapper(tmp_path):
++    return _make_file_mapper(str(tmp_path))
++
++
++def _make_gc(mapper: FileMapper, **kwargs) -> FsGCManager:
++    params = dict(
++        max_bytes=10 * _BLOCK_BYTES,
++        low_watermark=0.8,
++        # Long enough that the background thread never sweeps on its own; each
++        # test calls sweep() explicitly so assertions are deterministic.
++        interval_s=3600.0,
++        stamp_interval_s=1.0,
++        grace_s=60.0,
++    )
++    params.update(kwargs)
++    return FsGCManager(mapper, **params)  # type: ignore[arg-type]
++
++
++def test_rejects_grace_not_exceeding_stamp_interval(mapper):
++    # Otherwise a block in active use can be stamped, then age past the grace
++    # window before its next stamp is due, and be swept while still hot.
++    with pytest.raises(ValueError, match="must exceed stamp_interval_s"):
++        _make_gc(mapper, stamp_interval_s=60.0, grace_s=60.0)
++
++
++def test_rejects_out_of_range_low_watermark(mapper):
++    with pytest.raises(ValueError, match="low_watermark"):
++        _make_gc(mapper, low_watermark=1.5)
++
++
++def test_under_cap_is_a_noop(mapper):
++    gc = _make_gc(mapper)
++    try:
++        paths = [_write_block(mapper, i, age_s=1000) for i in range(5)]
++        assert gc.sweep() == 0
++        assert all(os.path.exists(p) for p in paths)
++    finally:
++        gc.shutdown()
++
++
++def test_evicts_in_mtime_order_down_to_the_low_watermark(mapper):
++    gc = _make_gc(mapper)
++    try:
++        # 15 blocks over a 10-block cap, oldest first. The sweep must free down
++        # to the 8-block watermark, i.e. remove exactly the 7 oldest.
++        paths = [_write_block(mapper, i, age_s=1000 - i) for i in range(15)]
++
++        freed = gc.sweep()
++
++        assert freed == 7 * _BLOCK_BYTES
++        assert not any(os.path.exists(p) for p in paths[:7])
++        assert all(os.path.exists(p) for p in paths[7:])
++    finally:
++        gc.shutdown()
++
++
++def test_grace_window_keeps_recently_used_blocks_even_over_cap(mapper):
++    gc = _make_gc(mapper, grace_s=60.0)
++    try:
++        # Everything is inside the grace window, so the tier is knowingly left
++        # over its cap rather than evicting blocks that are still in use.
++        paths = [_write_block(mapper, i, age_s=1) for i in range(15)]
++
++        assert gc.sweep() == 0
++        assert all(os.path.exists(p) for p in paths)
++    finally:
++        gc.shutdown()
++
++
++def test_protect_keeps_an_lru_block_a_sweep_would_otherwise_evict(mapper):
++    """The one case the grace window cannot cover.
++
++    A promotion stamps its keys when the scheduler matches them, but the read
++    itself can execute much later -- queued behind other reads on a busy tier.
++    Once the mtime ages past grace_s the sweep would happily unlink the file out
++    from under the in-flight read, so submit_load/submit_store pin the keys.
++    """
++    gc = _make_gc(mapper)
++    try:
++        # All 15 are far outside the grace window, so recency protects nothing.
++        paths = [_write_block(mapper, i, age_s=1000 - i) for i in range(15)]
++
++        # The 3 oldest have reads in flight; they are exactly the blocks the
++        # sweep wants to remove first.
++        gc.protect([_key(0), _key(1), _key(2)])
++
++        freed = gc.sweep()
++
++        # Still frees the full 7 blocks needed to reach the watermark, just
++        # taking the next-oldest unprotected ones instead.
++        assert freed == 7 * _BLOCK_BYTES
++        assert all(os.path.exists(p) for p in paths[:3]), "in-flight blocks unlinked"
++        assert not any(os.path.exists(p) for p in paths[3:10])
++        assert all(os.path.exists(p) for p in paths[10:])
++
++        # Once the jobs finish the blocks become evictable again. Refill past
++        # the cap first: the previous sweep left the tier at its watermark, so
++        # another sweep would legitimately have nothing to do.
++        gc.release([_key(0), _key(1), _key(2)])
++        for i in range(15, 20):
++            _write_block(mapper, i, age_s=1)
++
++        # 13 blocks over a 10-block cap needs 5 freed, and the released blocks
++        # are still the oldest on disk, so they are now the first to go.
++        assert gc.sweep() == 5 * _BLOCK_BYTES
++        assert not any(os.path.exists(p) for p in paths[:3]), (
++            "still pinned after release"
++        )
++    finally:
++        gc.shutdown()
++
++
++def test_release_is_refcounted(mapper):
++    """Two tiers' jobs can protect the same key; one finishing must not unpin it."""
++    gc = _make_gc(mapper)
++    try:
++        paths = [_write_block(mapper, i, age_s=1000 - i) for i in range(15)]
++
++        gc.protect([_key(0)])
++        gc.protect([_key(0)])
++        gc.release([_key(0)])
++
++        gc.sweep()
++        assert os.path.exists(paths[0]), "unpinned while a job was still in flight"
++    finally:
++        gc.shutdown()
++
++
++def test_touch_stamps_mtime_so_eviction_order_follows_use(mapper):
++    gc = _make_gc(mapper)
++    try:
++        path = _write_block(mapper, 0, age_s=1000)
++        before = os.stat(path).st_mtime
++
++        gc.touch([_key(0)])
++
++        deadline = time.monotonic() + 5.0
++        while os.stat(path).st_mtime == before and time.monotonic() < deadline:
++            time.sleep(0.01)
++        assert os.stat(path).st_mtime > before
++    finally:
++        gc.shutdown()
++
++
++def test_touch_rate_limits_repeat_stamps_of_the_same_key(mapper):
++    """touch() arrives once per request per scheduling attempt with every key of
++    the request, so an unthrottled utime per call would be thousands of syscalls
++    per step."""
++    gc = _make_gc(mapper, stamp_interval_s=30.0, grace_s=60.0)
++    try:
++        path = _write_block(mapper, 0, age_s=1000)
++        gc.touch([_key(0)])
++
++        deadline = time.monotonic() + 5.0
++        while os.stat(path).st_mtime < time.time() - 900 and (
++            time.monotonic() < deadline
++        ):
++            time.sleep(0.01)
++        stamped = os.stat(path).st_mtime
++
++        # Backdate the file, then touch again well inside stamp_interval_s: the
++        # second touch must be dropped, leaving the backdated mtime in place.
++        old = time.time() - 1000
++        os.utime(path, (old, old))
++        gc.touch([_key(0)])
++        time.sleep(0.5)
++
++        assert os.stat(path).st_mtime == pytest.approx(old)
++        assert stamped > old
++    finally:
++        gc.shutdown()
++
++
++def test_touch_tolerates_keys_with_no_file(mapper):
++    """A block can live only in the DRAM primary tier, or its cascade to disk
++    can have failed; neither is an error."""
++    gc = _make_gc(mapper)
++    try:
++        gc.touch([_key(0), _key(1)])
++        time.sleep(0.2)
++        assert gc.sweep() == 0
++    finally:
++        gc.shutdown()
++
++
++def test_sweep_ignores_non_block_files(mapper):
++    """store_block writes <dest>.tmp before os.replace, and config.json must
++    survive; only .bin files are eviction candidates."""
++    gc = _make_gc(mapper, max_bytes=_BLOCK_BYTES)
++    try:
++        paths = [_write_block(mapper, i, age_s=1000 - i) for i in range(4)]
++        tmp_path = paths[0] + ".tmp"
++        with open(tmp_path, "wb") as f:
++            f.write(b"\0" * _BLOCK_BYTES)
++        stamp = time.time() - 2000
++        os.utime(tmp_path, (stamp, stamp))
++
++        gc.sweep()
++
++        assert os.path.exists(tmp_path), "in-progress store was unlinked"
++    finally:
++        gc.shutdown()
+diff --git a/tests/v1/kv_offload/tiering/test_fs_tier.py b/tests/v1/kv_offload/tiering/test_fs_tier.py
+index dcc92a4fa8bf048b419d2b871964310701643e48..873e707e8c9da7abf3834d8e3ad66a878f283be0 100644
+--- a/tests/v1/kv_offload/tiering/test_fs_tier.py
++++ b/tests/v1/kv_offload/tiering/test_fs_tier.py
+@@ -298,6 +298,45 @@ def test_failed_load_missing_file(fs_tier):
+     assert not results[0].success
+ 
+ 
++def test_failed_load_invalidates_cached_lookup(fs_tier):
++    """A block that vanished must not stay cached as a hit.
++
++    The cached existence result is what routes a promotion to this tier, and
++    nothing else clears it until every request that looked the key up has
++    finished. If a failed load left it cached as present, the scheduler would
++    re-submit the same failing promotion on every step and the request waiting
++    for those tokens would never finish, so the entry would never be cleaned
++    up either -- a livelock rather than a recompute.
++    """
++    tier, _ = fs_tier
++    tier.submit_store(make_job(1, [key(1)], [0]))
++    assert all(r.success for r in drain(tier))
++    assert lookup_and_wait(tier, [key(1)]) == [LookupResult.HIT]
++
++    # Removed behind the tier's back: by capacity management, by another
++    # instance sharing root_dir, or by any external cleanup.
++    os.unlink(tier.file_mapper.get_file_name(key(1)))
++
++    tier.submit_load(make_job(2, [key(1)], [0], is_promotion=True))
++    results = drain(tier)
++    assert not results[0].success
++
++    assert tier.lookup(key(1), _CTX) == LookupResult.MISS
++
++
++def test_successful_load_keeps_cached_lookup(fs_tier):
++    """The invalidation above must be scoped to failures."""
++    tier, _ = fs_tier
++    tier.submit_store(make_job(1, [key(1)], [0]))
++    assert all(r.success for r in drain(tier))
++    assert lookup_and_wait(tier, [key(1)]) == [LookupResult.HIT]
++
++    tier.submit_load(make_job(2, [key(1)], [0], is_promotion=True))
++    assert all(r.success for r in drain(tier))
++
++    assert tier.lookup(key(1), _CTX) == LookupResult.HIT
++
++
+ def test_multiple_jobs_tracked_independently(fs_tier):
+     tier, _ = fs_tier
+     job1 = make_job(1, [key(1)], [0])
+diff --git a/tests/v1/kv_offload/tiering/test_obj_tier.py b/tests/v1/kv_offload/tiering/test_obj_tier.py
+index 7500df8b4b94216009fa4895ffbae4d39acc4962..a110c3c3b0ca4593b55480ec05b4d7a94acd2dd7 100644
+--- a/tests/v1/kv_offload/tiering/test_obj_tier.py
++++ b/tests/v1/kv_offload/tiering/test_obj_tier.py
+@@ -437,6 +437,62 @@ class TestMockObjTierFailures:
+         assert not by_id[1].success
+         assert by_id[2].success
+ 
++    def test_failed_load_invalidates_cached_lookup(self):
++        """An object that vanished must not stay cached as a hit.
++
++        The cached existence result is what routes a promotion to this tier,
++        and nothing else clears it until every request that looked the key up
++        has finished. If a failed load left it cached as present, the
++        scheduler would re-submit the same failing promotion on every step and
++        the request waiting for those tokens would never finish, so the entry
++        would never be cleaned up either -- a livelock rather than a
++        recompute.
++        """
++        tier, agent = _make_tier(num_blocks=4)
++        tier.submit_store(make_job(1, [key(1)], [0]))
++        assert all(r.success for r in drain(tier))
++        assert lookup_and_wait(tier, [key(1)]) == [LookupResult.HIT]
++
++        # Removed behind the tier's back: a bucket lifecycle rule, another
++        # instance sharing the bucket, or any external cleanup. The probe hit
++        # is now stale and the read against it fails.
++        agent._stored_obj_keys.clear()
++        agent.check_xfer_state = lambda h: "ERR"
++
++        tier.submit_load(make_job(2, [key(1)], [0]))
++        results = drain(tier)
++        assert not results[0].success
++
++        assert tier.lookup(key(1), _CTX) == LookupResult.MISS
++
++    def test_submission_time_load_failure_invalidates_cached_lookup(self):
++        """Loads that die before the transfer starts must invalidate too;
++        re-submitting them against the same cached hit is the same livelock."""
++        tier, agent = _make_tier(num_blocks=4)
++        tier.submit_store(make_job(1, [key(1)], [0]))
++        assert all(r.success for r in drain(tier))
++        assert lookup_and_wait(tier, [key(1)]) == [LookupResult.HIT]
++
++        agent.register_memory = lambda *a, **k: None
++        tier.submit_load(make_job(2, [key(1)], [0]))
++        results = list(tier.get_finished_jobs())
++        assert len(results) == 1
++        assert not results[0].success
++
++        assert tier.lookup(key(1), _CTX) == LookupResult.MISS
++
++    def test_successful_load_keeps_cached_lookup(self):
++        """The invalidation above must be scoped to failures."""
++        tier, _ = _make_tier(num_blocks=4)
++        tier.submit_store(make_job(1, [key(1)], [0]))
++        assert all(r.success for r in drain(tier))
++        assert lookup_and_wait(tier, [key(1)]) == [LookupResult.HIT]
++
++        tier.submit_load(make_job(2, [key(1)], [0]))
++        assert all(r.success for r in drain(tier))
++
++        assert tier.lookup(key(1), _CTX) == LookupResult.HIT
++
+ 
+ class TestMockObjTierShutdown:
+     def test_shutdown_clears_in_flight_transfers(self):
+diff --git a/tests/v1/spec_decode/test_dflash_context_cudagraph.py b/tests/v1/spec_decode/test_dflash_context_cudagraph.py
+new file mode 100644
+index 0000000000000000000000000000000000000000..9374fd076a4004bb9405aea9e80fd48c4b95d4f9
+--- /dev/null
++++ b/tests/v1/spec_decode/test_dflash_context_cudagraph.py
+@@ -0,0 +1,151 @@
++# SPDX-License-Identifier: Apache-2.0
++# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
++
++from types import SimpleNamespace
++
++import numpy as np
++import pytest
++import torch
++
++from vllm.config.compilation import CUDAGraphMode
++from vllm.platforms import current_platform
++from vllm.v1.attention.backends.utils import PAD_SLOT_ID
++from vllm.v1.worker.gpu.spec_decode.dflash.cudagraph import (
++    DFlashContextCudaGraphManager,
++)
++from vllm.v1.worker.gpu.spec_decode.dflash.speculator import (
++    _DFlashInputBatch,
++    prepare_dflash_inputs,
++)
++
++
++def _make_dispatch_manager(*, captured: bool = True) -> SimpleNamespace:
++    return SimpleNamespace(
++        compilation_config=SimpleNamespace(
++            cudagraph_capture_sizes=[1, 2, 4, 8, 16],
++            max_cudagraph_capture_size=8,
++        ),
++        cudagraph_mode=CUDAGraphMode.FULL_DECODE_ONLY,
++        max_num_context_tokens=12,
++        _capture_descs={},
++        _graphs_captured=captured,
++    )
++
++
++def test_context_graph_dispatch_uses_smallest_capture_bucket():
++    manager = _make_dispatch_manager()
++
++    DFlashContextCudaGraphManager._init_candidates(manager)
++
++    assert [d.num_tokens for d in manager._capture_descs[CUDAGraphMode.FULL]] == [
++        8,
++        4,
++        2,
++        1,
++    ]
++    assert DFlashContextCudaGraphManager.dispatch_context(manager, 1).num_tokens == 1
++    assert DFlashContextCudaGraphManager.dispatch_context(manager, 3).num_tokens == 4
++    assert DFlashContextCudaGraphManager.dispatch_context(manager, 7).num_tokens == 8
++    assert (
++        DFlashContextCudaGraphManager.dispatch_context(manager, 9).cg_mode
++        == CUDAGraphMode.NONE
++    )
++
++
++def test_context_graph_dispatch_falls_back_before_capture():
++    manager = _make_dispatch_manager(captured=False)
++    DFlashContextCudaGraphManager._init_candidates(manager)
++
++    desc = DFlashContextCudaGraphManager.dispatch_context(manager, 3)
++
++    assert desc.cg_mode == CUDAGraphMode.NONE
++    assert desc.num_tokens == 3
++
++
++@pytest.mark.skipif(not current_platform.is_cuda(), reason="Requires CUDA")
++def test_prepare_dflash_inputs_makes_context_graph_padding_inert():
++    device = torch.device("cuda")
++    max_num_reqs = 4
++    max_num_tokens = 16
++    num_reqs = 2
++    num_speculative_steps = 2
++    num_query_per_req = 3
++    num_context_tokens = 3
++    padded_context_tokens = 8
++
++    input_buffers = SimpleNamespace(
++        input_ids=torch.zeros(max_num_tokens, dtype=torch.int64, device=device),
++        positions=torch.zeros(max_num_tokens, dtype=torch.int64, device=device),
++        query_start_loc=torch.zeros(max_num_reqs + 1, dtype=torch.int32, device=device),
++        seq_lens=torch.zeros(max_num_reqs, dtype=torch.int32, device=device),
++    )
++    input_batch = _DFlashInputBatch(
++        num_reqs=num_reqs,
++        num_scheduled_tokens=np.array([2, 1], dtype=np.int32),
++        positions=torch.arange(num_context_tokens, dtype=torch.int64, device=device),
++        query_start_loc=torch.tensor([0, 2, 3], dtype=torch.int32, device=device),
++        idx_mapping=torch.arange(num_reqs, dtype=torch.int32, device=device),
++    )
++
++    query_slots = torch.full((max_num_tokens,), 777, dtype=torch.int64, device=device)
++    context_positions = torch.full_like(query_slots, 777)
++    context_slots = torch.full_like(query_slots, 777)
++    sample_rows = max_num_reqs * num_speculative_steps
++    block_table = torch.arange(
++        1,
++        1 + max_num_reqs * 4,
++        dtype=torch.int32,
++        device=device,
++    ).view(max_num_reqs, 4)
++
++    prepare_dflash_inputs(
++        input_buffers,
++        query_slots,
++        context_positions,
++        context_slots,
++        torch.zeros(sample_rows, dtype=torch.int64, device=device),
++        torch.zeros(sample_rows, dtype=torch.int64, device=device),
++        torch.full((sample_rows,), -1, dtype=torch.int32, device=device),
++        input_batch,
++        torch.zeros(num_reqs, dtype=torch.int32, device=device),
++        torch.zeros(num_reqs, dtype=torch.int32, device=device),
++        torch.zeros(max_num_reqs, dtype=torch.int32, device=device),
++        torch.zeros(max_num_reqs, dtype=torch.int32, device=device),
++        block_table,
++        16,
++        torch.zeros(max_num_reqs, dtype=torch.int32, device=device),
++        1,
++        num_query_per_req,
++        num_speculative_steps,
++        max_num_reqs,
++        max_num_tokens,
++        1024,
++        context_num_tokens_padded=padded_context_tokens,
++    )
++    torch.cuda.synchronize()
++
++    torch.testing.assert_close(
++        context_positions[:num_context_tokens],
++        torch.arange(num_context_tokens, dtype=torch.int64, device=device),
++    )
++    torch.testing.assert_close(
++        context_slots[:num_context_tokens],
++        torch.tensor([16, 17, 82], dtype=torch.int64, device=device),
++    )
++    torch.testing.assert_close(
++        context_positions[num_context_tokens:padded_context_tokens],
++        torch.zeros(
++            padded_context_tokens - num_context_tokens,
++            dtype=torch.int64,
++            device=device,
++        ),
++    )
++    torch.testing.assert_close(
++        context_slots[num_context_tokens:padded_context_tokens],
++        torch.full(
++            (padded_context_tokens - num_context_tokens,),
++            PAD_SLOT_ID,
++            dtype=torch.int64,
++            device=device,
++        ),
++    )
+diff --git a/tests/v1/spec_decode/test_dflash_cudagraph_lifetime.py b/tests/v1/spec_decode/test_dflash_cudagraph_lifetime.py
+index 11fb1b66e85b09cf4f5cb74ee88a19c87dbd6a3a..95db690e834c5176809be1e84c60f87143cfc747 100644
+--- a/tests/v1/spec_decode/test_dflash_cudagraph_lifetime.py
++++ b/tests/v1/spec_decode/test_dflash_cudagraph_lifetime.py
+@@ -7,6 +7,8 @@ from unittest.mock import Mock
+ import torch
+ 
+ from vllm.config.compilation import CUDAGraphMode
++from vllm.v1.attention.backend import AttentionCGSupport
++from vllm.v1.worker.gpu.spec_decode.dflash import speculator as spec_module
+ from vllm.v1.worker.gpu.spec_decode.dflash.speculator import DFlashSpeculator
+ 
+ 
+@@ -63,3 +65,138 @@ def test_dflash_does_not_retain_eager_backbone_output(monkeypatch):
+     )
+ 
+     assert speculator._captured_backbone_outputs == []
++
++
++def test_dflash_capture_uses_phase_specific_draft_channel_ids():
++    events = []
++
++    class FakeQueryManager:
++        def capture(self, *args, **kwargs):
++            events.append(("query", kwargs["channel_id"]))
++
++    class FakeContextManager:
++        def capture_context(self, *args, **kwargs):
++            events.append(("context", kwargs["channel_id"]))
++
++    speculator = SimpleNamespace(
++        _speculator_name="DFlash",
++        sample_indices=torch.zeros(1),
++        sample_pos=torch.zeros(1),
++        sample_idx_mapping=torch.zeros(1),
++        query_cudagraph_manager=FakeQueryManager(),
++        context_cudagraph_manager=FakeContextManager(),
++        _context_slot_mappings=torch.zeros(1, 1),
++        context_positions=torch.ones(1),
++        _capture_context_kv=object(),
++        _generate_draft=object(),
++        input_buffers=object(),
++        block_tables=object(),
++        attn_groups=object(),
++        kv_cache_config=object(),
++        max_model_len=1,
++        _group_causal=True,
++    )
++
++    DFlashSpeculator.capture(speculator, capture_phase="profile")
++    DFlashSpeculator.capture(speculator, capture_phase="production")
++
++    assert events == [
++        ("query", "vllm:draft:dflash:profile"),
++        ("context", "vllm:draft:dflash:context:profile"),
++        ("query", "vllm:draft:dflash:production"),
++        ("context", "vllm:draft:dflash:context:production"),
++    ]
++
++
++def test_dflash_graph_channel_is_bound_at_capture_not_construction(monkeypatch):
++    created = []
++
++    class FakeQueryManager:
++        def __init__(self, vllm_config, device, cudagraph_mode, decode_query_len):
++            created.append(
++                ("query", vllm_config, device, cudagraph_mode, decode_query_len)
++            )
++
++    class FakeContextManager:
++        def __init__(self, vllm_config, device, max_num_context_tokens):
++            created.append(("context", vllm_config, device, max_num_context_tokens))
++
++    monkeypatch.setattr(spec_module, "DFlashCudaGraphManager", FakeQueryManager)
++    monkeypatch.setattr(
++        spec_module,
++        "DFlashContextCudaGraphManager",
++        FakeContextManager,
++    )
++
++    speculator = object.__new__(DFlashSpeculator)
++    speculator.vllm_config = object()
++    speculator.device = torch.device("cpu")
++    speculator.num_query_per_req = 6
++    speculator.max_num_tokens = 128
++    speculator._speculator_name = "DSpark"
++    speculator.attn_cg_support = SimpleNamespace(
++        min_cg_support=AttentionCGSupport.UNIFORM_BATCH,
++        min_cg_attn_backend="test",
++    )
++
++    DFlashSpeculator.init_cudagraph_manager(speculator, CUDAGraphMode.FULL)
++
++    assert created == [
++        (
++            "query",
++            speculator.vllm_config,
++            speculator.device,
++            CUDAGraphMode.FULL_DECODE_ONLY,
++            6,
++        ),
++        ("context", speculator.vllm_config, speculator.device, 128),
++    ]
++
++
++def test_dflash_context_precompute_replays_full_graph():
++    manager = Mock()
++    model = Mock()
++    speculator = SimpleNamespace(
++        context_cudagraph_manager=manager,
++        model=model,
++        hidden_states=torch.zeros(8, 4),
++        context_positions=torch.zeros(8, dtype=torch.int64),
++    )
++    desc = SimpleNamespace(cg_mode=CUDAGraphMode.FULL)
++
++    DFlashSpeculator._precompute_context_kv(
++        speculator,
++        num_target_tokens=3,
++        batch_desc=desc,
++        context_slots=torch.zeros(3, dtype=torch.int64),
++    )
++
++    manager.run_fullgraph.assert_called_once_with(desc)
++    model.precompute_and_store_context_kv.assert_not_called()
++
++
++def test_dflash_context_precompute_keeps_eager_fallback():
++    model = Mock()
++    hidden_states = torch.zeros(8, 4)
++    context_positions = torch.zeros(8, dtype=torch.int64)
++    context_slots = torch.zeros(3, dtype=torch.int64)
++    speculator = SimpleNamespace(
++        context_cudagraph_manager=None,
++        model=model,
++        hidden_states=hidden_states,
++        context_positions=context_positions,
++    )
++
++    DFlashSpeculator._precompute_context_kv(
++        speculator,
++        num_target_tokens=3,
++        batch_desc=SimpleNamespace(cg_mode=CUDAGraphMode.NONE),
++        context_slots=context_slots,
++    )
++
++    args = model.precompute_and_store_context_kv.call_args.args
++    assert args[0].data_ptr() == hidden_states.data_ptr()
++    assert args[0].shape == (3, 4)
++    assert args[1].data_ptr() == context_positions.data_ptr()
++    assert args[1].shape == (3,)
++    assert args[2] is context_slots
+diff --git a/tests/v1/worker/test_gpu_autoregressive_speculator.py b/tests/v1/worker/test_gpu_autoregressive_speculator.py
+index 89dc32ee4c68d96afc57d5e2c380657364a9f4fe..b4adbc44ca527001aadb85b3101715d51ea5899f 100644
+--- a/tests/v1/worker/test_gpu_autoregressive_speculator.py
++++ b/tests/v1/worker/test_gpu_autoregressive_speculator.py
+@@ -166,3 +166,78 @@ def test_ar_probabilistic_draft_uses_shared_sampler(monkeypatch):
+ 
+     assert captured["positions"] is positions
+     assert captured["active_rows"] is speculator.active_num_reqs
++
++
++def test_autoregressive_capture_ids_are_deterministic_and_phase_separated():
++    def capture_channel_ids() -> list[str]:
++        events = []
++
++        class FakeManager:
++            use_breakable_cg = False
++
++            def capture(self, *args, **kwargs):
++                events.append(kwargs["channel_id"])
++
++        speculator = object.__new__(_TestSpeculator)
++        speculator.last_token_indices = torch.zeros(1)
++        speculator.prefill_cudagraph_manager = FakeManager()
++        speculator.decode_cudagraph_manager = FakeManager()
++        speculator.model = object()
++        speculator._prefill = object()
++        speculator._generate_draft = object()
++        speculator.model_state = object()
++        speculator.target_input_buffers = object()
++        speculator.input_buffers = object()
++        speculator.block_tables = object()
++        speculator.target_attn_groups = object()
++        speculator.attn_groups = object()
++        speculator.kv_cache_config = object()
++        speculator.num_speculative_steps = 3
++
++        speculator.capture(capture_phase="profile")
++        speculator.capture(capture_phase="production")
++        return events
++
++    expected = [
++        "vllm:draft:prefill:profile",
++        "vllm:draft:decode:profile",
++        "vllm:draft:prefill:production",
++        "vllm:draft:decode:production",
++    ]
++    assert capture_channel_ids() == capture_channel_ids() == expected
++
++
++def test_autoregressive_graph_channel_is_bound_at_capture_not_construction(
++    monkeypatch,
++):
++    created = []
++
++    class FakeManager:
++        def __init__(self, vllm_config, device, cudagraph_mode, decode_query_len):
++            created.append((vllm_config, device, cudagraph_mode, decode_query_len))
++
++    monkeypatch.setattr(spec_module, "SpeculatorCudaGraphManager", FakeManager)
++    speculator = object.__new__(_TestSpeculator)
++    speculator.vllm_config = object()
++    speculator.device = torch.device("cpu")
++    speculator.num_speculative_steps = 3
++
++    AutoRegressiveSpeculator.init_cudagraph_manager(
++        speculator,
++        CUDAGraphMode.FULL,
++    )
++
++    assert created == [
++        (
++            speculator.vllm_config,
++            speculator.device,
++            CUDAGraphMode.FULL,
++            4,
++        ),
++        (
++            speculator.vllm_config,
++            speculator.device,
++            CUDAGraphMode.FULL_DECODE_ONLY,
++            1,
++        ),
++    ]
+diff --git a/tests/v1/worker/test_gpu_model_runner.py b/tests/v1/worker/test_gpu_model_runner.py
+index 254432312cb3209f44a504e389a67ef8a382f46d..e341d2cbe7b469d6a1e120364a7a987891c5bc54 100644
+--- a/tests/v1/worker/test_gpu_model_runner.py
++++ b/tests/v1/worker/test_gpu_model_runner.py
+@@ -1,6 +1,7 @@
+ # SPDX-License-Identifier: Apache-2.0
+ # SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+ 
++from contextlib import contextmanager, nullcontext
+ from types import SimpleNamespace
+ from unittest.mock import Mock
+ 
+@@ -12,6 +13,7 @@ import vllm.v1.worker.gpu_model_runner as gpu_model_runner_module
+ from vllm.config import (
+     AttentionConfig,
+     CacheConfig,
++    CUDAGraphMode,
+     ModelConfig,
+     ParallelConfig,
+     SchedulerConfig,
+@@ -1779,3 +1781,367 @@ def test_mamba_cache_raises_when_max_num_seqs_exceeds_blocks():
+ 
+         with pytest.raises(ValueError, match="max_num_seqs"):
+             runner.initialize_kv_cache(kv_cache_config)
++
++
++def test_v1_capture_separates_target_and_draft_semantic_channels(monkeypatch):
++    runner = GPUModelRunner.__new__(GPUModelRunner)
++    runner.compilation_config = SimpleNamespace(cudagraph_mode=CUDAGraphMode.PIECEWISE)
++    runner.speculative_config = SimpleNamespace(
++        enforce_eager=False,
++        use_eagle=lambda: False,
++        uses_draft_model=lambda: True,
++        uses_extract_hidden_states=lambda: False,
++    )
++    runner.cudagraph_dispatcher = SimpleNamespace(
++        get_capture_descs=lambda: [
++            (CUDAGraphMode.FULL, []),
++            (CUDAGraphMode.PIECEWISE, [object()]),
++        ]
++    )
++    runner.encoder_cudagraph_manager = None
++    runner.device = torch.device("cpu")
++    runner._maybe_init_encoder_cudagraph_manager = lambda: None
++    runner._freeze_gc = nullcontext
++
++    active_channel: list[str] = []
++    channel_entries: list[str] = []
++    captures: list[tuple[str, bool]] = []
++
++    @contextmanager
++    def fake_graph_capture(*, device, channel_id, **kwargs):
++        assert device == runner.device
++        active_channel.append(channel_id)
++        channel_entries.append(channel_id)
++        try:
++            yield SimpleNamespace(channel_id=channel_id)
++        finally:
++            assert active_channel.pop() == channel_id
++
++    def fake_capture_cudagraphs(*, run_drafter, **kwargs):
++        assert len(active_channel) == 1
++        captures.append((active_channel[0], run_drafter))
++
++    runner._capture_cudagraphs = fake_capture_cudagraphs
++    runner.encoder_cudagraph_manager = SimpleNamespace(
++        capture=lambda **_: captures.append((active_channel[0], True))
++    )
++    memory_info = iter(((1000, 0), (900, 0)))
++    monkeypatch.setattr(gpu_model_runner_module, "graph_capture", fake_graph_capture)
++    monkeypatch.setattr(
++        gpu_model_runner_module,
++        "set_cudagraph_capturing_enabled",
++        lambda _: None,
++    )
++    monkeypatch.setattr(gpu_model_runner_module, "lock_workspace", lambda: None)
++    monkeypatch.setattr(
++        gpu_model_runner_module,
++        "current_platform",
++        SimpleNamespace(graph_pool_handle=object),
++    )
++    monkeypatch.setattr(
++        torch.accelerator,
++        "synchronize",
++        lambda: None,
++    )
++    monkeypatch.setattr(torch.accelerator, "empty_cache", lambda: None)
++    monkeypatch.setattr(
++        torch.accelerator,
++        "get_memory_info",
++        lambda: next(memory_info),
++    )
++
++    assert runner.capture_model() == 100
++    assert captures == [
++        ("vllm:target:production", False),
++        ("vllm:draft:production", True),
++        ("vllm:encoder:production", True),
++    ]
++    assert channel_entries == [
++        "vllm:target:production",
++        "vllm:draft:production",
++        "vllm:encoder:production",
++    ]
++
++
++def test_v1_full_capture_without_speculation_is_target_only(monkeypatch):
++    runner = GPUModelRunner.__new__(GPUModelRunner)
++    runner.compilation_config = SimpleNamespace(cudagraph_mode=CUDAGraphMode.FULL)
++    runner.speculative_config = None
++    runner.cudagraph_dispatcher = SimpleNamespace(
++        get_capture_descs=lambda: [(CUDAGraphMode.FULL, [object()])]
++    )
++    runner.encoder_cudagraph_manager = None
++    runner.device = torch.device("cpu")
++    runner._maybe_init_encoder_cudagraph_manager = lambda: None
++    runner._freeze_gc = nullcontext
++
++    channels: list[str] = []
++    captures: list[bool] = []
++
++    @contextmanager
++    def fake_graph_capture(*, channel_id, **kwargs):
++        channels.append(channel_id)
++        yield SimpleNamespace(channel_id=channel_id)
++
++    runner._capture_cudagraphs = lambda *, run_drafter, **_: captures.append(
++        run_drafter
++    )
++    memory_info = iter(((1000, 0), (900, 0)))
++    monkeypatch.setattr(gpu_model_runner_module, "graph_capture", fake_graph_capture)
++    monkeypatch.setattr(
++        gpu_model_runner_module,
++        "set_cudagraph_capturing_enabled",
++        lambda _: None,
++    )
++    monkeypatch.setattr(gpu_model_runner_module, "lock_workspace", lambda: None)
++    monkeypatch.setattr(
++        torch.accelerator,
++        "synchronize",
++        lambda: None,
++    )
++    monkeypatch.setattr(torch.accelerator, "empty_cache", lambda: None)
++    monkeypatch.setattr(
++        torch.accelerator,
++        "get_memory_info",
++        lambda: next(memory_info),
++    )
++
++    assert runner.capture_model() == 100
++    assert channels == ["vllm:target:production"]
++    assert captures == [True]
++
++
++def test_v1_profile_rolls_back_distinct_target_and_draft_channels(monkeypatch):
++    runner = GPUModelRunner.__new__(GPUModelRunner)
++    runner.vllm_config = object()
++    runner.device = torch.device("cpu")
++    runner.speculative_config = SimpleNamespace(
++        enforce_eager=False,
++        use_eagle=lambda: False,
++        uses_draft_model=lambda: True,
++        uses_extract_hidden_states=lambda: False,
++    )
++    desc = SimpleNamespace(num_tokens=32)
++    runner.cudagraph_dispatcher = SimpleNamespace(
++        get_capture_descs=lambda: [
++            (CUDAGraphMode.FULL, []),
++            (CUDAGraphMode.PIECEWISE, [desc]),
++        ],
++        cudagraph_keys={},
++        keys_initialized=True,
++    )
++    runner.max_model_len = 4096
++    runner.max_num_tokens = 256
++    runner.lora_config = None
++    runner._freeze_gc = nullcontext
++    runner._init_minimal_kv_cache_for_profiling = lambda: None
++    runner._create_encoder_cudagraph_manager = lambda: None
++    runner.maybe_remove_all_loras = lambda _: None
++
++    events: list[object] = []
++    active_channel: list[str] = []
++
++    @contextmanager
++    def fake_graph_capture(*, device, channel_id, **kwargs):
++        assert device == runner.device
++        active_channel.append(channel_id)
++        events.append(("enter", channel_id))
++        try:
++            yield SimpleNamespace(channel_id=channel_id)
++        finally:
++            assert active_channel.pop() == channel_id
++            events.append(("exit", channel_id))
++
++    def fake_warmup_and_capture(*args, run_drafter, **kwargs):
++        assert len(active_channel) == 1
++        events.append(("capture", active_channel[0], run_drafter))
++
++    runner._warmup_and_capture = fake_warmup_and_capture
++    runner._cleanup_profiling_kv_cache = lambda: events.extend(
++        ("cleanup-sync", "cleanup")
++    )
++
++    checkpoint = ((lambda _: None, "checkpoint"),)
++
++    def checkpoint_graph_channels():
++        events.append("checkpoint")
++        return checkpoint
++
++    monkeypatch.setattr(
++        gpu_model_runner_module,
++        "checkpoint_b12x_graph_channels",
++        checkpoint_graph_channels,
++    )
++    monkeypatch.setattr(
++        gpu_model_runner_module,
++        "rollback_b12x_graph_channels",
++        lambda value: events.append(("rollback", value)),
++    )
++    monkeypatch.setattr(gpu_model_runner_module, "graph_capture", fake_graph_capture)
++    monkeypatch.setattr(
++        gpu_model_runner_module,
++        "set_current_vllm_config",
++        lambda _: nullcontext(),
++    )
++    monkeypatch.setattr(
++        gpu_model_runner_module,
++        "current_platform",
++        SimpleNamespace(
++            graph_pool_handle=object,
++            is_rocm=lambda: False,
++        ),
++    )
++    monkeypatch.setattr(
++        gpu_model_runner_module,
++        "set_cudagraph_capturing_enabled",
++        lambda enabled: events.append(("capture-enabled", enabled)),
++    )
++    monkeypatch.setattr(
++        gpu_model_runner_module.CUDAGraphWrapper,
++        "_all_instances",
++        [],
++    )
++    monkeypatch.setattr(
++        gpu_model_runner_module.BreakableCUDAGraphWrapper,
++        "_all_instances",
++        [],
++    )
++    monkeypatch.setattr(
++        gpu_model_runner_module.CUDAGraphWrapper,
++        "clear_all_graphs",
++        lambda: events.append("clear-target"),
++    )
++    monkeypatch.setattr(
++        gpu_model_runner_module.BreakableCUDAGraphWrapper,
++        "clear_all_graphs",
++        lambda: events.append("clear-breakable"),
++    )
++    memory_info = iter(((1000, 0), (900, 0), (900, 0), (800, 0)))
++    monkeypatch.setattr(
++        torch.accelerator,
++        "synchronize",
++        lambda: events.append("sync"),
++    )
++    monkeypatch.setattr(torch.accelerator, "empty_cache", lambda: None)
++    monkeypatch.setattr(
++        torch.accelerator,
++        "get_memory_info",
++        lambda: next(memory_info),
++    )
++
++    assert runner.profile_cudagraph_memory() == 200
++    assert ("capture", "vllm:target:profile", False) in events
++    assert ("capture", "vllm:draft:profile", True) in events
++    assert events.index("clear-target") < events.index("cleanup")
++    assert events.index("cleanup-sync") < events.index("cleanup")
++    assert events.index("cleanup") < events.index(("rollback", checkpoint))
++    assert events[-1] == ("rollback", checkpoint)
++
++
++@pytest.mark.parametrize("cleanup_fails", [False, True])
++def test_v1_profile_restores_state_when_capture_or_cleanup_fails(
++    monkeypatch,
++    cleanup_fails,
++):
++    runner = GPUModelRunner.__new__(GPUModelRunner)
++    runner.vllm_config = object()
++    runner.device = torch.device("cpu")
++    runner.speculative_config = None
++    desc = SimpleNamespace(num_tokens=32)
++    runner.cudagraph_dispatcher = SimpleNamespace(
++        get_capture_descs=lambda: [(CUDAGraphMode.FULL, [desc])],
++        cudagraph_keys={},
++        keys_initialized=True,
++    )
++    runner.max_model_len = 4096
++    runner.max_num_tokens = 256
++    runner.lora_config = None
++    runner._freeze_gc = nullcontext
++    runner._init_minimal_kv_cache_for_profiling = lambda: None
++    runner._create_encoder_cudagraph_manager = lambda: None
++    runner.maybe_remove_all_loras = lambda _: None
++
++    events: list[object] = []
++
++    @contextmanager
++    def fake_graph_capture(**kwargs):
++        yield SimpleNamespace(channel_id=kwargs["channel_id"])
++
++    def fail_capture(*args, **kwargs):
++        events.append("capture-failed")
++        raise RuntimeError("expected capture failure")
++
++    runner._warmup_and_capture = fail_capture
++    runner._cleanup_profiling_kv_cache = lambda: events.extend(
++        ("cleanup-sync", "cleanup")
++    )
++    checkpoint = ((lambda _: None, "checkpoint"),)
++
++    monkeypatch.setattr(
++        gpu_model_runner_module,
++        "checkpoint_b12x_graph_channels",
++        lambda: checkpoint,
++    )
++    monkeypatch.setattr(
++        gpu_model_runner_module,
++        "rollback_b12x_graph_channels",
++        lambda value: events.append(("rollback", value)),
++    )
++    monkeypatch.setattr(gpu_model_runner_module, "graph_capture", fake_graph_capture)
++    monkeypatch.setattr(
++        gpu_model_runner_module,
++        "set_current_vllm_config",
++        lambda _: nullcontext(),
++    )
++    monkeypatch.setattr(
++        gpu_model_runner_module,
++        "current_platform",
++        SimpleNamespace(graph_pool_handle=object, is_rocm=lambda: False),
++    )
++    monkeypatch.setattr(
++        gpu_model_runner_module,
++        "set_cudagraph_capturing_enabled",
++        lambda enabled: events.append(("capture-enabled", enabled)),
++    )
++    original_pool = object()
++    wrapper = SimpleNamespace(graph_pool=original_pool)
++    monkeypatch.setattr(
++        gpu_model_runner_module.CUDAGraphWrapper,
++        "_all_instances",
++        [wrapper],
++    )
++    monkeypatch.setattr(
++        gpu_model_runner_module.BreakableCUDAGraphWrapper,
++        "_all_instances",
++        [],
++    )
++
++    def clear_target_graphs():
++        events.append("clear-target")
++        if cleanup_fails:
++            raise RuntimeError("expected cleanup failure")
++
++    monkeypatch.setattr(
++        gpu_model_runner_module.CUDAGraphWrapper,
++        "clear_all_graphs",
++        clear_target_graphs,
++    )
++    monkeypatch.setattr(
++        gpu_model_runner_module.BreakableCUDAGraphWrapper,
++        "clear_all_graphs",
++        lambda: events.append("clear-breakable"),
++    )
++    monkeypatch.setattr(torch.accelerator, "synchronize", lambda: None)
++    monkeypatch.setattr(torch.accelerator, "empty_cache", lambda: None)
++    monkeypatch.setattr(torch.accelerator, "get_memory_info", lambda: (1000, 0))
++
++    expected_error = "expected cleanup failure" if cleanup_fails else "capture failure"
++    with pytest.raises(RuntimeError, match=expected_error):
++        runner.profile_cudagraph_memory()
++
++    assert wrapper.graph_pool is original_pool
++    if not cleanup_fails:
++        assert events.index("clear-target") < events.index("cleanup")
++        assert events.index("cleanup-sync") < events.index("cleanup")
++        assert events.index("cleanup") < events.index(("rollback", checkpoint))
++    assert events[-1] == ("rollback", checkpoint)
+diff --git a/vllm/config/quantization.py b/vllm/config/quantization.py
+index b1a42cd8bfd5527cbb1e00caef4a0bb65f2fa7cf..826704b1918f71bdde8f587db64b75237b63fd41 100644
+--- a/vllm/config/quantization.py
++++ b/vllm/config/quantization.py
+@@ -153,11 +153,14 @@ ONLINE_QUANT_SHORTHAND_NAMES: tuple[str, ...] = (
+ )
+ 
+ 
+-# Checkpoint formats that support overlaying online quantization on BF16 projections
+-# which the checkpoint explicitly leaves unquantized (shared experts via
+-# `shared_experts`, other dense linears via `linear`).
+-_MODELOPT_ONLINE_OVERLAY_NAMES = frozenset(
+-    {
++# Checkpoint formats that support overlaying online quantization on projections
++# which the checkpoint explicitly leaves in BF16 (shared experts via
++# `shared_experts`, other dense linears via `linear`). Each checkpoint backend
++# still owns the layer-level dispatch, so serialized weights always take
++# precedence over this overlay.
++_CHECKPOINT_ONLINE_OVERLAY_WEIGHTS = {
++    name: frozenset({kMxfp8Dynamic, kFp8Static128BlockSym})
++    for name in {
+         "modelopt",
+         "modelopt_fp4",
+         "modelopt_mxfp8",
+@@ -165,16 +168,15 @@ _MODELOPT_ONLINE_OVERLAY_NAMES = frozenset(
+         "mxfp4",
+         "nvfp4_nf3_hybrid",
+     }
+-)
+-
+-
+-_MODELOPT_ONLINE_OVERLAY_WEIGHTS = frozenset({kMxfp8Dynamic, kFp8Static128BlockSym})
++}
++_CHECKPOINT_ONLINE_OVERLAY_WEIGHTS["exl3"] = frozenset({kMxfp8Dynamic})
+ 
+ 
+-def _is_modelopt_online_overlay(
++def _is_checkpoint_online_overlay(
+     quantization: str | None, args: QuantizationConfigArgs
+ ) -> bool:
+-    if quantization not in _MODELOPT_ONLINE_OVERLAY_NAMES or args.moe is not None:
++    supported_weights = _CHECKPOINT_ONLINE_OVERLAY_WEIGHTS.get(quantization)
++    if supported_weights is None or args.moe is not None:
+         return False
+     specs = [s for s in (args.linear, args.shared_experts) if s is not None]
+     if not specs:
+@@ -183,8 +185,7 @@ def _is_modelopt_online_overlay(
+         # `ignore` only filters the dense-linear overlay.
+         return False
+     return all(
+-        spec.weight in _MODELOPT_ONLINE_OVERLAY_WEIGHTS and spec.activation is None
+-        for spec in specs
++        spec.weight in supported_weights and spec.activation is None for spec in specs
+     )
+ 
+ 
+@@ -192,28 +193,39 @@ def resolve_quantization_config(
+     quantization: str | None,
+     quantization_config: dict[str, Any] | QuantizationConfigArgs | None,
+ ) -> QuantizationConfigArgs | None:
+-    """Resolve `--quantization` shorthand and `--quantization-config` into a
+-    QuantizationConfigArgs.
++    """Resolve quantization CLI settings into structured arguments.
+ 
+     `quantization` may be a CLI shorthand that desugars into a base config via
+     `_ONLINE_SHORTHANDS`. `quantization_config` is a dict or pre-built args
+     object. When both are online settings, fields explicitly set in
+-    `quantization_config` take precedence over the shorthand. ModelOpt accepts
+-    online overlays for BF16 dense/shared-expert projections.
++    `quantization_config` take precedence over the shorthand. Selected
++    checkpoint formats accept online overlays for BF16 dense/shared-expert
++    projections.
++
++    Args:
++        quantization: Quantization method name or online shorthand.
++        quantization_config: Explicit online quantization fields, if any.
++
++    Returns:
++        The resolved quantization arguments, or ``None`` when no online
++        configuration was requested.
++
++    Raises:
++        ValueError: If an explicit configuration cannot overlay the selected
++            checkpoint quantization method.
+     """
+     if isinstance(quantization_config, dict):
+         quantization_config = QuantizationConfigArgs(**quantization_config)
+ 
+     if quantization is not None and quantization not in ONLINE_QUANT_SHORTHAND_NAMES:
+-        if quantization_config is not None and not _is_modelopt_online_overlay(
++        if quantization_config is not None and not _is_checkpoint_online_overlay(
+             quantization, quantization_config
+         ):
+             raise ValueError(
+                 f"quantization_config is only supported when quantization is "
+                 f"one of {sorted(ONLINE_QUANT_SHORTHAND_NAMES)}, or when "
+-                f"using the ModelOpt online overlay (weight='mxfp8' or "
+-                f"weight='fp8_per_block_static' on 'shared_experts' and/or "
+-                f"'linear', optional 'ignore'), "
++                f"using a supported checkpoint online overlay on "
++                f"'shared_experts' and/or 'linear' (optional 'ignore'), "
+                 f"got quantization={quantization!r}"
+             )
+         return quantization_config
+diff --git a/vllm/distributed/device_communicators/cuda_communicator.py b/vllm/distributed/device_communicators/cuda_communicator.py
+index 82fa3723ed1030b01c303412ca594d8ed915e7ec..60ca32c96315b29d7dfbcd6ae430faf533a7e9c4 100644
+--- a/vllm/distributed/device_communicators/cuda_communicator.py
++++ b/vllm/distributed/device_communicators/cuda_communicator.py
+@@ -662,11 +662,14 @@ class CudaCommunicator(DeviceCommunicatorBase):
+             raise ValueError("No PyNCCL communicator found")
+ 
+     def destroy(self):
++        if self.ca_comm is not None:
++            # B12X close is coordinated across ranks and must run before
++            # its NCCL exchange group is destroyed.
++            self.ca_comm.close()
++            self.ca_comm = None
+         if self.pynccl_comm is not None:
+             self.pynccl_comm.destroy()
+             self.pynccl_comm = None
+-        if self.ca_comm is not None:
+-            self.ca_comm = None
+         if self.aiter_ar_comm is not None:
+             self.aiter_ar_comm.close()
+             self.aiter_ar_comm = None
+diff --git a/vllm/distributed/device_communicators/cuda_wrapper.py b/vllm/distributed/device_communicators/cuda_wrapper.py
+index a5026163e9342506c0f04af18a652cc133034beb..188a86a401ac300363bfdd00ef67eff2e33621d2 100644
+--- a/vllm/distributed/device_communicators/cuda_wrapper.py
++++ b/vllm/distributed/device_communicators/cuda_wrapper.py
+@@ -48,6 +48,8 @@ class CudaRTLibrary:
+         Function("cudaDeviceReset", cudaError_t, []),
+         # const char* 	cudaGetErrorString ( cudaError_t error )
+         Function("cudaGetErrorString", ctypes.c_char_p, [cudaError_t]),
++        # cudaError_t cudaGetLastError ( void )
++        Function("cudaGetLastError", cudaError_t, []),
+         # ​cudaError_t 	cudaMalloc ( void** devPtr, size_t size )
+         Function(
+             "cudaMalloc",
+@@ -86,6 +88,7 @@ class CudaRTLibrary:
+         "cudaDeviceSynchronize": "hipDeviceSynchronize",
+         "cudaDeviceReset": "hipDeviceReset",
+         "cudaGetErrorString": "hipGetErrorString",
++        "cudaGetLastError": "hipGetLastError",
+         "cudaMalloc": "hipMalloc",
+         "cudaFree": "hipFree",
+         "cudaMemset": "hipMemset",
+@@ -142,6 +145,14 @@ class CudaRTLibrary:
+     def cudaGetErrorString(self, error: cudaError_t) -> str:
+         return self.funcs["cudaGetErrorString"](error).decode("utf-8")
+ 
++    def cudaGetLastError(self) -> int:
++        """Return and clear the calling thread's pending runtime error.
++
++        Returns:
++            The CUDA or HIP runtime error code that was cleared.
++        """
++        return int(self.funcs["cudaGetLastError"]())
++
+     def cudaSetDevice(self, device: int) -> None:
+         self.CUDART_CHECK(self.funcs["cudaSetDevice"](device))
+ 
+diff --git a/vllm/distributed/device_communicators/custom_all_reduce.py b/vllm/distributed/device_communicators/custom_all_reduce.py
+index 3933ef27ed57fb581113e9f2a2ca3c13df2c5cd2..0ab989c952b297ca2e73a595c846a81ec145faf7 100644
+--- a/vllm/distributed/device_communicators/custom_all_reduce.py
++++ b/vllm/distributed/device_communicators/custom_all_reduce.py
+@@ -31,15 +31,19 @@ except Exception:
+ 
+ logger = init_logger(__name__)
+ 
+-_B12X_PCIE_EAGER_CHANNEL_ID = "eager:vllm-tp-allreduce"
++# The eager scheduler has one stable all-reduce stream owner.  Never derive
++# this identity from a process-local CUDA stream handle; B12X deliberately
++# fails closed if the same logical owner is rebound to a second eager stream.
++_B12X_PCIE_EAGER_CHANNEL_ID = "vllm:eager:allreduce"
++_B12X_PCIE_MAX_CONCURRENT_CHANNELS = 2
+ 
+ 
+ def _get_pcie_allreduce_backend() -> str:
+     backend = envs.VLLM_PCIE_ALLREDUCE_BACKEND.lower()
+-    if backend not in {"b12x", "cpp"}:
++    if backend not in {"b12x", "cpp", "flashinfer-ipc"}:
+         raise ValueError(
+             "Invalid VLLM_PCIE_ALLREDUCE_BACKEND: "
+-            f"{backend!r}. Valid values: b12x, cpp."
++            f"{backend!r}. Valid values: b12x, cpp, flashinfer-ipc."
+         )
+     return backend
+ 
+@@ -48,6 +52,13 @@ def _b12x_pcie_allreduce_requested() -> bool:
+     return envs.VLLM_ENABLE_PCIE_ALLREDUCE and _get_pcie_allreduce_backend() == "b12x"
+ 
+ 
++def _flashinfer_pcie_allreduce_requested() -> bool:
++    return (
++        envs.VLLM_ENABLE_PCIE_ALLREDUCE
++        and _get_pcie_allreduce_backend() == "flashinfer-ipc"
++    )
++
++
+ def _is_piecewise_cudagraph_runtime() -> bool:
+     try:
+         from vllm.config import CUDAGraphMode
+@@ -121,6 +132,17 @@ def _load_b12x_pcie_dma() -> Any | None:
+     return PCIeDmaAllReduce
+ 
+ 
++@lru_cache(maxsize=1)
++def _load_flashinfer_pcie_oneshot_pool() -> Any | None:
++    try:
++        from vllm.distributed.device_communicators.flashinfer_pcie_all_reduce import (
++            FlashInferPcieIpcAllReducePool,
++        )
++    except Exception:
++        return None
++    return FlashInferPcieIpcAllReducePool
++
++
+ def _get_physical_device_numa_node(physical_device_id: int) -> int | None:
+     try:
+         import pynvml
+@@ -269,6 +291,7 @@ class CustomAllreduce:
+         self._cpp_ar_cutoff_size: int | None = None
+         self._cpp_ar_ignore_cutoff_max_rows = 0
+         self._pcie_cpp_backend = False
++        self._pcie_backend_name: str | None = None
+         self._pcie_logged_first_allreduce = False
+         self._ptr = 0
+ 
+@@ -304,9 +327,11 @@ class CustomAllreduce:
+             return
+ 
+         b12x_pcie_requested = _b12x_pcie_allreduce_requested()
++        flashinfer_pcie_requested = _flashinfer_pcie_allreduce_requested()
++        integrated_pcie_requested = b12x_pcie_requested or flashinfer_pcie_requested
+         if (
+             world_size not in CustomAllreduce._SUPPORTED_WORLD_SIZES
+-            and not b12x_pcie_requested
++            and not integrated_pcie_requested
+         ):
+             logger.warning(
+                 "Custom allreduce is disabled due to an unsupported world"
+@@ -363,16 +388,17 @@ class CustomAllreduce:
+         assert current_platform.is_cuda_alike()
+         fully_connected = current_platform.is_fully_connected(physical_device_ids)
+         use_pcie_oneshot = False
+-        if b12x_pcie_requested:
++        if integrated_pcie_requested:
+             if not current_platform.is_cuda():
+                 logger.warning(
+-                    "Custom allreduce is disabled because b12x PCIe oneshot "
+-                    "allreduce requires CUDA."
++                    "Custom allreduce is disabled because the integrated "
++                    "PCIe oneshot backend requires CUDA."
+                 )
+                 return
+             logger.debug(
+-                "b12x PCIe oneshot allreduce requested "
++                "%s PCIe oneshot allreduce requested "
+                 "(world_size=%d, physical_device_ids=%s, fully_connected=%s).",
++                _get_pcie_allreduce_backend(),
+                 world_size,
+                 physical_device_ids,
+                 fully_connected,
+@@ -429,21 +455,28 @@ class CustomAllreduce:
+             return
+ 
+         if use_pcie_oneshot:
++            pcie_backend = _get_pcie_allreduce_backend()
+             allow_cross_numa = envs.VLLM_PCIE_ONESHOT_ALLOW_CROSS_NUMA
+             if _is_cross_numa_topology(physical_device_ids) and not allow_cross_numa:
+                 logger.warning(
+-                    "Custom allreduce is disabled because b12x PCIe oneshot "
++                    "Custom allreduce is disabled because %s PCIe oneshot "
+                     "allreduce was requested on a cross-NUMA PCIe topology "
+                     "(physical_device_ids=%s). Set "
+                     "VLLM_PCIE_ONESHOT_ALLOW_CROSS_NUMA=1 or unset it to force it.",
++                    pcie_backend,
+                     physical_device_ids,
+                 )
+                 return
+-            pool_cls = _load_b12x_pcie_oneshot_pool()
++            pool_cls = (
++                _load_b12x_pcie_oneshot_pool()
++                if pcie_backend == "b12x"
++                else _load_flashinfer_pcie_oneshot_pool()
++            )
+             if pool_cls is None:
+                 logger.warning(
+-                    "PCIe custom allreduce was requested, but "
+-                    "b12x.comm.pcie.OneshotAllReducePool is unavailable."
++                    "%s PCIe custom allreduce was requested, but its runtime "
++                    "is unavailable.",
++                    pcie_backend,
+                 )
+                 return
+             # DMA must accommodate the largest scheduled prefill tensor. The
+@@ -461,7 +494,8 @@ class CustomAllreduce:
+                 max_num_batched_tokens = 8192
+                 logger.warning(
+                     "vLLM config unavailable during CustomAllreduce init; "
+-                    "allocating b12x PCIe buffers for hidden=%d, rows<=%d.",
++                    "allocating %s PCIe buffers for hidden=%d, rows<=%d.",
++                    pcie_backend,
+                     model_hidden_size,
+                     max_num_batched_tokens,
+                 )
+@@ -474,8 +508,9 @@ class CustomAllreduce:
+             ) = _b12x_pcie_oneshot_limits()
+             if self.nccl_group is None:
+                 logger.warning(
+-                    "Custom allreduce is disabled because b12x PCIe oneshot "
+-                    "allreduce requires a CUDA/NCCL device process group."
++                    "Custom allreduce is disabled because %s PCIe oneshot "
++                    "allreduce requires a CUDA/NCCL device process group.",
++                    pcie_backend,
+                 )
+                 return
+             self.max_size = pcie_buffer_size
+@@ -491,10 +526,15 @@ class CustomAllreduce:
+                     eager_buffer_bytes=pcie_oneshot_buffer_size,
+                     max_size=pcie_oneshot_buffer_size,
+                     single_channel=pcie_single_channel,
++                    max_concurrent_channels=_B12X_PCIE_MAX_CONCURRENT_CHANNELS,
+                 )
+                 if not pcie_single_channel:
+                     pcie_runtime.prepare_channels((_B12X_PCIE_EAGER_CHANNEL_ID,))
+-                pcie_runtime.for_stream(channel_id=_B12X_PCIE_EAGER_CHANNEL_ID)
++                pcie_runtime.for_stream(
++                    channel_id=(
++                        None if pcie_single_channel else _B12X_PCIE_EAGER_CHANNEL_ID
++                    )
++                )
+             except Exception as exc:
+                 pcie_init_error = exc
+ 
+@@ -507,25 +547,35 @@ class CustomAllreduce:
+                     pcie_runtime.close()
+                 if pcie_init_error is not None:
+                     logger.warning(
+-                        "b12x PCIe oneshot allreduce initialization failed on "
++                        "%s PCIe oneshot allreduce initialization failed on "
+                         "rank %d: %s. Falling back to PyNCCL allreduce.",
++                        pcie_backend,
+                         rank,
+                         pcie_init_error,
+                     )
+                 else:
+                     logger.warning(
+-                        "b12x PCIe oneshot allreduce initialization failed on "
+-                        "another TP rank. Falling back to PyNCCL allreduce."
++                        "%s PCIe oneshot allreduce initialization failed on "
++                        "another TP rank. Falling back to PyNCCL allreduce.",
++                        pcie_backend,
+                     )
+                 return
+             assert pcie_runtime is not None
+             self._pcie_runtime = pcie_runtime
++            self._pcie_backend_name = pcie_backend
+             # Prefill-size DMA allreduce alongside the oneshot. A deployment
+             # preflight can tune its crossover or disable it when lossless DMA
+             # never beats NCCL on the selected PCIe topology.
+-            dma_min_bytes = _b12x_pcie_dma_min_bytes()
++            dma_min_bytes = (
++                _b12x_pcie_dma_min_bytes() if pcie_backend == "b12x" else None
++            )
+             dma_cls = None if dma_min_bytes is None else _load_b12x_pcie_dma()
+-            if dma_min_bytes is None:
++            if pcie_backend != "b12x":
++                logger.info(
++                    "FlashInfer PCIe IPC handles only tuned one-shot shapes; "
++                    "larger allreduces stay on PyNCCL."
++                )
++            elif dma_min_bytes is None:
+                 logger.info(
+                     "b12x PCIe DMA allreduce disabled by "
+                     "VLLM_PCIE_DMA_MIN_BYTES=off; large allreduces stay on PyNCCL."
+@@ -579,19 +629,21 @@ class CustomAllreduce:
+ 
+             if rank == 0:
+                 logger.info(
+-                    "Configured b12x PCIe crossovers: "
++                    "Configured %s PCIe crossovers: "
+                     "oneshot max=%d, fused max=%d, DMA min=%s.",
++                    pcie_backend,
+                     self._pcie_allreduce_max_size,
+                     self._pcie_fused_add_rms_norm_max_size,
+                     dma_min_bytes if dma_min_bytes is not None else "off",
+                 )
+             self.disabled = False
+             logger.debug(
+-                "Using b12x PCIe oneshot allreduce backend "
++                "Using %s PCIe oneshot allreduce backend "
+                 "(world_size=%d, allreduce_max_size=%d, "
+                 "fused_add_rms_norm_max_size=%d, oneshot_buffer_size=%d, "
+                 "dma_buffer_size=%d, "
+                 "single_channel=%s).",
++                pcie_backend,
+                 world_size,
+                 self._pcie_allreduce_max_size,
+                 self._pcie_fused_add_rms_norm_max_size,
+@@ -670,8 +722,16 @@ class CustomAllreduce:
+ 
+         Legacy custom all-reduce registers graph buffers on exit. B12X
+         PCIe channels are instead created on the graph's owning stream and
+-        remain valid for the graph lifetime. Distributed B12X capture requires
+-        a rank-stable semantic ``channel_id``.
++        remain valid for the graph lifetime.
++
++        Args:
++            stream: CUDA stream owned by the enclosing graph capture.
++            channel_id: Stable identity shared by every rank for this graph
++                owner. Required when the B12X PCIe runtime is active.
++
++        Raises:
++            RuntimeError: If the PCIe runtime is active and ``channel_id`` is
++                ``None``.
+         """
+         old_pcie_capture_stream = self._pcie_capture_stream
+         old_pcie_capture_channel_id = self._pcie_capture_channel_id
+@@ -680,6 +740,11 @@ class CustomAllreduce:
+             if self._pcie_runtime is None:
+                 yield
+             else:
++                if channel_id is None:
++                    raise RuntimeError(
++                        "distributed PCIe graph capture requires an explicit "
++                        "semantic channel_id"
++                    )
+                 self._pcie_capture_stream = stream
+                 self._pcie_capture_channel_id = channel_id
+                 with self._pcie_runtime.capture(
+@@ -815,6 +880,8 @@ class CustomAllreduce:
+ 
+     def backend_name(self) -> str:
+         if self._pcie_runtime is not None:
++            if self._pcie_backend_name == "flashinfer-ipc":
++                return "FLASHINFER_PCIE_IPC"
+             if self._pcie_dma is not None:
+                 return "B12X_PCIE_ONESHOT_DMA"
+             return "B12X_PCIE_ONESHOT"
+@@ -949,6 +1016,24 @@ class CustomAllreduce:
+                 # all-reduce; returning a placeholder is only valid for warmup.
+                 if _is_piecewise_cudagraph_runtime():
+                     return self.all_reduce(input, registered=False)
++                # The warmup intentionally skips communication, but CuTe-based
++                # PCIe launchers still need their graph specialization loaded
++                # before the nested Inductor capture starts.
++                inp_size = input.numel() * input.element_size()
++                prepare_graph_all_reduce = getattr(
++                    self._pcie_runtime,
++                    "prepare_graph_all_reduce",
++                    None,
++                )
++                if (
++                    prepare_graph_all_reduce is not None
++                    and self._pcie_allreduce_max_size is not None
++                    and inp_size <= self._pcie_allreduce_max_size
++                ):
++                    prepare_graph_all_reduce(
++                        input,
++                        stream=self._pcie_runtime_stream(),
++                    )
+                 # If warm up, mimic the allocation pattern since custom
+                 # allreduce is out-of-place.
+                 return torch.empty_like(input)
+@@ -959,12 +1044,12 @@ class CustomAllreduce:
+             return self.all_reduce(input, registered=False)
+ 
+     def close(self):
+-        if self._pcie_dma is not None:
+-            self._pcie_dma.close()
+-            self._pcie_dma = None
+         if self._pcie_runtime is not None:
+             self._pcie_runtime.close()
+             self._pcie_runtime = None
++        if self._pcie_dma is not None:
++            self._pcie_dma.close()
++            self._pcie_dma = None
+         if not self.disabled and self._ptr:
+             if ops is not None:
+                 ops.dispose(self._ptr)
+@@ -972,7 +1057,16 @@ class CustomAllreduce:
+             self.free_shared_buffer(self.meta_ptrs, rank=self.rank)
+             self.free_shared_buffer(self.buffer_ptrs, rank=self.rank)
+ 
+-    def __del__(self):
++    def __del__(self) -> None:
++        # A finalizer cannot collectively close B12X after another rank
++        # has exited or vLLM has destroyed the process group. The backend owns
++        # abnormal resource finalization; explicit close() is coordinated by
++        # CudaCommunicator.destroy() while both process groups are still live.
++        if (
++            getattr(self, "_pcie_runtime", None) is not None
++            or getattr(self, "_pcie_dma", None) is not None
++        ):
++            return
+         self.close()
+ 
+     @staticmethod
+diff --git a/vllm/distributed/device_communicators/flashinfer_pcie_all_reduce.py b/vllm/distributed/device_communicators/flashinfer_pcie_all_reduce.py
+new file mode 100644
+index 0000000000000000000000000000000000000000..1d3b43082c028a21f45c57b88e6a218330884069
+--- /dev/null
++++ b/vllm/distributed/device_communicators/flashinfer_pcie_all_reduce.py
+@@ -0,0 +1,208 @@
++# SPDX-License-Identifier: Apache-2.0
++# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
++
++"""Stream-isolated adapter for FlashInfer's PCIe IPC all-reduce."""
++
++from __future__ import annotations
++
++from collections.abc import Iterator, Sequence
++from contextlib import contextmanager
++from functools import lru_cache
++from typing import Any
++
++import torch
++import torch.distributed as dist
++from torch.distributed import ProcessGroup
++
++
++@lru_cache(maxsize=1)
++def _load_workspace_class() -> type:
++    from flashinfer.comm import PcieIpcAllReduceWorkspace
++
++    return PcieIpcAllReduceWorkspace
++
++
++class _FlashInferPcieChannel:
++    def __init__(
++        self,
++        owner: FlashInferPcieIpcAllReducePool,
++        channel_id: str,
++    ) -> None:
++        self._owner = owner
++        self._channel_id = channel_id
++
++    def should_allreduce(self, inp: torch.Tensor) -> bool:
++        return self._owner._workspace(self._channel_id).supports(inp)
++
++    def register_graph_buffers(self) -> None:
++        # FlashInfer owns fixed IPC slabs; graph replay does not register input
++        # pointers with the legacy vLLM custom-allreduce runtime.
++        return None
++
++
++class FlashInferPcieIpcAllReducePool:
++    """Give every eager/CUDA-graph owner a distinct FlashInfer workspace.
++
++    FlashInfer's protocol state is stream-affine. vLLM may own an eager stream
++    plus independent target and draft CUDA-graph streams, so sharing one
++    workspace would permit their epochs to interleave. Semantic ``channel_id``
++    values provide a rank-stable key and one IPC workspace is allocated for
++    each live channel.
++    """
++
++    _EAGER_CHANNEL_ID = "vllm:eager:allreduce"
++
++    def __init__(
++        self,
++        *,
++        exchange_group: ProcessGroup,
++        device: torch.device | int | str,
++        max_size: int,
++        single_channel: bool = False,
++    ) -> None:
++        self.group = exchange_group
++        self.device = torch.device(device)
++        self.rank = dist.get_rank(group=exchange_group)
++        self.world_size = dist.get_world_size(group=exchange_group)
++        self.max_size = max_size
++        self.max_numel = max_size // torch.bfloat16.itemsize
++        self.single_channel = single_channel
++        self._workspaces: dict[str, Any] = {}
++        self._active_channel_id: str | None = None
++        self._closed = False
++
++        if max_size <= 0 or max_size % 16:
++            raise ValueError(
++                "FlashInfer PCIe IPC max_size must be a positive multiple "
++                f"of 16 bytes, got {max_size}"
++            )
++        # Workspace creation is collective. Keep construction allocation-free so
++        # the integration layer can prepare semantic channels at a rank-stable
++        # lifecycle point; standalone callers may still create them on first use.
++
++    @classmethod
++    def from_exchange_group(
++        cls,
++        *,
++        exchange_group: ProcessGroup,
++        device: torch.device | int | str,
++        eager_buffer_bytes: int,
++        max_size: int,
++        single_channel: bool = False,
++        max_concurrent_channels: int | None = None,
++        **_: Any,
++    ) -> FlashInferPcieIpcAllReducePool:
++        del eager_buffer_bytes, max_concurrent_channels
++        return cls(
++            exchange_group=exchange_group,
++            device=device,
++            max_size=max_size,
++            single_channel=single_channel,
++        )
++
++    def _canonical_channel_id(self, channel_id: str | None) -> str:
++        if self.single_channel or channel_id is None:
++            return self._EAGER_CHANNEL_ID
++        return channel_id
++
++    def _verify_channel_id(self, channel_id: str) -> None:
++        gathered: list[str | None] = [None] * self.world_size
++        dist.all_gather_object(gathered, channel_id, group=self.group)
++        if any(peer != channel_id for peer in gathered):
++            raise RuntimeError(
++                "FlashInfer PCIe IPC channel creation must be rank-stable; "
++                f"received {gathered}"
++            )
++
++    def _workspace(self, channel_id: str | None) -> Any:
++        if self._closed:
++            raise RuntimeError("FlashInfer PCIe IPC pool is closed")
++        key = self._canonical_channel_id(channel_id)
++        workspace = self._workspaces.get(key)
++        if workspace is None:
++            self._verify_channel_id(key)
++            workspace = _load_workspace_class()(
++                group=self.group,
++                max_numel=self.max_numel,
++                dtype=torch.bfloat16,
++            )
++            self._workspaces[key] = workspace
++        return workspace
++
++    def prepare_channels(self, channel_ids: Sequence[str]) -> None:
++        for channel_id in channel_ids:
++            self._workspace(channel_id)
++
++    def for_stream(
++        self,
++        stream: torch.cuda.Stream | None = None,
++        *,
++        channel_id: str | None = None,
++    ) -> _FlashInferPcieChannel:
++        del stream
++        key = self._canonical_channel_id(channel_id)
++        self._workspace(key)
++        return _FlashInferPcieChannel(self, key)
++
++    @contextmanager
++    def capture(
++        self,
++        stream: torch.cuda.Stream | None = None,
++        *,
++        channel_id: str | None = None,
++    ) -> Iterator[FlashInferPcieIpcAllReducePool]:
++        del stream
++        key = self._canonical_channel_id(channel_id)
++        self._workspace(key)
++        previous = self._active_channel_id
++        self._active_channel_id = key
++        try:
++            yield self
++        finally:
++            self._active_channel_id = previous
++
++    def prepare_graph_all_reduce(
++        self,
++        inp: torch.Tensor,
++        *,
++        stream: torch.cuda.Stream | None = None,
++    ) -> None:
++        del stream
++        channel_id = self._active_channel_id or self._EAGER_CHANNEL_ID
++        if not self._workspace(channel_id).supports(inp):
++            raise ValueError(
++                "FlashInfer PCIe IPC graph warmup received an unsupported "
++                f"shape {tuple(inp.shape)}"
++            )
++
++    def all_reduce(
++        self,
++        inp: torch.Tensor,
++        *,
++        out: torch.Tensor | None = None,
++        stream: torch.cuda.Stream | None = None,
++        channel_id: str | None = None,
++    ) -> torch.Tensor:
++        workspace = self._workspace(channel_id)
++        if stream is None or torch.cuda.current_stream(self.device) == stream:
++            return workspace.all_reduce(inp, out=out)
++        with torch.cuda.stream(stream):
++            return workspace.all_reduce(inp, out=out)
++
++    def checkpoint_channels(self) -> tuple[str, ...]:
++        return tuple(self._workspaces)
++
++    def rollback_channels(self, checkpoint: tuple[str, ...]) -> None:
++        retained = set(checkpoint)
++        for channel_id in reversed(tuple(self._workspaces)):
++            if channel_id in retained:
++                continue
++            self._workspaces.pop(channel_id).destroy()
++
++    def close(self) -> None:
++        if self._closed:
++            return
++        for workspace in reversed(tuple(self._workspaces.values())):
++            workspace.destroy()
++        self._workspaces.clear()
++        self._closed = True
+diff --git a/vllm/distributed/kv_transfer/kv_connector/v1/offloading/scheduler.py b/vllm/distributed/kv_transfer/kv_connector/v1/offloading/scheduler.py
+index 0d15ec22fdf9fd5cb41245495b073b0b6388f9d2..15ce871a1598eb1e81fc4f23f93067a6e7caef3a 100644
+--- a/vllm/distributed/kv_transfer/kv_connector/v1/offloading/scheduler.py
++++ b/vllm/distributed/kv_transfer/kv_connector/v1/offloading/scheduler.py
+@@ -6,6 +6,7 @@ from dataclasses import dataclass, field
+ from itertools import chain, islice
+ from typing import Any, NamedTuple
+ 
++import vllm.envs as envs
+ from vllm.config import VllmConfig
+ from vllm.distributed.kv_events import KVCacheEvent
+ from vllm.distributed.kv_transfer.kv_connector.utils import yield_req_data
+@@ -84,10 +85,11 @@ class GroupOffloadConfig(NamedTuple):
+     kv_event_group_spec: OffloadingEventGroupSpec
+     # None below means full attention
+     sliding_window_size_in_chunks: int | None
+-    # Number of this group's offloaded chunks per full-attention alignment
+-    # segment. Used to skip storing SWA chunks that can never serve a load
+-    # hit (e.g. DeepSeek V4 where SWA groups have much smaller block sizes
+-    # than the MLA full-attention group).
++    # Number of this group's offloaded chunks per sparsity segment (the
++    # full-attention alignment size, or VLLM_PREFIX_CACHE_RETENTION_INTERVAL
++    # when sparse retention is configured). Used to skip storing SWA chunks
++    # that can never serve a load hit (e.g. DeepSeek V4 where SWA groups have
++    # much smaller block sizes than the MLA full-attention group).
+     # None for full-attention groups or when the optimization doesn't apply.
+     alignment_chunk_count: int | None = None
+     # True for EAGLE/MTP draft-model attention groups. The trailing chunk
+@@ -136,6 +138,11 @@ class SchedulerOffloadConfig(NamedTuple):
+     blocks_per_chunk: int
+     num_workers: int
+     offload_prompt_only: bool
++    # Token alignment of the per-request "replay boundary" tail (see
++    # OffloadingConnectorScheduler._replay_tail_end_chunk). Set to the
++    # full-attention alignment size when sparse retention
++    # (VLLM_PREFIX_CACHE_RETENTION_INTERVAL) is enabled, else None.
++    replay_alignment_tokens: int | None = None
+ 
+     @classmethod
+     def from_spec(
+@@ -164,16 +171,34 @@ class SchedulerOffloadConfig(NamedTuple):
+         if len(full_attn_tokens_per_chunk) == 1:
+             alignment_tokens = full_attn_tokens_per_chunk.pop()
+ 
++        # Mirror SlidingWindowManager.reachable_block_mask's segment-size
++        # choice: with sparse retention (VLLM_PREFIX_CACHE_RETENTION_INTERVAL)
++        # the local GPU prefix cache keeps SWA tails once per retention
++        # segment rather than at every full-attention block boundary. Use the
++        # same granularity so stored tails sit exactly where lookups converge.
++        # An interval of 0 (latest-boundary-only retention) disables the
++        # store-side skip entirely (conservative: store all chunks).
++        retention_interval = envs.VLLM_PREFIX_CACHE_RETENTION_INTERVAL
++        segment_tokens: int | None = (
++            alignment_tokens
++            if retention_interval is None
++            else (None if retention_interval == 0 else retention_interval)
++        )
++
+         def _alignment_chunk_count(
+             tokens_per_chunk: int,
+             sliding_window_size_in_chunks: int | None,
++            is_eagle_group: bool,
+         ) -> int | None:
+-            if alignment_tokens is None or sliding_window_size_in_chunks is None:
++            if segment_tokens is None or sliding_window_size_in_chunks is None:
+                 return None
+-            if alignment_tokens <= tokens_per_chunk:
++            if segment_tokens <= tokens_per_chunk:
+                 return None
+-            per_segment = alignment_tokens // tokens_per_chunk
+-            if sliding_window_size_in_chunks >= per_segment:
++            per_segment = segment_tokens // tokens_per_chunk
++            # Contiguous chunks a hit needs at a segment boundary, including
++            # the "+1 peek" chunk for EAGLE/MTP groups (see _lookup).
++            need = sliding_window_size_in_chunks + (1 if is_eagle_group else 0)
++            if need >= per_segment:
+                 return None
+             return per_segment
+ 
+@@ -216,7 +241,9 @@ class SchedulerOffloadConfig(NamedTuple):
+                         )
+                     ),
+                     alignment_chunk_count=_alignment_chunk_count(
+-                        tokens_per_block * spec.blocks_per_chunk, sw
++                        tokens_per_block * spec.blocks_per_chunk,
++                        sw,
++                        idx in eagle_groups,
+                     ),
+                     kv_event_group_spec=get_offloading_event_group_spec(
+                         kv_cache_config.kv_cache_groups[idx]
+@@ -227,6 +254,9 @@ class SchedulerOffloadConfig(NamedTuple):
+             ),
+             blocks_per_chunk=spec.blocks_per_chunk,
+             offload_prompt_only=spec.offload_prompt_only,
++            replay_alignment_tokens=(
++                alignment_tokens if retention_interval is not None else None
++            ),
+         )
+ 
+ 
+@@ -258,6 +288,8 @@ class RequestOffloadState:
+     # time.monotonic() of this request's first deferred offload lookup;
+     # None once consumed (observed) or while no lookup is pending.
+     deferred_lookup_start_time: float | None = None
++    # True once on_request_finished has been signaled to the manager.
++    finished_signaled: bool = False
+ 
+     def __post_init__(self) -> None:
+         self.group_states = tuple(
+@@ -413,6 +445,20 @@ class OffloadingConnectorScheduler:
+             spec, kv_cache_config
+         )
+ 
++        # Tokens that must remain past a replay boundary for it to be
++        # servable: the last prompt token is always recomputed (hence the
++        # default of 1), and each EAGLE/MTP group must be able to match one
++        # complete chunk past the boundary (its "+1 peek", dropped after
++        # verification in _lookup).
++        self._replay_reserve_tokens: int = max(
++            (
++                group_config.tokens_per_chunk
++                for group_config in self.config.kv_group_configs
++                if group_config.is_eagle_group
++            ),
++            default=1,
++        )
++
+         self._req_status: dict[ReqId, RequestOffloadState] = {}
+         self._current_batch_load_jobs: dict[int, TransferJob] = {}
+         self._current_batch_jobs_to_flush: set[int] = set()
+@@ -458,7 +504,10 @@ class OffloadingConnectorScheduler:
+         return job_id
+ 
+     def _remove_pending_job(self, job_id: int, block_ids: list[int] | None) -> None:
+-        for bid in block_ids or ():
++        # Lockstep MLA groups share physical block IDs, so a transfer job may
++        # contain the same ID once per logical group. The pending-job index is
++        # set-backed and therefore registers each (block, job) pair only once.
++        for bid in set(block_ids or ()):
+             pending = self._block_id_to_pending_jobs[bid]
+             pending.remove(job_id)
+             if not pending:
+@@ -475,13 +524,6 @@ class OffloadingConnectorScheduler:
+             num = min(num, req_status.req.num_prompt_tokens)
+         return num
+ 
+-    def _maybe_cleanup_finished_req(
+-        self, req_id: str, req_status: RequestOffloadState
+-    ) -> None:
+-        """Clean up req_status if finished and no in-flight jobs."""
+-        if req_status.req.is_finished() and not req_status.transfer_jobs:
+-            del self._req_status[req_id]
+-
+     def _maximal_prefix_lookup(
+         self, keys: Iterable[OffloadKey], req_context: ReqContext
+     ) -> int | None:
+@@ -943,6 +985,37 @@ class OffloadingConnectorScheduler:
+                         ):
+                             group_state.block_ids[j] = 0
+ 
++    def _reachable_tail_end_chunks(
++        self, group_config: GroupOffloadConfig, req: Request, shift: int
++    ) -> tuple[int, ...]:
++        """End chunk indices (exclusive) of serviceable boundary tails.
++
++        Mirrors the replay-boundary handling of
++        SlidingWindowManager.reachable_block_mask: with sparse retention,
++        segment tails exist only once per retention interval. Retain tails at
++        the request replay boundary and at a detected shared-prefix junction.
++        Clamp each boundary to the latest point that every group can service,
++        including a complete EAGLE/MTP peek chunk.
++        """
++        alignment_tokens = self.config.replay_alignment_tokens
++        if alignment_tokens is None:
++            return ()
++
++        latest_serviceable = req.num_prompt_tokens - self._replay_reserve_tokens
++        boundaries = [latest_serviceable]
++        if req.shared_prefix_boundary:
++            boundaries.append(min(req.shared_prefix_boundary, latest_serviceable))
++
++        ends: list[int] = []
++        for boundary in boundaries:
++            aligned = boundary // alignment_tokens * alignment_tokens
++            if aligned <= 0 or aligned % group_config.tokens_per_chunk != 0:
++                continue
++            end = aligned // group_config.tokens_per_chunk + shift
++            if end not in ends:
++                ends.append(end)
++        return tuple(ends)
++
+     def _build_store_jobs(
+         self,
+         scheduler_output: SchedulerOutput,
+@@ -995,28 +1068,50 @@ class OffloadingConnectorScheduler:
+ 
+                 alignment_chunk_count = group_config.alignment_chunk_count
+                 tail = group_config.sliding_window_size_in_chunks
++                # Chunks reachable by _sliding_window_lookup, mirroring
++                # SlidingWindowManager.reachable_block_mask: a hit needs
++                # `need` contiguous chunks ending at a segment boundary. For
++                # EAGLE/MTP groups the run includes the "+1 peek" chunk and
++                # is shifted one chunk past the boundary, so that after
++                # _lookup drops the peek the hit lands exactly on it.
++                need = shift = 0
++                reachable_end_chunks: tuple[int, ...] = ()
++                if alignment_chunk_count is not None:
++                    assert tail is not None
++                    shift = 1 if group_config.is_eagle_group else 0
++                    need = tail + shift
++                    reachable_end_chunks = self._reachable_tail_end_chunks(
++                        group_config, req, shift
++                    )
+ 
+                 for key_idx, (offload_key, block_id) in enumerate(
+                     zip(offload_keys, offload_block_ids)
+                 ):
+                     if block_id == 0:
+                         continue
+-                    # Skip SWA chunks that can never serve a load hit:
+-                    # within each full-attention alignment segment, only the
+-                    # trailing `tail` chunks are reachable by
++                    # Skip SWA chunks that can never serve a load hit: only
++                    # the trailing `need` chunks of each alignment segment
++                    # (plus the replay-boundary tail) are reachable by
+                     # _sliding_window_lookup. For DeepSeek V4 with 100K
+                     # tokens this reduces SWA stores by ~78%.
+                     if alignment_chunk_count is not None:
+-                        assert tail is not None
+                         abs_chunk_idx = start_chunk_idx + key_idx
+-                        pos_in_segment = abs_chunk_idx % alignment_chunk_count
+-                        if pos_in_segment < alignment_chunk_count - tail:
++                        reachable = (
++                            abs_chunk_idx >= shift
++                            and (abs_chunk_idx - shift) % alignment_chunk_count
++                            >= alignment_chunk_count - need
++                        )
++                        if not reachable:
++                            reachable = any(
++                                end - need <= abs_chunk_idx < end
++                                for end in reachable_end_chunks
++                            )
++                        if not reachable:
+                             continue
+                     new_offload_keys.append(offload_key)
+ 
+             if not new_offload_keys:
+                 req_status.advance_stored_idx(num_offloadable_tokens)
+-                self._maybe_cleanup_finished_req(req_id, req_status)
+                 continue
+ 
+             store_output = self.manager.prepare_store(
+@@ -1027,12 +1122,10 @@ class OffloadingConnectorScheduler:
+                     _ConnectorMetricName.ALLOCATION_FAILURE
+                 )
+                 logger.warning("Request %s: cannot store chunks", req_id)
+-                self._maybe_cleanup_finished_req(req_id, req_status)
+                 continue
+ 
+             if not store_output.keys_to_store:
+                 req_status.advance_stored_idx(num_offloadable_tokens)
+-                self._maybe_cleanup_finished_req(req_id, req_status)
+                 continue
+ 
+             self._touch(req_status)
+@@ -1176,6 +1269,17 @@ class OffloadingConnectorScheduler:
+             store_jobs=self._build_store_jobs(scheduler_output),
+             jobs_to_flush=self._current_batch_jobs_to_flush,
+         )
++
++        # prepare_store must remain valid until every final store has been
++        # submitted. Tiering managers may release per-request state here.
++        for req_id in scheduler_output.finished_req_ids or ():
++            req_status = self._req_status.get(req_id)
++            if req_status is None:
++                continue
++            req_status.finished_signaled = True
++            self.manager.on_request_finished(req_status.req_context)
++            if not req_status.transfer_jobs:
++                del self._req_status[req_id]
+         self._current_batch_load_jobs = {}
+         self._current_batch_jobs_to_flush = set()
+         self._current_batch_allocated_block_ids = set()
+@@ -1266,7 +1370,7 @@ class OffloadingConnectorScheduler:
+ 
+             del self._jobs[job_id]
+             req_status.transfer_jobs.remove(job_id)
+-            if not req_status.transfer_jobs and req_status.req.is_finished():
++            if req_status.finished_signaled and not req_status.transfer_jobs:
+                 del self._req_status[job_status.req_id]
+ 
+     def get_stats(self) -> OffloadingConnectorStats | None:
+@@ -1308,7 +1412,6 @@ class OffloadingConnectorScheduler:
+             self.manager.on_request_finished(req_context)
+             return False, None
+ 
+-        self.manager.on_request_finished(req_status.req_context)
+         self._maybe_observe_lookup_async_delay(req_status)
+ 
+         # Update offload keys with final block hash so _build_store_jobs can
+@@ -1352,6 +1455,8 @@ class OffloadingConnectorScheduler:
+ 
+         for req_id, status in list(self._req_status.items()):
+             if status.req.is_finished():
++                if not status.finished_signaled:
++                    self.manager.on_request_finished(status.req_context)
+                 del self._req_status[req_id]
+ 
+         # Reset offloading manager cache
+diff --git a/vllm/distributed/parallel_state.py b/vllm/distributed/parallel_state.py
+index b8f4bcb087e3498ef0f6d349c2a82098eaf5448e..1a71847b7934298bbf16ff53c4256b37e6d5de12 100644
+--- a/vllm/distributed/parallel_state.py
++++ b/vllm/distributed/parallel_state.py
+@@ -1265,14 +1265,14 @@ class GroupCoordinator:
+         return self.device_communicator.recv(size, dtype, src)
+ 
+     def destroy(self):
++        if self.device_communicator is not None:
++            self.device_communicator.destroy()
+         if hasattr(self, "device_group"):
+             torch.distributed.destroy_process_group(self.device_group)
+             del self.device_group
+         if hasattr(self, "cpu_group"):
+             torch.distributed.destroy_process_group(self.cpu_group)
+             del self.cpu_group
+-        if self.device_communicator is not None:
+-            self.device_communicator.destroy()
+         if self.mq_broadcaster is not None:
+             self.mq_broadcaster = None
+ 
+@@ -1546,6 +1546,11 @@ def _validate_indexer_shard_count(indexer_shards: int, dcp_size: int) -> None:
+         )
+ 
+ 
++def _needs_indexer_replica_groups(indexer_shards: int, dcp_size: int) -> bool:
++    """Return whether the indexer needs replica-specific process groups."""
++    return 1 <= indexer_shards < dcp_size
++
++
+ _DCP_CKV_PREFETCH: GroupCoordinator | None = None
+ 
+ 
+@@ -1655,8 +1660,8 @@ def graph_capture(
+     is capturing the CUDA graph. Its main purpose is to ensure that some
+     operations will be run after the graph is captured, before the graph
+     is replayed. It returns a `GraphCaptureContext` object which contains the
+-    necessary data for the graph capture. Currently, it only contains the
+-    stream that the graph capture is running on. This stream is set to the
++    necessary data for the graph capture: its stream and an optional semantic
++    channel identity for distributed capture resources. The stream is set to the
+     current CUDA stream when the context manager is entered and reset to the
+     default stream when the context manager is exited. This is to ensure that
+     the graph capture is running on a separate stream from the default stream,
+@@ -1666,9 +1671,14 @@ def graph_capture(
+     A caller may pass an explicit ``graph_capture_context`` to control the
+     stream used (e.g. to capture on the default stream).
+ 
+-    ``channel_id`` identifies the graph semantically to distributed transports.
+-    It must be stable and identical across ranks; CUDA stream handles are local
+-    process state and are not valid distributed identities.
++    Args:
++        device: Device that owns a newly created capture stream.
++        graph_capture_context: Existing capture context to reuse.
++        channel_id: Stable distributed identity for this graph owner.
++
++    Raises:
++        ValueError: If ``channel_id`` conflicts with the identity stored on
++            ``graph_capture_context``.
+     """
+     if graph_capture_context is None:
+         context = GraphCaptureContext(
+@@ -1683,12 +1693,14 @@ def graph_capture(
+                     "graph capture context and argument specify different "
+                     "semantic channel IDs"
+                 )
+-            context.channel_id = channel_id
++            if context.channel_id is None:
++                context = GraphCaptureContext(context.stream, channel_id=channel_id)
+     maybe_dcp_capture = (
+         get_dcp_group().graph_capture(context)
+         if _DCP is not None and get_dcp_group().world_size > 1
+         else nullcontext()
+     )
++    maybe_b12x_dcp_capture: contextlib.AbstractContextManager[Any]
+     if _DCP is not None and get_dcp_group().world_size > 1:
+         # Import locally to avoid making distributed initialization depend on
+         # attention modules. The helper is a no-op until DCP warmup creates a
+@@ -2126,7 +2138,9 @@ def initialize_model_parallel(
+     )
+     indexer_shards = int(envs.VLLM_DCP_INDEXER_SHARDS)
+     _validate_indexer_shard_count(indexer_shards, decode_context_model_parallel_size)
+-    if 1 < indexer_shards < decode_context_model_parallel_size:
++    if _needs_indexer_replica_groups(
++        indexer_shards, decode_context_model_parallel_size
++    ):
+         indexer_dcp_ranks, indexer_query_split_ranks = (
+             _build_indexer_replica_group_ranks(tp_group_ranks, indexer_shards)
+         )
+diff --git a/vllm/entrypoints/chat_utils.py b/vllm/entrypoints/chat_utils.py
+index 61244a3e164b6fb34ff2f6f6e68f84cbdd550a88..5e8f909ce5e18dd330dde886398066e04ea1b486 100644
+--- a/vllm/entrypoints/chat_utils.py
++++ b/vllm/entrypoints/chat_utils.py
+@@ -359,7 +359,12 @@ class CustomChatCompletionMessageParam(TypedDict, total=False):
+     """The reasoning content for interleaved thinking."""
+ 
+     tools: list[ChatCompletionFunctionToolParam] | None
+-    """The tools for developer role."""
++    """Message-level tools, preserved for "system" and "developer" roles.
++
++    Used by chat templates/encoders (e.g. DeepSeek-V4, DeepSeek-V3.2) that
++    accept tools attached directly to a system or developer message, as
++    opposed to (or in addition to) the request-level `tools` parameter.
++    """
+ 
+     task: str | None
+     """Model-specific task marker. Currently passed through for DeepSeek V4."""
+@@ -396,7 +401,12 @@ class ConversationMessage(TypedDict, total=False):
+     """Deprecated: The reasoning content for interleaved thinking."""
+ 
+     tools: list[ChatCompletionFunctionToolParam] | None
+-    """The tools for developer role."""
++    """Message-level tools, preserved for "system" and "developer" roles.
++
++    Used by chat templates/encoders (e.g. DeepSeek-V4, DeepSeek-V3.2) that
++    accept tools attached directly to a system or developer message, as
++    opposed to (or in addition to) the request-level `tools` parameter.
++    """
+ 
+     task: str | None
+     """Model-specific task marker. Currently passed through for DeepSeek V4."""
+@@ -1857,8 +1867,8 @@ def _parse_chat_message_content(
+         if "task" in message and isinstance(message["task"], str):
+             result_msg["task"] = message["task"]
+ 
+-        if role == "developer":
+-            result_msg["tools"] = message.get("tools", None)
++        if role in ("system", "developer") and message.get("tools") is not None:
++            result_msg["tools"] = message["tools"]
+     return result
+ 
+ 
+diff --git a/vllm/envs.py b/vllm/envs.py
+index 96226926fc5532b41a05eff5526aac922acccd83..e31ada8006c924295e43d1683290f19808abfb3a 100755
+--- a/vllm/envs.py
++++ b/vllm/envs.py
+@@ -87,6 +87,8 @@ if TYPE_CHECKING:
+     VLLM_B12X_MLA_CKV_GATHER_MAX_TOKENS: int = 524288
+     VLLM_B12X_MLA_CKV_PREFETCH_DEPTH: int = 1
+     VLLM_B12X_MLA_CKV_PREFETCH_WORKSPACE_MIB: int = 1024
++    VLLM_B12X_MLA_SPEC_DECODE_MAX_Q: int = 8
++    VLLM_B12X_MLA_SPEC_EXTEND_AS_DECODE: str = "auto"
+     VLLM_MINIMAX_M3_ENABLE_TORCH_COMPILE: bool = False
+     VLLM_B12X_CUDAGRAPH_PIECEWISE_PREWARM: bool = False
+     VLLM_B12X_MOE_FORCE_MODELOPT_PREP: bool = False
+@@ -234,12 +236,17 @@ if TYPE_CHECKING:
+     VLLM_FLASHINFER_AUTOTUNE_SKIP_OPS: list[str] | None = None
+     VLLM_FLASHINFER_ALLREDUCE_BACKEND: Literal["auto", "trtllm", "mnnvl"] = "auto"
+     VLLM_ENABLE_PCIE_ALLREDUCE: bool = False
+-    VLLM_PCIE_ALLREDUCE_BACKEND: Literal["b12x", "cpp"] = "cpp"
++    VLLM_PCIE_ALLREDUCE_BACKEND: Literal["b12x", "cpp", "flashinfer-ipc"] = "cpp"
+     VLLM_PCIE_ONESHOT_ALLREDUCE_MAX_SIZE: str = "84KB"
+     VLLM_PCIE_ONESHOT_FUSED_ADD_RMS_NORM_MAX_SIZE: str = "84KB"
+     VLLM_PCIE_DMA_MIN_BYTES: str = "6MB"
+     VLLM_PCIE_ONESHOT_ALLOW_CROSS_NUMA: bool = True
+     VLLM_PCIE_ONESHOT_SINGLE_CHANNEL: bool = False
++    VLLM_PCIE_DMA_FP8: str | None = None
++    VLLM_CPP_AR_1STAGE_NCCL_CUTOFF: str | None = None
++    VLLM_CPP_AR_IGNORE_CUTOFF_MAX_ROWS: int | None = None
++    VLLM_USE_B12X_PCIE_DMA: bool = False
++    VLLM_CACHE_DIR: str | None = None
+     VLLM_FLASHINFER_WORKSPACE_BUFFER_SIZE: int = 394 * 1024 * 1024
+     VLLM_XGRAMMAR_CACHE_MB: int = 0
+     VLLM_REGEX_COMPILATION_TIMEOUT_S: int = 5
+@@ -1225,6 +1232,15 @@ environment_variables: dict[str, Callable[[], Any]] = {
+     "VLLM_B12X_MLA_CKV_PREFETCH_WORKSPACE_MIB": lambda: int(
+         os.getenv("VLLM_B12X_MLA_CKV_PREFETCH_WORKSPACE_MIB", "1024")
+     ),
++    # Short speculative extends may use the B12X sparse-MLA decode kernel.
++    # Backend validation remains authoritative because eligibility also
++    # depends on the active speculative configuration.
++    "VLLM_B12X_MLA_SPEC_DECODE_MAX_Q": lambda: int(
++        os.getenv("VLLM_B12X_MLA_SPEC_DECODE_MAX_Q", "8")
++    ),
++    "VLLM_B12X_MLA_SPEC_EXTEND_AS_DECODE": lambda: os.getenv(
++        "VLLM_B12X_MLA_SPEC_EXTEND_AS_DECODE", "auto"
++    ),
+     # Diagnostic flag retained for local experiments. MiniMax M3 compile is
+     # fail-closed in the model until the no-break path is validated.
+     "VLLM_MINIMAX_M3_ENABLE_TORCH_COMPILE": lambda: bool(
+@@ -1852,7 +1868,7 @@ environment_variables: dict[str, Callable[[], Any]] = {
+     "VLLM_PCIE_ALLREDUCE_BACKEND": env_with_choices(
+         "VLLM_PCIE_ALLREDUCE_BACKEND",
+         "cpp",
+-        ["b12x", "cpp"],
++        ["b12x", "cpp", "flashinfer-ipc"],
+     ),
+     # Max input size for the b12x PCIe oneshot allreduce dispatch.
+     # Accepts raw bytes or a KB/MB suffix (e.g. "84KB").
+@@ -1878,6 +1894,23 @@ environment_variables: dict[str, Callable[[], Any]] = {
+         os.getenv("VLLM_PCIE_ONESHOT_SINGLE_CHANNEL", "0").strip().lower()
+         not in ("", "0", "false", "no", "off")
+     ),
++    # Optional wire format and crossover tuning read by the custom-allreduce
++    # integration. Unset values delegate to backend-owned defaults.
++    "VLLM_PCIE_DMA_FP8": lambda: os.getenv("VLLM_PCIE_DMA_FP8"),
++    "VLLM_CPP_AR_1STAGE_NCCL_CUTOFF": lambda: os.getenv(
++        "VLLM_CPP_AR_1STAGE_NCCL_CUTOFF"
++    ),
++    "VLLM_CPP_AR_IGNORE_CUTOFF_MAX_ROWS": lambda: (
++        int(value)
++        if (value := os.getenv("VLLM_CPP_AR_IGNORE_CUTOFF_MAX_ROWS")) is not None
++        else None
++    ),
++    # The DS4 launcher exports these for B12X and compiler-cache consumers.
++    # Register them so vLLM validation does not reject a supported launch.
++    "VLLM_USE_B12X_PCIE_DMA": lambda: bool(
++        int(os.getenv("VLLM_USE_B12X_PCIE_DMA", "0"))
++    ),
++    "VLLM_CACHE_DIR": lambda: os.getenv("VLLM_CACHE_DIR"),
+     # Control the workspace buffer size for the FlashInfer backend.
+     "VLLM_FLASHINFER_WORKSPACE_BUFFER_SIZE": lambda: int(
+         os.getenv("VLLM_FLASHINFER_WORKSPACE_BUFFER_SIZE", str(394 * 1024 * 1024))
+@@ -2287,12 +2320,18 @@ environment_variables: dict[str, Callable[[], Any]] = {
+     "VLLM_EXL3_TRELLIS_MAX_M": lambda: os.getenv("VLLM_EXL3_TRELLIS_MAX_M"),
+     "VLLM_EXL3_TRELLIS_BLOCK_M": lambda: os.getenv("VLLM_EXL3_TRELLIS_BLOCK_M"),
+     "VLLM_EXL3_PREFILL_CHUNK": lambda: os.getenv("VLLM_EXL3_PREFILL_CHUNK"),
++    "VLLM_EXL3_PREFILL_CAPACITY": lambda: os.getenv("VLLM_EXL3_PREFILL_CAPACITY"),
+     "VLLM_EXL3_PREFILL_TRELLIS": lambda: os.getenv("VLLM_EXL3_PREFILL_TRELLIS"),
+     "VLLM_EXL3_PREFILL_BLOCK_M": lambda: os.getenv("VLLM_EXL3_PREFILL_BLOCK_M"),
++    # Deterministic online EXL3 encoding and its persistent rank-local cache.
++    "VLLM_EXL3_ONLINE_TRELLIS_BITS": lambda: os.getenv("VLLM_EXL3_ONLINE_TRELLIS_BITS"),
++    "VLLM_EXL3_ENCODER_SOURCE": lambda: os.getenv("VLLM_EXL3_ENCODER_SOURCE"),
++    "VLLM_EXL3_ENCODER_REVISION": lambda: os.getenv("VLLM_EXL3_ENCODER_REVISION"),
++    "VLLM_EXL3_ONLINE_CACHE_DIR": lambda: os.getenv("VLLM_EXL3_ONLINE_CACHE_DIR"),
++    "VLLM_EXL3_ONLINE_CACHE_MODE": lambda: os.getenv("VLLM_EXL3_ONLINE_CACHE_MODE"),
+     # Prebuilt exllamav3 extension location and torch-ABI compatibility shim.
+     "VLLM_EXL3_EXT_PATH": lambda: os.getenv("VLLM_EXL3_EXT_PATH"),
+     "VLLM_EXL3_ABI_SHIM": lambda: os.getenv("VLLM_EXL3_ABI_SHIM"),
+-
+ }
+ 
+ 
+diff --git a/vllm/model_executor/kernels/mhc/tilelang.py b/vllm/model_executor/kernels/mhc/tilelang.py
+index 885ec74f91e3957f32efda5b083257d735d498a8..639f6e059766f943b98615796b8ad8242770842d 100644
+--- a/vllm/model_executor/kernels/mhc/tilelang.py
++++ b/vllm/model_executor/kernels/mhc/tilelang.py
+@@ -407,6 +407,67 @@ def mhc_pre_broadcast_tilelang(
+     )
+ 
+ 
++def _mhc_pre_broadcast_tilelang_fake(
++    residual: torch.Tensor,
++    fn: torch.Tensor,
++    hc_scale: torch.Tensor,
++    hc_base: torch.Tensor,
++    rms_eps: float,
++    hc_pre_eps: float,
++    hc_sinkhorn_eps: float,
++    hc_post_mult_value: float,
++    sinkhorn_repeat: int,
++    n_splits: int = 1,
++    norm_weight: torch.Tensor | None = None,
++    norm_eps: float = 1e-6,
++    fn_broadcast: torch.Tensor | None = None,
++) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor, torch.Tensor]:
++    del (
++        hc_scale,
++        hc_base,
++        rms_eps,
++        hc_pre_eps,
++        hc_sinkhorn_eps,
++        hc_post_mult_value,
++        sinkhorn_repeat,
++        n_splits,
++        norm_weight,
++        norm_eps,
++        fn_broadcast,
++    )
++    num_tokens, hidden_size = residual.shape
++    hc_mult = fn.shape[1] // hidden_size
++    return (
++        torch.empty(
++            num_tokens,
++            hc_mult,
++            hidden_size,
++            dtype=torch.bfloat16,
++            device=residual.device,
++        ),
++        torch.empty(
++            num_tokens,
++            hc_mult,
++            1,
++            dtype=torch.float32,
++            device=residual.device,
++        ),
++        torch.empty(
++            num_tokens,
++            hc_mult,
++            hc_mult,
++            dtype=torch.float32,
++            device=residual.device,
++        ),
++        torch.empty(
++            num_tokens,
++            hidden_size,
++            dtype=torch.bfloat16,
++            device=residual.device,
++        ),
++    )
++
++
+ def mhc_post_tilelang(
+     x: torch.Tensor,
+     residual: torch.Tensor,
+@@ -782,6 +843,7 @@ def _hc_head_fused_kernel_tilelang_fake(
+ 
+ 
+ _mhc_pre_tilelang_impl = mhc_pre_tilelang
++_mhc_pre_broadcast_tilelang_impl = mhc_pre_broadcast_tilelang
+ _mhc_post_tilelang_impl = mhc_post_tilelang
+ _mhc_fused_post_pre_tilelang_impl = mhc_fused_post_pre_tilelang
+ 
+@@ -791,6 +853,12 @@ direct_register_custom_op(
+     mutates_args=[],
+     fake_impl=_mhc_pre_tilelang_fake,
+ )
++direct_register_custom_op(
++    op_name="mhc_pre_broadcast_tilelang",
++    op_func=_mhc_pre_broadcast_tilelang_impl,
++    mutates_args=[],
++    fake_impl=_mhc_pre_broadcast_tilelang_fake,
++)
+ direct_register_custom_op(
+     op_name="mhc_post_tilelang",
+     op_func=_mhc_post_tilelang_impl,
+@@ -816,6 +884,17 @@ def mhc_pre_tilelang(*args, **kwargs):
+     return torch.ops.vllm.mhc_pre_tilelang(*args, **kwargs)
+ 
+ 
++def mhc_pre_broadcast_tilelang(*args, **kwargs):
++    """Call broadcast MHC pre through the registered custom op.
++
++    The implementation invokes DeepGEMM through a pybind extension, which
++    cannot be traced by Dynamo. Keeping that call behind a custom-op boundary
++    lets full-graph compilation represent the operation without entering its
++    Python implementation.
++    """
++    return torch.ops.vllm.mhc_pre_broadcast_tilelang(*args, **kwargs)
++
++
+ def mhc_post_tilelang(*args, **kwargs):
+     """Call MHC post through the registered custom op."""
+     return torch.ops.vllm.mhc_post_tilelang(*args, **kwargs)
+@@ -825,6 +904,7 @@ def mhc_fused_post_pre_tilelang(*args, **kwargs):
+     """Call fused MHC post/pre through the registered custom op."""
+     return torch.ops.vllm.mhc_fused_post_pre_tilelang(*args, **kwargs)
+ 
++
+ direct_register_custom_op(
+     op_name="hc_head_fused_kernel_tilelang",
+     op_func=_hc_head_fused_kernel_tilelang,
+diff --git a/vllm/model_executor/layers/attention/mla_attention.py b/vllm/model_executor/layers/attention/mla_attention.py
+index 9fefa3dd4f194f25c788630795e2835a869247a3..1931df061abaa20779c4bf73d4acc8d104c2d7ec 100644
+--- a/vllm/model_executor/layers/attention/mla_attention.py
++++ b/vllm/model_executor/layers/attention/mla_attention.py
+@@ -333,6 +333,22 @@ def _run_mla_query_bmm(
+     torch.bmm(query.contiguous() if use_safe_op else query, weight, out=output)
+ 
+ 
++def is_packed_quantized_dtype(dtype: torch.dtype) -> bool:
++    """Return whether ``dtype`` is a packed quantized-weight container.
++
++    NVFP4 packs into ``uint8``; compressed-tensors int4/int8 packs into
++    ``int32``. Neither is a real activation dtype, so ``kv_c_normed`` must not
++    be cast to them -- the linear layer unpacks and quantizes internally.
++
++    Args:
++        dtype: Data type to classify.
++
++    Returns:
++        Whether the data type stores packed quantized weights.
++    """
++    return dtype in (torch.uint8, torch.int32)
++
++
+ @functools.cache
+ def _b12x_absorb_bmm_enabled() -> bool:
+     return envs.VLLM_B12X_ABSORB_BMM
+@@ -3178,12 +3194,13 @@ class MLACommonBaseImpl(MLAAttentionImpl[A], Generic[A]):
+                 if hasattr(self.kv_b_proj, "weight")
+                 else self.kv_b_proj.params_dtype
+             )
+-            # For NVFP4, weights are packed uint8 — keep input in model dtype
+-            # since the NVFP4 linear layer quantizes internally.
++            # Packed quantized weights (NVFP4 → uint8, compressed-tensors
++            # int4/int8 → int32) are containers, not activation dtypes — keep
++            # the input in model dtype; the linear layer quantizes internally.
+             if (
+                 use_fp8_prefill or _kv_b_proj_w_dtype != current_platform.fp8_dtype()
+-            ) and _kv_b_proj_w_dtype != torch.uint8:
+-                kv_c_normed = kv_c_normed.to(self.kv_b_proj.weight.dtype)
++            ) and not is_packed_quantized_dtype(_kv_b_proj_w_dtype):
++                kv_c_normed = kv_c_normed.to(_kv_b_proj_w_dtype)
+ 
+             k_pe = workspace[:toks][..., self.kv_lora_rank :].unsqueeze(1)
+             kv_nope = self.kv_b_proj(kv_c_normed)[0].view(
+@@ -3334,9 +3351,11 @@ class MLACommonBaseImpl(MLAAttentionImpl[A], Generic[A]):
+                 if hasattr(self.kv_b_proj, "weight")
+                 else self.kv_b_proj.params_dtype
+             )
++            # Same packed-container rule as _compute_prefill_context above; this
++            # is the branch forward_mha takes when dcp_world_size > 1.
+             if (
+                 use_fp8_prefill or kv_b_proj_w_dtype != current_platform.fp8_dtype()
+-            ) and kv_b_proj_w_dtype != torch.uint8:
++            ) and not is_packed_quantized_dtype(kv_b_proj_w_dtype):
+                 kv_c_normed = kv_c_normed.to(kv_b_proj_w_dtype)
+ 
+             kv_nope = self.kv_b_proj(kv_c_normed)[0].view(
+diff --git a/vllm/model_executor/layers/quantization/exl3.py b/vllm/model_executor/layers/quantization/exl3.py
+index 39932667b1da2017e9500f37b7587479b04acb41..36bd8c525b3bdada590480628856801f56a6e2a2 100644
+--- a/vllm/model_executor/layers/quantization/exl3.py
++++ b/vllm/model_executor/layers/quantization/exl3.py
+@@ -24,13 +24,16 @@ import importlib
+ import os
+ import re
+ import sys
+-from types import SimpleNamespace
++import zlib
++from pathlib import Path
++from types import ModuleType, SimpleNamespace
+ from typing import TYPE_CHECKING, Any
+ 
+ import torch
+ from transformers import PretrainedConfig
+ 
+ from vllm.config import get_current_vllm_config_or_none
++from vllm.config.quantization import QuantizationConfigArgs
+ from vllm.distributed import (
+     get_tensor_model_parallel_rank,
+     get_tensor_model_parallel_world_size,
+@@ -53,7 +56,24 @@ from vllm.model_executor.layers.quantization.base_config import (
+     QuantizationConfig,
+     QuantizeMethodBase,
+ )
++from vllm.model_executor.layers.quantization.compressed_tensors.utils import (
++    should_ignore_layer,
++)
++from vllm.model_executor.layers.quantization.exl3_online_cache import (
++    Exl3OnlineCacheKey,
++    cache_mode,
++    load_or_quantize,
++    resolve_encoder_identity,
++    resolve_model_identity,
++)
++from vllm.model_executor.layers.quantization.online.fp8 import _Fp8OnlineLinearBase
++from vllm.model_executor.layers.quantization.online.mxfp8 import (
++    Mxfp8OnlineLinearMethod,
++    is_shared_expert_projection,
++)
++from vllm.model_executor.layers.quantization.utils.quant_utils import kMxfp8Dynamic
+ from vllm.model_executor.parameter import BasevLLMParameter
++from vllm.model_executor.utils import replace_parameter
+ from vllm.transformers_utils.repo_utils import get_hf_file_to_dict
+ 
+ if TYPE_CHECKING:
+@@ -70,10 +90,62 @@ _HADAMARD_BLOCK = 128
+ _EXL3_EXT: Any | None = None
+ _B12X_FUSED_MOE_API: Any | None = None
+ _B12X_MIXED_TRELLIS_API: Any | None = None
++_B12X_TRELLIS_LINEAR_API: Any | None = None
++_EXL3_ONLINE_QUANTIZER: Any | None = None
++_EXL3_ONLINE_WARMED_SIGNATURES: set[tuple[int, int, int, int]] = set()
++_B12X_TRELLIS_WARMED_DEVICES: set[int] = set()
++# The dense W4A16 kernel caps its temporary accumulation arena at
++# SMs * 4 * block_m * 256 fp32 elements.  SM120/SM121 devices supported by
++# this path have at most 192 SMs, and block_m never exceeds 64.  Keeping this
++# architecture bound here lets Inductor own and reuse the temporary across
++# layers instead of allocating inside CUDA graph capture.
++_B12X_TRELLIS_C_TMP_CAP = 192 * 4 * 64 * 256
+ _RANK_SLICED_RUNTIMES: dict[tuple[Any, ...], dict[str, Any]] = {}
+ _MIXED_TRELLIS_RUNTIMES: dict[tuple[Any, ...], dict[str, Any]] = {}
+ _NEXT_RUNTIME_SCOPE_ID = 0
+ _MIXED_TRELLIS_ROUTE_BLOCK_SIZE = 8
++_GLM52_MIXED_TRELLIS_PREFILL_BLOCK_SIZE = 32
++_GLM52_MIXED_TRELLIS_BLOCK32_SIGNATURES = frozenset(
++    {
++        ((3, 192), (4, 64)),
++        ((3, 206), (4, 50)),
++        ((3, 148), (4, 108)),
++    }
++)
++
++
++def _resolve_mixed_trellis_prefill_block_m(
++    *,
++    configured_block_m: int,
++    explicit_override: bool,
++    hidden_size: int,
++    intermediate_size: int,
++    tier_signature: tuple[tuple[int, int], ...],
++    topk: int,
++    device_major: int,
++    prefill_tile_config: tuple[int, int, int, int],
++) -> int:
++    """Select the qualified GLM-5.2 mixed-K prefill route block.
++
++    B12X's paired-M8 FC2 schedule makes block-32 numerically equivalent
++    to the established block-64 path while reducing scratch and improving the
++    dominant large-prefill kernel on SM12x. The allowlist contains only tier
++    partitions qualified end-to-end on GLM-5.2 checkpoints. Explicit operator
++    tuning and every other model geometry retain the configured value.
++    """
++
++    qualified = (
++        not explicit_override
++        and int(device_major) == 12
++        and int(hidden_size) == 6144
++        and int(intermediate_size) == 512
++        and tier_signature in _GLM52_MIXED_TRELLIS_BLOCK32_SIGNATURES
++        and int(topk) == 8
++        and tuple(int(value) for value in prefill_tile_config) == (128, 128, 32, 512)
++    )
++    if qualified:
++        return _GLM52_MIXED_TRELLIS_PREFILL_BLOCK_SIZE
++    return int(configured_block_m)
+ 
+ 
+ # Smallest m the Trellis kernel path can service, and therefore the smallest
+@@ -88,6 +160,75 @@ MIN_CAPTURABLE_TRELLIS_M = 1
+ _DEFAULT_TRELLIS_MIN_M = MIN_CAPTURABLE_TRELLIS_M
+ 
+ 
++def _online_trellis_bits() -> int | None:
++    raw = os.environ.get("VLLM_EXL3_ONLINE_TRELLIS_BITS")
++    if raw is None or not raw.strip():
++        return None
++    try:
++        bits = int(raw)
++    except ValueError:
++        raise ValueError(
++            f"VLLM_EXL3_ONLINE_TRELLIS_BITS must be an integer from 3 to 8, got {raw!r}"
++        ) from None
++    if bits not in range(3, 9):
++        raise ValueError(
++            f"VLLM_EXL3_ONLINE_TRELLIS_BITS must be from 3 to 8, got {bits}"
++        )
++    return bits
++
++
++def _online_trellis_shape_supported(input_size: int, output_size: int) -> bool:
++    return input_size % _HADAMARD_BLOCK == 0 and output_size % _HADAMARD_BLOCK == 0
++
++
++def _load_exl3_online_quantizer() -> Any:
++    """Load the encoder without importing ExLlamaV3's serving front end."""
++
++    global _EXL3_ONLINE_QUANTIZER
++    if _EXL3_ONLINE_QUANTIZER is not None:
++        return _EXL3_ONLINE_QUANTIZER
++
++    raw_root = os.environ.get("VLLM_EXL3_ENCODER_SOURCE")
++    if raw_root is None or not raw_root.strip():
++        raise RuntimeError(
++            "online EXL3 Trellis requires VLLM_EXL3_ENCODER_SOURCE to point "
++            "to the exllamav3 Python package directory"
++        )
++    package_root = Path(raw_root).resolve()
++    quantizer_path = package_root / "modules" / "quant" / "exl3_lib"
++    if not (quantizer_path / "quantize.py").is_file():
++        raise RuntimeError(
++            "VLLM_EXL3_ENCODER_SOURCE does not contain the ExLlamaV3 encoder: "
++            f"{package_root}"
++        )
++
++    package_name = "_vllm_exl3_encoder"
++    packages = {
++        package_name: package_root,
++        f"{package_name}.modules": package_root / "modules",
++        f"{package_name}.modules.quant": package_root / "modules" / "quant",
++        f"{package_name}.modules.quant.exl3_lib": quantizer_path,
++    }
++    for name, path in packages.items():
++        if name in sys.modules:
++            continue
++        module = ModuleType(name)
++        module.__path__ = [str(path)]
++        module.__package__ = name
++        sys.modules[name] = module
++
++    quantize = importlib.import_module(
++        f"{package_name}.modules.quant.exl3_lib.quantize"
++    )
++    if not hasattr(quantize, "quantize_exl3"):
++        raise RuntimeError(
++            "VLLM_EXL3_ENCODER_SOURCE points to an incompatible ExLlamaV3 "
++            "encoder: modules.quant.exl3_lib.quantize has no quantize_exl3"
++        )
++    _EXL3_ONLINE_QUANTIZER = quantize.quantize_exl3
++    return _EXL3_ONLINE_QUANTIZER
++
++
+ def _is_draft_layer(layer: Any) -> bool:
+     """True for a rank-sliced MTP/nextn/eagle draft MoE layer.
+ 
+@@ -154,10 +295,23 @@ def _runtime_scope_id(quant_config: Any) -> int:
+ 
+ 
+ _RANK_SLICED_FORMAT = "exl3-trellis"
++_PER_EXPERT_ROTATION_LAYOUT = "per_expert_v1"
++_SHARED_H_ROTATION_LAYOUT = "shared_h_v1"
++_SHARED_H_TENSOR_SCHEMA = (
++    "model.layers.{L}.mlp.experts.shared_h.{proj}.rank{r}.{suh|svh}"
++)
+ _RANK_SLICED_WEIGHT_RE = re.compile(
+     r"^(?P<prefix>.+)\.rank(?P<rank>\d+)\."
+     r"(?P<field>trellis|suh|svh|mcg|mul1)$"
+ )
++_SHARED_H_WEIGHT_RE = re.compile(
++    r"^(?P<experts_prefix>.+\.experts)\.shared_h\."
++    r"(?P<projection>gate_proj|up_proj|down_proj)\.rank(?P<rank>\d+)\."
++    r"(?P<field>suh|svh)$"
++)
++_EXPERT_PROJECTION_RE = re.compile(
++    r"^.+\.experts\.\d+\.(?P<projection>gate_proj|up_proj|down_proj)$"
++)
+ 
+ ShardId = str | int | tuple[int, ...] | None
+ 
+@@ -242,11 +396,29 @@ def _load_b12x_mixed_trellis() -> Any:
+         max_packed_route_slots=host.max_packed_route_slots,
+         prepare_weights=prepare.prepare_trellis256_moe_weights,
+         run_mixed_trellis=module.run_mixed_trellis,
++        warmup_mixed_trellis_route_pack=module.warmup_mixed_trellis_route_pack,
+     )
+     _B12X_MIXED_TRELLIS_API = api
+     return api
+ 
+ 
++def _load_b12x_trellis_linear() -> Any:
++    """Resolve the native dense Trellis API lazily."""
++
++    global _B12X_TRELLIS_LINEAR_API
++    if _B12X_TRELLIS_LINEAR_API is not None:
++        return _B12X_TRELLIS_LINEAR_API
++    try:
++        from b12x.gemm import trellis_linear
++    except Exception as exc:
++        raise RuntimeError(
++            "Online EXL3 prefill requires b12x.gemm.trellis_linear. "
++            "Install a matching B12X build."
++        ) from exc
++    _B12X_TRELLIS_LINEAR_API = trellis_linear
++    return trellis_linear
++
++
+ def _unique_tensor_storage_bytes(*buffers: Any) -> int:
+     """Count unique tensor storage while ignoring buffer metadata fields."""
+ 
+@@ -264,6 +436,15 @@ def _unique_tensor_storage_bytes(*buffers: Any) -> int:
+     return total
+ 
+ 
++def _scratch_view(backing: torch.Tensor, spec: Any) -> torch.Tensor:
++    """Return a typed plan-scratch view over a shared byte arena."""
++
++    nbytes = int(spec.dtype.itemsize)
++    for dim in spec.shape:
++        nbytes *= int(dim)
++    return backing.narrow(0, 0, nbytes).view(spec.dtype).view(tuple(spec.shape))
++
++
+ def _positive_env_int(name: str, default: int) -> int:
+     # An env var that is present but blank means "unset". Compose and Kubernetes
+     # both render an unset variable as the empty string, so int("") would abort
+@@ -284,6 +465,21 @@ def _positive_env_int(name: str, default: int) -> int:
+     return value
+ 
+ 
++def _resolve_prefill_capacity(max_batched_tokens: int) -> int:
++    """Resolve the optional EXL3 arena bound within the scheduler contract."""
++
++    prefill_capacity = _positive_env_int(
++        "VLLM_EXL3_PREFILL_CAPACITY", max_batched_tokens
++    )
++    if prefill_capacity > max_batched_tokens:
++        raise ValueError(
++            "VLLM_EXL3_PREFILL_CAPACITY cannot exceed "
++            "max_num_batched_tokens: "
++            f"capacity={prefill_capacity}, max={max_batched_tokens}"
++        )
++    return prefill_capacity
++
++
+ @torch.library.custom_op(
+     "vllm::exl3_gemm",
+     mutates_args=(),
+@@ -338,6 +534,166 @@ def _exl3_gemm_fake(
+     )
+ 
+ 
++def _b12x_trellis_weight(
++    trellis: torch.Tensor,
++    suh: torch.Tensor,
++    svh: torch.Tensor,
++    dtype: torch.dtype,
++) -> Any:
++    """Prepare each online weight before capture and retain its native views."""
++
++    api = _load_b12x_trellis_linear()
++    # Keep prepared views on the owning tensor. A process-global pointer-keyed
++    # cache can alias after allocator address reuse and retains released models
++    # forever. This small reference cycle is collected with the tensor.
++    cache = getattr(trellis, "_vllm_b12x_prepared_weights", None)
++    if cache is None:
++        cache = {}
++        trellis._vllm_b12x_prepared_weights = cache
++    key = (id(suh), id(svh), dtype)
++    weight = cache.get(key)
++    if weight is None:
++        weight = api.prepare_weight(
++            trellis,
++            suh,
++            svh,
++            codebook="mcg",
++            params_dtype=dtype,
++        )
++        cache[key] = weight
++    return weight
++
++
++def _b12x_trellis_k6_supported(
++    trellis: torch.Tensor,
++    *,
++    has_mcg: bool,
++    has_mul1: bool,
++) -> bool:
++    """Gate the native path to the exact K6/MCG contract it implements."""
++
++    return bool(
++        has_mcg
++        and not has_mul1
++        and trellis.dtype == torch.int16
++        and trellis.ndim == 3
++        and int(trellis.shape[2]) == 96
++        and int(trellis.shape[0]) % 8 == 0
++        and int(trellis.shape[1]) % 8 == 0
++    )
++
++
++def _warm_b12x_trellis_device(
++    trellis: torch.Tensor,
++    suh: torch.Tensor,
++    svh: torch.Tensor,
++) -> None:
++    """Build the runtime extension before any CUDA graph starts capturing."""
++
++    device_index = trellis.device.index
++    if device_index is None:
++        device_index = torch.cuda.current_device()
++    if device_index in _B12X_TRELLIS_WARMED_DEVICES:
++        return
++    source = torch.zeros(
++        (1, int(trellis.shape[0]) * 16),
++        dtype=torch.float16,
++        device=trellis.device,
++    )
++    _b12x_trellis_linear(source, trellis, suh, svh)
++    torch.cuda.synchronize(trellis.device)
++    _B12X_TRELLIS_WARMED_DEVICES.add(device_index)
++
++
++def _b12x_trellis_c_tmp_elements(rows: int, columns: int) -> int:
++    """Return graph-safe dense-W4A16 scratch capacity for one static shape."""
++
++    rows = int(rows)
++    columns = int(columns)
++    if rows <= 128:
++        # The cooperative K6 small-M kernel does not consume W4A16 scratch.
++        return 1
++    padded_rows = max(
++        ((rows + 47) // 48) * 48,
++        ((rows + 63) // 64) * 64,
++    )
++    return min(columns * padded_rows, _B12X_TRELLIS_C_TMP_CAP)
++
++
++@torch.library.custom_op(
++    "vllm::b12x_trellis_linear_out",
++    mutates_args=("output", "gemm_output", "c_tmp", "rotated_f16"),
++    device_types="cuda",
++)
++def _b12x_trellis_linear_out(
++    x: torch.Tensor,
++    trellis: torch.Tensor,
++    suh: torch.Tensor,
++    svh: torch.Tensor,
++    output: torch.Tensor,
++    gemm_output: torch.Tensor,
++    c_tmp: torch.Tensor,
++    rotated_f16: torch.Tensor,
++) -> None:
++    """Execute dense Trellis into graph-owned output and scratch tensors."""
++
++    api = _load_b12x_trellis_linear()
++    weight = _b12x_trellis_weight(trellis, suh, svh, x.dtype)
++    api.run(
++        x,
++        weight,
++        output=output,
++        gemm_output=gemm_output,
++        c_tmp=c_tmp,
++        rotated_f16=rotated_f16,
++    )
++
++
++@_b12x_trellis_linear_out.register_fake
++def _b12x_trellis_linear_out_fake(
++    x: torch.Tensor,
++    trellis: torch.Tensor,
++    suh: torch.Tensor,
++    svh: torch.Tensor,
++    output: torch.Tensor,
++    gemm_output: torch.Tensor,
++    c_tmp: torch.Tensor,
++    rotated_f16: torch.Tensor,
++) -> None:
++    del x, trellis, suh, svh, output, gemm_output, c_tmp, rotated_f16
++
++
++def _b12x_trellis_linear(
++    x: torch.Tensor,
++    trellis: torch.Tensor,
++    suh: torch.Tensor,
++    svh: torch.Tensor,
++) -> torch.Tensor:
++    """Run every online-K6 batch through B12X with explicit storage."""
++
++    output = torch.empty(
++        (x.shape[0], trellis.shape[1] * 16), dtype=x.dtype, device=x.device
++    )
++    gemm_output = torch.empty_like(output)
++    c_tmp = torch.empty(
++        (_b12x_trellis_c_tmp_elements(x.shape[0], output.shape[1]),),
++        dtype=torch.float32,
++        device=x.device,
++    )
++    rotated_f16 = torch.empty_like(x)
++    _b12x_trellis_linear_out(
++        x,
++        trellis,
++        suh,
++        svh,
++        output,
++        gemm_output,
++        c_tmp,
++        rotated_f16,
++    )
++    return output
++
++
+ class Exl3Config(QuantizationConfig):
+     """Configuration for modern and legacy EXL3 trellis checkpoints."""
+ 
+@@ -357,8 +713,11 @@ class Exl3Config(QuantizationConfig):
+         self.tensor_storage = tensor_storage or {}
+         self._eager_checked = False
+         self.rank_sliced_metadata: dict[str, Any] | None = None
++        self.rank_sliced_rotation_layout = _PER_EXPERT_ROTATION_LAYOUT
+         self.rank_sliced_k_values: tuple[int, ...] | None = None
+         self.rank_sliced_bits_by_layer: dict[int, tuple[int, ...]] = {}
++        self._online_model_identity: str | None = None
++        self._online_encoder_identity: str | None = None
+ 
+     def get_name(self) -> str:
+         return "exl3"
+@@ -407,6 +766,12 @@ class Exl3Config(QuantizationConfig):
+         hf_config: PretrainedConfig | None = None,
+         revision: str | None = None,
+     ) -> None:
++        if _online_trellis_bits() is not None:
++            self._configure_online_cache_identity(
++                model_name,
++                hf_config=hf_config,
++                revision=revision,
++            )
+         rank_sliced = getattr(hf_config, "hybrid_tr3_tail", None)
+         if (
+             isinstance(rank_sliced, dict)
+@@ -449,6 +814,36 @@ class Exl3Config(QuantizationConfig):
+         self._validate_storage_metadata()
+         self._force_independent_lm_head(hf_config)
+ 
++    def _configure_online_cache_identity(
++        self,
++        model_name: str,
++        *,
++        hf_config: PretrainedConfig | None,
++        revision: str | None,
++    ) -> None:
++        if self._online_model_identity is not None:
++            return
++        encoder_source = os.getenv("VLLM_EXL3_ENCODER_SOURCE")
++        if encoder_source is None or not encoder_source.strip():
++            raise ValueError(
++                "VLLM_EXL3_ENCODER_SOURCE is required when "
++                "VLLM_EXL3_ONLINE_TRELLIS_BITS is enabled"
++            )
++        if cache_mode() == "off":
++            self._online_model_identity = "cache-disabled"
++            self._online_encoder_identity = "cache-disabled"
++            return
++        resolved_revision = revision or getattr(hf_config, "_commit_hash", None)
++        self._online_model_identity = resolve_model_identity(
++            model_name,
++            revision=resolved_revision,
++            hf_config=hf_config,
++        )
++        self._online_encoder_identity = resolve_encoder_identity(
++            encoder_source,
++            revision=os.getenv("VLLM_EXL3_ENCODER_REVISION"),
++        )
++
+     def _configure_rank_sliced(self, metadata: dict[str, Any]) -> None:
+         required = {
+             "bits",
+@@ -484,7 +879,30 @@ class Exl3Config(QuantizationConfig):
+                 "unsupported rank-sliced EXL3 tensor schema: "
+                 f"{metadata['tensor_schema']!r}"
+             )
++        rotation_layout = str(
++            metadata.get("rotation_layout", _PER_EXPERT_ROTATION_LAYOUT)
++        )
++        if rotation_layout not in {
++            _PER_EXPERT_ROTATION_LAYOUT,
++            _SHARED_H_ROTATION_LAYOUT,
++        }:
++            raise ValueError(
++                f"unsupported rank-sliced EXL3 rotation_layout: {rotation_layout!r}"
++            )
++        shared_schema = metadata.get("shared_h_tensor_schema")
++        if rotation_layout == _SHARED_H_ROTATION_LAYOUT:
++            if shared_schema != _SHARED_H_TENSOR_SCHEMA:
++                raise ValueError(
++                    "shared_h_v1 rank-sliced EXL3 requires "
++                    f"shared_h_tensor_schema={_SHARED_H_TENSOR_SCHEMA!r}"
++                )
++        elif shared_schema is not None:
++            raise ValueError(
++                "shared_h_tensor_schema is only valid with "
++                "rotation_layout='shared_h_v1'"
++            )
+         self.rank_sliced_metadata = dict(metadata)
++        self.rank_sliced_rotation_layout = rotation_layout
+         bits_field = metadata["bits"]
+         if isinstance(bits_field, str) and bits_field.strip().lower() == "mixed":
+             k_values = tuple(
+@@ -658,15 +1076,105 @@ class Exl3Config(QuantizationConfig):
+         if is_lm_head and not prefix:
+             prefix = "lm_head"
+         if isinstance(layer, LinearBase) or is_lm_head:
+-            if not self._linear_prefix_is_exl3(prefix):
+-                return UnquantizedLinearMethod()
+-            return Exl3LinearMethod(self)
++            if self._linear_prefix_is_exl3(prefix):
++                return Exl3LinearMethod(self)
++            if not is_lm_head and (
++                method := self._get_bf16_online_linear_method(layer, prefix)
++            ):
++                return method
++            return UnquantizedLinearMethod()
+         if isinstance(layer, RoutedExperts):
+             if not self._moe_prefix_is_exl3(prefix, layer):
+                 return None
+             return Exl3MoEMethod(self, layer.moe_config)
+         return None
+ 
++    def _get_bf16_online_linear_method(
++        self, layer: torch.nn.Module, prefix: str
++    ) -> QuantizeMethodBase | None:
++        """Overlay online quantization on linears absent from EXL3 storage.
++
++        EXL3-owned dense matrices are selected before this method and routed
++        experts never enter it. Shared-expert projections have an independent
++        spec so a broad ``linear`` overlay cannot quantize them accidentally.
++        When ``VLLM_EXL3_ONLINE_TRELLIS_BITS`` is set, eligible projections use
++        online EXL3 Trellis encoding instead of MXFP8.
++
++        Args:
++            layer: Candidate module for the online overlay.
++            prefix: Fully qualified checkpoint module name.
++
++        Returns:
++            An online Trellis or MXFP8 method for an eligible BF16 projection,
++            otherwise ``None``.
++
++        Raises:
++            ValueError: If the EXL3 overlay requests an unsupported weight or
++                activation format.
++        """
++        if not isinstance(layer, LinearBase):
++            return None
++
++        vllm_config = get_current_vllm_config_or_none()
++        if vllm_config is None:
++            return None
++        args = vllm_config.model_config.quantization_config
++        if not isinstance(args, QuantizationConfigArgs):
++            return None
++
++        shared_expert = is_shared_expert_projection(prefix)
++        spec = args.shared_experts if shared_expert else args.linear
++        if spec is None:
++            return None
++        if (
++            not shared_expert
++            and args.ignore
++            and should_ignore_layer(
++                prefix,
++                ignore=args.ignore,
++                fused_mapping=self.packed_modules_mapping,
++            )
++        ):
++            return None
++        if spec.weight != kMxfp8Dynamic or spec.activation is not None:
++            raise ValueError(
++                "EXL3 BF16 online overlay only supports weight='mxfp8' "
++                "with no activation override."
++            )
++
++        if (bits := _online_trellis_bits()) is not None:
++            if self._online_model_identity is None:
++                model_config = vllm_config.model_config
++                self._configure_online_cache_identity(
++                    model_config.model,
++                    hf_config=model_config.hf_config,
++                    revision=model_config.revision,
++                )
++            assert self._online_model_identity is not None
++            assert self._online_encoder_identity is not None
++            logger.warning_once(
++                "EXL3 BF16 online Trellis: encoding eligible non-EXL3 "
++                "linear weights at K=%d; 128-unaligned matrices retain the "
++                "configured MXFP8 path (module example: %s).",
++                bits,
++                prefix,
++            )
++            return Exl3OnlineLinearMethod(
++                bits=bits,
++                prefix=prefix,
++                model_identity=self._online_model_identity,
++                encoder_identity=self._online_encoder_identity,
++            )
++
++        logger.info_once(
++            "EXL3 BF16 online overlay: quantizing non-EXL3 %s projections "
++            "to MXFP8 at load time (module example: %s).",
++            "shared-expert" if shared_expert else "dense-linear",
++            prefix,
++        )
++        logger.debug("EXL3 BF16 MXFP8 overlay applied to %s", prefix)
++        return Mxfp8OnlineLinearMethod()
++
+     def _storage_entry(self, prefix: str) -> dict[str, Any] | None:
+         candidates = [prefix]
+         if prefix.startswith("model."):
+@@ -706,10 +1214,17 @@ class Exl3Config(QuantizationConfig):
+         if not source_leaves:
+             return False
+         base = prefix.rsplit(".", 1)[0] if "." in prefix else ""
+-        return all(
++        source_is_exl3 = [
+             self._is_exl3_prefix(f"{base}.{source}" if base else source)
+             for source in source_leaves
+-        )
++        ]
++        if any(source_is_exl3) and not all(source_is_exl3):
++            raise ValueError(
++                f"Packed EXL3 projection {prefix!r} mixes EXL3 and BF16 "
++                "source shards; a fused module must use one quantization "
++                "scheme."
++            )
++        return all(source_is_exl3)
+ 
+     def _moe_prefix_is_exl3(
+         self, prefix: str, layer: torch.nn.Module | None = None
+@@ -765,9 +1280,40 @@ class Exl3Config(QuantizationConfig):
+         """Drop non-local TP payloads and remove the serialized rank segment."""
+         if self.rank_sliced_metadata is None:
+             return name
++        shared_match = _SHARED_H_WEIGHT_RE.match(name)
++        if shared_match is not None:
++            if self.rank_sliced_rotation_layout != _SHARED_H_ROTATION_LAYOUT:
++                raise ValueError(
++                    "rank-sliced EXL3 contains shared-H tensors but metadata "
++                    "does not declare rotation_layout='shared_h_v1'"
++                )
++            projection = shared_match.group("projection")
++            field = shared_match.group("field")
++            expected_field = "svh" if projection == "down_proj" else "suh"
++            if field != expected_field:
++                raise ValueError(
++                    "invalid shared-H EXL3 tensor: "
++                    f"projection={projection!r} requires {expected_field}, got {field}"
++                )
++            if int(shared_match.group("rank")) != get_tensor_model_parallel_rank():
++                return None
++            return f"{shared_match.group('experts_prefix')}.0.{projection}.{field}"
+         match = _RANK_SLICED_WEIGHT_RE.match(name)
+         if match is None:
+             return name
++        if self.rank_sliced_rotation_layout == _SHARED_H_ROTATION_LAYOUT:
++            projection_match = _EXPERT_PROJECTION_RE.match(match.group("prefix"))
++            if projection_match is not None:
++                projection = projection_match.group("projection")
++                field = match.group("field")
++                is_h_side = (
++                    projection in {"gate_proj", "up_proj"} and field == "suh"
++                ) or (projection == "down_proj" and field == "svh")
++                if is_h_side:
++                    raise ValueError(
++                        "shared_h_v1 must store H-side rotations under "
++                        "experts.shared_h, not under an expert id"
++                    )
+         if int(match.group("rank")) != get_tensor_model_parallel_rank():
+             return None
+         return f"{match.group('prefix')}.{match.group('field')}"
+@@ -800,6 +1346,218 @@ def _exl3_weight_loader(
+     param.load_exl3_weight(loaded_weight, loaded_shard_id)
+ 
+ 
++class Exl3OnlineLinearMethod(_Fp8OnlineLinearBase):
++    """Encode eligible BF16 linear shards to cached dense EXL3 weights."""
++
++    def __init__(
++        self,
++        *,
++        bits: int,
++        prefix: str,
++        model_identity: str,
++        encoder_identity: str,
++    ) -> None:
++        super().__init__()
++        self.bits = bits
++        self.prefix = prefix
++        self.model_identity = model_identity
++        self.encoder_identity = encoder_identity
++        self.fallback: Mxfp8OnlineLinearMethod | None = None
++
++    def create_weights(
++        self,
++        layer: torch.nn.Module,
++        input_size_per_partition: int,
++        output_partition_sizes: list[int],
++        input_size: int,
++        output_size: int,
++        params_dtype: torch.dtype,
++        **extra_weight_attrs,
++    ) -> None:
++        output_size_per_partition = sum(output_partition_sizes)
++        layer.exl3_online_trellis = _online_trellis_shape_supported(
++            input_size_per_partition, output_size_per_partition
++        )
++        if not layer.exl3_online_trellis:
++            self.fallback = Mxfp8OnlineLinearMethod()
++            self.fallback.create_weights(
++                layer,
++                input_size_per_partition,
++                output_partition_sizes,
++                input_size,
++                output_size,
++                params_dtype,
++                **extra_weight_attrs,
++            )
++            logger.info_once(
++                "EXL3 online Trellis retains MXFP8 for 128-unaligned shards "
++                "(example %s: K=%d, N=%d).",
++                self.prefix,
++                input_size_per_partition,
++                output_size_per_partition,
++            )
++            return
++
++        super().create_weights(
++            layer,
++            input_size_per_partition,
++            output_partition_sizes,
++            input_size,
++            output_size,
++            params_dtype,
++            **extra_weight_attrs,
++        )
++        layer.exl3_online_input_size = input_size_per_partition
++        layer.exl3_online_output_size = output_size_per_partition
++
++    @staticmethod
++    def _h_data(input_size: int, device: torch.device) -> dict[str, Any]:
++        return {
++            "H": torch.zeros(
++                input_size, input_size, dtype=torch.float32, device="meta"
++            ),
++            "first_key": "vllm-online",
++            "count": 0,
++            "finalized": False,
++            "num_total": 0,
++            "inf_nan": torch.zeros(2, dtype=torch.long, device=device),
++            "device": device,
++        }
++
++    def _warm_decode_shapes(self, layer: torch.nn.Module) -> None:
++        device = layer.exl3_online_trellis_weight.device
++        _b12x_trellis_weight(
++            layer.exl3_online_trellis_weight,
++            layer.exl3_online_suh,
++            layer.exl3_online_svh,
++            torch.float16,
++        )
++        device_index = device.index
++        if device_index is None:
++            device_index = torch.cuda.current_device()
++        signature = (
++            device_index,
++            layer.exl3_online_input_size,
++            layer.exl3_online_output_size,
++            self.bits,
++        )
++        if signature in _EXL3_ONLINE_WARMED_SIGNATURES:
++            return
++        for rows in range(1, 7):
++            source = torch.zeros(
++                (rows, layer.exl3_online_input_size),
++                dtype=torch.float16,
++                device=device,
++            )
++            _b12x_trellis_linear(
++                source,
++                layer.exl3_online_trellis_weight,
++                layer.exl3_online_suh,
++                layer.exl3_online_svh,
++            )
++        torch.cuda.synchronize(device)
++        _EXL3_ONLINE_WARMED_SIGNATURES.add(signature)
++
++    def process_weights_after_loading(self, layer: torch.nn.Module) -> None:
++        if self.fallback is not None:
++            self.fallback.process_weights_after_loading(layer)
++            return
++        if getattr(layer, "_already_called_process_weights_after_loading", False):
++            return
++
++        device = layer.weight.device
++        seed = zlib.crc32(self.prefix.encode("utf-8")) & 0x7FFFFFFF
++        cache_key = Exl3OnlineCacheKey(
++            model_identity=self.model_identity,
++            encoder_identity=self.encoder_identity,
++            prefix=self.prefix,
++            bits=self.bits,
++            seed=seed,
++            tp_world_size=get_tensor_model_parallel_world_size(),
++            tp_rank=get_tensor_model_parallel_rank(),
++            input_size=layer.exl3_online_input_size,
++            output_size=layer.exl3_online_output_size,
++        )
++
++        def encode() -> tuple[dict[str, torch.Tensor], float]:
++            source = layer.weight.detach().t().float().contiguous()
++            quant_args = {
++                "K": self.bits,
++                "seed": seed,
++                "devices": [device],
++                "apply_out_scales": True,
++                "mcg": True,
++            }
++            quantize_exl3 = _load_exl3_online_quantizer()
++            _, proxy_error, tensors = quantize_exl3(
++                source,
++                self._h_data(layer.exl3_online_input_size, device),
++                quant_args,
++                return_weight_q=False,
++                verbose=False,
++            )
++            if not quant_args.get("q_fallback", False):
++                raise RuntimeError(
++                    "online EXL3 Trellis unexpectedly used calibrated LDLQ"
++                )
++            return {name: tensors[name] for name in ("trellis", "suh", "svh")}, float(
++                proxy_error
++            )
++
++        result = load_or_quantize(cache_key, device=device, quantize=encode)
++
++        layer.register_buffer(
++            "exl3_online_trellis_weight",
++            result.tensors["trellis"],
++            persistent=False,
++        )
++        layer.register_buffer(
++            "exl3_online_suh", result.tensors["suh"], persistent=False
++        )
++        layer.register_buffer(
++            "exl3_online_svh", result.tensors["svh"], persistent=False
++        )
++        replace_parameter(
++            layer,
++            "weight",
++            torch.empty(0, dtype=torch.uint8, device=device),
++        )
++        layer._already_called_process_weights_after_loading = True
++        self._warm_decode_shapes(layer)
++        logger.info(
++            "Online EXL3 K%d %s %s%s",
++            self.bits,
++            "cache hit for" if result.hit else "encoded",
++            self.prefix,
++            ""
++            if result.proxy_error is None
++            else f" (fallback proxy error {result.proxy_error:.8f})",
++        )
++
++    def apply(
++        self,
++        layer: torch.nn.Module,
++        x: torch.Tensor,
++        bias: torch.Tensor | None = None,
++    ) -> torch.Tensor:
++        if self.fallback is not None:
++            return self.fallback.apply(layer, x, bias)
++
++        original_shape = x.shape[:-1]
++        original_dtype = x.dtype
++        x_2d = x.reshape(-1, x.shape[-1]).to(torch.float16).contiguous()
++        output = _b12x_trellis_linear(
++            x_2d,
++            layer.exl3_online_trellis_weight,
++            layer.exl3_online_suh,
++            layer.exl3_online_svh,
++        )
++        if bias is not None:
++            output = output + bias.to(dtype=output.dtype)
++        output = output.reshape(*original_shape, layer.exl3_online_output_size)
++        return output if output.dtype == original_dtype else output.to(original_dtype)
++
++
+ class Exl3LinearMethod(LinearMethodBase):
+     def __init__(self, quant_config: Exl3Config) -> None:
+         self.quant_config = quant_config
+@@ -905,6 +1663,24 @@ class Exl3LinearMethod(LinearMethodBase):
+                     device=device, non_blocking=True
+                 ).contiguous()
+ 
++        for shard_id in layer.exl3_shard_ids:
++            trellis = layer.trellis.exl3_tensors[shard_id]
++            if not _b12x_trellis_k6_supported(
++                trellis,
++                has_mcg=shard_id in layer.mcg.exl3_tensors,
++                has_mul1=shard_id in layer.mul1.exl3_tensors,
++            ):
++                continue
++            suh = layer.suh.exl3_tensors[shard_id]
++            svh = layer.svh.exl3_tensors[shard_id]
++            _b12x_trellis_weight(
++                trellis,
++                suh,
++                svh,
++                torch.float16,
++            )
++            _warm_b12x_trellis_device(trellis, suh, svh)
++
+     def apply(
+         self,
+         layer: torch.nn.Module,
+@@ -1158,14 +1934,28 @@ class Exl3LinearMethod(LinearMethodBase):
+             )
+         if x.shape[-1] < packed_k:
+             x = torch.nn.functional.pad(x, (0, packed_k - x.shape[-1]))
+-        output = _exl3_gemm(
+-            x,
++        has_mcg = shard_id in layer.mcg.exl3_tensors
++        has_mul1 = shard_id in layer.mul1.exl3_tensors
++        if _b12x_trellis_k6_supported(
+             trellis,
+-            layer.suh.exl3_tensors[shard_id],
+-            layer.svh.exl3_tensors[shard_id],
+-            shard_id in layer.mcg.exl3_tensors,
+-            shard_id in layer.mul1.exl3_tensors,
+-        )
++            has_mcg=has_mcg,
++            has_mul1=has_mul1,
++        ):
++            output = _b12x_trellis_linear(
++                x,
++                trellis,
++                layer.suh.exl3_tensors[shard_id],
++                layer.svh.exl3_tensors[shard_id],
++            )
++        else:
++            output = _exl3_gemm(
++                x,
++                trellis,
++                layer.suh.exl3_tensors[shard_id],
++                layer.svh.exl3_tensors[shard_id],
++                has_mcg,
++                has_mul1,
++            )
+         logical_n = Exl3LinearMethod._output_shard_size(layer, shard_id)
+         if output.shape[-1] < logical_n:
+             raise ValueError(
+@@ -1308,6 +2098,12 @@ class Exl3MoEMethod(FusedMoEMethodBase):
+         layer.exl3_intermediate_size_per_partition = intermediate_size_per_partition
+         layer.exl3_params_dtype = params_dtype
+         rank_sliced = self.quant_config.rank_sliced_metadata is not None
++        shared_h = (
++            rank_sliced
++            and self.quant_config.rank_sliced_rotation_layout
++            == _SHARED_H_ROTATION_LAYOUT
++        )
++        layer.exl3_shared_h_rotations = shared_h
+         if rank_sliced:
+             checkpoint_tp = int(self.quant_config.rank_sliced_metadata["tp"])
+             if checkpoint_tp != layer.exl3_tp_size:
+@@ -1360,11 +2156,15 @@ class Exl3MoEMethod(FusedMoEMethodBase):
+             layer.exl3_mixed_bitrate = len(set(layer.exl3_layer_bitrates)) > 1
+         for prefix, shard_ids in (("w13", ("w1", "w3")), ("w2", ("w2",))):
+             for suffix in ("suh", "svh", "trellis", "mcg", "mul1"):
++                shared_parameter = shared_h and (
++                    (prefix == "w13" and suffix == "suh")
++                    or (prefix == "w2" and suffix == "svh")
++                )
+                 layer.register_parameter(
+                     f"{prefix}_{suffix}",
+                     Exl3MoEParameter(
+                         weight_loader=_exl3_moe_weight_loader,
+-                        num_experts=num_experts,
++                        num_experts=1 if shared_parameter else num_experts,
+                         shard_ids=shard_ids,
+                         preallocate=rank_sliced
+                         and suffix
+@@ -1382,7 +2182,16 @@ class Exl3MoEMethod(FusedMoEMethodBase):
+         for prefix, shard_ids in required.items():
+             for attr in ("suh", "svh", "trellis"):
+                 tensors = getattr(layer, f"{prefix}_{attr}").exl3_tensors
+-                for expert_id in range(layer.local_num_experts):
++                shared_parameter = getattr(
++                    layer, "exl3_shared_h_rotations", False
++                ) and (
++                    (prefix == "w13" and attr == "suh")
++                    or (prefix == "w2" and attr == "svh")
++                )
++                expert_ids = (
++                    (0,) if shared_parameter else range(layer.local_num_experts)
++                )
++                for expert_id in expert_ids:
+                     for shard_id in shard_ids:
+                         if (expert_id, shard_id) not in tensors:
+                             missing.append(f"{prefix}_{attr}[{expert_id},{shard_id}]")
+@@ -1484,8 +2293,20 @@ class Exl3MoEMethod(FusedMoEMethodBase):
+                 for shard_id in shard_ids:
+                     key = (expert_id, shard_id)
+                     trellis = getattr(layer, f"{group}_trellis").exl3_tensors[key]
+-                    suh = getattr(layer, f"{group}_suh").exl3_tensors[key]
+-                    svh = getattr(layer, f"{group}_svh").exl3_tensors[key]
++                    suh_key = (
++                        (0, shard_id)
++                        if getattr(layer, "exl3_shared_h_rotations", False)
++                        and group == "w13"
++                        else key
++                    )
++                    svh_key = (
++                        (0, shard_id)
++                        if getattr(layer, "exl3_shared_h_rotations", False)
++                        and group == "w2"
++                        else key
++                    )
++                    suh = getattr(layer, f"{group}_suh").exl3_tensors[suh_key]
++                    svh = getattr(layer, f"{group}_svh").exl3_tensors[svh_key]
+                     if (
+                         trellis.dtype != torch.int16
+                         or trellis.ndim != 3
+@@ -1531,17 +2352,40 @@ class Exl3MoEMethod(FusedMoEMethodBase):
+         return backing
+ 
+     @staticmethod
+-    def _pointer_table(slab: torch.Tensor) -> torch.Tensor:
++    def _pointer_table(
++        slab: torch.Tensor,
++        *,
++        num_experts: int | None = None,
++    ) -> torch.Tensor:
+         if slab.ndim < 2 or not slab[0].is_contiguous():
+             raise RuntimeError("EXL3 pointer-table rows must be contiguous")
++        rows = int(slab.shape[0])
++        entries = rows if num_experts is None else int(num_experts)
++        if rows not in {1, entries}:
++            raise RuntimeError(
++                "EXL3 pointer-table rows must be per-expert or broadcast: "
++                f"rows={rows}, experts={entries}"
++            )
+         step = slab.stride(0) * slab.element_size()
+         base = slab.data_ptr()
+         return torch.tensor(
+-            [base + expert_id * step for expert_id in range(slab.shape[0])],
++            [
++                base + (0 if rows == 1 else expert_id) * step
++                for expert_id in range(entries)
++            ],
+             dtype=torch.int64,
+             device=slab.device,
+         )
+ 
++    @staticmethod
++    def _select_rotation_rows(
++        rotations: torch.Tensor,
++        expert_ids: torch.Tensor,
++    ) -> torch.Tensor:
++        if int(rotations.shape[0]) == 1:
++            return rotations
++        return rotations.index_select(0, expert_ids).contiguous()
++
+     @staticmethod
+     def _trellis_tile_config(hidden_size: int, intermediate_size: int):
+         if hidden_size % 128 or intermediate_size % 128:
+@@ -1569,8 +2413,16 @@ class Exl3MoEMethod(FusedMoEMethodBase):
+             return (128, 128, 64, 256)
+         return (128, 128, 128, 128)
+ 
++    @staticmethod
++    def _mixed_trellis_prefill_tile_config(hidden_size: int, intermediate_size: int):
++        # Route packing stays block-64, while B12X's mixed-kernel ABI v2
++        # executes FC2 as arithmetic-equivalent 8-row subtiles.  Reuse the
++        # checkpoint's original one-grid tile geometry so prefill has the same
++        # reduction order as the stock-r16 quality reference.
++        return Exl3MoEMethod._mixed_trellis_tile_config(hidden_size, intermediate_size)
++
+     def _prepare_mixed_rank_sliced_weights(self, layer: RoutedExperts) -> None:
+-        api = _load_b12x_mixed_trellis()
++        mixed_api = _load_b12x_mixed_trellis()
+         num_experts = int(layer.local_num_experts)
+         hidden_size = int(layer.exl3_hidden_size)
+         intermediate_size = int(layer.exl3_intermediate_size_per_partition)
+@@ -1609,9 +2461,44 @@ class Exl3MoEMethod(FusedMoEMethodBase):
+         down_suh = self._rank_sliced_backing(layer, "w2_suh")
+         down_svh = self._rank_sliced_backing(layer, "w2_svh")
+         device = gate_suh.device
+-        tile_config = self._mixed_trellis_tile_config(hidden_size, intermediate_size)
++        mixed_tile_config = self._mixed_trellis_tile_config(
++            hidden_size, intermediate_size
++        )
++        prefill_tile_config = self._mixed_trellis_prefill_tile_config(
++            hidden_size, intermediate_size
++        )
++        tier_order = tuple(
++            expert_id for expert_ids in tiers.values() for expert_id in expert_ids
++        )
++        tier_index = torch.tensor(tier_order, dtype=torch.long, device=device)
++        combined_gate_suh = self._select_rotation_rows(gate_suh, tier_index)
++        combined_up_suh = self._select_rotation_rows(up_suh, tier_index)
++        broadcast_suh = int(combined_gate_suh.shape[0]) == 1
++        if broadcast_suh != (int(combined_up_suh.shape[0]) == 1):
++            raise ValueError(
++                "mixed EXL3 gate/up SUH rotations must both be per-expert "
++                "or both broadcast"
++            )
++        combined_intermediate_rotations = torch.cat(
++            (
++                gate_svh.index_select(0, tier_index),
++                up_svh.index_select(0, tier_index),
++                down_suh.index_select(0, tier_index),
++            ),
++            dim=1,
++        ).contiguous()
++        combined_down_svh = self._select_rotation_rows(down_svh, tier_index)
++        broadcast_svh = int(combined_down_svh.shape[0]) == 1
++        combined_rotations = SimpleNamespace(
++            intermediate=combined_intermediate_rotations,
++            gate_suh=combined_gate_suh,
++            up_suh=combined_up_suh,
++            down_svh=combined_down_svh,
++        )
+         prepared_tiers = []
++        prefill_tiers = []
+         tier_ids = []
++        tier_offset = 0
+         for bits, expert_ids in tiers.items():
+             expected_last = 16 * bits
+             w13 = torch.stack(
+@@ -1650,25 +2537,42 @@ class Exl3MoEMethod(FusedMoEMethodBase):
+                     f"expected={expected_w13}/{expected_w2}"
+                 )
+ 
+-            index = torch.tensor(expert_ids, dtype=torch.long, device=device)
+-            tier_gate_suh = gate_suh.index_select(0, index).contiguous()
+-            tier_up_suh = up_suh.index_select(0, index).contiguous()
+-            intermediate_rotations = torch.cat(
+-                (
+-                    gate_svh.index_select(0, index),
+-                    up_svh.index_select(0, index),
+-                    down_suh.index_select(0, index),
+-                ),
+-                dim=1,
+-            ).contiguous()
+-            tier_down_svh = down_svh.index_select(0, index).contiguous()
+-            prepared_tiers.append(
+-                api.prepare_weights(
++            tier_slice = slice(tier_offset, tier_offset + len(expert_ids))
++            tier_gate_suh = (
++                combined_gate_suh
++                if int(combined_gate_suh.shape[0]) == 1
++                else combined_gate_suh[tier_slice]
++            )
++            tier_up_suh = (
++                combined_up_suh
++                if int(combined_up_suh.shape[0]) == 1
++                else combined_up_suh[tier_slice]
++            )
++            intermediate_rotations = combined_intermediate_rotations[tier_slice]
++            tier_down_svh = (
++                combined_down_svh
++                if int(combined_down_svh.shape[0]) == 1
++                else combined_down_svh[tier_slice]
++            )
++
++            def prepare_tier(
++                tile_config: tuple[int, int, int, int],
++                *,
++                w13: torch.Tensor = w13,
++                w2: torch.Tensor = w2,
++                expert_count: int = len(expert_ids),
++                bits: int = bits,
++                tier_gate_suh: torch.Tensor = tier_gate_suh,
++                tier_up_suh: torch.Tensor = tier_up_suh,
++                intermediate_rotations: torch.Tensor = intermediate_rotations,
++                tier_down_svh: torch.Tensor = tier_down_svh,
++            ):
++                return mixed_api.prepare_weights(
+                     w13=w13,
+                     w2=w2,
+                     hidden_size=hidden_size,
+                     intermediate_size=intermediate_size,
+-                    num_experts=len(expert_ids),
++                    num_experts=expert_count,
+                     activation=layer.activation.value,
+                     fc1_tile_n=tile_config[1],
+                     fc2_tile_n=tile_config[3],
+@@ -1683,22 +2587,29 @@ class Exl3MoEMethod(FusedMoEMethodBase):
+                     tile_config=tile_config,
+                     workspace=w13.view(torch.int32).reshape(-1)[:1],
+                 )
+-            )
++
++            prepared_tiers.append(prepare_tier(mixed_tile_config))
++            prefill_tiers.append(prepare_tier(prefill_tile_config))
+             tier_ids.append(expert_ids)
++            tier_offset += len(expert_ids)
+ 
+-        global_to_combined, descriptor_map = api.build_tiered_maps(
++        global_to_combined, descriptor_map = mixed_api.build_tiered_maps(
+             tier_ids[0], tier_ids[1], device=device
+         )
+         layer.exl3_mixed_trellis = {
+             "tiers": tuple(prepared_tiers),
++            "prefill_tiers": tuple(prefill_tiers),
+             "tier_ids": tuple(tier_ids),
+             "tier_bits": tuple(tiers),
+             "global_to_combined": global_to_combined,
+             "descriptor_map": descriptor_map,
+-            "rotations": api.combine_trellis_rotations(*prepared_tiers),
+-            "tile_config": tile_config,
++            "rotations": combined_rotations,
++            "broadcast_suh": broadcast_suh,
++            "broadcast_svh": broadcast_svh,
++            "tile_config": mixed_tile_config,
++            "prefill_tile_config": prefill_tile_config,
+         }
+-        layer.exl3_trellis_tile_config = tile_config
++        layer.exl3_trellis_tile_config = mixed_tile_config
+ 
+         # The prepared tier objects own compact, tier-ordered copies. Release
+         # per-expert source tensors and the original rotation slabs now rather
+@@ -1807,13 +2718,22 @@ class Exl3MoEMethod(FusedMoEMethodBase):
+             down_suh,
+             down_svh,
+         )
+-        layer.exl3_pointer_tables = tuple(self._pointer_table(slab) for slab in slabs)
++        layer.exl3_pointer_tables = tuple(
++            self._pointer_table(slab, num_experts=num_experts) for slab in slabs
++        )
+         layer.exl3_expert_map = torch.arange(
+             num_experts,
+             dtype=torch.int64,
+             device=w13.device,
+         )
+         layer.exl3_trellis_tile_config = tile_config
++        if getattr(layer, "exl3_shared_h_rotations", False):
++            saved_bytes = (num_experts - 1) * 3 * hidden_size * 2
++            logger.info_once(
++                "EXL3 shared-H rotation layout active; saving %.2f MiB per "
++                "routed-expert layer and TP rank",
++                saved_bytes / (1024 * 1024),
++            )
+ 
+     def get_fused_moe_quant_config(
+         self, layer: RoutedExperts
+@@ -1832,15 +2752,73 @@ class Exl3MoEMethod(FusedMoEMethodBase):
+         topk_ids: torch.Tensor,
+     ) -> dict[str, Any]:
+         mixed = layer.exl3_mixed_trellis
+-        max_decode_m = _positive_env_int("VLLM_EXL3_TRELLIS_MAX_M", 32)
+-        max_batched_tokens = int(layer.exl3_max_num_batched_tokens)
+-        if max_decode_m > max_batched_tokens:
+-            max_decode_m = max_batched_tokens
+         topk = int(topk_ids.shape[1])
+-        tier_signature = tuple(
+-            (int(bits), len(ids))
+-            for bits, ids in zip(mixed["tier_bits"], mixed["tier_ids"], strict=True)
+-        )
++        policy = mixed.get("runtime_policy")
++        if policy is None:
++            max_decode_m = _positive_env_int("VLLM_EXL3_TRELLIS_MAX_M", 32)
++            max_batched_tokens = int(layer.exl3_max_num_batched_tokens)
++            prefill_capacity = _resolve_prefill_capacity(max_batched_tokens)
++            prefill_block_raw = os.environ.get("VLLM_EXL3_PREFILL_BLOCK_M")
++            configured_block_m = _positive_env_int("VLLM_EXL3_PREFILL_BLOCK_M", 64)
++            max_decode_m = min(max_decode_m, max_batched_tokens)
++            tier_signature = tuple(
++                (int(bits), len(ids))
++                for bits, ids in zip(mixed["tier_bits"], mixed["tier_ids"], strict=True)
++            )
++            props = torch.cuda.get_device_properties(x.device)
++            explicit_block_m = bool(
++                prefill_block_raw is not None and prefill_block_raw.strip()
++            )
++            prefill_block_m = _resolve_mixed_trellis_prefill_block_m(
++                configured_block_m=configured_block_m,
++                explicit_override=explicit_block_m,
++                hidden_size=int(layer.exl3_hidden_size),
++                intermediate_size=int(layer.exl3_intermediate_size_per_partition),
++                tier_signature=tier_signature,
++                topk=topk,
++                device_major=int(getattr(props, "major", 0)),
++                prefill_tile_config=mixed["prefill_tile_config"],
++            )
++            policy = {
++                "device_index": x.device.index,
++                "topk": topk,
++                "max_decode_m": max_decode_m,
++                "max_batched_tokens": max_batched_tokens,
++                "prefill_capacity": prefill_capacity,
++                "prefill_block_m": prefill_block_m,
++                "tier_signature": tier_signature,
++                "sms": int(props.multi_processor_count),
++                "max_shared_mem": int(props.shared_memory_per_block_optin),
++            }
++            mixed["runtime_policy"] = policy
++            logger.info_once(
++                "EXL3 mixed Trellis prefill block policy: selected=%d "
++                "configured=%d explicit=%s shape=%dx%d tiers=%s topk=%d "
++                "sm=%d tile=%s",
++                prefill_block_m,
++                configured_block_m,
++                explicit_block_m,
++                int(layer.exl3_hidden_size),
++                int(layer.exl3_intermediate_size_per_partition),
++                tier_signature,
++                topk,
++                int(getattr(props, "major", 0)),
++                mixed["prefill_tile_config"],
++            )
++        elif policy["device_index"] != x.device.index or policy["topk"] != topk:
++            raise RuntimeError(
++                "mixed-bitrate EXL3 runtime geometry changed after planning: "
++                f"device/topk={x.device.index}/{topk}, expected "
++                f"{policy['device_index']}/{policy['topk']}"
++            )
++
++        max_decode_m = policy["max_decode_m"]
++        max_batched_tokens = policy["max_batched_tokens"]
++        prefill_capacity = policy["prefill_capacity"]
++        prefill_block_m = policy["prefill_block_m"]
++        tier_signature = policy["tier_signature"]
++        broadcast_suh = bool(mixed["broadcast_suh"])
++        broadcast_svh = bool(mixed["broadcast_svh"])
+         key = (
+             _runtime_owner_token(self.quant_config, layer),
+             x.device.index,
+@@ -1852,10 +2830,16 @@ class Exl3MoEMethod(FusedMoEMethodBase):
+             topk,
+             max_decode_m,
+             max_batched_tokens,
++            prefill_capacity,
+             mixed["tile_config"],
++            mixed["prefill_tile_config"],
++            prefill_block_m,
++            broadcast_suh,
++            broadcast_svh,
+         )
+         runtime = _MIXED_TRELLIS_RUNTIMES.get(key)
+         if runtime is not None:
++            mixed["runtime"] = runtime
+             return runtime
+         if torch.cuda.is_current_stream_capturing():
+             raise RuntimeError(
+@@ -1868,18 +2852,21 @@ class Exl3MoEMethod(FusedMoEMethodBase):
+                 f"{topk_ids.dtype}"
+             )
+ 
+-        api = _load_b12x_mixed_trellis()
++        mixed_api = _load_b12x_mixed_trellis()
+         device = x.device
+-        props = torch.cuda.get_device_properties(device)
+         total_experts = sum(experts for _, experts in tier_signature)
+ 
+-        def make_state(capacity: int) -> dict[str, Any]:
+-            route_slots = api.max_packed_route_slots(
++        def make_state(
++            capacity: int,
++            block_size_m: int,
++            tile_config: tuple[int, int, int, int],
++        ) -> dict[str, Any]:
++            route_slots = mixed_api.max_packed_route_slots(
+                 capacity * topk,
+-                _MIXED_TRELLIS_ROUTE_BLOCK_SIZE,
++                block_size_m,
+                 total_experts,
+             )
+-            launch = api.compile_mixed_trellis(
++            launch = mixed_api.compile_mixed_trellis(
+                 size_m=capacity,
+                 hidden_size=int(layer.exl3_hidden_size),
+                 intermediate_size=int(layer.exl3_intermediate_size_per_partition),
+@@ -1888,49 +2875,64 @@ class Exl3MoEMethod(FusedMoEMethodBase):
+                 tier0_bits=tier_signature[0][0],
+                 tier1_bits=tier_signature[1][0],
+                 top_k=topk,
+-                max_m_blocks=(route_slots + _MIXED_TRELLIS_ROUTE_BLOCK_SIZE - 1)
+-                // _MIXED_TRELLIS_ROUTE_BLOCK_SIZE,
+-                moe_block_size=_MIXED_TRELLIS_ROUTE_BLOCK_SIZE,
+-                sms=int(props.multi_processor_count),
+-                max_shared_mem=int(props.shared_memory_per_block_optin),
+-                force_tile_config=mixed["tile_config"],
++                max_m_blocks=(route_slots + block_size_m - 1) // block_size_m,
++                moe_block_size=block_size_m,
++                sms=policy["sms"],
++                max_shared_mem=policy["max_shared_mem"],
++                force_tile_config=tile_config,
+                 rotation_input_dtype=("bf16" if x.dtype == torch.bfloat16 else "fp16"),
+                 route_ids_dtype=topk_ids.dtype,
++                broadcast_suh=broadcast_suh,
++                broadcast_svh=broadcast_svh,
+             )
+             return {
+                 "capacity": capacity,
+                 "launch": launch,
+-                "buffers": api.make_mixed_trellis_buffers(
++                "buffers": mixed_api.make_mixed_trellis_buffers(
+                     launch,
+                     device=device,
+-                    sms=int(props.multi_processor_count),
++                    sms=policy["sms"],
+                 ),
+             }
+ 
+-        decode = make_state(max_decode_m)
+-        prefill = (
+-            make_state(max_batched_tokens)
+-            if max_batched_tokens > max_decode_m
+-            else decode
++        decode = make_state(
++            max_decode_m,
++            _MIXED_TRELLIS_ROUTE_BLOCK_SIZE,
++            mixed["tile_config"],
+         )
++        prefill = None
++        if max_batched_tokens > max_decode_m:
++            if os.environ.get("VLLM_EXL3_PREFILL_TRELLIS", "1") != "1":
++                raise ValueError("mixed-K EXL3 requires VLLM_EXL3_PREFILL_TRELLIS=1")
++            prefill = make_state(
++                prefill_capacity,
++                prefill_block_m,
++                mixed["prefill_tile_config"],
++            )
+         runtime = {
+-            "api": api,
++            "mixed_api": mixed_api,
+             "decode": decode,
+             "prefill": prefill,
+             "max_decode_m": max_decode_m,
+             "max_batched_tokens": max_batched_tokens,
++            "prefill_capacity": prefill_capacity,
+         }
+         _MIXED_TRELLIS_RUNTIMES[key] = runtime
+-        buffer_bytes = _unique_tensor_storage_bytes(
+-            decode["buffers"], prefill["buffers"]
++        mixed["runtime"] = runtime
++        decode_bytes = _unique_tensor_storage_bytes(decode["buffers"])
++        prefill_bytes = (
++            0 if prefill is None else _unique_tensor_storage_bytes(prefill["buffers"])
+         )
+         logger.info_once(
+-            "EXL3 mixed Trellis runtime planned: tiers=%s decode_capacity=%d "
+-            "prefill_capacity=%d buffers=%.1f MiB",
++            "EXL3 mixed Trellis runtime planned: tiers=%s one-grid decode=%d "
++            "one-grid prefill=%d/%d block_m=%d buffers=%.1f+%.1f MiB",
+             tier_signature,
+             max_decode_m,
++            prefill_capacity,
+             max_batched_tokens,
+-            buffer_bytes / (1 << 20),
++            prefill_block_m,
++            decode_bytes / (1 << 20),
++            prefill_bytes / (1 << 20),
+         )
+         return runtime
+ 
+@@ -1948,23 +2950,65 @@ class Exl3MoEMethod(FusedMoEMethodBase):
+                 "mixed-bitrate EXL3 batch exceeds planned capacity: "
+                 f"m={m}, capacity={runtime['max_batched_tokens']}"
+             )
+-        state = (
+-            runtime["decode"] if m <= runtime["max_decode_m"] else runtime["prefill"]
+-        )
+         mixed = layer.exl3_mixed_trellis
+-        output = runtime["api"].run_mixed_trellis(
+-            x,
+-            mixed["tiers"][0],
+-            mixed["tiers"][1],
+-            topk_weights,
+-            topk_ids,
+-            mixed["global_to_combined"],
+-            mixed["descriptor_map"],
+-            mixed["rotations"],
+-            state["launch"],
+-            state["buffers"],
+-        )
+-        return output.to(x.dtype)
++
++        def run_state(
++            slice_x: torch.Tensor,
++            slice_weights: torch.Tensor,
++            slice_ids: torch.Tensor,
++            state: dict[str, Any],
++            tiers: tuple[Any, Any],
++        ) -> torch.Tensor:
++            return (
++                runtime["mixed_api"]
++                .run_mixed_trellis(
++                    slice_x,
++                    tiers[0],
++                    tiers[1],
++                    slice_weights,
++                    slice_ids,
++                    mixed["global_to_combined"],
++                    mixed["descriptor_map"],
++                    mixed["rotations"],
++                    state["launch"],
++                    state["buffers"],
++                )
++                .to(slice_x.dtype)
++            )
++
++        if m <= runtime["max_decode_m"]:
++            return run_state(
++                x,
++                topk_weights,
++                topk_ids,
++                runtime["decode"],
++                mixed["tiers"],
++            )
++
++        if runtime["prefill"] is None:
++            raise RuntimeError("mixed-K EXL3 one-grid prefill plan is unavailable")
++        prefill_capacity = int(runtime["prefill_capacity"])
++        if m <= prefill_capacity:
++            return run_state(
++                x,
++                topk_weights,
++                topk_ids,
++                runtime["prefill"],
++                mixed["prefill_tiers"],
++            )
++
++        output = torch.empty_like(x)
++        for start in range(0, m, prefill_capacity):
++            stop = min(start + prefill_capacity, m)
++            slice_output = run_state(
++                x[start:stop],
++                topk_weights[start:stop],
++                topk_ids[start:stop],
++                runtime["prefill"],
++                mixed["prefill_tiers"],
++            )
++            output[start:stop].copy_(slice_output)
++        return output
+ 
+     def _rank_sliced_runtime(
+         self,
+@@ -1996,12 +3040,11 @@ class Exl3MoEMethod(FusedMoEMethodBase):
+             raise ValueError(
+                 "VLLM_EXL3_TRELLIS_MIN_M cannot exceed VLLM_EXL3_TRELLIS_MAX_M"
+             )
+-        # Batch-INVARIANT capacity. Including x.shape[0] here made the runtime
+-        # cache key depend on the live batch, so any m above the planned capacity
+-        # produced a cache MISS -- silently planning a fresh ~1 GiB arena mid-serve
+-        # and making the capacity guard in _apply_rank_sliced unreachable. The
+-        # planned capacity is a property of the layer, not of one forward pass.
++        # Both capacities are batch-invariant runtime properties. The scheduler
++        # bound remains fail-closed while a smaller opt-in Trellis capacity is
++        # handled by slicing at dispatch.
+         max_batched_tokens = int(layer.exl3_max_num_batched_tokens)
++        prefill_capacity = _resolve_prefill_capacity(max_batched_tokens)
+         prefill_plan_enabled = prefill_trellis and max_batched_tokens > max_trellis_m
+         parity_rows = (
+             min(chunk, max_batched_tokens)
+@@ -2036,6 +3079,7 @@ class Exl3MoEMethod(FusedMoEMethodBase):
+             prefill_trellis,
+             prefill_block_m,
+             layer.exl3_trellis_tile_config,
++            prefill_capacity,
+         )
+         runtime = _RANK_SLICED_RUNTIMES.get(key)
+         if runtime is not None:
+@@ -2079,7 +3123,7 @@ class Exl3MoEMethod(FusedMoEMethodBase):
+         prefill_scratch = None
+         if prefill_plan_enabled:
+             prefill_plan, prefill_scratch = _plan_with_scratch(
+-                max_batched_tokens, prefill_block_m
++                prefill_capacity, prefill_block_m
+             )
+ 
+         ext = _load_exl3_ext()
+@@ -2110,6 +3154,7 @@ class Exl3MoEMethod(FusedMoEMethodBase):
+             "min_trellis_m": min_trellis_m,
+             "max_trellis_m": max_trellis_m,
+             "max_batched_tokens": max_batched_tokens,
++            "prefill_capacity": prefill_capacity,
+             "parity_rows": parity_rows,
+             "topk": topk,
+             "chunk": chunk,
+@@ -2182,12 +3227,13 @@ class Exl3MoEMethod(FusedMoEMethodBase):
+         )
+         logger.info_once(
+             "EXL3 rank-sliced runtime planned: Trellis m=%d..%d block_m=%d, "
+-            "prefill %s capacity=%d chunk=%d topk=%d",
++            "prefill %s scheduler_capacity=%d chunk=%d topk=%d",
+             min_trellis_m,
+             max_trellis_m,
+             block_m,
+             (
+-                f"trellis block_m={prefill_block_m} arena={prefill_arena_mib:.1f}MiB"
++                f"trellis block_m={prefill_block_m} "
++                f"capacity={prefill_capacity} arena={prefill_arena_mib:.1f}MiB"
+                 if prefill_plan is not None
+                 else "parity"
+             ),
+@@ -2231,16 +3277,33 @@ class Exl3MoEMethod(FusedMoEMethodBase):
+                     "EXL3 batch exceeds its planned capacity: "
+                     f"m={m}, capacity={runtime['max_batched_tokens']}"
+                 )
+-            binding = runtime["api"].bind(
+-                runtime["prefill_plan"],
+-                scratch=runtime["prefill_scratch"],
+-                a=x,
+-                experts=layer.exl3_trellis_weights,
+-                topk_weights=topk_weights,
+-                topk_ids=topk_ids,
+-            )
+-            output = runtime["api"].run(binding=binding)
+-            return output.to(x.dtype)
++            prefill_capacity = int(runtime["prefill_capacity"])
++            if m <= prefill_capacity:
++                binding = runtime["api"].bind(
++                    runtime["prefill_plan"],
++                    scratch=runtime["prefill_scratch"],
++                    a=x,
++                    experts=layer.exl3_trellis_weights,
++                    topk_weights=topk_weights,
++                    topk_ids=topk_ids,
++                )
++                output = runtime["api"].run(binding=binding)
++                return output.to(x.dtype)
++
++            output = torch.empty_like(x)
++            for start in range(0, m, prefill_capacity):
++                stop = min(start + prefill_capacity, m)
++                binding = runtime["api"].bind(
++                    runtime["prefill_plan"],
++                    scratch=runtime["prefill_scratch"],
++                    a=x[start:stop],
++                    experts=layer.exl3_trellis_weights,
++                    topk_weights=topk_weights[start:stop],
++                    topk_ids=topk_ids[start:stop],
++                )
++                slice_output = runtime["api"].run(binding=binding)
++                output[start:stop].copy_(slice_output)
++            return output
+ 
+         if torch.cuda.is_current_stream_capturing():
+             raise RuntimeError(
+@@ -2444,4 +3507,57 @@ class Exl3MoEMethod(FusedMoEMethodBase):
+         return output[..., :logical_n]
+ 
+ 
+-__all__ = ["Exl3Config", "Exl3LinearMethod", "Exl3MoEMethod"]
++def warmup_exl3_mixed_trellis_route_pack(model: torch.nn.Module) -> int:
++    """Materialize mixed-Trellis route-pack modules before KV sizing.
++
++    The first profile pass creates every layer's immutable mixed-Trellis
++    runtime. Route packing itself has power-of-two capacity specializations,
++    however, so profiling only the maximum batch leaves smaller decode,
++    speculative, and final-prefill-chunk modules lazy. Delegate enumeration to
++    B12X while those persistent CUDA allocations can still be measured by the
++    worker's second profile pass.
++    """
++    warmed = 0
++    seen_layers: set[int] = set()
++    for module in model.modules():
++        routed_experts = getattr(module, "routed_experts", module)
++        mixed = getattr(routed_experts, "exl3_mixed_trellis", None)
++        if not isinstance(mixed, dict) or id(routed_experts) in seen_layers:
++            continue
++        seen_layers.add(id(routed_experts))
++
++        runtime = mixed.get("runtime")
++        if runtime is None:
++            layer_name = getattr(routed_experts, "layer_name", "<unknown>")
++            raise RuntimeError(
++                "mixed-bitrate EXL3 route-pack warmup found no runtime for "
++                f"{layer_name}; the eager profile pass must plan the runtime "
++                "before kernel warmup"
++            )
++        api = runtime["mixed_api"]
++        warmup = getattr(api, "warmup_mixed_trellis_route_pack", None)
++        if not callable(warmup):
++            raise RuntimeError(
++                "mixed-bitrate EXL3 route-pack warmup requires a matching B12X build"
++            )
++
++        for state_name in ("decode", "prefill"):
++            state = runtime.get(state_name)
++            if state is None:
++                continue
++            warmed += int(
++                warmup(
++                    state["launch"],
++                    state["buffers"],
++                    expert_map=mixed["global_to_combined"],
++                )
++            )
++    return warmed
++
++
++__all__ = [
++    "Exl3Config",
++    "Exl3LinearMethod",
++    "Exl3MoEMethod",
++    "warmup_exl3_mixed_trellis_route_pack",
++]
+diff --git a/vllm/model_executor/layers/quantization/exl3_online_cache.py b/vllm/model_executor/layers/quantization/exl3_online_cache.py
+new file mode 100644
+index 0000000000000000000000000000000000000000..2855f2b1a43fb6b6d7eeed5a933e042cdc76b80d
+--- /dev/null
++++ b/vllm/model_executor/layers/quantization/exl3_online_cache.py
+@@ -0,0 +1,339 @@
++# SPDX-License-Identifier: Apache-2.0
++# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
++
++"""Persistent cache for deterministic online EXL3 weight encoding."""
++
++from __future__ import annotations
++
++import hashlib
++import json
++import os
++import tempfile
++from collections.abc import Callable, Mapping
++from dataclasses import asdict, dataclass
++from pathlib import Path
++from typing import Any, Literal
++
++import filelock
++import torch
++from safetensors import safe_open
++from safetensors.torch import save_file
++
++from vllm.logger import init_logger
++
++logger = init_logger(__name__)
++
++_CACHE_SCHEMA = 1
++_CACHE_TENSORS = frozenset({"trellis", "suh", "svh"})
++CacheMode = Literal["off", "readonly", "readwrite"]
++QuantizeFn = Callable[[], tuple[Mapping[str, torch.Tensor], float | None]]
++
++
++@dataclass(frozen=True)
++class Exl3OnlineCacheKey:
++    """All inputs that can change one rank-local online EXL3 payload."""
++
++    model_identity: str
++    encoder_identity: str
++    prefix: str
++    bits: int
++    seed: int
++    tp_world_size: int
++    tp_rank: int
++    input_size: int
++    output_size: int
++    codebook: str = "mcg"
++    apply_out_scales: bool = True
++    schema: int = _CACHE_SCHEMA
++
++    def canonical_json(self) -> str:
++        return json.dumps(asdict(self), sort_keys=True, separators=(",", ":"))
++
++    def digest(self) -> str:
++        return hashlib.sha256(self.canonical_json().encode()).hexdigest()
++
++
++@dataclass(frozen=True)
++class Exl3OnlineCacheResult:
++    tensors: dict[str, torch.Tensor]
++    proxy_error: float | None
++    hit: bool
++    path: Path | None
++
++
++def _sha256_file(path: Path) -> str:
++    digest = hashlib.sha256()
++    with path.open("rb") as source:
++        while chunk := source.read(1024 * 1024):
++            digest.update(chunk)
++    return digest.hexdigest()
++
++
++def resolve_model_identity(
++    model_name: str,
++    *,
++    revision: str | None = None,
++    hf_config: Any | None = None,
++) -> str:
++    """Fingerprint a Hub revision or a local checkpoint without reading weights."""
++
++    resolved_revision = getattr(hf_config, "_commit_hash", None) or revision
++    model_path = Path(model_name).expanduser()
++    if not model_path.exists():
++        if not resolved_revision:
++            raise ValueError(
++                "online EXL3 caching requires a resolved revision for Hub "
++                f"checkpoint {model_name!r}; pass --revision or set "
++                "VLLM_EXL3_ONLINE_CACHE_MODE=off"
++            )
++        payload = {
++            "kind": "hub",
++            "model": model_name,
++            "revision": resolved_revision,
++        }
++        return hashlib.sha256(json.dumps(payload, sort_keys=True).encode()).hexdigest()
++
++    model_path = model_path.resolve()
++    if model_path.is_file():
++        stat = model_path.stat()
++        payload = {
++            "kind": "file",
++            "path": str(model_path),
++            "size": stat.st_size,
++            "mtime_ns": stat.st_mtime_ns,
++        }
++        if stat.st_size <= 16 * 1024 * 1024:
++            payload["sha256"] = _sha256_file(model_path)
++        return hashlib.sha256(json.dumps(payload, sort_keys=True).encode()).hexdigest()
++
++    markers: list[tuple[str, str]] = []
++    for name in (
++        "config.json",
++        "quantization_config.json",
++        "model.safetensors.index.json",
++        "pytorch_model.bin.index.json",
++        "tier_bitmap.json",
++    ):
++        path = model_path / name
++        if path.is_file():
++            markers.append((name, _sha256_file(path)))
++
++    shards: list[tuple[str, str, int, int]] = []
++    for pattern in ("*.safetensors", "*.bin", "*.gguf"):
++        for path in sorted(model_path.glob(pattern)):
++            resolved = path.resolve()
++            stat = resolved.stat()
++            shards.append(
++                (
++                    path.name,
++                    str(resolved),
++                    stat.st_size,
++                    stat.st_mtime_ns,
++                )
++            )
++    payload = {
++        "kind": "directory",
++        "path": str(model_path),
++        "revision": resolved_revision,
++        "markers": markers,
++        "shards": shards,
++    }
++    return hashlib.sha256(
++        json.dumps(payload, sort_keys=True, separators=(",", ":")).encode()
++    ).hexdigest()
++
++
++def resolve_encoder_identity(
++    package_root: str | Path,
++    *,
++    revision: str | None = None,
++) -> str:
++    """Identify the encoder implementation used to produce cached tensors."""
++
++    root = Path(package_root).expanduser().resolve()
++    if revision and revision.strip():
++        payload = {"root": str(root), "revision": revision.strip()}
++    else:
++        files = [
++            (str(path.relative_to(root)), _sha256_file(path))
++            for path in sorted(root.rglob("*.py"))
++            if path.is_file()
++        ]
++        if not files:
++            raise ValueError(f"EXL3 encoder source contains no Python files: {root}")
++        payload = {"root": str(root), "files": files}
++    return hashlib.sha256(
++        json.dumps(payload, sort_keys=True, separators=(",", ":")).encode()
++    ).hexdigest()
++
++
++def cache_mode() -> CacheMode:
++    raw = os.getenv("VLLM_EXL3_ONLINE_CACHE_MODE", "readwrite").strip().lower()
++    aliases = {"read-only": "readonly", "rw": "readwrite", "none": "off"}
++    raw = aliases.get(raw, raw)
++    if raw not in {"off", "readonly", "readwrite"}:
++        raise ValueError(
++            "VLLM_EXL3_ONLINE_CACHE_MODE must be off, readonly, or readwrite; "
++            f"got {raw!r}"
++        )
++    return raw  # type: ignore[return-value]
++
++
++def cache_root() -> Path:
++    """Return the trusted online-weight cache directory.
++
++    Cached payloads become model weights after schema validation. The directory
++    must therefore be writable only by the serving user and trusted to the same
++    degree as the source checkpoint.
++    """
++
++    configured = os.getenv("VLLM_EXL3_ONLINE_CACHE_DIR")
++    if configured and configured.strip():
++        return Path(configured).expanduser()
++    vllm_root = Path(os.getenv("VLLM_CACHE_ROOT", "~/.cache/vllm")).expanduser()
++    return vllm_root / "exl3_online"
++
++
++def cache_path(key: Exl3OnlineCacheKey) -> Path:
++    digest = key.digest()
++    model_dir = key.model_identity[:20]
++    rank_dir = f"tp{key.tp_world_size}-rank{key.tp_rank}"
++    return (
++        cache_root()
++        / f"v{_CACHE_SCHEMA}"
++        / model_dir
++        / rank_dir
++        / f"{digest}.safetensors"
++    )
++
++
++def _validate_tensors(
++    tensors: Mapping[str, torch.Tensor], key: Exl3OnlineCacheKey
++) -> None:
++    if set(tensors) != _CACHE_TENSORS:
++        raise ValueError(
++            f"online EXL3 cache tensor set is {sorted(tensors)}, "
++            f"expected {sorted(_CACHE_TENSORS)}"
++        )
++    expected = {
++        "trellis": (
++            torch.int16,
++            (key.input_size // 16, key.output_size // 16, key.bits * 16),
++        ),
++        "suh": (torch.float16, (key.input_size,)),
++        "svh": (torch.float16, (key.output_size,)),
++    }
++    for name, (dtype, shape) in expected.items():
++        tensor = tensors[name]
++        if tensor.dtype != dtype or tuple(tensor.shape) != shape:
++            raise ValueError(
++                f"online EXL3 cache {name} has {tensor.dtype}/{tuple(tensor.shape)}, "
++                f"expected {dtype}/{shape}"
++            )
++        if not tensor.is_contiguous():
++            raise ValueError(f"online EXL3 cache {name} must be contiguous")
++
++
++def _load(path: Path, key: Exl3OnlineCacheKey) -> Exl3OnlineCacheResult:
++    with safe_open(path, framework="pt", device="cpu") as handle:
++        metadata = handle.metadata() or {}
++        if metadata.get("cache_key") != key.canonical_json():
++            raise ValueError("online EXL3 cache key metadata does not match")
++        # ``safe_open`` exposes ``keys()`` but is not itself iterable.
++        tensors = {name: handle.get_tensor(name) for name in handle.keys()}  # noqa: SIM118
++    _validate_tensors(tensors, key)
++    raw_error = metadata.get("proxy_error")
++    proxy_error = None if raw_error in (None, "") else float(raw_error)
++    return Exl3OnlineCacheResult(dict(tensors), proxy_error, True, path)
++
++
++def _to_device(
++    result: Exl3OnlineCacheResult, device: torch.device
++) -> Exl3OnlineCacheResult:
++    tensors = {
++        name: tensor.to(device=device, non_blocking=False).contiguous()
++        for name, tensor in result.tensors.items()
++    }
++    return Exl3OnlineCacheResult(tensors, result.proxy_error, result.hit, result.path)
++
++
++def _quantize(
++    key: Exl3OnlineCacheKey,
++    quantize: QuantizeFn,
++    *,
++    path: Path | None,
++) -> Exl3OnlineCacheResult:
++    tensors, proxy_error = quantize()
++    tensors = {name: tensor.contiguous() for name, tensor in tensors.items()}
++    _validate_tensors(tensors, key)
++    return Exl3OnlineCacheResult(tensors, proxy_error, False, path)
++
++
++def _save(path: Path, key: Exl3OnlineCacheKey, result: Exl3OnlineCacheResult) -> None:
++    path.parent.mkdir(parents=True, exist_ok=True)
++    cpu_tensors = {
++        name: tensor.detach().to(device="cpu").contiguous()
++        for name, tensor in result.tensors.items()
++    }
++    metadata = {
++        "cache_key": key.canonical_json(),
++        "proxy_error": "" if result.proxy_error is None else repr(result.proxy_error),
++    }
++    fd, temporary_name = tempfile.mkstemp(
++        prefix=f".{path.name}.", suffix=".tmp", dir=path.parent
++    )
++    os.close(fd)
++    temporary = Path(temporary_name)
++    try:
++        save_file(cpu_tensors, temporary, metadata=metadata)
++        with temporary.open("rb") as output:
++            os.fsync(output.fileno())
++        os.replace(temporary, path)
++    finally:
++        temporary.unlink(missing_ok=True)
++
++
++def load_or_quantize(
++    key: Exl3OnlineCacheKey,
++    *,
++    device: torch.device,
++    quantize: QuantizeFn,
++) -> Exl3OnlineCacheResult:
++    """Load one rank-local payload or encode and atomically publish it."""
++
++    mode = cache_mode()
++    if mode == "off":
++        return _quantize(key, quantize, path=None)
++
++    path = cache_path(key)
++    if path.is_file():
++        try:
++            return _to_device(_load(path, key), device)
++        except Exception as exc:
++            logger.warning("Ignoring invalid online EXL3 cache %s: %s", path, exc)
++
++    if mode == "readonly":
++        return _quantize(key, quantize, path=None)
++
++    try:
++        path.parent.mkdir(parents=True, exist_ok=True)
++        lock = filelock.FileLock(f"{path}.lock")
++        with lock:
++            if path.is_file():
++                try:
++                    return _to_device(_load(path, key), device)
++                except Exception as exc:
++                    logger.warning(
++                        "Replacing invalid online EXL3 cache %s: %s", path, exc
++                    )
++                    path.unlink(missing_ok=True)
++            result = _quantize(key, quantize, path=path)
++            _save(path, key, result)
++            return result
++    except OSError as exc:
++        logger.warning(
++            "Online EXL3 cache is unavailable at %s; encoding without cache: %s",
++            path,
++            exc,
++        )
++        return _quantize(key, quantize, path=None)
+diff --git a/vllm/model_executor/layers/quantization/input_quant_fp8.py b/vllm/model_executor/layers/quantization/input_quant_fp8.py
+index e8810919c2046ffe672e9eea675a80f62c28375a..60d348687e0534fe3b3ee413420ed4cd7cf1d4c4 100644
+--- a/vllm/model_executor/layers/quantization/input_quant_fp8.py
++++ b/vllm/model_executor/layers/quantization/input_quant_fp8.py
+@@ -16,6 +16,7 @@ from vllm.model_executor.layers.quantization.utils.quant_utils import (
+ from vllm.platforms import current_platform
+ from vllm.utils.deep_gemm import (
+     DeepGemmQuantScaleFMT,
++    get_tma_aligned_size,
+     is_deep_gemm_e8m0_used,
+     is_deep_gemm_supported,
+ )
+@@ -90,12 +91,7 @@ class QuantFP8(CustomOp):
+     ) -> tuple[torch.Tensor, torch.Tensor]:
+         from vllm.model_executor.layers.quantization.utils import fp8_utils
+ 
+-        if (
+-            self.is_group_quant
+-            and self.use_ue8m0
+-            and self.use_deep_gemm_supported
+-            and (DeepGemmQuantScaleFMT.from_oracle() == DeepGemmQuantScaleFMT.UE8M0)
+-        ):
++        if self.is_group_quant and self._deepgemm_wants_packed_scales():
+             return fp8_utils.per_token_group_quant_fp8_packed_for_deepgemm(
+                 x,
+                 group_size=self.group_size,
+@@ -190,6 +186,13 @@ class QuantFP8(CustomOp):
+     ):
+         if self.is_group_quant and not self.static:
+             assert scale is None, "Dynamic group quantization does not use scale"
++            # Must mirror forward_cuda's choice exactly. When DeepGEMM wants
++            # packed UE8M0, plain float32 scales are the wrong *format*, not
++            # merely a different layout, and CustomOp.default_on() is False
++            # under inductor -- so this is the path a compiled run takes and
++            # DeepGEMM silently receives unpacked scales.
++            if self._deepgemm_wants_packed_scales():
++                return self._quantize_group_native_packed(x)
+             return self._quantize_group_native(x)
+ 
+         assert (scale is not None) == self.static
+@@ -230,6 +233,70 @@ class QuantFP8(CustomOp):
+ 
+         return out, scale
+ 
++    def _deepgemm_wants_packed_scales(self) -> bool:
++        """Whether the consumer expects DeepGEMM's packed UE8M0 scale format.
++
++        Shared by forward_cuda and forward_native so the two cannot disagree
++        about the scale format they emit. The oracle only answers UE8M0 on the
++        SM120 family; elsewhere it answers FLOAT32_CEIL_UE8M0 and both paths
++        return plain float32 scales.
++        """
++        return (
++            self.use_ue8m0
++            and self.use_deep_gemm_supported
++            and DeepGemmQuantScaleFMT.from_oracle() == DeepGemmQuantScaleFMT.UE8M0
++        )
++
++    def _quantize_group_native_packed(
++        self, x: torch.Tensor
++    ) -> tuple[torch.Tensor, torch.Tensor]:
++        """Native equivalent of per_token_group_quant_fp8_packed_for_deepgemm.
++
++        Verified bit-identical to the C++ op (values, shape and TMA-aligned
++        stride) across square, wide and ragged-row shapes. Expressed in plain
++        torch ops so inductor can fuse it with neighbouring work, which a custom
++        op cannot be.
++        """
++        hidden_dim = x.shape[-1]
++        assert hidden_dim % self.group_size == 0, (
++            f"hidden dim {hidden_dim} must be divisible by group {self.group_size}"
++        )
++        mn = x.numel() // hidden_dim
++        num_groups = hidden_dim // self.group_size
++        k_packed = (num_groups + 3) // 4
++
++        xg = x.reshape(mn, num_groups, self.group_size).float()
++        absmax = xg.abs().amax(dim=-1).clamp(min=_FP8_MIN_SCALING_FACTOR)
++
++        # UE8M0 keeps only a power-of-two scale, so the exponent is the payload.
++        exponent = torch.ceil(torch.log2(absmax / _FP8_MAX))
++        quantized = (xg / torch.exp2(exponent).unsqueeze(-1)).clamp(_FP8_MIN, _FP8_MAX)
++        x_q = quantized.to(_FP8_DTYPE).reshape(x.shape)
++
++        # e8m0 byte is the biased exponent; four bytes pack into one int32.
++        byte = (exponent + 127.0).clamp(0, 255).to(torch.int32)
++        pad = k_packed * 4 - num_groups
++        if pad:
++            byte = F.pad(byte, (0, pad))
++        b = byte.reshape(mn, k_packed, 4)
++        packed = b[..., 0] | (b[..., 1] << 8) | (b[..., 2] << 16) | (b[..., 3] << 24)
++
++        # DeepGEMM requires size(-2) == mn, stride(-2) == 1 and
++        # stride(-1) == get_tma_aligned_size(mn): the mn dim must be the fast
++        # one, with the slow stride padded out to the TMA-aligned size.
++        #
++        # Build it by padding the transposed buffer, materializing, transposing
++        # back and slicing -- NOT via empty_strided + copy_. Inductor is free to
++        # ignore an empty_strided layout request and materialize row-major,
++        # which trips the assertion, but it does preserve a transpose-derived
++        # view, and slicing the leading dim afterwards keeps the strides intact.
++        #
++        # A bare transpose-of-contiguous is correct only when mn is already
++        # TMA-aligned and silently yields stride(-1) == mn otherwise.
++        tma_aligned_mn = get_tma_aligned_size(mn, packed.element_size())
++        packed_t = F.pad(packed.transpose(0, 1), (0, tma_aligned_mn - mn))
++        return x_q, packed_t.contiguous().transpose(0, 1)[:mn]
++
+     def _quantize_group_native(
+         self, x: torch.Tensor
+     ) -> tuple[torch.Tensor, torch.Tensor]:
+diff --git a/vllm/model_executor/warmup/kernel_warmup.py b/vllm/model_executor/warmup/kernel_warmup.py
+index 36a17fa8aa263009adc60acc5bf8ca172fa49645..87e1f5be2b93ce125fd479b39712c1252b16db86 100644
+--- a/vllm/model_executor/warmup/kernel_warmup.py
++++ b/vllm/model_executor/warmup/kernel_warmup.py
+@@ -23,6 +23,9 @@ from vllm.model_executor.kernels.linear.scaled_mm.b12x_tensor import (
+     warmup_b12x_tensor_fp8_linear,
+ )
+ from vllm.model_executor.layers.fused_moe.b12x_moe import warmup_b12x_moe_dynamic
++from vllm.model_executor.layers.quantization.exl3 import (
++    warmup_exl3_mixed_trellis_route_pack,
++)
+ from vllm.model_executor.warmup.b12x_sparse_indexer_warmup import (
+     warmup_b12x_sparse_indexer,
+ )
+@@ -366,6 +369,16 @@ def kernel_warmup(worker: "Worker"):
+         max_tokens=max(moe_token_counts),
+         token_counts=moe_token_counts,
+     )
++    free_before_exl3_warmup = torch.cuda.mem_get_info()[0]
++    warmed_exl3_route_pack = warmup_exl3_mixed_trellis_route_pack(worker.get_model())
++    if warmed_exl3_route_pack:
++        free_after_exl3_warmup = torch.cuda.mem_get_info()[0]
++        logger.info(
++            "Warmed up %d EXL3 mixed-Trellis route-pack variant(s); "
++            "free-memory delta %.1f MiB.",
++            warmed_exl3_route_pack,
++            (free_before_exl3_warmup - free_after_exl3_warmup) / (1 << 20),
++        )
+ 
+     minimax_m3_msa_warmup(worker)
+ 
+@@ -442,6 +455,28 @@ def _flashinfer_autotune_skip_ops(runner: "GPUModelRunner") -> set[str] | None:
+     return None
+ 
+ 
++def _flashinfer_autotune_dummy_run_kwargs(
++    runner: "GPUModelRunner",
++) -> dict[str, object]:
++    kwargs = dict(
++        num_tokens=runner.scheduler_config.max_num_batched_tokens,
++        skip_eplb=True,
++        is_profile=True,
++    )
++
++    # V2 initializes attention backends and block tables only after the initial
++    # memory profile.  Kernel autotuning runs during that profile, so execute
++    # the model kernels without attention until those tables exist.  Attention
++    # backends have their own warmup after KV-cache initialization.
++    if (
++        getattr(runner.vllm_config, "use_v2_model_runner", False)
++        and not hasattr(runner, "block_tables")
++    ):
++        kwargs["skip_attn"] = True
++
++    return kwargs
++
++
+ def flashinfer_autotune(runner: "GPUModelRunner") -> None:
+     """
+     Autotune FlashInfer operations.
+@@ -475,11 +510,7 @@ def flashinfer_autotune(runner: "GPUModelRunner") -> None:
+ 
+     if not use_persistent_cache:
+         with torch.inference_mode(), fi_utils.autotune(**autotune_kwargs):
+-            runner._dummy_run(
+-                num_tokens=runner.scheduler_config.max_num_batched_tokens,
+-                skip_eplb=True,
+-                is_profile=True,
+-            )
++            runner._dummy_run(**_flashinfer_autotune_dummy_run_kwargs(runner))
+         get_world_group().barrier()
+         return
+ 
+@@ -494,11 +525,7 @@ def flashinfer_autotune(runner: "GPUModelRunner") -> None:
+     # When autotuning with number of tokens m, flashinfer will autotune
+     # operations for all number of tokens up to m, so we only need to
+     # run with the max number of tokens.
+-    dummy_run_kwargs = dict(
+-        num_tokens=runner.scheduler_config.max_num_batched_tokens,
+-        skip_eplb=True,
+-        is_profile=True,
+-    )
++    dummy_run_kwargs = _flashinfer_autotune_dummy_run_kwargs(runner)
+ 
+     with torch.inference_mode():
+         if is_leader:
+diff --git a/vllm/models/deepseek_v4/nvidia/b12x.py b/vllm/models/deepseek_v4/nvidia/b12x.py
+index 6f5e3113da5e73ffdcb44c954faccd7e8981e3ba..2893589fd62d13244c7f17790acb63ec7299309d 100644
+--- a/vllm/models/deepseek_v4/nvidia/b12x.py
++++ b/vllm/models/deepseek_v4/nvidia/b12x.py
+@@ -20,6 +20,7 @@ from typing import TYPE_CHECKING, ClassVar, Literal, cast
+ 
+ import torch
+ 
++from vllm.config import VllmConfig
+ from vllm.forward_context import get_forward_context
+ from vllm.models.deepseek_v4.common.ops import (
+     compute_dcp_global_topk_indices_and_lens,
+@@ -30,6 +31,12 @@ from vllm.models.deepseek_v4.nvidia.flashmla import (
+     DeepseekV4FlashMLABackend,
+ )
+ from vllm.models.deepseek_v4.sparse_mla import DeepseekV4FlashMLAMetadata
++from vllm.v1.attention.backends.mla.compressor_utils import (
++    get_c128a_topk_width,
++    get_compressed_mla_max_q_chunks,
++    get_compressed_mla_split_cap,
++    get_dspark_swa_index_width,
++)
+ from vllm.v1.attention.ops.common import cp_lse_ag_out_rs
+ from vllm.v1.attention.ops.dcp_alltoall import (
+     dcp_a2a_lse_reduce,
+@@ -44,22 +51,58 @@ if TYPE_CHECKING:
+ _DSV4_HEAD_DIM = 512
+ _DSV4_V_HEAD_DIM = 512
+ _DSV4_CACHE_BYTES_PER_TOKEN = 584
+-_DSV4_CACHE_PAD_ALIGNMENT_BYTES = 576
+-_DECODE_SPLIT_TILE = 64
+-_C128A_TOPK_ALIGNMENT = 128
+ _VALIDATE_DCP_INDICES_ENV = "VLLM_DSV4_DCP_VALIDATE_INDICES"
+ 
+ 
++def _get_dspark_decode_row_capacity(vllm_config: VllmConfig) -> int | None:
++    """Return the largest target-verifier row count the scheduler can emit."""
++    speculative_config = vllm_config.speculative_config
++    if speculative_config is None or not speculative_config.use_dspark():
++        return None
++    num_speculative_tokens = int(speculative_config.num_speculative_tokens or 0)
++    if num_speculative_tokens <= 0:
++        return None
++    scheduler_config = vllm_config.scheduler_config
++    return min(
++        int(scheduler_config.max_num_batched_tokens),
++        int(scheduler_config.max_num_seqs) * (1 + num_speculative_tokens),
++    )
++
++
++def _validate_compressed_mla_decode_row_capacity(
++    *,
++    rows: int,
++    mode: Literal["decode", "extend"],
++    decode_row_capacity: int | None,
++) -> None:
++    if mode != "decode" or decode_row_capacity is None:
++        return
++    if int(rows) > int(decode_row_capacity):
++        raise ValueError(
++            f"compressed MLA decode rows {rows} exceed the declared "
++            f"capacity {decode_row_capacity}"
++        )
++
++
+ def _cdiv(x: int, y: int) -> int:
+     return (int(x) + int(y) - 1) // int(y)
+ 
+ 
+ def _dsv4_b12x_page_nbytes(page_size: int) -> int:
+-    payload_nbytes = int(page_size) * _DSV4_CACHE_BYTES_PER_TOKEN
+-    return (
+-        _cdiv(payload_nbytes, _DSV4_CACHE_PAD_ALIGNMENT_BYTES)
+-        * _DSV4_CACHE_PAD_ALIGNMENT_BYTES
+-    )
++    """Return the logical DSV4 payload bytes in one cache page.
++
++    vLLM may place padding between physical pages, but the padding is not part
++    of the compressed-MLA payload.  Keeping it out of the exported view also
++    supports standalone contiguous allocations, whose physical page stride is
++    exactly ``page_size * 584`` bytes.
++
++    Args:
++        page_size: Number of tokens stored in one cache page.
++
++    Returns:
++        The logical compressed-MLA payload size in bytes.
++    """
++    return int(page_size) * _DSV4_CACHE_BYTES_PER_TOKEN
+ 
+ 
+ def _b12x_cache_page_view(
+@@ -67,7 +110,25 @@ def _b12x_cache_page_view(
+     page_size: int,
+     name: str,
+ ) -> torch.Tensor:
+-    """Return a uint8 ``[pages, padded_page_bytes]`` view for b12x kernels."""
++    """Return a uint8 ``[pages, payload_bytes]`` view for SparkInfer kernels.
++
++    Preserve the physical page stride so both padded packed allocations and
++    contiguous per-layer allocations follow the same runtime contract.
++
++    Args:
++        cache: Source paged cache tensor.
++        page_size: Number of tokens stored in one cache page.
++        name: Cache name used in validation errors.
++
++    Returns:
++        A logical byte view that preserves the source physical page stride.
++
++    Raises:
++        ValueError: If ``page_size`` is not positive.
++        RuntimeError: If the cache is not paged, a page cannot contain the
++            logical payload, pages overlap, or the payload within a page is
++            not contiguous.
++    """
+     page_nbytes = _dsv4_b12x_page_nbytes(page_size)
+     if page_nbytes <= 0:
+         raise ValueError(f"{name} page_size must be positive, got {page_size}")
+@@ -77,11 +138,19 @@ def _b12x_cache_page_view(
+         if int(byte_cache.shape[1]) < page_nbytes:
+             raise RuntimeError(
+                 f"{name} page width {int(byte_cache.shape[1])} is smaller than "
+-                f"DSV4 padded page width {page_nbytes}"
++                f"DSV4 payload width {page_nbytes}"
++            )
++        if int(byte_cache.stride(1)) != 1:
++            raise RuntimeError(
++                f"{name} page payload must be contiguous, got stride "
++                f"{tuple(byte_cache.stride())}"
+             )
+-        if not byte_cache.is_contiguous():
+-            raise RuntimeError(f"{name} page cache must be contiguous")
+-        return byte_cache
++        if int(byte_cache.stride(0)) < page_nbytes:
++            raise RuntimeError(
++                f"{name} page stride {int(byte_cache.stride(0))} is smaller than "
++                f"DSV4 page payload {page_nbytes}"
++            )
++        return byte_cache[:, :page_nbytes]
+ 
+     if byte_cache.ndim < 2:
+         raise RuntimeError(
+@@ -93,13 +162,22 @@ def _b12x_cache_page_view(
+     if page_stride_nbytes < page_nbytes:
+         raise RuntimeError(
+             f"{name} page stride {page_stride_nbytes} is smaller than DSV4 page "
+-            f"width {page_nbytes}"
++            f"payload {page_nbytes}"
+         )
+ 
++    expected_stride = 1
++    for dim in range(byte_cache.ndim - 1, 0, -1):
++        if int(byte_cache.stride(dim)) != expected_stride:
++            raise RuntimeError(
++                f"{name} page payload must be contiguous, got stride "
++                f"{tuple(byte_cache.stride())}"
++            )
++        expected_stride *= int(byte_cache.shape[dim])
++
+     # Packed DS4 KV cache views have a storage offset for this layer and a
+-    # larger per-block stride for the whole packed block. Expose only this
+-    # layer's page payload while preserving stride(0), so B12X can use the
+-    # packed block stride without materializing/copying.
++    # larger per-block stride for the whole packed block. Expose only the
++    # logical payload while preserving stride(0), so SparkInfer can use the
++    # physical block stride without materializing/copying.
+     page_view = torch.as_strided(
+         byte_cache,
+         size=(pages, page_nbytes),
+@@ -239,6 +317,7 @@ def _run_compressed_mla(
+     indexed_lens: torch.Tensor | None,
+     indexed_page_size: int | None,
+     mode: Literal["decode", "extend"] = "decode",
++    decode_row_capacity: int | None = None,
+     return_lse: bool = False,
+     lse_scale: Literal["natural", "base2"] = "natural",
+ ) -> torch.Tensor | None:
+@@ -262,6 +341,11 @@ def _run_compressed_mla(
+     )
+ 
+     rows, heads = int(q.shape[0]), int(q.shape[1])
++    _validate_compressed_mla_decode_row_capacity(
++        rows=rows,
++        mode=mode,
++        decode_row_capacity=decode_row_capacity,
++    )
+     q = q.contiguous()
+     swa_indices = swa_indices.contiguous()
+     swa_lens = swa_lens.contiguous()
+@@ -287,13 +371,14 @@ def _run_compressed_mla(
+     width = int(swa_indices.shape[-1])
+     if indexed_indices is not None:
+         width += int(indexed_indices.shape[-1])
+-    decode_split_cap = max(1, _cdiv(width, _DECODE_SPLIT_TILE))
++    decode_split_cap = get_compressed_mla_split_cap(width)
+     # Keep the legacy 64-wide split cap for decode, but let the b12x contract
+     # select the smaller batched-prefill split count when rows > decode max.
+     num_splits_cap = compressed_mla_split_chunks_for_contract(
+         rows=max(1, rows),
+         width=width,
+         max_chunks=decode_split_cap,
++        decode_row_capacity=decode_row_capacity,
+     )
+ 
+     plan = plan_compressed_mla_scratch(
+@@ -306,6 +391,7 @@ def _run_compressed_mla(
+             v_head_dim=_DSV4_V_HEAD_DIM,
+             page_size=int(swa_page_size),
+             max_chunks_per_row=num_splits_cap,
++            decode_row_capacity=decode_row_capacity,
+         )
+     )
+     scratch = current_workspace_manager().get_simultaneous(*plan.shapes_and_dtypes())
+@@ -364,6 +450,7 @@ def _run_dcp_compressed_mla(
+     indexed_lens: torch.Tensor | None,
+     indexed_page_size: int | None,
+     mode: Literal["decode", "extend"] = "decode",
++    decode_row_capacity: int | None = None,
+ ) -> None:
+     from vllm.distributed.parallel_state import get_dcp_group
+ 
+@@ -396,6 +483,7 @@ def _run_dcp_compressed_mla(
+         indexed_lens=indexed_lens,
+         indexed_page_size=indexed_page_size,
+         mode=mode,
++        decode_row_capacity=decode_row_capacity,
+         return_lse=True,
+         lse_scale="natural",
+     )
+@@ -493,28 +581,57 @@ class DeepseekV4B12xMLAAttention(DeepseekV4FlashMLAAttention):
+             elif self.indexer is not None:
+                 indexed_width = int(self.indexer.topk_tokens)
+         elif self.compress_ratio > 1:
+-            indexed_width = _cdiv(self.max_model_len, self.compress_ratio)
+-            indexed_width = _cdiv(indexed_width, _C128A_TOPK_ALIGNMENT)
+-            indexed_width *= _C128A_TOPK_ALIGNMENT
++            indexed_width = get_c128a_topk_width(
++                self.max_model_len,
++                self.compress_ratio,
++            )
+ 
+-        width = max(int(self.window_size) + indexed_width, 1)
++        swa_width = int(self.window_size)
++        speculative_config = self.vllm_config.speculative_config
++        decode_row_capacity = _get_dspark_decode_row_capacity(self.vllm_config)
++        if speculative_config is not None and speculative_config.use_dspark():
++            swa_width = max(
++                swa_width,
++                get_dspark_swa_index_width(
++                    swa_width,
++                    speculative_config.num_speculative_tokens or 0,
++                ),
++            )
++
++        width = max(swa_width + indexed_width, 1)
+         rows = max(int(self.max_num_batched_tokens), 1)
+-        decode_split_cap = max(1, _cdiv(width, _DECODE_SPLIT_TILE))
++        decode_split_cap = get_compressed_mla_split_cap(width)
+         num_splits_cap = compressed_mla_split_chunks_for_contract(
+             rows=rows,
+             width=width,
+             max_chunks=decode_split_cap,
++            decode_row_capacity=decode_row_capacity,
++        )
++        max_q_chunks = get_compressed_mla_max_q_chunks(
++            rows,
++            width,
++            decode_split_cap,
++            compressed_mla_split_chunks_for_contract,
++            decode_row_capacity=decode_row_capacity,
++        )
++        dcp_world_size = max(
++            int(self.vllm_config.parallel_config.decode_context_parallel_size),
++            1,
+         )
++        # max_q_rows covers final row-sized buffers; max_q_chunks covers split
++        # intermediates whose peak can occur below max_q_rows.
+         plan = plan_compressed_mla_scratch(
+             B12XCompressedMLAScratchCaps(
+                 device=q.device,
+-                num_q_heads=int(q.shape[1]),
++                num_q_heads=int(q.shape[1]) * dcp_world_size,
+                 max_q_rows=rows,
+                 max_width=width,
+                 head_dim=_DSV4_HEAD_DIM,
+                 v_head_dim=_DSV4_V_HEAD_DIM,
+                 page_size=int(self.swa_cache_layer.block_size),
+                 max_chunks_per_row=num_splits_cap,
++                max_q_chunks=max_q_chunks,
++                decode_row_capacity=decode_row_capacity,
+             )
+         )
+         current_workspace_manager().get_simultaneous(*plan.shapes_and_dtypes())
+@@ -549,6 +666,7 @@ class DeepseekV4B12xMLAAttention(DeepseekV4FlashMLAAttention):
+         if attn_metadata is None:
+             # Warmup dummy run: no metadata, so reserve the largest compressed
+             # MLA scratch this layer can request before vLLM locks workspace.
++            # Its config-derived geometry is identical on later dummy calls.
+             output.zero_()
+             self._reserve_dummy_compressed_mla_scratch(q)
+             return
+@@ -620,6 +738,7 @@ class DeepseekV4B12xMLAAttention(DeepseekV4FlashMLAAttention):
+         num_decodes = swa_metadata.num_decodes
+         num_decode_tokens = swa_metadata.num_decode_tokens
+         dcp_world_size = vllm_config.parallel_config.decode_context_parallel_size
++        decode_row_capacity = _get_dspark_decode_row_capacity(vllm_config)
+         dcp_rank = 0
+         if dcp_world_size > 1:
+             from vllm.distributed.parallel_state import get_dcp_group
+@@ -697,6 +816,7 @@ class DeepseekV4B12xMLAAttention(DeepseekV4FlashMLAAttention):
+                 indexed_lens=topk_lens,
+                 indexed_page_size=indexed_page_size,
+                 mode="decode",
++                decode_row_capacity=decode_row_capacity,
+             )
+         else:
+             _run_compressed_mla(
+@@ -713,6 +833,7 @@ class DeepseekV4B12xMLAAttention(DeepseekV4FlashMLAAttention):
+                 indexed_lens=topk_lens,
+                 indexed_page_size=indexed_page_size,
+                 mode="decode",
++                decode_row_capacity=decode_row_capacity,
+             )
+ 
+     def _forward_b12x_prefill(
+diff --git a/vllm/models/deepseek_v4/sparse_mla.py b/vllm/models/deepseek_v4/sparse_mla.py
+index 623bff0828d59ff275e39fb738ef66368c4d3987..d53b732b1ef9e122137eac343cf588f792b9ae01 100644
+--- a/vllm/models/deepseek_v4/sparse_mla.py
++++ b/vllm/models/deepseek_v4/sparse_mla.py
+@@ -11,7 +11,6 @@ from vllm.config import VllmConfig
+ from vllm.config.cache import CacheDType
+ from vllm.platforms.interface import DeviceCapability
+ from vllm.triton_utils import tl, triton
+-from vllm.utils.math_utils import cdiv
+ from vllm.v1.attention.backend import (
+     AttentionBackend,
+     AttentionCGSupport,
+@@ -20,17 +19,13 @@ from vllm.v1.attention.backend import (
+     CommonAttentionMetadata,
+     MultipleOf,
+ )
+-from vllm.v1.attention.backends.mla.compressor_utils import get_compressed_slot_mapping
++from vllm.v1.attention.backends.mla.compressor_utils import (
++    get_c128a_topk_width,
++    get_compressed_slot_mapping,
++)
+ from vllm.v1.attention.backends.utils import split_decodes_and_prefills
+ from vllm.v1.kv_cache_interface import AttentionSpec
+ 
+-# Pad C128A topk width to this alignment. 128 covers both h_q=64 (B_TOPK=64) and
+-# h_q=128 (B_TOPK=128). FlashMLA decode asserts extra_topk % B_TOPK == 0;
+-# unaligned widths (e.g. 17 = ceil(2136/128)) crash the sm100 head64 kernel.
+-# Padded slots stay -1 and decode_lens caps them via topk_length, so the pad is a
+-# no-op at kernel level. Mirrors _SPARSE_PREFILL_TOPK_ALIGNMENT in cache_utils.py.
+-_C128A_TOPK_ALIGNMENT = 128
+-
+ 
+ class DeepseekV4FlashMLABackend(AttentionBackend):
+     """DeepSeek-V4 sparse-MLA backend.
+@@ -191,12 +186,9 @@ class DeepseekV4FlashMLAMetadataBuilder(
+ 
+         # Pre-allocate C128A topk buffers for CUDA graph address stability.
+         if self.compress_ratio == 128:
+-            c128a_max_compressed = cdiv(
+-                self.model_config.max_model_len, self.compress_ratio
+-            )
+-            c128a_max_compressed = (
+-                cdiv(c128a_max_compressed, _C128A_TOPK_ALIGNMENT)
+-                * _C128A_TOPK_ALIGNMENT
++            c128a_max_compressed = get_c128a_topk_width(
++                self.model_config.max_model_len,
++                self.compress_ratio,
+             )
+             # Stored so _build_c128a_metadata passes it as the kernel's
+             # max_compressed_tokens, matching the buffer stride. Otherwise the
+diff --git a/vllm/tokenizers/deepseek_v4.py b/vllm/tokenizers/deepseek_v4.py
+index 3897149626f87d6dd1c23e4520d49e037cd40f8e..3cf84de82312520d6669137789fd47f7ba9db75c 100644
+--- a/vllm/tokenizers/deepseek_v4.py
++++ b/vllm/tokenizers/deepseek_v4.py
+@@ -37,8 +37,26 @@ def get_deepseek_v4_tokenizer(tokenizer: HfTokenizer) -> HfTokenizer:
+             conversation = kwargs.get("conversation", messages)
+             messages = conversation.copy()
+             if tools is not None and len(tools) > 0:
+-                messages.insert(0, {"role": "system"})
+-                messages[0]["tools"] = tools  # type: ignore[typeddict-unknown-key]
++                for index, message in enumerate(messages):
++                    if message.get("role") in ("system", "developer"):
++                        prompt_message = message.copy()
++                        message_tools = prompt_message.get("tools")
++                        request_tool_names = {
++                            tool.get("function", {}).get("name") for tool in tools
++                        }
++                        merged_tools = [
++                            tool
++                            for tool in message_tools or []
++                            if tool.get("function", {}).get("name")
++                            not in request_tool_names
++                        ]
++                        merged_tools.extend(tools)
++                        prompt_message["tools"] = merged_tools  # type: ignore[typeddict-unknown-key]
++                        messages[index] = prompt_message
++                        break
++                else:
++                    messages.insert(0, {"role": "system"})
++                    messages[0]["tools"] = tools  # type: ignore[typeddict-unknown-key]
+ 
+             reasoning_effort = kwargs.get("reasoning_effort")
+             if not isinstance(reasoning_effort, str):
+@@ -48,6 +66,8 @@ def get_deepseek_v4_tokenizer(tokenizer: HfTokenizer) -> HfTokenizer:
+                 reasoning_effort = None
+             elif reasoning_effort in ("max", "xhigh"):
+                 reasoning_effort = "max"
++            elif reasoning_effort == "low":
++                reasoning_effort = "low"
+             else:
+                 reasoning_effort = "high"
+ 
+diff --git a/vllm/tokenizers/deepseek_v4_encoding.py b/vllm/tokenizers/deepseek_v4_encoding.py
+index 16bfa1a99a1bdd52104f6440af12b6c197ca3741..e69c530317fcb7be0fe2989c8b04c4523876fccf 100644
+--- a/vllm/tokenizers/deepseek_v4_encoding.py
++++ b/vllm/tokenizers/deepseek_v4_encoding.py
+@@ -65,11 +65,31 @@ tool_output_template: str = (
+     "<tool_result>{content}</tool_result>"
+ )
+ 
+-REASONING_EFFORT_MAX = (
+-    "Reasoning Effort: Absolute maximum with no shortcuts permitted.\n"
+-    "You MUST be very thorough in your thinking and comprehensively decompose the problem to resolve the root cause, rigorously stress-testing your logic against all potential paths, edge cases, and adversarial scenarios.\n"
+-    "Explicitly write out your entire deliberation process, documenting every intermediate step, considered alternative, and rejected hypothesis to ensure absolutely no assumption is left unchecked.\n\n"
+-)
++REASONING_EFFORT_PROMPTS: Dict[str, str] = {
++    "low": "",
++    "high": (
++        "Reasoning Effort: Absolute maximum with no shortcuts permitted.\n"
++        "You MUST be very thorough in your thinking and comprehensively "
++        "decompose the problem to resolve the root cause, rigorously "
++        "stress-testing your logic against all potential paths, edge cases, "
++        "and adversarial scenarios.\n"
++        "Explicitly write out your entire deliberation process, documenting "
++        "every intermediate step, considered alternative, and rejected "
++        "hypothesis to ensure absolutely no assumption is left unchecked.\n\n"
++    ),
++    "max": (
++        "Reasoning Effort: Beyond maximum — exhaustive, relentless, and "
++        "uncompromising.\n"
++        "You MUST reason with the utmost depth and rigor, leaving absolutely "
++        "nothing to chance: exhaustively decompose the problem into its most "
++        "fundamental components, trace every causal chain to its root, and "
++        "resolve the underlying cause rather than any surface symptom.\n"
++        "Do not stop reasoning until you have independently verified the "
++        "solution from multiple angles and are certain that no assumption "
++        "remains unchecked and no error remains undiscovered.\n\n"
++    ),
++}
++DEFAULT_REASONING_EFFORT = "low"
+ 
+ TOOLS_TEMPLATE = """## Tools
+ 
+@@ -139,10 +159,19 @@ def encode_arguments_to_dsml(tool_call: Dict[str, Any]) -> str:
+     p_dsml_template = '<{dsml_token}parameter name="{key}" string="{is_str}">{value}</{dsml_token}parameter>'
+     P_dsml_strs = []
+ 
+-    if isinstance(tool_call["arguments"], str):
+-        arguments = json.loads(tool_call["arguments"])
++    raw_arguments = tool_call.get("arguments")
++    if isinstance(raw_arguments, str):
++        try:
++            arguments = json.loads(raw_arguments)
++        except (TypeError, ValueError):
++            arguments = {"arguments": raw_arguments}
+     else:
+-        arguments = tool_call["arguments"]
++        arguments = raw_arguments
++
++    # Historical tool calls are not always normalized to an object. Preserve
++    # those values as one explicit parameter instead of failing prompt render.
++    if not isinstance(arguments, dict):
++        arguments = {"arguments": arguments}
+ 
+     for k, v in arguments.items():
+         p_dsml_str = p_dsml_template.format(
+@@ -202,7 +231,8 @@ def render_message(index: int, messages: List[Dict[str, Any]], thinking_mode: st
+         messages: Full list of messages in the conversation.
+         thinking_mode: Either "chat" or "thinking".
+         drop_thinking: Whether to drop reasoning content from earlier turns.
+-        reasoning_effort: Optional reasoning effort level ("max", "high", or None).
++        reasoning_effort: Reasoning effort level, one of "low", "high", "max".
++            None is treated as "low".
+ 
+     Returns:
+         Encoded string for this message.
+@@ -227,10 +257,13 @@ def render_message(index: int, messages: List[Dict[str, Any]], thinking_mode: st
+     if tool_calls:
+         tool_calls = tool_calls_from_openai_format(tool_calls)
+ 
+-    # Reasoning effort prefix (only at index 0 in thinking mode with max effort)
+-    assert reasoning_effort in ['max', None, 'high'], f"Invalid reasoning effort: {reasoning_effort}"
+-    if index == 0 and thinking_mode == "thinking" and reasoning_effort == 'max':
+-        prompt += REASONING_EFFORT_MAX
++    reasoning_effort = reasoning_effort or DEFAULT_REASONING_EFFORT
++    assert reasoning_effort in REASONING_EFFORT_PROMPTS, (
++        f"Invalid reasoning effort: {reasoning_effort}, expected one of "
++        f"{list(REASONING_EFFORT_PROMPTS)}"
++    )
++    if index == 0 and thinking_mode == "thinking":
++        prompt += REASONING_EFFORT_PROMPTS[reasoning_effort]
+ 
+     if role == "system":
+         prompt += system_msg_template.format(content=content or "")
+@@ -497,7 +530,8 @@ def encode_messages(
+         drop_thinking: If True, drop reasoning from earlier assistant turns
+                       (only keep reasoning for messages after the last user message).
+         add_default_bos_token: Whether to prepend BOS token at conversation start.
+-        reasoning_effort: Optional reasoning effort level ("max", "high", or None).
++        reasoning_effort: Reasoning effort level, one of "low", "high", "max".
++            Only takes effect in thinking mode. None is treated as "low".
+ 
+     Returns:
+         The encoded prompt string.
+diff --git a/vllm/v1/attention/backends/flashinfer.py b/vllm/v1/attention/backends/flashinfer.py
+index 816a8a7aa117689b2d9a064a41dc35f4ff36138b..1724f3db7819e65ad7c43266e6d934b8927f9f7c 100755
+--- a/vllm/v1/attention/backends/flashinfer.py
++++ b/vllm/v1/attention/backends/flashinfer.py
+@@ -617,6 +617,77 @@ class FlashInferMetadata:
+     cascade_wrapper: MultiLevelCascadeAttentionWrapper | None
+ 
+ 
++def persistent_decode_wrapper_eligible(
++    *,
++    pure_decode: bool,
++    num_decode_tokens: int,
++    decode_cudagraph_max_bs: int,
++    decode_q_len: int,
++    planned_decode_q_len: int,
++) -> bool:
++    """Whether a decode-classified batch may reuse a persistent (CUDA-graph)
++    FlashInfer decode wrapper.
++
++    Persistent wrappers are planned once, during graph capture, with a frozen
++    ``q_len_per_req`` of exactly ``planned_decode_q_len`` (1 + num_spec_tokens;
++    1 without speculative decoding). Reuse is only sound when the runtime
++    per-request query length matches that frozen shape — FlashInfer's
++    ``fast_decode_plan`` hard-errors otherwise ("q_len_per_req is part of the
++    frozen cudagraph shape").
++
++    WARNING: ``planned_decode_q_len`` is NOT ``reorder_batch_threshold``. With
++    parallel drafting the decode-classification ceiling is
++    ``1 + 2 * num_spec_tokens``, which deliberately admits reduced-depth steps
++    (spec truncation near ``max_tokens``, short chunked-prefill tails fused
++    with the spec step). Those are valid decode batches, but they must take
++    the dynamic wrapper, which replans for the current shape on every call.
++
++    Args:
++        pure_decode: True when the batch contains no prefill requests.
++        num_decode_tokens: Total scheduled tokens across the decode requests.
++        decode_cudagraph_max_bs: Token capacity the persistent wrappers were
++            sized for ((1 + num_spec_tokens) * max_num_reqs, capped by
++            ``max_cudagraph_capture_size``).
++        decode_q_len: Runtime per-request query length of the active
++            (non-padding) decode requests.
++        planned_decode_q_len: Frozen per-request query length the persistent
++            wrappers were planned with (1 + num_spec_tokens).
++
++    Returns:
++        True when the batch may be routed to the persistent (CUDA-graph)
++        decode wrapper; False when it must use the dynamic wrapper.
++    """
++    return (
++        pure_decode
++        and num_decode_tokens <= decode_cudagraph_max_bs
++        and decode_q_len == planned_decode_q_len
++    )
++
++
++def decode_q_len_from_indptr(qo_indptr_cpu: torch.Tensor, num_decodes: int) -> int:
++    """Per-request query length of the active decode requests in a batch.
++
++    Uniform CUDA-graph decode batches may carry zero-length padding rows
++    (``split_decodes_and_prefills`` classifies ``q_len == 0`` padding as
++    decode so ``num_decodes`` matches the captured size). Averaging
++    ``num_decode_tokens`` over ``num_decodes`` would understate the active
++    query length for such batches and wrongly demote them to the dynamic
++    wrapper, so the length is taken as the maximum per-request span instead
++    (decode rows are uniform-or-zero by construction).
++
++    Args:
++        qo_indptr_cpu: CPU query-start-loc tensor for the batch.
++        num_decodes: Number of decode-classified requests, including any
++            zero-length padding rows.
++
++    Returns:
++        The uniform query length of the active decode requests, or 0 when
++        every row is padding.
++    """
++    lens = qo_indptr_cpu[1 : num_decodes + 1] - qo_indptr_cpu[:num_decodes]
++    return int(lens.max().item()) if num_decodes > 0 else 0
++
++
+ class FlashInferMetadataBuilder(AttentionMetadataBuilder[FlashInferMetadata]):
+     reorder_batch_threshold: int = 1
+ 
+@@ -664,6 +735,10 @@ class FlashInferMetadataBuilder(AttentionMetadataBuilder[FlashInferMetadata]):
+             if speculative_config is not None
+             else 0
+         )
++        # The frozen per-request query length persistent decode wrappers are
++        # planned with during capture. See persistent_decode_wrapper_eligible
++        # for why this must never be conflated with reorder_batch_threshold.
++        self._planned_decode_q_len = 1 + num_spec_tokens
+         self.enable_cuda_graph = (
+             self.compilation_config.cudagraph_mode.decode_mode() == CUDAGraphMode.FULL
+         )
+@@ -1507,16 +1582,21 @@ class FlashInferMetadataBuilder(AttentionMetadataBuilder[FlashInferMetadata]):
+             else:
+                 assert seq_lens_cpu is not None
+                 pure_decode = num_prefills == 0
++                # Spec-as-decode verify batches carry a uniform per-request
++                # query length; uniform CUDA-graph batches may additionally
++                # carry zero-length padding rows, so the active length comes
++                # from the per-request spans, not an average.
++                decode_q_len = decode_q_len_from_indptr(qo_indptr_cpu, num_decodes)
+                 use_cudagraph = (
+                     self.enable_cuda_graph
+-                    and pure_decode
+-                    and num_decode_tokens <= self._decode_cudagraph_max_bs
++                    and persistent_decode_wrapper_eligible(
++                        pure_decode=pure_decode,
++                        num_decode_tokens=num_decode_tokens,
++                        decode_cudagraph_max_bs=self._decode_cudagraph_max_bs,
++                        decode_q_len=decode_q_len,
++                        planned_decode_q_len=self._planned_decode_q_len,
++                    )
+                 )
+-                # Spec-as-decode verify batches carry a uniform
+-                # num_decode_tokens // num_decodes tokens per request; the
+-                # wrapper's batch size and kv metadata are per request.
+-                assert num_decode_tokens % num_decodes == 0
+-                decode_q_len = num_decode_tokens // num_decodes
+ 
+                 decode_wrapper = self._get_decode_wrapper(num_decodes, use_cudagraph)
+                 # Use the persistent buffer with padding length,
+diff --git a/vllm/v1/attention/backends/mla/compressor_utils.py b/vllm/v1/attention/backends/mla/compressor_utils.py
+index 9ec2085e8d180b0d40dd06f692db7d29916cbb54..cfa5f62d0748f10e62be38c17253bd0fb71adf4a 100644
+--- a/vllm/v1/attention/backends/mla/compressor_utils.py
++++ b/vllm/v1/attention/backends/mla/compressor_utils.py
+@@ -1,8 +1,94 @@
+ # SPDX-License-Identifier: Apache-2.0
+ # SPDX-FileCopyrightText: Copyright contributors to the vLLM project
++from collections.abc import Callable
++from functools import cache
++
+ import torch
+ 
+ from vllm.triton_utils import tl, triton
++from vllm.utils.math_utils import cdiv
++
++_C128A_TOPK_ALIGNMENT = 128
++_COMPRESSED_MLA_SPLIT_ALIGNMENT = 64
++_DSPARK_SWA_INDEX_ALIGNMENT = 512
++
++
++def get_c128a_topk_width(max_model_len: int, compress_ratio: int) -> int:
++    """Return C128 indexed width padded for FlashMLA B_TOPK divisibility.
++
++    Args:
++        max_model_len: Maximum model context length in tokens.
++        compress_ratio: Ratio used to compress the indexed KV cache.
++
++    Returns:
++        The aligned compressed top-k width.
++    """
++    compressed_width = cdiv(max_model_len, compress_ratio)
++    return cdiv(compressed_width, _C128A_TOPK_ALIGNMENT) * _C128A_TOPK_ALIGNMENT
++
++
++def get_dspark_swa_index_width(
++    window_size: int,
++    num_speculative_tokens: int,
++) -> int:
++    """Return the padded width of non-causal DSpark SWA indices.
++
++    Args:
++        window_size: Sliding-window attention width.
++        num_speculative_tokens: Number of DSpark draft tokens.
++
++    Returns:
++        The aligned non-causal index width.
++    """
++    width = max(int(window_size), 0) + max(int(num_speculative_tokens), 0)
++    return cdiv(width, _DSPARK_SWA_INDEX_ALIGNMENT) * _DSPARK_SWA_INDEX_ALIGNMENT
++
++
++def get_compressed_mla_split_cap(width: int) -> int:
++    """Return the maximum compressed-MLA split count for ``width``.
++
++    Args:
++        width: Combined SWA and indexed width.
++
++    Returns:
++        The split count capped by the kernel tile width.
++    """
++    return max(1, cdiv(max(int(width), 1), _COMPRESSED_MLA_SPLIT_ALIGNMENT))
++
++
++@cache
++def get_compressed_mla_max_q_chunks(
++    max_rows: int,
++    width: int,
++    max_chunks: int,
++    split_chunks_for_contract: Callable[..., int],
++    decode_row_capacity: int | None = None,
++) -> int:
++    """Return the q-chunk cap over every reachable row count.
++
++    Args:
++        max_rows: Maximum number of query rows in one scheduler step.
++        width: Combined SWA and indexed width.
++        max_chunks: Maximum chunks allowed for each row.
++        split_chunks_for_contract: Kernel contract split-count function.
++        decode_row_capacity: Integration-declared decode/verifier row capacity.
++
++    Returns:
++        The largest reachable product of rows and chunks per row.
++    """
++    max_rows = max(int(max_rows), 1)
++    width = max(int(width), 1)
++    max_chunks = max(int(max_chunks), 1)
++    return max(
++        rows
++        * split_chunks_for_contract(
++            rows=rows,
++            width=width,
++            max_chunks=max_chunks,
++            decode_row_capacity=decode_row_capacity,
++        )
++        for rows in range(1, max_rows + 1)
++    )
+ 
+ 
+ @triton.jit
+@@ -48,15 +134,12 @@ def _compressed_slot_mapping_kernel(
+         else:
+             virtual_block_size = block_size * DCP_WORLD_SIZE
+             block_ids = pos_after_compress // virtual_block_size
+-            virtual_block_offsets = (
+-                pos_after_compress - block_ids * virtual_block_size
+-            )
++            virtual_block_offsets = pos_after_compress - block_ids * virtual_block_size
+             is_local = (
+                 virtual_block_offsets // CP_KV_CACHE_INTERLEAVE_SIZE
+             ) % DCP_WORLD_SIZE == DCP_RANK
+             block_offsets = (
+-                virtual_block_offsets
+-                // (DCP_WORLD_SIZE * CP_KV_CACHE_INTERLEAVE_SIZE)
++                virtual_block_offsets // (DCP_WORLD_SIZE * CP_KV_CACHE_INTERLEAVE_SIZE)
+             ) * CP_KV_CACHE_INTERLEAVE_SIZE + (
+                 virtual_block_offsets % CP_KV_CACHE_INTERLEAVE_SIZE
+             )
+diff --git a/vllm/v1/attention/backends/mla/sparse_swa.py b/vllm/v1/attention/backends/mla/sparse_swa.py
+index 5c23e98d3bb136b3776b1302649e6d3c24897f11..45bdf5d2e6964127e570aacec849c193bb1f34c9 100644
+--- a/vllm/v1/attention/backends/mla/sparse_swa.py
++++ b/vllm/v1/attention/backends/mla/sparse_swa.py
+@@ -17,6 +17,9 @@ from vllm.v1.attention.backend import (
+     CommonAttentionMetadata,
+     MultipleOf,
+ )
++from vllm.v1.attention.backends.mla.compressor_utils import (
++    get_dspark_swa_index_width,
++)
+ from vllm.v1.attention.ops.flashmla import FlashMLASchedMeta, get_mla_metadata
+ from vllm.v1.kv_cache_interface import (
+     KVCacheSpec,
+@@ -416,7 +419,10 @@ class DeepseekSparseSWAMetadataBuilder(AttentionMetadataBuilder):
+         # width. decode_swa_lens keeps the padding out of the attention result.
+         self.is_dspark = spec_config is not None and spec_config.use_dspark()
+         self.noncausal_index_width = (
+-            cdiv(self.window_size + self.num_speculative_tokens, 512) * 512
++            get_dspark_swa_index_width(
++                self.window_size,
++                self.num_speculative_tokens,
++            )
+             if self.is_dspark
+             else 0
+         )
+diff --git a/vllm/v1/attention/ops/dcp_alltoall.py b/vllm/v1/attention/ops/dcp_alltoall.py
+index e371cf22e442a163bce41dcfe046c791ab1323a7..6fc3036ea8bce0f80b241e5a39fbe645842a552e 100644
+--- a/vllm/v1/attention/ops/dcp_alltoall.py
++++ b/vllm/v1/attention/ops/dcp_alltoall.py
+@@ -41,11 +41,14 @@ logger = init_logger(__name__)
+ 
+ _B12X_DCP_A2A_POOLS: dict[tuple[int, int, int, int, int, int], Any] = {}
+ _B12X_DCP_A2A_DISABLED: set[tuple[int, int, int, int, int, int]] = set()
++# DCP likewise has one stable eager scheduler owner.  Graph target/draft/encoder
++# identities are supplied separately by their GraphCaptureContext.
++_B12X_DCP_EAGER_CHANNEL_ID = "vllm:eager:dcp"
++_B12X_DCP_MAX_CONCURRENT_CHANNELS = 2
+ _DCP_A2A_GRAPH_BUFFERS: dict[
+     tuple[tuple[int, ...], torch.device, torch.dtype],
+     tuple[torch.Tensor, torch.Tensor],
+ ] = {}
+-_B12X_DCP_A2A_EAGER_CHANNEL_ID = "eager:vllm-dcp-a2a"
+ 
+ 
+ def _is_supported_bhd_layout(tensor: torch.Tensor) -> bool:
+@@ -54,9 +57,7 @@ def _is_supported_bhd_layout(tensor: torch.Tensor) -> bool:
+         return False
+     batch, heads, head_dim = (int(value) for value in tensor.shape)
+     stride_batch, stride_head, _ = (int(value) for value in tensor.stride())
+-    packed_token_major = (
+-        stride_batch == heads * head_dim and stride_head == head_dim
+-    )
++    packed_token_major = stride_batch == heads * head_dim and stride_head == head_dim
+     capacity_strided_head_major = (
+         stride_batch == head_dim and stride_head >= batch * head_dim
+     )
+@@ -131,9 +132,10 @@ def _get_b12x_dcp_a2a_pool(
+             head_dim=head_dim,
+             query_head_dim=query_head_dim,
+             single_channel=False,
++            max_concurrent_channels=_B12X_DCP_MAX_CONCURRENT_CHANNELS,
+         )
+-        pool.prepare_channels((_B12X_DCP_A2A_EAGER_CHANNEL_ID,))
+-        pool.for_stream(channel_id=_B12X_DCP_A2A_EAGER_CHANNEL_ID)
++        pool.prepare_channels((_B12X_DCP_EAGER_CHANNEL_ID,))
++        pool.for_stream(channel_id=_B12X_DCP_EAGER_CHANNEL_ID)
+     except Exception as exc:
+         init_error = exc
+ 
+@@ -195,6 +197,11 @@ def capture_b12x_dcp_a2a(
+         ),
+         key=lambda item: item[0][1:],
+     )
++    if matching_pools and channel_id is None:
++        raise RuntimeError(
++            "distributed PCIe DCP graph capture requires an explicit semantic "
++            "channel_id"
++        )
+     with ExitStack() as stack:
+         for _, pool in matching_pools:
+             stack.enter_context(pool.capture(stream=stream, channel_id=channel_id))
+@@ -318,7 +325,7 @@ def _try_b12x_dcp_lse_reduce(
+         cp_attn_lse,
+         out=reduced,
+         is_lse_base_on_e=is_lse_base_on_e,
+-        channel_id=_B12X_DCP_A2A_EAGER_CHANNEL_ID,
++        channel_id=_B12X_DCP_EAGER_CHANNEL_ID,
+     )
+ 
+ 
+@@ -371,7 +378,7 @@ def _try_b12x_dcp_all_gather_heads(
+         return None
+     return pool.all_gather_heads(
+         local_input,
+-        channel_id=_B12X_DCP_A2A_EAGER_CHANNEL_ID,
++        channel_id=_B12X_DCP_EAGER_CHANNEL_ID,
+     )
+ 
+ 
+diff --git a/vllm/v1/kv_offload/cpu/gpu_worker.py b/vllm/v1/kv_offload/cpu/gpu_worker.py
+index baf9a66719a05c4d69969406ccf3e64e87bb9693..94448857963e21225c4bd97888e0dc46618c5917 100644
+--- a/vllm/v1/kv_offload/cpu/gpu_worker.py
++++ b/vllm/v1/kv_offload/cpu/gpu_worker.py
+@@ -4,6 +4,7 @@ import functools
+ import time
+ from collections import deque
+ from dataclasses import dataclass
++from math import lcm
+ 
+ import numpy as np
+ import torch
+@@ -23,6 +24,10 @@ from vllm.v1.kv_offload.base import (
+     OffloadingWorker,
+     TransferResult,
+ )
++from vllm.v1.kv_offload.cpu.host_mem_ops import (
++    register_host_memory,
++    unregister_host_memory,
++)
+ from vllm.v1.kv_offload.cpu.shared_offload_region import SharedOffloadRegion
+ from vllm.v1.kv_offload.cpu.swap_blocks_triton import (
+     THRESHOLD_BYTES,
+@@ -31,6 +36,75 @@ from vllm.v1.kv_offload.cpu.swap_blocks_triton import (
+ 
+ logger = init_logger(__name__)
+ 
++HOST_REGISTER_SEGMENT_BYTES = 256 << 20
++HOST_REGISTER_ALIGNMENT_BYTES = 64 << 10
++
++
++def _split_copy_descriptors_at_host_boundaries(
++    src: np.ndarray,
++    dst: np.ndarray,
++    sizes: np.ndarray,
++    count: int,
++    *,
++    host_is_src: bool,
++    host_base: int,
++    segment_bytes: int,
++) -> int:
++    """Split raw copies that cross separately registered host segments.
++
++    ``cuMemcpyBatchAsync`` rejects a single descriptor spanning two adjacent
++    ``cudaHostRegister`` regions. Expand only those descriptors in place;
++    processing backwards keeps unread inputs intact.
++    """
++    assert segment_bytes > 0
++    host_ptrs = src if host_is_src else dst
++    host_offsets = host_ptrs[:count] - host_base
++    copy_sizes = sizes[:count]
++    assert np.all(host_offsets >= 0) and np.all(copy_sizes > 0)
++    part_counts = np.floor_divide(
++        np.remainder(host_offsets, segment_bytes) + copy_sizes + segment_bytes - 1,
++        segment_bytes,
++    )
++    expanded_count = int(part_counts.sum())
++
++    if expanded_count == count:
++        return count
++
++    assert expanded_count <= len(src)
++    write_idx = expanded_count
++    for read_idx in range(count - 1, -1, -1):
++        src_ptr = int(src[read_idx])
++        dst_ptr = int(dst[read_idx])
++        size = int(sizes[read_idx])
++        host_ptr = src_ptr if host_is_src else dst_ptr
++        part_count = int(part_counts[read_idx])
++        if part_count == 1:
++            write_idx -= 1
++            src[write_idx] = src_ptr
++            dst[write_idx] = dst_ptr
++            sizes[write_idx] = size
++            continue
++
++        parts: list[tuple[int, int]] = []
++        copied = 0
++        while copied < size:
++            host_offset = host_ptr + copied - host_base
++            bytes_to_boundary = segment_bytes - host_offset % segment_bytes
++            part_size = min(size - copied, bytes_to_boundary)
++            parts.append((copied, part_size))
++            copied += part_size
++
++        assert len(parts) == part_count
++        write_idx -= len(parts)
++        for part_idx, (offset, part_size) in enumerate(parts):
++            out_idx = write_idx + part_idx
++            src[out_idx] = src_ptr + offset
++            dst[out_idx] = dst_ptr + offset
++            sizes[out_idx] = part_size
++
++    assert write_idx == 0
++    return expanded_count
++
+ 
+ def _select_swap_blocks_fn(
+     kv_cache_groups_data_refs: list[list[CanonicalKVCacheRef]],
+@@ -121,7 +195,12 @@ def compute_sub_block_ptrs(
+ 
+ 
+ def pin_mmap_region(region: SharedOffloadRegion) -> None:
+-    """Register the entire mmap as CUDA pinned memory via cudaHostRegister."""
++    """Register the mmap as CUDA pinned memory.
++
++    Large virtual mappings can be rejected by ``cudaHostRegister`` even when
++    enough host memory is available. Preserve the single-registration fast
++    path, then retry large mappings as bounded, non-overlapping segments.
++    """
+     if not current_platform.is_cuda_alike():
+         logger.info(
+             "Skipping mmap host registration on %s; cudaHostRegister is only "
+@@ -133,21 +212,83 @@ def pin_mmap_region(region: SharedOffloadRegion) -> None:
+     rank = region.rank
+ 
+     base_ptr = region._base.data_ptr()
+-    result = torch.cuda.cudart().cudaHostRegister(base_ptr, region.total_size_bytes, 0)
+-    if result.value != 0:
+-        logger.warning(
+-            "cudaHostRegister failed for rank=%d (code=%d) — "
+-            "transfers will still work but may be slower (unpinned DMA)",
+-            rank,
+-            result,
++    region._registered_host_ptrs.clear()
++    region._host_register_segment_bytes = None
++    result = register_host_memory(base_ptr, region.total_size_bytes)
++    if result != 0:
++        if region.total_size_bytes <= HOST_REGISTER_SEGMENT_BYTES:
++            logger.warning(
++                "cudaHostRegister failed for rank=%d (code=%d); "
++                "transfers will continue with unpinned memory",
++                rank,
++                result,
++            )
++            return
++
++        # Keep every canonical KV row inside one registration. CUDA's batched
++        # memcpy API rejects a descriptor spanning two adjacent registrations.
++        row_stride = region._row_stride
++        # CUDA 13 rejects adjacent registrations when their split offset does
++        # not preserve its 64 KiB host-registration granularity. Align to both
++        # that boundary and a full KV row so neither registration ranges nor
++        # batch-copy descriptors straddle a split.
++        segment_alignment = lcm(row_stride, HOST_REGISTER_ALIGNMENT_BYTES)
++        alignments_per_segment = max(
++            1, HOST_REGISTER_SEGMENT_BYTES // segment_alignment
+         )
+-    else:
+-        logger.debug(
+-            "cudaHostRegister rank=%d %.2f GB",
++        segment_bytes = alignments_per_segment * segment_alignment
++        registered_ptrs: list[int] = []
++        for offset in range(0, region.total_size_bytes, segment_bytes):
++            ptr = base_ptr + offset
++            size = min(
++                segment_bytes,
++                region.total_size_bytes - offset,
++            )
++            segment_result = register_host_memory(ptr, size)
++            if segment_result == 0:
++                registered_ptrs.append(ptr)
++                continue
++
++            for registered_ptr in reversed(registered_ptrs):
++                unregister_result = unregister_host_memory(registered_ptr)
++                if unregister_result != 0:
++                    logger.warning(
++                        "cudaHostUnregister rollback failed for rank=%d "
++                        "ptr=%#x (code=%d)",
++                        rank,
++                        registered_ptr,
++                        unregister_result,
++                    )
++            logger.warning(
++                "Segmented cudaHostRegister failed for rank=%d offset=%d "
++                "size=%d (code=%d); transfers will continue with unpinned memory",
++                rank,
++                offset,
++                size,
++                segment_result,
++            )
++            return
++
++        region._registered_host_ptrs.extend(registered_ptrs)
++        region._host_register_segment_bytes = segment_bytes
++        region.is_pinned = True
++        logger.info(
++            "Registered rank=%d mmap as %d row-aligned host-memory segments "
++            "(segment=%d bytes, total=%.2f GB)",
+             rank,
++            len(registered_ptrs),
++            segment_bytes,
+             region.total_size_bytes / 1e9,
+         )
+-        region.is_pinned = True
++        return
++
++    region._registered_host_ptrs.append(base_ptr)
++    region.is_pinned = True
++    logger.debug(
++        "cudaHostRegister rank=%d %.2f GB",
++        rank,
++        region.total_size_bytes / 1e9,
++    )
+ 
+ 
+ def _new_descriptor_buffers(
+@@ -179,6 +320,8 @@ class SingleDirectionOffloadingHandler:
+         kv_cache_groups_data_refs: list[list[CanonicalKVCacheRef]],
+         gpu_to_cpu: bool,
+         mmap_region: SharedOffloadRegion | None = None,
++        segmented_host_base: int | None = None,
++        segmented_host_bytes: int | None = None,
+     ):
+         """
+         Initialize a SingleDirectionOffloadingHandler.
+@@ -218,6 +361,21 @@ class SingleDirectionOffloadingHandler:
+         self._swap_blocks_batch = _select_swap_blocks_fn(
+             kv_cache_groups_data_refs, gpu_to_cpu
+         )
++        self._segmented_host_base = segmented_host_base
++        self._segmented_host_bytes = segmented_host_bytes
++        assert (segmented_host_base is None) == (segmented_host_bytes is None)
++        page_sizes = [
++            data_ref.page_size_bytes
++            for group in kv_cache_groups_data_refs
++            for data_ref in group
++        ]
++        self._descriptor_capacity_multiplier = 1
++        if segmented_host_base is not None and page_sizes:
++            assert segmented_host_bytes is not None
++            max_page_size = max(page_sizes)
++            self._descriptor_capacity_multiplier = 1 + cdiv(
++                max_page_size - 1, segmented_host_bytes
++            )
+ 
+         # GPU blocks may be smaller
+         # cpu_page_size = gpu_page_size * blocks_per_chunk.
+@@ -287,13 +445,16 @@ class SingleDirectionOffloadingHandler:
+             num_copy_ops += group_size * len(group_data_refs)
+ 
+         # reuse a pooled buffer set, growing it if this transfer needs more room
++        descriptor_capacity = num_copy_ops * self._descriptor_capacity_multiplier
+         batch_src, batch_dst, batch_sizes = (
+             self._buffer_pool.pop()
+             if self._buffer_pool
+-            else _new_descriptor_buffers(num_copy_ops)
++            else _new_descriptor_buffers(descriptor_capacity)
+         )
+-        if batch_src.numel() < num_copy_ops:
+-            batch_src, batch_dst, batch_sizes = _new_descriptor_buffers(num_copy_ops)
++        if batch_src.numel() < descriptor_capacity:
++            batch_src, batch_dst, batch_sizes = _new_descriptor_buffers(
++                descriptor_capacity
++            )
+ 
+         src = batch_src[:num_copy_ops]
+         dst = batch_dst[:num_copy_ops]
+@@ -359,6 +520,21 @@ class SingleDirectionOffloadingHandler:
+         assert dst_offset == num_dst_blocks
+         assert op_idx == num_copy_ops
+ 
++        if self._segmented_host_base is not None and num_copy_ops > 0:
++            assert self._segmented_host_bytes is not None
++            num_copy_ops = _split_copy_descriptors_at_host_boundaries(
++                batch_src.numpy(),
++                batch_dst.numpy(),
++                batch_sizes.numpy(),
++                num_copy_ops,
++                host_is_src=not self.gpu_to_cpu,
++                host_base=self._segmented_host_base,
++                segment_bytes=self._segmented_host_bytes,
++            )
++            src = batch_src[:num_copy_ops]
++            dst = batch_dst[:num_copy_ops]
++            sizes = batch_sizes[:num_copy_ops]
++
+         stream = (
+             self._stream_pool.pop() if self._stream_pool else current_platform.Stream()
+         )
+@@ -480,6 +656,8 @@ class CPUOffloadingWorker(OffloadingWorker):
+         logger.info("Allocating %d CPU tensors...", len(kv_caches.tensors))
+         if mmap_region is not None and pin_memory:
+             pin_mmap_region(mmap_region)
++        segmented_host_base = None
++        segmented_host_bytes = None
+ 
+         gpu_tensors: list[torch.Tensor] = []
+         cpu_tensors: list[torch.Tensor] = []
+@@ -511,6 +689,15 @@ class CPUOffloadingWorker(OffloadingWorker):
+             gpu_tensors.append(gpu_tensor)
+             cpu_tensors.append(cpu_tensor)
+ 
++        if mmap_region is not None and len(mmap_region._registered_host_ptrs) > 1:
++            registration_bytes = mmap_region._host_register_segment_bytes
++            assert registration_bytes is not None
++            # Row-aligned registrations are the zero-overhead fast path. Keep
++            # the descriptor splitter only for alternate layouts.
++            if any(registration_bytes % tensor.stride(0) for tensor in cpu_tensors):
++                segmented_host_base = mmap_region._base.data_ptr()
++                segmented_host_bytes = registration_bytes
++
+         self._store_handler = SingleDirectionOffloadingHandler(
+             gpu_tensors=gpu_tensors,
+             cpu_tensors=cpu_tensors,
+@@ -518,6 +705,8 @@ class CPUOffloadingWorker(OffloadingWorker):
+             kv_cache_groups_data_refs=kv_caches.group_data_refs,
+             gpu_to_cpu=True,
+             mmap_region=mmap_region,
++            segmented_host_base=segmented_host_base,
++            segmented_host_bytes=segmented_host_bytes,
+         )
+ 
+         self._load_handler = SingleDirectionOffloadingHandler(
+@@ -526,6 +715,8 @@ class CPUOffloadingWorker(OffloadingWorker):
+             blocks_per_chunk=blocks_per_chunk,
+             kv_cache_groups_data_refs=kv_caches.group_data_refs,
+             gpu_to_cpu=False,
++            segmented_host_base=segmented_host_base,
++            segmented_host_bytes=segmented_host_bytes,
+         )
+ 
+     def submit_store(
+diff --git a/vllm/v1/kv_offload/cpu/host_mem_ops.py b/vllm/v1/kv_offload/cpu/host_mem_ops.py
+new file mode 100644
+index 0000000000000000000000000000000000000000..a6e6d4f59b89d16161d5fb2e66415f794e69a862
+--- /dev/null
++++ b/vllm/v1/kv_offload/cpu/host_mem_ops.py
+@@ -0,0 +1,65 @@
++# SPDX-License-Identifier: Apache-2.0
++# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
++"""Low-level host-memory registration helpers for CPU KV offload."""
++
++import torch
++
++from vllm.distributed.device_communicators.cuda_wrapper import CudaRTLibrary
++from vllm.platforms import current_platform
++
++
++def _get_cuda_driver():
++    from cuda.bindings import driver
++
++    return driver
++
++
++def register_host_memory(ptr: int, size: int) -> int:
++    """Register host memory and return a CUDA/HIP error code.
++
++    CUDA uses the driver API deliberately. A failed runtime
++    ``cudaHostRegister`` updates the calling thread's last-error state, which
++    can make a later unrelated PyTorch operation fail even when offload falls
++    back to pageable memory. Driver API failures are returned directly and do
++    not contaminate that runtime state.
++
++    Args:
++        ptr: Base address of the host-memory region.
++        size: Region size in bytes.
++
++    Returns:
++        The CUDA or HIP registration error code.
++    """
++    if current_platform.is_cuda():
++        (result,) = _get_cuda_driver().cuMemHostRegister(ptr, size, 0)
++        return int(result.value)
++
++    cudart = torch.cuda.cudart()
++    result = cudart.cudaHostRegister(ptr, size, 0)
++    code = int(result.value)
++    if code != 0:
++        # HIP uses the runtime API, so consume its expected registration error
++        # before the caller continues with pageable memory.
++        CudaRTLibrary().cudaGetLastError()
++    return code
++
++
++def unregister_host_memory(ptr: int) -> int:
++    """Unregister host memory and return a CUDA/HIP error code.
++
++    Args:
++        ptr: Base address passed to :func:`register_host_memory`.
++
++    Returns:
++        The CUDA or HIP unregistration error code.
++    """
++    if current_platform.is_cuda():
++        (result,) = _get_cuda_driver().cuMemHostUnregister(ptr)
++        return int(result.value)
++
++    cudart = torch.cuda.cudart()
++    result = cudart.cudaHostUnregister(ptr)
++    code = int(result.value)
++    if code != 0:
++        CudaRTLibrary().cudaGetLastError()
++    return code
+diff --git a/vllm/v1/kv_offload/cpu/shared_offload_region.py b/vllm/v1/kv_offload/cpu/shared_offload_region.py
+index 290c0d5107d4d7298b0bea86f35608da527f25b1..1fd3594f66578fa1d0a634f88c5b6e8cf4e192e6 100644
+--- a/vllm/v1/kv_offload/cpu/shared_offload_region.py
++++ b/vllm/v1/kv_offload/cpu/shared_offload_region.py
+@@ -1,5 +1,6 @@
+ # SPDX-License-Identifier: Apache-2.0
+ # SPDX-FileCopyrightText: Copyright contributors to the vLLM project
++import contextlib
+ import mmap
+ import os
+ import time
+@@ -8,6 +9,7 @@ import torch
+ 
+ from vllm.logger import init_logger
+ from vllm.platforms import current_platform
++from vllm.v1.kv_offload.cpu.host_mem_ops import unregister_host_memory
+ 
+ logger = init_logger(__name__)
+ 
+@@ -45,16 +47,36 @@ class SharedOffloadRegion:
+         rank: int | None,
+         kv_bytes_per_block: int,
+         cpu_page_size: int,
++        *,
++        unlink_after_workers_map: bool = False,
++        num_workers: int | None = None,
++        prefault: bool = True,
+     ) -> None:
+         self.page_size = mmap.PAGESIZE
+         assert kv_bytes_per_block % self.page_size == 0
++        if unlink_after_workers_map:
++            if num_workers is None or num_workers <= 0:
++                raise ValueError(
++                    "num_workers must be positive when "
++                    "unlink_after_workers_map is enabled"
++                )
++            if rank is not None and not 0 <= rank < num_workers:
++                raise ValueError(f"rank {rank} is outside num_workers={num_workers}")
+ 
+         self.num_blocks = num_blocks
+         self._row_stride = kv_bytes_per_block
+         self.total_size_bytes = self.num_blocks * self._row_stride
+ 
+         self.mmap_path = f"/dev/shm/vllm_offload_{engine_id}.mmap"
++        self._mapping_marker: str | None = None
+         self._creator = False  # set True only if this worker creates the file
++        self.fd: int | None = None
++        self.mmap_obj: mmap.mmap | None = None
++        self._base: torch.Tensor | None = None
++        self._views: list[torch.Tensor] = []
++        self._registered_host_ptrs: list[int] = []
++        self._host_register_segment_bytes: int | None = None
++        self.is_pinned: bool = False
+         self.rank = rank
+         if rank is not None:
+             # byte offset to this worker's first slot within each block row
+@@ -62,60 +84,123 @@ class SharedOffloadRegion:
+             # exclusive upper bound for this worker's area within each row
+             self._worker_area_end = (rank + 1) * cpu_page_size
+         try:
+-            # Exclusive create — only one worker succeeds
+-            self.fd: int | None = os.open(
+-                self.mmap_path, os.O_CREAT | os.O_EXCL | os.O_RDWR, 0o600
+-            )
+-            os.ftruncate(self.fd, self.total_size_bytes)
+-            self._creator = True
+-            logger.info(
+-                "Created mmap file %s (%.2f GB)",
+-                self.mmap_path,
+-                self.total_size_bytes / 1e9,
+-            )
+-        except FileExistsError:
+-            self.fd = os.open(self.mmap_path, os.O_RDWR)
+-            _wait_for_file_size(self.fd, self.total_size_bytes)
+-            logger.info("Opened existing mmap file %s", self.mmap_path)
+-
+-        self.mmap_obj: mmap.mmap | None = mmap.mmap(
+-            self.fd,
+-            self.total_size_bytes,
+-            flags=mmap.MAP_SHARED,
+-            prot=mmap.PROT_READ | mmap.PROT_WRITE,
+-        )
+-
+-        # MADV_POPULATE_WRITE was added in Linux 5.14 (value 23).
+-        _MADV_POPULATE_WRITE = getattr(mmap, "MADV_POPULATE_WRITE", 23)
+-        if rank is not None:
+-            # Populate only this worker's pages (one slot per block row).
+-            worker_offset = rank * cpu_page_size
+-            _t0 = time.perf_counter()
+-            page_size = self.page_size
+-            for block in range(num_blocks):
+-                raw_offset = block * self._row_stride + worker_offset
+-                aligned_offset = (raw_offset // page_size) * page_size
+-                end = raw_offset + cpu_page_size
+-                aligned_length = end - aligned_offset
+-                self.mmap_obj.madvise(
+-                    _MADV_POPULATE_WRITE, aligned_offset, aligned_length
++            try:
++                # Exclusive create — only one worker succeeds.
++                self.fd = os.open(
++                    self.mmap_path, os.O_CREAT | os.O_EXCL | os.O_RDWR, 0o600
+                 )
+-            logger.debug(
+-                "MADV_POPULATE_WRITE loop: %d blocks in %.3f s",
+-                num_blocks,
+-                time.perf_counter() - _t0,
+-            )
+-        else:
+-            # No rank — populate the entire shared region in one call.
+-            _t0 = time.perf_counter()
+-            self.mmap_obj.madvise(_MADV_POPULATE_WRITE, 0, self.total_size_bytes)
+-            logger.debug(
+-                "MADV_POPULATE_WRITE entire region: %.3f s", time.perf_counter() - _t0
++                os.ftruncate(self.fd, self.total_size_bytes)
++                self._creator = True
++                logger.info(
++                    "Created mmap file %s (%.2f GB)",
++                    self.mmap_path,
++                    self.total_size_bytes / 1e9,
++                )
++            except FileExistsError:
++                self.fd = os.open(self.mmap_path, os.O_RDWR)
++                _wait_for_file_size(self.fd, self.total_size_bytes)
++                logger.info("Opened existing mmap file %s", self.mmap_path)
++
++            assert self.fd is not None
++            mmap_obj = mmap.mmap(
++                self.fd,
++                self.total_size_bytes,
++                flags=mmap.MAP_SHARED,
++                prot=mmap.PROT_READ | mmap.PROT_WRITE,
+             )
++            self.mmap_obj = mmap_obj
+ 
+-        self._base = torch.frombuffer(memoryview(self.mmap_obj), dtype=torch.int8)
+-        self._views: list[torch.Tensor] = []
+-        self.is_pinned: bool = False
++            if unlink_after_workers_map and rank is not None:
++                assert num_workers is not None
++                self._unlink_after_worker_mappings(num_workers)
++
++            if prefault:
++                # MADV_POPULATE_WRITE was added in Linux 5.14 (value 23).
++                populate_write = getattr(mmap, "MADV_POPULATE_WRITE", 23)
++                if rank is not None:
++                    # Populate only this worker's pages (one slot per block row).
++                    worker_offset = rank * cpu_page_size
++                    start = time.perf_counter()
++                    page_size = self.page_size
++                    for block in range(num_blocks):
++                        raw_offset = block * self._row_stride + worker_offset
++                        aligned_offset = (raw_offset // page_size) * page_size
++                        end = raw_offset + cpu_page_size
++                        aligned_length = end - aligned_offset
++                        mmap_obj.madvise(populate_write, aligned_offset, aligned_length)
++                    logger.debug(
++                        "MADV_POPULATE_WRITE loop: %d blocks in %.3f s",
++                        num_blocks,
++                        time.perf_counter() - start,
++                    )
++                else:
++                    start = time.perf_counter()
++                    mmap_obj.madvise(populate_write, 0, self.total_size_bytes)
++                    logger.debug(
++                        "MADV_POPULATE_WRITE entire region: %.3f s",
++                        time.perf_counter() - start,
++                    )
++
++            self._base = torch.frombuffer(memoryview(mmap_obj), dtype=torch.int8)
++        except BaseException:
++            self.cleanup()
++            raise
++
++    def _unlink_after_worker_mappings(
++        self, num_workers: int, timeout: float = 30.0
++    ) -> None:
++        """Make the mmap anonymous after every worker has mapped the file.
++
++        The pathname is needed only while workers rendezvous during startup.
++        Once every rank owns a mapping, unlinking is safe: POSIX keeps the
++        pages alive until the last mapping closes and releases them even when
++        a worker is terminated before Python cleanup runs.
++
++        Raises:
++            TimeoutError: If not every worker publishes its mapping marker.
++        """
++        assert self.rank is not None
++        marker_prefix = f"{self.mmap_path}.mapped."
++        marker_path = f"{marker_prefix}{self.rank}"
++        marker_fd = os.open(marker_path, os.O_CREAT | os.O_EXCL | os.O_WRONLY, 0o600)
++        os.close(marker_fd)
++        self._mapping_marker = marker_path
++
++        # Rank 0 is the coordinator, independent of which rank created the
++        # backing file. Other ranks can continue as soon as their mapping is
++        # established; rank 0 keeps the pathname available until all markers
++        # are visible.
++        if self.rank != 0:
++            return
++
++        marker_paths = [f"{marker_prefix}{rank}" for rank in range(num_workers)]
++        try:
++            deadline = time.monotonic() + timeout
++            while not all(os.path.exists(path) for path in marker_paths):
++                if time.monotonic() > deadline:
++                    missing = [
++                        path for path in marker_paths if not os.path.exists(path)
++                    ]
++                    raise TimeoutError(
++                        "Timed out waiting for worker mmap markers: "
++                        + ", ".join(missing)
++                    )
++                time.sleep(0.005)
++
++            try:
++                os.unlink(self.mmap_path)
++                logger.info(
++                    "Unlinked mmap file %s after %d workers mapped it",
++                    self.mmap_path,
++                    num_workers,
++                )
++            except FileNotFoundError:
++                pass
++        finally:
++            for path in marker_paths:
++                with contextlib.suppress(FileNotFoundError):
++                    os.unlink(path)
++            self._mapping_marker = None
+ 
+     def create_next_view(self, tensor_page_size: int) -> torch.Tensor:
+         """Allocate a strided int8 view for this worker, one canonical tensor.
+@@ -140,6 +225,7 @@ class SharedOffloadRegion:
+             tensor_page_size: Bytes per block for this  tensor.
+         """
+         assert self.rank is not None
++        assert self._base is not None
+         new_offset = self._worker_offset + tensor_page_size
+         assert new_offset <= self._worker_area_end, (
+             f"Worker offset {new_offset} exceeds worker area end "
+@@ -162,6 +248,7 @@ class SharedOffloadRegion:
+         Shape: (num_blocks, row_stride_bytes). Secondary tiers address
+         block *b* as ``view[b]``.
+         """
++        assert self._base is not None
+         kv_tensor = self._base.view(self.num_blocks, self._row_stride)
+         np_arr = kv_tensor.numpy()
+         assert np_arr.ctypes.data == self._base.data_ptr(), (
+@@ -173,14 +260,18 @@ class SharedOffloadRegion:
+     def cleanup(self) -> None:
+         if self.is_pinned and self._base is not None:
+             if current_platform.is_cuda_alike():
+-                base_ptr = self._base.data_ptr()
+-                result = torch.cuda.cudart().cudaHostUnregister(base_ptr)
+-                if result.value != 0:
+-                    logger.warning(
+-                        "cudaHostUnregister failed for rank=%d (code=%d)",
+-                        self.rank,
+-                        result,
+-                    )
++                registered_ptrs = self._registered_host_ptrs or [self._base.data_ptr()]
++                for ptr in reversed(registered_ptrs):
++                    result = unregister_host_memory(ptr)
++                    if result != 0:
++                        logger.warning(
++                            "cudaHostUnregister failed for rank=%d ptr=%#x (code=%d)",
++                            self.rank,
++                            ptr,
++                            result,
++                        )
++            self._registered_host_ptrs.clear()
++            self._host_register_segment_bytes = None
+             self.is_pinned = False
+         # Release views before _base: each view holds a _base reference and a
+         # direct StorageImpl reference.  Freeing views first lets both refcounts
+@@ -201,10 +292,16 @@ class SharedOffloadRegion:
+             except Exception:
+                 logger.warning("Failed to close fd %s", self.fd, exc_info=True)
+             self.fd = None
++        if self._mapping_marker is not None:
++            with contextlib.suppress(FileNotFoundError):
++                os.unlink(self._mapping_marker)
++            self._mapping_marker = None
+         if self._creator and getattr(self, "mmap_path", None):
+             try:
+                 os.unlink(self.mmap_path)
+                 logger.info("Removed mmap file %s", self.mmap_path)
++            except FileNotFoundError:
++                pass
+             except Exception:
+                 logger.warning(
+                     "Failed to unlink path %s", self.mmap_path, exc_info=True
+diff --git a/vllm/v1/kv_offload/cpu/spec.py b/vllm/v1/kv_offload/cpu/spec.py
+index f6d1c29aff930bf485354a45478040261fa68205..cbd857670faa5770764ce690044c1f831df0fd1a 100644
+--- a/vllm/v1/kv_offload/cpu/spec.py
++++ b/vllm/v1/kv_offload/cpu/spec.py
+@@ -2,6 +2,7 @@
+ # SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+ from typing import Any
+ 
++import torch
+ from typing_extensions import override
+ 
+ from vllm.platforms import current_platform
+@@ -20,10 +21,11 @@ from vllm.v1.kv_offload.config import OffloadingConfig
+ from vllm.v1.kv_offload.cpu.common import CPUOffloadingMetrics
+ from vllm.v1.kv_offload.cpu.gpu_worker import CPUOffloadingWorker
+ from vllm.v1.kv_offload.cpu.manager import CPUOffloadingManager
++from vllm.v1.kv_offload.cpu.shared_offload_region import SharedOffloadRegion
+ 
+ 
+ class CPUOffloadingSpec(OffloadingSpec):
+-    BLOCK_SIZE_ALIGNMENT = 1
++    BLOCK_SIZE_ALIGNMENT = SharedOffloadRegion.BLOCK_SIZE_ALIGNMENT
+ 
+     @classmethod
+     def build_metric_definitions(
+@@ -133,10 +135,24 @@ class CPUOffloadingSpec(OffloadingSpec):
+         return self._manager
+ 
+     def create_worker(self, kv_caches: CanonicalKVCaches) -> CPUOffloadingWorker:
++        mmap_region: SharedOffloadRegion | None = None
++        if current_platform.is_cuda_alike() and self.num_blocks > 0:
++            world_size = self.config.parallel.world_size
++            rank = torch.accelerator.current_device_index() % world_size
++            mmap_region = SharedOffloadRegion(
++                engine_id=self.config.engine_id,
++                num_blocks=self.num_blocks,
++                rank=rank,
++                kv_bytes_per_block=self.kv_bytes_per_chunk,
++                cpu_page_size=self.cpu_page_size_per_worker,
++                unlink_after_workers_map=True,
++                num_workers=world_size,
++            )
+         return CPUOffloadingWorker(
+             kv_caches=kv_caches,
+             blocks_per_chunk=self.blocks_per_chunk,
+             num_cpu_blocks=self.num_blocks,
++            mmap_region=mmap_region,
+         )
+ 
+     @override
+diff --git a/vllm/v1/kv_offload/tiering/async_lookup.py b/vllm/v1/kv_offload/tiering/async_lookup.py
+index c75a9604009b9a4336e0064aa07f991879541e37..64645bbf4508973a011bda250c3b54c7669560e0 100644
+--- a/vllm/v1/kv_offload/tiering/async_lookup.py
++++ b/vllm/v1/kv_offload/tiering/async_lookup.py
+@@ -172,6 +172,33 @@ class AsyncLookupManager(ABC):
+                 if state is not None:
+                     state.result = result
+ 
++    def invalidate(self, keys: Iterable[OffloadKey]) -> None:
++        """Mark keys as absent so the next lookup() stops reporting a hit.
++
++        A cached ``True`` is only a snapshot of the tier at the time of the
++        existence check; the block can disappear afterwards (evicted by this
++        instance's own capacity management, by another instance sharing
++        ``root_dir``, or by any external cleanup). Nothing else clears the
++        entry until every request that looked the key up has finished, so a
++        transfer that fails on a vanished block would otherwise be retried
++        against the same stale ``True`` on every subsequent step, and the
++        request that is waiting for it never finishes -- a livelock, with the
++        failing job re-submitted forever.
++
++        ``False`` rather than ``None``: a fresh lookup is only ever queued for a
++        key with no state at all, so ``None`` would make lookup() report RETRY
++        forever instead of recomputing. Whether absence is also literally true
++        depends on the tier -- the fs tier's ``load_block`` unlinks any file it
++        could not read, while a failed object-store read leaves the object in
++        place -- but a pessimistic ``False`` is always safe: it costs at most a
++        recompute, and it expires with the requests that looked the key up,
++        after which a fresh existence check can hit again.
++        """
++        for key in keys:
++            state = self._lookup_state.get(key)
++            if state is not None:
++                state.result = False
++
+     def cleanup(self, req_id: str) -> None:
+         """Remove entries no longer needed by any active request.
+ 
+diff --git a/vllm/v1/kv_offload/tiering/fs/gc_manager.py b/vllm/v1/kv_offload/tiering/fs/gc_manager.py
+new file mode 100644
+index 0000000000000000000000000000000000000000..fc4c92e718c93cc74156d5aec26a06af98c296e2
+--- /dev/null
++++ b/vllm/v1/kv_offload/tiering/fs/gc_manager.py
+@@ -0,0 +1,324 @@
++# SPDX-License-Identifier: Apache-2.0
++# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
++"""
++Garbage collection for the fs secondary tier.
++
++The fs tier keeps no index of its own -- the filesystem *is* the index, since
++`lookup()` is a plain existence check -- so out of the box it has neither a
++capacity limit nor eviction, and grows until the filesystem fills.
++
++`FsGCManager` adds both, using file mtime as the single source of truth for
++recency:
++
++  - `touch()` stamps mtime when the scheduler marks a block recently used.
++    `TieringOffloadingManager` calls this on every secondary tier, including
++    for blocks served from the DRAM primary tier -- which never read this
++    tier's files and would otherwise age out while still hot. Reads cannot
++    supply this signal on their own: `store_block` sets mtime once at write
++    time, reads never update file metadata, and `load_block` opens O_DIRECT so
++    a read need not touch the device at all.
++  - A background sweep walks the tree, and when the total exceeds `max_bytes`
++    unlinks in mtime order until it is back under the low watermark.
++
++Keeping recency on disk rather than in a private dict means the ordering
++survives a restart (the fs tier's contents are reusable across runs when
++PYTHONHASHSEED is pinned), the accounting cannot drift from reality since every
++sweep re-measures it, and external tooling (`du`, `find -newermt`, a separate
++reaper) sees the same truth.
++
++Both `touch()` and the sweep run off the scheduler thread. `touch()` is called
++once per request per scheduling attempt with *all* of the request's offload keys
++(~1.9k keys for a 200k-token context), so stamping inline would cost
++milliseconds of syscalls per call and dirty thousands of inodes; instead a key
++is stamped at most once per `stamp_interval_s` and the `os.utime` calls happen
++on a daemon thread.
++
++Deleting a file that a promotion is about to read is not a correctness problem
++-- the failed promotion frees the DRAM block and the tokens get recomputed --
++but it wastes work and silently drops the block from disk, so the sweep protects
++any key with an in-flight job (`protect`/`release`) and any file whose mtime is
++within `grace_s`. Because `stamp_interval_s < grace_s`, every key used within
++`grace_s - stamp_interval_s` is guaranteed to have a protected mtime. That
++margin is eroded by clock skew wherever mtimes are not set by this host's
++clock -- on NFS or a network PVC the server stamps them while the sweep cutoff
++comes from local `time.time()` -- so on shared storage keep it well above the
++sweep duration rather than tightening the two intervals toward each other.
++
++Known limitation: sweeps do not emit KV events. When the owning tier publishes
++BlockStored events (enable_kv_events), a sweep's unlinks have no removed=True
++counterpart, so an external consumer of the event stream can believe evicted
++blocks still exist. Emitting removals would require reconstructing OffloadKeys
++from the swept paths and handing them across threads to the scheduler-owned
++events list -- and the stream would still be incomplete, because failed-load
++unlinks, peer instances sharing root_dir, and external reapers also remove
++files without events. MEDIUM_FS presence events are best-effort by design;
++consumers must tolerate a BlockStored block that is no longer there. This
++instance's own scheduler already does: a failed load invalidates its cached
++lookup and the tokens are recomputed.
++"""
++
++import os
++import threading
++import time
++from collections import OrderedDict
++from collections.abc import Collection, Iterator
++
++from vllm.logger import init_logger
++from vllm.v1.kv_offload.base import OffloadKey
++from vllm.v1.kv_offload.file_mapper import FileMapper
++
++logger = init_logger(__name__)
++
++# Bound the wait so shutdown() stays responsive when no work arrives.
++_WAKE_TIMEOUT_S = 1.0
++
++# Only block files are candidates. In particular `store_block` writes to
++# "<dest>.tmp" before os.replace, and config.json must never be removed. A
++# writer killed mid-store therefore leaks a .tmp that no sweep counts or
++# reaps; the window is one block write wide, so this is bounded in practice.
++_BLOCK_SUFFIX = ".bin"
++
++
++class FsGCManager:
++    """Bounds the fs tier's on-disk size, evicting least-recently-used blocks."""
++
++    def __init__(
++        self,
++        file_mapper: FileMapper,
++        max_bytes: int,
++        low_watermark: float = 0.9,
++        interval_s: float = 60.0,
++        stamp_interval_s: float = 60.0,
++        grace_s: float = 300.0,
++        max_tracked: int = 200_000,
++    ) -> None:
++        if not 0.0 < low_watermark <= 1.0:
++            raise ValueError(f"low_watermark must be in (0, 1], got {low_watermark}")
++        if grace_s <= stamp_interval_s:
++            raise ValueError(
++                f"grace_s ({grace_s}) must exceed stamp_interval_s "
++                f"({stamp_interval_s}), otherwise a block in active use can "
++                f"have an mtime old enough to be swept"
++            )
++
++        self.file_mapper = file_mapper
++        self.max_bytes = max_bytes
++        self.target_bytes = int(max_bytes * low_watermark)
++        self.interval_s = interval_s
++        self.stamp_interval_s = stamp_interval_s
++        self.grace_s = grace_s
++        self.max_tracked = max_tracked
++
++        # Blocks live under a per-rank sibling of the digest directory.
++        self.block_root = f"{file_mapper.base_path}_r{file_mapper.rank}"
++
++        # key -> monotonic time of last stamp, in LRU order so it can be
++        # trimmed. Losing an entry only costs one redundant utime later.
++        self._last_stamped: OrderedDict[OffloadKey, float] = OrderedDict()
++        # Dedup set of keys awaiting a stamp; dict preserves insertion order.
++        self._pending_stamps: dict[OffloadKey, None] = {}
++        # Keys with in-flight store/load jobs, which must not be unlinked.
++        self._protected: dict[OffloadKey, int] = {}
++
++        self._lock = threading.Lock()
++        self._wake = threading.Event()
++        self._stopping = False
++        self._stamped = 0
++        self._stamp_errors = 0
++
++        self._thread = threading.Thread(
++            target=self._run, name="vllm_kv_fs_gc", daemon=True
++        )
++        self._thread.start()
++        logger.info(
++            "fs tier GC enabled: cap %.1f GiB, sweeping to %.1f GiB every %gs "
++            "(mtime tracks last use, so eviction is LRU and survives restarts)",
++            max_bytes / 2**30,
++            self.target_bytes / 2**30,
++            interval_s,
++        )
++
++    # ------------------------------------------------------------------
++    # Scheduler-thread entry points
++    # ------------------------------------------------------------------
++
++    def touch(self, keys: Collection[OffloadKey]) -> None:
++        """Record keys as recently used. Cheap: one dict lookup per key."""
++        now = time.monotonic()
++        with self._lock:
++            if self._stopping:
++                return
++            for key in keys:
++                last = self._last_stamped.get(key)
++                if last is not None and now - last < self.stamp_interval_s:
++                    continue
++                self._last_stamped[key] = now
++                self._last_stamped.move_to_end(key)
++                self._pending_stamps[key] = None
++            while len(self._last_stamped) > self.max_tracked:
++                self._last_stamped.popitem(last=False)
++            has_work = bool(self._pending_stamps)
++        if has_work:
++            self._wake.set()
++
++    def protect(self, keys: Collection[OffloadKey]) -> None:
++        """Pin keys with an in-flight job so the sweep cannot unlink them."""
++        with self._lock:
++            for key in keys:
++                self._protected[key] = self._protected.get(key, 0) + 1
++
++    def release(self, keys: Collection[OffloadKey]) -> None:
++        """Undo one `protect` for each key."""
++        with self._lock:
++            for key in keys:
++                count = self._protected.get(key)
++                if count is None:
++                    continue
++                if count <= 1:
++                    del self._protected[key]
++                else:
++                    self._protected[key] = count - 1
++
++    # ------------------------------------------------------------------
++    # Background thread
++    # ------------------------------------------------------------------
++
++    def _run(self) -> None:
++        next_sweep = time.monotonic() + self.interval_s
++        while True:
++            self._wake.wait(_WAKE_TIMEOUT_S)
++            self._wake.clear()
++
++            with self._lock:
++                stopping = self._stopping
++                batch = list(self._pending_stamps)
++                self._pending_stamps.clear()
++            try:
++                self._stamp(batch)
++            except Exception:
++                # _stamp handles the expected per-key OSError itself; anything
++                # else escaping here would kill this daemon thread and
++                # silently un-bound the tier again, with no signal beyond the
++                # absence of sweep logs.
++                logger.exception("fs tier GC stamping failed")
++
++            if stopping:
++                return
++            now = time.monotonic()
++            if now >= next_sweep:
++                next_sweep = now + self.interval_s
++                try:
++                    self.sweep()
++                except Exception:
++                    logger.exception("fs tier GC sweep failed")
++
++    def _stamp(self, keys: list[OffloadKey]) -> None:
++        for key in keys:
++            # A key legitimately may have no file: the block can live only in
++            # the DRAM primary tier, or its cascade may have failed.
++            try:
++                os.utime(self.file_mapper.get_file_name(key), None)
++                self._stamped += 1
++            except OSError:
++                self._stamp_errors += 1
++
++    def _iter_blocks(self, path: str) -> Iterator[tuple[str, int, float]]:
++        """Yield (path, size, mtime) for every block file under `path`."""
++        try:
++            entries = list(os.scandir(path))
++        except FileNotFoundError:
++            return
++        for entry in entries:
++            try:
++                if entry.is_dir(follow_symlinks=False):
++                    yield from self._iter_blocks(entry.path)
++                elif entry.name.endswith(_BLOCK_SUFFIX):
++                    stat = entry.stat(follow_symlinks=False)
++                    yield entry.path, stat.st_size, stat.st_mtime
++            except OSError:
++                # Raced with a store or another sweep; skip it.
++                continue
++
++    def sweep(self) -> int:
++        """Unlink LRU blocks until under the low watermark. Returns bytes freed."""
++        started = time.monotonic()
++        blocks = list(self._iter_blocks(self.block_root))
++        total = sum(size for _, size, _ in blocks)
++        if total <= self.max_bytes:
++            logger.debug(
++                "fs tier GC: %.2f GiB in %d blocks, under the %.2f GiB cap",
++                total / 2**30,
++                len(blocks),
++                self.max_bytes / 2**30,
++            )
++            return 0
++
++        with self._lock:
++            protected_paths = {
++                self.file_mapper.get_file_name(key) for key in self._protected
++            }
++        cutoff = time.time() - self.grace_s
++
++        blocks.sort(key=lambda block: block[2])
++        freed = 0
++        removed = 0
++        in_flight = 0
++        within_grace = 0
++        for path, size, mtime in blocks:
++            if total - freed <= self.target_bytes:
++                break
++            # Check protection before recency: a block with an in-flight job must
++            # survive however old its mtime is, and the two reasons are worth
++            # telling apart. in_flight > 0 means the grace window alone was not
++            # enough and protect() is doing real work; within_grace > 0 means the
++            # working set itself is at least as large as the cap.
++            if path in protected_paths:
++                in_flight += 1
++                continue
++            if mtime > cutoff:
++                within_grace += 1
++                continue
++            try:
++                os.unlink(path)
++            except OSError:
++                continue
++            freed += size
++            removed += 1
++
++        logger.info(
++            "fs tier GC: %.2f GiB over the %.2f GiB cap, freed %.2f GiB in %d "
++            "blocks, kept %d with jobs in flight and %d used within the %gs "
++            "grace window, now %.2f GiB, took %.2fs",
++            total / 2**30,
++            self.max_bytes / 2**30,
++            freed / 2**30,
++            removed,
++            in_flight,
++            within_grace,
++            self.grace_s,
++            (total - freed) / 2**30,
++            time.monotonic() - started,
++        )
++        return freed
++
++    def shutdown(self) -> None:
++        """Stop the sweep thread. Best-effort, and nothing depends on it.
++
++        The engine reaches this through scheduler -> connector -> tier only if
++        it gets that far: EngineCore.shutdown() tears the executor down first,
++        and the API server's SIGTERM path force-kills the engine core with
++        timeout=0s, so in practice this often does not run at all. That is
++        safe -- the thread is a daemon, mtimes are already committed on disk
++        and sweeps are idempotent -- but it means queued stamps can be dropped
++        (costing at most `stamp_interval_s` of recency) and the summary below
++        should not be relied on as a shutdown signal.
++        """
++        with self._lock:
++            self._stopping = True
++        self._wake.set()
++        self._thread.join(timeout=5.0)
++        logger.info(
++            "fs tier GC stopped (%d mtime stamps, %d failed)",
++            self._stamped,
++            self._stamp_errors,
++        )
+diff --git a/vllm/v1/kv_offload/tiering/fs/manager.py b/vllm/v1/kv_offload/tiering/fs/manager.py
+index f12ef2c6d4d3daddefbc6ced42309e6ff83b7fa4..7229afb640cf91eac4e9ae9b17045acf40460eb3 100644
+--- a/vllm/v1/kv_offload/tiering/fs/manager.py
++++ b/vllm/v1/kv_offload/tiering/fs/manager.py
+@@ -18,7 +18,7 @@ File naming:  <base_path>_r<rank>/<hhh>/<hh>_g<group_idx>/<hash_hex>.bin
+ import functools
+ import json
+ import os
+-from collections.abc import Iterable
++from collections.abc import Collection, Iterable
+ from typing import TYPE_CHECKING, ClassVar
+ 
+ try:
+@@ -49,6 +49,7 @@ from vllm.v1.kv_offload.tiering.base import (
+     ScheduleEndContext,
+     SecondaryTierManager,
+ )
++from vllm.v1.kv_offload.tiering.fs.gc_manager import FsGCManager
+ from vllm.v1.kv_offload.tiering.fs.io import load_block, store_block
+ from vllm.v1.kv_offload.tiering.fs.thread_pool import DualQueueThreadPool
+ 
+@@ -112,6 +113,12 @@ class FileSystemTierManager(SecondaryTierManager):
+         n_write_threads: int = 16,
+         enable_kv_events: bool = False,
+         locality: str | None = None,
++        gc_max_size_gb: float | None = None,
++        gc_low_watermark: float = 0.9,
++        gc_interval_s: float = 60.0,
++        gc_stamp_interval_s: float = 60.0,
++        gc_grace_s: float = 300.0,
++        gc_max_tracked: int = 200_000,
+     ):
+         """
+         Args:
+@@ -127,6 +134,28 @@ class FileSystemTierManager(SecondaryTierManager):
+                 cache events are enabled globally (kv_events_config).
+             locality: Whether this tier's storage is LOCAL or REMOTE relative
+                 to the publishing vLLM instance.
++            gc_max_size_gb: On-disk budget for this tier, in GiB. None (the
++                default) leaves the tier unbounded, as before. When set, a
++                background sweep evicts least-recently-used blocks to stay under
++                it; see FsGCManager. The budget is per engine rather than per
++                rank: the tier is constructed once on the scheduler side
++                (get_manager), so TP and PP ranks share a single
++                <base_path>_r<rank> subtree and a single budget. Engines sharing
++                a root_dir enforce the budget independently over the same
++                subtree and so evict each other's blocks, and blocks written
++                under a different layout fingerprint (a different <base_path>)
++                are never swept at all. Note that sweeps emit no removed=True KV
++                events (see FsGCManager for why), so with enable_kv_events an
++                external consumer must treat BlockStored as best-effort.
++            gc_low_watermark: Fraction of gc_max_size_gb a sweep evicts down to,
++                so eviction is batched rather than continuous.
++            gc_interval_s: Seconds between sweeps.
++            gc_stamp_interval_s: Minimum seconds between mtime stamps of the
++                same block. Must be less than gc_grace_s.
++            gc_grace_s: Blocks used within this many seconds are never swept,
++                which keeps a sweep from racing a promotion that is about to
++                read the file.
++            gc_max_tracked: Cap on keys tracked for the stamp rate limit.
+         """
+         super().__init__(offloading_spec, primary_kv_view, tier_type)
+         self.locality = Locality(locality) if locality is not None else None
+@@ -176,6 +205,23 @@ class FileSystemTierManager(SecondaryTierManager):
+ 
+         self._lookup_manager = FsAsyncLookupManager(tier=self, tier_type=self.tier_type)
+ 
++        # Keys of in-flight load jobs, so a failed load can invalidate the
++        # cached existence results that sent it here.
++        self._load_job_keys: dict[JobId, list[OffloadKey]] = {}
++
++        self._gc_manager: FsGCManager | None = None
++        self._gc_job_keys: dict[JobId, list[OffloadKey]] = {}
++        if gc_max_size_gb is not None:
++            self._gc_manager = FsGCManager(
++                self.file_mapper,
++                max_bytes=int(gc_max_size_gb * 2**30),
++                low_watermark=gc_low_watermark,
++                interval_s=gc_interval_s,
++                stamp_interval_s=gc_stamp_interval_s,
++                grace_s=gc_grace_s,
++                max_tracked=gc_max_tracked,
++            )
++
+     @override
+     def on_new_request(self, req_context: ReqContext) -> RequestOffloadingContext:
+         return RequestOffloadingContext()
+@@ -191,6 +237,7 @@ class FileSystemTierManager(SecondaryTierManager):
+     def submit_store(self, job_metadata: JobMetadata) -> None:
+         if self.events is not None:
+             self._store_job_keys[job_metadata.job_id] = list(job_metadata.keys)
++        self._gc_protect(job_metadata)
+         tasks = (
+             functools.partial(
+                 store_block,
+@@ -205,6 +252,8 @@ class FileSystemTierManager(SecondaryTierManager):
+ 
+     @override
+     def submit_load(self, job_metadata: JobMetadata) -> None:
++        self._gc_protect(job_metadata)
++        self._load_job_keys[job_metadata.job_id] = list(job_metadata.keys)
+         tasks = (
+             functools.partial(
+                 load_block,
+@@ -224,6 +273,18 @@ class FileSystemTierManager(SecondaryTierManager):
+         """
+         results = []
+         for job_id, success in self._pool.get_finished():
++            if self._gc_manager is not None:
++                keys = self._gc_job_keys.pop(job_id, None)
++                if keys is not None:
++                    self._gc_manager.release(keys)
++            load_keys = self._load_job_keys.pop(job_id, None)
++            if load_keys is not None and not success:
++                # The blocks this load needed are gone or unreadable, and
++                # load_block has unlinked whatever it could not read. Drop the
++                # cached existence results so the next lookup reports a miss and
++                # the tokens are recomputed; leaving them cached as present
++                # would re-submit this same failing load on every step.
++                self._lookup_manager.invalidate(load_keys)
+             if self.events is not None:
+                 keys = self._store_job_keys.pop(job_id, None)
+                 if success and keys:
+@@ -256,6 +317,26 @@ class FileSystemTierManager(SecondaryTierManager):
+     def on_schedule_end(self, context: ScheduleEndContext) -> None:
+         self._lookup_manager.flush()
+ 
++    @override
++    def touch(self, keys: Collection[OffloadKey], req_context: ReqContext) -> None:
++        """Refresh on-disk recency so GC evicts least-recently-used blocks.
++
++        Called by TieringOffloadingManager for every tier whenever the scheduler
++        matches a request's blocks -- including blocks served from the DRAM
++        primary tier, which never read this tier's files and would otherwise age
++        out while still hot. No-op unless a GC budget is configured.
++        """
++        if self._gc_manager is not None:
++            self._gc_manager.touch(keys)
++
++    def _gc_protect(self, job_metadata: JobMetadata) -> None:
++        """Pin a job's keys for as long as its transfers are in flight."""
++        if self._gc_manager is None:
++            return
++        keys = list(job_metadata.keys)
++        self._gc_job_keys[job_metadata.job_id] = keys
++        self._gc_manager.protect(keys)
++
+     @override
+     def shutdown(self) -> None:
+         """
+@@ -264,5 +345,7 @@ class FileSystemTierManager(SecondaryTierManager):
+         Shuts down the lookup manager and the thread pool,
+         clearing pending tasks and waiting for active threads to complete.
+         """
++        if self._gc_manager is not None:
++            self._gc_manager.shutdown()
+         self._lookup_manager.shutdown()
+         self._pool.shutdown(wait=True)
+diff --git a/vllm/v1/kv_offload/tiering/obj/manager.py b/vllm/v1/kv_offload/tiering/obj/manager.py
+index f4af8c44c53146918a3677854c96d6e1b3cc4830..c8fb9b7a147be5e7131dca3f7f665a6c2c58eced 100644
+--- a/vllm/v1/kv_offload/tiering/obj/manager.py
++++ b/vllm/v1/kv_offload/tiering/obj/manager.py
+@@ -141,6 +141,9 @@ class ObjectStoreSecondaryTierManager(SecondaryTierManager):
+                 )
+         # Keys of in-flight store jobs, tracked only when events are enabled.
+         self._store_job_keys: dict[JobId, list[OffloadKey]] = {}
++        # Keys of in-flight load jobs, so a failed load can invalidate the
++        # cached existence results that sent it here.
++        self._load_job_keys: dict[JobId, list[OffloadKey]] = {}
+ 
+         agent_config = nixl_agent_config(backends=[])
+         self._agent = nixl_agent("ObjAgent", agent_config)
+@@ -281,6 +284,11 @@ class ObjectStoreSecondaryTierManager(SecondaryTierManager):
+         )
+ 
+     def submit_load(self, job_metadata: JobMetadata) -> None:
++        # Recorded before _submit_transfer so its submission-time failure
++        # paths (register_memory, prep_xfer_dlist, make_prepped_xfer,
++        # transfer) also invalidate the cached lookups that routed this
++        # load here, not just transfers that fail in flight.
++        self._load_job_keys[job_metadata.job_id] = list(job_metadata.keys)
+         obj_keys = (self._file_mapper.get_file_name(k) for k in job_metadata.keys)
+         self._submit_transfer(
+             job_metadata.job_id, job_metadata.block_ids, obj_keys, NIXL_READ
+@@ -323,8 +331,20 @@ class ObjectStoreSecondaryTierManager(SecondaryTierManager):
+         self._poll_active_transfers()
+         results = self._pending_results
+         self._pending_results = []
+-        if self.events is not None:
+-            for result in results:
++        for result in results:
++            load_keys = self._load_job_keys.pop(result.job_id, None)
++            if load_keys is not None and not result.success:
++                # The store no longer answers for these keys (vanished object
++                # or persistently failing read). Drop the cached existence
++                # results so the next lookup reports a miss and the tokens are
++                # recomputed; leaving them cached as present would re-submit
++                # this same failing load on every step. Unlike the fs tier's
++                # load_block, a failed read does not remove the object, so
++                # this can be pessimistic -- but only until the requests that
++                # looked the keys up finish, after which a fresh existence
++                # probe can hit again.
++                self._lookup_manager.invalidate(load_keys)
++            if self.events is not None:
+                 keys = self._store_job_keys.pop(result.job_id, None)
+                 if result.success and keys:
+                     self.events.append(
+diff --git a/vllm/v1/kv_offload/tiering/spec.py b/vllm/v1/kv_offload/tiering/spec.py
+index 964699968c9b7630fd8375e15dbb7bd4dc1e2253..6190b0486af17c9783aae5bc80303727b237e942 100644
+--- a/vllm/v1/kv_offload/tiering/spec.py
++++ b/vllm/v1/kv_offload/tiering/spec.py
+@@ -179,6 +179,10 @@ class TieringOffloadingSpec(CPUOffloadingSpec):
+                 rank=None,
+                 kv_bytes_per_block=self.kv_bytes_per_chunk,
+                 cpu_page_size=self.cpu_page_size_per_worker,
++                # Workers already prefault every row. Repeating that work over
++                # the full region can fail for very large L1 tiers and provides
++                # no benefit to the scheduler's zero-copy secondary-tier view.
++                prefault=False,
+             )
+             self._scheduler_mmap = scheduler_mmap
+ 
+diff --git a/vllm/v1/worker/gpu/cudagraph_utils.py b/vllm/v1/worker/gpu/cudagraph_utils.py
+index 53042f71fda561d6570f37bf4a55e1e3dc66f8fa..1f4cc19e3b4fbf70c26a88f6a9ff5aed7f1d6bfa 100644
+--- a/vllm/v1/worker/gpu/cudagraph_utils.py
++++ b/vllm/v1/worker/gpu/cudagraph_utils.py
+@@ -123,7 +123,6 @@ class CudaGraphManager:
+         decode_query_len: int,
+         lora_capture_cases: list[int] | None = None,
+         varlen_spec_decode: bool = False,
+-        channel_id: str = "graph:vllm-model",
+     ):
+         self.vllm_config = vllm_config
+         self.device = device
+@@ -133,7 +132,6 @@ class CudaGraphManager:
+         self.cudagraph_mode = cudagraph_mode
+         self.decode_query_len = decode_query_len
+         self.varlen_spec_decode = varlen_spec_decode
+-        self.channel_id = channel_id
+ 
+         self.dp_size = vllm_config.parallel_config.data_parallel_size
+         self.tp_size = vllm_config.parallel_config.tensor_parallel_size
+@@ -448,6 +446,8 @@ class CudaGraphManager:
+     def capture(
+         self,
+         create_forward_fn: CreateForwardFn,
++        *,
++        channel_id: str,
+         progress_bar_desc: str = "Capturing CUDA graphs",
+     ) -> None:
+         """Capture CUDA graphs.
+@@ -458,13 +458,14 @@ class CudaGraphManager:
+                 it is invoked once with warmup=True and again with warmup=False
+                 because attention backends may mutate or lazily initialize
+                 metadata during warmup.
++            channel_id: Stable distributed identity for this graph owner.
+         """
+         # Keep event handles created by descriptor warmups alive together with
+         # the graph artifacts captured below. Some multi-stream custom ops run
+         # on joined auxiliary streams where CUDA's per-current-stream capture
+         # query is false even though later graph nodes retain those handles.
+         with (
+-            graph_capture(device=self.device, channel_id=self.channel_id),
++            graph_capture(device=self.device, channel_id=channel_id),
+             vllm_cudagraph_capture_scope(),
+         ):
+             # Capture in order: PIECEWISE first, then FULL. PIECEWISE has larger
+@@ -643,6 +644,8 @@ class ModelCudaGraphManager(CudaGraphManager):
+         has_lora: bool = False,
+         use_aux_hidden_state_outputs: bool = False,
+         lora_capture_hook: Callable[[int, int, int], None] | None = None,
++        *,
++        channel_id: str,
+         progress_bar_desc: str = "Capturing CUDA graphs",
+     ) -> None:
+         """Capture CUDA graphs for model forward pass."""
+@@ -757,7 +760,11 @@ class ModelCudaGraphManager(CudaGraphManager):
+ 
+             return forward_fn
+ 
+-        super().capture(create_forward_fn, progress_bar_desc)
++        super().capture(
++            create_forward_fn,
++            channel_id=channel_id,
++            progress_bar_desc=progress_bar_desc,
++        )
+ 
+     def clear(self) -> None:
+         super().clear()
+diff --git a/vllm/v1/worker/gpu/model_runner.py b/vllm/v1/worker/gpu/model_runner.py
+index 423df0dd2cee33796508f30ca89cd6cd995f6c4b..ea5340100e69745a88e4720edf299d691aac9d17 100644
+--- a/vllm/v1/worker/gpu/model_runner.py
++++ b/vllm/v1/worker/gpu/model_runner.py
+@@ -967,11 +967,12 @@ class GPUModelRunner(LoRAModelRunnerMixin):
+                     has_lora=self.lora_config is not None,
+                     use_aux_hidden_state_outputs=self.use_aux_hidden_state_outputs,
+                     lora_capture_hook=create_lora_capture_hook(self.lora_config, self),
++                    channel_id="vllm:target:profile",
+                     progress_bar_desc="Profiling CUDA graph memory",
+                 )
+                 if self.speculator is not None:
+                     with use_workspace_lane(1):
+-                        self.speculator.capture()
++                        self.speculator.capture(capture_phase="profile")
+                 self._zero_cudagraph_capture_kv_blocks()
+             end_free_gpu_memory = torch.accelerator.get_memory_info()[0]
+             gross_cuda_graph_size = max(start_free_gpu_memory - end_free_gpu_memory, 0)
+@@ -1050,10 +1051,11 @@ class GPUModelRunner(LoRAModelRunnerMixin):
+                     has_lora=self.lora_config is not None,
+                     use_aux_hidden_state_outputs=self.use_aux_hidden_state_outputs,
+                     lora_capture_hook=create_lora_capture_hook(self.lora_config, self),
++                    channel_id="vllm:target:production",
+                 )
+                 if self.speculator is not None:
+                     with use_workspace_lane(1):
+-                        self.speculator.capture()
++                        self.speculator.capture(capture_phase="production")
+                 self._zero_cudagraph_capture_kv_blocks()
+         finally:
+             self._release_cudagraph_pool_anchor()
+diff --git a/vllm/v1/worker/gpu/spec_decode/autoregressive/cudagraph_utils.py b/vllm/v1/worker/gpu/spec_decode/autoregressive/cudagraph_utils.py
+index 19919043c831574b73c8617615a352e885c648f8..c625d91aee8496d3f518361fff2d234ecdf8329a 100644
+--- a/vllm/v1/worker/gpu/spec_decode/autoregressive/cudagraph_utils.py
++++ b/vllm/v1/worker/gpu/spec_decode/autoregressive/cudagraph_utils.py
+@@ -35,6 +35,8 @@ class SpeculatorCudaGraphManager(CudaGraphManager):
+         block_tables: BlockTables,
+         attn_groups: list[list[AttentionGroup]],
+         kv_cache_config: KVCacheConfig,
++        *,
++        channel_id: str,
+         progress_bar_desc: str = "Capturing CUDA graphs",
+     ) -> None:
+         def create_forward_fn(
+@@ -71,4 +73,8 @@ class SpeculatorCudaGraphManager(CudaGraphManager):
+                 cg_mode,
+             )
+ 
+-        super().capture(create_forward_fn, progress_bar_desc)
++        super().capture(
++            create_forward_fn,
++            channel_id=channel_id,
++            progress_bar_desc=progress_bar_desc,
++        )
+diff --git a/vllm/v1/worker/gpu/spec_decode/autoregressive/speculator.py b/vllm/v1/worker/gpu/spec_decode/autoregressive/speculator.py
+index ea21ff9756b3ae6392558a3d7308575acb697419..d9ab74a28fb9bd1d0f288829f35a5446c5185255 100644
+--- a/vllm/v1/worker/gpu/spec_decode/autoregressive/speculator.py
++++ b/vllm/v1/worker/gpu/spec_decode/autoregressive/speculator.py
+@@ -21,7 +21,10 @@ from vllm.v1.worker.gpu.input_batch import InputBatch, InputBuffers
+ from vllm.v1.worker.gpu.spec_decode.autoregressive.cudagraph_utils import (
+     SpeculatorCudaGraphManager,
+ )
+-from vllm.v1.worker.gpu.spec_decode.speculator import DraftModelSpeculator
++from vllm.v1.worker.gpu.spec_decode.speculator import (
++    CUDAGraphCapturePhase,
++    DraftModelSpeculator,
++)
+ 
+ logger = init_logger(__name__)
+ 
+@@ -71,7 +74,6 @@ class AutoRegressiveSpeculator(DraftModelSpeculator):
+             self.device,
+             cudagraph_mode,
+             self.num_speculative_steps + 1,
+-            channel_id="graph:vllm-speculator-prefill",
+         )
+ 
+         # PIECEWISE cudagraphs are not supported for draft decodes.
+@@ -86,10 +88,9 @@ class AutoRegressiveSpeculator(DraftModelSpeculator):
+             self.device,
+             cudagraph_mode,
+             decode_query_len=1,
+-            channel_id="graph:vllm-speculator-decode",
+         )
+ 
+-    def capture(self) -> None:
++    def capture(self, *, capture_phase: CUDAGraphCapturePhase) -> None:
+         logger.info("Capturing model for speculator...")
+         # Reset indices to zeros to prevent stale values from prior
+         # dummy runs to cause out-of-bounds indexing during capture.
+@@ -113,6 +114,7 @@ class AutoRegressiveSpeculator(DraftModelSpeculator):
+             self.block_tables,
+             self.target_attn_groups,
+             self.kv_cache_config,
++            channel_id=f"vllm:draft:prefill:{capture_phase}",
+             progress_bar_desc="Capturing prefill CUDA graphs",
+         )
+ 
+@@ -130,6 +132,7 @@ class AutoRegressiveSpeculator(DraftModelSpeculator):
+             self.block_tables,
+             self.attn_groups,
+             self.kv_cache_config,
++            channel_id=f"vllm:draft:decode:{capture_phase}",
+             progress_bar_desc="Capturing decode CUDA graphs",
+         )
+ 
+diff --git a/vllm/v1/worker/gpu/spec_decode/dflash/cudagraph.py b/vllm/v1/worker/gpu/spec_decode/dflash/cudagraph.py
+index 5b36fee76eb227cd735648b9e31ac97ff1aabbec..21165755a8343e03ab1cf088c5e662b4255d9210 100644
+--- a/vllm/v1/worker/gpu/spec_decode/dflash/cudagraph.py
++++ b/vllm/v1/worker/gpu/spec_decode/dflash/cudagraph.py
+@@ -4,6 +4,7 @@ from collections.abc import Callable, Mapping
+ 
+ import torch
+ 
++from vllm.config import VllmConfig
+ from vllm.config.compilation import CUDAGraphMode
+ from vllm.v1.kv_cache_interface import KVCacheConfig
+ from vllm.v1.worker.gpu.attn_utils import (
+@@ -72,6 +73,8 @@ class DFlashCudaGraphManager(CudaGraphManager):
+         kv_cache_config: KVCacheConfig,
+         max_model_len: int,
+         causal: bool | Mapping[int, bool],
++        *,
++        channel_id: str,
+         progress_bar_desc: str = "Capturing CUDA graphs",
+     ) -> None:
+         def create_forward_fn(
+@@ -108,4 +111,106 @@ class DFlashCudaGraphManager(CudaGraphManager):
+                 num_query_per_req=desc.uniform_token_count,
+             )
+ 
+-        super().capture(create_forward_fn, progress_bar_desc)
++        super().capture(
++            create_forward_fn,
++            channel_id=channel_id,
++            progress_bar_desc=progress_bar_desc,
++        )
++
++
++class DFlashContextCudaGraphManager(CudaGraphManager):
++    """CUDA graphs for the variable-size DFlash context-KV projection.
++
++    The draft-query graph is keyed by request count, while the context rows
++    depend on how many target tokens survived verification. Keeping a second
++    manager avoids padding every request to the full speculative width. Each
++    real row count is mapped to the smallest configured capture bucket.
++    """
++
++    def _init_candidates(self) -> None:
++        capture_sizes = self.compilation_config.cudagraph_capture_sizes
++        if not (self.cudagraph_mode and capture_sizes):
++            return
++
++        max_capture_size = self.compilation_config.max_cudagraph_capture_size
++        capture_sizes = sorted(
++            {
++                size
++                for size in capture_sizes
++                if 0 < size <= self.max_num_context_tokens and size <= max_capture_size
++            }
++        )
++        if not capture_sizes:
++            return
++
++        descs = [
++            BatchExecutionDescriptor(
++                cg_mode=CUDAGraphMode.FULL,
++                num_tokens=size,
++                num_reqs=None,
++            )
++            for size in reversed(capture_sizes)
++        ]
++        self._capture_descs[CUDAGraphMode.FULL] = descs
++
++        self._context_candidates = {}
++        previous = 0
++        for size in capture_sizes:
++            desc = BatchExecutionDescriptor(
++                cg_mode=CUDAGraphMode.FULL,
++                num_tokens=size,
++                num_reqs=None,
++            )
++            for num_tokens in range(previous + 1, size + 1):
++                self._context_candidates[num_tokens] = desc
++            previous = size
++
++    def __init__(
++        self,
++        vllm_config: VllmConfig,
++        device: torch.device,
++        max_num_context_tokens: int,
++    ) -> None:
++        self.max_num_context_tokens = max_num_context_tokens
++        self._context_candidates: dict[int, BatchExecutionDescriptor] = {}
++        super().__init__(
++            vllm_config,
++            device,
++            CUDAGraphMode.FULL_DECODE_ONLY,
++            decode_query_len=1,
++        )
++
++    def dispatch_context(self, num_tokens: int) -> BatchExecutionDescriptor:
++        if self._graphs_captured:
++            desc = self._context_candidates.get(num_tokens)
++            if desc is not None:
++                return desc
++        return BatchExecutionDescriptor(
++            cg_mode=CUDAGraphMode.NONE,
++            num_tokens=num_tokens,
++            num_reqs=None,
++        )
++
++    def capture_context(
++        self,
++        forward_fn: Callable[[int], None],
++        *,
++        channel_id: str,
++    ) -> None:
++        def create_forward_fn(
++            desc: BatchExecutionDescriptor,
++            warmup: bool,
++        ) -> Callable[[CUDAGraphMode], None]:
++            del warmup
++
++            def run_context(cg_mode: CUDAGraphMode) -> None:
++                del cg_mode
++                forward_fn(desc.num_tokens)
++
++            return run_context
++
++        super().capture(
++            create_forward_fn,
++            channel_id=channel_id,
++            progress_bar_desc="Capturing DFlash context-KV CUDA graphs",
++        )
+diff --git a/vllm/v1/worker/gpu/spec_decode/dflash/speculator.py b/vllm/v1/worker/gpu/spec_decode/dflash/speculator.py
+index a3cefda68bfb53aa4677d028b1ae6329bdab44b0..b997f045b9d28b115f9bc88574458d8448615592 100644
+--- a/vllm/v1/worker/gpu/spec_decode/dflash/speculator.py
++++ b/vllm/v1/worker/gpu/spec_decode/dflash/speculator.py
+@@ -27,15 +27,25 @@ from vllm.v1.attention.backends.utils import PAD_SLOT_ID
+ from vllm.v1.kv_cache_interface import KVCacheConfig
+ from vllm.v1.worker.gpu.attn_utils import build_slot_mappings_by_layer
+ from vllm.v1.worker.gpu.block_table import BlockTables
++from vllm.v1.worker.gpu.cudagraph_utils import (
++    BatchExecutionDescriptor,
++    CudaGraphManager,
++)
+ from vllm.v1.worker.gpu.dp_utils import dispatch_cg_and_sync_dp
+ from vllm.v1.worker.gpu.input_batch import InputBatch, InputBuffers
+ from vllm.v1.worker.gpu.model_states.interface import ModelState
+-from vllm.v1.worker.gpu.spec_decode.dflash.cudagraph import DFlashCudaGraphManager
++from vllm.v1.worker.gpu.spec_decode.dflash.cudagraph import (
++    DFlashContextCudaGraphManager,
++    DFlashCudaGraphManager,
++)
+ from vllm.v1.worker.gpu.spec_decode.dflash.utils import (
+     load_dflash_model,
+     maybe_load_mask_embedding,
+ )
+-from vllm.v1.worker.gpu.spec_decode.speculator import DraftModelSpeculator
++from vllm.v1.worker.gpu.spec_decode.speculator import (
++    CUDAGraphCapturePhase,
++    DraftModelSpeculator,
++)
+ from vllm.v1.worker.gpu.spec_decode.utils import get_parallel_drafting_token_id
+ from vllm.v1.worker.utils import AttentionGroup
+ 
+@@ -128,6 +138,7 @@ class DFlashSpeculator(DraftModelSpeculator):
+         ).repeat(self.max_num_reqs)
+ 
+         self.query_cudagraph_manager: DFlashCudaGraphManager | None = None
++        self.context_cudagraph_manager: DFlashContextCudaGraphManager | None = None
+         self.draft_kv_cache_group_id: int = -1
+         # Manual CUDA graphs keep raw addresses for model intermediates. Retain
+         # each captured backbone output so its storage cannot be recycled while
+@@ -182,10 +193,15 @@ class DFlashSpeculator(DraftModelSpeculator):
+             self.device,
+             cudagraph_mode,
+             decode_query_len=self.num_query_per_req,
+-            channel_id="graph:vllm-dflash-query",
+         )
++        if wants_full and supports_full and self._speculator_name == "DSpark":
++            self.context_cudagraph_manager = DFlashContextCudaGraphManager(
++                self.vllm_config,
++                self.device,
++                max_num_context_tokens=self.max_num_tokens,
++            )
+ 
+-    def capture(self) -> None:
++    def capture(self, *, capture_phase: CUDAGraphCapturePhase) -> None:
+         logger.info("Capturing model for %s speculator...", self._speculator_name)
+         # Reset sampling indices to prevent stale values from prior dummy runs
+         # from being baked into the captured graph. Mapping rows stay inert.
+@@ -201,13 +217,24 @@ class DFlashSpeculator(DraftModelSpeculator):
+             self.kv_cache_config,
+             self.max_model_len,
+             causal=self._group_causal,
++            channel_id=f"vllm:draft:dflash:{capture_phase}",
+             progress_bar_desc=f"Capturing {self._speculator_name.lower()} CUDA graphs",
+         )
++        if self.context_cudagraph_manager is not None:
++            self._context_slot_mappings.fill_(PAD_SLOT_ID)
++            self.context_positions.zero_()
++            self.context_cudagraph_manager.capture_context(
++                self._capture_context_kv,
++                channel_id=f"vllm:draft:dflash:context:{capture_phase}",
++            )
+ 
+-    def get_cudagraph_managers(self) -> tuple[DFlashCudaGraphManager, ...]:
+-        if self.query_cudagraph_manager is None:
+-            return ()
+-        return (self.query_cudagraph_manager,)
++    def get_cudagraph_managers(self) -> tuple[CudaGraphManager, ...]:
++        managers: list[CudaGraphManager] = []
++        if self.query_cudagraph_manager is not None:
++            managers.append(self.query_cudagraph_manager)
++        if self.context_cudagraph_manager is not None:
++            managers.append(self.context_cudagraph_manager)
++        return tuple(managers)
+ 
+     def clear_cudagraphs(self) -> None:
+         super().clear_cudagraphs()
+@@ -372,9 +399,9 @@ class DFlashSpeculator(DraftModelSpeculator):
+         )
+ 
+         # Per-group context slot buffers for the precompute (one row per group).
+-        self._context_slot_mappings = torch.zeros(
+-            len(self.draft_kv_cache_group_ids),
+-            self.max_num_tokens,
++        self._context_slot_mappings = torch.full(
++            (len(self.draft_kv_cache_group_ids), self.max_num_tokens),
++            PAD_SLOT_ID,
+             dtype=torch.int64,
+             device=self.device,
+         )
+@@ -430,6 +457,40 @@ class DFlashSpeculator(DraftModelSpeculator):
+             )
+         return last_hidden_states
+ 
++    def _context_slots_for_layers(
++        self,
++        num_tokens: int,
++    ) -> torch.Tensor | list[torch.Tensor]:
++        if self._layer_group_idx is not None:
++            return [
++                self._context_slot_mappings[gidx][:num_tokens]
++                for gidx in self._layer_group_idx
++            ]
++        return self._context_slot_mappings[0][:num_tokens]
++
++    def _capture_context_kv(self, num_tokens: int) -> None:
++        self.model.precompute_and_store_context_kv(
++            self.hidden_states[:num_tokens],
++            self.context_positions[:num_tokens],
++            self._context_slots_for_layers(num_tokens),
++        )
++
++    def _precompute_context_kv(
++        self,
++        num_target_tokens: int,
++        batch_desc: BatchExecutionDescriptor,
++        context_slots: torch.Tensor | list[torch.Tensor | None] | None,
++    ) -> None:
++        if batch_desc.cg_mode == CUDAGraphMode.FULL:
++            assert self.context_cudagraph_manager is not None
++            self.context_cudagraph_manager.run_fullgraph(batch_desc)
++            return
++        self.model.precompute_and_store_context_kv(
++            self.hidden_states[:num_target_tokens],
++            self.context_positions[:num_target_tokens],
++            context_slots,
++        )
++
+     def _generate_draft(
+         self,
+         num_reqs: int,
+@@ -594,6 +655,17 @@ class DFlashSpeculator(DraftModelSpeculator):
+         # The query slot mapping is written into the shared BlockTables slot_mappings.
+         # That buffer's address is what the captured CUDA graph reads from at replay.
+         assert self.draft_kv_cache_group_id >= 0
++        if self.context_cudagraph_manager is not None and not (dummy_run or is_profile):
++            context_batch_desc = self.context_cudagraph_manager.dispatch_context(
++                num_target_tokens
++            )
++        else:
++            context_batch_desc = BatchExecutionDescriptor(
++                cg_mode=CUDAGraphMode.NONE,
++                num_tokens=num_target_tokens,
++                num_reqs=None,
++            )
++        context_num_tokens_padded = context_batch_desc.num_tokens
+         # Support multiple draft KV cache groups by preparing inputs once for each
+         for i, gid in enumerate(self.draft_kv_cache_group_ids):
+             prepare_dflash_inputs(
+@@ -619,6 +691,7 @@ class DFlashSpeculator(DraftModelSpeculator):
+                 self.max_num_tokens,
+                 self.max_model_len,
+                 self.sample_from_anchor,
++                context_num_tokens_padded=context_num_tokens_padded,
+             )
+ 
+         # Cache-restored tokens (e.g. prefix-cache hits) never flowed through
+@@ -642,9 +715,8 @@ class DFlashSpeculator(DraftModelSpeculator):
+                     self.block_tables.kernel_block_sizes[gid],
+                 )
+ 
+-        # Pre-insert context K/V into the cache. Runs eagerly outside the captured graph
+-        # because the context shape varies per step. During dummy runs the block tables
+-        # are placeholders, so we skip the cache write to avoid clobbering real entries.
++        # Pre-insert context K/V into the cache. Decode replays a row-bucketed
++        # FULL graph; profiling, dummy, and out-of-envelope shapes remain eager.
+         # Each layer uses the context slots of its own kv-cache group.
+         if dummy_run:
+             context_slots: torch.Tensor | list[torch.Tensor | None] | None = None
+@@ -655,9 +727,9 @@ class DFlashSpeculator(DraftModelSpeculator):
+             ]
+         else:
+             context_slots = self._context_slot_mappings[0][:num_target_tokens]
+-        self.model.precompute_and_store_context_kv(
+-            self.hidden_states[:num_target_tokens],
+-            self.context_positions[:num_target_tokens],
++        self._precompute_context_kv(
++            num_target_tokens,
++            context_batch_desc,
+             context_slots,
+         )
+ 
+@@ -746,6 +818,7 @@ def _prepare_dflash_inputs_kernel(
+     max_num_reqs,
+     max_num_tokens,
+     max_model_len,
++    context_num_tokens_padded,
+     SAMPLE_FROM_ANCHOR: tl.constexpr,
+     PAD_SLOT_ID: tl.constexpr,
+     BLOCK_SIZE: tl.constexpr,
+@@ -897,6 +970,13 @@ def _prepare_dflash_inputs_kernel(
+                 tl.store(out_input_ids_ptr + block, 0, mask=mask)
+                 tl.store(out_query_positions_ptr + block, 0, mask=mask)
+                 tl.store(out_query_slot_mapping_ptr + block, PAD_SLOT_ID, mask=mask)
++            # Context-KV graphs round the actual target rows up to a capture
++            # bucket. Keep padded rows in-range and suppress their cache writes.
++            for i in range(ctx_end, context_num_tokens_padded, BLOCK_SIZE):
++                block = i + tl.arange(0, BLOCK_SIZE)
++                mask = block < context_num_tokens_padded
++                tl.store(out_context_positions_ptr + block, 0, mask=mask)
++                tl.store(out_context_slot_mapping_ptr + block, PAD_SLOT_ID, mask=mask)
+ 
+ 
+ def prepare_dflash_inputs(
+@@ -928,6 +1008,7 @@ def prepare_dflash_inputs(
+     max_num_tokens: int,
+     max_model_len: int,
+     sample_from_anchor: bool = False,
++    context_num_tokens_padded: int | None = None,
+ ) -> None:
+     num_reqs = input_batch.num_reqs
+     assert num_reqs > 0
+@@ -937,6 +1018,15 @@ def prepare_dflash_inputs(
+     max_tokens_per_req = max_target_query_len + num_query_per_req
+     BLOCK_SIZE = min(256, triton.next_power_of_2(max(1, max_tokens_per_req)))
+     num_blocks = triton.cdiv(max_tokens_per_req, BLOCK_SIZE)
++    num_context_tokens = int(input_batch.num_scheduled_tokens.sum())
++    if context_num_tokens_padded is None:
++        context_num_tokens_padded = num_context_tokens
++    if not num_context_tokens <= context_num_tokens_padded <= max_num_tokens:
++        raise ValueError(
++            "DFlash context graph padding must cover the actual context rows "
++            f"without exceeding the input buffer: actual={num_context_tokens}, "
++            f"padded={context_num_tokens_padded}, max={max_num_tokens}."
++        )
+     _prepare_dflash_inputs_kernel[(num_reqs, num_blocks)](
+         input_buffers.input_ids,
+         input_buffers.positions,
+@@ -965,6 +1055,7 @@ def prepare_dflash_inputs(
+         max_num_reqs,
+         max_num_tokens,
+         max_model_len,
++        context_num_tokens_padded,
+         SAMPLE_FROM_ANCHOR=sample_from_anchor,
+         PAD_SLOT_ID=PAD_SLOT_ID,
+         BLOCK_SIZE=BLOCK_SIZE,
+diff --git a/vllm/v1/worker/gpu/spec_decode/speculator.py b/vllm/v1/worker/gpu/spec_decode/speculator.py
+index 0784f580ac0106849ec5f56aa6750d3784979695..a59cd1270bdd030f2beed072d5f1f4b726d6d916 100644
+--- a/vllm/v1/worker/gpu/spec_decode/speculator.py
++++ b/vllm/v1/worker/gpu/spec_decode/speculator.py
+@@ -2,7 +2,7 @@
+ # SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+ from abc import ABC, abstractmethod
+ from collections.abc import Mapping
+-from typing import TYPE_CHECKING, Any
++from typing import TYPE_CHECKING, Any, Literal
+ 
+ import torch
+ import torch.nn as nn
+@@ -32,6 +32,8 @@ if TYPE_CHECKING:
+ 
+ logger = init_logger(__name__)
+ 
++CUDAGraphCapturePhase = Literal["profile", "production"]
++
+ 
+ class BaseSpeculator(ABC):
+     # Draft-token capacity surface, implemented by speculators with a
+@@ -51,7 +53,7 @@ class BaseSpeculator(ABC):
+         pass
+ 
+     @abstractmethod
+-    def capture(self) -> None:
++    def capture(self, *, capture_phase: CUDAGraphCapturePhase) -> None:
+         pass
+ 
+     def get_cudagraph_managers(self) -> tuple["CudaGraphManager", ...]:
+diff --git a/vllm/v1/worker/gpu_model_runner.py b/vllm/v1/worker/gpu_model_runner.py
+index f6053f52bb01f21fc9dd131c183d758d504128ee..7d1216710fd4a4e7e6ac5c13b17934d04aa273ab 100644
+--- a/vllm/v1/worker/gpu_model_runner.py
++++ b/vllm/v1/worker/gpu_model_runner.py
+@@ -44,12 +44,14 @@ from vllm.distributed.kv_transfer import get_kv_transfer_group, has_kv_transfer_
+ from vllm.distributed.kv_transfer.kv_connector.utils import copy_kv_blocks
+ from vllm.distributed.parallel_state import (
+     GraphCaptureContext,
++    checkpoint_b12x_graph_channels,
+     get_dcp_group,
+     get_pp_group,
+     get_tp_group,
+     graph_capture,
+     is_global_first_rank,
+     prepare_communication_buffer_for_model,
++    rollback_b12x_graph_channels,
+ )
+ from vllm.forward_context import (
+     BatchDescriptor,
+@@ -4643,11 +4645,7 @@ class GPUModelRunner(
+             )
+             # Whether the drafter runs a GPU model forward (and thus carries
+             # TP/EP/DP collectives), independent of padded-batch timing.
+-            drafter_runs_model_forward = (
+-                spec_config.use_eagle()
+-                or spec_config.uses_draft_model()
+-                or spec_config.uses_extract_hidden_states()
+-            )
++            drafter_runs_model_forward = self._drafter_runs_model_forward()
+             use_gpu_toks = (
+                 drafter_runs_model_forward
+                 and not spec_config.disable_padded_drafter_batch
+@@ -5845,6 +5843,7 @@ class GPUModelRunner(
+         profile_seq_lens: int | None = None,
+         include_mm_inputs: bool = True,
+         single_request_prefill: bool = False,
++        run_drafter: bool = True,
+     ) -> tuple[torch.Tensor, torch.Tensor]:
+         """
+         Run a dummy forward pass to warm up/profile run or capture the
+@@ -5878,6 +5877,7 @@ class GPUModelRunner(
+             single_request_prefill: If True, create one prefill request with
+                 `num_tokens` tokens. This covers text-only single-request
+                 prefill kernels without keying warmup on a live prompt length.
++            run_drafter: Whether to execute the draft-model portion of the run.
+         """
+         mm_config = self.vllm_config.model_config.multimodal_config
+         if mm_config and mm_config.mm_encoder_only:
+@@ -6177,11 +6177,7 @@ class GPUModelRunner(
+             else:
+                 hidden_states = outputs
+ 
+-            if self.speculative_config and (
+-                self.speculative_config.use_eagle()
+-                or self.speculative_config.uses_draft_model()
+-                or self.speculative_config.uses_extract_hidden_states()
+-            ):
++            if run_drafter and self._drafter_runs_model_forward():
+                 assert isinstance(
+                     self.drafter,
+                     EagleProposer
+@@ -6672,7 +6668,7 @@ class GPUModelRunner(
+ 
+         saved_num_cudagraph_captured = compilation_counter.num_cudagraph_captured
+ 
+-        capture_descs = self.cudagraph_dispatcher.get_capture_descs()
++        capture_descs = list(self.cudagraph_dispatcher.get_capture_descs())
+         # Use a temporary manager for memory profiling. The persistent manager
+         # is initialized later so it does not keep profiling-only graph state.
+         encoder_cudagraph_manager = self._create_encoder_cudagraph_manager()
+@@ -6715,88 +6711,117 @@ class GPUModelRunner(
+             original_pools[id(instance)] = instance.graph_pool
+             instance.graph_pool = profiling_pool
+ 
+-        shared_memory_estimate = {}
+-        per_graph_estimate = {}
++        shared_memory_estimate: dict[CUDAGraphMode, int] = {}
++        per_graph_estimate: dict[CUDAGraphMode, int] = {}
+         encoder_memory_estimate = 0
+ 
+-        # On ROCm, capture these throwaway profiling graphs on vLLM's dedicated
+-        # compute stream instead of the fresh side stream graph_capture()
+-        # allocates by default. torch's allocator pools free blocks per stream,
+-        # so a side-stream forward strands a persistent aiter scratch buffer in
+-        # a separate pool, shifting the physical placement of the real KV cache
+-        # allocated afterward and slowing bandwidth-bound decode ~20%. The
+-        # graphs are discarded, so a side stream is unnecessary here.
+-        # Use current_stream(), not torch.cuda.current_stream(): before vLLM
+-        # initializes its dedicated stream, torch returns the per-thread default
+-        # stream (cuda_stream=0), which cannot be used for cudagraph capture.
+-        # cap_ctx=None keeps the side-stream path on CUDA.
+-        cap_ctx = (
+-            GraphCaptureContext(
+-                current_stream(),
+-                channel_id="graph:vllm-model",
+-            )
+-            if current_platform.is_rocm()
+-            else None
+-        )
+-
+         # Cleanup-only guard: CUDA graph capture errors should still propagate
+         # because encoder graph capture is opt-in.
++        graph_channel_checkpoints: tuple[tuple[Callable[[Any], None], Any], ...] = ()
+         try:
++            graph_channel_checkpoints = checkpoint_b12x_graph_channels()
+             set_cudagraph_capturing_enabled(True)
+-            with (
+-                self._freeze_gc(),
+-                graph_capture(
+-                    device=self.device,
+-                    graph_capture_context=cap_ctx,
+-                    channel_id="graph:vllm-model",
+-                ),
+-            ):
+-                torch.accelerator.synchronize()
+-                torch.accelerator.empty_cache()
+-
+-                for mode, descs in capture_descs:
+-                    profile_descs = descs[:2]
+-                    mem_samples: list[int] = []
+-
+-                    for i, desc in enumerate(profile_descs):
+-                        mem_before = torch.accelerator.get_memory_info()[0]
+-                        self._warmup_and_capture(
+-                            desc,
+-                            cudagraph_runtime_mode=mode,
+-                            profile_seq_lens=(
+-                                min(
+-                                    self.max_model_len,
+-                                    self.max_num_tokens // desc.num_tokens,
+-                                )
+-                                if mode == CUDAGraphMode.FULL and i == 0
+-                                else None
+-                            ),
++            with self._freeze_gc():
++                for component, channel_id in (
++                    ("target", "vllm:target:profile"),
++                    ("draft", "vllm:draft:profile"),
++                ):
++                    component_descs = [
++                        (mode, descs)
++                        for mode, descs in capture_descs
++                        if descs
++                        and (
++                            component == "target"
++                            or self._captures_independent_drafter_graphs(mode)
+                         )
+-                        torch.accelerator.synchronize()
+-                        free_after = torch.accelerator.get_memory_info()[0]
+-                        mem_samples.append(mem_before - free_after)
++                    ]
++                    if not component_descs:
++                        continue
+ 
+-                    first_capture = mem_samples[0]
+-                    # Use at least 1 MiB per graph for driver overhead
+-                    per_graph = max(
+-                        mem_samples[1] if len(mem_samples) > 1 else 0, 1 << 20
++                    # ROCm profiles on vLLM's dedicated compute stream to avoid
++                    # stranding allocator pages in a disposable side stream.
++                    cap_ctx = (
++                        GraphCaptureContext(current_stream(), channel_id=channel_id)
++                        if current_platform.is_rocm()
++                        else None
+                     )
++                    with graph_capture(
++                        device=self.device,
++                        graph_capture_context=cap_ctx,
++                        channel_id=channel_id,
++                    ):
++                        torch.accelerator.synchronize()
++                        torch.accelerator.empty_cache()
+ 
+-                    shared_memory_estimate[mode] = first_capture
+-                    per_graph_estimate[mode] = per_graph * (len(descs) - 1)
++                        for mode, descs in component_descs:
++                            profile_descs = descs[:2]
++                            mem_samples: list[int] = []
++                            captures_drafter = (
++                                self._captures_independent_drafter_graphs(mode)
++                            )
+ 
+-                    logger.debug(
+-                        "Estimated %s CUDA graph memory: "
+-                        "%.2f MiB first-capture + (%d-1) × %.2f MiB per-graph",
+-                        mode.name,
+-                        first_capture / (1 << 20),
+-                        len(descs),
+-                        per_graph / (1 << 20),
+-                    )
++                            for i, desc in enumerate(profile_descs):
++                                mem_before = torch.accelerator.get_memory_info()[0]
++                                self._warmup_and_capture(
++                                    desc,
++                                    cudagraph_runtime_mode=mode,
++                                    profile_seq_lens=(
++                                        min(
++                                            self.max_model_len,
++                                            self.max_num_tokens // desc.num_tokens,
++                                        )
++                                        if mode == CUDAGraphMode.FULL and i == 0
++                                        else None
++                                    ),
++                                    run_drafter=(
++                                        component == "draft" or not captures_drafter
++                                    ),
++                                )
++                                torch.accelerator.synchronize()
++                                free_after = torch.accelerator.get_memory_info()[0]
++                                mem_samples.append(max(mem_before - free_after, 0))
++
++                            first_capture = mem_samples[0]
++                            # Use at least 1 MiB per graph for driver overhead.
++                            per_graph = max(
++                                mem_samples[1] if len(mem_samples) > 1 else 0,
++                                1 << 20,
++                            )
++
++                            shared_memory_estimate[mode] = (
++                                shared_memory_estimate.get(mode, 0) + first_capture
++                            )
++                            per_graph_estimate[mode] = per_graph_estimate.get(
++                                mode, 0
++                            ) + per_graph * (len(descs) - 1)
++
++                            logger.debug(
++                                "Estimated %s %s CUDA graph memory: "
++                                "%.2f MiB first-capture + (%d-1) x %.2f MiB "
++                                "per-graph",
++                                component,
++                                mode.name,
++                                first_capture / (1 << 20),
++                                len(descs),
++                                per_graph / (1 << 20),
++                            )
+ 
+                 if encoder_cudagraph_manager is not None:
++                    channel_id = "vllm:encoder:profile"
++                    cap_ctx = (
++                        GraphCaptureContext(current_stream(), channel_id=channel_id)
++                        if current_platform.is_rocm()
++                        else None
++                    )
+                     mem_before = torch.accelerator.get_memory_info()[0]
+-                    encoder_cudagraph_manager.capture(graph_pool=encoder_profiling_pool)
++                    with graph_capture(
++                        device=self.device,
++                        graph_capture_context=cap_ctx,
++                        channel_id=channel_id,
++                    ):
++                        encoder_cudagraph_manager.capture(
++                            graph_pool=encoder_profiling_pool
++                        )
+                     torch.accelerator.synchronize()
+                     free_after = torch.accelerator.get_memory_info()[0]
+                     encoder_memory_estimate = max(mem_before - free_after, 0)
+@@ -6807,23 +6832,26 @@ class GPUModelRunner(
+                         encoder_graphs,
+                     )
+         finally:
+-            set_cudagraph_capturing_enabled(False)
+-            CUDAGraphWrapper.clear_all_graphs()
+-            BreakableCUDAGraphWrapper.clear_all_graphs()
+-            if encoder_cudagraph_manager is not None:
+-                encoder_cudagraph_manager.clear()
+-            all_wrappers = list(CUDAGraphWrapper._all_instances) + list(
+-                BreakableCUDAGraphWrapper._all_instances
+-            )
+-            for instance in all_wrappers:
+-                if id(instance) in original_pools:
+-                    instance.graph_pool = original_pools[id(instance)]
+-            for key_set in self.cudagraph_dispatcher.cudagraph_keys.values():
+-                key_set.clear()
+-            self.cudagraph_dispatcher.keys_initialized = False
+-            self.maybe_remove_all_loras(self.lora_config)
+-            self._cleanup_profiling_kv_cache()
+-            compilation_counter.num_cudagraph_captured = saved_num_cudagraph_captured
++            try:
++                try:
++                    set_cudagraph_capturing_enabled(False)
++                    CUDAGraphWrapper.clear_all_graphs()
++                    BreakableCUDAGraphWrapper.clear_all_graphs()
++                    if encoder_cudagraph_manager is not None:
++                        encoder_cudagraph_manager.clear()
++                finally:
++                    for instance in all_wrappers:
++                        instance.graph_pool = original_pools[id(instance)]
++                for key_set in self.cudagraph_dispatcher.cudagraph_keys.values():
++                    key_set.clear()
++                self.cudagraph_dispatcher.keys_initialized = False
++                self.maybe_remove_all_loras(self.lora_config)
++                self._cleanup_profiling_kv_cache()
++                compilation_counter.num_cudagraph_captured = (
++                    saved_num_cudagraph_captured
++                )
++            finally:
++                rollback_b12x_graph_channels(graph_channel_checkpoints)
+ 
+         # FULL and PIECEWISE graphs share the global pool at runtime and are
+         # never replayed concurrently, so the pool overlays their memory.
+@@ -6860,42 +6888,58 @@ class GPUModelRunner(
+         # Trigger CUDA graph capture for specific shapes.
+         # Capture the large shapes first so that the smaller shapes
+         # can reuse the memory pool allocated for the large shapes.
++        capture_descs = list(self.cudagraph_dispatcher.get_capture_descs())
+         set_cudagraph_capturing_enabled(True)
+-        with (
+-            self._freeze_gc(),
+-            graph_capture(
+-                device=self.device,
+-                channel_id="graph:vllm-model",
+-            ),
+-        ):
+-            torch.accelerator.synchronize()
+-            torch.accelerator.empty_cache()
+-            start_free_gpu_memory = torch.accelerator.get_memory_info()[0]
+-
+-            for (
+-                runtime_mode,
+-                batch_descs,
+-            ) in self.cudagraph_dispatcher.get_capture_descs():
+-                self._capture_cudagraphs(
+-                    batch_descriptors=batch_descs,
+-                    cudagraph_runtime_mode=runtime_mode,
+-                )
++        try:
++            with self._freeze_gc():
+                 torch.accelerator.synchronize()
++                torch.accelerator.empty_cache()
++                start_free_gpu_memory = torch.accelerator.get_memory_info()[0]
+ 
+-            # Capture encoder CUDA graphs if enabled
+-            if self.encoder_cudagraph_manager is not None:
+-                encoder_graph_pool = current_platform.graph_pool_handle()
+-                self.encoder_cudagraph_manager.capture(graph_pool=encoder_graph_pool)
++                for component, channel_id in (
++                    ("target", "vllm:target:production"),
++                    ("draft", "vllm:draft:production"),
++                ):
++                    component_descs = [
++                        (mode, descs)
++                        for mode, descs in capture_descs
++                        if descs
++                        and (
++                            component == "target"
++                            or self._captures_independent_drafter_graphs(mode)
++                        )
++                    ]
++                    if not component_descs:
++                        continue
++                    with graph_capture(device=self.device, channel_id=channel_id):
++                        for runtime_mode, batch_descs in component_descs:
++                            captures_drafter = (
++                                self._captures_independent_drafter_graphs(runtime_mode)
++                            )
++                            self._capture_cudagraphs(
++                                batch_descriptors=batch_descs,
++                                cudagraph_runtime_mode=runtime_mode,
++                                run_drafter=(
++                                    component == "draft" or not captures_drafter
++                                ),
++                            )
++                            torch.accelerator.synchronize()
+ 
+-            torch.accelerator.synchronize()
+-            end_free_gpu_memory = torch.accelerator.get_memory_info()[0]
++                if self.encoder_cudagraph_manager is not None:
++                    encoder_graph_pool = current_platform.graph_pool_handle()
++                    with graph_capture(
++                        device=self.device,
++                        channel_id="vllm:encoder:production",
++                    ):
++                        self.encoder_cudagraph_manager.capture(
++                            graph_pool=encoder_graph_pool
++                        )
+ 
+-        # Disable cudagraph capturing globally, so any unexpected cudagraph
+-        # capturing will be detected and raise an error after here.
+-        # Note: We don't put it into graph_capture context manager because
+-        # we may do lazy capturing in future that still allows capturing
+-        # after here.
+-        set_cudagraph_capturing_enabled(False)
++                torch.accelerator.synchronize()
++                end_free_gpu_memory = torch.accelerator.get_memory_info()[0]
++        finally:
++            # Leave capture mode disabled even when one graph owner fails.
++            set_cudagraph_capturing_enabled(False)
+ 
+         torch.accelerator.synchronize()
+         torch.accelerator.empty_cache()
+@@ -6915,6 +6959,35 @@ class GPUModelRunner(
+         )
+         return cuda_graph_size
+ 
++    def _captures_independent_drafter_graphs(
++        self,
++        cudagraph_runtime_mode: CUDAGraphMode,
++    ) -> bool:
++        """Return whether PIECEWISE capture needs a separate drafter pass.
++
++        Args:
++            cudagraph_runtime_mode: CUDA graph mode being captured.
++
++        Returns:
++            Whether the mode owns independently replayable drafter graphs.
++        """
++        spec_config = self.speculative_config
++        return (
++            cudagraph_runtime_mode == CUDAGraphMode.PIECEWISE
++            and spec_config is not None
++            and not spec_config.enforce_eager
++            and self._drafter_runs_model_forward()
++        )
++
++    def _drafter_runs_model_forward(self) -> bool:
++        """Return whether the configured drafter executes a model forward."""
++        spec_config = self.speculative_config
++        return spec_config is not None and (
++            spec_config.use_eagle()
++            or spec_config.uses_draft_model()
++            or spec_config.uses_extract_hidden_states()
++        )
++
+     def _warmup_and_capture(
+         self,
+         desc: BatchDescriptor,
+@@ -6922,6 +6995,7 @@ class GPUModelRunner(
+         profile_seq_lens: int | None = None,
+         allow_microbatching: bool = False,
+         num_warmups: int | None = None,
++        run_drafter: bool = True,
+     ):
+         if num_warmups is None:
+             num_warmups = self.compilation_config.cudagraph_num_of_warmups
+@@ -6937,6 +7011,7 @@ class GPUModelRunner(
+                 remove_lora=False,
+                 num_active_loras=desc.num_active_loras,
+                 profile_seq_lens=profile_seq_lens,
++                run_drafter=run_drafter,
+             )
+         self._dummy_run(
+             desc.num_tokens,
+@@ -6948,12 +7023,15 @@ class GPUModelRunner(
+             num_active_loras=desc.num_active_loras,
+             is_graph_capturing=True,
+             profile_seq_lens=profile_seq_lens,
++            run_drafter=run_drafter,
+         )
+ 
+     def _capture_cudagraphs(
+         self,
+         batch_descriptors: list[BatchDescriptor],
+         cudagraph_runtime_mode: CUDAGraphMode,
++        *,
++        run_drafter: bool = True,
+     ):
+         assert (
+             cudagraph_runtime_mode != CUDAGraphMode.NONE
+@@ -6996,6 +7074,7 @@ class GPUModelRunner(
+                 batch_desc,
+                 cudagraph_runtime_mode=cudagraph_runtime_mode,
+                 allow_microbatching=allow_microbatching,
++                run_drafter=run_drafter,
+             )
+             torch.accelerator.synchronize()
+         self.maybe_remove_all_loras(self.lora_config)

--- a/patches/releases/gilded-gnosis-v20-r33/b12x/integration.lock.json
+++ b/patches/releases/gilded-gnosis-v20-r33/b12x/integration.lock.json
@@ -1,0 +1,61 @@
+{
+  "base": {
+    "commit": "9bbae67841e4818e7472e1edcdca8ebcbda68611",
+    "ref": "refs/heads/master",
+    "repository": "https://github.com/local-inference-lab/b12x.git"
+  },
+  "manifest": {
+    "sha256": "7d9bd254aedbdbac3e0a0eb12bcf38a214f7adfdf68402e096a480309da05c3d"
+  },
+  "name": "gilded-gnosis-v20-b12x",
+  "pull_requests": [
+    {
+      "disposition": "merged",
+      "head": "282d61a483c908eaa440a19ba0d70a557c73197f",
+      "number": 125,
+      "ref": "refs/pull/125/head",
+      "title": "Declare compressed MLA decode row capacity"
+    },
+    {
+      "disposition": "merged",
+      "head": "6022e6e7c7ea1199a06a27cf5a777c2804b13cfb",
+      "number": 126,
+      "ref": "refs/pull/126/head",
+      "title": "Prewarm target and native-MTP route packing"
+    },
+    {
+      "disposition": "merged",
+      "head": "287fec1c8e6457a5d687f0b7a96a4e1579c1b791",
+      "number": 133,
+      "ref": "refs/pull/133/head",
+      "title": "Add topology-scoped fused all-reduce paths"
+    },
+    {
+      "disposition": "merged",
+      "head": "0b44e769caa3c38d99d346a3a343a47df68d2e3b",
+      "number": 135,
+      "ref": "refs/pull/135/head",
+      "title": "Preserve dense GEMM API contracts with block FP8"
+    },
+    {
+      "disposition": "merged",
+      "head": "b3f572da20b7167bdcdf866419dc414d56945ad6",
+      "number": 136,
+      "ref": "refs/pull/136/head",
+      "title": "Restore capture-safe K6 small-M dispatch"
+    },
+    {
+      "disposition": "merged",
+      "head": "850bc0d0c48c626f236b0ee7e8ea41cc44d75d6d",
+      "number": 137,
+      "ref": "refs/pull/137/head",
+      "title": "Realign mixed Trellis with the QSRT ABI"
+    }
+  ],
+  "result": {
+    "patch": "integration.patch",
+    "patch_sha256": "6ee9f0b437379fd8246781b5a99da10eed2ad47eb8d7426272d3f8bff1553303",
+    "tree": "06db0f4b27dbd19eb934da0da27eff7a7c49d8c4"
+  },
+  "schema_version": 1
+}

--- a/patches/releases/gilded-gnosis-v20-r33/b12x/integration.patch
+++ b/patches/releases/gilded-gnosis-v20-r33/b12x/integration.patch
@@ -1,0 +1,3228 @@
+diff --git a/b12x/_lib/dense_gemm.py b/b12x/_lib/dense_gemm.py
+index 1c72c8cbd9017784ab359034595aa01cbd16ea68..818e37b22cfdf9627f98aa0f3a2394380ad91ca8 100644
+--- a/b12x/_lib/dense_gemm.py
++++ b/b12x/_lib/dense_gemm.py
+@@ -630,6 +630,7 @@ class DenseGemmKernel:
+         mxfp6_fmt_b: Optional[str] = None,
+         b_packed: bool = False,
+         plain_fp8: bool = False,
++        fused_quant_bf16: Optional[bool] = None,
+         block_fp8: bool = False,
+     ):
+         # When set, A/B operands are MX codes carried in Float8E4M3FN
+@@ -1884,10 +1885,12 @@ class DenseGemmKernel:
+         accumulators = cute.make_rmem_tensor(acc_shape, self.acc_dtype)
+         if cutlass.const_expr(self.block_fp8):
+             stage_accumulators = cute.make_rmem_tensor(acc_shape, self.acc_dtype)
+-            c_identity = cute.make_identity_tensor(
++            block_c_identity = cute.make_identity_tensor(
+                 cute.slice_(self.tile_shape_mnk, (None, None, 0))
+             )
+-            coord_mn = _reshape_acc_to_mn(thr_mma.partition_C(c_identity))
++            block_coord_mn = _reshape_acc_to_mn(
++                thr_mma.partition_C(block_c_identity)
++            )
+ 
+         # Cluster/thread sync
+         if cute.size(self.cluster_shape_mnk) > 1:
+@@ -2340,7 +2343,7 @@ class DenseGemmKernel:
+                                 self._accumulate_block_fp8_stage(
+                                     accumulators,
+                                     stage_accumulators,
+-                                    coord_mn,
++                                    block_coord_mn,
+                                     directSFA_mkl,
+                                     directSFB_nkl,
+                                     tile_coord_mnl,
+@@ -2485,7 +2488,7 @@ class DenseGemmKernel:
+                             self._accumulate_block_fp8_stage(
+                                 accumulators,
+                                 stage_accumulators,
+-                                coord_mn,
++                                block_coord_mn,
+                                 directSFA_mkl,
+                                 directSFB_nkl,
+                                 tile_coord_mnl,
+@@ -7094,6 +7097,7 @@ def dense_gemm(
+     x_bf16: Optional[torch.Tensor] = None,
+     w_gscale: Optional[torch.Tensor] = None,
+     plain_fp8: bool = False,
++    row_scale: Optional[torch.Tensor] = None,
+     block_fp8: bool = False,
+ ) -> torch.Tensor:
+     """Execute dense block-scaled GEMM for one expert-major batch stack.
+@@ -7134,6 +7138,11 @@ def dense_gemm(
+     SM12x dense pipeline. The scalar ``alpha`` carries the combined activation
+     and weight dequantization scale.
+ 
++    ``row_scale``: optional contiguous ``(M,)`` tensor in the C dtype, applied
++    per output row in the epilogue. It replaces a separate ``out.mul_(v)``
++    launch and reproduces that multiply bit-for-bit, including its second
++    rounding to the C dtype. MX-FP6 only.
++
+     ``block_fp8``: accumulate ordinary E4M3 MMA over each K128 block, then
+     apply compact FP32 activation ``[M,K/128]`` and weight
+     ``[N/128,K/128]`` scales before adding it to the final accumulator.
+diff --git a/b12x/attention/_shared/mla/compressed_config.py b/b12x/attention/_shared/mla/compressed_config.py
+index 3d333ba382f7a762d812018a4adf636c4aeb0a20..ac1fb708058a5667a64767b8096b31df1a3508e9 100644
+--- a/b12x/attention/_shared/mla/compressed_config.py
++++ b/b12x/attention/_shared/mla/compressed_config.py
+@@ -22,9 +22,18 @@ def compressed_mla_split_config_for_contract(
+     rows: int,
+     width: int,
+     max_chunks: int | None = None,
++    decode_row_capacity: int | None = None,
+ ) -> SparseMLASplitDecodeConfig:
+     rows = max(int(rows), 1)
+     width = max(int(width), 1)
++    decode_split_max_rows = _COMPRESSED_MLA_DECODE_SPLIT_MAX_ROWS
++    if decode_row_capacity is not None:
++        decode_row_capacity = int(decode_row_capacity)
++        if decode_row_capacity <= 0:
++            raise ValueError(
++                f"decode_row_capacity must be positive, got {decode_row_capacity}"
++            )
++        decode_split_max_rows = max(decode_split_max_rows, decode_row_capacity)
+     chunk_limit = _COMPRESSED_MLA_SPLIT_MAX_CHUNKS
+     if max_chunks is not None:
+         chunk_limit = max(1, min(int(max_chunks), chunk_limit))
+@@ -32,7 +41,7 @@ def compressed_mla_split_config_for_contract(
+     decode_chunks = (
+         width + _COMPRESSED_MLA_DECODE_SPLIT_CHUNK_SIZE - 1
+     ) // _COMPRESSED_MLA_DECODE_SPLIT_CHUNK_SIZE
+-    if rows <= _COMPRESSED_MLA_DECODE_SPLIT_MAX_ROWS and decode_chunks <= chunk_limit:
++    if rows <= decode_split_max_rows and decode_chunks <= chunk_limit:
+         return SparseMLASplitDecodeConfig(
+             chunk_size=_COMPRESSED_MLA_DECODE_SPLIT_CHUNK_SIZE,
+             num_chunks=decode_chunks,
+@@ -41,10 +50,7 @@ def compressed_mla_split_config_for_contract(
+     wide_decode_chunks = (
+         width + _COMPRESSED_MLA_DECODE_WIDE_CHUNK_SIZE - 1
+     ) // _COMPRESSED_MLA_DECODE_WIDE_CHUNK_SIZE
+-    if (
+-        rows <= _COMPRESSED_MLA_DECODE_SPLIT_MAX_ROWS
+-        and wide_decode_chunks <= chunk_limit
+-    ):
++    if rows <= decode_split_max_rows and wide_decode_chunks <= chunk_limit:
+         return SparseMLASplitDecodeConfig(
+             chunk_size=_COMPRESSED_MLA_DECODE_WIDE_CHUNK_SIZE,
+             num_chunks=wide_decode_chunks,
+@@ -68,11 +74,13 @@ def compressed_mla_split_chunks_for_contract(
+     rows: int,
+     width: int,
+     max_chunks: int | None = None,
++    decode_row_capacity: int | None = None,
+ ) -> int:
+     return compressed_mla_split_config_for_contract(
+         rows=rows,
+         width=width,
+         max_chunks=max_chunks,
++        decode_row_capacity=decode_row_capacity,
+     ).num_chunks
+ 
+ 
+diff --git a/b12x/attention/compressed_mla/_scratch.py b/b12x/attention/compressed_mla/_scratch.py
+index b462b0ec0ddb7c456a6cec54cc00dc585a8e771f..ec9244ebc6fa4f94c8778f79117cf33f1db4e0c5 100644
+--- a/b12x/attention/compressed_mla/_scratch.py
++++ b/b12x/attention/compressed_mla/_scratch.py
+@@ -46,6 +46,7 @@ class B12XCompressedMLAScratchCaps:
+     max_kv_rows: int = 0
+     max_chunks_per_row: int = 64
+     max_q_chunks: int | None = None
++    decode_row_capacity: int | None = None
+     page_size: int = 64
+ 
+     def __post_init__(self) -> None:
+@@ -74,6 +75,13 @@ class B12XCompressedMLAScratchCaps:
+         )
+         if self.max_q_chunks is not None:
+             object.__setattr__(self, "max_q_chunks", max(int(self.max_q_chunks), 1))
++        if self.decode_row_capacity is not None:
++            decode_row_capacity = int(self.decode_row_capacity)
++            if decode_row_capacity <= 0:
++                raise ValueError(
++                    f"decode_row_capacity must be positive, got {decode_row_capacity}"
++                )
++            object.__setattr__(self, "decode_row_capacity", decode_row_capacity)
+         object.__setattr__(self, "page_size", max(int(self.page_size), 1))
+ 
+ 
+@@ -376,6 +384,7 @@ def _materialize_compressed_mla_scratch(
+         rows=caps.max_q_rows,
+         width=caps.max_width,
+         max_chunks=caps.max_chunks_per_row,
++        decode_row_capacity=caps.decode_row_capacity,
+     )
+     scratch.set_split_chunk_config(
+         kv_chunk_size=split_cfg.chunk_size,
+diff --git a/b12x/comm/pcie/_cute_intrinsics.py b/b12x/comm/pcie/_cute_intrinsics.py
+index 36d10cd2130930e18898d4109b795daf2e547df2..6f2daab78ea857079cdbc74cec904b54aa0688a2 100644
+--- a/b12x/comm/pcie/_cute_intrinsics.py
++++ b/b12x/comm/pcie/_cute_intrinsics.py
+@@ -17,6 +17,25 @@ from cutlass._mlir.dialects import llvm
+ from cutlass.cutlass_dsl import T, dsl_user_op
+ 
+ 
++@dsl_user_op
++def f32_as_u32(value: Float32, *, loc=None, ip=None) -> Uint32:
++    """Bitcast float32 to uint32 without numeric conversion."""
++
++    return Uint32(
++        llvm.inline_asm(
++            T.i32(),
++            [Float32(value).ir_value(loc=loc, ip=ip)],
++            "mov.b32 $0, $1;",
++            "=r,f",
++            has_side_effects=False,
++            is_align_stack=False,
++            asm_dialect=llvm.AsmDialect.AD_ATT,
++            loc=loc,
++            ip=ip,
++        )
++    )
++
++
+ @dsl_user_op
+ def ld_global_u64(addr: Int64, *, loc=None, ip=None) -> Uint64:
+     return Uint64(
+@@ -195,9 +214,7 @@ def unpack_bf16x2(value: Uint32, *, loc=None, ip=None) -> Tuple[Float32, Float32
+ 
+ 
+ @dsl_user_op
+-def pack_f32x2_to_f16x2(
+-    lo: Float32, hi: Float32, *, loc=None, ip=None
+-) -> Uint32:
++def pack_f32x2_to_f16x2(lo: Float32, hi: Float32, *, loc=None, ip=None) -> Uint32:
+     return Uint32(
+         llvm.inline_asm(
+             T.i32(),
+@@ -217,9 +234,7 @@ def pack_f32x2_to_f16x2(
+ 
+ 
+ @dsl_user_op
+-def pack_f32x2_to_bf16x2(
+-    lo: Float32, hi: Float32, *, loc=None, ip=None
+-) -> Uint32:
++def pack_f32x2_to_bf16x2(lo: Float32, hi: Float32, *, loc=None, ip=None) -> Uint32:
+     """Match two scalar ``__float2bfloat16`` conversions without saturation."""
+     return Uint32(
+         llvm.inline_asm(
+@@ -313,9 +328,7 @@ def ld_relaxed_gpu_u32(addr: Int64, *, loc=None, ip=None) -> Uint32:
+ 
+ 
+ @dsl_user_op
+-def atomic_add_global_u32(
+-    addr: Int64, value: Uint32, *, loc=None, ip=None
+-) -> Uint32:
++def atomic_add_global_u32(addr: Int64, value: Uint32, *, loc=None, ip=None) -> Uint32:
+     return Uint32(
+         llvm.inline_asm(
+             T.i32(),
+diff --git a/b12x/comm/pcie/_oneshot_cute.py b/b12x/comm/pcie/_oneshot_cute.py
+index 7a846996dfa12c1f8e0650dc340bb1aca3f19cb5..d0b5ca091d1ef824df4ccf207fa6b68b144853c4 100644
+--- a/b12x/comm/pcie/_oneshot_cute.py
++++ b/b12x/comm/pcie/_oneshot_cute.py
+@@ -30,6 +30,7 @@ from b12x._lib.utils import current_cuda_stream, make_ptr
+ 
+ from ._cute_intrinsics import (
+     atomic_add_global_u32,
++    f32_as_u32,
+     graph_epoch_arrive,
+     ld_global_f32,
+     ld_relaxed_gpu_u32,
+@@ -108,9 +109,7 @@ class _PackedMath:
+                     accumulator[lane + 1] = accumulator[lane + 1] + hi
+ 
+     @cute.jit
+-    def _store_accumulator(
+-        self, address: Int64, accumulator: cute.Tensor
+-    ) -> None:
++    def _store_accumulator(self, address: Int64, accumulator: cute.Tensor) -> None:
+         if cutlass.const_expr(self._dtype_name == "float32"):
+             st_global_v4_f32(
+                 address,
+@@ -131,16 +130,12 @@ class _PackedMath:
+                     packed[word] = pack_f32x2_to_bf16x2(
+                         accumulator[lane], accumulator[lane + 1]
+                     )
+-            st_global_v4_u32(
+-                address, packed[0], packed[1], packed[2], packed[3]
+-            )
++            st_global_v4_u32(address, packed[0], packed[1], packed[2], packed[3])
+ 
+     @cute.jit
+     def _copy_pack(self, source: Int64, destination: Int64) -> None:
+         words = ld_global_v4_u32(source)
+-        st_global_v4_u32(
+-            destination, words[0], words[1], words[2], words[3]
+-        )
++        st_global_v4_u32(destination, words[0], words[1], words[2], words[3])
+ 
+     @cute.jit
+     def _warp_reduce_down(self, value: Float32) -> Float32:
+@@ -204,14 +199,24 @@ class _OneshotLaunch(_PackedMath):
+             self_counter = self_signal + (
+                 Int64(bidx) * Int64(_MAX_RANKS) + Int64(tidx)
+             ) * Int64(4)
+-            peer_slot0 = peer_signal + Int64(_SELF_COUNTER_BYTES) + (
+-                Int64(bidx) * Int64(_MAX_RANKS * _FLAG_STRIDE)
+-                + Int64(self._rank * _FLAG_STRIDE)
+-            ) * Int64(4)
+-            wait_slot0 = self_signal + Int64(_SELF_COUNTER_BYTES) + (
+-                Int64(bidx) * Int64(_MAX_RANKS * _FLAG_STRIDE)
+-                + Int64(tidx) * Int64(_FLAG_STRIDE)
+-            ) * Int64(4)
++            peer_slot0 = (
++                peer_signal
++                + Int64(_SELF_COUNTER_BYTES)
++                + (
++                    Int64(bidx) * Int64(_MAX_RANKS * _FLAG_STRIDE)
++                    + Int64(self._rank * _FLAG_STRIDE)
++                )
++                * Int64(4)
++            )
++            wait_slot0 = (
++                self_signal
++                + Int64(_SELF_COUNTER_BYTES)
++                + (
++                    Int64(bidx) * Int64(_MAX_RANKS * _FLAG_STRIDE)
++                    + Int64(tidx) * Int64(_FLAG_STRIDE)
++                )
++                * Int64(4)
++            )
+             pcie_arrive_and_wait(
+                 self_counter,
+                 peer_slot0,
+@@ -258,9 +263,7 @@ class _OneshotLaunch(_PackedMath):
+         self._multi_gpu_barrier(signal_ptrs)
+ 
+         while index < size_packs:
+-            accumulator = cute.make_rmem_tensor(
+-                (self._pack_elems,), cutlass.Float32
+-            )
++            accumulator = cute.make_rmem_tensor((self._pack_elems,), cutlass.Float32)
+             for peer_index in cutlass.range_constexpr(self._world_size):
+                 peer_rank = (self._rank + peer_index) % self._world_size
+                 peer_base = Int64(peer_ptrs[peer_rank])
+@@ -269,9 +272,7 @@ class _OneshotLaunch(_PackedMath):
+                     peer_base + Int64(index) * Int64(16),
+                     peer_index == 0,
+                 )
+-            self._store_accumulator(
+-                output_base + Int64(index) * Int64(16), accumulator
+-            )
++            self._store_accumulator(output_base + Int64(index) * Int64(16), accumulator)
+             index += stride
+ 
+         if cutlass.const_expr(self._device_slot_selection):
+@@ -298,8 +299,23 @@ class _FusedOneshotLaunch(_PackedMath):
+         threads: int,
+     ) -> None:
+         super().__init__(dtype_name)
+-        if mode not in ("registered", "stage_pull", "stage_push"):
++        if mode not in (
++            "registered",
++            "stage_pull",
++            "stage_push",
++            "stage_remote_push",
++            "stage_tp8_owner",
++        ):
+             raise ValueError(f"invalid fused oneshot mode {mode!r}")
++        if mode == "stage_remote_push" and world_size not in (2, 4):
++            raise ValueError("fused remote push requires TP2 or TP4")
++        if mode == "stage_tp8_owner" and world_size != 8:
++            raise ValueError("fused owner transport requires TP8")
++        if mode == "stage_tp8_owner" and dtype_name not in (
++            "float16",
++            "bfloat16",
++        ):
++            raise ValueError("fused TP8 owner transport requires float16 or bfloat16")
+         self._world_size = int(world_size)
+         self._rank = int(rank)
+         self._mode = mode
+@@ -308,6 +324,10 @@ class _FusedOneshotLaunch(_PackedMath):
+         self._device_slot_selection = bool(device_slot_selection)
+         self._slot_bias = int(slot_bias) & 1
+         self._threads = int(threads)
++        # C1 uses the ordinary staged protocol while C2-C8 use three scoped
++        # phases. Keep their reusable barrier generations in separate rank
++        # slots when one graph-owned channel alternates between those shapes.
++        self._barrier_rank_offset = 8 if mode == "stage_tp8_owner" else 0
+ 
+     @cute.jit
+     def __call__(
+@@ -347,32 +367,80 @@ class _FusedOneshotLaunch(_PackedMath):
+             stream=stream,
+         )
+ 
++    @cute.jit
++    def _pair_arrive_and_wait(
++        self,
++        signal_ptrs: cute.Pointer,
++        peer_rank: Int32,
++    ) -> None:
++        bidx, _, _ = cute.arch.block_idx()
++        barrier_peer = peer_rank + Int32(self._barrier_rank_offset)
++        self_signal = Int64(signal_ptrs[self._rank])
++        peer_signal = Int64(signal_ptrs[peer_rank])
++        self_counter = self_signal + (
++            Int64(bidx) * Int64(_MAX_RANKS) + Int64(barrier_peer)
++        ) * Int64(4)
++        peer_slot0 = (
++            peer_signal
++            + Int64(_SELF_COUNTER_BYTES)
++            + (
++                Int64(bidx) * Int64(_MAX_RANKS * _FLAG_STRIDE)
++                + Int64((self._rank + self._barrier_rank_offset) * _FLAG_STRIDE)
++            )
++            * Int64(4)
++        )
++        wait_slot0 = (
++            self_signal
++            + Int64(_SELF_COUNTER_BYTES)
++            + (
++                Int64(bidx) * Int64(_MAX_RANKS * _FLAG_STRIDE)
++                + Int64(barrier_peer) * Int64(_FLAG_STRIDE)
++            )
++            * Int64(4)
++        )
++        pcie_arrive_and_wait(
++            self_counter,
++            peer_slot0,
++            wait_slot0,
++            Int64(_PEER_SLOT_BYTES),
++        )
++
+     @cute.jit
+     def _multi_gpu_barrier(self, signal_ptrs: cute.Pointer) -> None:
+         tidx, _, _ = cute.arch.thread_idx()
+-        bidx, _, _ = cute.arch.block_idx()
+         if cutlass.const_expr(self._mode != "registered"):
+             cute.arch.sync_threads()
+         if tidx < Int32(self._world_size):
+-            self_signal = Int64(signal_ptrs[self._rank])
+-            peer_signal = Int64(signal_ptrs[tidx])
+-            self_counter = self_signal + (
+-                Int64(bidx) * Int64(_MAX_RANKS) + Int64(tidx)
+-            ) * Int64(4)
+-            peer_slot0 = peer_signal + Int64(_SELF_COUNTER_BYTES) + (
+-                Int64(bidx) * Int64(_MAX_RANKS * _FLAG_STRIDE)
+-                + Int64(self._rank * _FLAG_STRIDE)
+-            ) * Int64(4)
+-            wait_slot0 = self_signal + Int64(_SELF_COUNTER_BYTES) + (
+-                Int64(bidx) * Int64(_MAX_RANKS * _FLAG_STRIDE)
+-                + Int64(tidx) * Int64(_FLAG_STRIDE)
+-            ) * Int64(4)
+-            pcie_arrive_and_wait(
+-                self_counter,
+-                peer_slot0,
+-                wait_slot0,
+-                Int64(_PEER_SLOT_BYTES),
+-            )
++            self._pair_arrive_and_wait(signal_ptrs, Int32(tidx))
++        cute.arch.sync_threads()
++
++    @cute.jit
++    def _tp8_island_barrier(self, signal_ptrs: cute.Pointer) -> None:
++        """Publish and acquire payloads within one four-rank island."""
++
++        tidx, _, _ = cute.arch.thread_idx()
++        island_base = Int32(0 if self._rank < 4 else 4)
++        cute.arch.sync_threads()
++        if tidx < Int32(4):
++            peer_rank = island_base + Int32(tidx)
++            if peer_rank != Int32(self._rank):
++                self._pair_arrive_and_wait(signal_ptrs, peer_rank)
++        cute.arch.sync_threads()
++
++    @cute.jit
++    def _tp8_owner_pair_barrier(self, signal_ptrs: cute.Pointer) -> None:
++        """Publish and acquire one FP32 partial between paired owners.
++
++        This barrier must remain mutual so paired owners can skew by at most
++        one invocation. Eager slots alternate between invocations, making
++        that bounded skew use different storage. Both properties are safety
++        requirements for local-partial publication and final consumption.
++        """
++
++        tidx, _, _ = cute.arch.thread_idx()
++        cute.arch.sync_threads()
++        if Int32(tidx) == Int32(0):
++            self._pair_arrive_and_wait(signal_ptrs, Int32(self._rank ^ 4))
+         cute.arch.sync_threads()
+ 
+     @cute.jit
+@@ -381,6 +449,7 @@ class _FusedOneshotLaunch(_PackedMath):
+         peer_ptrs: cute.Pointer,
+         input_base: Int64,
+         index: Int64,
++        total_packs: Int64,
+         shard_packs: Int64,
+     ) -> None:
+         if cutlass.const_expr(self._mode == "stage_pull"):
+@@ -388,7 +457,9 @@ class _FusedOneshotLaunch(_PackedMath):
+                 input_base + index * Int64(16),
+                 Int64(peer_ptrs[self._rank]) + index * Int64(16),
+             )
+-        elif cutlass.const_expr(self._mode == "stage_push"):
++        elif cutlass.const_expr(
++            self._mode == "stage_push" or self._mode == "stage_remote_push"
++        ):
+             source = input_base + index * Int64(16)
+             words = ld_global_v4_u32(source)
+             for peer_index in cutlass.range_constexpr(1, self._world_size):
+@@ -396,8 +467,135 @@ class _FusedOneshotLaunch(_PackedMath):
+                 destination = Int64(peer_ptrs[destination_rank]) + (
+                     Int64(self._rank) * shard_packs + index
+                 ) * Int64(16)
++                st_global_v4_u32(destination, words[0], words[1], words[2], words[3])
++        elif cutlass.const_expr(self._mode == "stage_tp8_owner"):
++            part = total_packs // Int64(4)
++            chunk = index // part
++            if chunk > Int64(3):
++                chunk = Int64(3)
++            island_base = Int64(0 if self._rank < 4 else 4)
++            owner_rank = island_base + chunk
++            destination = Int64(peer_ptrs[owner_rank]) + (
++                Int64(self._rank) * shard_packs + index
++            ) * Int64(16)
++            words = ld_global_v4_u32(input_base + index * Int64(16))
++            st_global_v4_u32(destination, words[0], words[1], words[2], words[3])
++
++    @cute.jit
++    def _tp8_publish_local_partial(
++        self,
++        peer_ptrs: cute.Pointer,
++        index: Int64,
++        total_packs: Int64,
++        shard_packs: Int64,
++    ) -> None:
++        part = total_packs // Int64(4)
++        chunk = index // part
++        if chunk > Int64(3):
++            chunk = Int64(3)
++        island_base = 0 if self._rank < 4 else 4
++        owner_rank = Int32(island_base) + Int32(chunk)
++        if Int32(self._rank) == owner_rank:
++            local_stage = Int64(peer_ptrs[self._rank])
++            local_sum = cute.make_rmem_tensor((self._pack_elems,), cutlass.Float32)
++            for peer_local in cutlass.range_constexpr(4):
++                source_rank = island_base + peer_local
++                self._load_accumulate(
++                    local_sum,
++                    local_stage
++                    + (Int64(source_rank) * shard_packs + index) * Int64(16),
++                    peer_local == 0,
++                )
++
++            low = (
++                f32_as_u32(local_sum[0]),
++                f32_as_u32(local_sum[1]),
++                f32_as_u32(local_sum[2]),
++                f32_as_u32(local_sum[3]),
++            )
++            high = (
++                f32_as_u32(local_sum[4]),
++                f32_as_u32(local_sum[5]),
++                f32_as_u32(local_sum[6]),
++                f32_as_u32(local_sum[7]),
++            )
++            cross_owner = self._rank ^ 4
++            for destination_rank in (self._rank, cross_owner):
++                destination_stage = Int64(peer_ptrs[destination_rank])
++                st_global_v4_u32(
++                    destination_stage
++                    + (Int64(self._rank) * shard_packs + index) * Int64(16),
++                    low[0],
++                    low[1],
++                    low[2],
++                    low[3],
++                )
+                 st_global_v4_u32(
+-                    destination, words[0], words[1], words[2], words[3]
++                    destination_stage
++                    + (Int64(self._rank ^ 1) * shard_packs + index) * Int64(16),
++                    high[0],
++                    high[1],
++                    high[2],
++                    high[3],
++                )
++
++    @cute.jit
++    def _tp8_publish_final(
++        self,
++        peer_ptrs: cute.Pointer,
++        index: Int64,
++        total_packs: Int64,
++        shard_packs: Int64,
++    ) -> None:
++        part = total_packs // Int64(4)
++        chunk = index // part
++        if chunk > Int64(3):
++            chunk = Int64(3)
++        island_base = 0 if self._rank < 4 else 4
++        owner_rank = Int32(island_base) + Int32(chunk)
++        if Int32(self._rank) == owner_rank:
++            local_stage = Int64(peer_ptrs[self._rank])
++            cross_owner = self._rank ^ 4
++            local_low = ld_global_v4_u32(
++                local_stage + (Int64(self._rank) * shard_packs + index) * Int64(16)
++            )
++            local_high = ld_global_v4_u32(
++                local_stage + (Int64(self._rank ^ 1) * shard_packs + index) * Int64(16)
++            )
++            cross_low = ld_global_v4_u32(
++                local_stage + (Int64(cross_owner) * shard_packs + index) * Int64(16)
++            )
++            cross_high = ld_global_v4_u32(
++                local_stage + (Int64(cross_owner ^ 1) * shard_packs + index) * Int64(16)
++            )
++            final_low = cute.make_rmem_tensor((4,), cutlass.Uint32)
++            final_high = cute.make_rmem_tensor((4,), cutlass.Uint32)
++            for lane in cutlass.range_constexpr(4):
++                final_low[lane] = f32_as_u32(
++                    u32_as_f32(local_low[lane]) + u32_as_f32(cross_low[lane])
++                )
++                final_high[lane] = f32_as_u32(
++                    u32_as_f32(local_high[lane]) + u32_as_f32(cross_high[lane])
++                )
++
++            for peer_local in cutlass.range_constexpr(4):
++                destination_rank = island_base + peer_local
++                destination_stage = Int64(peer_ptrs[destination_rank])
++                st_global_v4_u32(
++                    destination_stage
++                    + (Int64(self._rank) * shard_packs + index) * Int64(16),
++                    final_low[0],
++                    final_low[1],
++                    final_low[2],
++                    final_low[3],
++                )
++                st_global_v4_u32(
++                    destination_stage
++                    + (Int64(self._rank ^ 1) * shard_packs + index) * Int64(16),
++                    final_high[0],
++                    final_high[1],
++                    final_high[2],
++                    final_high[3],
+                 )
+ 
+     @cute.jit
+@@ -407,10 +605,44 @@ class _FusedOneshotLaunch(_PackedMath):
+         input_base: Int64,
+         residual_base: Int64,
+         index: Int64,
++        total_packs: Int64,
+         shard_packs: Int64,
+         accumulator: cute.Tensor,
+     ) -> None:
+-        if cutlass.const_expr(self._mode == "stage_push"):
++        if cutlass.const_expr(self._mode == "stage_tp8_owner"):
++            part = total_packs // Int64(4)
++            chunk = index // part
++            if chunk > Int64(3):
++                chunk = Int64(3)
++            island_base = Int64(0 if self._rank < 4 else 4)
++            owner_rank = island_base + chunk
++            local_stage = Int64(peer_ptrs[self._rank])
++            low = ld_global_v4_u32(
++                local_stage + (owner_rank * shard_packs + index) * Int64(16)
++            )
++            high = ld_global_v4_u32(
++                local_stage
++                + ((owner_rank ^ Int64(1)) * shard_packs + index) * Int64(16)
++            )
++            for lane in cutlass.range_constexpr(4):
++                accumulator[lane] = u32_as_f32(low[lane])
++                accumulator[lane + 4] = u32_as_f32(high[lane])
++        elif cutlass.const_expr(self._mode == "stage_remote_push"):
++            self._load_accumulate(
++                accumulator,
++                input_base + index * Int64(16),
++                True,
++            )
++            local_stage = Int64(peer_ptrs[self._rank])
++            for peer_index in cutlass.range_constexpr(1, self._world_size):
++                source_rank = (self._rank + peer_index) % self._world_size
++                self._load_accumulate(
++                    accumulator,
++                    local_stage
++                    + (Int64(source_rank) * shard_packs + index) * Int64(16),
++                    False,
++                )
++        elif cutlass.const_expr(self._mode == "stage_push"):
+             self._load_accumulate(
+                 accumulator,
+                 input_base + index * Int64(16),
+@@ -423,10 +655,7 @@ class _FusedOneshotLaunch(_PackedMath):
+                     self._load_accumulate(
+                         accumulator,
+                         local_stage
+-                        + (
+-                            Int64(source_rank) * shard_packs + index
+-                        )
+-                        * Int64(16),
++                        + (Int64(source_rank) * shard_packs + index) * Int64(16),
+                         not initialized,
+                     )
+                     initialized = True
+@@ -480,7 +709,6 @@ class _FusedOneshotLaunch(_PackedMath):
+         shard_packs: Int64,
+         epsilon: Float32,
+     ) -> None:
+-        del rows
+         tidx, _, _ = cute.arch.thread_idx()
+         bidx, _, _ = cute.arch.block_idx()
+         gdim, _, _ = cute.arch.grid_dim()
+@@ -494,6 +722,7 @@ class _FusedOneshotLaunch(_PackedMath):
+             col_stride = ctas_per_row * Int32(self._threads)
+         col0 = row_cta * Int32(self._threads) + Int32(tidx)
+         row_offset = Int64(row) * Int64(hidden_packs)
++        total_packs = Int64(rows) * Int64(hidden_packs)
+ 
+         input_base = Int64(input_ptr.toint())
+         residual_base = Int64(residual_ptr.toint())
+@@ -502,9 +731,7 @@ class _FusedOneshotLaunch(_PackedMath):
+         residual_output_base = Int64(residual_output_ptr.toint())
+         self_signal = Int64(signal_ptrs[self._rank])
+         if cutlass.const_expr(self._device_slot_selection):
+-            generation = ld_relaxed_gpu_u32(
+-                self_signal + Int64(_GRAPH_EPOCH_OFFSET)
+-            )
++            generation = ld_relaxed_gpu_u32(self_signal + Int64(_GRAPH_EPOCH_OFFSET))
+             slot = (generation + Uint32(self._slot_bias)) % Uint32(2)
+             peer_ptrs = peer_ptrs + Int64(slot) * Int64(_MAX_RANKS)
+ 
+@@ -535,6 +762,7 @@ class _FusedOneshotLaunch(_PackedMath):
+                         peer_ptrs,
+                         input_base,
+                         row_offset + Int64(col),
++                        total_packs,
+                         shard_packs,
+                     )
+         elif cutlass.const_expr(self._mode != "registered"):
+@@ -544,16 +772,39 @@ class _FusedOneshotLaunch(_PackedMath):
+                     peer_ptrs,
+                     input_base,
+                     row_offset + Int64(col),
++                    total_packs,
+                     shard_packs,
+                 )
+                 col += col_stride
+ 
+-        self._multi_gpu_barrier(signal_ptrs)
++        if cutlass.const_expr(self._mode == "stage_tp8_owner"):
++            self._tp8_island_barrier(signal_ptrs)
++            col = col0
++            while col < hidden_packs:
++                self._tp8_publish_local_partial(
++                    peer_ptrs,
++                    row_offset + Int64(col),
++                    total_packs,
++                    shard_packs,
++                )
++                col += col_stride
++            self._tp8_owner_pair_barrier(signal_ptrs)
++
++            col = col0
++            while col < hidden_packs:
++                self._tp8_publish_final(
++                    peer_ptrs,
++                    row_offset + Int64(col),
++                    total_packs,
++                    shard_packs,
++                )
++                col += col_stride
++            self._tp8_island_barrier(signal_ptrs)
++        else:
++            self._multi_gpu_barrier(signal_ptrs)
+ 
+         square_sum = Float32(0.0)
+-        values = cute.make_rmem_tensor(
+-            (_REG_PACKS, self._pack_elems), cutlass.Float32
+-        )
++        values = cute.make_rmem_tensor((_REG_PACKS, self._pack_elems), cutlass.Float32)
+         if cutlass.const_expr(self._register_normalize):
+             for pack_number in cutlass.range_constexpr(_REG_PACKS):
+                 col = col0 + Int32(pack_number) * col_stride
+@@ -567,6 +818,7 @@ class _FusedOneshotLaunch(_PackedMath):
+                         input_base,
+                         residual_base,
+                         index,
++                        total_packs,
+                         shard_packs,
+                         accumulator,
+                     )
+@@ -589,6 +841,7 @@ class _FusedOneshotLaunch(_PackedMath):
+                     input_base,
+                     residual_base,
+                     index,
++                    total_packs,
+                     shard_packs,
+                     accumulator,
+                 )
+@@ -604,38 +857,28 @@ class _FusedOneshotLaunch(_PackedMath):
+         hidden_size_f = Float32(hidden_packs * Int32(self._pack_elems))
+         if cutlass.const_expr(self._single_cta):
+             if Int32(tidx) == Int32(0):
+-                inv_rms_smem[0] = rsqrt_approx_f32(
+-                    square_sum / hidden_size_f + epsilon
+-                )
++                inv_rms_smem[0] = rsqrt_approx_f32(square_sum / hidden_size_f + epsilon)
+         else:
+             if Int32(tidx) == Int32(0):
+                 st_global_f32(
+-                    self_signal
+-                    + Int64(_RMS_PARTIAL_OFFSET)
+-                    + Int64(bidx) * Int64(4),
++                    self_signal + Int64(_RMS_PARTIAL_OFFSET) + Int64(bidx) * Int64(4),
+                     square_sum,
+                 )
+                 threadfence_gpu()
+                 arrive_address = (
+-                    self_signal
+-                    + Int64(_RMS_ARRIVE_OFFSET)
+-                    + Int64(row) * Int64(4)
++                    self_signal + Int64(_RMS_ARRIVE_OFFSET) + Int64(row) * Int64(4)
+                 )
+                 prior = atomic_add_global_u32(arrive_address, Uint32(1))
+                 if prior == Uint32(ctas_per_row - Int32(1)):
+                     st_global_u32(arrive_address, Uint32(0))
+                     threadfence_gpu()
+                     atomic_add_global_u32(
+-                        self_signal
+-                        + Int64(_RMS_GEN_OFFSET)
+-                        + Int64(row) * Int64(4),
++                        self_signal + Int64(_RMS_GEN_OFFSET) + Int64(row) * Int64(4),
+                         Uint32(1),
+                     )
+                 else:
+                     spin_until_changed_acquire_gpu(
+-                        self_signal
+-                        + Int64(_RMS_GEN_OFFSET)
+-                        + Int64(row) * Int64(4),
++                        self_signal + Int64(_RMS_GEN_OFFSET) + Int64(row) * Int64(4),
+                         row_generation,
+                     )
+             cute.arch.sync_threads()
+@@ -646,10 +889,7 @@ class _FusedOneshotLaunch(_PackedMath):
+                     partial = partial + ld_global_f32(
+                         self_signal
+                         + Int64(_RMS_PARTIAL_OFFSET)
+-                        + (
+-                            Int64(row) * Int64(ctas_per_row)
+-                            + Int64(partial_index)
+-                        )
++                        + (Int64(row) * Int64(ctas_per_row) + Int64(partial_index))
+                         * Int64(4)
+                     )
+                     partial_index += Int32(32)
+@@ -665,9 +905,7 @@ class _FusedOneshotLaunch(_PackedMath):
+             for pack_number in cutlass.range_constexpr(_REG_PACKS):
+                 col = col0 + Int32(pack_number) * col_stride
+                 if col < hidden_packs:
+-                    scale = cute.make_rmem_tensor(
+-                        (self._pack_elems,), cutlass.Float32
+-                    )
++                    scale = cute.make_rmem_tensor((self._pack_elems,), cutlass.Float32)
+                     self._load_accumulate(
+                         scale, weight_base + Int64(col) * Int64(16), True
+                     )
+@@ -675,38 +913,28 @@ class _FusedOneshotLaunch(_PackedMath):
+                         (self._pack_elems,), cutlass.Float32
+                     )
+                     for lane in cutlass.range_constexpr(self._pack_elems):
+-                        normalized[lane] = (
+-                            values[pack_number, lane]
+-                            * (inv_rms * scale[lane])
++                        normalized[lane] = values[pack_number, lane] * (
++                            inv_rms * scale[lane]
+                         )
+                     self._store_accumulator(
+-                        output_base
+-                        + (row_offset + Int64(col)) * Int64(16),
++                        output_base + (row_offset + Int64(col)) * Int64(16),
+                         normalized,
+                     )
+         else:
+             col = col0
+             while col < hidden_packs:
+                 index = row_offset + Int64(col)
+-                value = cute.make_rmem_tensor(
+-                    (self._pack_elems,), cutlass.Float32
+-                )
+-                scale = cute.make_rmem_tensor(
+-                    (self._pack_elems,), cutlass.Float32
+-                )
++                value = cute.make_rmem_tensor((self._pack_elems,), cutlass.Float32)
++                scale = cute.make_rmem_tensor((self._pack_elems,), cutlass.Float32)
+                 self._load_accumulate(
+                     value,
+                     residual_output_base + index * Int64(16),
+                     True,
+                 )
+-                self._load_accumulate(
+-                    scale, weight_base + Int64(col) * Int64(16), True
+-                )
++                self._load_accumulate(scale, weight_base + Int64(col) * Int64(16), True)
+                 for lane in cutlass.range_constexpr(self._pack_elems):
+                     value[lane] = value[lane] * (inv_rms * scale[lane])
+-                self._store_accumulator(
+-                    output_base + index * Int64(16), value
+-                )
++                self._store_accumulator(output_base + index * Int64(16), value)
+                 col += col_stride
+ 
+         if cutlass.const_expr(self._device_slot_selection):
+@@ -719,9 +947,7 @@ class _FusedOneshotLaunch(_PackedMath):
+ 
+ 
+ def _dummy(dtype, alignment: int):
+-    return make_ptr(
+-        dtype, 16, cute.AddressSpace.gmem, assumed_align=alignment
+-    )
++    return make_ptr(dtype, 16, cute.AddressSpace.gmem, assumed_align=alignment)
+ 
+ 
+ def _oneshot_process_key(
+@@ -758,16 +984,19 @@ def is_oneshot_launcher_prepared(
+ ) -> bool:
+     """Return whether this exact process-local launcher is already loaded."""
+ 
+-    return _oneshot_process_key(
+-        dtype_name,
+-        world_size,
+-        rank,
+-        stage_input,
+-        device_slot_selection,
+-        slot_bias,
+-        threads,
+-        device_index,
+-    ) in _PREPARED_ONESHOT_LAUNCHERS
++    return (
++        _oneshot_process_key(
++            dtype_name,
++            world_size,
++            rank,
++            stage_input,
++            device_slot_selection,
++            slot_bias,
++            threads,
++            device_index,
++        )
++        in _PREPARED_ONESHOT_LAUNCHERS
++    )
+ 
+ 
+ @functools.cache
+@@ -823,9 +1052,7 @@ def get_oneshot_launcher(
+         1,
+         1,
+         current_cuda_stream(),
+-        compile_spec=KernelCompileSpec.from_key(
+-            "comm.pcie.oneshot", 1, cache_key
+-        ),
++        compile_spec=KernelCompileSpec.from_key("comm.pcie.oneshot", 1, cache_key),
+     )
+ 
+     def run(
+@@ -910,18 +1137,21 @@ def is_fused_oneshot_launcher_prepared(
+ ) -> bool:
+     """Return whether this exact fused graph launcher is already loaded."""
+ 
+-    return _fused_oneshot_process_key(
+-        dtype_name,
+-        world_size,
+-        rank,
+-        mode,
+-        single_cta,
+-        register_normalize,
+-        device_slot_selection,
+-        slot_bias,
+-        threads,
+-        device_index,
+-    ) in _PREPARED_FUSED_ONESHOT_LAUNCHERS
++    return (
++        _fused_oneshot_process_key(
++            dtype_name,
++            world_size,
++            rank,
++            mode,
++            single_cta,
++            register_normalize,
++            device_slot_selection,
++            slot_bias,
++            threads,
++            device_index,
++        )
++        in _PREPARED_FUSED_ONESHOT_LAUNCHERS
++    )
+ 
+ 
+ @functools.cache
+@@ -1013,13 +1243,39 @@ def get_fused_oneshot_launcher(
+         grid_x: int,
+     ) -> None:
+         raw(
+-            make_ptr(cutlass.Uint64, peer_table_address, cute.AddressSpace.gmem, assumed_align=8),
+-            make_ptr(cutlass.Uint64, signal_table_address, cute.AddressSpace.gmem, assumed_align=8),
+-            make_ptr(cutlass.Uint32, input_address, cute.AddressSpace.gmem, assumed_align=16),
+-            make_ptr(cutlass.Uint32, residual_address, cute.AddressSpace.gmem, assumed_align=16),
+-            make_ptr(cutlass.Uint32, weight_address, cute.AddressSpace.gmem, assumed_align=16),
+-            make_ptr(cutlass.Uint32, output_address, cute.AddressSpace.gmem, assumed_align=16),
+-            make_ptr(cutlass.Uint32, residual_output_address, cute.AddressSpace.gmem, assumed_align=16),
++            make_ptr(
++                cutlass.Uint64,
++                peer_table_address,
++                cute.AddressSpace.gmem,
++                assumed_align=8,
++            ),
++            make_ptr(
++                cutlass.Uint64,
++                signal_table_address,
++                cute.AddressSpace.gmem,
++                assumed_align=8,
++            ),
++            make_ptr(
++                cutlass.Uint32, input_address, cute.AddressSpace.gmem, assumed_align=16
++            ),
++            make_ptr(
++                cutlass.Uint32,
++                residual_address,
++                cute.AddressSpace.gmem,
++                assumed_align=16,
++            ),
++            make_ptr(
++                cutlass.Uint32, weight_address, cute.AddressSpace.gmem, assumed_align=16
++            ),
++            make_ptr(
++                cutlass.Uint32, output_address, cute.AddressSpace.gmem, assumed_align=16
++            ),
++            make_ptr(
++                cutlass.Uint32,
++                residual_output_address,
++                cute.AddressSpace.gmem,
++                assumed_align=16,
++            ),
+             int(hidden_packs),
+             int(rows),
+             int(ctas_per_row),
+diff --git a/b12x/comm/pcie/pcie_oneshot.py b/b12x/comm/pcie/pcie_oneshot.py
+index 614266b4b705566dd29340a87bd0aa5ea5415b8e..6dcc3c8df2e8ba22617f6e8fd5f67ca990126172 100644
+--- a/b12x/comm/pcie/pcie_oneshot.py
++++ b/b12x/comm/pcie/pcie_oneshot.py
+@@ -114,6 +114,51 @@ def _push_mode_enabled() -> bool:
+     return os.getenv("B12X_PCIE_ONESHOT_PUSH", "0") not in ("", "0")
+ 
+ 
++def _tp2_remote_push_enabled() -> bool:
++    """Enable the qualified fused TP2 remote-write transport."""
++
++    return os.getenv("B12X_PCIE_TP2_REMOTE_PUSH", "0") not in ("", "0")
++
++
++def _tp4_remote_push_enabled() -> bool:
++    """Enable the qualified fused TP4 remote-write transport."""
++
++    return os.getenv("B12X_PCIE_TP4_REMOTE_PUSH", "0") not in ("", "0")
++
++
++def _tp8_owner_reduce_enabled() -> bool:
++    """Enable the qualified topology-scoped fused TP8 transport by default."""
++
++    return os.getenv("B12X_PCIE_TP8_OWNER_REDUCE", "1") not in ("", "0")
++
++
++def _uses_sharded_eager_storage(
++    world_size: int,
++    transport_policy: Optional[tuple[bool, bool, bool, bool]] = None,
++) -> bool:
++    """Return whether staged fused transport needs one shard per source."""
++
++    push, tp2_remote, tp4_remote, tp8_owner = (
++        _transport_policy_contract() if transport_policy is None else transport_policy
++    )
++    return push or (
++        (world_size == 2 and tp2_remote)
++        or (world_size == 4 and tp4_remote)
++        or (world_size == 8 and tp8_owner)
++    )
++
++
++def _transport_policy_contract() -> tuple[bool, bool, bool, bool]:
++    """Values that must agree across ranks before IPC storage is allocated."""
++
++    return (
++        _push_mode_enabled(),
++        _tp2_remote_push_enabled(),
++        _tp4_remote_push_enabled(),
++        _tp8_owner_reduce_enabled(),
++    )
++
++
+ def _is_weak_contiguous(inp: torch.Tensor) -> bool:
+     if inp.is_contiguous():
+         return True
+@@ -569,9 +614,7 @@ def _require_full_grid_residency(
+         visible_sms = int(
+             torch.cuda.get_device_properties(device).multi_processor_count
+         )
+-        test_visible_sms = int(
+-            os.getenv("B12X_PCIE_TEST_VISIBLE_SM_COUNT", "0") or "0"
+-        )
++        test_visible_sms = int(os.getenv("B12X_PCIE_TEST_VISIBLE_SM_COUNT", "0") or "0")
+         if test_visible_sms > 0:
+             visible_sms = min(visible_sms, test_visible_sms)
+         if visible_sms < required_sms:
+@@ -1206,6 +1249,9 @@ class _CuTeOneshotState:
+     registered_tables: dict[int, int]
+     eager_tables: Optional[tuple[int, int]] = None
+     eager_ptrs: Optional[tuple[tuple[int, ...], tuple[int, ...]]] = None
++    eager_buffer_bytes: Optional[int] = None
++    transport_policy: tuple[bool, bool, bool, bool] = (False, False, False, False)
++    sharded_eager_storage: bool = False
+     eager_slot: int = 0
+     device_slot_selection: bool = False
+     slot_bias: int = 0
+@@ -1236,6 +1282,8 @@ class _CuTeOneshotBackend:
+         self._next_handle = 1
+         self._states: dict[int, _CuTeOneshotState] = {}
+ 
++    supports_eager_storage_contract = True
++
+     @staticmethod
+     def meta_size() -> int:
+         return _SIGNAL_BYTES
+@@ -1315,6 +1363,8 @@ class _CuTeOneshotBackend:
+         handle: int,
+         pointers0: Sequence[int],
+         pointers1: Sequence[int],
++        eager_buffer_bytes: Optional[int] = None,
++        transport_policy: Optional[tuple[bool, bool, bool, bool]] = None,
+     ) -> None:
+         state = self._state(handle)
+         ptrs0 = tuple(int(pointer) for pointer in pointers0)
+@@ -1323,6 +1373,18 @@ class _CuTeOneshotBackend:
+         table1 = self._write_table(state, ptrs1)
+         state.eager_tables = (table0, table1)
+         state.eager_ptrs = (ptrs0, ptrs1)
++        state.eager_buffer_bytes = (
++            None if eager_buffer_bytes is None else int(eager_buffer_bytes)
++        )
++        state.transport_policy = (
++            _transport_policy_contract()
++            if transport_policy is None
++            else tuple(bool(value) for value in transport_policy)
++        )
++        state.sharded_eager_storage = _uses_sharded_eager_storage(
++            state.world_size,
++            state.transport_policy,
++        )
+         state.registered_tables[ptrs0[state.rank]] = table0
+         state.registered_tables[ptrs1[state.rank]] = table1
+         state.eager_slot = 0
+@@ -1331,9 +1393,7 @@ class _CuTeOneshotBackend:
+     def _launch_geometry(size_packs: int) -> tuple[int, int]:
+         threads = int(os.getenv("B12X_PCIE_ONESHOT_THREADS", "256"))
+         threads = min(512, max(64, (threads // 32) * 32))
+-        block_limit = int(
+-            os.getenv("B12X_PCIE_ONESHOT_BLOCK_LIMIT", "8")
+-        )
++        block_limit = int(os.getenv("B12X_PCIE_ONESHOT_BLOCK_LIMIT", "8"))
+         if block_limit <= 0 or block_limit > _MAX_BLOCKS:
+             raise ValueError(
+                 f"B12X_PCIE_ONESHOT_BLOCK_LIMIT must be in [1, {_MAX_BLOCKS}]"
+@@ -1346,6 +1406,43 @@ class _CuTeOneshotBackend:
+         threads = int(os.getenv("B12X_PCIE_FUSED_THREADS", "256"))
+         return min(512, max(64, (threads // 32) * 32))
+ 
++    @staticmethod
++    def _fused_topology_mode(
++        state: _CuTeOneshotState,
++        inp: torch.Tensor,
++    ) -> Optional[str]:
++        """Select only topology transports with a qualified shape contract."""
++
++        if (
++            state.eager_tables is None
++            or state.eager_buffer_bytes is None
++            or inp.dtype not in (torch.float16, torch.bfloat16)
++            or inp.ndim == 0
++        ):
++            return None
++        hidden = int(inp.shape[-1])
++        if hidden <= 0 or inp.numel() % hidden != 0:
++            return None
++        rows = inp.numel() // hidden
++        _, tp2_remote, tp4_remote, tp8_owner = state.transport_policy
++        if (
++            state.world_size == 8
++            and tp8_owner
++            and hidden in (4096, 6144)
++            and 2 <= rows <= 8
++        ):
++            return "stage_tp8_owner"
++        if (
++            state.world_size == 4
++            and tp4_remote
++            and hidden in (4096, 6144)
++            and 1 <= rows <= 32
++        ):
++            return "stage_remote_push"
++        if state.world_size == 2 and tp2_remote and hidden == 4096 and 1 <= rows <= 32:
++            return "stage_remote_push"
++        return None
++
+     @classmethod
+     def _fused_launch_config(
+         cls,
+@@ -1360,17 +1457,20 @@ class _CuTeOneshotBackend:
+         if override > 0:
+             ctas_per_row = override
+         else:
+-            min_ctas = (
+-                hidden_packs + threads * _REG_PACKS - 1
+-            ) // (threads * _REG_PACKS)
++            min_ctas = (hidden_packs + threads * _REG_PACKS - 1) // (
++                threads * _REG_PACKS
++            )
+             ctas_per_row = max(max(1, 3 // rows), min_ctas)
+         ctas_per_row = max(1, min(ctas_per_row, _MAX_BLOCKS // rows))
+-        register_normalize = (
+-            hidden_packs + ctas_per_row * threads - 1
+-        ) // (ctas_per_row * threads) <= _REG_PACKS
+-        if state.eager_tables is None:
++        register_normalize = (hidden_packs + ctas_per_row * threads - 1) // (
++            ctas_per_row * threads
++        ) <= _REG_PACKS
++        topology_mode = cls._fused_topology_mode(state, inp)
++        if topology_mode is not None:
++            mode = topology_mode
++        elif state.eager_tables is None:
+             mode = "registered"
+-        elif _push_mode_enabled():
++        elif state.transport_policy[0]:
+             mode = "stage_push"
+         else:
+             mode = "stage_pull"
+@@ -1378,11 +1478,7 @@ class _CuTeOneshotBackend:
+ 
+     @staticmethod
+     def _device_index(device: torch.device) -> int:
+-        return (
+-            device.index
+-            if device.index is not None
+-            else torch.cuda.current_device()
+-        )
++        return device.index if device.index is not None else torch.cuda.current_device()
+ 
+     def prepare_all_reduce(self, handle: int, inp: torch.Tensor) -> None:
+         """Compile/load every graph slot variant without launching a kernel."""
+@@ -1412,7 +1508,10 @@ class _CuTeOneshotBackend:
+         """Compile/load fused graph variants without launching a kernel."""
+ 
+         state = self._state(handle)
+-        if state.eager_tables is None and int(inp.data_ptr()) not in state.registered_tables:
++        if (
++            state.eager_tables is None
++            and int(inp.data_ptr()) not in state.registered_tables
++        ):
+             raise RuntimeError("input buffer is not registered")
+         mode, single_cta, register_normalize, threads = self._fused_launch_config(
+             state, inp
+@@ -1421,9 +1520,7 @@ class _CuTeOneshotBackend:
+ 
+         device_index = self._device_index(inp.device)
+         variants = (
+-            ((True, 0), (True, 1))
+-            if state.eager_tables is not None
+-            else ((False, 0),)
++            ((True, 0), (True, 1)) if state.eager_tables is not None else ((False, 0),)
+         )
+         for device_slot_selection, slot_bias in variants:
+             get_fused_oneshot_launcher(
+@@ -1440,9 +1537,7 @@ class _CuTeOneshotBackend:
+             )
+ 
+     @staticmethod
+-    def _select_table(
+-        state: _CuTeOneshotState, input_pointer: int
+-    ) -> tuple[int, bool]:
++    def _select_table(state: _CuTeOneshotState, input_pointer: int) -> tuple[int, bool]:
+         if state.eager_tables is not None:
+             if state.device_slot_selection:
+                 # The two 16-entry tables are adjacent in rank_data.  A
+@@ -1477,9 +1572,7 @@ class _CuTeOneshotBackend:
+             capturing and state.eager_tables is not None
+         )
+         prospective_slot_bias = (
+-            state.slot_bias
+-            if state.device_slot_selection
+-            else state.eager_slot & 1
++            state.slot_bias if state.device_slot_selection else state.eager_slot & 1
+         )
+         if capturing:
+             from ._oneshot_cute import is_oneshot_launcher_prepared
+@@ -1498,7 +1591,11 @@ class _CuTeOneshotBackend:
+                     "cold PCIe oneshot CUDA graph capture is not allowed; "
+                     "call prepare_graph_all_reduce() before capture"
+                 )
+-        if capturing and state.eager_tables is not None and not state.device_slot_selection:
++        if (
++            capturing
++            and state.eager_tables is not None
++            and not state.device_slot_selection
++        ):
+             # The graph epoch begins at zero.  Bias it to the host slot that
+             # would have been selected for this invocation, then keep both
+             # values fixed in the captured specialization.
+@@ -1563,9 +1660,7 @@ class _CuTeOneshotBackend:
+             capturing and state.eager_tables is not None
+         )
+         prospective_slot_bias = (
+-            state.slot_bias
+-            if state.device_slot_selection
+-            else state.eager_slot & 1
++            state.slot_bias if state.device_slot_selection else state.eager_slot & 1
+         )
+         if capturing:
+             from ._oneshot_cute import is_fused_oneshot_launcher_prepared
+@@ -1602,9 +1697,9 @@ class _CuTeOneshotBackend:
+         if override > 0:
+             ctas_per_row = override
+         else:
+-            min_ctas = (
+-                hidden_packs + threads * _REG_PACKS - 1
+-            ) // (threads * _REG_PACKS)
++            min_ctas = (hidden_packs + threads * _REG_PACKS - 1) // (
++                threads * _REG_PACKS
++            )
+             ctas_per_row = max(max(1, 3 // rows), min_ctas)
+         ctas_per_row = max(1, min(ctas_per_row, _MAX_BLOCKS // rows))
+         assert single_cta_check == (ctas_per_row == 1)
+@@ -1650,7 +1745,7 @@ class _CuTeOneshotBackend:
+                 hidden_packs,
+                 rows,
+                 ctas_per_row,
+-                inp.numel() // pack_elems,
++                int(state.eager_buffer_bytes or inp.numel() * inp.element_size()) // 16,
+                 float(epsilon),
+                 blocks,
+             )
+@@ -1664,9 +1759,7 @@ class _CuTeOneshotBackend:
+     def register_graph_buffers(self, handle: int, handles, offsets) -> None:
+         self._state(handle)
+         if any(handles) or any(offsets):
+-            raise RuntimeError(
+-                "CuTe oneshot graph capture requires eager IPC buffers"
+-            )
++            raise RuntimeError("CuTe oneshot graph capture requires eager IPC buffers")
+ 
+     def dispose(self, handle: int) -> None:
+         with self._lock:
+@@ -1766,6 +1859,7 @@ class PCIeOneshotAllReduce:
+             normalized_eager_bytes = (
+                 None if eager_buffer_bytes is None else int(eager_buffer_bytes)
+             )
++            normalized_transport_policy = _transport_policy_contract()
+             if normalized_world_size not in SUPPORTED_WORLD_SIZES:
+                 raise ValueError(f"unsupported world size {normalized_world_size}")
+             if not 0 <= normalized_rank < normalized_world_size:
+@@ -1832,6 +1926,7 @@ class PCIeOneshotAllReduce:
+                 normalized_eager0,
+                 normalized_eager1,
+                 normalized_eager_bytes,
++                normalized_transport_policy,
+                 normalized_max_size,
+                 normalized_rank_data_bytes,
+             )
+@@ -1853,6 +1948,7 @@ class PCIeOneshotAllReduce:
+             normalized_eager0,
+             normalized_eager1,
+             normalized_eager_bytes,
++            normalized_transport_policy,
+             normalized_max_size,
+             normalized_rank_data_bytes,
+         ) = normalized
+@@ -1865,6 +1961,7 @@ class PCIeOneshotAllReduce:
+             eager_buffer_ptrs0=normalized_eager0,
+             eager_buffer_ptrs1=normalized_eager1,
+             eager_buffer_bytes=normalized_eager_bytes,
++            transport_policy=normalized_transport_policy,
+             exchange_group=resolved_group,
+             ipc=ipc,
+             owned_buffers=owned_buffers,
+@@ -1911,6 +2008,7 @@ class PCIeOneshotAllReduce:
+                     self.rank_data_bytes,
+                     self.eager_buffer_bytes,
+                     self._pending_eager_ptrs is not None,
++                    self._transport_policy,
+                 ),
+             )
+ 
+@@ -1941,6 +2039,7 @@ class PCIeOneshotAllReduce:
+         eager_buffer_ptrs0: Optional[Sequence[int]],
+         eager_buffer_ptrs1: Optional[Sequence[int]],
+         eager_buffer_bytes: Optional[int],
++        transport_policy: tuple[bool, bool, bool, bool],
+         exchange_group: Optional[ProcessGroup],
+         ipc: Optional[CudaRTLibrary],
+         owned_buffers: Optional[Sequence[_OwnedSharedBuffer]],
+@@ -1959,6 +2058,11 @@ class PCIeOneshotAllReduce:
+         self.eager_buffer_bytes = (
+             None if eager_buffer_bytes is None else int(eager_buffer_bytes)
+         )
++        self._transport_policy = tuple(bool(value) for value in transport_policy)
++        self._sharded_eager_storage = _uses_sharded_eager_storage(
++            self.world_size,
++            self._transport_policy,
++        )
+         self._ipc = ipc
+         self._ext = ext_module
+         self._signal_ptrs = tuple(int(ptr) for ptr in signal_ptrs)
+@@ -1993,11 +2097,24 @@ class PCIeOneshotAllReduce:
+             )
+             if self._pending_eager_ptrs is not None:
+                 self._eager_ptrs = self._pending_eager_ptrs
+-                self._ext.register_pcie_buffers(
+-                    self._ptr,
+-                    list(self._eager_ptrs[0]),
+-                    list(self._eager_ptrs[1]),
+-                )
++                if getattr(
++                    self._ext,
++                    "supports_eager_storage_contract",
++                    False,
++                ):
++                    self._ext.register_pcie_buffers(
++                        self._ptr,
++                        list(self._eager_ptrs[0]),
++                        list(self._eager_ptrs[1]),
++                        self.eager_buffer_bytes,
++                        self._transport_policy,
++                    )
++                else:
++                    self._ext.register_pcie_buffers(
++                        self._ptr,
++                        list(self._eager_ptrs[0]),
++                        list(self._eager_ptrs[1]),
++                    )
+         except Exception as exc:
+             init_error = exc
+         finally:
+@@ -2068,6 +2185,7 @@ class PCIeOneshotAllReduce:
+             normalized_eager_bytes = int(eager_buffer_bytes)
+             normalized_max_size = int(max_size)
+             normalized_rank_data_bytes = int(rank_data_bytes)
++            normalized_transport_policy = _transport_policy_contract()
+             if world_size not in SUPPORTED_WORLD_SIZES:
+                 raise ValueError(f"unsupported world size {world_size}")
+             if device_obj.type != "cuda":
+@@ -2085,14 +2203,19 @@ class PCIeOneshotAllReduce:
+                 normalized_eager_bytes,
+                 normalized_max_size,
+                 normalized_rank_data_bytes,
++                normalized_transport_policy,
+             )
+ 
+-        device_obj, eager_buffer_bytes, max_size, rank_data_bytes = (
+-            _run_collective_preallocation_setup(
+-                owner="PCIe oneshot argument validation",
+-                exchange_group=exchange_group,
+-                setup=validate_factory_arguments,
+-            )
++        (
++            device_obj,
++            eager_buffer_bytes,
++            max_size,
++            rank_data_bytes,
++            transport_policy,
++        ) = _run_collective_preallocation_setup(
++            owner="PCIe oneshot argument validation",
++            exchange_group=exchange_group,
++            setup=validate_factory_arguments,
+         )
+ 
+         _require_full_grid_residency(
+@@ -2121,7 +2244,7 @@ class PCIeOneshotAllReduce:
+                 eager_buffer_bytes,
+                 max_size,
+                 rank_data_bytes,
+-                _push_mode_enabled(),
++                transport_policy,
+             ),
+         )
+ 
+@@ -2129,6 +2252,10 @@ class PCIeOneshotAllReduce:
+             exchange_group,
+             signal_bytes=signal_bytes,
+             eager_buffer_bytes=eager_buffer_bytes,
++            sharded_eager_storage=_uses_sharded_eager_storage(
++                world_size,
++                transport_policy,
++            ),
+             ipc=ipc,
+         )
+         owned_buffers = [channel_buffers.owned_buffer]
+@@ -2140,6 +2267,7 @@ class PCIeOneshotAllReduce:
+             eager_buffer_ptrs0=channel_buffers.eager0_ptrs,
+             eager_buffer_ptrs1=channel_buffers.eager1_ptrs,
+             eager_buffer_bytes=eager_buffer_bytes,
++            transport_policy=transport_policy,
+             exchange_group=exchange_group,
+             ipc=ipc,
+             owned_buffers=owned_buffers,
+@@ -2399,6 +2527,7 @@ class PCIeOneshotAllReduce:
+         *,
+         signal_bytes: int,
+         eager_buffer_bytes: int,
++        sharded_eager_storage: bool,
+         ipc: CudaRTLibrary,
+     ) -> _ChannelSharedBuffers:
+         signal_bytes = int(signal_bytes)
+@@ -2407,7 +2536,7 @@ class PCIeOneshotAllReduce:
+             raise ValueError("signal_bytes must be positive")
+         if eager_buffer_bytes <= 0:
+             raise ValueError("eager_buffer_bytes must be positive")
+-        if _push_mode_enabled():
++        if sharded_eager_storage:
+             eager_buffer_bytes *= dist.get_world_size(group=exchange_group)
+ 
+         signal_offset = 0
+@@ -2523,7 +2652,9 @@ class PCIeOneshotAllReduce:
+         if not self.should_allreduce(inp) or inp.ndim == 0:
+             raise ValueError("input does not satisfy fused PCIe oneshot requirements")
+         if inp.shape[-1] * inp.element_size() % 16 != 0:
+-            raise ValueError("the last input dimension must occupy a multiple of 16 bytes")
++            raise ValueError(
++                "the last input dimension must occupy a multiple of 16 bytes"
++            )
+         self._check_stream()
+         self._prepare_input(inp, peer_input_ptrs)
+         self._ext.prepare_fused_all_reduce(self._ptr, inp)
+@@ -3030,6 +3161,7 @@ class PCIeOneshotAllReducePool:
+             normalized_rank_data_bytes = int(rank_data_bytes)
+             normalized_single_channel = bool(single_channel)
+             normalized_max_concurrent_channels = int(max_concurrent_channels)
++            normalized_transport_policy = _transport_policy_contract()
+             if normalized_world_size not in SUPPORTED_WORLD_SIZES:
+                 raise ValueError(f"unsupported world size {normalized_world_size}")
+             if not 0 <= normalized_rank < normalized_world_size:
+@@ -3075,6 +3207,7 @@ class PCIeOneshotAllReducePool:
+                 normalized_rank_data_bytes,
+                 normalized_single_channel,
+                 normalized_max_concurrent_channels,
++                normalized_transport_policy,
+             )
+ 
+         if channel_factory is None and resolved_group is not None:
+@@ -3095,7 +3228,12 @@ class PCIeOneshotAllReducePool:
+             self.rank_data_bytes,
+             self.single_channel,
+             self.max_concurrent_channels,
++            self._transport_policy,
+         ) = normalized
++        self._sharded_eager_storage = _uses_sharded_eager_storage(
++            self.world_size,
++            self._transport_policy,
++        )
+         self.exchange_group = resolved_group
+         self.process_group = self.exchange_group
+         self._channel_factory = channel_factory
+@@ -3145,7 +3283,7 @@ class PCIeOneshotAllReducePool:
+                     self.rank_data_bytes,
+                     self.single_channel,
+                     self.max_concurrent_channels,
+-                    _push_mode_enabled(),
++                    self._transport_policy,
+                 ),
+             )
+             # A genuine single-channel pool has no independent eager/graph
+@@ -3223,6 +3361,7 @@ class PCIeOneshotAllReducePool:
+             self.exchange_group,
+             signal_bytes=self._signal_bytes,
+             eager_buffer_bytes=self.eager_buffer_bytes,
++            sharded_eager_storage=self._sharded_eager_storage,
+             ipc=self._ipc,
+         )
+         owned_buffers = [channel_buffers.owned_buffer]
+@@ -3234,6 +3373,7 @@ class PCIeOneshotAllReducePool:
+             eager_buffer_ptrs0=channel_buffers.eager0_ptrs,
+             eager_buffer_ptrs1=channel_buffers.eager1_ptrs,
+             eager_buffer_bytes=self.eager_buffer_bytes,
++            transport_policy=self._transport_policy,
+             exchange_group=self.exchange_group,
+             ipc=self._ipc,
+             owned_buffers=owned_buffers,
+@@ -3486,9 +3626,7 @@ class PCIeOneshotAllReducePool:
+                         inp, peer_input_ptrs=peer_input_ptrs
+                     )
+             else:
+-                channel.prepare_graph_all_reduce(
+-                    inp, peer_input_ptrs=peer_input_ptrs
+-                )
++                channel.prepare_graph_all_reduce(inp, peer_input_ptrs=peer_input_ptrs)
+ 
+     def prepare_graph_fused_add_rms_norm(
+         self,
+diff --git a/b12x/moe/_shared/kernels/w4a16/host.py b/b12x/moe/_shared/kernels/w4a16/host.py
+index 6517d2883880bd41438ac6b85c8272488593ddd3..868ef398adef1332d677e5cbc4386431ea9b8501 100644
+--- a/b12x/moe/_shared/kernels/w4a16/host.py
++++ b/b12x/moe/_shared/kernels/w4a16/host.py
+@@ -190,6 +190,32 @@ def route_pack_token_capacity(tokens: int, topk: int) -> int:
+     return 1 << (max(int(tokens), 1) - 1).bit_length()
+ 
+ 
++def route_pack_warmup_token_counts(capacity: int) -> tuple[int, ...]:
++    """Return live row counts covering capacity and scalar specializations.
++
++    Triton specializes the runtime ``live_numel`` scalar on alignment as well
++    as the constexpr route-capacity bucket. For a power-of-two bucket, the
++    bucket maximum and its first live member cover both alignment classes
++    reached by the GLM top-k route counts (for example 8 and 5 rows in the
++    8-row bucket). Warming only bucket maxima leaves the less-aligned variant
++    to compile on the first odd-sized request.
++    """
++    capacity = int(capacity)
++    if capacity < 1:
++        raise ValueError(f"route-pack warmup capacity must be positive, got {capacity}")
++    counts: list[int] = []
++    bucket = 1
++    while True:
++        first_in_bucket = 1 if bucket == 1 else bucket // 2 + 1
++        if first_in_bucket > capacity:
++            break
++        for count in (first_in_bucket, min(bucket, capacity)):
++            if not counts or counts[-1] != count:
++                counts.append(count)
++        bucket *= 2
++    return tuple(counts)
++
++
+ def route_pack_capacity(
+     numel: int,
+     block_size: int,
+@@ -405,6 +431,7 @@ __all__ = [
+     "route_pack_numel_capacity",
+     "route_pack_capacity",
+     "route_pack_token_capacity",
++    "route_pack_warmup_token_counts",
+     "select_route_block_size_m",
+     "unswizzle_block_scale",
+     "unswizzle_expert_scales",
+diff --git a/b12x/moe/_shared/kernels/w4a16/kernel.py b/b12x/moe/_shared/kernels/w4a16/kernel.py
+index 1d0baeddc379086b325ef1c98de9a70f4697660b..51c18da5ee6875e72fa55fcac0a9ba263ae5e112 100644
+--- a/b12x/moe/_shared/kernels/w4a16/kernel.py
++++ b/b12x/moe/_shared/kernels/w4a16/kernel.py
+@@ -441,7 +441,17 @@ def _candidate_tile_fits(
+         or int(tile_k) % scale_group_size != 0
+     ):
+         return False
+-    if int(tile_n) < 64 or int(tile_k) < 64 or int(cta_threads) < 128:
++    ultra_wide_fc2 = (
++        int(tile_n) == 512
++        and int(tile_k) == 32
++        and int(cta_threads) == 256
++        and _scale_group_size(scale_format) == 32
++    )
++    if (
++        int(tile_n) < 64
++        or (int(tile_k) < 64 and not ultra_wide_fc2)
++        or int(cta_threads) < 128
++    ):
+         return False
+     smem_bytes = _shared_memory_footprint(
+         cta_m_blocks=cta_m_blocks,
+@@ -1963,7 +1973,7 @@ class W4A16GemmKernel:
+             reduce_slice_idx,
+             lock_slot,
+             active_size_m,
+-            -1,
++            Int32(0),
+         )
+ 
+     @cute.jit
+@@ -2466,6 +2476,7 @@ class W4A16GemmKernel:
+             a_rows_per_iter,
+             output_n_tile,
+             expert_idx,
++            -1,
+         )
+ 
+         b_scale_cur = cute.make_rmem_tensor((2, 4), Uint32)
+@@ -2478,6 +2489,8 @@ class W4A16GemmKernel:
+             s_sh_rd,
+             Int32(0),
+             Int32(0),
++            Int32(0),
++            0,
+         )
+         a0_regs_cur = cute.make_rmem_tensor((2,), Uint32)
+         a0_regs_next = cute.make_rmem_tensor((2,), Uint32)
+@@ -2524,6 +2537,7 @@ class W4A16GemmKernel:
+             a_rows_per_iter,
+             output_n_tile,
+             expert_idx,
++            0,
+         )
+ 
+         self._finish_tile(
+@@ -2979,6 +2993,7 @@ class W4A16GemmKernel:
+         a_rows_per_iter: Int32,
+         output_n_tile: Int32,
+         expert_idx: Int32,
++        dynamic_pair_override: cutlass.Constexpr[int],
+     ):
+         b_frag = cute.make_rmem_tensor((2, 2), Uint32)
+         tile_idx = Int32(0)
+@@ -3000,6 +3015,7 @@ class W4A16GemmKernel:
+                             kk,
+                             tile_idx,
+                             k_tiles,
++                            dynamic_pair_override,
+                         )
+ 
+                         self._prefetch_pipeline_step(
+@@ -3028,6 +3044,7 @@ class W4A16GemmKernel:
+                             a_rows_per_iter,
+                             output_n_tile,
+                             expert_idx,
++                            dynamic_pair_override,
+                         )
+ 
+                         for jj in cutlass.range_constexpr(4):
+@@ -3068,6 +3085,8 @@ class W4A16GemmKernel:
+                     s_sh_rd,
+                     Int32(0),
+                     Int32(0),
++                    tile_idx,
++                    dynamic_pair_override,
+                 )
+                 self._load_a_registers_m8_bundle(
+                     a0_regs_cur,
+@@ -3856,6 +3875,7 @@ class W4A16GemmKernel:
+         kk: cutlass.Constexpr[int],
+         tile_idx: Int32,
+         k_tiles: Int32,
++        dynamic_pair_override: cutlass.Constexpr[int],
+     ):
+         self._clear_b_scale_register_bundle(b_scale_next)
+         self._clear_a_register_bundle_m8(a0_regs_next)
+@@ -3871,6 +3891,8 @@ class W4A16GemmKernel:
+                     s_sh_rd,
+                     Int32(pipe),
+                     Int32(kk + 1),
++                    tile_idx,
++                    dynamic_pair_override,
+                 )
+                 self._load_a_registers_m8_bundle(
+                     a0_regs_next,
+@@ -3898,6 +3920,8 @@ class W4A16GemmKernel:
+                     s_sh_rd,
+                     next_pipe,
+                     Int32(0),
++                    next_tile,
++                    dynamic_pair_override,
+                 )
+                 self._load_a_registers_m8_bundle(
+                     a0_regs_next,
+@@ -4199,12 +4223,10 @@ class W4A16GemmKernel:
+             for jj in cutlass.range_constexpr(4):
+                 local_n16 = Int32(4) * w_n + Int32(jj)
+                 tile_base = Int32(0)
+-                if cutlass.const_expr(int(low_bits) == int(high_bits)):
+-                    tile_base = kt_base_u32 + local_n16 * Int32(8 * low_bits)
+-                    wa[jj], wb[jj] = self._load_trellis256_pair_tile_windows(
+-                        b_region, tile_base, lane, low_bits
+-                    )
+-                elif logical_k16 < Int32(8):
++                if (
++                    cutlass.const_expr(int(low_bits) == int(high_bits))
++                    or logical_k16 < Int32(8)
++                ):
+                     tile_base = kt_base_u32 + local_n16 * Int32(8 * low_bits)
+                     wa[jj], wb[jj] = self._load_trellis256_pair_tile_windows(
+                         b_region, tile_base, lane, low_bits
+@@ -11241,6 +11263,28 @@ def _trellis_dense_buffer(
+     return buffer
+ 
+ 
++def _use_k6_mcg_small(
++    *,
++    device: torch.device,
++    m: int,
++    trellis_bits: int,
++    trellis_codebook: str,
++    trellis_pair_kind,
++    compute_dtype: torch.dtype,
++    external_hadamard_128,
++) -> bool:
++    """Select the capture-safe K6/MCG kernel only on its compiled target."""
++    return (
++        tuple(torch.cuda.get_device_capability(device)) == (12, 0)
++        and m <= 128
++        and trellis_bits == 6
++        and trellis_codebook == "mcg"
++        and trellis_pair_kind is None
++        and compute_dtype == torch.float16
++        and external_hadamard_128 is None
++    )
++
++
+ def _run_trellis256_dense_current_device(
+     x: torch.Tensor,
+     prepared_dense,
+@@ -11324,6 +11368,70 @@ def _run_trellis256_dense_current_device(
+         None if hadamard_128 is None else _resolve_exl3_hadamard_128(hadamard_128)
+     )
+ 
++    # Keep the established K6/MCG decode path independent from the generic
++    # Trellis scheduler. It owns both H128 rotations, needs no GEMM scratch,
++    # and is safe to capture with only caller-owned output/rotation storage.
++    # Compact pair payloads and the newer SQG codebooks use the generic path.
++    use_k6_mcg_small = _use_k6_mcg_small(
++        device=x.device,
++        m=m,
++        trellis_bits=trellis_bits,
++        trellis_codebook=trellis_codebook,
++        trellis_pair_kind=trellis_pair_kind,
++        compute_dtype=compute_dtype,
++        external_hadamard_128=external_hadamard_128,
++    )
++    if use_k6_mcg_small:
++        if x.dtype == torch.float16:
++            x_f16 = x
++        else:
++            input_f16 = _trellis_dense_buffer(
++                "input_f16",
++                input_f16,
++                shape=(m, size_k),
++                dtype=torch.float16,
++                device=x.device,
++            )
++            input_f16.copy_(x)
++            x_f16 = input_f16
++        rotated_f16 = _trellis_dense_buffer(
++            "rotated_f16",
++            rotated_f16,
++            shape=(m, size_k),
++            dtype=torch.float16,
++            device=x.device,
++        )
++        if output.dtype == torch.float16:
++            small_output = output
++        else:
++            output_f16 = _trellis_dense_buffer(
++                "output_f16",
++                output_f16,
++                shape=(m, size_n),
++                dtype=torch.float16,
++                device=x.device,
++            )
++            small_output = output_f16
++        from b12x.gemm.trellis_linear._small_m import run_k6_mcg
++
++        trellis_i16 = prepared_dense.trellis.view(torch.int16).view(
++            size_k // 16,
++            size_n // 16,
++            96,
++        )
++        run_k6_mcg(
++            x_f16,
++            trellis_i16,
++            small_output,
++            prepared_dense.suh,
++            rotated_f16,
++            prepared_dense.svh,
++            prepared_dense.workspace,
++        )
++        if output.dtype != torch.float16:
++            output.copy_(small_output)
++        return output
++
+     gemm_output = _trellis_dense_buffer(
+         "gemm_output",
+         gemm_output,
+diff --git a/b12x/moe/_shared/kernels/w4a16/mixed_trellis.py b/b12x/moe/_shared/kernels/w4a16/mixed_trellis.py
+index a97ee2e62b57463012fd2aaa64edb59cbdd452ab..d9a5e9ab471fdfb34cbbe6b739e47f0314be7de5 100644
+--- a/b12x/moe/_shared/kernels/w4a16/mixed_trellis.py
++++ b/b12x/moe/_shared/kernels/w4a16/mixed_trellis.py
+@@ -27,7 +27,11 @@ from b12x._lib.intrinsics import shared_ptr_to_u32
+ from b12x._lib.runtime_control import raise_if_kernel_resolution_frozen
+ from b12x._lib.utils import current_cuda_stream, make_ptr
+ 
+-from .host import max_packed_route_slots, packed_gemm_scratch_elements
++from .host import (
++    max_packed_route_slots,
++    packed_gemm_scratch_elements,
++    route_pack_warmup_token_counts,
++)
+ from .kernel import (
+     W4A16FusedMoeKernel,
+     _cutlass_element_dtype,
+@@ -245,6 +249,9 @@ class W4A16MixedTrellisKernel:
+         factor = gemm.schedule_route_block_factor
+         first_route_block = route_block_idx * Int32(factor)
+         first_lock_slot = lock_slot * Int32(factor)
++        # Mixed K3/K4 execution is pinned to the MCG codebook, whose tile
++        # decoder does not consume the generic Trellis LUT ABI slot.
++        trellis_lut_addr = cutlass.Int64(0)
+         if cutlass.const_expr(gemm.paired_m8_routes):
+             gemm._run_tile_m8_pair(
+                 a_flat,
+@@ -257,6 +264,7 @@ class W4A16MixedTrellisKernel:
+                 topk_weights,
+                 c_tmp,
+                 locks,
++                trellis_lut_addr,
+                 smem_base,
+                 tid,
+                 first_route_block,
+@@ -282,6 +290,7 @@ class W4A16MixedTrellisKernel:
+                     topk_weights,
+                     c_tmp,
+                     locks,
++                    trellis_lut_addr,
+                     smem_base,
+                     tid,
+                     first_route_block + Int32(subtile),
+@@ -761,6 +770,10 @@ class W4A16MixedTrellisKernel:
+             gate_suh,
+             up_suh,
+             descriptor_map,
++            # Mixed tier emit hooks own Trellis decoding, so the shared
++            # driver's LUT ABI slots are intentionally unused.
++            cutlass.Int64(0),
++            cutlass.Int64(0),
+             total_experts,
+             total_experts,
+             smem_base,
+@@ -774,6 +787,67 @@ class W4A16MixedTrellisKernel:
+ 
+ 
+ _CACHE: dict[tuple[object, ...], MixedTrellisCompileResult] = {}
++_ROUTE_PACK_WARMED: set[tuple[object, ...]] = set()
++
++
++def warmup_mixed_trellis_route_pack(
++    launch: MixedTrellisCompileResult,
++    buffers: MixedTrellisBuffers,
++    *,
++    expert_map: torch.Tensor,
++) -> int:
++    """Materialize every route-pack specialization reachable by ``launch``.
++
++    Route packing buckets token capacity to powers of two. A profile pass at
++    the maximum batch therefore does not cover smaller decode, speculative,
++    or final-prefill-chunk buckets. Load those CUDA modules eagerly while the
++    serving framework is still profiling persistent memory, so KV sizing sees
++    their real driver footprint instead of discovering it under live traffic.
++    """
++    device = buffers.packed_route_indices.device
++    if device.type != "cuda":
++        raise RuntimeError("mixed Trellis route-pack warmup requires CUDA buffers")
++    if torch.cuda.is_current_stream_capturing():
++        raise RuntimeError("mixed Trellis route-pack warmup cannot run during capture")
++
++    total_experts = int(launch.tier0_num_experts) + int(launch.tier1_num_experts)
++    warmed = 0
++    pending_keys: list[tuple[object, ...]] = []
++    with torch.cuda.device(device):
++        device_index = int(torch.cuda.current_device())
++        for token_count in route_pack_warmup_token_counts(launch.size_m):
++            key = (
++                device_index,
++                str(launch.route_ids_dtype),
++                int(token_count),
++                int(launch.top_k),
++                total_experts,
++                int(launch.moe_block_size),
++                True,
++            )
++            if key in _ROUTE_PACK_WARMED:
++                continue
++            dummy_topk_ids = torch.zeros(
++                (token_count, launch.top_k),
++                dtype=launch.route_ids_dtype,
++                device=device,
++            )
++            pack_topk_routes_by_expert(
++                dummy_topk_ids,
++                launch.moe_block_size,
++                total_experts,
++                expert_map=expert_map,
++                packed_route_indices=buffers.packed_route_indices,
++                block_expert_ids=buffers.block_expert_ids,
++                packed_route_count=buffers.packed_route_count,
++                expert_offsets=buffers.expert_offsets,
++                expert_counts=buffers.expert_counts,
++            )
++            pending_keys.append(key)
++            warmed += 1
++        torch.cuda.current_stream(device).synchronize()
++        _ROUTE_PACK_WARMED.update(pending_keys)
++    return warmed
+ 
+ 
+ def compile_mixed_trellis(
+@@ -834,6 +908,7 @@ def compile_mixed_trellis(
+             scale_format="e4m3_k32",
+             w13_layout="trellis3_t256_proj",
+             trellis_bits=bits,
++            trellis_codebook="mcg",
+             intermediate_rotation=True,
+             full_rotation=True,
+             rotation_input_dtype=rotation_input_dtype,
+@@ -1521,4 +1596,5 @@ __all__ = [
+     "compile_mixed_trellis",
+     "make_mixed_trellis_buffers",
+     "run_mixed_trellis",
++    "warmup_mixed_trellis_route_pack",
+ ]
+diff --git a/b12x/moe/fused_moe/_impl.py b/b12x/moe/fused_moe/_impl.py
+index 47b08f478ccb030d333b94467f30cf036ddb3572..7f7b0fbd5babb6b3c5b0d02e2876162038cdbab8 100644
+--- a/b12x/moe/fused_moe/_impl.py
++++ b/b12x/moe/fused_moe/_impl.py
+@@ -6527,7 +6527,10 @@ def _plan_full_rotation_w4a16_launches(
+     if torch.cuda.is_current_stream_capturing():
+         raise RuntimeError("Trellis launch planning cannot run during capture")
+ 
+-    from b12x.moe._shared.kernels.w4a16.host import route_pack_capacity
++    from b12x.moe._shared.kernels.w4a16.host import (
++        route_pack_capacity,
++        route_pack_warmup_token_counts,
++    )
+     from b12x.moe._shared.kernels.w4a16.kernel import (
+         _DEFAULT_MAX_SHARED_MEM,
+         compile_w4a16_fused_moe,
+@@ -6637,68 +6640,80 @@ def _plan_full_rotation_w4a16_launches(
+             for ids_dtype in (torch.int32, torch.int64)
+             for mapped in (False, True)
+         )
+-        for mapped in (False, True):
+-            route_pack_key = (
+-                core_plan.device.type,
+-                int(torch.cuda.current_device()),
+-                capacity_tokens * core_plan.num_topk,
+-                int(block_size_m),
+-                int(core_plan.route_E),
+-                mapped,
+-            )
+-            if route_pack_key in _W4A16_ROUTE_PACK_PREWARMED:
+-                continue
++        packed_route_indices = torch.empty(
++            capacity_route_slots,
++            dtype=torch.int32,
++            device=core_plan.device,
++        )
++        block_expert_ids = torch.empty(
++            capacity_m_blocks,
++            dtype=torch.int32,
++            device=core_plan.device,
++        )
++        packed_route_count = torch.empty(
++            1,
++            dtype=torch.int32,
++            device=core_plan.device,
++        )
++        expert_offsets = torch.empty(
++            core_plan.route_E + 1,
++            dtype=torch.int32,
++            device=core_plan.device,
++        )
++        expert_counts = torch.empty(
++            core_plan.route_E,
++            dtype=torch.int32,
++            device=core_plan.device,
++        )
++        pending_route_pack_keys: list[tuple[object, ...]] = []
++        for route_ids_dtype in (torch.int32, torch.int64):
+             dummy_topk_ids = torch.zeros(
+                 capacity_tokens,
+                 core_plan.num_topk,
+-                dtype=torch.int32,
+-                device=core_plan.device,
+-            )
+-            packed_route_indices = torch.empty(
+-                capacity_route_slots,
+-                dtype=torch.int32,
+-                device=core_plan.device,
+-            )
+-            block_expert_ids = torch.empty(
+-                capacity_m_blocks,
+-                dtype=torch.int32,
+-                device=core_plan.device,
+-            )
+-            packed_route_count = torch.empty(
+-                1,
+-                dtype=torch.int32,
+-                device=core_plan.device,
+-            )
+-            expert_offsets = torch.empty(
+-                core_plan.route_E + 1,
+-                dtype=torch.int32,
+-                device=core_plan.device,
+-            )
+-            expert_counts = torch.empty(
+-                core_plan.route_E,
+-                dtype=torch.int32,
++                dtype=route_ids_dtype,
+                 device=core_plan.device,
+             )
+-            expert_map = None
+-            if mapped:
+-                expert_map = torch.arange(
+-                    core_plan.route_E,
+-                    dtype=torch.int32,
+-                    device=core_plan.device,
+-                )
+-            pack_topk_routes_by_expert(
+-                dummy_topk_ids,
+-                block_size_m,
+-                core_plan.route_E,
+-                expert_map=expert_map,
+-                packed_route_indices=packed_route_indices,
+-                block_expert_ids=block_expert_ids,
+-                packed_route_count=packed_route_count,
+-                expert_offsets=expert_offsets,
+-                expert_counts=expert_counts,
++            for mapped in (False, True):
++                expert_map = None
++                if mapped:
++                    expert_map = torch.arange(
++                        core_plan.route_E,
++                        dtype=torch.int32,
++                        device=core_plan.device,
++                    )
++                for token_count in route_pack_warmup_token_counts(capacity_tokens):
++                    route_pack_key = (
++                        core_plan.device.type,
++                        int(torch.cuda.current_device()),
++                        str(route_ids_dtype),
++                        token_count * core_plan.num_topk,
++                        int(block_size_m),
++                        int(core_plan.route_E),
++                        mapped,
++                    )
++                    if route_pack_key in _W4A16_ROUTE_PACK_PREWARMED:
++                        continue
++                    pack_topk_routes_by_expert(
++                        dummy_topk_ids[:token_count],
++                        block_size_m,
++                        core_plan.route_E,
++                        expert_map=expert_map,
++                        packed_route_indices=packed_route_indices,
++                        block_expert_ids=block_expert_ids,
++                        packed_route_count=packed_route_count,
++                        expert_offsets=expert_offsets,
++                        expert_counts=expert_counts,
++                    )
++                    pending_route_pack_keys.append(route_pack_key)
++        torch.cuda.current_stream(core_plan.device).synchronize()
++        _W4A16_ROUTE_PACK_PREWARMED.update(pending_route_pack_keys)
++        if pending_route_pack_keys:
++            logger.info(
++                "Prewarmed %d full-rotation W4A16 route-pack variant(s) "
++                "for token capacity %d.",
++                len(pending_route_pack_keys),
++                capacity_tokens,
+             )
+-            torch.cuda.current_stream(core_plan.device).synchronize()
+-            _W4A16_ROUTE_PACK_PREWARMED.add(route_pack_key)
+     return fused_launches, topk_sum_launches
+ 
+ 
+@@ -7031,6 +7046,7 @@ def _prewarm_w4a16_planned_launches(
+             route_pack_key = (
+                 workspace.device.type,
+                 int(torch.cuda.current_device()),
++                str(torch.int32),
+                 int(token_count) * int(workspace.num_topk),
+                 int(block_size_m),
+                 int(workspace.route_E),
+diff --git a/tests/attention/test_attention_mla_compressed.py b/tests/attention/test_attention_mla_compressed.py
+index d16f936d42d32bfa33114fd73fb9b3016fc51aa4..bdb70f9cac99e551bb1c5a8b97903055bb9151ba 100644
+--- a/tests/attention/test_attention_mla_compressed.py
++++ b/tests/attention/test_attention_mla_compressed.py
+@@ -23,17 +23,20 @@ from b12x.attention._shared.mla.compressed_reference import (
+     gather_compressed_mla_kv_cache_reference,
+     pack_compressed_mla_kv_cache_reference,
+ )
++from b12x.attention._shared.mla.api import clear_mla_caches
+ from b12x.attention._shared.mla.compressed_api import (
+     _should_use_sm121_single_pass_decode,
++    compressed_mla_decode_forward,
+ )
+-from b12x.attention._shared.mla.kernel import _dsv4_h16_auto
+ from b12x.attention._shared.mla.compressed_config import (
++    compressed_mla_split_chunks_for_contract,
+     compressed_mla_split_config_for_contract,
+ )
+-from b12x.attention._shared.mla.api import clear_mla_caches
+-from b12x.attention._shared.mla.compressed_api import compressed_mla_decode_forward
+-from b12x.attention._shared.mla.compressed_config import compressed_mla_split_chunks_for_contract
+-from b12x.attention.compressed_mla._scratch import B12XCompressedMLAScratchCaps, plan_compressed_mla_scratch
++from b12x.attention._shared.mla.kernel import _dsv4_h16_auto
++from b12x.attention.compressed_mla._scratch import (
++    B12XCompressedMLAScratchCaps,
++    plan_compressed_mla_scratch,
++)
+ from b12x._lib.compiler import clear_compile_cache, compile_cache_info
+ 
+ from tests._reference.helpers import require_b12x
+@@ -218,6 +221,7 @@ def _make_compressed_binding(
+     v_head_dim: int = _COMPRESSED_HEAD_DIM,
+     max_chunks_per_row: int = 64,
+     max_page_table_width: int | None = None,
++    decode_row_capacity: int | None = None,
+ ):
+     plan = plan_compressed_mla_scratch(
+         B12XCompressedMLAScratchCaps(
+@@ -233,6 +237,7 @@ def _make_compressed_binding(
+             max_batch=rows,
+             max_kv_rows=max_kv_rows,
+             max_chunks_per_row=max_chunks_per_row,
++            decode_row_capacity=decode_row_capacity,
+         )
+     )
+     (spec,) = plan.scratch_specs()
+@@ -324,6 +329,160 @@ def test_compressed_mla_mtp_graph_rows_keep_decode_split_contract() -> None:
+     assert larger_prefill_cfg.num_chunks == 1
+ 
+ 
++@pytest.mark.parametrize(
++    ("decode_row_capacity", "last_decode_row"),
++    [
++        pytest.param(144, 256, id="legacy-floor"),
++        pytest.param(384, 384, id="mns64-k5"),
++        pytest.param(512, 512, id="mns64-k7"),
++        pytest.param(768, 768, id="mns128-k5"),
++    ],
++)
++def test_compressed_mla_declared_decode_row_capacity_extends_contract(
++    decode_row_capacity: int,
++    last_decode_row: int,
++) -> None:
++    decode_cfg = compressed_mla_split_config_for_contract(
++        rows=last_decode_row,
++        width=384,
++        max_chunks=6,
++        decode_row_capacity=decode_row_capacity,
++    )
++    next_cfg = compressed_mla_split_config_for_contract(
++        rows=last_decode_row + 1,
++        width=384,
++        max_chunks=6,
++        decode_row_capacity=decode_row_capacity,
++    )
++
++    assert decode_cfg.chunk_size == 64
++    assert decode_cfg.num_chunks == 6
++    assert next_cfg.chunk_size == 1024
++    assert next_cfg.num_chunks == 1
++
++
++def test_compressed_mla_declared_decode_row_capacity_rejects_nonpositive() -> None:
++    with pytest.raises(ValueError, match="decode_row_capacity must be positive"):
++        compressed_mla_split_config_for_contract(
++            rows=1,
++            width=384,
++            max_chunks=6,
++            decode_row_capacity=0,
++        )
++
++
++@pytest.mark.parametrize("rows", [1, 24, 65, 144, 192, 256])
++@pytest.mark.parametrize("width", [128, 384, 2176, 4608])
++@pytest.mark.parametrize("decode_row_capacity", [144, 384, 768])
++def test_declared_capacity_preserves_legacy_plans_through_256_rows(
++    rows: int,
++    width: int,
++    decode_row_capacity: int,
++) -> None:
++    legacy = compressed_mla_split_config_for_contract(
++        rows=rows,
++        width=width,
++    )
++    declared = compressed_mla_split_config_for_contract(
++        rows=rows,
++        width=width,
++        decode_row_capacity=decode_row_capacity,
++    )
++
++    assert declared == legacy
++
++
++@pytest.mark.parametrize("rows", [384, 512, 768])
++@torch.inference_mode()
++def test_declared_decode_capacity_matches_reference_under_graph_replay(
++    rows: int,
++) -> None:
++    device = require_b12x()
++    clear_mla_caches()
++    width = 384
++    live_width = 32
++    q = _make_q(rows=rows, seed=6130 + rows, device=device)
++    swa_cache_bytes = _make_cache(
++        tokens=64,
++        page_size=COMPRESSED_MLA_DSV4_PAGE_SIZE,
++        seed=6131 + rows,
++        device=device,
++    )
++    swa_cache = swa_cache_bytes.view(torch.float8_e4m3fn)
++    base_indices = torch.arange(live_width, dtype=torch.int32, device=device)
++    swa_indices = torch.full(
++        (rows, width),
++        -1,
++        dtype=torch.int32,
++        device=device,
++    )
++    swa_indices[:, :live_width] = base_indices
++    swa_lengths = torch.full(
++        (rows,),
++        live_width,
++        dtype=torch.int32,
++        device=device,
++    )
++    attn_sink = torch.linspace(
++        -0.1,
++        0.1,
++        _LOCAL_Q_HEADS,
++        dtype=torch.float32,
++        device=device,
++    )
++    split_cap = math.ceil(width / 64)
++    binding = _make_compressed_binding(
++        device=device,
++        rows=rows,
++        topk=width,
++        max_kv_rows=rows * width,
++        q=q,
++        swa_indices=swa_indices,
++        swa_lengths=swa_lengths,
++        use_cuda_graph=True,
++        max_chunks_per_row=split_cap,
++        decode_row_capacity=rows,
++    )
++
++    captured_out: torch.Tensor | None = None
++
++    def run() -> torch.Tensor:
++        nonlocal captured_out
++        captured_out = compressed_mla_decode_forward(
++            swa_k_cache=swa_cache,
++            binding=binding,
++            attn_sink=attn_sink,
++            sm_scale=_SM_SCALE,
++        )
++        return captured_out
++
++    run()
++    torch.cuda.synchronize(device)
++    graph = torch.cuda.CUDAGraph()
++    with torch.cuda.graph(graph):
++        run()
++    graph.replay()
++    torch.cuda.synchronize(device)
++    assert captured_out is not None
++
++    expected = compressed_sparse_mla_reference(
++        q,
++        swa_cache_bytes,
++        swa_indices,
++        swa_lengths,
++        attn_sink=attn_sink,
++        sm_scale=_SM_SCALE,
++    )
++    max_abs = (captured_out.float() - expected.float()).abs().max().item()
++    cosine = torch.nn.functional.cosine_similarity(
++        captured_out.float().reshape(-1),
++        expected.float().reshape(-1),
++        dim=0,
++    )
++    assert max_abs <= 0.10
++    assert cosine.item() >= 0.9995
++
++
+ def test_compressed_mla_arena_scratch_uses_contract_q_chunks() -> None:
+     device = require_b12x()
+     selected_widths = (128, 640, 2880)
+@@ -397,6 +556,7 @@ def test_compressed_mla_arena_scratch_uses_contract_q_chunks() -> None:
+     assert legacy_ragged > capped * 3
+     assert capped < int(2.25 * (1 << 30))
+ 
++
+ def test_compressed_mla_reference_pack_gathers_across_padded_pages() -> None:
+     device = require_b12x()
+     gen = torch.Generator(device=device)
+@@ -490,15 +650,18 @@ def test_compressed_mla_fixed_workspace_split_plan_uses_contract_not_live_shape(
+         max_page_table_width=page_table_width,
+     )
+ 
+-    with torch.inference_mode(), torch.no_grad():
+-        with pytest.raises(ValueError, match="mapped indexed_page_table"):
+-            compressed_api_impl.compressed_mla_decode_forward(
+-                swa_k_cache=swa_cache.view(torch.float8_e4m3fn),
+-                binding=binding,
+-                indexed_k_cache=indexed_cache,
+-                indexed_page_size=COMPRESSED_MLA_C4_PAGE_SIZE,
+-                sm_scale=_SM_SCALE,
+-            )
++    with (
++        torch.inference_mode(),
++        torch.no_grad(),
++        pytest.raises(ValueError, match="mapped indexed_page_table"),
++    ):
++        compressed_api_impl.compressed_mla_decode_forward(
++            swa_k_cache=swa_cache.view(torch.float8_e4m3fn),
++            binding=binding,
++            indexed_k_cache=indexed_cache,
++            indexed_page_size=COMPRESSED_MLA_C4_PAGE_SIZE,
++            sm_scale=_SM_SCALE,
++        )
+ 
+ 
+ @torch.inference_mode()
+@@ -910,7 +1073,9 @@ def test_compressed_mla_mapped_page_table_is_rejected() -> None:
+         swa_lengths=swa_lengths,
+         indexed_indices=torch.arange(8, dtype=torch.int32, device=device).unsqueeze(0),
+         indexed_lengths=indexed_lengths,
+-        indexed_page_table=torch.arange(2, dtype=torch.int32, device=device).unsqueeze(0),
++        indexed_page_table=torch.arange(2, dtype=torch.int32, device=device).unsqueeze(
++            0
++        ),
+         use_cuda_graph=True,
+     )
+ 
+@@ -1164,8 +1329,7 @@ def test_compressed_mla_prefill_is_run_to_run_deterministic() -> None:
+     for row in range(rows):
+         length = min(width, row + 1)
+         swa_indices[row, :length] = (
+-            torch.arange(row, row - length, -1, dtype=torch.int32, device=device)
+-            % 64
++            torch.arange(row, row - length, -1, dtype=torch.int32, device=device) % 64
+         )
+         swa_lengths[row] = length
+     attn_sink = torch.linspace(
+diff --git a/tests/comm/test_pcie_oneshot.py b/tests/comm/test_pcie_oneshot.py
+index ffb61ba0d7e7657381aef79840fc49f526961f77..898b48f65544ef5086fb957726f0ad4be9b477d8 100644
+--- a/tests/comm/test_pcie_oneshot.py
++++ b/tests/comm/test_pcie_oneshot.py
+@@ -20,10 +20,14 @@ from b12x.comm.pcie.pcie_oneshot import (
+     _require_full_grid_residency,
+     _ABANDONED_PCIE_RUNTIME_QUARANTINE,
+     _RETAINED_FAILED_IPC_EXPORTS,
++    _CuTeOneshotBackend,
+     _CuTeOneshotState,
+     _enable_device_slot_selection,
++    _transport_policy_contract,
++    _uses_sharded_eager_storage,
+     parse_pcie_oneshot_max_size,
+ )
++from b12x.comm.pcie._oneshot_cute import _FusedOneshotLaunch
+ 
+ 
+ @pytest.fixture(autouse=True)
+@@ -252,6 +256,178 @@ def test_graph_slot_bias_preserves_the_next_host_slot() -> None:
+     assert state.slot_bias == 1
+ 
+ 
++def _make_cute_state(world_size: int, *, eager: bool = True) -> _CuTeOneshotState:
++    transport_policy = _transport_policy_contract()
++    return _CuTeOneshotState(
++        rank=0,
++        world_size=world_size,
++        signal_ptrs=tuple(range(100, 100 + world_size)),
++        rank_data=torch.empty(256, dtype=torch.uint8),
++        signal_table_address=0,
++        next_table_offset=128,
++        registered_tables={},
++        eager_tables=(300, 400) if eager else None,
++        eager_buffer_bytes=128 * 1024 if eager else None,
++        transport_policy=transport_policy,
++        sharded_eager_storage=_uses_sharded_eager_storage(
++            world_size,
++            transport_policy,
++        ),
++    )
++
++
++def test_tp8_owner_launcher_rejects_float32() -> None:
++    with pytest.raises(ValueError, match="requires float16 or bfloat16"):
++        _FusedOneshotLaunch(
++            "float32",
++            world_size=8,
++            rank=0,
++            mode="stage_tp8_owner",
++            single_cta=True,
++            register_normalize=True,
++            device_slot_selection=False,
++            slot_bias=0,
++            threads=256,
++        )
++
++
++@pytest.mark.parametrize(
++    ("rows", "hidden", "dtype", "expected"),
++    (
++        (1, 6144, torch.bfloat16, "stage_pull"),
++        (2, 4096, torch.float16, "stage_tp8_owner"),
++        (4, 6144, torch.bfloat16, "stage_tp8_owner"),
++        (8, 6144, torch.bfloat16, "stage_tp8_owner"),
++        (9, 6144, torch.bfloat16, "stage_pull"),
++        (4, 8192, torch.bfloat16, "stage_pull"),
++        (4, 6144, torch.float32, "stage_pull"),
++    ),
++)
++def test_tp8_owner_reduce_default_has_a_bounded_shape_contract(
++    monkeypatch,
++    rows: int,
++    hidden: int,
++    dtype: torch.dtype,
++    expected: str,
++) -> None:
++    monkeypatch.delenv("B12X_PCIE_ONESHOT_PUSH", raising=False)
++    monkeypatch.delenv("B12X_PCIE_TP8_OWNER_REDUCE", raising=False)
++    mode, _, _, _ = _CuTeOneshotBackend._fused_launch_config(
++        _make_cute_state(8), torch.empty((rows, hidden), dtype=dtype)
++    )
++    assert mode == expected
++
++
++def test_tp8_owner_reduce_can_be_disabled(monkeypatch) -> None:
++    monkeypatch.delenv("B12X_PCIE_ONESHOT_PUSH", raising=False)
++    monkeypatch.setenv("B12X_PCIE_TP8_OWNER_REDUCE", "0")
++    mode, _, _, _ = _CuTeOneshotBackend._fused_launch_config(
++        _make_cute_state(8), torch.empty((4, 6144), dtype=torch.bfloat16)
++    )
++    assert mode == "stage_pull"
++
++
++@pytest.mark.parametrize(
++    ("world_size", "env_name", "shape", "expected_when_enabled"),
++    (
++        (2, "B12X_PCIE_TP2_REMOTE_PUSH", (4, 4096), "stage_remote_push"),
++        (4, "B12X_PCIE_TP4_REMOTE_PUSH", (32, 6144), "stage_remote_push"),
++    ),
++)
++def test_tp2_tp4_remote_push_is_opt_in(
++    monkeypatch,
++    world_size: int,
++    env_name: str,
++    shape: tuple[int, int],
++    expected_when_enabled: str,
++) -> None:
++    monkeypatch.delenv("B12X_PCIE_ONESHOT_PUSH", raising=False)
++    monkeypatch.delenv(env_name, raising=False)
++    inp = torch.empty(shape, dtype=torch.bfloat16)
++    mode, _, _, _ = _CuTeOneshotBackend._fused_launch_config(
++        _make_cute_state(world_size), inp
++    )
++    assert mode == "stage_pull"
++
++    monkeypatch.setenv(env_name, "1")
++    mode, _, _, _ = _CuTeOneshotBackend._fused_launch_config(
++        _make_cute_state(world_size), inp
++    )
++    assert mode == expected_when_enabled
++
++
++def test_topology_policy_is_immutable_after_channel_setup(monkeypatch) -> None:
++    monkeypatch.delenv("B12X_PCIE_ONESHOT_PUSH", raising=False)
++    monkeypatch.setenv("B12X_PCIE_TP4_REMOTE_PUSH", "1")
++    state = _make_cute_state(4)
++
++    monkeypatch.setenv("B12X_PCIE_TP4_REMOTE_PUSH", "0")
++    mode, _, _, _ = _CuTeOneshotBackend._fused_launch_config(
++        state,
++        torch.empty((4, 6144), dtype=torch.bfloat16),
++    )
++
++    assert mode == "stage_remote_push"
++
++
++@pytest.mark.parametrize(
++    ("world_size", "env_name", "shape"),
++    (
++        (2, "B12X_PCIE_TP2_REMOTE_PUSH", (4, 6144)),
++        (2, "B12X_PCIE_TP2_REMOTE_PUSH", (33, 4096)),
++        (4, "B12X_PCIE_TP4_REMOTE_PUSH", (33, 6144)),
++        (4, "B12X_PCIE_TP4_REMOTE_PUSH", (4, 8192)),
++    ),
++)
++def test_tp2_tp4_remote_push_falls_back_outside_qualified_shapes(
++    monkeypatch,
++    world_size: int,
++    env_name: str,
++    shape: tuple[int, int],
++) -> None:
++    monkeypatch.delenv("B12X_PCIE_ONESHOT_PUSH", raising=False)
++    monkeypatch.setenv(env_name, "1")
++    mode, _, _, _ = _CuTeOneshotBackend._fused_launch_config(
++        _make_cute_state(world_size),
++        torch.empty(shape, dtype=torch.bfloat16),
++    )
++    assert mode == "stage_pull"
++
++
++def test_registered_fused_input_never_selects_topology_transport(
++    monkeypatch,
++) -> None:
++    monkeypatch.setenv("B12X_PCIE_TP4_REMOTE_PUSH", "1")
++    mode, _, _, _ = _CuTeOneshotBackend._fused_launch_config(
++        _make_cute_state(4, eager=False),
++        torch.empty((4, 6144), dtype=torch.bfloat16),
++    )
++    assert mode == "registered"
++
++
++def test_topology_transport_storage_policy_matches_opt_in_defaults(
++    monkeypatch,
++) -> None:
++    for name in (
++        "B12X_PCIE_ONESHOT_PUSH",
++        "B12X_PCIE_TP2_REMOTE_PUSH",
++        "B12X_PCIE_TP4_REMOTE_PUSH",
++        "B12X_PCIE_TP8_OWNER_REDUCE",
++    ):
++        monkeypatch.delenv(name, raising=False)
++
++    assert not _uses_sharded_eager_storage(2)
++    assert not _uses_sharded_eager_storage(4)
++    assert _uses_sharded_eager_storage(8)
++    assert _transport_policy_contract() == (False, False, False, True)
++
++    monkeypatch.setenv("B12X_PCIE_TP8_OWNER_REDUCE", "0")
++    monkeypatch.setenv("B12X_PCIE_TP4_REMOTE_PUSH", "1")
++    assert _uses_sharded_eager_storage(4)
++    assert not _uses_sharded_eager_storage(8)
++    assert _transport_policy_contract() == (False, False, True, False)
++
++
+ def test_register_buffer_is_idempotent_for_same_mapping():
+     runtime = _make_runtime()
+     ext = runtime._ext
+@@ -1218,6 +1394,7 @@ def test_eager_channel_buffers_use_single_ipc_slab(monkeypatch):
+         exchange_group,
+         signal_bytes=signal_bytes,
+         eager_buffer_bytes=eager_bytes,
++        sharded_eager_storage=False,
+         ipc=ipc,
+     )
+ 
+@@ -1281,6 +1458,7 @@ def test_eager_channel_buffers_cleanup_when_slab_zero_fails(monkeypatch):
+             object(),
+             signal_bytes=300,
+             eager_buffer_bytes=128,
++            sharded_eager_storage=False,
+             ipc=ipc,
+         )
+ 
+@@ -1486,9 +1664,7 @@ def test_collective_logical_channel_mismatch_rejects_before_allocation(monkeypat
+         _requested, existing = local_state
+         return [local_state, (("other",), existing)]
+ 
+-    monkeypatch.setattr(
+-        "b12x.comm.pcie.pcie_oneshot._broadcast_gather_object", gather
+-    )
++    monkeypatch.setattr("b12x.comm.pcie.pcie_oneshot._broadcast_gather_object", gather)
+ 
+     with pytest.raises(RuntimeError, match="differs across ranks"):
+         pool.prepare_channels(("target",))
+@@ -1535,9 +1711,7 @@ def test_empty_logical_channel_set_still_enters_collective_contract(monkeypatch)
+         _, existing = local_state
+         return [local_state, (("peer-channel",), existing)]
+ 
+-    monkeypatch.setattr(
+-        "b12x.comm.pcie.pcie_oneshot._broadcast_gather_object", gather
+-    )
++    monkeypatch.setattr("b12x.comm.pcie.pcie_oneshot._broadcast_gather_object", gather)
+ 
+     with pytest.raises(RuntimeError, match="differs across ranks"):
+         pool.prepare_channels(())
+@@ -1599,9 +1773,7 @@ def test_collective_capture_allows_opposite_order_from_agreed_catalog(monkeypatc
+         assert requested == "graph:target"
+         return [local_state, ("graph:draft", catalog)]
+ 
+-    monkeypatch.setattr(
+-        "b12x.comm.pcie.pcie_oneshot._broadcast_gather_object", gather
+-    )
++    monkeypatch.setattr("b12x.comm.pcie.pcie_oneshot._broadcast_gather_object", gather)
+ 
+     with pool.capture(7, channel_id="graph:target") as channel:
+         assert channel is target
+@@ -1631,9 +1803,7 @@ def test_collective_capture_rejects_divergent_catalog_before_allocation(monkeypa
+             return [(), ()]
+         return [local_state, ("graph:target", ())]
+ 
+-    monkeypatch.setattr(
+-        "b12x.comm.pcie.pcie_oneshot._broadcast_gather_object", gather
+-    )
++    monkeypatch.setattr("b12x.comm.pcie.pcie_oneshot._broadcast_gather_object", gather)
+ 
+     with (
+         pytest.raises(RuntimeError, match="prepared channel catalog differs"),
+@@ -1665,9 +1835,7 @@ def test_collective_capture_rejects_differing_unprepared_ids(monkeypatch):
+         _, catalog = local_state
+         return [local_state, ("graph:unknown", catalog)]
+ 
+-    monkeypatch.setattr(
+-        "b12x.comm.pcie.pcie_oneshot._broadcast_gather_object", gather
+-    )
++    monkeypatch.setattr("b12x.comm.pcie.pcie_oneshot._broadcast_gather_object", gather)
+ 
+     with (
+         pytest.raises(RuntimeError, match="unprepared logical channels"),
+diff --git a/tests/comm/test_pcie_oneshot_fused_rmsnorm_gpu.py b/tests/comm/test_pcie_oneshot_fused_rmsnorm_gpu.py
+index 8159ba77b76f81b11779e2fd1cddaff2e0339018..9ed9199c607a2e39d75c204cd5f4c0e588fd3593 100644
+--- a/tests/comm/test_pcie_oneshot_fused_rmsnorm_gpu.py
++++ b/tests/comm/test_pcie_oneshot_fused_rmsnorm_gpu.py
+@@ -12,7 +12,10 @@ import torch.distributed as dist
+ import torch.multiprocessing as mp
+ from cuda.bindings import runtime as cudart
+ 
+-from b12x.comm.pcie.pcie_oneshot import PCIeOneshotAllReducePool
++from b12x.comm.pcie.pcie_oneshot import (
++    PCIeOneshotAllReducePool,
++    _CuTeOneshotBackend,
++)
+ 
+ 
+ pytestmark = pytest.mark.skipif(
+@@ -22,9 +25,7 @@ pytestmark = pytest.mark.skipif(
+         "RMSNorm GPU tests"
+     ),
+ )
+-TEST_TIMEOUT_SECONDS = float(
+-    os.getenv("B12X_PCIE_ONESHOT_RMS_TIMEOUT_SECONDS", "300")
+-)
++TEST_TIMEOUT_SECONDS = float(os.getenv("B12X_PCIE_ONESHOT_RMS_TIMEOUT_SECONDS", "300"))
+ 
+ 
+ def _free_port() -> int:
+@@ -145,10 +146,15 @@ def _run_eager(
+     rank: int,
+ ) -> None:
+     epsilon = 1e-6
+-    for dtype in (torch.float16, torch.bfloat16, torch.float32):
++    cases = [
++        (dtype, rows, hidden_size)
++        for dtype in (torch.float16, torch.bfloat16, torch.float32)
+         for rows, hidden_size in (
+             (1, 6144),
+             (1, 8192),
++            (2, 4096),
++            (4, 4096),
++            (8, 4096),
+             (2, 6144),
+             (3, 6144),
+             (4, 6144),
+@@ -156,40 +162,47 @@ def _run_eager(
+             (6, 6144),
+             (8, 6144),
+             (3, 128),
+-        ):
+-            if rows * hidden_size * dtype.itemsize > 128 * 1024:
+-                continue
+-            inp, residual, weight = _make_inputs(
+-                rows,
+-                hidden_size,
+-                dtype,
+-                device,
+-                rank,
+-            )
+-            expected_out, expected_residual = _reference(
+-                inp,
+-                residual,
+-                weight,
+-                epsilon,
+-            )
+-            torch.cuda.synchronize(device)
+-            wrong_device = (rank + 1) % dist.get_world_size()
+-            exercise_device_guard = dtype == torch.float16 and rows == 1 and hidden_size == 6144
+-            if exercise_device_guard:
+-                torch.cuda.set_device(wrong_device)
+-            out, residual_out = pool.all_reduce_fused_add_rms_norm(
+-                inp,
+-                residual,
+-                weight,
+-                epsilon,
+-                channel_id="eager:fused-rmsnorm",
+-            )
+-            if exercise_device_guard:
+-                assert torch.cuda.current_device() == wrong_device
+-                torch.cuda.set_device(rank)
+-            torch.cuda.synchronize(device)
+-            _assert_close(out, expected_out, dtype)
+-            _assert_close(residual_out, expected_residual, dtype)
++        )
++        if rows * hidden_size * dtype.itemsize <= 128 * 1024
++    ]
++    if os.getenv("B12X_PCIE_ONESHOT_RMS_TOPOLOGY_ONLY", "0") not in ("", "0"):
++        hidden_size = 4096 if dist.get_world_size() == 2 else 6144
++        cases = [(torch.bfloat16, rows, hidden_size) for rows in (1, 2, 4, 8)]
++
++    for dtype, rows, hidden_size in cases:
++        inp, residual, weight = _make_inputs(
++            rows,
++            hidden_size,
++            dtype,
++            device,
++            rank,
++        )
++        expected_out, expected_residual = _reference(
++            inp,
++            residual,
++            weight,
++            epsilon,
++        )
++        torch.cuda.synchronize(device)
++        wrong_device = (rank + 1) % dist.get_world_size()
++        exercise_device_guard = (
++            dtype == torch.float16 and rows == 1 and hidden_size == 6144
++        )
++        if exercise_device_guard:
++            torch.cuda.set_device(wrong_device)
++        out, residual_out = pool.all_reduce_fused_add_rms_norm(
++            inp,
++            residual,
++            weight,
++            epsilon,
++            channel_id="eager:fused-rmsnorm",
++        )
++        if exercise_device_guard:
++            assert torch.cuda.current_device() == wrong_device
++            torch.cuda.set_device(rank)
++        torch.cuda.synchronize(device)
++        _assert_close(out, expected_out, dtype)
++        _assert_close(residual_out, expected_residual, dtype)
+ 
+ 
+ def _run_graph(
+@@ -197,8 +210,8 @@ def _run_graph(
+     device: torch.device,
+     rank: int,
+ ) -> None:
+-    rows = 4
+-    hidden_size = 6144
++    rows = int(os.getenv("B12X_PCIE_ONESHOT_RMS_GRAPH_ROWS", "4"))
++    hidden_size = int(os.getenv("B12X_PCIE_ONESHOT_RMS_GRAPH_HIDDEN", "6144"))
+     epsilon = 1e-6
+     dtype = torch.bfloat16
+     inp, residual, weight = _make_inputs(
+@@ -227,10 +240,30 @@ def _run_graph(
+     # preserves the one-kernel production topology.
+     _cuda_graph_kernel_chain(graph)
+     stream = torch.cuda.current_stream(device)
++    world_size = dist.get_world_size()
++    topology_remote = (
++        (
++            world_size == 2
++            and os.getenv("B12X_PCIE_TP2_REMOTE_PUSH", "0") not in ("", "0")
++        )
++        or (
++            world_size == 4
++            and os.getenv("B12X_PCIE_TP4_REMOTE_PUSH", "0") not in ("", "0")
++        )
++        or (
++            world_size == 8
++            and os.getenv("B12X_PCIE_TP8_OWNER_REDUCE", "1") not in ("", "0")
++        )
++    )
+     offset = 0
+-    if os.getenv("B12X_PCIE_ONESHOT_PUSH", "0") not in ("", "0"):
+-        remote_source = (rank + 1) % dist.get_world_size()
+-        offset = remote_source * inp.numel() * inp.element_size()
++    if os.getenv("B12X_PCIE_ONESHOT_PUSH", "0") not in ("", "0") or topology_remote:
++        if world_size == 8 and topology_remote:
++            # TP8 owner mode publishes owner data into each rank's staging
++            # slot, so probe the island owner rather than a neighboring rank.
++            remote_source = 0 if rank < 4 else 4
++        else:
++            remote_source = (rank + 1) % world_size
++        offset = remote_source * channel.eager_buffer_bytes
+     snapshots = [_local_eager_words(channel, stream, offset=offset)]
+ 
+     for iteration in range(3):
+@@ -273,6 +306,87 @@ def _run_graph(
+     )
+ 
+ 
++def _run_tp8_graph_mode_transition(
++    pool: PCIeOneshotAllReducePool,
++    device: torch.device,
++    rank: int,
++) -> None:
++    """Replay C1 fallback followed by C4 owner reduction on one channel."""
++
++    if dist.get_world_size() != 8 or os.getenv("B12X_PCIE_TP8_OWNER_REDUCE", "1") in (
++        "",
++        "0",
++    ):
++        return
++
++    hidden_size = 6144
++    epsilon = 1e-6
++    dtype = torch.bfloat16
++    stream = torch.cuda.Stream(device=device)
++    channel_id = "graph:fused-transition"
++    channel = pool.for_stream(stream, channel_id=channel_id)
++
++    calls = []
++    modes = []
++    state = channel._ext._state(channel._ptr)
++    for rows, iteration in ((1, 41), (4, 43)):
++        inp, residual, weight = _make_inputs(
++            rows,
++            hidden_size,
++            dtype,
++            device,
++            rank,
++            iteration=iteration,
++        )
++        out = torch.empty_like(inp)
++        calls.append((inp, residual, weight, out))
++        modes.append(_CuTeOneshotBackend._fused_launch_config(state, inp)[0])
++        with torch.cuda.stream(stream):
++            channel.prepare_graph_fused_add_rms_norm(inp)
++    assert modes == ["stage_pull", "stage_tp8_owner"]
++
++    graph = torch.cuda.CUDAGraph(keep_graph=True)
++    with (
++        pool.capture(stream=stream, channel_id=channel_id),
++        torch.cuda.graph(graph, stream=stream),
++    ):
++        for inp, residual, weight, out in calls:
++            pool.all_reduce_fused_add_rms_norm(
++                inp,
++                residual,
++                weight,
++                epsilon,
++                out=out,
++                residual_out=residual,
++                stream=stream,
++                channel_id=channel_id,
++            )
++
++    for replay in range(3):
++        expected = []
++        for rows, (inp, residual, weight, _out) in zip((1, 4), calls, strict=True):
++            next_inp, next_residual, _ = _make_inputs(
++                rows,
++                hidden_size,
++                dtype,
++                device,
++                rank,
++                iteration=47 + replay,
++            )
++            inp.copy_(next_inp)
++            residual.copy_(next_residual)
++            expected.append(_reference(inp, residual, weight, epsilon))
++
++        graph.replay()
++        stream.synchronize()
++        for (_inp, residual, _weight, out), (
++            expected_out,
++            expected_residual,
++        ) in zip(calls, expected, strict=True):
++            _assert_close(out, expected_out, dtype)
++            _assert_close(residual, expected_residual, dtype)
++
++
+ def _worker(rank: int, world_size: int, port: int) -> None:
+     torch.cuda.set_device(rank)
+     device = torch.device(f"cuda:{rank}")
+@@ -291,11 +405,19 @@ def _worker(rank: int, world_size: int, port: int) -> None:
+         max_concurrent_channels=2,
+     )
+     try:
+-        pool.prepare_channels(("eager:fused-rmsnorm", "graph:fused-rmsnorm"))
++        pool.prepare_channels(
++            (
++                "eager:fused-rmsnorm",
++                "graph:fused-rmsnorm",
++                "graph:fused-transition",
++            )
++        )
+         pool.for_stream(channel_id="eager:fused-rmsnorm")
+         _run_eager(pool, device, rank)
+         dist.barrier()
+         _run_graph(pool, device, rank)
++        dist.barrier()
++        _run_tp8_graph_mode_transition(pool, device, rank)
+         torch.cuda.synchronize(device)
+     finally:
+         pool.close()
+diff --git a/tests/gemm/test_fp6_packed_b.py b/tests/gemm/test_fp6_packed_b.py
+index 466efd0c6ab52869b1f530defde2742d1c4aa801..231bb22792773d32b6fc1d19f52ecd0524c024f3 100644
+--- a/tests/gemm/test_fp6_packed_b.py
++++ b/tests/gemm/test_fp6_packed_b.py
+@@ -7,6 +7,8 @@ streaming format differs.
+ """
+ from __future__ import annotations
+ 
++import inspect
++
+ import pytest
+ import torch
+ 
+@@ -15,6 +17,18 @@ cuda_required = pytest.mark.skipif(
+ )
+ 
+ 
++def test_dense_gemm_preserves_fp6_api_contracts():
++    """Keep the FP6 caller and dense GEMM implementation contracts in sync."""
++    from b12x._lib.dense_gemm import DenseGemmKernel, dense_gemm
++
++    parameter = inspect.signature(dense_gemm).parameters["row_scale"]
++    assert parameter.default is None
++    kernel_parameter = inspect.signature(DenseGemmKernel).parameters[
++        "fused_quant_bf16"
++    ]
++    assert kernel_parameter.default is None
++
++
+ def _gemm_operands(m: int, n: int, k: int, source_format: str):
+     """Quantized operands for one case, mirroring ``dense_fp6_linear_expanded``."""
+     from b12x._lib.fp6 import SF_VEC_SIZE_FP6, as_grouped_mxfp6_scale_view
+diff --git a/tests/gemm/test_trellis_linear.py b/tests/gemm/test_trellis_linear.py
+index 70ba4a82b7c4fb95c0f298d9e49fc6ce1b509f7a..58231212060ceee7a07db03429cbace71b5476e5 100644
+--- a/tests/gemm/test_trellis_linear.py
++++ b/tests/gemm/test_trellis_linear.py
+@@ -36,6 +36,7 @@ from b12x.moe._shared.kernels.trellis_w4a8_transform import (
+ from b12x.moe._shared.kernels.w4a16.kernel import (
+     _run_trellis_dense_hadamard128,
+     _trellis256_dense_launch_geometry,
++    _use_k6_mcg_small,
+ )
+ from b12x.moe._shared.kernels.w4a16.prepare import (
+     prepare_qsrt_pair_moe_weights,
+@@ -413,6 +414,39 @@ def test_k6_small_m_rejects_unsupported_arch_before_jit(monkeypatch) -> None:
+         _small_m.run_k6_mcg(*(torch.empty(0) for _ in range(7)))
+ 
+ 
++@pytest.mark.parametrize(
++    ("capability", "expected"),
++    [
++        ((12, 0), True),
++        ((12, 1), False),
++        ((9, 0), False),
++    ],
++)
++def test_k6_small_m_dispatch_requires_compiled_target(
++    monkeypatch,
++    capability: tuple[int, int],
++    expected: bool,
++) -> None:
++    monkeypatch.setattr(
++        torch.cuda,
++        "get_device_capability",
++        lambda _device: capability,
++    )
++
++    assert (
++        _use_k6_mcg_small(
++            device=torch.device("cuda"),
++            m=128,
++            trellis_bits=6,
++            trellis_codebook="mcg",
++            trellis_pair_kind=None,
++            compute_dtype=torch.float16,
++            external_hadamard_128=None,
++        )
++        is expected
++    )
++
++
+ @pytest.mark.parametrize(
+     ("size_m", "size_k", "size_n", "expected"),
+     [
+diff --git a/tests/moe/test_mixed_trellis_source_contract.py b/tests/moe/test_mixed_trellis_source_contract.py
+new file mode 100644
+index 0000000000000000000000000000000000000000..34372720e9520c47143b5118b807ce0bb9b3dd03
+--- /dev/null
++++ b/tests/moe/test_mixed_trellis_source_contract.py
+@@ -0,0 +1,107 @@
++from __future__ import annotations
++
++import ast
++from pathlib import Path
++
++
++ROOT = Path(__file__).resolve().parents[2]
++
++
++def _method(path: Path, class_name: str, method_name: str) -> ast.FunctionDef:
++    tree = ast.parse(path.read_text(encoding="utf-8"), filename=str(path))
++    for node in tree.body:
++        if isinstance(node, ast.ClassDef) and node.name == class_name:
++            for member in node.body:
++                if isinstance(member, ast.FunctionDef) and member.name == method_name:
++                    return member
++    raise AssertionError(f"missing {class_name}.{method_name} in {path}")
++
++
++def test_mixed_trellis_call_tracks_shared_moe_body_abi() -> None:
++    kernel_path = ROOT / "b12x/moe/_shared/kernels/w4a16/kernel.py"
++    mixed_path = ROOT / "b12x/moe/_shared/kernels/w4a16/mixed_trellis.py"
++    body = _method(kernel_path, "W4A16FusedMoeKernel", "_moe_body")
++    mixed = _method(mixed_path, "W4A16MixedTrellisKernel", "kernel")
++
++    calls = [
++        node
++        for node in ast.walk(mixed)
++        if isinstance(node, ast.Call)
++        and isinstance(node.func, ast.Attribute)
++        and node.func.attr == "_moe_body"
++    ]
++    assert len(calls) == 1
++    call = calls[0]
++    assert not call.keywords
++
++    parameters = [argument.arg for argument in body.args.args][1:]
++    arguments = [ast.unparse(argument) for argument in call.args]
++    assert len(arguments) == len(parameters)
++    bound = dict(zip(parameters, arguments, strict=True))
++
++    assert bound["fc1_trellis_lut_addr"] == "cutlass.Int64(0)"
++    assert bound["fc2_trellis_lut_addr"] == "cutlass.Int64(0)"
++    assert bound["weight_num_experts"] == "total_experts"
++    assert bound["route_num_experts"] == "total_experts"
++    assert bound["active_m"] == "active_m"
++    assert bound["fc1_emit_tile"] == "fc1_emit"
++    assert bound["fc2_emit_tile"] == "fc2_emit"
++
++
++def test_mixed_trellis_dispatch_tracks_tile_abis() -> None:
++    kernel_path = ROOT / "b12x/moe/_shared/kernels/w4a16/kernel.py"
++    mixed_path = ROOT / "b12x/moe/_shared/kernels/w4a16/mixed_trellis.py"
++    dispatch = _method(mixed_path, "W4A16MixedTrellisKernel", "_dispatch_tier_gemm")
++
++    for method_name in ("_run_tile", "_run_tile_m8_pair"):
++        target = _method(kernel_path, "W4A16GemmKernel", method_name)
++        calls = [
++            node
++            for node in ast.walk(dispatch)
++            if isinstance(node, ast.Call)
++            and isinstance(node.func, ast.Attribute)
++            and node.func.attr == method_name
++        ]
++        assert len(calls) == 1
++        parameters = [argument.arg for argument in target.args.args][1:]
++        arguments = [ast.unparse(argument) for argument in calls[0].args]
++        assert len(arguments) == len(parameters)
++        bound = dict(zip(parameters, arguments, strict=True))
++        assert bound["trellis_lut_addr"] == "trellis_lut_addr"
++        assert bound["active_size_m"] == "active_size_m"
++
++
++def test_w4a16_internal_calls_supply_required_arguments() -> None:
++    path = ROOT / "b12x/moe/_shared/kernels/w4a16/kernel.py"
++    tree = ast.parse(path.read_text(encoding="utf-8"), filename=str(path))
++    kernel = next(
++        node
++        for node in tree.body
++        if isinstance(node, ast.ClassDef) and node.name == "W4A16GemmKernel"
++    )
++    methods = {
++        node.name: node for node in kernel.body if isinstance(node, ast.FunctionDef)
++    }
++
++    mismatches: list[str] = []
++    for caller in methods.values():
++        for call in ast.walk(caller):
++            if not (
++                isinstance(call, ast.Call)
++                and isinstance(call.func, ast.Attribute)
++                and isinstance(call.func.value, ast.Name)
++                and call.func.value.id == "self"
++                and call.func.attr in methods
++            ):
++                continue
++            callee = methods[call.func.attr]
++            maximum = len(callee.args.args) - 1
++            required = maximum - len(callee.args.defaults)
++            supplied = len(call.args) + len(call.keywords)
++            if not required <= supplied <= maximum:
++                mismatches.append(
++                    f"{caller.name}:{call.lineno} -> {callee.name}: "
++                    f"supplied={supplied}, required={required}, maximum={maximum}"
++                )
++
++    assert not mismatches, "\n".join(mismatches)
+diff --git a/tests/moe/test_w4a16_mixed_trellis.py b/tests/moe/test_w4a16_mixed_trellis.py
+index d31c34f295ac3660de59dd27ba10e2014d4e47a2..6bbca4d024433af864b5299d16b60eecbd3d9703 100644
+--- a/tests/moe/test_w4a16_mixed_trellis.py
++++ b/tests/moe/test_w4a16_mixed_trellis.py
+@@ -145,8 +145,10 @@ def test_mixed_kernel_tracks_shared_moe_body_contract() -> None:
+ 
+     driver_parameters = inspect.signature(W4A16FusedMoeKernel._moe_body).parameters
+     assert len(calls[0].args) + len(calls[0].keywords) == len(driver_parameters) - 1
+-    assert [ast.unparse(arg) for arg in calls[0].args[-10:]] == [
++    assert [ast.unparse(arg) for arg in calls[0].args[-12:]] == [
+         "descriptor_map",
++        "cutlass.Int64(0)",
++        "cutlass.Int64(0)",
+         "total_experts",
+         "total_experts",
+         "smem_base",
+diff --git a/tests/moe/test_w4a16_route_pack_warmup.py b/tests/moe/test_w4a16_route_pack_warmup.py
+new file mode 100644
+index 0000000000000000000000000000000000000000..6c7288b314ebc2785418085ce323881960fe192e
+--- /dev/null
++++ b/tests/moe/test_w4a16_route_pack_warmup.py
+@@ -0,0 +1,54 @@
++import pytest
++
++from b12x.moe._shared.kernels.w4a16.host import (
++    route_pack_warmup_token_counts,
++)
++
++
++@pytest.mark.parametrize(
++    ("capacity", "expected"),
++    [
++        (1, (1,)),
++        (5, (1, 2, 3, 4, 5)),
++        (6, (1, 2, 3, 4, 5, 6)),
++        (32, (1, 2, 3, 4, 5, 8, 9, 16, 17, 32)),
++        (
++            3072,
++            (
++                1,
++                2,
++                3,
++                4,
++                5,
++                8,
++                9,
++                16,
++                17,
++                32,
++                33,
++                64,
++                65,
++                128,
++                129,
++                256,
++                257,
++                512,
++                513,
++                1024,
++                1025,
++                2048,
++                2049,
++                3072,
++            ),
++        ),
++    ],
++)
++def test_route_pack_warmup_covers_capacity_buckets(
++    capacity: int, expected: tuple[int, ...]
++) -> None:
++    assert route_pack_warmup_token_counts(capacity) == expected
++
++
++def test_route_pack_warmup_rejects_empty_capacity() -> None:
++    with pytest.raises(ValueError, match="capacity must be positive"):
++        route_pack_warmup_token_counts(0)

--- a/patches/releases/gilded-gnosis-v20-r33/lmcache/integration.lock.json
+++ b/patches/releases/gilded-gnosis-v20-r33/lmcache/integration.lock.json
@@ -1,0 +1,96 @@
+{
+  "base": {
+    "commit": "9cebd405d0caf4bebe01d694b5a8bf4e3e354314",
+    "ref": "refs/heads/release/v0.5.2-glm52-dcp-base",
+    "repository": "https://github.com/local-inference-lab/LMCache.git"
+  },
+  "manifest": {
+    "sha256": "7cce6c13a12987da499b1adb3e52c25447604aecfa2ec5d90d0dbbb6f76d570c"
+  },
+  "name": "gilded-gnosis-v20-lmcache",
+  "pull_requests": [
+    {
+      "disposition": "merged",
+      "head": "7b7583aef55e98ba05a6c199e71601d78552e794",
+      "number": 7,
+      "ref": "refs/pull/7/head",
+      "title": "Return bounded LMCache MP RPC handler errors"
+    },
+    {
+      "disposition": "merged",
+      "head": "31c4175d2134518e5b43fe8f4a7d072df6043a13",
+      "number": 8,
+      "ref": "refs/pull/8/head",
+      "title": "Recover failed MP retrieves by recomputing invalid blocks"
+    },
+    {
+      "disposition": "merged",
+      "head": "c3b73de74d855f6263deea8b6c6c4dde87e6e5b9",
+      "number": 9,
+      "ref": "refs/pull/9/head",
+      "title": "Restore the largest exact L1 prefix after allocation failure"
+    },
+    {
+      "disposition": "merged",
+      "head": "59186798bb5859b7add7bcac81dff9f2fd4037ab",
+      "number": 10,
+      "ref": "refs/pull/10/head",
+      "title": "Protect native lookup keys from concurrent deletion"
+    },
+    {
+      "disposition": "merged",
+      "head": "2cee5a2c1ef7e80028e94b1bc4bfbfc02e2c2a8d",
+      "number": 11,
+      "ref": "refs/pull/11/head",
+      "title": "Log bounded prefetch failure key samples"
+    },
+    {
+      "disposition": "merged",
+      "head": "baf1345106ebe568a116a35fdcee36bfec73da57",
+      "number": 12,
+      "ref": "refs/pull/12/head",
+      "title": "Return native per-key store results"
+    },
+    {
+      "disposition": "merged",
+      "head": "d4dce69bf90362953cf9ac9a86cccc186b3219dc",
+      "number": 13,
+      "ref": "refs/pull/13/head",
+      "title": "Enforce native filesystem O_DIRECT alignment"
+    },
+    {
+      "disposition": "merged",
+      "head": "502b3c60f2e61625d6e32a31d0d725eedc620792",
+      "number": 14,
+      "ref": "refs/pull/14/head",
+      "title": "Support current and legacy native filesystem object-group keys"
+    },
+    {
+      "disposition": "merged",
+      "head": "7729a9c75f2c29f14a27ea1e84ee6970950197ce",
+      "number": 15,
+      "ref": "refs/pull/15/head",
+      "title": "Make native stores durable and capacity-bounded"
+    },
+    {
+      "disposition": "merged",
+      "head": "e6c2708fe8ae8a96d3c66e83bf4b548c734fbb13",
+      "number": 16,
+      "ref": "refs/pull/16/head",
+      "title": "Restore native filesystem capacity accounting after restart"
+    },
+    {
+      "disposition": "merged",
+      "head": "f9639e2094f70955a1145bfd7219b6fdd39ee143",
+      "number": 17,
+      "ref": "refs/pull/17/head",
+      "title": "Add bounded L1 writeback to durable storage"
+    }
+  ],
+  "result": {
+    "patch": "integration.patch",
+    "patch_sha256": "e9f5369ee134cbc697e77d9fd9d77219aceea5fabf2fe90e3b74542bbeb200ca",
+    "tree": "9a05c8818bae48d15b79c7e876418bb813c08cd0"
+  },
+  "schema_version": 1
+}

--- a/patches/releases/gilded-gnosis-v20-r33/lmcache/integration.patch
+++ b/patches/releases/gilded-gnosis-v20-r33/lmcache/integration.patch
@@ -1,0 +1,4262 @@
+diff --git a/csrc/storage_backends/connector_base.h b/csrc/storage_backends/connector_base.h
+index c2cd35a174a1225c467d1479ea347b0d6e5ebd0e..0df7677cef0d0172a7cb60f7c9f3599cb189b555 100644
+--- a/csrc/storage_backends/connector_base.h
++++ b/csrc/storage_backends/connector_base.h
+@@ -111,6 +111,9 @@ class ConnectorBase : public IStorageConnector {
+     auto [batch_future_id, batch_state, num_tiles, tile_size] =
+         prepare_batch_operation(num_items, Op::BATCH_TILE_SET);
+ 
++    // pre-allocate per-key results so partial store failures are visible
++    batch_state->per_key_results.assign(num_items, 0);
++
+     // fan out work to threads
+     for (size_t tile_idx = 0; tile_idx < num_tiles; ++tile_idx) {
+       auto tile_req = create_tile_request(
+@@ -326,10 +329,30 @@ class ConnectorBase : public IStorageConnector {
+       }
+     }
+   }
++  // Records a per-key result for every key in the tile (continuing past
++  // failures instead of aborting the tile), then rethrows so batch-level
++  // ok=false semantics are preserved for consumers that ignore per-key
++  // results.
+   virtual void do_batch_set(ConnectionType& conn, const Request& req) {
++    bool any_failed = false;
++    std::string first_error;
+     for (size_t i = 0; i < req.keys.size(); ++i) {
+-      do_single_set(conn, req.keys[i], req.buf_ptrs[i], req.buf_lens[i],
+-                    req.batch_chunk_num_bytes);
++      try {
++        do_single_set(conn, req.keys[i], req.buf_ptrs[i], req.buf_lens[i],
++                      req.batch_chunk_num_bytes);
++        req.batch->per_key_results[req.start_idx + i] = 1;
++      } catch (const std::exception& e) {
++        req.batch->per_key_results[req.start_idx + i] = 0;
++        if (!any_failed) {
++          any_failed = true;
++          first_error = e.what();
++        }
++        fprintf(stderr, "[LMCache SET] key %s failed: %s\n",
++                req.keys[i].c_str(), e.what());
++      }
++    }
++    if (any_failed) {
++      throw std::runtime_error("batch set partially failed: " + first_error);
+     }
+   }
+   virtual void do_batch_exists(ConnectionType& conn, const Request& req) {
+@@ -612,9 +635,10 @@ class ConnectorBase : public IStorageConnector {
+         std::lock_guard<std::mutex> lk(req.batch->err_mu);
+         batch_comp.error = req.batch->first_error;
+       }
+-      // for batch exists and batch get, move per-key results
++      // move per-key results for every op that records them
+       if (req.batch->batch_op == Op::BATCH_TILE_EXISTS ||
+           req.batch->batch_op == Op::BATCH_TILE_GET ||
++          req.batch->batch_op == Op::BATCH_TILE_SET ||
+           req.batch->batch_op == Op::BATCH_TILE_DELETE) {
+         batch_comp.result_bytes = std::move(req.batch->per_key_results);
+       }
+diff --git a/csrc/storage_backends/fs/connector.cpp b/csrc/storage_backends/fs/connector.cpp
+index e54d98f54f5428afad363cf1c5f5f380cdd8fffb..727ed016f10ae0b0c6e863c4234439dbaac0e7f8 100644
+--- a/csrc/storage_backends/fs/connector.cpp
++++ b/csrc/storage_backends/fs/connector.cpp
+@@ -2,10 +2,22 @@
+ 
+ #include "connector.h"
+ #include <cerrno>
++#include <cstdint>
+ #include <cstdio>
+ #include <stdexcept>
+ #include <string>
+ 
++namespace {
++// O_DIRECT requires the buffer ADDRESS to be block-aligned as well as the
++// length; a misaligned address fails the read/write with EINVAL. Buffers
++// come from Python and carry no alignment guarantee, so fall back to
++// buffered I/O whenever either constraint is unmet.
++bool odirect_eligible(const void* buf, size_t len, size_t disk_block_size) {
++  return disk_block_size > 0 && len % disk_block_size == 0 &&
++         reinterpret_cast<uintptr_t>(buf) % disk_block_size == 0;
++}
++}  // namespace
++
+ namespace lmcache {
+ namespace connector {
+ 
+@@ -27,22 +39,23 @@ std::string FSConnector::replace_all(const std::string& str,
+ 
+ std::string FSConnector::key_to_filename(const std::string& key) {
+   // Input key format (from _object_key_to_string):
+-  //   Unsalted: <model_name>@<kv_rank_hex>@<chunk_hash_hex>
+-  //   Salted  : <model_name>@<kv_rank_hex>@<chunk_hash_hex>@<cache_salt>
++  //   Legacy unsalted: <model_name>@<kv_rank_hex>@<chunk_hash_hex>
++  //   Legacy salted  : <model_name>@<kv_rank_hex>@<chunk_hash_hex>@<cache_salt>
++  //   Current unsalted:
++  //     <model_name>@<kv_rank_hex>@<object_group_id_hex>@<chunk_hash_hex>
++  //   Current salted appends @<cache_salt> to the current unsalted shape.
+   //
+   // Output filename (matching fs_l2_adapter.py._object_key_to_filename):
+   //   Unsalted: <model_name_safe>@0x<kv_rank_hex>@<chunk_hash_hex>.data
+   //   Salted  :
+   //   <model_name_safe>@0x<kv_rank_hex>@<chunk_hash_hex>@<cache_salt>.data
+   //
+-  // The unsalted 3-field shape is bit-identical to the pre-cache_salt
+-  // format, so existing cache directories remain valid.
+-  //
+-  // NOTE: both model_name and cache_salt are forbidden from containing
+-  // '@' (invariant enforced on the Python side), so splitting on '@'
+-  // is unambiguous — no marker, no rsplit.
++  // Four fields are intentionally not interpreted: that shape can mean a
++  // legacy salted key or a current unsalted key, and both map correctly by
++  // preserving every field after kv_rank verbatim.
+ 
+-  // Split on '@' — must yield 3 (unsalted) or 4 (salted) fields.
++  // Split on '@'. Current ObjectKey serialization has four or five fields;
++  // three-field legacy keys remain readable for cache compatibility.
+   std::vector<std::string> parts;
+   size_t start = 0;
+   for (size_t pos = 0; pos <= key.size(); ++pos) {
+@@ -51,34 +64,28 @@ std::string FSConnector::key_to_filename(const std::string& key) {
+       start = pos + 1;
+     }
+   }
+-  if (parts.size() != 3 && parts.size() != 4) {
++  if (parts.size() < 3 || parts.size() > 5) {
+     throw std::runtime_error(
+-        "FSConnector: malformed key (expected 3 or 4 '@'-separated fields): " +
++        "FSConnector: malformed key (expected 3 to 5 '@'-separated fields): " +
+         key);
+   }
+ 
+   const std::string& model_name = parts[0];
+   const std::string& kv_rank_hex = parts[1];
+-  const std::string& chunk_hash = parts[2];
+-  const std::string cache_salt = parts.size() == 4 ? parts[3] : std::string();
+ 
+   // Replace '/' with '-SEP-' for filesystem safety
+   std::string safe_model = replace_all(model_name, "/", PATH_SLASH_REPLACEMENT);
+ 
+-  // Emit filename. Salt is appended at the tail so the unsalted shape
+-  // matches what older builds wrote to disk.
++  // Emit the model and normalized rank, preserving all remaining fields.
+   std::string result;
+-  result.reserve(safe_model.size() + kv_rank_hex.size() + chunk_hash.size() +
+-                 cache_salt.size() + 32);
++  result.reserve(key.size() + 16);
+   result += safe_model;
+   result += KEY_SEP;
+   result += "0x";
+   result += kv_rank_hex;
+-  result += KEY_SEP;
+-  result += chunk_hash;
+-  if (!cache_salt.empty()) {
++  for (size_t i = 2; i < parts.size(); ++i) {
+     result += KEY_SEP;
+-    result += cache_salt;
++    result += parts[i];
+   }
+   result += FILE_EXT;
+   return result;
+@@ -174,8 +181,11 @@ void FSConnector::do_single_get(WorkerFSConn& conn, const std::string& key,
+   int flags = O_RDONLY;
+   bool do_odirect = conn.use_odirect;
+   if (do_odirect) {
+-    bool aligned = conn.disk_block_size > 0 && len % conn.disk_block_size == 0;
+-    if (aligned) {
++    const bool split_aligned = conn.disk_block_size > 0 &&
++                               (conn.read_ahead_size == 0 ||
++                                len <= conn.read_ahead_size ||
++                                conn.read_ahead_size % conn.disk_block_size == 0);
++    if (odirect_eligible(buf, len, conn.disk_block_size) && split_aligned) {
+ #ifdef O_DIRECT
+       flags |= O_DIRECT;
+ #endif
+@@ -243,8 +253,7 @@ void FSConnector::do_single_set(WorkerFSConn& conn, const std::string& key,
+   int flags = O_CREAT | O_WRONLY | O_TRUNC;
+   bool do_odirect = conn.use_odirect;
+   if (do_odirect) {
+-    bool aligned = conn.disk_block_size > 0 && len % conn.disk_block_size == 0;
+-    if (aligned) {
++    if (odirect_eligible(buf, len, conn.disk_block_size)) {
+ #ifdef O_DIRECT
+       flags |= O_DIRECT;
+ #endif
+diff --git a/csrc/storage_backends/fs/connector.h b/csrc/storage_backends/fs/connector.h
+index 03b7b9cc5e0a2cac7ab9e39404d80c760b4e9018..7b9010947c18de36684317ed7c2628c3d2be0161 100644
+--- a/csrc/storage_backends/fs/connector.h
++++ b/csrc/storage_backends/fs/connector.h
+@@ -21,7 +21,9 @@ static constexpr const char* FILE_EXT = ".data";
+ static constexpr const char* TMP_EXT = ".tmp";
+ 
+ // Per-worker connection state for the FS connector.
+-// Each worker maintains its own I/O buffer for O_DIRECT.
++// O_DIRECT engages per request only when both the transfer length and the
++// caller's buffer address are multiples of the disk block size; anything
++// else falls back to buffered I/O.
+ struct WorkerFSConn {
+   std::filesystem::path base_path;
+   std::filesystem::path tmp_dir;  // empty if not configured
+@@ -52,17 +54,20 @@ class FSConnector : public ConnectorBase<WorkerFSConn> {
+   // Build the filesystem-safe filename from a serialized key string.
+   //
+   // Input key (from NativeConnectorL2Adapter._object_key_to_string):
+-  //   Unsalted: "{model}@{kv_rank:08x}@{hash.hex()}"
+-  //   Salted  : "{model}@{kv_rank:08x}@{hash.hex()}@{cache_salt}"
++  //   Current unsalted:
++  //     "{model}@{kv_rank:08x}@{object_group:x}@{hash.hex()}"
++  //   Current salted appends "@{cache_salt}". Legacy three/four-field keys
++  //   without object_group_id remain supported.
+   //
+   // Output filename (matching fs_l2_adapter.py._object_key_to_filename):
+-  //   Unsalted: "{safe_model}@{kv_rank:#010x}@{hash.hex()}.data"
+-  //   Salted  : "{safe_model}@{kv_rank:#010x}@{hash.hex()}@{cache_salt}.data"
++  //   Current unsalted:
++  //     "{safe_model}@{kv_rank:#010x}@{object_group:x}@{hash.hex()}.data"
++  //   Current salted appends "@{cache_salt}" before ".data".
+   //
+   // Differences from the input: '/' in model becomes '-SEP-', kv_rank
+-  // gains a '0x' prefix, and '.data' is appended. Both model_name and
+-  // cache_salt are forbidden from containing '@' (enforced on the
+-  // Python side), so the parse is unambiguous.
++  // gains a '0x' prefix, and '.data' is appended. All fields after kv_rank
++  // are preserved because four fields can represent either a legacy salted
++  // key or a current unsalted key.
+   static std::string key_to_filename(const std::string& key);
+ 
+   static std::string replace_all(const std::string& str,
+diff --git a/csrc/storage_backends/mooncake/connector.cpp b/csrc/storage_backends/mooncake/connector.cpp
+index 685fa4165b188b517a5c0de50753e5ae2e596d6f..0d5109e0dbb5595476806071d62c6dedd6f2bf98 100644
+--- a/csrc/storage_backends/mooncake/connector.cpp
++++ b/csrc/storage_backends/mooncake/connector.cpp
+@@ -173,12 +173,23 @@ void MooncakeConnector::do_batch_set(WorkerMooncakeConn& conn,
+       conn.client->batch_put_from(req.keys, req.buf_ptrs, req.buf_lens);
+   ensure_batch_result_size(results, req.keys.size(), "batch_put_from");
+ 
++  // Record per-key results before failing the tile so partial store
++  // failures stay visible to consumers that honor them.
++  size_t first_failed = results.size();
+   for (size_t i = 0; i < results.size(); ++i) {
+-    if (results[i] != 0) {
+-      throw std::runtime_error("Mooncake batch_put_from failed for key: " +
+-                               req.keys[i]);
++    if (results[i] == 0) {
++      req.batch->per_key_results[req.start_idx + i] = 1;
++    } else {
++      req.batch->per_key_results[req.start_idx + i] = 0;
++      if (first_failed == results.size()) {
++        first_failed = i;
++      }
+     }
+   }
++  if (first_failed != results.size()) {
++    throw std::runtime_error("Mooncake batch_put_from failed for key: " +
++                             req.keys[first_failed]);
++  }
+ }
+ 
+ void MooncakeConnector::do_batch_exists(WorkerMooncakeConn& conn,
+diff --git a/lmcache/integration/vllm/lmcache_mp_connector.py b/lmcache/integration/vllm/lmcache_mp_connector.py
+index d268070c3c0daa534a616c88312f8da7b5c665de..21af3747ede9f78c608841a692acc9c25e0bbc29 100644
+--- a/lmcache/integration/vllm/lmcache_mp_connector.py
++++ b/lmcache/integration/vllm/lmcache_mp_connector.py
+@@ -464,6 +464,42 @@ class LMCacheMPRequestMetadata:
+             "number of LMCache hit tokens. "
+         )
+         if end_token_idx > start_token_idx:
++            # allocated_block_ids must cover [start_token_idx, end_token_idx)
++            # in every engine group. slice_block_ids_per_group() validates
++            # chunk alignment only; its plain Python slice truncates
++            # silently, so a tracker primed with LMCache hit counts on a
++            # scheduling pass whose allocation never materialised would emit
++            # a retrieve op with too few block ids. The MP server fails
++            # closed on the short list, wasting a doomed round-trip and
++            # relying on the failure being surfaced at all. Suppress the op
++            # instead so the request recomputes cleanly. Never clamp
++            # end_token_idx: a clamped retrieve completes a load vLLM does
++            # not expect and re-creates the desync downstream.
++            # One allocated id of group g covers group_tokens_per_block[g]
++            # global token positions (KV-spec block_size, DCP-scaled), the
++            # same arithmetic GetStoreMetadata uses to bound its
++            # allocated_tokens.
++            for group_idx, tokens_per_block in enumerate(group_tokens_per_block):
++                allocated = len(tracker.allocated_block_ids.get(group_idx, []))
++                if allocated * tokens_per_block < end_token_idx:
++                    logger.warning(
++                        "LMCache retrieve suppressed for request_id=%s: "
++                        "engine group %d has %d allocated block(s) x %d "
++                        "tokens/block = %d tokens < end_token_idx=%d "
++                        "(start_token_idx=%d, vllm_hit_tokens=%d, "
++                        "lmcache_hit_tokens=%d) -- tracker/allocation "
++                        "desync; falling back to recompute.",
++                        tracker.request_id,
++                        group_idx,
++                        allocated,
++                        tokens_per_block,
++                        allocated * tokens_per_block,
++                        end_token_idx,
++                        start_token_idx,
++                        tracker.num_vllm_hit_tokens,
++                        tracker.num_lmcache_hit_tokens,
++                    )
++                    return None
+             block_ids = slice_block_ids_per_group(
+                 tracker.allocated_block_ids,
+                 group_tokens_per_block,
+diff --git a/lmcache/integration/vllm/vllm_multi_process_adapter.py b/lmcache/integration/vllm/vllm_multi_process_adapter.py
+index d74fe3af02cbefc7755c8446434a36034c681ef3..dd5aa0e6033292eaad06dd8f0b7961d58cf6b2f1 100644
+--- a/lmcache/integration/vllm/vllm_multi_process_adapter.py
++++ b/lmcache/integration/vllm/vllm_multi_process_adapter.py
+@@ -1173,8 +1173,11 @@ class LMCacheMPWorkerAdapter:
+         self.store_events: dict[str, list[_IpcEvent]] = {}
+         self.retrieve_events: dict[str, _IpcEvent] = {}
+ 
+-        # Block IDs that failed due to retrieve timeout
++        # Block IDs of failed retrieves (timeout, server-reported failure,
++        # or raising future), consumed by get_block_ids_with_load_errors().
+         self.error_block_ids: set[int] = set()
++        # Total failed retrieves on this worker, for log-based diagnostics.
++        self.retrieve_failure_count: int = 0
+ 
+         # Retrieve request ids dropped by the unhealthy early-return of
+         # submit_retrieve_request. get_finished must still report each id
+@@ -1657,6 +1660,9 @@ class LMCacheMPWorkerAdapter:
+             - The second set contains the finished retrieve request ids,
+                 including retrieves dropped at submit time while unhealthy
+                 (reported exactly once; blocks already in error_block_ids).
++                A failed retrieve (server result False or a raising future)
++                is reported finished with its block ids recorded in
++                error_block_ids so the scheduler recomputes them.
+ 
+         Notes:
+             When enabling async scheduling in vLLM, the same request ID may appear
+@@ -1701,19 +1707,45 @@ class LMCacheMPWorkerAdapter:
+ 
+         finished_stores = self._poll_store_futures()
+         finished_retrieves = set()
+-        for request_id, (r_future, _) in self.retrieve_futures.items():
++        for request_id, (r_future, r_block_ids) in self.retrieve_futures.items():
+             if not r_future.query():
+                 continue
+ 
+-            r_result = r_future.result()
++            try:
++                r_result = r_future.result()
++            except Exception as exc:
++                # A raising future must not propagate out of get_finished
++                # (that would kill the engine step); contain it as a failed
++                # retrieve on the standard failure path.
++                logger.error(
++                    "LMCache retrieve future raised for request_id=%s: %r "
++                    "-- treating as failed retrieve.",
++                    request_id,
++                    exc,
++                )
++                r_result = False
+             finished_retrieves.add(request_id)
+ 
+             if not r_result:
++                # Surface the failure to the scheduler. Reporting the
++                # request finished without recording the failed span would
++                # ACK the load as successful: the request then decodes over
++                # never-written GPU blocks and the phantom blocks enter the
++                # shared prefix cache. error_block_ids feeds
++                # get_block_ids_with_load_errors() ->
++                # kv_connector_output.invalid_block_ids -> scheduler
++                # recompute. The MP server collapses per-key results into
++                # one bool, so marking the op's whole span is
++                # conservative-correct for partial failures too.
++                self.error_block_ids.update(r_block_ids)
++                self.retrieve_failure_count += 1
+                 logger.error(
+-                    "Something went wrong when processing the "
+-                    "retrieve request for request_id=%s, result=%s",
++                    "LMCache retrieve failed for request_id=%s: %d block(s) "
++                    "marked invalid for scheduler recompute "
++                    "(total retrieve failures this worker: %d)",
+                     request_id,
+-                    r_result,
++                    len(r_block_ids),
++                    self.retrieve_failure_count,
+                 )
+ 
+         # Store futures and events are removed together by _poll_store_futures.
+@@ -1758,8 +1790,8 @@ class LMCacheMPWorkerAdapter:
+ 
+     def get_block_ids_with_load_errors(self) -> set[int]:
+         """
+-        Returns the block IDs that failed due to retrieve timeout,
+-        then clears the internal set.
++        Returns the block IDs of failed retrieves (timeout, server-reported
++        failure, or raising future), then clears the internal set.
+         """
+         errors = self.error_block_ids.copy()
+         self.error_block_ids.clear()
+diff --git a/lmcache/v1/distributed/config.py b/lmcache/v1/distributed/config.py
+index de36535a57df7ceb8ca8bbb97276c4733e568270..ac11158668fdbfd00f36512cc08a90b7f42860b4 100644
+--- a/lmcache/v1/distributed/config.py
++++ b/lmcache/v1/distributed/config.py
+@@ -226,6 +226,21 @@ class EvictionConfig:
+     extra_logging_interval: float = field(default=10.0)
+     """ Seconds between L1 memory usage log lines when extra logging is enabled. """
+ 
++    write_back_on_evict: bool = field(default=False)
++    """ Flush evicted L1 objects to L2 synchronously and delete them from L1
++    only once every key in the batch is durable; without this, eviction
++    discards the objects. Requires an L2 adapter with store_objects_sync(). """
++
++    periodic_flush_interval: float = field(default=0.0)
++    """ Seconds between periodic L1-to-L2 backup flush scans while below the
++    eviction watermark (0 disables). Backup keeps the L1 copy; only L2 gains
++    a copy, so a restart or session expiry no longer costs a cold prefill. """
++
++    emergency_evict_for_prefetch: bool = field(default=False)
++    """ Allow the prefetch controller to synchronously evict LRU L1 keys to
++    make room for large L2-to-L1 restores. Effective only together with
++    write_back_on_evict, so victims are persisted before deletion. """
++
+ 
+ @dataclass
+ class StorageManagerConfig:
+@@ -296,6 +311,12 @@ def validate_storage_manager_config(config: StorageManagerConfig) -> None:
+         ValueError: If mutually exclusive L1 tiers are both configured, or
+             hybrid L1 is paired with incompatible L2 adapters.
+     """
++    eviction = config.eviction_config
++    if eviction.periodic_flush_interval < 0:
++        raise ValueError("periodic_flush_interval must be >= 0")
++    if eviction.emergency_evict_for_prefetch and not eviction.write_back_on_evict:
++        raise ValueError("emergency_evict_for_prefetch requires write_back_on_evict")
++
+     if (
+         config.l1_manager_config.gds_l1_config is not None
+         and config.l1_manager_config.memory_config.devdax_path
+@@ -471,6 +492,28 @@ def add_storage_manager_args(
+         help="The fraction of memory to evict when triggered (0.0 to 1.0). "
+         "Default is 0.2.",
+     )
++    eviction_group.add_argument(
++        "--write-back-on-evict",
++        action="store_true",
++        help="Flush evicted L1 objects to L2 synchronously and delete them "
++        "from L1 only once every key in the batch is durable. Requires an "
++        "L2 adapter with a synchronous store path.",
++    )
++    eviction_group.add_argument(
++        "--periodic-flush-interval",
++        type=float,
++        default=0.0,
++        help="Seconds between periodic L1-to-L2 backup flush scans while "
++        "below the eviction watermark (0 disables). The backup keeps the "
++        "L1 copy; only L2 gains a copy.",
++    )
++    eviction_group.add_argument(
++        "--emergency-evict-for-prefetch",
++        action="store_true",
++        help="Allow the prefetch controller to synchronously evict LRU L1 "
++        "keys to make room for large L2-to-L1 restores. Effective only "
++        "together with --write-back-on-evict.",
++    )
+ 
+     # L2 Policies
+     # Import here to break circular dependency:
+@@ -596,6 +639,11 @@ def parse_args_to_config(
+         eviction_ratio=args.eviction_ratio,
+         extra_logging_enabled=getattr(args, "enable_extra_logging", False),
+         extra_logging_interval=getattr(args, "extra_logging_interval", 10.0),
++        write_back_on_evict=getattr(args, "write_back_on_evict", False),
++        periodic_flush_interval=getattr(args, "periodic_flush_interval", 0.0),
++        emergency_evict_for_prefetch=getattr(
++            args, "emergency_evict_for_prefetch", False
++        ),
+     )
+ 
+     l2_adapter_config = parse_args_to_l2_adapters_config(args)
+diff --git a/lmcache/v1/distributed/l1_manager.py b/lmcache/v1/distributed/l1_manager.py
+index 44cf55f615f2bf491bdf72784ac152a7ee422457..4a2be000b86a576759cb3d5579acbc45181b14e7 100644
+--- a/lmcache/v1/distributed/l1_manager.py
++++ b/lmcache/v1/distributed/l1_manager.py
+@@ -5,6 +5,7 @@ Managing objects and memory for L1 cache
+ 
+ # Standard
+ from dataclasses import dataclass
++from itertools import chain, islice
+ from typing import Literal
+ import threading
+ 
+@@ -462,6 +463,11 @@ class L1Manager:
+         Errors:
+             KEY_NOT_WRITABLE: The key exists but is not writable.
+             OUT_OF_MEMORY: Not enough memory to allocate for the object.
++
++        Note:
++            When the full batch does not fit, the longest prefix of the
++            to-be-allocated keys that fits is allocated and the remaining
++            keys report OUT_OF_MEMORY.
+         """
+         need_to_allocate: list[tuple[ObjectKey, bool]] = []
+         ret: dict[ObjectKey, L1OperationResult] = {}
+@@ -499,6 +505,26 @@ class L1Manager:
+             layout_desc, len(need_to_allocate)
+         )
+ 
++        # A full-batch allocation failure would fail every key even when
++        # most of the batch fits, collapsing large L2->L1 restores to zero
++        # prefix hits and forcing full re-prefills upstream. Fall back to
++        # allocating the longest prefix that fits; callers already handle
++        # per-key OOM (prefetch trims to the contiguous prefix, the store
++        # path skips failed keys).
++        if err != L1Error.SUCCESS and len(need_to_allocate) > 1:
++            if allocated_objs:
++                self._memory_manager.free(allocated_objs)
++                allocated_objs = []
++            err, allocated_objs = self._allocate_largest_prefix(
++                layout_desc, len(need_to_allocate)
++            )
++            if err == L1Error.SUCCESS:
++                logger.warning(
++                    "Partial L1 allocation: %d/%d objects (prefix) allocated",
++                    len(allocated_objs),
++                    len(need_to_allocate),
++                )
++
+         if err != L1Error.SUCCESS:
+             for key, _ in need_to_allocate:
+                 ret[key] = (L1Error.OUT_OF_MEMORY, None)
+@@ -508,6 +534,10 @@ class L1Manager:
+                 self._memory_manager.free(allocated_objs)
+ 
+         else:
++            # Mark any unallocated tail as OOM so every requested key keeps
++            # an explicit per-key result.
++            for key, _ in need_to_allocate[len(allocated_objs) :]:
++                ret[key] = (L1Error.OUT_OF_MEMORY, None)
+             for (key, is_temp), mem_obj in zip(
+                 need_to_allocate, allocated_objs, strict=False
+             ):
+@@ -531,6 +561,41 @@ class L1Manager:
+         )
+         return ret
+ 
++    def _allocate_largest_prefix(
++        self, layout_desc: MemoryLayoutDesc, want: int
++    ) -> tuple[L1Error, list[MemoryObj]]:
++        """Allocate the largest prefix below an already-failed full batch.
++
++        L1 allocators have an all-or-nothing batch contract. While holding the
++        L1 manager lock, allocation feasibility is therefore monotonic: if a
++        batch of size ``n`` fits, every smaller batch also fits. Binary search
++        finds the maximum without relying on byte estimates that can be wrong
++        for alignment or fragmented free lists. Successful probes are freed
++        before the final allocation.
++
++        This recovery path runs only after the ``want`` allocation failed, so
++        normal reservations still perform exactly one allocation.
++        """
++        low = 1
++        high = want - 1
++        largest = 0
++
++        while low <= high:
++            candidate = (low + high) // 2
++            err, objects = self._memory_manager.allocate(layout_desc, candidate)
++            if err == L1Error.SUCCESS:
++                largest = candidate
++                self._memory_manager.free(objects)
++                low = candidate + 1
++            else:
++                if objects:
++                    self._memory_manager.free(objects)
++                high = candidate - 1
++
++        if largest == 0:
++            return L1Error.OUT_OF_MEMORY, []
++        return self._memory_manager.allocate(layout_desc, largest)
++
+     @l1_mgr_synchronized
+     def finish_write(
+         self,
+@@ -793,6 +858,59 @@ class L1Manager:
+             locked_count,
+         )
+ 
++    @l1_mgr_synchronized
++    def get_evictable_keys(
++        self,
++        limit: int,
++        cursor: int = 0,
++        scan_limit: int | None = None,
++    ) -> tuple[list[ObjectKey], int]:
++        """Return a bounded, rotating batch of evictable keys.
++
++        ``cursor`` is an insertion-order offset returned by the previous call.
++        The scan wraps once and inspects at most ``scan_limit`` entries, so a
++        periodic backup cannot materialize the complete L1 keyspace while the
++        manager lock is held. Concurrent insertions or removals may shift the
++        offset, but every returned key is revalidated by ``reserve_read``.
++
++        Args:
++            limit: Maximum number of keys to return.
++            cursor: Insertion-order offset at which to resume scanning.
++            scan_limit: Maximum entries to inspect. Defaults to four batches.
++
++        Returns:
++            A pair of the eligible keys and the cursor for the next call.
++        """
++        if limit <= 0 or not self._objects:
++            return [], 0
++
++        object_count = len(self._objects)
++        start = cursor % object_count
++        max_scan = min(
++            object_count,
++            max(limit, scan_limit if scan_limit is not None else limit * 4),
++        )
++        ordered_keys = chain(
++            islice(self._objects, start, None),
++            islice(self._objects, 0, start),
++        )
++        keys: list[ObjectKey] = []
++        scanned = 0
++        for key in ordered_keys:
++            scanned += 1
++            if self.is_key_evictable(key):
++                keys.append(key)
++                if len(keys) >= limit:
++                    break
++            if scanned >= max_scan:
++                break
++        return keys, (start + scanned) % object_count
++
++    @l1_mgr_synchronized
++    def num_objects(self) -> int:
++        """Return the number of objects currently tracked in L1."""
++        return len(self._objects)
++
+     def is_key_evictable(self, key: ObjectKey) -> bool:
+         """Check if a key is eligible for eviction (not locked).
+ 
+diff --git a/lmcache/v1/distributed/l2_adapters/base.py b/lmcache/v1/distributed/l2_adapters/base.py
+index 1838553e285ce0f2c7a0b3d9a3180b6ad57ed499..dcc71deaa4c5097911fc810a6e80e80225baa384 100644
+--- a/lmcache/v1/distributed/l2_adapters/base.py
++++ b/lmcache/v1/distributed/l2_adapters/base.py
+@@ -135,6 +135,7 @@ class L2AdapterInterface(ABC):
+         # every adapter exposes the same shape via ``get_usage()``.
+         self._max_capacity_bytes: int = max_capacity_bytes
+         self._total_bytes_used: int = 0
++        self._reserved_store_bytes: int = 0
+         self._bytes_by_cache_salt: dict[str, int] = {}
+         self._usage_lock = threading.Lock()
+ 
+@@ -354,13 +355,8 @@ class L2AdapterInterface(ABC):
+         """Register a listener to receive L2 adapter events."""
+         self._listeners.append(listener)
+ 
+-    def _notify_keys_stored(self, keys: list[ObjectKey], sizes: list[int]) -> None:
+-        """Update byte accounting and notify listeners that ``keys`` were
+-        stored. ``sizes[i]`` is the byte size of ``keys[i]``.
+-
+-        Accounting is held under ``_usage_lock``; listener callbacks fire
+-        outside the lock so a slow listener cannot stall further notifies.
+-        """
++    def _account_keys_stored(self, keys: list[ObjectKey], sizes: list[int]) -> None:
++        """Apply stored-key byte accounting without invoking listeners."""
+         # Aggregate per-salt deltas before touching
+         # ``_bytes_by_cache_salt`` — one dict read/write per unique
+         # salt instead of one per key. This matters when the registry is
+@@ -377,9 +373,90 @@ class L2AdapterInterface(ABC):
+                 self._bytes_by_cache_salt[salt] = (
+                     self._bytes_by_cache_salt.get(salt, 0) + d
+                 )
++
++    def _try_reserve_store_bytes(self, size: int) -> bool:
++        """Reserve capacity before an asynchronous L2 store is submitted.
++
++        The reservation covers transient backend storage as well as the final
++        object. This keeps a burst of in-flight writes from exceeding a hard
++        adapter capacity before completion accounting becomes visible.
++        """
++        if size < 0:
++            raise ValueError("store reservation size must be non-negative")
++        with self._usage_lock:
++            projected = self._total_bytes_used + self._reserved_store_bytes + size
++            if self._max_capacity_bytes > 0 and projected > self._max_capacity_bytes:
++                return False
++            self._reserved_store_bytes += size
++            return True
++
++    def _settle_store_reservation(
++        self,
++        reserved_bytes: int,
++        keys: list[ObjectKey],
++        sizes: list[int],
++    ) -> None:
++        """Atomically release a store reservation and account durable keys."""
++        if reserved_bytes < 0:
++            raise ValueError("reserved_bytes must be non-negative")
++
++        delta: dict[str, int] = {}
++        total_delta = 0
++        for key, size in zip(keys, sizes, strict=True):
++            delta[key.cache_salt] = delta.get(key.cache_salt, 0) + size
++            total_delta += size
++
++        with self._usage_lock:
++            if reserved_bytes > self._reserved_store_bytes:
++                raise RuntimeError(
++                    "store reservation accounting underflow: "
++                    f"settling {reserved_bytes} bytes with only "
++                    f"{self._reserved_store_bytes} reserved"
++                )
++            self._reserved_store_bytes -= reserved_bytes
++            self._total_bytes_used += total_delta
++            for salt, d in delta.items():
++                self._bytes_by_cache_salt[salt] = (
++                    self._bytes_by_cache_salt.get(salt, 0) + d
++                )
++
++    def _release_store_reservation(self, reserved_bytes: int) -> None:
++        """Release capacity for a store that will not produce a completion."""
++        if reserved_bytes < 0:
++            raise ValueError("reserved_bytes must be non-negative")
++        with self._usage_lock:
++            if reserved_bytes > self._reserved_store_bytes:
++                raise RuntimeError(
++                    "store reservation accounting underflow: "
++                    f"releasing {reserved_bytes} bytes with only "
++                    f"{self._reserved_store_bytes} reserved"
++                )
++            self._reserved_store_bytes -= reserved_bytes
++
++    def get_reserved_store_bytes(self) -> int:
++        """Return bytes reserved by submitted stores awaiting completion."""
++        with self._usage_lock:
++            return self._reserved_store_bytes
++
++    def _notify_keys_stored_listeners(
++        self,
++        keys: list[ObjectKey],
++        sizes: list[int],
++    ) -> None:
++        """Notify stored-key observers after accounting is committed."""
+         for listener in self._listeners:
+             listener.on_l2_keys_stored(keys, sizes)
+ 
++    def _notify_keys_stored(self, keys: list[ObjectKey], sizes: list[int]) -> None:
++        """Update byte accounting and notify listeners that ``keys`` were
++        stored. ``sizes[i]`` is the byte size of ``keys[i]``.
++
++        Accounting is held under ``_usage_lock``; listener callbacks fire
++        outside the lock so a slow listener cannot stall further notifies.
++        """
++        self._account_keys_stored(keys, sizes)
++        self._notify_keys_stored_listeners(keys, sizes)
++
+     def _notify_keys_accessed(self, keys: list[ObjectKey]) -> None:
+         # ``_notify_keys_accessed`` carries no byte impact — only LRU
+         # bookkeeping cares about it, so no accounting is needed here.
+diff --git a/lmcache/v1/distributed/l2_adapters/fs_native_l2_adapter.py b/lmcache/v1/distributed/l2_adapters/fs_native_l2_adapter.py
+index 2d703499d20c5aa1c0ecc8e1f0667f2bf857c6a2..dacdead73b3eb1a34bec530fe14c535759607b2a 100644
+--- a/lmcache/v1/distributed/l2_adapters/fs_native_l2_adapter.py
++++ b/lmcache/v1/distributed/l2_adapters/fs_native_l2_adapter.py
+@@ -10,9 +10,11 @@ Backed by the native C++ filesystem connector wrapped with
+ from __future__ import annotations
+ 
+ # Standard
++from pathlib import Path
+ from typing import TYPE_CHECKING, Optional
+ 
+ if TYPE_CHECKING:
++    from lmcache.v1.distributed.api import ObjectKey
+     from lmcache.v1.distributed.internal_api import (
+         L1MemoryDesc,
+     )
+@@ -158,7 +160,7 @@ def _create_fs_native_l2_adapter(
+         config.use_odirect,
+         config.read_ahead_size,
+     )
+-    return NativeConnectorL2Adapter(
++    adapter = NativeConnectorL2Adapter(
+         native_client,
+         max_capacity_gb=config.max_capacity_gb,
+         type_name="FSNativeL2Adapter",
+@@ -169,6 +171,53 @@ def _create_fs_native_l2_adapter(
+             "read_ahead_size": config.read_ahead_size,
+         },
+     )
++    try:
++        keys, sizes = _scan_existing_fs_native_files(config.base_path)
++        adapter.prime_existing_keys(keys, sizes)
++    except Exception:
++        adapter.close()
++        raise
++    return adapter
++
++
++def _scan_existing_fs_native_files(
++    base_path: str,
++) -> tuple[list["ObjectKey"], list[int]]:
++    """Recover durable keys and sizes, ordered from oldest to newest."""
++    # First Party
++    from lmcache.v1.distributed.l2_adapters.fs_l2_adapter import (
++        _filename_to_object_key,
++    )
++
++    root = Path(base_path)
++    if not root.is_dir():
++        return [], []
++
++    entries: list[tuple[int, str, ObjectKey, int]] = []
++    for path in root.glob("*.data"):
++        try:
++            if not path.is_file():
++                continue
++            key = _filename_to_object_key(path.name)
++            if key is None:
++                logger.warning("Ignoring unrecognized cache file: %s", path)
++                continue
++            stat = path.stat()
++            if stat.st_size <= 0:
++                logger.warning("Ignoring empty cache file: %s", path)
++                continue
++            entries.append((stat.st_mtime_ns, path.name, key, stat.st_size))
++        except OSError as exc:
++            # Silently omitting a durable object would under-report usage and
++            # seed an incomplete eviction index. Fail adapter construction so
++            # the operator can repair the directory or retry the startup scan.
++            raise RuntimeError(f"Could not inspect cache file {path}: {exc}") from exc
++
++    entries.sort(key=lambda entry: (entry[0], entry[1]))
++    return (
++        [entry[2] for entry in entries],
++        [entry[3] for entry in entries],
++    )
+ 
+ 
+ register_l2_adapter_type("fs_native", FSNativeL2AdapterConfig)
+diff --git a/lmcache/v1/distributed/l2_adapters/native_connector_l2_adapter.py b/lmcache/v1/distributed/l2_adapters/native_connector_l2_adapter.py
+index c10d3802dfbdba50b6a49e4d764ebf10a567a0df..97518b74a161dd995548a7894eb0e13a3fed0df2 100644
+--- a/lmcache/v1/distributed/l2_adapters/native_connector_l2_adapter.py
++++ b/lmcache/v1/distributed/l2_adapters/native_connector_l2_adapter.py
+@@ -30,7 +30,7 @@ import threading
+ from lmcache.logging import init_logger
+ from lmcache.native_storage_ops import Bitmap
+ from lmcache.v1.distributed.api import MemoryLayoutDesc, ObjectKey
+-from lmcache.v1.distributed.internal_api import L2StoreResult
++from lmcache.v1.distributed.internal_api import L2AdapterListener, L2StoreResult
+ from lmcache.v1.distributed.l2_adapters.base import (
+     L2AdapterInterface,
+     L2TaskId,
+@@ -98,6 +98,7 @@ class NativeConnectorL2Adapter(L2AdapterInterface):
+ 
+     # Operation type tags for the pending-ops map
+     _OP_STORE = "store"
++    _OP_SYNC_STORE = "sync_store"
+     _OP_LOOKUP = "lookup"
+     _OP_LOAD = "load"
+     _OP_DELETE = "delete"
+@@ -144,15 +145,30 @@ class NativeConnectorL2Adapter(L2AdapterInterface):
+         # Pending delete events for synchronous delete() calls
+         self._pending_delete_events: dict[L2TaskId, threading.Event] = {}
+ 
++        # Synchronous stores use private completions so StoreController cannot
++        # consume another thread's result from _completed_stores.
++        self._pending_sync_store_events: dict[
++            L2TaskId, tuple[threading.Event, dict[str, Any]]
++        ] = {}
++
+         # Per-key size tracking. ``_key_sizes`` lets us look up byte sizes
+         # at delete time (the native completion only carries booleans, not
+         # sizes) so we can pass them to ``_notify_keys_deleted``. Aggregate
+         # and per-user totals live in the base class — see ``get_usage``.
+         self._key_sizes: dict[ObjectKey, int] = {}
+-        # Pending store sizes: native future_id -> (keys, per_key_sizes).
++        # Pending store sizes:
++        #   native future_id -> (keys, per_key_sizes, reserved_bytes).
+         # Bridges the async store submit → demux completion gap so the
+         # demux thread can fire ``_notify_keys_stored(keys, sizes)``.
+-        self._pending_store_sizes: dict[int, tuple[list[ObjectKey], list[int]]] = {}
++        self._pending_store_sizes: dict[
++            int, tuple[list[ObjectKey], list[int], int]
++        ] = {}
++
++        # A filesystem factory may prime durable objects before the eviction
++        # listener exists. Keep one temporary startup snapshot for that first
++        # listener; _key_sizes remains the sole long-lived key index.
++        self._startup_primed = False
++        self._startup_replay: tuple[list[ObjectKey], list[int]] | None = None
+ 
+         # Task ID counter
+         self._next_task_id: L2TaskId = 0
+@@ -194,20 +210,39 @@ class NativeConnectorL2Adapter(L2AdapterInterface):
+         key_strings = [_object_key_to_string(k) for k in keys]
+         memviews = [_obj_to_memoryview(obj) for obj in objects]
+         per_key_sizes = [obj.get_size() for obj in objects]
++        reserved_bytes = sum(per_key_sizes)
+ 
+         # Register pending op BEFORE submit to avoid race
+         # with demux thread. The native submit is
+         # non-blocking so holding the lock is brief.
+         with self._lock:
+             task_id = self._get_next_task_id()
+-            future_id = int(self._client.submit_batch_set(key_strings, memviews))
++            if not self._try_reserve_store_bytes(reserved_bytes):
++                self._completed_stores[task_id] = L2StoreResult(False, 0)
++                self._store_efd.notify()
++                logger.warning(
++                    "Rejected native L2 store of %d bytes: capacity would "
++                    "exceed %d bytes",
++                    reserved_bytes,
++                    self._max_capacity_bytes,
++                )
++                return task_id
++            try:
++                future_id = int(self._client.submit_batch_set(key_strings, memviews))
++            except Exception:
++                self._release_store_reservation(reserved_bytes)
++                raise
+             self._pending_ops[future_id] = (
+                 self._OP_STORE,
+                 task_id,
+                 len(keys),
+                 None,
+             )
+-            self._pending_store_sizes[future_id] = (list(keys), per_key_sizes)
++            self._pending_store_sizes[future_id] = (
++                list(keys),
++                per_key_sizes,
++                reserved_bytes,
++            )
+ 
+         return task_id
+ 
+@@ -219,6 +254,83 @@ class NativeConnectorL2Adapter(L2AdapterInterface):
+             self._completed_stores = {}
+         return completed
+ 
++    def store_objects_sync(
++        self,
++        keys: list[ObjectKey],
++        objects: list[MemoryObj],
++        timeout: float | None = None,
++    ) -> tuple[bool, int, int]:
++        """Persist objects and wait for their native backend completion.
++
++        Returns ``(success, persisted_count, bytes_written)``. ``success`` is
++        true only when every key persisted, while the other fields account
++        for successful keys in a partially failed batch.
++        """
++        if len(keys) != len(objects):
++            raise ValueError("keys and objects length mismatch")
++        if not keys:
++            return True, 0, 0
++        if timeout is not None and timeout <= 0:
++            raise ValueError("timeout must be positive")
++
++        key_strings = [_object_key_to_string(key) for key in keys]
++        memviews = [_obj_to_memoryview(obj) for obj in objects]
++        per_key_sizes = [obj.get_size() for obj in objects]
++        reserved_bytes = sum(per_key_sizes)
++        done_event = threading.Event()
++        result: dict[str, Any] = {
++            "ok": False,
++            "persisted_count": 0,
++            "bytes_written": 0,
++        }
++
++        with self._lock:
++            task_id = self._get_next_task_id()
++            if not self._try_reserve_store_bytes(reserved_bytes):
++                logger.warning(
++                    "Rejected synchronous native L2 store of %d bytes: "
++                    "capacity would exceed %d bytes",
++                    reserved_bytes,
++                    self._max_capacity_bytes,
++                )
++                return False, 0, 0
++            try:
++                future_id = int(self._client.submit_batch_set(key_strings, memviews))
++            except Exception:
++                self._release_store_reservation(reserved_bytes)
++                raise
++            self._pending_ops[future_id] = (
++                self._OP_SYNC_STORE,
++                task_id,
++                len(keys),
++                None,
++            )
++            self._pending_store_sizes[future_id] = (
++                list(keys),
++                per_key_sizes,
++                reserved_bytes,
++            )
++            self._pending_sync_store_events[task_id] = (done_event, result)
++
++        wait_timeout = (
++            timeout if timeout is not None else max(30.0, min(300.0, len(keys) * 5.0))
++        )
++        if not done_event.wait(timeout=wait_timeout):
++            with self._lock:
++                self._pending_sync_store_events.pop(task_id, None)
++            logger.warning(
++                "store_objects_sync() timed out after %.1fs for %d keys",
++                wait_timeout,
++                len(keys),
++            )
++            return False, 0, 0
++
++        return (
++            bool(result["ok"]),
++            int(result["persisted_count"]),
++            int(result["bytes_written"]),
++        )
++
+     # ---------------------------------------------------------------
+     # Lookup and Lock Interface
+     # ---------------------------------------------------------------
+@@ -297,22 +409,46 @@ class NativeConnectorL2Adapter(L2AdapterInterface):
+         tracking stays in sync.
+ 
+         No-op if the connector does not expose ``submit_batch_delete``
+-        or if the key list is empty.
++        or if the key list is empty. Keys currently lookup-locked by an
++        in-flight prefetch are skipped: the load task would race the
++        unlink and fail with a phantom not_found.
+         """
+         if not keys or not self._has_delete:
+             return
+ 
+-        key_strings = [_object_key_to_string(k) for k in keys]
+         done_event = threading.Event()
+ 
+         with self._lock:
++            # A key becomes lookup-locked only when the native EXISTS
++            # completion is demultiplexed. Protect pending lookup keys as
++            # well, otherwise eviction can delete a key between lookup
++            # submission and lock acquisition. Filtering and delete submit
++            # stay in one critical section so a new lookup cannot enter that
++            # same gap.
++            protected_keys = set(self._locked_keys)
++            for op_type, _task_id, _num_keys, op_keys in self._pending_ops.values():
++                if op_type == self._OP_LOOKUP and op_keys is not None:
++                    protected_keys.update(op_keys)
++
++            delete_keys = [key for key in keys if key not in protected_keys]
++            skipped_count = len(keys) - len(delete_keys)
++            if skipped_count:
++                logger.info(
++                    "delete(): skipping %d lookup-pending or locked keys; %d remain",
++                    skipped_count,
++                    len(delete_keys),
++                )
++            if not delete_keys:
++                return
++
++            key_strings = [_object_key_to_string(k) for k in delete_keys]
+             task_id = self._get_next_task_id()
+             future_id = int(self._client.submit_batch_delete(key_strings))
+             self._pending_ops[future_id] = (
+                 self._OP_DELETE,
+                 task_id,
+-                len(keys),
+-                list(keys),
++                len(delete_keys),
++                delete_keys,
+             )
+             self._pending_delete_events[task_id] = done_event
+ 
+@@ -328,7 +464,7 @@ class NativeConnectorL2Adapter(L2AdapterInterface):
+                         break
+             logger.warning(
+                 "delete() timed out after 30s for %d keys",
+-                len(keys),
++                len(delete_keys),
+             )
+             return
+ 
+@@ -345,6 +481,52 @@ class NativeConnectorL2Adapter(L2AdapterInterface):
+     # Status Interface
+     # ---------------------------------------------------------------
+ 
++    def prime_existing_keys(
++        self,
++        keys: list[ObjectKey],
++        sizes: list[int],
++    ) -> None:
++        """Account durable objects discovered before adapter registration."""
++        if len(keys) != len(sizes):
++            raise ValueError("keys and sizes length mismatch")
++
++        unique: dict[ObjectKey, int] = {}
++        for key, size in zip(keys, sizes, strict=True):
++            if size <= 0:
++                raise ValueError("existing object sizes must be positive")
++            unique.setdefault(key, int(size))
++
++        primed_keys = list(unique)
++        primed_sizes = list(unique.values())
++        with self._lock:
++            if self._startup_primed:
++                raise RuntimeError("existing keys were already primed")
++            if self._listeners:
++                raise RuntimeError("existing keys must be primed before listeners")
++            self._startup_primed = True
++            self._key_sizes.update(unique)
++            self._startup_replay = (primed_keys, primed_sizes)
++
++        # No listener is registered during factory construction. This uses
++        # the common accounting implementation without retaining a second
++        # byte-accounting path in this adapter.
++        if primed_keys:
++            self._notify_keys_stored(primed_keys, primed_sizes)
++            logger.info(
++                "Startup scan primed %.2f GB in %d existing objects",
++                sum(primed_sizes) / 1e9,
++                len(primed_keys),
++            )
++
++    def register_listener(self, listener: L2AdapterListener) -> None:
++        """Register a listener and replay the one-time startup snapshot."""
++        with self._lock:
++            replay = self._startup_replay
++            self._startup_replay = None
++        if replay is not None and replay[0]:
++            listener.on_l2_keys_stored(*replay)
++        super().register_listener(listener)
++
+     def report_status(self) -> dict[str, Any]:
+         """Return a status dict for this native-connector L2 adapter.
+ 
+@@ -360,6 +542,7 @@ class NativeConnectorL2Adapter(L2AdapterInterface):
+         status: dict[str, Any] = {
+             "is_healthy": (self._demux_thread.is_alive() and not self._stop.is_set()),
+             "type": self._type_name,
++            "reserved_store_bytes": self.get_reserved_store_bytes(),
+         }
+         status.update(self._extra_status)
+         return status
+@@ -372,6 +555,22 @@ class NativeConnectorL2Adapter(L2AdapterInterface):
+         self._stop.set()
+         self._demux_thread.join(timeout=5)
+ 
++        with self._lock:
++            sync_events = [
++                event for event, _result in self._pending_sync_store_events.values()
++            ]
++            self._pending_sync_store_events.clear()
++            abandoned_reservations = sum(
++                reserved_bytes
++                for _keys, _sizes, reserved_bytes in self._pending_store_sizes.values()
++            )
++            self._pending_store_sizes.clear()
++            self._pending_ops.clear()
++        if abandoned_reservations:
++            self._release_store_reservation(abandoned_reservations)
++        for event in sync_events:
++            event.set()
++
+         self._client.close()
+ 
+         self._store_efd.close()
+@@ -420,11 +619,13 @@ class NativeConnectorL2Adapter(L2AdapterInterface):
+             keys_accessed: list[ObjectKey] = []
+             keys_deleted: list[ObjectKey] = []
+             sizes_deleted: list[int] = []
++            settled_store_reservations = 0
+             # Events for synchronous ``delete()`` callers. We set these
+             # AFTER firing ``_notify_keys_deleted`` below so that when
+             # the caller unblocks and calls ``get_usage()``, the base
+             # class's byte counters already reflect the deletion.
+             delete_done_events: list[threading.Event] = []
++            sync_store_done_events: list[threading.Event] = []
+ 
+             with self._lock:
+                 for (
+@@ -449,12 +650,31 @@ class NativeConnectorL2Adapter(L2AdapterInterface):
+                         lookup_keys,
+                     ) = entry
+ 
+-                    if op_type == self._OP_STORE:
++                    if op_type in (self._OP_STORE, self._OP_SYNC_STORE):
+                         store_info = self._pending_store_sizes.pop(fid, None)
+                         task_bytes = 0
+-                        if ok and store_info is not None:
+-                            store_keys, sizes = store_info
+-                            for key, size in zip(store_keys, sizes, strict=True):
++                        persisted_count = 0
++                        completion_ok = False
++                        if store_info is not None:
++                            store_keys, sizes, reserved_bytes = store_info
++                            settled_store_reservations += reserved_bytes
++                            if result_bools is None:
++                                stored_flags = [bool(ok)] * len(store_keys)
++                            else:
++                                stored_flags = [bool(value) for value in result_bools]
++                                if len(stored_flags) < len(store_keys):
++                                    stored_flags.extend(
++                                        [False] * (len(store_keys) - len(stored_flags))
++                                    )
++                                elif len(stored_flags) > len(store_keys):
++                                    stored_flags = stored_flags[: len(store_keys)]
++                            completion_ok = bool(ok) and all(stored_flags)
++                            for key, size, stored in zip(
++                                store_keys, sizes, stored_flags, strict=True
++                            ):
++                                if not stored:
++                                    continue
++                                persisted_count += 1
+                                 # First-store wins for byte accounting:
+                                 # a re-store of an existing key adds 0
+                                 # bytes (the backend already holds it).
+@@ -470,8 +690,21 @@ class NativeConnectorL2Adapter(L2AdapterInterface):
+                                 else:
+                                     keys_stored.append(key)
+                                     sizes_stored.append(0)
+-                        self._completed_stores[task_id] = L2StoreResult(ok, task_bytes)
+-                        self._store_efd.notify()
++                        if op_type == self._OP_STORE:
++                            self._completed_stores[task_id] = L2StoreResult(
++                                completion_ok, task_bytes
++                            )
++                            self._store_efd.notify()
++                        else:
++                            sync_entry = self._pending_sync_store_events.pop(
++                                task_id, None
++                            )
++                            if sync_entry is not None:
++                                sync_event, sync_result = sync_entry
++                                sync_result["ok"] = completion_ok
++                                sync_result["persisted_count"] = persisted_count
++                                sync_result["bytes_written"] = task_bytes
++                                sync_store_done_events.append(sync_event)
+ 
+                     elif op_type == self._OP_LOOKUP:
+                         bitmap = Bitmap(num_keys)
+@@ -519,10 +752,22 @@ class NativeConnectorL2Adapter(L2AdapterInterface):
+                         if evt is not None:
+                             delete_done_events.append(evt)
+ 
+-            # Fire listener notifications outside the lock so a slow
+-            # listener cannot stall further demux iterations.
++            # Release in-flight reservations and commit durable-byte
++            # accounting in one critical section before waking callers.
++            if settled_store_reservations or keys_stored:
++                self._settle_store_reservation(
++                    settled_store_reservations,
++                    keys_stored,
++                    sizes_stored,
++                )
++            for evt in sync_store_done_events:
++                evt.set()
++
++            # Observer callbacks remain outside the lock and after synchronous
++            # durability completion. A slow observer must not defeat a caller's
++            # store timeout after persistence and accounting have committed.
+             if keys_stored:
+-                self._notify_keys_stored(keys_stored, sizes_stored)
++                self._notify_keys_stored_listeners(keys_stored, sizes_stored)
+             if keys_accessed:
+                 self._notify_keys_accessed(keys_accessed)
+             if keys_deleted:
+diff --git a/lmcache/v1/distributed/storage_controllers/eviction_controller.py b/lmcache/v1/distributed/storage_controllers/eviction_controller.py
+index 8624207de385ab334a102852b6d1b7c19d3182b0..899d8bf2166c2451fde6605dc839fa912e0e22f5 100644
+--- a/lmcache/v1/distributed/storage_controllers/eviction_controller.py
++++ b/lmcache/v1/distributed/storage_controllers/eviction_controller.py
+@@ -6,7 +6,10 @@ from __future__ import annotations
+ # Standard
+ from abc import abstractmethod
+ from collections import Counter
++from enum import Enum, auto
+ from typing import TYPE_CHECKING
++import inspect
++import math
+ import threading
+ import time
+ 
+@@ -16,6 +19,7 @@ from lmcache.v1.distributed.api import ObjectKey
+ from lmcache.v1.distributed.config import EvictionConfig
+ from lmcache.v1.distributed.eviction import L1EvictionPolicy, L2EvictionPolicy
+ from lmcache.v1.distributed.eviction_policy import CreateEvictionPolicy
++from lmcache.v1.distributed.error import L1Error
+ from lmcache.v1.distributed.internal_api import (
+     EvictionAction,
+     EvictionDestination,
+@@ -33,6 +37,12 @@ if TYPE_CHECKING:
+ logger = init_logger(__name__)
+ 
+ 
++class _SyncFlushResult(Enum):
++    SUCCESS = auto()
++    FAILURE = auto()
++    DEADLINE_EXHAUSTED = auto()
++
++
+ class EvictionController(StorageControllerInterface):
+     """
+     Abstract base class for eviction controllers.
+@@ -92,12 +102,33 @@ class L1EvictionController(EvictionController):
+     Uses an L1EvictionPolicy bridge to keep the eviction policy up-to-date
+     with L1 manager events, and periodically triggers eviction based on
+     L1 memory usage.
++
++    With ``EvictionConfig.write_back_on_evict`` enabled and L2 adapters
++    injected via ``set_l2_adapters``, eviction actions target
++    ``EvictionDestination.L2_CACHE``: readable objects are synchronously
++    persisted to L2 in bounded batches and deleted from L1 only once every
++    key in the batch is durable. Repeated flush failures open a circuit
++    breaker that pauses write-back instead of retrying every second.
++
++    ``EvictionConfig.periodic_flush_interval`` additionally enables a
++    below-watermark backup flush that copies evictable L1 keys to L2
++    without deleting them from L1.
+     """
+ 
++    # Bounded batches keep each blocking sync-store call short.
++    _SYNC_FLUSH_BATCH_SIZE = 128
++    # Keys per periodic backup flush cycle.
++    _BACKUP_FLUSH_BATCH_SIZE = 128
++    # A prefetch request must not stall the controller indefinitely on L2.
++    _EMERGENCY_FLUSH_TIMEOUT_SECONDS = 1.0
++    # Periodic backup runs under the flush lock and must remain stoppable.
++    _PERIODIC_FLUSH_TIMEOUT_SECONDS = 5.0
++
+     def __init__(
+         self,
+         l1_manager: L1Manager,
+         eviction_config: EvictionConfig,
++        l2_adapters: dict[int, L2AdapterInterface] | None = None,
+     ):
+         super().__init__()
+         self._eviction_config = eviction_config
+@@ -108,13 +139,101 @@ class L1EvictionController(EvictionController):
+         self._event_bus = get_event_bus()
+         self._last_extra_log = time.monotonic()
+ 
++        self._write_back_enabled = bool(eviction_config.write_back_on_evict)
++        self._l2_adapters: dict[int, L2AdapterInterface] = {}
++        self._l2_adapter_supports_timeout: dict[int, bool] = {}
++        self._l2_adapters_lock = threading.Lock()
++        # Serializes all synchronous L2 flushes and adapter-set replacement.
++        # StorageManager can therefore remove an adapter only after any L1
++        # writeback currently using it has finished.
++        self._flush_lock = threading.Lock()
++        # Sync-flush circuit breaker: a dead L2 must not cause a
++        # multi-thousand-key synchronous retry and warning storm every
++        # second.
++        self._sync_flush_failures: int = 0
++        self._sync_flush_backoff_until: float = 0.0
++        self._last_backup_flush = time.monotonic()
++        self._backup_flush_cursor: int = 0
++        # Serializes emergency evictions from concurrent callers.
++        self._emergency_evict_lock = threading.Lock()
++        if self._write_back_enabled:
++            # Writeback must fail closed. Register the L2 destination even
++            # before a compatible adapter exists so policy never falls back
++            # to DISCARD when persistence is unavailable.
++            self._eviction_policy.register_eviction_destination(
++                EvictionDestination.L2_CACHE
++            )
++        if l2_adapters:
++            self.set_l2_adapters(l2_adapters)
++
++    def set_l2_adapters(self, l2_adapters: dict[int, L2AdapterInterface]) -> None:
++        """Late-inject L2 adapters after StorageManager creates them.
++
++        Only adapters with an explicit synchronous durability contract are
++        eligible. The L2 eviction destination itself is registered at
++        construction so enabled writeback always fails closed.
++        """
++        compatible: dict[int, L2AdapterInterface] = {}
++        supports_timeout: dict[int, bool] = {}
++        for adapter_id, adapter in l2_adapters.items():
++            sync_store = getattr(adapter, "store_objects_sync", None)
++            if not callable(sync_store):
++                continue
++            compatible[adapter_id] = adapter
++            try:
++                supports_timeout[adapter_id] = (
++                    "timeout" in inspect.signature(sync_store).parameters
++                )
++            except (TypeError, ValueError):
++                supports_timeout[adapter_id] = False
++        ignored = sorted(set(l2_adapters) - set(compatible))
++        if ignored:
++            logger.warning(
++                "L1 writeback ignored adapters without store_objects_sync: %s",
++                ignored,
++            )
++        with self._flush_lock:
++            with self._l2_adapters_lock:
++                self._l2_adapters = compatible
++                self._l2_adapter_supports_timeout = supports_timeout
++
++    def has_l2_flush_adapter(self) -> bool:
++        """Return whether a synchronous durability backend is available."""
++        return bool(self._snapshot_l2_adapters())
++
++    def _snapshot_l2_adapters(self) -> list[tuple[int, L2AdapterInterface]]:
++        with self._l2_adapters_lock:
++            return list(self._l2_adapters.items())
++
++    def _snapshot_l2_flush_adapters(
++        self,
++    ) -> list[tuple[int, L2AdapterInterface, bool]]:
++        with self._l2_adapters_lock:
++            return [
++                (
++                    adapter_id,
++                    adapter,
++                    self._l2_adapter_supports_timeout.get(adapter_id, False),
++                )
++                for adapter_id, adapter in self._l2_adapters.items()
++            ]
++
+     def report_status(self) -> dict:
++        adapters = self._snapshot_l2_adapters()
+         return {
+             "is_healthy": self._thread.is_alive(),
+             "thread_alive": self._thread.is_alive(),
+             "eviction_policy": self._eviction_config.eviction_policy,
+             "trigger_watermark": self._eviction_config.trigger_watermark,
+             "eviction_ratio": self._eviction_config.eviction_ratio,
++            "write_back_enabled": self._write_back_enabled,
++            "l2_flush_enabled": bool(adapters),
++            "l2_flush_adapter_ids": [adapter_id for adapter_id, _ in adapters],
++            "periodic_flush_interval": (self._eviction_config.periodic_flush_interval),
++            "sync_flush_failures": self._sync_flush_failures,
++            "sync_flush_backoff_seconds": max(
++                0.0, self._sync_flush_backoff_until - time.monotonic()
++            ),
+         }
+ 
+     def _publish_skipped(self, usage: float, watermark: float) -> None:
+@@ -160,6 +279,7 @@ class L1EvictionController(EvictionController):
+     def eviction_loop(self):
+         watermark = self._eviction_config.trigger_watermark
+         eviction_ratio = self._eviction_config.eviction_ratio
++        backup_interval = self._eviction_config.periodic_flush_interval
+ 
+         while not self._stop_flag.is_set():
+             time.sleep(1)
+@@ -168,6 +288,13 @@ class L1EvictionController(EvictionController):
+                 self._maybe_log_memory_usage(used_bytes, total_bytes)
+             usage = 0 if total_bytes == 0 else used_bytes / total_bytes
+             if usage < watermark:
++                if (
++                    backup_interval > 0
++                    and self._snapshot_l2_adapters()
++                    and time.monotonic() - self._last_backup_flush >= backup_interval
++                ):
++                    self._last_backup_flush = time.monotonic()
++                    self._backup_to_l2_no_delete(self._BACKUP_FLUSH_BATCH_SIZE)
+                 logger.debug(
+                     "L1 memory usage %.2f below watermark %.2f; skipping eviction.",
+                     usage,
+@@ -176,6 +303,13 @@ class L1EvictionController(EvictionController):
+                 self._publish_skipped(usage, watermark)
+                 continue
+ 
++            if (
++                self._write_back_enabled
++                and time.monotonic() < self._sync_flush_backoff_until
++            ):
++                self._publish_skipped(usage, watermark)
++                continue
++
+             logger.info(
+                 "L1 memory usage %.2f above watermark %.2f; triggering eviction.",
+                 usage,
+@@ -190,13 +324,340 @@ class L1EvictionController(EvictionController):
+             self._publish_triggered(usage, watermark)
+ 
+     def execute_eviction_action(self, action: EvictionAction):
+-        if action.destination == EvictionDestination.DISCARD:
++        if action.destination == EvictionDestination.L2_CACHE:
++            self._flush_to_l2_then_delete(action.keys)
++        elif action.destination == EvictionDestination.DISCARD:
+             self._l1_manager.delete(action.keys)
+         else:
+             logger.error("Unsupported eviction destination: %s", action.destination)
+             logger.error("Treating it as DISCARD.")
+             self._l1_manager.delete(action.keys)
+ 
++    def emergency_evict_bytes(self, target_free_bytes: int, requester: str = "") -> int:
++        """Synchronously evict LRU L1 keys until at least
++        ``target_free_bytes`` bytes are free.
++
++        Victims take the normal eviction path, so with write-back enabled
++        they are flushed to L2 before deletion. Intended for the prefetch
++        controller when a large L2-to-L1 restore cannot reserve L1 buffers.
++
++        Args:
++            target_free_bytes: The free-space goal in bytes.
++            requester: Optional label for logging.
++
++        Returns:
++            The free byte count after eviction.
++        """
++        deadline = time.monotonic() + self._EMERGENCY_FLUSH_TIMEOUT_SECONDS
++        if not self._emergency_evict_lock.acquire(
++            timeout=self._EMERGENCY_FLUSH_TIMEOUT_SECONDS
++        ):
++            used, total = self._l1_manager.get_memory_usage()
++            return max(0, total - used)
++        try:
++            used, total = self._l1_manager.get_memory_usage()
++            free = max(0, total - used)
++            if free >= target_free_bytes:
++                return free
++            deficit = target_free_bytes - free
++            num_objects = self._l1_manager.num_objects()
++            if num_objects <= 0:
++                return free
++            if self._write_back_enabled and (
++                time.monotonic() < self._sync_flush_backoff_until
++                or not self.has_l2_flush_adapter()
++            ):
++                return free
++            per_key = max(1, used // num_objects)
++            need_keys = math.ceil(deficit / per_key)
++            need_keys += max(1, math.ceil(need_keys / 8))
++            tracked = num_objects
++            get_tracked = getattr(self._eviction_policy, "get_num_tracked_keys", None)
++            if callable(get_tracked):
++                tracked = max(1, int(get_tracked()))
++            ratio = min(1.0, need_keys / max(tracked, 1))
++            start = time.monotonic()
++            actions = self._eviction_policy.get_eviction_actions(
++                ratio,
++                key_eligible_filter=self._l1_manager.is_key_evictable,
++            )
++            evicted_keys = 0
++            for action in actions:
++                evicted_keys += len(action.keys)
++                if action.destination == EvictionDestination.L2_CACHE:
++                    self._flush_to_l2_then_delete(action.keys, deadline=deadline)
++                else:
++                    self.execute_eviction_action(action)
++                if time.monotonic() >= deadline:
++                    break
++            used_after, total_after = self._l1_manager.get_memory_usage()
++            free_after = max(0, total_after - used_after)
++            logger.info(
++                "Emergency L1 eviction%s: wanted %.0f MB free, evicted %d "
++                "keys in %.0f ms; free %.0f MB -> %.0f MB",
++                (" for " + requester) if requester else "",
++                target_free_bytes / 1e6,
++                evicted_keys,
++                (time.monotonic() - start) * 1000.0,
++                free / 1e6,
++                free_after / 1e6,
++            )
++            return free_after
++        finally:
++            self._emergency_evict_lock.release()
++
++    def _flush_to_l2_then_delete(
++        self,
++        keys: list[ObjectKey],
++        deadline: float | None = None,
++    ) -> None:
++        """Persist bounded batches to L2 and delete only fully durable
++        batches from L1.
++
++        The native adapter reports a store successful only when every key
++        persisted, so this method conservatively retains the whole readable
++        batch on any partial failure. Repeated failures open the circuit
++        breaker with exponential backoff.
++        """
++        if deadline is None:
++            self._flush_lock.acquire()
++        else:
++            remaining = deadline - time.monotonic()
++            if remaining <= 0 or not self._flush_lock.acquire(timeout=remaining):
++                return
++        try:
++            if not keys:
++                return
++            if time.monotonic() < self._sync_flush_backoff_until:
++                return
++
++            all_ok = True
++            deadline_exhausted = False
++            for start in range(0, len(keys), self._SYNC_FLUSH_BATCH_SIZE):
++                if deadline is not None and time.monotonic() >= deadline:
++                    deadline_exhausted = True
++                    break
++                batch = keys[start : start + self._SYNC_FLUSH_BATCH_SIZE]
++                result = self._flush_one_l2_batch_then_delete(batch, deadline=deadline)
++                if result == _SyncFlushResult.DEADLINE_EXHAUSTED:
++                    deadline_exhausted = True
++                    break
++                if result == _SyncFlushResult.FAILURE:
++                    all_ok = False
++                    break
++
++            if deadline_exhausted:
++                logger.debug(
++                    "L1-to-L2 emergency flush exhausted its time budget; "
++                    "remaining L1 keys preserved"
++                )
++            elif all_ok:
++                self._sync_flush_failures = 0
++                self._sync_flush_backoff_until = 0.0
++            else:
++                self._sync_flush_failures += 1
++                delay = min(60.0, float(2 ** min(self._sync_flush_failures, 6)))
++                self._sync_flush_backoff_until = time.monotonic() + delay
++                logger.warning(
++                    "L1-to-L2 flush circuit breaker: failure=%d, retry in %.0fs; "
++                    "remaining L1 keys preserved",
++                    self._sync_flush_failures,
++                    delay,
++                )
++        finally:
++            self._flush_lock.release()
++
++    def _flush_one_l2_batch_then_delete(
++        self,
++        keys: list[ObjectKey],
++        deadline: float | None = None,
++    ) -> _SyncFlushResult:
++        """Flush one batch to L2; delete from L1 only when fully durable.
++
++        Returns:
++            SUCCESS when every readable key was persisted (or none were
++            readable), FAILURE for an actual persistence failure, and
++            DEADLINE_EXHAUSTED when an emergency flush consumed its budget.
++        """
++        if not keys:
++            return _SyncFlushResult.SUCCESS
++
++        read_result = self._l1_manager.reserve_read(keys)
++        readable_keys: list[ObjectKey] = []
++        readable_objs = []
++        for key in keys:
++            entry = read_result.get(key)
++            if (
++                entry is not None
++                and entry[0] == L1Error.SUCCESS
++                and entry[1] is not None
++            ):
++                readable_keys.append(key)
++                readable_objs.append(entry[1])
++
++        flushed = not readable_keys
++        deadline_exhausted = False
++        if readable_keys:
++            try:
++                for (
++                    idx,
++                    adapter,
++                    supports_timeout,
++                ) in self._snapshot_l2_flush_adapters():
++                    sync_store = adapter.store_objects_sync
++                    try:
++                        if deadline is None:
++                            result = sync_store(readable_keys, readable_objs)
++                        else:
++                            remaining = deadline - time.monotonic()
++                            if remaining <= 0:
++                                deadline_exhausted = True
++                                break
++                            if not supports_timeout:
++                                logger.warning(
++                                    "Emergency L1 writeback skipped adapter %d: "
++                                    "store_objects_sync has no timeout contract",
++                                    idx,
++                                )
++                                continue
++                            result = sync_store(
++                                readable_keys,
++                                readable_objs,
++                                timeout=remaining,
++                            )
++                        ok, persisted_count, bytes_written = result
++                    except Exception:
++                        if deadline is not None and time.monotonic() >= deadline:
++                            deadline_exhausted = True
++                            break
++                        logger.exception(
++                            "L1-to-L2 flush: sync store failed on adapter %d", idx
++                        )
++                        continue
++                    if not ok and deadline is not None and time.monotonic() >= deadline:
++                        deadline_exhausted = True
++                        break
++                    # Never delete unless every readable key is durable.
++                    if ok and persisted_count == len(readable_keys):
++                        flushed = True
++                        logger.info(
++                            "L1-to-L2 flush: sync persisted %d/%d keys "
++                            "(%d bytes) via adapter %d",
++                            persisted_count,
++                            len(readable_keys),
++                            bytes_written,
++                            idx,
++                        )
++                        break
++                    logger.warning(
++                        "L1-to-L2 flush: adapter %d partial/failed persist "
++                        "(%d/%d keys, %d bytes)",
++                        idx,
++                        persisted_count,
++                        len(readable_keys),
++                        bytes_written,
++                    )
++            finally:
++                self._l1_manager.finish_read(readable_keys)
++
++        # Only keys we read and then fully persisted may be deleted. A key
++        # that failed reserve_read can have become locked after candidate
++        # selection and must never be treated as absent.
++        keys_to_delete = list(readable_keys) if flushed else []
++        if not flushed and readable_keys:
++            logger.warning(
++                "L1-to-L2 flush: preserving %d readable keys after failed persist",
++                len(readable_keys),
++            )
++
++        if keys_to_delete:
++            result = self._l1_manager.delete(keys_to_delete)
++            not_deleted = [k for k, err in result.items() if err != L1Error.SUCCESS]
++            if not_deleted:
++                logger.debug(
++                    "L1-to-L2 flush: %d keys not deleted, likely still locked",
++                    len(not_deleted),
++                )
++        if deadline_exhausted:
++            return _SyncFlushResult.DEADLINE_EXHAUSTED
++        if flushed:
++            return _SyncFlushResult.SUCCESS
++        return _SyncFlushResult.FAILURE
++
++    def _backup_to_l2_no_delete(self, batch_limit: int) -> None:
++        """Flush evictable L1 keys to L2 without deleting them from L1.
++
++        A backup, not an eviction: keys remain in L1 for fast access while
++        L2 gains a copy, so losing L1 (session expiry, restart) no longer
++        costs a cold prefill. A rotating cursor spreads repeated scans over
++        the whole L1 keyspace instead of hammering the first ``batch_limit``
++        insertion-ordered keys forever. Adapters skip keys they already
++        hold, so the flush is idempotent.
++        """
++        with self._flush_lock:
++            self._backup_to_l2_no_delete_locked(batch_limit)
++
++    def _backup_to_l2_no_delete_locked(self, batch_limit: int) -> None:
++        """Implementation of periodic backup under ``_flush_lock``."""
++        batch, self._backup_flush_cursor = self._l1_manager.get_evictable_keys(
++            limit=batch_limit,
++            cursor=self._backup_flush_cursor,
++        )
++        if not batch:
++            return
++
++        read_result = self._l1_manager.reserve_read(batch)
++        readable_keys: list[ObjectKey] = []
++        readable_objs = []
++        for key in batch:
++            entry = read_result.get(key)
++            if (
++                entry is not None
++                and entry[0] == L1Error.SUCCESS
++                and entry[1] is not None
++            ):
++                readable_keys.append(key)
++                readable_objs.append(entry[1])
++
++        if not readable_keys:
++            return
++
++        persisted_keys = 0
++        persisted_bytes = 0
++        try:
++            for idx, adapter, supports_timeout in self._snapshot_l2_flush_adapters():
++                if not supports_timeout:
++                    logger.warning(
++                        "Periodic L2 backup skipped adapter %d: "
++                        "store_objects_sync has no timeout contract",
++                        idx,
++                    )
++                    continue
++                sync_store = adapter.store_objects_sync
++                try:
++                    ok, persisted, written = sync_store(
++                        readable_keys,
++                        readable_objs,
++                        timeout=self._PERIODIC_FLUSH_TIMEOUT_SECONDS,
++                    )
++                    if ok and persisted == len(readable_keys):
++                        persisted_keys = persisted
++                        persisted_bytes = written
++                        break
++                except Exception:
++                    logger.exception("Periodic L2 backup: sync store failed on %d", idx)
++        finally:
++            self._l1_manager.finish_read(readable_keys)
++
++        if persisted_bytes > 0:
++            logger.info(
++                "Periodic L2 backup: persisted %d keys (%d new bytes, "
++                "%d evictable in L1, none deleted)",
++                persisted_keys,
++                persisted_bytes,
++                len(batch),
++            )
++
+ 
+ class L2AdapterEvictionState:
+     """Per-adapter eviction state: its own policy, listener, and config."""
+diff --git a/lmcache/v1/distributed/storage_controllers/prefetch_controller.py b/lmcache/v1/distributed/storage_controllers/prefetch_controller.py
+index 2138a33aa01ce95d7926bd4f6bcda79ae7d1955a..46239e518abaee70412223ec76eaa89f934a4bbe 100644
+--- a/lmcache/v1/distributed/storage_controllers/prefetch_controller.py
++++ b/lmcache/v1/distributed/storage_controllers/prefetch_controller.py
+@@ -55,6 +55,9 @@ from lmcache.v1.platform import (
+ 
+ if TYPE_CHECKING:
+     # First Party
++    from lmcache.v1.distributed.storage_controllers.eviction_controller import (
++        L1EvictionController,
++    )
+     from lmcache.v1.memory_management import MemoryObj
+ 
+ logger = init_logger(__name__)
+@@ -121,6 +124,17 @@ def trim_load_plan_with_mask(
+     return trimmed_plan
+ 
+ 
++def _layout_nbytes(layout_desc: MemoryLayoutDesc) -> int:
++    """Return the byte size of one object with the given layout."""
++    total = 0
++    for shape, dtype in zip(layout_desc.shapes, layout_desc.dtypes, strict=True):
++        numel = 1
++        for dim in shape:
++            numel *= int(dim)
++        total += numel * dtype.itemsize
++    return total
++
++
+ # Poll timeout in milliseconds for the prefetch loop
+ PREFETCH_LOOP_POLL_TIMEOUT_MS = 500
+ 
+@@ -227,6 +241,11 @@ class PrefetchController(StorageControllerInterface):
+         self._policy = policy
+         self._max_in_flight = max_in_flight
+ 
++        # Optional L1 eviction controller for emergency make-room before
++        # large restores; injected by StorageManager when
++        # EvictionConfig.emergency_evict_for_prefetch is enabled.
++        self._l1_eviction_controller: "L1EvictionController | None" = None
++
+         # Adapters that are being drained and will be removed after all
+         # the in-flight operations are done.
+         self._draining: dict[int, threading.Event] = {}
+@@ -847,6 +866,25 @@ class PrefetchController(StorageControllerInterface):
+     # =========================================================================
+     # Load phase
+     # =========================================================================
++    def _select_l1_retentions(
++        self,
++        request_id: int,
++        keys: list[ObjectKey],
++    ) -> list[bool]:
++        """Return one retention decision per key, degrading safely on a
++        malformed policy result."""
++        retentions = self._policy.select_l1_retentions(keys)
++        if len(retentions) != len(keys):
++            logger.error(
++                "Prefetch request %d: policy returned %d retentions for "
++                "%d keys; defaulting to temporary entries",
++                request_id,
++                len(retentions),
++                len(keys),
++            )
++            return [False] * len(keys)
++        return retentions
++
+     def _transition_to_load_phase(self, request: InFlightPrefetchRequest) -> None:
+         """Compute load plan, reserve L1 buffers, and submit load tasks."""
+         request.phase = PrefetchPhase.PLAN_AND_LOAD
+@@ -899,15 +937,23 @@ class PrefetchController(StorageControllerInterface):
+         if request.mode is PrefetchMode.WARM:
+             retentions = [True] * len(keys_to_reserve)
+         else:
+-            retentions = self._policy.select_l1_retentions(
++            retentions = self._select_l1_retentions(
++                request.request_id,
+                 keys_to_reserve,
+             )
++            # Non-WARM only: a WARM warm-up must never trigger emergency
++            # eviction of other sessions' chunks.
++            self._make_room_for_restore(request, keys_to_reserve)
+         write_results = l1_mgr.reserve_write(
+             keys=keys_to_reserve,
+             is_temporary=[not r for r in retentions],
+             layout_desc=request.layout_desc,
+             mode="new",
+         )
++        if request.mode is not PrefetchMode.WARM:
++            write_results = self._retry_oom_reservations(
++                request, keys_to_reserve, retentions, write_results
++            )
+ 
+         # Step 4: filter to successfully reserved keys
+         reserved_key_set: set[ObjectKey] = set()
+@@ -1038,6 +1084,123 @@ class PrefetchController(StorageControllerInterface):
+             len(reserved_key_set),
+         )
+ 
++    def set_l1_eviction_controller(
++        self,
++        controller: "L1EvictionController | None",
++    ) -> None:
++        """Enable emergency L1 eviction for large restores.
++
++        With a controller injected, a non-WARM restore that would not fit
++        in free L1 space synchronously evicts LRU keys (write-back first)
++        before reserving, and retries OOM reservations once. Pass ``None``
++        after the last synchronous L2 adapter is removed to disable this path.
++        """
++        self._l1_eviction_controller = controller
++
++    # Never let a single restore claim more than this fraction of L1: a
++    # huge context must not wipe every hot chunk of the running sessions.
++    _EMERGENCY_EVICT_MAX_L1_FRACTION = 0.6
++    # Headroom per object for alignment and allocator bookkeeping.
++    _PER_OBJECT_HEADROOM_BYTES = 8192
++
++    def _make_room_for_restore(
++        self,
++        request: InFlightPrefetchRequest,
++        keys_to_reserve: list[ObjectKey],
++    ) -> None:
++        """Pre-evict LRU L1 chunks so the upcoming reserve_write for this
++        restore can succeed. No-op unless an eviction controller was
++        injected via ``set_l1_eviction_controller``."""
++        evictor = self._l1_eviction_controller
++        if evictor is None or not keys_to_reserve:
++            return
++        per_obj = _layout_nbytes(request.layout_desc)
++        if per_obj <= 0:
++            return
++        used, total = self._l1_manager.get_memory_usage()
++        need = (per_obj + self._PER_OBJECT_HEADROOM_BYTES) * len(keys_to_reserve)
++        need = min(need, int(total * self._EMERGENCY_EVICT_MAX_L1_FRACTION))
++        free = max(0, total - used)
++        if free >= need:
++            return
++        try:
++            evictor.emergency_evict_bytes(
++                need, requester=f"prefetch_request={request.request_id}"
++            )
++        except Exception:
++            logger.exception(
++                "Emergency eviction failed for prefetch request %d",
++                request.request_id,
++            )
++
++    def _retry_oom_reservations(
++        self,
++        request: InFlightPrefetchRequest,
++        keys_to_reserve: list[ObjectKey],
++        retentions: list[bool],
++        write_results: dict[ObjectKey, tuple[L1Error, "MemoryObj | None"]],
++    ) -> dict[ObjectKey, tuple[L1Error, "MemoryObj | None"]]:
++        """One retry round for keys whose reservation failed with
++        OUT_OF_MEMORY: evict the missing amount, reserve just those keys
++        again, and merge the results. No-op unless an eviction controller
++        was injected."""
++        evictor = self._l1_eviction_controller
++        if evictor is None:
++            return write_results
++        oom_keys: list[ObjectKey] = []
++        retention_by_key = dict(zip(keys_to_reserve, retentions, strict=True))
++        for key in keys_to_reserve:
++            entry = write_results.get(key)
++            if entry is None:
++                oom_keys.append(key)
++                continue
++            err, mem_obj = entry
++            if err == L1Error.OUT_OF_MEMORY or (
++                err == L1Error.SUCCESS and mem_obj is None
++            ):
++                oom_keys.append(key)
++        if not oom_keys:
++            return write_results
++        per_obj = _layout_nbytes(request.layout_desc)
++        if per_obj <= 0:
++            return write_results
++        _, total = self._l1_manager.get_memory_usage()
++        need = (per_obj + self._PER_OBJECT_HEADROOM_BYTES) * len(oom_keys)
++        need = min(need, int(total * self._EMERGENCY_EVICT_MAX_L1_FRACTION))
++        try:
++            evictor.emergency_evict_bytes(
++                need, requester=f"prefetch_request={request.request_id}/retry"
++            )
++        except Exception:
++            logger.exception(
++                "Emergency eviction retry failed for prefetch request %d",
++                request.request_id,
++            )
++            return write_results
++        retry_results = self._l1_manager.reserve_write(
++            keys=oom_keys,
++            is_temporary=[not retention_by_key[k] for k in oom_keys],
++            layout_desc=request.layout_desc,
++            mode="new",
++        )
++        recovered = sum(
++            1
++            for k in oom_keys
++            if retry_results.get(k)
++            and retry_results[k][0] == L1Error.SUCCESS
++            and retry_results[k][1] is not None
++        )
++        if recovered:
++            logger.info(
++                "Retry recovered %d/%d OOM reservations for prefetch request %d",
++                recovered,
++                len(oom_keys),
++                request.request_id,
++            )
++        merged = dict(write_results)
++        merged.update(retry_results)
++        return merged
++
+     def _update_lookup_results(
+         self, request_id: PrefetchRequestId, prefix_hit_count: int
+     ) -> None:
+@@ -1181,6 +1344,17 @@ class PrefetchController(StorageControllerInterface):
+         # added once the serde PR lands and adapters can distinguish
+         # deserialization errors from missing objects.
+         if failed_keys:
++            # These keys were reported present by the L2 lookup but the load
++            # returned no data. Sample a few so the on-disk state can be
++            # inspected post hoc.
++            logger.warning(
++                "Prefetch request %d: %d/%d plan keys failed to load from "
++                "L2 (lookup hit, load empty); sample: %s",
++                request.request_id,
++                len(failed_keys),
++                len(request.write_reserved_keys),
++                [str(k)[:160] for k in failed_keys[:3]],
++            )
+             self._event_bus.publish(
+                 Event(
+                     event_type=EventType.L2_PREFETCH_FAILED,
+diff --git a/lmcache/v1/distributed/storage_manager.py b/lmcache/v1/distributed/storage_manager.py
+index 3054e2441c5c7d98d817ca7a1f9ac30b4a7e92d7..a7da312a475264ddd1c829ad73937fc103cbf1a8 100644
+--- a/lmcache/v1/distributed/storage_manager.py
++++ b/lmcache/v1/distributed/storage_manager.py
+@@ -66,6 +66,7 @@ logger = init_logger(__name__)
+ 
+ class StorageManager:
+     def __init__(self, config: StorageManagerConfig):
++        self._eviction_config = config.eviction_config
+         self._l1_manager = L1Manager(config.l1_manager_config)
+         self._event_bus = get_event_bus()
+ 
+@@ -154,6 +155,31 @@ class StorageManager:
+         )
+         self._prefetch_controller.start()
+ 
++        # Opt-in L1 write-back tier: wire L2 adapters into the L1 eviction
++        # controller so evicted or periodically backed-up chunks are flushed
++        # to L2, and optionally let the prefetch controller trigger
++        # emergency eviction to make room for large restores.
++        eviction_config = config.eviction_config
++        wants_l1_write_back = (
++            eviction_config.write_back_on_evict
++            or eviction_config.periodic_flush_interval > 0
++        )
++        if wants_l1_write_back:
++            self._sync_l1_writeback_adapters()
++            if not self._eviction_controller.has_l2_flush_adapter():
++                logger.warning(
++                    "write_back_on_evict / periodic_flush_interval is set but "
++                    "no L2 adapter exposes store_objects_sync"
++                )
++        if (
++            eviction_config.emergency_evict_for_prefetch
++            and not self._eviction_controller.has_l2_flush_adapter()
++        ):
++            logger.warning(
++                "emergency_evict_for_prefetch has no synchronous L2 "
++                "adapter; inactive until one is added"
++            )
++
+         # L2 usage gauge — one observation per adapter, tagged by
+         # ``l2_name``.  Parallel to L1Manager's ``l1_memory_usage_bytes``.
+         register_gauge(
+@@ -904,6 +930,7 @@ class StorageManager:
+             with self._adapters_lock:
+                 self._l2_adapters[adapter_id] = adapter
+                 self._adapter_descriptors[adapter_id] = descriptor
++            self._sync_l1_writeback_adapters()
+             self._store_controller.add_adapter(adapter_id, adapter, descriptor)
+             self._prefetch_controller.add_adapter(adapter_id, adapter, descriptor)
+             if self._should_enable_l2_eviction(adapter, config.eviction_config):
+@@ -956,6 +983,9 @@ class StorageManager:
+             with self._adapters_lock:
+                 adapter = self._l2_adapters.pop(adapter_id)
+                 self._adapter_descriptors.pop(adapter_id, None)
++            # Waits for any synchronous L1 flush using the removed adapter
++            # before adapter.close() releases its native resources.
++            self._sync_l1_writeback_adapters()
+             adapter.close()
+             logger.info("Deleted L2 adapter %d", adapter_id)
+ 
+@@ -1121,6 +1151,21 @@ class StorageManager:
+             return False
+         return True
+ 
++    def _sync_l1_writeback_adapters(self) -> None:
++        """Publish the current adapter set to the optional L1 writeback tier."""
++        config = self._eviction_config
++        if not (config.write_back_on_evict or config.periodic_flush_interval > 0):
++            return
++        with self._adapters_lock:
++            adapters = dict(self._l2_adapters)
++        self._eviction_controller.set_l2_adapters(adapters)
++        if config.emergency_evict_for_prefetch:
++            self._prefetch_controller.set_l1_eviction_controller(
++                self._eviction_controller
++                if self._eviction_controller.has_l2_flush_adapter()
++                else None
++            )
++
+     def _unwrap_reconfigurable_l2_adapter(
+         self,
+         adapter: L2AdapterInterface,
+diff --git a/lmcache/v1/multiprocess/futures.py b/lmcache/v1/multiprocess/futures.py
+index beadae5505e4062d95b3e5f083d8e72b6bdf06d1..ab5195eec56aa3fcd9b52550aac52dc6133680b4 100644
+--- a/lmcache/v1/multiprocess/futures.py
++++ b/lmcache/v1/multiprocess/futures.py
+@@ -14,6 +14,7 @@ class MessagingFuture(Generic[T]):
+     def __init__(self):
+         self.is_done_ = threading.Event()
+         self.result_ = None
++        self.exception_: BaseException | None = None
+ 
+     def query(self) -> bool:
+         """
+@@ -54,6 +55,8 @@ class MessagingFuture(Generic[T]):
+         flag = self.wait(timeout)
+         if not flag:
+             raise LMCacheTimeoutError("Future result not available within timeout")
++        if self.exception_ is not None:
++            raise self.exception_
+         return self.result_
+ 
+     def set_result(self, result: T) -> None:
+@@ -68,6 +71,13 @@ class MessagingFuture(Generic[T]):
+         self.result_ = result
+         self.is_done_.set()
+ 
++    def set_exception(self, exception: BaseException) -> None:
++        """Complete the future with an exception from the messaging system."""
++        if not isinstance(exception, BaseException):
++            raise TypeError("exception must derive from BaseException")
++        self.exception_ = exception
++        self.is_done_.set()
++
+     def to_cuda_future(
+         self,
+         device: Any | None = None,
+diff --git a/lmcache/v1/multiprocess/mq.py b/lmcache/v1/multiprocess/mq.py
+index 271ff93b2a933f6c0f70f95a95d6f2249e7636c1..a5d0d0cf7322a523a9a8b89a0c5af2e2466109b1 100644
+--- a/lmcache/v1/multiprocess/mq.py
++++ b/lmcache/v1/multiprocess/mq.py
+@@ -40,6 +40,26 @@ T = TypeVar("T")
+ # Internal type used for the client-server communication
+ RequestUID = int
+ 
++_ERROR_RESPONSE_MARKER = b"LMCACHE_RPC_ERROR_V1"
++_MAX_REMOTE_ERROR_MESSAGE_BYTES = 4096
++
++
++class RemoteHandlerError(RuntimeError):
++    """A request handler failed in the remote LMCache process."""
++
++    def __init__(
++        self, request_type: RequestType, error_type: str, message: str
++    ) -> None:
++        self.request_type = request_type
++        self.error_type = error_type
++        self.remote_message = message
++        super().__init__(f"{request_type.name} handler failed: {error_type}: {message}")
++
++
++class _RemoteErrorPayload(msgspec.Struct, frozen=True):
++    error_type: str
++    message: str
++
+ 
+ # Helper functions
+ def encode_request_uid(uid: RequestUID) -> bytes:
+@@ -346,7 +366,28 @@ class MessageQueueClient:
+ 
+         if request_uid in self.pending_futures:
+             future = self.pending_futures.pop(request_uid)
+-            if b_response:
++            if b_response and b_response[0] == _ERROR_RESPONSE_MARKER:
++                if len(b_response) != 2:
++                    future.set_exception(
++                        RuntimeError("Malformed LMCache RPC error response")
++                    )
++                    return
++                try:
++                    error = msgspec_decode(b_response[1], cls=_RemoteErrorPayload)
++                except Exception:
++                    future.set_exception(
++                        RuntimeError("Failed to decode LMCache RPC error response")
++                    )
++                    logger.exception("Failed to decode RPC error response")
++                    return
++                future.set_exception(
++                    RemoteHandlerError(
++                        request_type=request_type,
++                        error_type=error.error_type,
++                        message=error.message,
++                    )
++                )
++            elif b_response:
+                 response = msgspec_decode(b_response[0], cls=response_cls)
+                 future.set_result(response)
+             else:
+@@ -516,6 +557,24 @@ class MessageQueueServer:
+         # Thread pools assigned via add_normal_thread_pool / add_affinity_thread_pool
+         self.extra_pools: list[ThreadPoolExecutor | AffinityThreadPool] = []
+ 
++    def _queue_error_response(
++        self, prefix_frames: list[bytes], exception: BaseException
++    ) -> None:
++        """Return a bounded error response without touching ZMQ off-thread."""
++        message = str(exception).encode("utf-8")[:_MAX_REMOTE_ERROR_MESSAGE_BYTES]
++        payload = _RemoteErrorPayload(
++            error_type=type(exception).__name__,
++            message=message.decode("utf-8", errors="replace"),
++        )
++        self.output_queue.put(
++            prefix_frames
++            + [
++                _ERROR_RESPONSE_MARKER,
++                msgspec_encode(payload, cls=_RemoteErrorPayload),
++            ]
++        )
++        self._output_efd.notify()
++
+     def _call_sync_handler(
+         self,
+         handler_entry: SyncRequestHandler[Any],
+@@ -571,8 +630,9 @@ class MessageQueueServer:
+                 self.output_queue.put(frames_to_send)
+                 self._output_efd.notify()
+ 
+-            except Exception:
++            except Exception as exc:
+                 logger.exception("Error in blocking handler")
++                self._queue_error_response(prefix_frames, exc)
+ 
+         future.add_done_callback(_notify_response)
+ 
+@@ -619,13 +679,23 @@ class MessageQueueServer:
+                             payloads=payloads,
+                             prefix_frames=[identity, b_request_uid, b_request_type],
+                         )
+-                    except Exception:
++                    except Exception as exc:
+                         logger.exception("Error handling request %s", request_type)
++                        self._queue_error_response(
++                            [identity, b_request_uid, b_request_type], exc
++                        )
+                 else:
+                     logger.error(
+                         "No handler registered for request type %s", request_type
+                     )
+                     logger.error("Available handlers: %s", list(self.handlers.keys()))
++                    self._queue_error_response(
++                        [identity, b_request_uid, b_request_type],
++                        RuntimeError(
++                            "No handler registered for request type "
++                            f"{request_type.name}"
++                        ),
++                    )
+ 
+             # Send the responses
+             if outbound_state and outbound_state & zmq.POLLIN:
+diff --git a/tests/v1/distributed/test_fs_native_startup_scan.py b/tests/v1/distributed/test_fs_native_startup_scan.py
+new file mode 100644
+index 0000000000000000000000000000000000000000..796c27e183c9ff0bc923b4d5fbe7e7dfdb6957bc
+--- /dev/null
++++ b/tests/v1/distributed/test_fs_native_startup_scan.py
+@@ -0,0 +1,78 @@
++# SPDX-License-Identifier: Apache-2.0
++"""Restart accounting for the native filesystem L2 adapter."""
++
++# Standard
++import os
++
++# Third Party
++import pytest
++
++# First Party
++from lmcache.v1.distributed.api import ObjectKey
++from lmcache.v1.distributed.l2_adapters.fs_l2_adapter import (
++    _object_key_to_filename,
++)
++from lmcache.v1.distributed.l2_adapters.fs_native_l2_adapter import (
++    _scan_existing_fs_native_files,
++)
++
++
++def _key(chunk_id: int) -> ObjectKey:
++    return ObjectKey(
++        chunk_hash=ObjectKey.IntHash2Bytes(chunk_id),
++        model_name="test-model",
++        kv_rank=0,
++    )
++
++
++def _write(root, key: ObjectKey, size: int, mtime_ns: int) -> None:
++    path = root / _object_key_to_filename(key)
++    path.write_bytes(b"x" * size)
++    os.utime(path, ns=(mtime_ns, mtime_ns))
++
++
++def test_scan_returns_oldest_to_newest_keys_and_sizes(tmp_path):
++    newer = _key(2)
++    older = _key(1)
++    _write(tmp_path, newer, 200, 2_000_000_000)
++    _write(tmp_path, older, 100, 1_000_000_000)
++
++    keys, sizes = _scan_existing_fs_native_files(str(tmp_path))
++
++    assert keys == [older, newer]
++    assert sizes == [100, 200]
++
++
++def test_scan_skips_foreign_empty_and_temporary_files(tmp_path):
++    valid = _key(1)
++    _write(tmp_path, valid, 100, 1_000_000_000)
++    (tmp_path / "not-a-cache-file.data").write_bytes(b"x")
++    (tmp_path / _object_key_to_filename(_key(2))).write_bytes(b"")
++    (tmp_path / "pending.tmp").write_bytes(b"x")
++
++    keys, sizes = _scan_existing_fs_native_files(str(tmp_path))
++
++    assert keys == [valid]
++    assert sizes == [100]
++
++
++def test_scan_missing_directory_returns_empty(tmp_path):
++    assert _scan_existing_fs_native_files(str(tmp_path / "missing")) == ([], [])
++
++
++def test_scan_fails_closed_when_existing_file_cannot_be_inspected(
++    tmp_path, monkeypatch
++):
++    path = tmp_path / "broken.data"
++    path.write_bytes(b"x")
++    original_stat = type(path).stat
++
++    def fail_data_stat(self, *args, **kwargs):
++        if self == path:
++            raise OSError("injected stat failure")
++        return original_stat(self, *args, **kwargs)
++
++    monkeypatch.setattr(type(path), "stat", fail_data_stat)
++
++    with pytest.raises(RuntimeError, match="Could not inspect cache file"):
++        _scan_existing_fs_native_files(str(tmp_path))
+diff --git a/tests/v1/distributed/test_l1_manager.py b/tests/v1/distributed/test_l1_manager.py
+index fea845f903879a84856058ac107589a4b21e0fc7..5b0fb89bc77f4b274f8a27bc48c876aa3c7b54bb 100644
+--- a/tests/v1/distributed/test_l1_manager.py
++++ b/tests/v1/distributed/test_l1_manager.py
+@@ -132,18 +132,6 @@ def basic_layout():
+     )
+ 
+ 
+-@pytest.fixture
+-def large_layout():
+-    """Create a large MemoryLayoutDesc that will exhaust small memory.
+-
+-    Each allocation is 8MB (2M elements * 4 bytes).
+-    """
+-    return MemoryLayoutDesc(
+-        shapes=[torch.Size([2048, 1024])],  # 2M elements * 4 bytes = 8MB
+-        dtypes=[torch.float32],
+-    )
+-
+-
+ def make_object_key(chunk_hash: int, model_name: str = "test_model", kv_rank: int = 0):
+     """Helper to create ObjectKey instances."""
+     hash_bytes = ObjectKey.IntHash2Bytes(chunk_hash)
+@@ -879,14 +867,23 @@ class TestReserveWrite:
+ 
+         manager.close()
+ 
+-    def test_reserve_write_out_of_memory(self, small_l1_config, large_layout):
+-        """Test that reserve_write returns OUT_OF_MEMORY when allocation fails."""
++    def test_reserve_write_out_of_memory(self, small_l1_config):
++        """Test that reserve_write returns OUT_OF_MEMORY when allocation fails.
++
++        Uses an object larger than the whole pool; a batch that partially
++        fits allocates the longest prefix instead (see
++        tests/v1/distributed/test_l1_manager_partial_alloc.py).
++        """
+         manager = L1Manager(small_l1_config)
+         keys = [make_object_key(i) for i in range(10)]
+         is_temporary = [False] * 10
+ 
+-        # Request more memory than available (8MB * 10 = 80MB > 64MB)
+-        result = manager.reserve_write(keys, is_temporary, large_layout)
++        # A single object (128MB) exceeds the 64MB pool.
++        oversized_layout = MemoryLayoutDesc(
++            shapes=[torch.Size([2048 * 16, 1024])],
++            dtypes=[torch.float32],
++        )
++        result = manager.reserve_write(keys, is_temporary, oversized_layout)
+ 
+         # All keys should return OUT_OF_MEMORY
+         for key in keys:
+diff --git a/tests/v1/distributed/test_l1_manager_partial_alloc.py b/tests/v1/distributed/test_l1_manager_partial_alloc.py
+new file mode 100644
+index 0000000000000000000000000000000000000000..30ddc3fba0ce10c957ad6375874fac7df9cc8585
+--- /dev/null
++++ b/tests/v1/distributed/test_l1_manager_partial_alloc.py
+@@ -0,0 +1,151 @@
++# SPDX-License-Identifier: Apache-2.0
++"""Partial-prefix allocation behavior of ``L1Manager.reserve_write``.
++
++A batch whose full allocation does not fit must not fail every key
++(all-or-nothing would collapse large L2->L1 restores to zero prefix hits):
++the longest prefix that fits is allocated and only the tail reports
++OUT_OF_MEMORY. Uses the CPU shared-memory allocator, no GPU required.
++"""
++
++# Standard
++from collections.abc import Iterator
++from types import SimpleNamespace
++
++# Third Party
++import pytest
++import torch
++
++# First Party
++from lmcache.v1.distributed.api import MemoryLayoutDesc, ObjectKey
++from lmcache.v1.distributed.config import (
++    L1ManagerConfig,
++    L1MemoryManagerConfig,
++)
++from lmcache.v1.distributed.error import L1Error
++from lmcache.v1.distributed.l1_manager import L1Manager
++
++POOL_BYTES = 64 * 1024 * 1024
++
++# 8MB per object: ten of them cannot fit in the 64MB pool, most can.
++OBJECT_LAYOUT = MemoryLayoutDesc(
++    shapes=[torch.Size([2048, 1024])],
++    dtypes=[torch.float32],
++)
++
++# A single 128MB object exceeds the whole pool.
++OVERSIZED_LAYOUT = MemoryLayoutDesc(
++    shapes=[torch.Size([2048 * 16, 1024])],
++    dtypes=[torch.float32],
++)
++
++
++@pytest.fixture
++def manager() -> Iterator[L1Manager]:
++    config = L1ManagerConfig(
++        memory_config=L1MemoryManagerConfig(
++            size_in_bytes=POOL_BYTES,
++            use_lazy=False,
++            init_size_in_bytes=POOL_BYTES,
++            align_bytes=0x1000,
++        ),
++        write_ttl_seconds=600,
++        read_ttl_seconds=300,
++    )
++    manager = L1Manager(config)
++    yield manager
++    manager.close()
++
++
++def _make_keys(count: int) -> list[ObjectKey]:
++    return [
++        ObjectKey(
++            chunk_hash=ObjectKey.IntHash2Bytes(i),
++            model_name="test_model",
++            kv_rank=0,
++        )
++        for i in range(count)
++    ]
++
++
++def test_reserve_write_allocates_longest_prefix_on_oom(manager: L1Manager) -> None:
++    """When the full batch does not fit, a non-empty prefix succeeds and
++    only the tail reports OUT_OF_MEMORY; every requested key keeps an
++    explicit per-key result."""
++    keys = _make_keys(10)
++    result = manager.reserve_write(keys, [False] * 10, OBJECT_LAYOUT)
++
++    assert set(result) == set(keys)
++    statuses = [result[key][0] for key in keys]
++    num_success = statuses.count(L1Error.SUCCESS)
++    assert 0 < num_success < 10
++
++    # The successful keys form a prefix in request order.
++    assert statuses == [L1Error.SUCCESS] * num_success + [L1Error.OUT_OF_MEMORY] * (
++        10 - num_success
++    )
++    for key in keys[:num_success]:
++        assert result[key][1] is not None
++    for key in keys[num_success:]:
++        assert result[key][1] is None
++
++
++def test_partial_prefix_is_committable(manager: L1Manager) -> None:
++    """The allocated prefix stays usable: finish_write succeeds for it."""
++    keys = _make_keys(10)
++    result = manager.reserve_write(keys, [False] * 10, OBJECT_LAYOUT)
++    successful = [key for key in keys if result[key][0] == L1Error.SUCCESS]
++    assert successful
++
++    finish_result = manager.finish_write(successful)
++    for key in successful:
++        assert finish_result[key] == L1Error.SUCCESS
++
++
++def test_reserve_write_all_oom_when_nothing_fits(manager: L1Manager) -> None:
++    """An object larger than the pool still fails every key."""
++    keys = _make_keys(3)
++    result = manager.reserve_write(keys, [False] * 3, OVERSIZED_LAYOUT)
++
++    for key in keys:
++        assert result[key][0] == L1Error.OUT_OF_MEMORY
++        assert result[key][1] is None
++
++
++def test_single_key_batch_keeps_all_or_nothing(manager: L1Manager) -> None:
++    """A one-key batch has no prefix to fall back to; it simply fails."""
++    keys = _make_keys(1)
++    result = manager.reserve_write(keys, [False], OVERSIZED_LAYOUT)
++
++    assert result[keys[0]] == (L1Error.OUT_OF_MEMORY, None)
++
++
++def test_largest_prefix_search_does_not_stop_at_a_smaller_fit() -> None:
++    """The OOM fallback finds the maximum, rather than accepting a midpoint."""
++
++    class BoundedMemoryManager:
++        def __init__(self, capacity: int) -> None:
++            self.capacity = capacity
++            self.allocate_counts: list[int] = []
++
++        def allocate(self, _layout: MemoryLayoutDesc, count: int):
++            self.allocate_counts.append(count)
++            if count > self.capacity:
++                return L1Error.OUT_OF_MEMORY, []
++            return L1Error.SUCCESS, [object() for _ in range(count)]
++
++        def free(self, _objects: list[object]) -> L1Error:
++            return L1Error.SUCCESS
++
++    memory_manager = BoundedMemoryManager(capacity=7)
++    manager = SimpleNamespace(_memory_manager=memory_manager)
++
++    err, objects = L1Manager._allocate_largest_prefix(
++        manager,
++        OBJECT_LAYOUT,
++        10,  # type: ignore[arg-type]
++    )
++
++    assert err == L1Error.SUCCESS
++    assert len(objects) == 7
++    assert memory_manager.allocate_counts[-1] == 7
++    assert 8 in memory_manager.allocate_counts
+diff --git a/tests/v1/distributed/test_l1_write_back_eviction.py b/tests/v1/distributed/test_l1_write_back_eviction.py
+new file mode 100644
+index 0000000000000000000000000000000000000000..b677516e37c31959421ea88f777a734d7f61bd0d
+--- /dev/null
++++ b/tests/v1/distributed/test_l1_write_back_eviction.py
+@@ -0,0 +1,609 @@
++# SPDX-License-Identifier: Apache-2.0
++"""Opt-in L1 write-back tier.
++
++With ``EvictionConfig.write_back_on_evict`` enabled, L1 eviction flushes
++readable objects to L2 synchronously and deletes them from L1 only once
++every key in the batch is durable. ``periodic_flush_interval`` adds a
++below-watermark backup flush that keeps the L1 copy.
++``emergency_evict_for_prefetch`` lets the prefetch controller make room
++for large restores through the same write-back path.
++
++Uses the CPU shared-memory allocator; no GPU required.
++"""
++
++# Standard
++from collections.abc import Iterator
++import argparse
++import threading
++import time
++
++# Third Party
++import pytest
++import torch
++
++# First Party
++from lmcache.v1.distributed.api import MemoryLayoutDesc, ObjectKey
++from lmcache.v1.distributed.config import (
++    EvictionConfig,
++    L1ManagerConfig,
++    L1MemoryManagerConfig,
++    StorageManagerConfig,
++    add_storage_manager_args,
++    parse_args_to_config,
++)
++from lmcache.v1.distributed.error import L1Error
++from lmcache.v1.distributed.internal_api import (
++    EvictionAction,
++    EvictionDestination,
++)
++from lmcache.v1.distributed.l1_manager import L1Manager
++from lmcache.v1.distributed.storage_controllers.eviction_controller import (
++    L1EvictionController,
++)
++from lmcache.v1.distributed.storage_controllers.prefetch_controller import (
++    InFlightPrefetchRequest,
++    PrefetchController,
++    PrefetchPhase,
++)
++from lmcache.v1.distributed.storage_controllers.prefetch_policy import (
++    DefaultPrefetchPolicy,
++)
++from lmcache.v1.mp_observability.config import add_observability_args
++
++POOL_BYTES = 8 * 1024 * 1024
++
++# 1MB per object so a handful of objects create real memory pressure.
++OBJECT_LAYOUT = MemoryLayoutDesc(
++    shapes=[torch.Size([256, 1024])],
++    dtypes=[torch.float32],
++)
++
++
++class FakeSyncStoreAdapter:
++    """L2 adapter double exposing only the synchronous store path.
++
++    ``result`` overrides the returned tuple; by default every key is
++    reported durable.
++    """
++
++    def __init__(self) -> None:
++        self.stored_batches: list[list[ObjectKey]] = []
++        self.result: tuple[bool, int, int] | None = None
++
++    def store_objects_sync(
++        self,
++        keys: list[ObjectKey],
++        objects: list,
++        timeout: float | None = None,
++    ) -> tuple[bool, int, int]:
++        self.stored_batches.append(list(keys))
++        if self.result is not None:
++            return self.result
++        return True, len(keys), sum(obj.get_size() for obj in objects)
++
++
++class BlockingSyncStoreAdapter(FakeSyncStoreAdapter):
++    def __init__(self) -> None:
++        super().__init__()
++        self.entered = threading.Event()
++        self.release = threading.Event()
++
++    def store_objects_sync(self, keys, objects, timeout=None):
++        self.entered.set()
++        if not self.release.wait(timeout=timeout or 5.0):
++            return False, 0, 0
++        return super().store_objects_sync(keys, objects, timeout=timeout)
++
++
++@pytest.fixture
++def l1_manager() -> Iterator[L1Manager]:
++    config = L1ManagerConfig(
++        memory_config=L1MemoryManagerConfig(
++            size_in_bytes=POOL_BYTES,
++            use_lazy=False,
++            init_size_in_bytes=POOL_BYTES,
++            align_bytes=0x1000,
++        ),
++        write_ttl_seconds=600,
++        read_ttl_seconds=300,
++    )
++    manager = L1Manager(config)
++    yield manager
++    manager.close()
++
++
++def _make_controller(
++    l1_manager: L1Manager,
++    adapter: FakeSyncStoreAdapter,
++    **config_kwargs,
++) -> L1EvictionController:
++    config = EvictionConfig(eviction_policy="LRU", **config_kwargs)
++    return L1EvictionController(
++        l1_manager=l1_manager,
++        eviction_config=config,
++        l2_adapters={0: adapter},
++    )
++
++
++def _make_keys(count: int) -> list[ObjectKey]:
++    return [
++        ObjectKey(
++            chunk_hash=ObjectKey.IntHash2Bytes(i),
++            model_name="test_model",
++            kv_rank=0,
++        )
++        for i in range(count)
++    ]
++
++
++def _store_keys(l1_manager: L1Manager, keys: list[ObjectKey]) -> None:
++    result = l1_manager.reserve_write(keys, [False] * len(keys), OBJECT_LAYOUT)
++    for key in keys:
++        assert result[key][0] == L1Error.SUCCESS
++    l1_manager.finish_write(keys)
++
++
++def _readable_keys(l1_manager: L1Manager, keys: list[ObjectKey]) -> list[ObjectKey]:
++    result = l1_manager.reserve_read(keys)
++    readable = [
++        key
++        for key in keys
++        if result.get(key) is not None and result[key][0] == L1Error.SUCCESS
++    ]
++    if readable:
++        l1_manager.finish_read(readable)
++    return readable
++
++
++class TestWriteBackOnEvict:
++    def test_flush_then_delete(self, l1_manager):
++        """A durable flush deletes the batch from L1."""
++        adapter = FakeSyncStoreAdapter()
++        controller = _make_controller(l1_manager, adapter, write_back_on_evict=True)
++        keys = _make_keys(3)
++        _store_keys(l1_manager, keys)
++
++        controller.execute_eviction_action(
++            EvictionAction(keys=keys, destination=EvictionDestination.L2_CACHE)
++        )
++
++        assert adapter.stored_batches == [keys]
++        assert _readable_keys(l1_manager, keys) == []
++
++    def test_failed_flush_preserves_l1(self, l1_manager):
++        """A failed flush keeps every readable key in L1 and opens the
++        circuit breaker."""
++        adapter = FakeSyncStoreAdapter()
++        adapter.result = (False, 0, 0)
++        controller = _make_controller(l1_manager, adapter, write_back_on_evict=True)
++        keys = _make_keys(3)
++        _store_keys(l1_manager, keys)
++
++        controller.execute_eviction_action(
++            EvictionAction(keys=keys, destination=EvictionDestination.L2_CACHE)
++        )
++
++        assert _readable_keys(l1_manager, keys) == keys
++        status = controller.report_status()
++        assert status["sync_flush_failures"] == 1
++        assert status["sync_flush_backoff_seconds"] > 0.0
++
++    def test_partial_flush_preserves_l1(self, l1_manager):
++        """A partial persist is not durable; the batch stays in L1."""
++        adapter = FakeSyncStoreAdapter()
++        adapter.result = (False, 2, 1024)
++        controller = _make_controller(l1_manager, adapter, write_back_on_evict=True)
++        keys = _make_keys(3)
++        _store_keys(l1_manager, keys)
++
++        controller.execute_eviction_action(
++            EvictionAction(keys=keys, destination=EvictionDestination.L2_CACHE)
++        )
++
++        assert _readable_keys(l1_manager, keys) == keys
++
++    def test_missing_sync_adapter_fails_closed(self, l1_manager):
++        config = EvictionConfig(eviction_policy="LRU", write_back_on_evict=True)
++        controller = L1EvictionController(
++            l1_manager=l1_manager,
++            eviction_config=config,
++            l2_adapters={0: object()},
++        )
++        keys = _make_keys(2)
++        _store_keys(l1_manager, keys)
++
++        controller.execute_eviction_action(
++            EvictionAction(keys=keys, destination=EvictionDestination.L2_CACHE)
++        )
++
++        assert controller.has_l2_flush_adapter() is False
++        assert _readable_keys(l1_manager, keys) == keys
++
++    def test_reserve_read_failure_is_not_deleted(self, l1_manager, monkeypatch):
++        adapter = FakeSyncStoreAdapter()
++        controller = _make_controller(l1_manager, adapter, write_back_on_evict=True)
++        keys = _make_keys(1)
++        _store_keys(l1_manager, keys)
++        monkeypatch.setattr(
++            l1_manager,
++            "reserve_read",
++            lambda _keys: {keys[0]: (L1Error.KEY_IS_LOCKED, None)},
++        )
++
++        controller.execute_eviction_action(
++            EvictionAction(keys=keys, destination=EvictionDestination.L2_CACHE)
++        )
++
++        monkeypatch.undo()
++        assert adapter.stored_batches == []
++        assert _readable_keys(l1_manager, keys) == keys
++
++    def test_adapter_replacement_waits_for_active_flush(self, l1_manager):
++        adapter = BlockingSyncStoreAdapter()
++        controller = _make_controller(l1_manager, adapter, write_back_on_evict=True)
++        keys = _make_keys(1)
++        _store_keys(l1_manager, keys)
++        flush = threading.Thread(
++            target=lambda: controller.execute_eviction_action(
++                EvictionAction(keys=keys, destination=EvictionDestination.L2_CACHE)
++            )
++        )
++        replaced = threading.Event()
++        replace = threading.Thread(
++            target=lambda: (
++                controller.set_l2_adapters({}),
++                replaced.set(),
++            )
++        )
++
++        flush.start()
++        assert adapter.entered.wait(timeout=5.0)
++        replace.start()
++        time.sleep(0.05)
++        assert not replaced.is_set()
++
++        adapter.release.set()
++        flush.join(timeout=5.0)
++        replace.join(timeout=5.0)
++
++        assert replaced.is_set()
++        assert not flush.is_alive()
++        assert not replace.is_alive()
++
++
++class TestEmergencyEvict:
++    def test_emergency_evict_frees_bytes_via_write_back(self, l1_manager):
++        """emergency_evict_bytes flushes LRU victims to L2 and frees L1."""
++        adapter = FakeSyncStoreAdapter()
++        controller = _make_controller(l1_manager, adapter, write_back_on_evict=True)
++        keys = _make_keys(6)
++        _store_keys(l1_manager, keys)
++
++        used_before, total = l1_manager.get_memory_usage()
++        free_before = total - used_before
++
++        free_after = controller.emergency_evict_bytes(
++            free_before + 2 * 1024 * 1024, requester="test"
++        )
++
++        assert free_after > free_before
++        assert adapter.stored_batches
++        evicted = [k for batch in adapter.stored_batches for k in batch]
++        assert set(evicted) <= set(keys)
++        assert len(evicted) < len(keys)
++        # Evicted keys are gone from L1.
++        assert not set(evicted) & set(_readable_keys(l1_manager, keys))
++
++    def test_emergency_evict_noop_when_enough_free(self, l1_manager):
++        adapter = FakeSyncStoreAdapter()
++        controller = _make_controller(l1_manager, adapter, write_back_on_evict=True)
++        keys = _make_keys(2)
++        _store_keys(l1_manager, keys)
++
++        controller.emergency_evict_bytes(1024, requester="test")
++
++        assert adapter.stored_batches == []
++        assert _readable_keys(l1_manager, keys) == keys
++
++    def test_emergency_evict_skips_scan_during_backoff(self, l1_manager, monkeypatch):
++        adapter = FakeSyncStoreAdapter()
++        controller = _make_controller(l1_manager, adapter, write_back_on_evict=True)
++        keys = _make_keys(6)
++        _store_keys(l1_manager, keys)
++        controller._sync_flush_backoff_until = time.monotonic() + 60
++        monkeypatch.setattr(
++            controller._eviction_policy,
++            "get_eviction_actions",
++            lambda *args, **kwargs: pytest.fail("eviction scan should be skipped"),
++        )
++
++        used, total = l1_manager.get_memory_usage()
++        free = total - used
++        assert controller.emergency_evict_bytes(free + 1024) == free
++
++    def test_emergency_evict_has_bounded_store_wait(self, l1_manager):
++        adapter = BlockingSyncStoreAdapter()
++        controller = _make_controller(l1_manager, adapter, write_back_on_evict=True)
++        controller._EMERGENCY_FLUSH_TIMEOUT_SECONDS = 0.05
++        keys = _make_keys(6)
++        _store_keys(l1_manager, keys)
++        used, total = l1_manager.get_memory_usage()
++
++        start = time.monotonic()
++        free_after = controller.emergency_evict_bytes(total - used + 1024)
++        elapsed = time.monotonic() - start
++
++        assert adapter.entered.is_set()
++        assert elapsed < 0.5
++        assert free_after == total - used
++        assert _readable_keys(l1_manager, keys) == keys
++        status = controller.report_status()
++        assert status["sync_flush_failures"] == 0
++        assert status["sync_flush_backoff_seconds"] == 0.0
++
++
++class TestPeriodicBackupFlush:
++    def test_backup_flush_keeps_l1_copy(self, l1_manager):
++        """The periodic backup flush copies keys to L2 without deleting
++        them from L1."""
++        adapter = FakeSyncStoreAdapter()
++        controller = _make_controller(l1_manager, adapter, periodic_flush_interval=0.1)
++        keys = _make_keys(3)
++        _store_keys(l1_manager, keys)
++
++        controller.start()
++        try:
++            deadline = time.monotonic() + 5.0
++            while not adapter.stored_batches and time.monotonic() < deadline:
++                time.sleep(0.1)
++        finally:
++            controller.stop()
++
++        assert adapter.stored_batches
++        flushed = {k for batch in adapter.stored_batches for k in batch}
++        assert flushed <= set(keys)
++        assert _readable_keys(l1_manager, keys) == keys
++
++    def test_backup_batches_rotate_without_full_snapshot(self, l1_manager):
++        adapter = FakeSyncStoreAdapter()
++        controller = _make_controller(l1_manager, adapter)
++        keys = _make_keys(6)
++        _store_keys(l1_manager, keys)
++
++        for _ in range(3):
++            controller._backup_to_l2_no_delete(batch_limit=2)
++
++        assert [len(batch) for batch in adapter.stored_batches] == [2, 2, 2]
++        assert {key for batch in adapter.stored_batches for key in batch} == set(keys)
++
++    def test_backup_flush_has_bounded_store_wait(self, l1_manager):
++        adapter = BlockingSyncStoreAdapter()
++        controller = _make_controller(l1_manager, adapter)
++        controller._PERIODIC_FLUSH_TIMEOUT_SECONDS = 0.05
++        keys = _make_keys(2)
++        _store_keys(l1_manager, keys)
++
++        start = time.monotonic()
++        controller._backup_to_l2_no_delete(batch_limit=2)
++        elapsed = time.monotonic() - start
++
++        assert adapter.entered.is_set()
++        assert elapsed < 0.5
++        assert _readable_keys(l1_manager, keys) == keys
++
++    def test_evictable_batch_scan_wraps_and_is_bounded(self, l1_manager):
++        keys = _make_keys(5)
++        _store_keys(l1_manager, keys)
++        assert l1_manager.reserve_read([keys[0]])[keys[0]][0] == L1Error.SUCCESS
++        try:
++            first, cursor = l1_manager.get_evictable_keys(
++                limit=2,
++                cursor=0,
++                scan_limit=2,
++            )
++            second, cursor = l1_manager.get_evictable_keys(
++                limit=2,
++                cursor=cursor,
++                scan_limit=2,
++            )
++            third, _ = l1_manager.get_evictable_keys(
++                limit=2,
++                cursor=cursor,
++                scan_limit=2,
++            )
++        finally:
++            l1_manager.finish_read([keys[0]])
++
++        assert first == [keys[1]]
++        assert second == keys[2:4]
++        assert third == [keys[4]]
++
++
++class _RecordingEvictor:
++    """Eviction-controller double recording emergency_evict_bytes calls."""
++
++    def __init__(self) -> None:
++        self.calls: list[tuple[int, str]] = []
++
++    def emergency_evict_bytes(self, target_free_bytes: int, requester: str = "") -> int:
++        self.calls.append((target_free_bytes, requester))
++        return target_free_bytes
++
++
++@pytest.fixture
++def prefetch_controller(l1_manager: L1Manager) -> Iterator[PrefetchController]:
++    controller = PrefetchController(
++        l1_manager=l1_manager,
++        l2_adapters=[],
++        adapter_descriptors=[],
++        policy=DefaultPrefetchPolicy(),
++    )
++    yield controller
++    # The loop thread was never started, so stop() cannot join it.
++    controller._submission_efd.close()
++    controller._adapter_ctrl_efd.close()
++
++
++def _make_request(keys: list[ObjectKey]) -> InFlightPrefetchRequest:
++    return InFlightPrefetchRequest(
++        request_id=7,
++        keys=keys,
++        layout_desc=OBJECT_LAYOUT,
++        phase=PrefetchPhase.PLAN_AND_LOAD,
++    )
++
++
++class TestPrefetchMakeRoom:
++    def test_make_room_asks_evictor_when_short(self, l1_manager, prefetch_controller):
++        """A restore that does not fit in free L1 asks for eviction."""
++        controller = prefetch_controller
++        evictor = _RecordingEvictor()
++        controller.set_l1_eviction_controller(evictor)
++        resident = _make_keys(6)
++        _store_keys(l1_manager, resident)
++
++        restore_keys = [
++            ObjectKey(
++                chunk_hash=ObjectKey.IntHash2Bytes(100 + i),
++                model_name="test_model",
++                kv_rank=0,
++            )
++            for i in range(4)
++        ]
++        controller._make_room_for_restore(_make_request(restore_keys), restore_keys)
++
++        assert len(evictor.calls) == 1
++        target, requester = evictor.calls[0]
++        assert target > 0
++        assert "prefetch_request=7" in requester
++
++    def test_make_room_noop_when_space_available(self, l1_manager, prefetch_controller):
++        controller = prefetch_controller
++        evictor = _RecordingEvictor()
++        controller.set_l1_eviction_controller(evictor)
++
++        keys = _make_keys(2)
++        controller._make_room_for_restore(_make_request(keys), keys)
++
++        assert evictor.calls == []
++
++    def test_make_room_noop_without_evictor(self, l1_manager, prefetch_controller):
++        controller = prefetch_controller
++        keys = _make_keys(2)
++
++        controller._make_room_for_restore(_make_request(keys), keys)
++
++    def test_eviction_controller_can_be_disconnected(self, prefetch_controller):
++        evictor = _RecordingEvictor()
++        prefetch_controller.set_l1_eviction_controller(evictor)
++        prefetch_controller.set_l1_eviction_controller(None)
++
++        assert prefetch_controller._l1_eviction_controller is None
++
++    def test_short_retention_policy_degrades_to_temporary(
++        self, prefetch_controller, monkeypatch
++    ):
++        keys = _make_keys(3)
++        monkeypatch.setattr(
++            prefetch_controller._policy,
++            "select_l1_retentions",
++            lambda _keys: [True],
++        )
++
++        assert prefetch_controller._select_l1_retentions(7, keys) == [
++            False,
++            False,
++            False,
++        ]
++
++    def test_retry_recovers_oom_reservations(self, l1_manager, prefetch_controller):
++        """OOM reservations are retried once after emergency eviction."""
++        controller = prefetch_controller
++        evictor = _RecordingEvictor()
++        controller.set_l1_eviction_controller(evictor)
++        keys = _make_keys(2)
++        write_results = {key: (L1Error.OUT_OF_MEMORY, None) for key in keys}
++
++        merged = controller._retry_oom_reservations(
++            _make_request(keys), keys, [True, True], write_results
++        )
++
++        assert len(evictor.calls) == 1
++        for key in keys:
++            err, mem_obj = merged[key]
++            assert err == L1Error.SUCCESS
++            assert mem_obj is not None
++        l1_manager.finish_write(keys)
++
++    def test_retry_noop_when_all_reserved(self, l1_manager, prefetch_controller):
++        controller = prefetch_controller
++        evictor = _RecordingEvictor()
++        controller.set_l1_eviction_controller(evictor)
++        keys = _make_keys(2)
++        result = l1_manager.reserve_write(keys, [False, False], OBJECT_LAYOUT)
++
++        merged = controller._retry_oom_reservations(
++            _make_request(keys), keys, [True, True], result
++        )
++
++        assert evictor.calls == []
++        assert merged is result
++        l1_manager.finish_write(keys)
++
++
++class TestConfigPlumbing:
++    def test_parser_populates_write_back_fields(self):
++        parser = argparse.ArgumentParser()
++        add_storage_manager_args(parser)
++        add_observability_args(parser)
++        args = parser.parse_args(
++            [
++                "--l1-size-gb",
++                "1",
++                "--eviction-policy",
++                "LRU",
++                "--write-back-on-evict",
++                "--periodic-flush-interval",
++                "30.0",
++                "--emergency-evict-for-prefetch",
++            ]
++        )
++        config = parse_args_to_config(args)
++        assert config.eviction_config.write_back_on_evict is True
++        assert config.eviction_config.periodic_flush_interval == 30.0
++        assert config.eviction_config.emergency_evict_for_prefetch is True
++
++    def test_defaults_are_disabled(self):
++        parser = argparse.ArgumentParser()
++        add_storage_manager_args(parser)
++        add_observability_args(parser)
++        args = parser.parse_args(["--l1-size-gb", "1", "--eviction-policy", "LRU"])
++        config = parse_args_to_config(args)
++        assert config.eviction_config.write_back_on_evict is False
++        assert config.eviction_config.periodic_flush_interval == 0.0
++        assert config.eviction_config.emergency_evict_for_prefetch is False
++
++    @pytest.mark.parametrize(
++        "eviction_config",
++        [
++            EvictionConfig(
++                eviction_policy="LRU",
++                periodic_flush_interval=-1.0,
++            ),
++            EvictionConfig(
++                eviction_policy="LRU",
++                emergency_evict_for_prefetch=True,
++            ),
++        ],
++    )
++    def test_invalid_writeback_config_is_rejected(self, eviction_config):
++        with pytest.raises(ValueError):
++            StorageManagerConfig(
++                l1_manager_config=L1ManagerConfig(
++                    memory_config=L1MemoryManagerConfig(
++                        size_in_bytes=POOL_BYTES,
++                        use_lazy=False,
++                    )
++                ),
++                eviction_config=eviction_config,
++            )
+diff --git a/tests/v1/distributed/test_native_connector_l2_adapter.py b/tests/v1/distributed/test_native_connector_l2_adapter.py
+index dc16cdd1ae0161bf2306759cd2b72614a93c83fc..1f4348ad5e223aed6a96d25017a41c2b017a1126 100644
+--- a/tests/v1/distributed/test_native_connector_l2_adapter.py
++++ b/tests/v1/distributed/test_native_connector_l2_adapter.py
+@@ -10,6 +10,7 @@ C++ IStorageConnector interface, so no Redis or C++ build is needed.
+ import ctypes
+ import select
+ import threading
++import time
+ 
+ # Third Party
+ import pytest
+@@ -56,6 +57,9 @@ class MockNativeConnector:
+         self._completions: list[tuple[int, bool, str, list[bool] | None]] = []
+         self._lock = threading.Lock()
+         self._closed = False
++        self.report_set_per_key_results = True
++        self.fail_set_keys: set[str] = set()
++        self.suppress_set_completion = False
+ 
+     def event_fd(self) -> int:
+         return self._efd.fileno()
+@@ -66,9 +70,21 @@ class MockNativeConnector:
+             self._next_id += 1
+ 
+         try:
++            results = []
+             for key, mv in zip(keys, memoryviews, strict=False):
++                if key in self.fail_set_keys:
++                    results.append(False)
++                    continue
+                 self._store[key] = bytes(mv)
+-            self._push_completion(fid, True, "", None)
++                results.append(True)
++            ok = all(results)
++            if not self.suppress_set_completion:
++                self._push_completion(
++                    fid,
++                    ok,
++                    "" if ok else "injected set failure",
++                    results if self.report_set_per_key_results else None,
++                )
+         except Exception as e:
+             self._push_completion(fid, False, str(e), None)
+ 
+@@ -155,6 +171,27 @@ class MockNativeConnector:
+             pass
+ 
+ 
++class DeferredExistsConnector(MockNativeConnector):
++    """Hold EXISTS completion to expose the submit-to-lock race window."""
++
++    def __init__(self):
++        super().__init__()
++        self.pending_exists: tuple[int, list[str]] | None = None
++
++    def submit_batch_exists(self, keys: list[str]) -> int:
++        with self._lock:
++            fid = self._next_id
++            self._next_id += 1
++        self.pending_exists = (fid, list(keys))
++        return fid
++
++    def complete_exists(self) -> None:
++        assert self.pending_exists is not None
++        fid, keys = self.pending_exists
++        self.pending_exists = None
++        self._push_completion(fid, True, "", [key in self._store for key in keys])
++
++
+ # =============================================================================
+ # Test Fixtures
+ # =============================================================================
+@@ -203,6 +240,14 @@ def adapter():
+     adp.close()
+ 
+ 
++@pytest.fixture
++def adapter_and_mock():
++    mock_client = MockNativeConnector()
++    adp = NativeConnectorL2Adapter(mock_client)
++    yield adp, mock_client
++    adp.close()
++
++
+ # =============================================================================
+ # ObjectKey Serialization Tests
+ # =============================================================================
+@@ -1182,6 +1227,91 @@ class TestDeleteInterface:
+     def test_delete_empty_keys(self, adapter):
+         adapter.delete([])  # should not raise
+ 
++    def test_delete_skips_lookup_locked_keys(self, adapter):
++        """Keys lookup-locked by an in-flight prefetch survive delete();
++        unlocked keys in the same batch are still deleted, and the locked
++        key becomes deletable again after unlock."""
++        keys = [create_object_key(i) for i in range(2)]
++        objs = [create_memory_obj(fill_value=float(i)) for i in range(2)]
++        store_fd = adapter.get_store_event_fd()
++        lookup_fd = adapter.get_lookup_and_lock_event_fd()
++
++        adapter.submit_store_task(keys, objs)
++        wait_for_event_fd(store_fd, timeout=5.0)
++        adapter.pop_completed_store_tasks()
++
++        # An in-flight prefetch holds a lookup lock on keys[0].
++        task_id = adapter.submit_lookup_and_lock_task([keys[0]], _EMPTY_LAYOUT)
++        wait_for_event_fd(lookup_fd, timeout=5.0)
++        bitmap = adapter.query_lookup_and_lock_result(task_id)
++        assert bitmap.test(0) is True
++
++        adapter.delete(keys)
++
++        # keys[0] survived, keys[1] is gone. This lookup takes another
++        # lock on keys[0].
++        task_id = adapter.submit_lookup_and_lock_task(keys, _EMPTY_LAYOUT)
++        wait_for_event_fd(lookup_fd, timeout=5.0)
++        bitmap = adapter.query_lookup_and_lock_result(task_id)
++        assert bitmap.test(0) is True
++        assert bitmap.test(1) is False
++
++        # Release both locks; the key is deletable again.
++        adapter.submit_unlock([keys[0]])
++        adapter.submit_unlock([keys[0]])
++        adapter.delete([keys[0]])
++
++        task_id = adapter.submit_lookup_and_lock_task([keys[0]], _EMPTY_LAYOUT)
++        wait_for_event_fd(lookup_fd, timeout=5.0)
++        bitmap = adapter.query_lookup_and_lock_result(task_id)
++        assert bitmap.test(0) is False
++
++    def test_delete_all_keys_locked_is_noop(self, adapter):
++        """delete() returns without submitting when every key is locked."""
++        key = create_object_key(1)
++        obj = create_memory_obj()
++        store_fd = adapter.get_store_event_fd()
++        lookup_fd = adapter.get_lookup_and_lock_event_fd()
++
++        adapter.submit_store_task([key], [obj])
++        wait_for_event_fd(store_fd, timeout=5.0)
++        adapter.pop_completed_store_tasks()
++
++        task_id = adapter.submit_lookup_and_lock_task([key], _EMPTY_LAYOUT)
++        wait_for_event_fd(lookup_fd, timeout=5.0)
++        assert adapter.query_lookup_and_lock_result(task_id).test(0) is True
++
++        adapter.delete([key])
++
++        task_id = adapter.submit_lookup_and_lock_task([key], _EMPTY_LAYOUT)
++        wait_for_event_fd(lookup_fd, timeout=5.0)
++        assert adapter.query_lookup_and_lock_result(task_id).test(0) is True
++        adapter.submit_unlock([key])
++        adapter.submit_unlock([key])
++
++    def test_delete_skips_lookup_that_has_not_completed(self):
++        """Eviction cannot enter between lookup submission and lock acquire."""
++        client = DeferredExistsConnector()
++        adapter = NativeConnectorL2Adapter(client)
++        key = create_object_key(1)
++        obj = create_memory_obj()
++
++        try:
++            adapter.submit_store_task([key], [obj])
++            wait_for_event_fd(adapter.get_store_event_fd(), timeout=5.0)
++            adapter.pop_completed_store_tasks()
++
++            task_id = adapter.submit_lookup_and_lock_task([key], _EMPTY_LAYOUT)
++            adapter.delete([key])
++            assert _object_key_to_string(key) in client._store
++
++            client.complete_exists()
++            wait_for_event_fd(adapter.get_lookup_and_lock_event_fd(), timeout=5.0)
++            assert adapter.query_lookup_and_lock_result(task_id).test(0) is True
++            adapter.submit_unlock([key])
++        finally:
++            adapter.close()
++
+     def test_delete_batch(self, adapter):
+         keys = [create_object_key(i) for i in range(5)]
+         objs = [create_memory_obj(fill_value=float(i)) for i in range(5)]
+@@ -1294,7 +1424,6 @@ class TestUsageTracking:
+         # 400 bytes / 2000 bytes = 0.2
+         assert usage.usage_fraction == pytest.approx(0.2)
+         assert usage.total_bytes_used == 400
+-
+     def test_get_usage_after_delete(self, adapter_with_capacity):
+         adp = adapter_with_capacity
+         store_fd = adp.get_store_event_fd()
+@@ -1358,3 +1487,208 @@ class TestUsageTracking:
+         usage = adp.get_usage()
+         assert usage.usage_fraction == pytest.approx(0.2)
+         assert usage.total_bytes_used == 400
++
++    def test_inflight_stores_cannot_exceed_capacity(self):
++        mock_client = MockNativeConnector()
++        mock_client.suppress_set_completion = True
++        capacity = 800
++        adp = NativeConnectorL2Adapter(
++            mock_client,
++            max_capacity_gb=capacity / (1024**3),
++        )
++        try:
++            obj = create_memory_obj(size=100)  # 400 bytes
++            first = adp.submit_store_task([create_object_key(1)], [obj])
++            second = adp.submit_store_task([create_object_key(2)], [obj])
++            rejected = adp.submit_store_task([create_object_key(3)], [obj])
++
++            assert first != second != rejected
++            assert sum(len(value) for value in mock_client._store.values()) == capacity
++            assert adp.get_reserved_store_bytes() == capacity
++            assert wait_for_event_fd(adp.get_store_event_fd(), timeout=1.0)
++            result = adp.pop_completed_store_tasks()[rejected]
++            assert result.is_successful() is False
++            assert result.bytes_transferred() == 0
++        finally:
++            adp.close()
++
++    def test_failed_store_releases_capacity_reservation(self):
++        mock_client = MockNativeConnector()
++        capacity = 400
++        adp = NativeConnectorL2Adapter(
++            mock_client,
++            max_capacity_gb=capacity / (1024**3),
++        )
++        try:
++            first_key = create_object_key(1)
++            mock_client.fail_set_keys = {_object_key_to_string(first_key)}
++            first = adp.submit_store_task([first_key], [create_memory_obj(size=100)])
++            assert wait_for_event_fd(adp.get_store_event_fd(), timeout=1.0)
++            assert adp.pop_completed_store_tasks()[first].is_successful() is False
++            assert adp.get_reserved_store_bytes() == 0
++
++            mock_client.fail_set_keys.clear()
++            second = adp.submit_store_task(
++                [create_object_key(2)], [create_memory_obj(size=100)]
++            )
++            assert wait_for_event_fd(adp.get_store_event_fd(), timeout=1.0)
++            assert adp.pop_completed_store_tasks()[second].is_successful() is True
++            assert adp.get_usage().total_bytes_used == capacity
++        finally:
++            adp.close()
++
++    def test_synchronous_store_respects_capacity(self):
++        mock_client = MockNativeConnector()
++        capacity = 400
++        adp = NativeConnectorL2Adapter(
++            mock_client,
++            max_capacity_gb=capacity / (1024**3),
++        )
++        try:
++            first = adp.store_objects_sync(
++                [create_object_key(1)], [create_memory_obj(size=100)]
++            )
++            rejected = adp.store_objects_sync(
++                [create_object_key(2)], [create_memory_obj(size=100)]
++            )
++
++            assert first == (True, 1, capacity)
++            assert rejected == (False, 0, 0)
++            assert len(mock_client._store) == 1
++            assert adp.get_usage().total_bytes_used == capacity
++        finally:
++            adp.close()
++
++
++# =============================================================================
++# Durable Store Tests
++# =============================================================================
++
++
++class _BlockingStoreListener:
++    def __init__(self):
++        self.entered = threading.Event()
++        self.release = threading.Event()
++
++    def on_l2_keys_stored(self, keys, sizes) -> None:
++        self.entered.set()
++        assert self.release.wait(timeout=5.0)
++
++
++class TestStoreObjectsSync:
++    def test_success_uses_private_completion(self, adapter):
++        keys = [create_object_key(i) for i in range(2)]
++        objs = [create_memory_obj(fill_value=float(i)) for i in range(2)]
++
++        ok, persisted, bytes_written = adapter.store_objects_sync(keys, objs)
++
++        assert ok is True
++        assert persisted == 2
++        assert bytes_written == sum(obj.get_size() for obj in objs)
++        assert adapter.get_usage().total_bytes_used == bytes_written
++        assert adapter.pop_completed_store_tasks() == {}
++
++    def test_partial_failure_accounts_only_persisted_keys(self, adapter_and_mock):
++        adapter, mock_client = adapter_and_mock
++        keys = [create_object_key(i) for i in range(2)]
++        objs = [create_memory_obj(fill_value=float(i)) for i in range(2)]
++        mock_client.fail_set_keys = {_object_key_to_string(keys[1])}
++
++        ok, persisted, bytes_written = adapter.store_objects_sync(keys, objs)
++
++        assert ok is False
++        assert persisted == 1
++        assert bytes_written == objs[0].get_size()
++        assert adapter.get_usage().total_bytes_used == objs[0].get_size()
++
++    def test_async_partial_failure_uses_per_key_results(self, adapter_and_mock):
++        adapter, mock_client = adapter_and_mock
++        keys = [create_object_key(i) for i in range(2)]
++        objs = [create_memory_obj(fill_value=float(i)) for i in range(2)]
++        mock_client.fail_set_keys = {_object_key_to_string(keys[1])}
++
++        task_id = adapter.submit_store_task(keys, objs)
++        assert wait_for_event_fd(adapter.get_store_event_fd(), timeout=5.0)
++
++        result = adapter.pop_completed_store_tasks()[task_id]
++        assert result.is_successful() is False
++        assert adapter.get_usage().total_bytes_used == objs[0].get_size()
++
++    def test_batch_fallback_without_per_key_results(self, adapter_and_mock):
++        adapter, mock_client = adapter_and_mock
++        mock_client.report_set_per_key_results = False
++        keys = [create_object_key(i) for i in range(2)]
++        objs = [create_memory_obj(fill_value=float(i)) for i in range(2)]
++
++        ok, persisted, bytes_written = adapter.store_objects_sync(keys, objs)
++
++        assert ok is True
++        assert persisted == 2
++        assert bytes_written == sum(obj.get_size() for obj in objs)
++
++    def test_validates_inputs(self, adapter):
++        with pytest.raises(ValueError, match="length mismatch"):
++            adapter.store_objects_sync([create_object_key(1)], [])
++        with pytest.raises(ValueError, match="timeout must be positive"):
++            adapter.store_objects_sync(
++                [create_object_key(1)], [create_memory_obj()], timeout=0
++            )
++        assert adapter.store_objects_sync([], []) == (True, 0, 0)
++
++    def test_real_timeout_keeps_pending_operation_reserved(self, adapter_and_mock):
++        adapter, mock_client = adapter_and_mock
++        mock_client.suppress_set_completion = True
++
++        result = adapter.store_objects_sync(
++            [create_object_key(1)], [create_memory_obj()], timeout=0.05
++        )
++
++        assert result == (False, 0, 0)
++        assert adapter._pending_sync_store_events == {}
++        assert len(adapter._pending_ops) == 1
++        assert adapter.get_reserved_store_bytes() == create_memory_obj().get_size()
++
++    def test_completion_at_timeout_does_not_wait_for_observer(self, adapter):
++        listener = _BlockingStoreListener()
++        adapter.register_listener(listener)
++        result = []
++        worker = threading.Thread(
++            target=lambda: result.append(
++                adapter.store_objects_sync(
++                    [create_object_key(1)],
++                    [create_memory_obj()],
++                    timeout=0.05,
++                )
++            )
++        )
++        worker.start()
++        assert listener.entered.wait(timeout=5.0)
++        time.sleep(0.1)
++        assert not worker.is_alive()
++        assert result[0][0] is True
++        assert adapter.get_usage().total_bytes_used == result[0][2]
++
++        listener.release.set()
++        worker.join(timeout=5.0)
++
++        assert not worker.is_alive()
++
++    def test_close_unblocks_waiter(self, adapter_and_mock):
++        adapter, mock_client = adapter_and_mock
++        mock_client.suppress_set_completion = True
++        result = []
++        worker = threading.Thread(
++            target=lambda: result.append(
++                adapter.store_objects_sync(
++                    [create_object_key(1)], [create_memory_obj()], timeout=10.0
++                )
++            )
++        )
++        worker.start()
++        time.sleep(0.05)
++
++        adapter.close()
++        worker.join(timeout=5.0)
++
++        assert not worker.is_alive()
++        assert result == [(False, 0, 0)]
+diff --git a/tests/v1/distributed/test_native_connector_restart_accounting.py b/tests/v1/distributed/test_native_connector_restart_accounting.py
+new file mode 100644
+index 0000000000000000000000000000000000000000..dc5d6c68c3fcb236bafd2bfdf9a2b8c9582e00d8
+--- /dev/null
++++ b/tests/v1/distributed/test_native_connector_restart_accounting.py
+@@ -0,0 +1,66 @@
++# SPDX-License-Identifier: Apache-2.0
++"""Restart accounting behavior shared by native L2 connectors."""
++
++# Third Party
++import pytest
++
++# First Party
++from tests.v1.distributed.test_native_connector_l2_adapter import (
++    adapter,
++    create_object_key,
++)
++
++
++class _RecordingL2Listener:
++    def __init__(self):
++        self.stored = []
++
++    def on_l2_keys_stored(self, keys, sizes) -> None:
++        self.stored.append((list(keys), list(sizes)))
++
++
++class TestPrimeExistingKeys:
++    def test_priming_accounts_deduplicated_usage(self, adapter):
++        key = create_object_key(1)
++
++        adapter.prime_existing_keys([key, key], [100, 999])
++
++        assert adapter.get_usage().total_bytes_used == 100
++        assert adapter._key_sizes == {key: 100}
++
++    def test_first_listener_receives_startup_snapshot_once(self, adapter):
++        keys = [create_object_key(1), create_object_key(2)]
++        adapter.prime_existing_keys(keys, [100, 200])
++        first = _RecordingL2Listener()
++        second = _RecordingL2Listener()
++
++        adapter.register_listener(first)
++        adapter.register_listener(second)
++
++        assert first.stored == [(keys, [100, 200])]
++        assert second.stored == []
++        assert adapter.get_usage().total_bytes_used == 300
++
++    def test_empty_snapshot_is_consumed_without_callback(self, adapter):
++        adapter.prime_existing_keys([], [])
++        listener = _RecordingL2Listener()
++
++        adapter.register_listener(listener)
++
++        assert listener.stored == []
++
++    def test_rejects_invalid_or_repeated_priming(self, adapter):
++        with pytest.raises(ValueError, match="length mismatch"):
++            adapter.prime_existing_keys([create_object_key(1)], [1, 2])
++        with pytest.raises(ValueError, match="must be positive"):
++            adapter.prime_existing_keys([create_object_key(1)], [0])
++
++        adapter.prime_existing_keys([], [])
++        with pytest.raises(RuntimeError, match="already primed"):
++            adapter.prime_existing_keys([], [])
++
++    def test_rejects_priming_after_listener_registration(self, adapter):
++        adapter.register_listener(_RecordingL2Listener())
++
++        with pytest.raises(RuntimeError, match="before listeners"):
++            adapter.prime_existing_keys([], [])
+diff --git a/tests/v1/distributed/test_native_fs_connector_results.py b/tests/v1/distributed/test_native_fs_connector_results.py
+new file mode 100644
+index 0000000000000000000000000000000000000000..458fcf0edfcf8a04ab13a4431248640e557cb8c3
+--- /dev/null
++++ b/tests/v1/distributed/test_native_fs_connector_results.py
+@@ -0,0 +1,54 @@
++# SPDX-License-Identifier: Apache-2.0
++"""Native FS connector completion semantics.
++
++These tests exercise the compiled extension. They are skipped when the
++optional native FS module is not part of the test environment.
++"""
++
++# Standard
++import select
++import time
++
++# Third Party
++import pytest
++
++lmcache_fs = pytest.importorskip("lmcache.lmcache_fs")
++
++
++def _wait_for_completion(client, timeout: float = 5.0):
++    poller = select.poll()
++    poller.register(client.event_fd(), select.POLLIN)
++    deadline = time.monotonic() + timeout
++    while time.monotonic() < deadline:
++        if poller.poll(50):
++            completions = client.drain_completions()
++            if completions:
++                return completions
++    raise AssertionError("native connector completion timed out")
++
++
++def test_batch_set_reports_partial_results_and_continues(tmp_path):
++    client = lmcache_fs.LMCacheFSClient(str(tmp_path), 1)
++    try:
++        buffers = [bytearray(b"first"), bytearray(b"bad"), bytearray(b"last")]
++        keys = [
++            "model@00000000@01",
++            "malformed-key",
++            "model@00000000@03",
++        ]
++
++        future_id = client.submit_batch_set(
++            keys,
++            [memoryview(buffer) for buffer in buffers],
++        )
++        completions = _wait_for_completion(client)
++
++        assert len(completions) == 1
++        completed_id, ok, error, results = completions[0]
++        assert completed_id == future_id
++        assert ok is False
++        assert "partially failed" in error
++        assert results == [True, False, True]
++        assert len(list(tmp_path.glob("*.data"))) == 2
++    finally:
++        client.close()
+diff --git a/tests/v1/distributed/test_native_fs_key_compatibility.py b/tests/v1/distributed/test_native_fs_key_compatibility.py
+new file mode 100644
+index 0000000000000000000000000000000000000000..d18fba4e8f8c662a3826f1a8182ac681ca9a0584
+--- /dev/null
++++ b/tests/v1/distributed/test_native_fs_key_compatibility.py
+@@ -0,0 +1,55 @@
++# SPDX-License-Identifier: Apache-2.0
++"""ObjectKey compatibility of the compiled native FS connector."""
++
++# Standard
++import select
++import time
++
++# Third Party
++import pytest
++
++lmcache_fs = pytest.importorskip("lmcache.lmcache_fs")
++
++
++def _wait_for_completion(client, timeout: float = 5.0):
++    poller = select.poll()
++    poller.register(client.event_fd(), select.POLLIN)
++    deadline = time.monotonic() + timeout
++    while time.monotonic() < deadline:
++        if poller.poll(50):
++            completions = client.drain_completions()
++            if completions:
++                return completions[0]
++    raise AssertionError("native connector completion timed out")
++
++
++@pytest.mark.parametrize(
++    ("wire_key", "filename"),
++    [
++        ("model@00000000@aabb", "model@0x00000000@aabb.data"),
++        (
++            "model@00000000@aabb@salt",
++            "model@0x00000000@aabb@salt.data",
++        ),
++        (
++            "model@00000000@2@aabb",
++            "model@0x00000000@2@aabb.data",
++        ),
++        (
++            "model@00000000@2@aabb@salt",
++            "model@0x00000000@2@aabb@salt.data",
++        ),
++    ],
++)
++def test_legacy_and_current_key_shapes(wire_key, filename, tmp_path):
++    client = lmcache_fs.LMCacheFSClient(str(tmp_path), 1)
++    try:
++        payload = bytearray(b"payload")
++        future_id = client.submit_batch_set([wire_key], [memoryview(payload)])
++        completed_id, ok, error, _results = _wait_for_completion(client)
++
++        assert completed_id == future_id
++        assert ok, error
++        assert (tmp_path / filename).read_bytes() == payload
++    finally:
++        client.close()
+diff --git a/tests/v1/distributed/test_native_fs_odirect.py b/tests/v1/distributed/test_native_fs_odirect.py
+new file mode 100644
+index 0000000000000000000000000000000000000000..1d5118eca102011208e580b447f3d034cb8afd13
+--- /dev/null
++++ b/tests/v1/distributed/test_native_fs_odirect.py
+@@ -0,0 +1,80 @@
++# SPDX-License-Identifier: Apache-2.0
++"""O_DIRECT behavior of the compiled native FS connector."""
++
++# Standard
++import ctypes
++import select
++import time
++
++# Third Party
++import pytest
++
++lmcache_fs = pytest.importorskip("lmcache.lmcache_fs")
++
++
++def _aligned_view(size: int, alignment: int = 4096):
++    storage = bytearray(size + alignment)
++    address = ctypes.addressof(ctypes.c_char.from_buffer(storage))
++    offset = (-address) % alignment
++    return storage, memoryview(storage)[offset : offset + size]
++
++
++def _wait_for_completion(client, timeout: float = 5.0):
++    poller = select.poll()
++    poller.register(client.event_fd(), select.POLLIN)
++    deadline = time.monotonic() + timeout
++    while time.monotonic() < deadline:
++        if poller.poll(50):
++            completions = client.drain_completions()
++            if completions:
++                return completions[0]
++    raise AssertionError("native connector completion timed out")
++
++
++def test_odirect_falls_back_for_misaligned_buffer_address(tmp_path):
++    client = lmcache_fs.LMCacheFSClient(str(tmp_path), 1, "", True)
++    try:
++        payload_storage = bytearray(4097)
++        payload = memoryview(payload_storage)[1:]
++        payload[:] = b"x" * len(payload)
++        key = "model@00000000@01"
++
++        store_id = client.submit_batch_set([key], [payload])
++        completed_id, ok, error, _results = _wait_for_completion(client)
++        assert completed_id == store_id
++        assert ok, error
++
++        loaded_storage = bytearray(4097)
++        loaded = memoryview(loaded_storage)[1:]
++        load_id = client.submit_batch_get([key], [loaded])
++        completed_id, ok, error, results = _wait_for_completion(client)
++        assert completed_id == load_id
++        assert ok, error
++        assert results == [True]
++        assert loaded == payload
++    finally:
++        client.close()
++
++
++def test_odirect_falls_back_for_misaligned_readahead_split(tmp_path):
++    client = lmcache_fs.LMCacheFSClient(str(tmp_path), 1, "", True, 4095)
++    try:
++        payload_storage, payload = _aligned_view(8192)
++        payload[:] = b"x" * len(payload)
++        key = "model@00000000@02"
++
++        store_id = client.submit_batch_set([key], [payload])
++        completed_id, ok, error, _results = _wait_for_completion(client)
++        assert completed_id == store_id
++        assert ok, error
++
++        loaded_storage, loaded = _aligned_view(8192)
++        load_id = client.submit_batch_get([key], [loaded])
++        completed_id, ok, error, results = _wait_for_completion(client)
++        assert completed_id == load_id
++        assert ok, error
++        assert results == [True]
++        assert loaded == payload
++        del payload_storage, loaded_storage
++    finally:
++        client.close()
+diff --git a/tests/v1/distributed/test_prefetch_controller.py b/tests/v1/distributed/test_prefetch_controller.py
+index 09c06c5819646d20d65485ee446793a1a9a7f9d0..e86ac177a07f19f54bb6417858dea1d4ff116cfd 100644
+--- a/tests/v1/distributed/test_prefetch_controller.py
++++ b/tests/v1/distributed/test_prefetch_controller.py
+@@ -35,6 +35,9 @@ from lmcache.v1.distributed.l2_adapters.mock_l2_adapter import (
+     MockL2Adapter,
+     MockL2AdapterConfig,
+ )
++from lmcache.v1.distributed.storage_controllers import (
++    prefetch_controller as prefetch_controller_module,
++)
+ from lmcache.v1.distributed.storage_controllers.prefetch_controller import (
+     PrefetchController,
+     build_trim_mask,
+@@ -363,7 +366,7 @@ class TestSingleAdapterPrefetch:
+         ctrl.stop()
+         adapter.close()
+ 
+-    def test_fault_inject_load_gap_segmented_vs_prefix(self, l1_manager):
++    def test_fault_inject_load_gap_segmented_vs_prefix(self, l1_manager, monkeypatch):
+         """fault_inject (load fails at index 2) drives the segmented path.
+ 
+         Lookup reports all 5 keys present; the *load* of index 2 fails (the L2
+@@ -371,6 +374,14 @@ class TestSingleAdapterPrefetch:
+         post-gap keys {0,1,3,4}; PREFIX truncates at the hole to {0,1}. Distinct
+         key ranges per policy keep the shared L1 from serving the second pass.
+         """
++        warning_messages: list[str] = []
++
++        def capture_warning(message, *args, **_kwargs):
++            warning_messages.append(message % args)
++
++        monkeypatch.setattr(
++            prefetch_controller_module.logger, "warning", capture_warning
++        )
+         layout = make_layout()
+         for base, trim, expected in (
+             (0, TrimPolicy.SEGMENTED_PREFIX, [0, 1, 3, 4]),
+@@ -402,6 +413,11 @@ class TestSingleAdapterPrefetch:
+             ctrl.stop()
+             fault.close()
+ 
++        assert any(
++            "1/5 plan keys failed to load from L2" in message and "sample:" in message
++            for message in warning_messages
++        )
++
+     def test_key0_missing(self, l1_manager):
+         """L2 has keys {1,2,3} but not 0 → prefix = 0, nothing loaded."""
+         adapter = make_adapter()
+diff --git a/tests/v1/multiprocess/test_futures.py b/tests/v1/multiprocess/test_futures.py
+index 53cf694bc5c29ee852c5511d2753b6a8a676511a..c9086609ec879d9ed6fcceab478da9c5c7117d49 100644
+--- a/tests/v1/multiprocess/test_futures.py
++++ b/tests/v1/multiprocess/test_futures.py
+@@ -173,6 +173,27 @@ def test_messaging_future_complex_type():
+     thread.join()
+ 
+ 
++def test_messaging_future_exception_is_re_raised():
++    """A remote messaging failure completes the future instead of hanging it."""
++    future = MessagingFuture[int]()
++    error = RuntimeError("remote operation failed")
++
++    future.set_exception(error)
++
++    assert future.query()
++    assert future.wait(timeout=0.1)
++    with pytest.raises(RuntimeError, match="remote operation failed") as exc_info:
++        future.result(timeout=0.1)
++    assert exc_info.value is error
++
++
++def test_messaging_future_rejects_non_exception():
++    future = MessagingFuture[int]()
++
++    with pytest.raises(TypeError, match="must derive from BaseException"):
++        future.set_exception("not an exception")  # type: ignore[arg-type]
++
++
+ # ==============================================================================
+ # CUDAMessagingFuture Tests
+ # ==============================================================================
+diff --git a/tests/v1/multiprocess/test_mq.py b/tests/v1/multiprocess/test_mq.py
+index 75ff9cd7a0630391f0515622e36e1f38fe243764..93ef515bfc0c3a66feda76720178b2dd140a7211 100644
+--- a/tests/v1/multiprocess/test_mq.py
++++ b/tests/v1/multiprocess/test_mq.py
+@@ -21,6 +21,7 @@ from lmcache.v1.multiprocess.mq import (
+     BlockingRequestHandler,
+     MessageQueueClient,
+     MessageQueueServer,
++    RemoteHandlerError,
+ )
+ from lmcache.v1.multiprocess.protocol import (
+     RequestType,
+@@ -683,6 +684,58 @@ def test_shared_loop_dispatch():
+         server.close()
+ 
+ 
++def test_sync_handler_failure_completes_future_and_loop_recovers():
++    context = zmq.Context.instance()
++    server = MessageQueueServer("tcp://127.0.0.1:16021", context)
++    add_handler_helper(
++        server, RequestType.NOOP, test_mq_handler_helpers.failing_noop_handler
++    )
++    server.start()
++    client = MessageQueueClient("tcp://127.0.0.1:16021", context)
++
++    try:
++        failed = client.submit_request(RequestType.NOOP, [])
++        with pytest.raises(
++            RemoteHandlerError, match="intentional sync handler failure"
++        ) as exc_info:
++            failed.result(timeout=2)
++        assert exc_info.value.request_type is RequestType.NOOP
++        assert exc_info.value.error_type == "ValueError"
++
++        server.add_sync_handler(
++            RequestType.NOOP, [], test_mq_handler_helpers.noop_handler
++        )
++        assert (
++            client.submit_request(RequestType.NOOP, []).result(timeout=2) == "NOOP_OK"
++        )
++    finally:
++        client.close()
++        server.close()
++
++
++def test_blocking_handler_failure_completes_future():
++    context = zmq.Context.instance()
++    server = MessageQueueServer("tcp://127.0.0.1:16022", context)
++    add_handler_helper(
++        server, RequestType.LOOKUP, test_mq_handler_helpers.failing_lookup_handler
++    )
++    server.add_normal_thread_pool([RequestType.LOOKUP], max_workers=1)
++    server.start()
++    client = MessageQueueClient("tcp://127.0.0.1:16022", context)
++
++    try:
++        future = client.submit_request(RequestType.LOOKUP, [create_cache_key(1), 1])
++        with pytest.raises(
++            RemoteHandlerError, match="intentional blocking handler failure"
++        ) as exc_info:
++            future.result(timeout=2)
++        assert exc_info.value.request_type is RequestType.LOOKUP
++        assert exc_info.value.error_type == "OSError"
++    finally:
++        client.close()
++        server.close()
++
++
+ def test_shared_loop_recreate():
+     """
+     Test that closing all clients and creating new ones starts a fresh loop.
+diff --git a/tests/v1/multiprocess/test_mq_handler_helpers.py b/tests/v1/multiprocess/test_mq_handler_helpers.py
+index b1d65251d3fd0a615bc256fb483cf78a4a8ef16e..9837df531ef7414473af86834bc63afcb7f842c0 100644
+--- a/tests/v1/multiprocess/test_mq_handler_helpers.py
++++ b/tests/v1/multiprocess/test_mq_handler_helpers.py
+@@ -29,6 +29,11 @@ def noop_handler() -> str:
+     return "NOOP_OK"
+ 
+ 
++def failing_noop_handler() -> str:
++    """Raise a deterministic error for RPC error propagation tests."""
++    raise ValueError("intentional sync handler failure")
++
++
+ # ==============================================================================
+ # REGISTER_KV_CACHE Request Handlers
+ # ==============================================================================
+@@ -203,6 +208,12 @@ def lookup_handler(key: KeyType, tp_size: int) -> None:
+     assert isinstance(tp_size, int), f"Expected tp_size to be int, got {type(tp_size)}"
+ 
+ 
++def failing_lookup_handler(key: KeyType, tp_size: int) -> None:
++    """Raise a deterministic error from a blocking request handler."""
++    del key, tp_size
++    raise OSError("intentional blocking handler failure")
++
++
+ # ==============================================================================
+ # FREE_LOOKUP_LOCKS Request Handlers
+ # ==============================================================================
+diff --git a/tests/v1/test_vllm_mp_adapter.py b/tests/v1/test_vllm_mp_adapter.py
+index d64ca9ec7061a0714cba7c9c488e3fb0cef9179a..ddf180a64dd9e6b9d8f4af4114324bc927fbf12f 100644
+--- a/tests/v1/test_vllm_mp_adapter.py
++++ b/tests/v1/test_vllm_mp_adapter.py
+@@ -782,3 +782,65 @@ def test_recover_callback_rebuilds_transfer_ctx_without_closing_previous(
+     assert len(contexts) == 3
+     assert adapter.transfer_ctx is contexts[2]
+     contexts[1].close.assert_not_called()
++
++
++def _finished_retrieve_future(result: object) -> MagicMock:
++    """Build a completed retrieve future; an Exception *result* makes
++    ``result()`` raise it."""
++    future = MagicMock(name="retrieve_future")
++    future.query.return_value = True
++    if isinstance(result, Exception):
++        future.result.side_effect = result
++    else:
++        future.result.return_value = result
++    return future
++
++
++def test_failed_retrieve_marks_blocks_invalid(fake_adapter) -> None:
++    """A retrieve the healthy server answers with ``result=False`` is
++    reported finished AND its block ids are surfaced through
++    ``get_block_ids_with_load_errors`` so the scheduler recomputes them
++    instead of decoding over never-written blocks."""
++    adapter, _send_mock, _ = fake_adapter
++    adapter.retrieve_futures["req-1"] = (
++        _finished_retrieve_future(False),
++        [3, 4, 5],
++    )
++
++    ret_stores, finished_retrieves = adapter.get_finished(set())
++
++    assert ret_stores == set()
++    assert finished_retrieves == {"req-1"}
++    assert adapter.get_block_ids_with_load_errors() == {3, 4, 5}
++    # The error set is consumed on read.
++    assert adapter.get_block_ids_with_load_errors() == set()
++    assert adapter.retrieve_failure_count == 1
++
++
++def test_raising_retrieve_future_contained_as_failure(fake_adapter) -> None:
++    """A retrieve future whose ``result()`` raises must not propagate out
++    of ``get_finished`` (that would kill the engine step); it lands on the
++    same failure path as ``result=False``."""
++    adapter, _send_mock, _ = fake_adapter
++    adapter.retrieve_futures["req-1"] = (
++        _finished_retrieve_future(RuntimeError("ipc receive failed")),
++        [7, 8],
++    )
++
++    _ret_stores, finished_retrieves = adapter.get_finished(set())
++
++    assert finished_retrieves == {"req-1"}
++    assert adapter.get_block_ids_with_load_errors() == {7, 8}
++    assert adapter.retrieve_failure_count == 1
++
++
++def test_successful_retrieve_marks_no_blocks_invalid(fake_adapter) -> None:
++    """A successful retrieve reports no load errors."""
++    adapter, _send_mock, _ = fake_adapter
++    adapter.retrieve_futures["req-1"] = (_finished_retrieve_future(True), [1, 2])
++
++    _ret_stores, finished_retrieves = adapter.get_finished(set())
++
++    assert finished_retrieves == {"req-1"}
++    assert adapter.get_block_ids_with_load_errors() == set()
++    assert adapter.retrieve_failure_count == 0
+diff --git a/tests/v1/test_vllm_mp_connector_metadata.py b/tests/v1/test_vllm_mp_connector_metadata.py
+new file mode 100644
+index 0000000000000000000000000000000000000000..45d427bd561aed4dcc953eda04259e2854008e15
+--- /dev/null
++++ b/tests/v1/test_vllm_mp_connector_metadata.py
+@@ -0,0 +1,133 @@
++# SPDX-License-Identifier: Apache-2.0
++"""Unit tests for ``LMCacheMPRequestMetadata.GetRetrieveMetadata``.
++
++The retrieve op must only be emitted when the tracker's allocated block ids
++actually cover the retrieve token range in every engine group:
++``slice_block_ids_per_group`` validates chunk alignment only, and its plain
++Python slice truncates silently, so an uncovered range would otherwise emit
++an op with too few block ids.
++"""
++
++# Standard
++from types import SimpleNamespace
++
++# Third Party
++import pytest
++
++# First Party
++from lmcache.integration.vllm.lmcache_mp_connector import (
++    LMCacheMPRequestMetadata,
++    LMCacheMPRequestState,
++    LMCacheMPRequestTracker,
++)
++
++CHUNK_TOKENS = 64
++
++
++def _tracker(
++    num_tokens: int,
++    lmcache_hit_tokens: int,
++    vllm_hit_tokens: int,
++    allocated_block_ids: dict[int, list[int]],
++) -> LMCacheMPRequestTracker:
++    """Build a tracker that is ready for retrieving over *num_tokens*."""
++    request = SimpleNamespace(
++        request_id="req-1",
++        cache_salt="",
++        all_token_ids=list(range(num_tokens)),
++    )
++    tracker = LMCacheMPRequestTracker(request)
++    tracker.num_lmcache_hit_tokens = lmcache_hit_tokens
++    tracker.num_vllm_hit_tokens = vllm_hit_tokens
++    tracker.allocated_block_ids = allocated_block_ids
++    tracker.state = LMCacheMPRequestState.WAITING_FOR_LOAD
++    return tracker
++
++
++@pytest.mark.parametrize(
++    ("group_tokens_per_block", "allocated_block_ids", "expected_block_ids"),
++    [
++        # Single group, plain geometry: 64 tokens / 16 tokens per block.
++        ([16], {0: [0, 1, 2, 3]}, [[0, 1, 2, 3]]),
++        # Single group, DCP-scaled: one manager block id covers 64 tokens.
++        ([64], {0: [5]}, [[5]]),
++        # Hybrid geometries: each group sliced by its own tokens-per-block.
++        ([16, 32], {0: [0, 1, 2, 3], 1: [10, 11]}, [[0, 1, 2, 3], [10, 11]]),
++        # Extra allocated blocks beyond the range are fine (and not emitted).
++        ([16], {0: [0, 1, 2, 3, 4, 5]}, [[0, 1, 2, 3]]),
++    ],
++)
++def test_retrieve_metadata_emitted_when_allocation_covers_range(
++    group_tokens_per_block: list[int],
++    allocated_block_ids: dict[int, list[int]],
++    expected_block_ids: list[list[int]],
++) -> None:
++    tracker = _tracker(
++        num_tokens=CHUNK_TOKENS,
++        lmcache_hit_tokens=CHUNK_TOKENS,
++        vllm_hit_tokens=0,
++        allocated_block_ids=allocated_block_ids,
++    )
++
++    metadata = LMCacheMPRequestMetadata.GetRetrieveMetadata(
++        tracker, CHUNK_TOKENS, group_tokens_per_block
++    )
++
++    assert metadata is not None
++    assert metadata.direction == "RETRIEVE"
++    assert metadata.op.start == 0
++    assert metadata.op.end == CHUNK_TOKENS
++    assert metadata.op.block_ids == expected_block_ids
++
++
++@pytest.mark.parametrize(
++    ("group_tokens_per_block", "allocated_block_ids"),
++    [
++        # One block short in the only group.
++        ([16], {0: [0, 1, 2]}),
++        # DCP-scaled group with no allocation at all.
++        ([64], {0: []}),
++        # Group 0 covered, group 1 one block short.
++        ([16, 32], {0: [0, 1, 2, 3], 1: [10]}),
++        # Group key missing entirely (counts as zero blocks).
++        ([16, 16], {0: [0, 1, 2, 3]}),
++    ],
++)
++def test_retrieve_metadata_suppressed_when_allocation_short(
++    group_tokens_per_block: list[int],
++    allocated_block_ids: dict[int, list[int]],
++) -> None:
++    """Any engine group whose allocation does not cover the retrieve range
++    suppresses the op entirely: the request falls back to recompute instead
++    of retrieving over silently truncated block-id lists."""
++    tracker = _tracker(
++        num_tokens=CHUNK_TOKENS,
++        lmcache_hit_tokens=CHUNK_TOKENS,
++        vllm_hit_tokens=0,
++        allocated_block_ids=allocated_block_ids,
++    )
++
++    metadata = LMCacheMPRequestMetadata.GetRetrieveMetadata(
++        tracker, CHUNK_TOKENS, group_tokens_per_block
++    )
++
++    assert metadata is None
++
++
++def test_retrieve_metadata_skip_tokens_preserved_on_emitted_op() -> None:
++    """vLLM-hit tokens inside the first chunk round the start down and are
++    carried as skip_first_n_tokens; coverage is still checked against the
++    chunk-aligned end."""
++    tracker = _tracker(
++        num_tokens=CHUNK_TOKENS,
++        lmcache_hit_tokens=CHUNK_TOKENS,
++        vllm_hit_tokens=16,
++        allocated_block_ids={0: [0, 1, 2, 3]},
++    )
++
++    metadata = LMCacheMPRequestMetadata.GetRetrieveMetadata(tracker, CHUNK_TOKENS, [16])
++
++    assert metadata is not None
++    assert metadata.op.start == 0
++    assert metadata.op.end == CHUNK_TOKENS
++    assert metadata.op.skip_first_n_tokens == 16

--- a/patches/releases/gilded-gnosis-v20-r33/vllm/integration.lock.json
+++ b/patches/releases/gilded-gnosis-v20-r33/vllm/integration.lock.json
@@ -1,0 +1,152 @@
+{
+  "base": {
+    "commit": "e2666d9a65f41fc376607531453cbd57c4c71016",
+    "ref": "refs/heads/dev/gilded-gnosis",
+    "repository": "https://github.com/local-inference-lab/vllm.git"
+  },
+  "manifest": {
+    "sha256": "2f1c3ddc252aec35269247491717f58b5af35c01038fd5dd9cf6648996ac98c1"
+  },
+  "name": "gilded-gnosis-v20",
+  "pull_requests": [
+    {
+      "disposition": "merged",
+      "head": "99bf3f13f13012b72d6d67e49572d686b45b2833",
+      "number": 145,
+      "ref": "refs/pull/145/head",
+      "title": "GLM-5.2 calibrated NVFP4 MLA KV outer scales"
+    },
+    {
+      "disposition": "merged",
+      "head": "48e9d0f75d96db61429cbe7fe4fccb96739c58d6",
+      "number": 256,
+      "ref": "refs/pull/256/head",
+      "title": "Preserve activation dtype for int32-packed MLA weights"
+    },
+    {
+      "disposition": "merged",
+      "head": "aa75b01c476ffb5fc728232546fe5c215e3728ec",
+      "number": 188,
+      "ref": "refs/pull/188/head",
+      "title": "Emit packed UE8M0 scales from compiled QuantFP8"
+    },
+    {
+      "disposition": "merged",
+      "head": "1a2b01f43fbc151239c437e918dfdc27681ce4e7",
+      "number": 229,
+      "ref": "refs/pull/229/head",
+      "title": "Harden compressed MLA cache, workspace, and verifier capacity contracts"
+    },
+    {
+      "disposition": "merged",
+      "head": "5f144274d6e092237f4f4f437b7e9d3aaa427157",
+      "number": 213,
+      "ref": "refs/pull/213/head",
+      "title": "Skip pre-KV V2 attention during FlashInfer autotune"
+    },
+    {
+      "disposition": "merged",
+      "head": "8d989f18c2845e514313e80f65b07087b09d6a67",
+      "number": 214,
+      "ref": "refs/pull/214/head",
+      "title": "Add DeepSeek-V4-Flash-0731 profile and native L1/L2 offload"
+    },
+    {
+      "disposition": "merged",
+      "head": "bde9a133774e38a54511696cef1ac10b16ef700b",
+      "number": 217,
+      "ref": "refs/pull/217/head",
+      "title": "Harden shared regions for native CPU KV offload"
+    },
+    {
+      "disposition": "merged",
+      "head": "3b89c7a113f92522aa07cc3271422c04e458d771",
+      "number": 218,
+      "ref": "refs/pull/218/head",
+      "title": "Align native SWA/MTP retention and shared-prefix tails"
+    },
+    {
+      "disposition": "merged",
+      "head": "5ec935796f0afa19e3d8e41888ecc51a6a637528",
+      "number": 228,
+      "ref": "refs/pull/228/head",
+      "title": "Consolidate EXL3 runtime and prewarm mixed-Trellis route packing"
+    },
+    {
+      "disposition": "merged",
+      "head": "9401f9d8916f3bdf34123d2d493a918b748c8132",
+      "number": 230,
+      "ref": "refs/pull/230/head",
+      "title": "Keep broadcast MHC pre behind the compile boundary"
+    },
+    {
+      "disposition": "merged",
+      "head": "eaf24cc15f313c4b15afabb3f902cfe17f19f28f",
+      "number": 234,
+      "ref": "refs/pull/234/head",
+      "title": "Guard persistent FlashInfer decode wrappers by planned query length"
+    },
+    {
+      "disposition": "merged",
+      "head": "54349f9ce6d32a68c7c736f2ac3ac597afd6e208",
+      "number": 235,
+      "ref": "refs/pull/235/head",
+      "title": "Align DeepSeek-V4-0731 reasoning and tool prompt contract"
+    },
+    {
+      "disposition": "merged",
+      "head": "9dbd6d00b0340da173b61affb961954090632dec",
+      "number": 245,
+      "ref": "refs/pull/245/head",
+      "title": "Build one-shard indexer query-split topology"
+    },
+    {
+      "disposition": "merged",
+      "head": "85bc9770c94394fb070f3f9311d68bcaca6a354d",
+      "number": 248,
+      "ref": "refs/pull/248/head",
+      "title": "Prewarm CuTe PCIe one-shot all-reduce before graph capture"
+    },
+    {
+      "disposition": "merged",
+      "head": "c66ce7327ee586e5b600b9d7e12db30e93e8ec96",
+      "number": 251,
+      "ref": "refs/pull/251/head",
+      "title": "Isolate B12X graph channels and capture DSpark context KV"
+    },
+    {
+      "disposition": "merged",
+      "head": "1772842af39788286634e168ef766e15add83869",
+      "number": 253,
+      "ref": "refs/pull/253/head",
+      "title": "Add FlashInfer PCIe IPC all-reduce backend"
+    },
+    {
+      "disposition": "merged",
+      "head": "e3317de2336fc84396d7541950542c79b62102ae",
+      "number": 252,
+      "ref": "refs/pull/252/head",
+      "title": "Defer native KV-offload finalization until the final store is built"
+    },
+    {
+      "disposition": "merged",
+      "head": "5d961ad9d2efaba40531e8e4542a6c193412898d",
+      "number": 254,
+      "ref": "refs/pull/254/head",
+      "title": "Harden native offload cleanup and bound filesystem storage"
+    },
+    {
+      "disposition": "merged",
+      "head": "d1b7bbeb78da068ab0a505bd09505f6637cddcd9",
+      "number": 255,
+      "ref": "refs/pull/255/head",
+      "title": "Register GG runtime controls consumed directly by backends"
+    }
+  ],
+  "result": {
+    "patch": "integration.patch",
+    "patch_sha256": "c03a83a6cf81c213caa435ec6190f61b6b10c02ab8cc3d5b24fe6d291a121b39",
+    "tree": "fa13d334a2962756f9f7e9b562deb85387359f42"
+  },
+  "schema_version": 1
+}

--- a/patches/releases/gilded-gnosis-v20-r33/vllm/integration.patch
+++ b/patches/releases/gilded-gnosis-v20-r33/vllm/integration.patch
@@ -1,0 +1,14579 @@
+diff --git a/docs/features/quantization/online.md b/docs/features/quantization/online.md
+index bd4db0e0194320db6ea081be349d8f9b764f9162..169d2d01baac036213a13db54675db969be1fa76 100644
+--- a/docs/features/quantization/online.md
++++ b/docs/features/quantization/online.md
+@@ -100,7 +100,7 @@ vllm serve <glm-5.2-modelopt-checkpoint> \
+ Serialized checkpoint-quantized shared experts are preserved; only excluded
+ BF16 projection weights are converted at load time.
+ 
+-### MXFP8 dense linears on ModelOpt checkpoints
++### MXFP8 dense linears on quantized checkpoints
+ 
+ The `linear` field overlays online MXFP8 the same way onto every other
+ BF16 dense linear the ModelOpt checkpoint excludes: attention projections,
+@@ -143,6 +143,22 @@ vllm serve lukealonso/GLM-5.2-NVFP4 \
+   --quantization-config '{"linear":{"weight":"mxfp8"},"ignore":["re:.*kv_b_proj"]}'
+ ```
+ 
++EXL3 checkpoints can use the same overlay for dense and shared-expert
++projections that are absent from the EXL3 tensor metadata. Serialized EXL3
++dense matrices and routed experts always retain their checkpoint format;
++`moe` overlays are rejected. `lm_head` also remains in its checkpoint format
++or BF16. For example:
++
++```bash
++vllm serve <exl3-checkpoint> \
++  --quantization exl3 \
++  --quantization-config '{"linear":{"weight":"mxfp8"},"shared_experts":{"weight":"mxfp8"},"ignore":["re:.*\\.q_a_proj$","re:.*kv_a_proj_with_mqa","lm_head"]}'
++```
++
++As with ModelOpt, `linear` does not select shared experts. Add the
++`shared_experts` field explicitly when those BF16 projections should also be
++converted. Ignore patterns are matched against unfused checkpoint names.
++
+ ### Activation overrides on already-quantized checkpoints
+ 
+ For checkpoint-quantized models, `quantization_config` lets you pick an
+diff --git a/kv-scales/README.md b/kv-scales/README.md
+new file mode 100644
+index 0000000000000000000000000000000000000000..36b37d5aa188027675ec9eaa447e9597b3921e4c
+--- /dev/null
++++ b/kv-scales/README.md
+@@ -0,0 +1,49 @@
++# GLM-5.2 NVFP4 MLA KV outer scales
++
++Per-layer calibration for the `nvfp4_ds_mla` KV cache writer
++(`VLLM_NVFP4_MLA_SCALES_FILE`, format `nvfp4_ds_mla_outer_scale_v1`).
++
++GLM-5.2's post-RMSNorm 512-dim `kv_c` latent spans a ~240x amplitude range
++across layers. With the default outer scale of 1.0, shallow layers quantize
++with E4M3 block scales at or below the subnormal floor, and shallow-layer KV
++error is strongly amplified downstream. `s_l = max_abs(kv_c_normed) / (6*448)`
++re-centers every layer so its largest block scale lands at the top of the
++E4M3 range.
++
++## Files
++
++- `glm52-nvfp4-nf3-hybrid_mla_outer_scales_v1.json` — calibrated on
++  `madeby561/GLM-5.2-MXFP8-NVFP4-NF3-Hybrid` (K64R16), Salesforce/wikitext
++  (wikitext-2-raw-v1, test), 2048-token context, TP4; per-layer envelope with
++  an independent community capture of the same base model for shallow-layer
++  headroom. `max_abs` per layer is included for auditability.
++
++## Usage
++
++```bash
++VLLM_NVFP4_MLA_SCALES_FILE=/path/to/glm52-nvfp4-nf3-hybrid_mla_outer_scales_v1.json \
++  ./serve-glm52.sh   # nvfp4_ds_mla + B12X_MLA_SPARSE only; inert otherwise
++```
++
++## Results (teacher-forced prefill KLD vs BF16 reference, 5 fresh boots each)
++
++| KV config | mean +/- sd | max ctx (4x96GB) |
++|---|---|---|
++| fp8_ds_mla | 0.1263 +/- 0.0030 | 373k |
++| nvfp4_ds_mla + scales, bf16 rope | 0.1345 +/- 0.0035 | 550k |
++| nvfp4_ds_mla + scales, fp8 rope (`KV_FP8_ROPE=1`) | 0.1356 +/- 0.0054 | 600k+ |
++| nvfp4_ds_mla, no scales, bf16 rope | 0.158 | 550k |
++| nvfp4_ds_mla, no scales, fp8 rope | 0.168 | 600k+ |
++
++Protocol: local-inference-lab/rtx6kpro `benchmarks/glm52-kld-evaluation.md`
++(festr2 2026-07-08 reference logits, one fixed 2048-token window, 2047
++positions, full 154,880 vocab, `KL(ref || candidate)`).
++
++## Cache invalidation (required)
++
++CuTeDSL folds the outer-scale multiply out of the kernel when `latent_scale`
++traces at exactly 1.0. b12x builds without the identity/dynamic compile-spec
++fact (see lukealonso/b12x PR "mla: split latent_scale identity/dynamic
++compile-cache entries") replay stale identity cubins from persistent compile
++caches, silently dropping the restore. Clear mounted b12x compile caches once
++when enabling scales on such builds.
+diff --git a/kv-scales/glm52-nvfp4-nf3-hybrid_mla_outer_scales_v1.json b/kv-scales/glm52-nvfp4-nf3-hybrid_mla_outer_scales_v1.json
+new file mode 100644
+index 0000000000000000000000000000000000000000..7ae9d9351c4e8de79f6387b5f64a5fa9618bf155
+--- /dev/null
++++ b/kv-scales/glm52-nvfp4-nf3-hybrid_mla_outer_scales_v1.json
+@@ -0,0 +1,178 @@
++{
++ "format": "nvfp4_ds_mla_outer_scale_v1",
++ "num_layers": 78,
++ "latent_dim": 512,
++ "denominator": 2688.0,
++ "formula": "s_l = max_abs(kv_c_normed) / (6 * 448)",
++ "model": "madeby561/GLM-5.2-MXFP8-NVFP4-NF3-Hybrid (local K64R16 build; own capture)",
++ "dataset": {
++  "name": "Salesforce/wikitext",
++  "config": "wikitext-2-raw-v1",
++  "split": "test",
++  "context_length": 2048,
++  "windows": 1,
++  "note": "the canonical festr2-0708 census window"
++ },
++ "created_utc": "2026-07-20T16:40:43.312260+00:00",
++ "hook": "mla.py kv_a_layernorm output (bind-mount capture patch), per-TP-rank agreement checked",
++ "max_abs": [
++  0.04833984375,
++  0.021728515625,
++  0.03662109375,
++  0.1005859375,
++  0.023681640625,
++  0.03515625,
++  0.046875,
++  0.033203125,
++  0.259765625,
++  0.1474609375,
++  0.7734375,
++  1.0,
++  1.1171875,
++  0.150390625,
++  0.76171875,
++  0.392578125,
++  0.25390625,
++  0.455078125,
++  0.80859375,
++  0.80078125,
++  0.96875,
++  0.78515625,
++  0.58203125,
++  0.330078125,
++  0.89453125,
++  0.73046875,
++  1.0390625,
++  1.578125,
++  1.0078125,
++  0.92578125,
++  1.25,
++  1.5859375,
++  1.234375,
++  1.9140625,
++  1.9453125,
++  1.7578125,
++  1.7890625,
++  2.546875,
++  2.296875,
++  2.4375,
++  1.921875,
++  2.171875,
++  2.875,
++  2.546875,
++  2.765625,
++  3.234375,
++  2.5625,
++  3.390625,
++  2.40625,
++  2.546875,
++  3.09375,
++  2.90625,
++  3.671875,
++  2.46875,
++  2.609375,
++  2.359375,
++  3.078125,
++  3.171875,
++  2.578125,
++  2.359375,
++  3.890625,
++  2.953125,
++  4.09375,
++  4.09375,
++  5.0625,
++  5.1875,
++  2.984375,
++  2.875,
++  2.984375,
++  3.296875,
++  3.828125,
++  2.859375,
++  3.59375,
++  3.734375,
++  4.25,
++  4.1875,
++  4.84375,
++  3.75
++ ],
++ "scales": [
++  1.7983572823660715e-05,
++  8.083525158110119e-06,
++  1.3623918805803572e-05,
++  3.742036365327381e-05,
++  8.810134161086309e-06,
++  1.3078962053571428e-05,
++  1.743861607142857e-05,
++  1.2352353050595238e-05,
++  9.663899739583333e-05,
++  5.485897972470238e-05,
++  0.00028773716517857144,
++  0.0003720238095238095,
++  0.00041562034970238094,
++  5.5948893229166664e-05,
++  0.0002833775111607143,
++  0.00014604840959821428,
++  9.445917038690477e-05,
++  0.00016929989769345238,
++  0.00030081612723214287,
++  0.0002979096912202381,
++  0.0003603980654761905,
++  0.00029209681919642856,
++  0.00021652948288690475,
++  0.0001227969215029762,
++  0.00033278692336309525,
++  0.00027175176711309525,
++  0.0003865559895833333,
++  0.0005871000744047619,
++  0.0003749302455357143,
++  0.0003444126674107143,
++  0.0004650297619047619,
++  0.0005900065104166666,
++  0.0004592168898809524,
++  0.0007120768229166666,
++  0.0007237025669642857,
++  0.0006539481026785714,
++  0.0006655738467261905,
++  0.0009474981398809524,
++  0.0008544921875,
++  0.0009068080357142857,
++  0.0007149832589285714,
++  0.0008079892113095238,
++  0.0010695684523809525,
++  0.0009474981398809524,
++  0.0010288783482142857,
++  0.0012032645089285715,
++  0.0009533110119047619,
++  0.0012613932291666667,
++  0.0008951822916666666,
++  0.0009474981398809524,
++  0.0011509486607142857,
++  0.0010811941964285715,
++  0.001366024925595238,
++  0.0009184337797619048,
++  0.0009707496279761905,
++  0.0008777436755952381,
++  0.0011451357886904762,
++  0.0011800130208333333,
++  0.0009591238839285714,
++  0.0008777436755952381,
++  0.0014474051339285715,
++  0.0010986328125,
++  0.0015229724702380952,
++  0.0015229724702380952,
++  0.0018833705357142857,
++  0.001929873511904762,
++  0.001110258556547619,
++  0.0010695684523809525,
++  0.001110258556547619,
++  0.0012265159970238095,
++  0.0014241536458333333,
++  0.0010637555803571428,
++  0.0013369605654761905,
++  0.0013892764136904762,
++  0.0015811011904761905,
++  0.0015578497023809525,
++  0.0018019903273809525,
++  0.0013950892857142857
++ ]
++}
+\ No newline at end of file
+diff --git a/rust/src/chat/src/renderer/deepseek_v4/encoding.rs b/rust/src/chat/src/renderer/deepseek_v4/encoding.rs
+index 80438b0c4156783ada07acc582bd44af886641b4..c96dcfa9bdeb061432528146b393fe1e63c5829c 100644
+--- a/rust/src/chat/src/renderer/deepseek_v4/encoding.rs
++++ b/rust/src/chat/src/renderer/deepseek_v4/encoding.rs
+@@ -24,11 +24,16 @@ const THINKING_END_TOKEN: &str = "</think>";
+ const DSML_TOKEN: &str = "｜DSML｜";
+ const USER_SP_TOKEN: &str = "<｜User｜>";
+ const ASSISTANT_SP_TOKEN: &str = "<｜Assistant｜>";
+-const REASONING_EFFORT_MAX: &str = concat!(
++const REASONING_EFFORT_HIGH: &str = concat!(
+     "Reasoning Effort: Absolute maximum with no shortcuts permitted.\n",
+     "You MUST be very thorough in your thinking and comprehensively decompose the problem to resolve the root cause, rigorously stress-testing your logic against all potential paths, edge cases, and adversarial scenarios.\n",
+     "Explicitly write out your entire deliberation process, documenting every intermediate step, considered alternative, and rejected hypothesis to ensure absolutely no assumption is left unchecked.\n\n",
+ );
++const REASONING_EFFORT_MAX: &str = concat!(
++    "Reasoning Effort: Beyond maximum — exhaustive, relentless, and uncompromising.\n",
++    "You MUST reason with the utmost depth and rigor, leaving absolutely nothing to chance: exhaustively decompose the problem into its most fundamental components, trace every causal chain to its root, and resolve the underlying cause rather than any surface symptom.\n",
++    "Do not stop reasoning until you have independently verified the solution from multiple angles and are certain that no assumption remains unchecked and no error remains undiscovered.\n\n",
++);
+ 
+ #[derive(Debug, Clone, Copy, PartialEq, Eq)]
+ enum ThinkingMode {
+@@ -47,7 +52,7 @@ struct RenderedToolSchema<'a> {
+ 
+ /// Render one chat request into the final prompt string.
+ pub(super) fn render_request(request: &ChatRequest) -> Result<String> {
+-    let (thinking_mode, max_reasoning_effort) = resolve_thinking_options(request)?;
++    let (thinking_mode, reasoning_effort_prompt) = resolve_thinking_options(request)?;
+     let request_tools = request_tools(request);
+     let synthetic_tool_system = needs_synthetic_tool_system(request, request_tools);
+     let drop_thinking = request.parse_template_bool("drop_thinking")?.unwrap_or(true)
+@@ -55,8 +60,8 @@ pub(super) fn render_request(request: &ChatRequest) -> Result<String> {
+     let last_user_render_index =
+         find_last_user_render_index(request.messages.as_slice(), synthetic_tool_system);
+     let mut out = String::from(BOS_TOKEN);
+-    if thinking_mode == ThinkingMode::Thinking && max_reasoning_effort {
+-        out.push_str(REASONING_EFFORT_MAX);
++    if thinking_mode == ThinkingMode::Thinking {
++        out.push_str(reasoning_effort_prompt);
+     }
+ 
+     let mut request_tools_attached = false;
+@@ -124,20 +129,25 @@ pub(super) fn render_request(request: &ChatRequest) -> Result<String> {
+ /// wrapper, the Rust renderer only consumes the typed top-level
+ /// `reasoning_effort`; the generic template-kwargs map is left for HF
+ /// templates.
+-fn resolve_thinking_options(request: &ChatRequest) -> Result<(ThinkingMode, bool)> {
++fn resolve_thinking_options(request: &ChatRequest) -> Result<(ThinkingMode, &'static str)> {
+     let mut thinking_mode = match request.enable_thinking()?.unwrap_or(false) {
+         true => ThinkingMode::Thinking,
+         false => ThinkingMode::Chat,
+     };
+-    let mut max_reasoning_effort = false;
++    let mut reasoning_effort_prompt = "";
+ 
+     match request.chat_options.reasoning_effort {
+         Some(ReasoningEffort::None) => thinking_mode = ThinkingMode::Chat,
+-        Some(ReasoningEffort::Max | ReasoningEffort::XHigh) => max_reasoning_effort = true,
++        Some(ReasoningEffort::Max | ReasoningEffort::XHigh) => {
++            reasoning_effort_prompt = REASONING_EFFORT_MAX;
++        }
++        Some(ReasoningEffort::Minimal | ReasoningEffort::Medium | ReasoningEffort::High) => {
++            reasoning_effort_prompt = REASONING_EFFORT_HIGH;
++        }
+         Some(_) | None => {}
+     }
+ 
+-    Ok((thinking_mode, max_reasoning_effort))
++    Ok((thinking_mode, reasoning_effort_prompt))
+ }
+ 
+ /// Return request-level tools only when native tool parsing is enabled.
+diff --git a/rust/src/chat/src/renderer/deepseek_v4/tests.rs b/rust/src/chat/src/renderer/deepseek_v4/tests.rs
+index 73380cef260ed6e498698f0208986587e2ba4e5c..46d625588ba3a1517cf86ca9b5327528ae425da4 100644
+--- a/rust/src/chat/src/renderer/deepseek_v4/tests.rs
++++ b/rust/src/chat/src/renderer/deepseek_v4/tests.rs
+@@ -10,7 +10,9 @@ use super::DeepSeekV4ChatRenderer;
+ use crate::ChatRenderer;
+ use crate::event::{AssistantContentBlock, AssistantToolCall};
+ use crate::renderer::test_utils::{FixtureRequestOptions, fixture_chat_request};
+-use crate::request::{ChatMessage, ChatRequest, GenerationPromptMode, ReasoningEffort};
++use crate::request::{
++    ChatMessage, ChatRequest, ChatTool, ChatToolChoice, GenerationPromptMode, ReasoningEffort,
++};
+ 
+ fn render_request(request: &ChatRequest) -> String {
+     DeepSeekV4ChatRenderer::new()
+@@ -75,6 +77,29 @@ fn reasoning_effort_max_adds_prefix_when_thinking_is_enabled() {
+ 
+     let rendered = render_request(&request);
+ 
++    expect![[r#"
++        <｜begin▁of▁sentence｜>Reasoning Effort: Beyond maximum — exhaustive, relentless, and uncompromising.
++        You MUST reason with the utmost depth and rigor, leaving absolutely nothing to chance: exhaustively decompose the problem into its most fundamental components, trace every causal chain to its root, and resolve the underlying cause rather than any surface symptom.
++        Do not stop reasoning until you have independently verified the solution from multiple angles and are certain that no assumption remains unchecked and no error remains undiscovered.
++
++        <｜User｜>solve it<｜Assistant｜><think>"#]]
++    .assert_eq(&rendered);
++}
++
++#[test]
++fn reasoning_effort_high_adds_0731_high_prefix() {
++    let mut request = ChatRequest {
++        messages: vec![ChatMessage::user("solve it")],
++        ..ChatRequest::for_test()
++    };
++    request
++        .chat_options
++        .template_kwargs
++        .insert("thinking".to_string(), Value::Bool(true));
++    request.chat_options.reasoning_effort = Some(ReasoningEffort::High);
++
++    let rendered = render_request(&request);
++
+     expect![[r#"
+         <｜begin▁of▁sentence｜>Reasoning Effort: Absolute maximum with no shortcuts permitted.
+         You MUST be very thorough in your thinking and comprehensively decompose the problem to resolve the root cause, rigorously stress-testing your logic against all potential paths, edge cases, and adversarial scenarios.
+@@ -84,6 +109,57 @@ fn reasoning_effort_max_adds_prefix_when_thinking_is_enabled() {
+     .assert_eq(&rendered);
+ }
+ 
++#[test]
++fn reasoning_effort_low_keeps_the_default_prompt() {
++    let mut request = ChatRequest {
++        messages: vec![ChatMessage::user("solve it")],
++        ..ChatRequest::for_test()
++    };
++    request
++        .chat_options
++        .template_kwargs
++        .insert("thinking".to_string(), Value::Bool(true));
++    request.chat_options.reasoning_effort = Some(ReasoningEffort::Low);
++
++    let rendered = render_request(&request);
++
++    expect!["<｜begin▁of▁sentence｜><｜User｜>solve it<｜Assistant｜><think>"].assert_eq(&rendered);
++}
++
++#[test]
++fn request_tools_follow_existing_system_prompt() {
++    let mut request = ChatRequest {
++        messages: vec![
++            ChatMessage::system("Follow policy."),
++            ChatMessage::user("Find it."),
++        ],
++        tools: vec![ChatTool {
++            name: "lookup".to_string(),
++            description: Some("Look things up".to_string()),
++            parameters: serde_json::json!({
++                "type": "object",
++                "properties": {},
++            }),
++            strict: None,
++        }],
++        tool_choice: ChatToolChoice::Auto,
++        ..ChatRequest::for_test()
++    };
++    request
++        .chat_options
++        .template_kwargs
++        .insert("thinking".to_string(), Value::Bool(true));
++    request.chat_options.reasoning_effort = Some(ReasoningEffort::Max);
++
++    let rendered = render_request(&request);
++
++    let prefix = rendered.find("Reasoning Effort: Beyond maximum").unwrap();
++    let system = rendered.find("Follow policy.").unwrap();
++    let tools = rendered.find("## Tools").unwrap();
++    let user = rendered.find("<｜User｜>Find it.").unwrap();
++    assert!(prefix < system && system < tools && tools < user);
++}
++
+ #[test]
+ fn reasoning_effort_none_disables_thinking() {
+     let mut request = ChatRequest {
+diff --git a/serve-ds4-flash.sh b/serve-ds4-flash.sh
+index f9a640bed07f8e82381274cc027f6723c9ed57d5..ea2e218e3f84d63e0a1098e22a98e4217fd52118 100755
+--- a/serve-ds4-flash.sh
++++ b/serve-ds4-flash.sh
+@@ -40,9 +40,10 @@ case "${mode}" in
+   off|mtp0|standard-mtp0) mode=mtp0 ;;
+   mtp2|standard-mtp2) mode=mtp2 ;;
+   mtp3|standard-mtp3) mode=mtp3 ;;
++  dspark-off|dspark-mtp0) mode=dspark-mtp0 ;;
+   dspark) ;;
+   *)
+-    echo "MODE must be mtp0, mtp2, mtp3, or dspark; got '${mode}'" >&2
++    echo "MODE must be mtp0, mtp2, mtp3, dspark-off, dspark-mtp0, or dspark; got '${mode}'" >&2
+     exit 2
+     ;;
+ esac
+@@ -59,13 +60,13 @@ case "${backend}" in
+ esac
+ 
+ standard_model=${STANDARD_MODEL:-deepseek-ai/DeepSeek-V4-Flash}
+-dspark_model=${DSPARK_MODEL:-deepseek-ai/DeepSeek-V4-Flash-DSpark}
++dspark_model=${DSPARK_MODEL:-deepseek-ai/DeepSeek-V4-Flash-0731}
+ standard_model_revision=${STANDARD_MODEL_REVISION:-60d8d70770c6776ff598c94bb586a859a38244f1}
+-dspark_model_revision=${DSPARK_MODEL_REVISION:-62af8fffb2f7030cac4de2f0169f5b8d1101b646}
+-if [[ "${mode}" == "dspark" ]]; then
++dspark_model_revision=${DSPARK_MODEL_REVISION:-9e165c30e2704aec5d9d593cce3eebd58bbef1cb}
++if [[ "${mode}" == "dspark" || "${mode}" == "dspark-mtp0" ]]; then
+   model=${MODEL_PATH:-${MODEL:-${dspark_model}}}
+   spec_model=${SPEC_MODEL_PATH:-${model}}
+-  served_model_name=${SERVED_MODEL_NAME:-DeepSeek-V4-Flash-DSpark}
++  served_model_name=${SERVED_MODEL_NAME:-DeepSeek-V4-Flash-0731}
+   default_model_revision=${dspark_model_revision}
+ else
+   model=${MODEL_PATH:-${MODEL:-${standard_model}}}
+@@ -88,13 +89,21 @@ fi
+ host=${HOST:-0.0.0.0}
+ port=${PORT:-8000}
+ tp_size=${TP_SIZE:-${TP:-2}}
+-dcp_size=${DCP_SIZE:-1}
+-max_num_seqs=${MAX_NUM_SEQS:-64}
+-max_model_len=${MAX_MODEL_LEN:-262144}
++dcp_size=${DCP_SIZE:-${DCP:-1}}
++if [[ "${mode}" == "dspark" || "${mode}" == "dspark-mtp0" ]]; then
++  max_num_seqs=${MAX_NUM_SEQS:-16}
++  max_model_len=${MAX_MODEL_LEN:-131072}
++else
++  max_num_seqs=${MAX_NUM_SEQS:-64}
++  max_model_len=${MAX_MODEL_LEN:-262144}
++fi
+ max_num_batched_tokens=${MAX_NUM_BATCHED_TOKENS:-8192}
+ gpu_memory_utilization=${GPU_MEMORY_UTILIZATION:-}
+ block_size=${BLOCK_SIZE:-256}
+ load_format=${LOAD_FORMAT:-instanttensor}
++kv_offloading_size=${KV_OFFLOADING_SIZE:-}
++native_l2_path=${NATIVE_L2_PATH:-}
++native_l2_size=${NATIVE_L2_GB:-}
+ prefix_cache=$(bool_value PREFIX_CACHE "${PREFIX_CACHE:-1}")
+ enable_flashinfer_autotune=$(bool_value ENABLE_FLASHINFER_AUTOTUNE "${ENABLE_FLASHINFER_AUTOTUNE:-1}")
+ draft_sample_method=${DRAFT_SAMPLE_METHOD:-probabilistic}
+@@ -105,6 +114,33 @@ require_positive_int DCP_SIZE "${dcp_size}"
+ require_positive_int MAX_NUM_SEQS "${max_num_seqs}"
+ require_positive_int MAX_NUM_BATCHED_TOKENS "${max_num_batched_tokens}"
+ require_positive_int BLOCK_SIZE "${block_size}"
++if [[ -n "${kv_offloading_size}" \
++  && ! "${kv_offloading_size}" =~ ^([0-9]+([.][0-9]*)?|[.][0-9]+)$ ]]; then
++  echo "KV_OFFLOADING_SIZE must be a non-negative GiB value; got '${kv_offloading_size}'" >&2
++  exit 2
++fi
++native_l2_enabled=0
++if [[ -n "${native_l2_path}" || -n "${native_l2_size}" ]]; then
++  if [[ -z "${native_l2_path}" || -z "${native_l2_size}" ]]; then
++    echo "NATIVE_L2_PATH and NATIVE_L2_GB must be set together" >&2
++    exit 2
++  fi
++  if [[ "${native_l2_path}" != /* ]]; then
++    echo "NATIVE_L2_PATH must be an absolute container path" >&2
++    exit 2
++  fi
++  if [[ ! "${native_l2_size}" =~ ^([0-9]+([.][0-9]*)?|[.][0-9]+)$ \
++    || "${native_l2_size}" =~ ^0*([.]0*)?$ ]]; then
++    echo "NATIVE_L2_GB must be a positive GiB value; got '${native_l2_size}'" >&2
++    exit 2
++  fi
++  if [[ -z "${kv_offloading_size}" \
++    || "${kv_offloading_size}" =~ ^0*([.]0*)?$ ]]; then
++    echo "NATIVE_L2 requires a positive KV_OFFLOADING_SIZE for its L1 tier" >&2
++    exit 2
++  fi
++  native_l2_enabled=1
++fi
+ if [[ "${mode}" == "dspark" && "${dcp_size}" != "1" ]]; then
+   echo "DSpark non-causal attention currently requires DCP_SIZE=1" >&2
+   exit 2
+@@ -144,7 +180,14 @@ export VLLM_MEMORY_PROFILER_ESTIMATE_CUDAGRAPHS=${VLLM_MEMORY_PROFILER_ESTIMATE_
+ export VLLM_PREFIX_CACHE_RETENTION_INTERVAL=${VLLM_PREFIX_CACHE_RETENTION_INTERVAL:-4096}
+ export VLLM_MULTI_STREAM_GEMM_TOKEN_THRESHOLD=${VLLM_MULTI_STREAM_GEMM_TOKEN_THRESHOLD:-1024}
+ 
+-allreduce_mode=${ALLREDUCE_MODE:-b12x}
++allreduce_mode=${ALLREDUCE_MODE:-auto}
++if [[ "${allreduce_mode}" == "auto" ]]; then
++  if [[ "${tp_size}" == "2" ]]; then
++    allreduce_mode=flashinfer-ipc
++  else
++    allreduce_mode=b12x
++  fi
++fi
+ b12x_pcie_dma=$(bool_value B12X_PCIE_DMA "${B12X_PCIE_DMA:-0}")
+ export VLLM_USE_B12X_PCIE_DMA=${b12x_pcie_dma}
+ allreduce_args=()
+@@ -156,6 +199,15 @@ case "${allreduce_mode}" in
+     export VLLM_ALLOW_CUSTOM_ALLREDUCE_PCIE=0
+     export PYTORCH_CUDA_ALLOC_CONF=${PYTORCH_CUDA_ALLOC_CONF:-expandable_segments:True}
+     ;;
++  flashinfer-ipc)
++    export VLLM_ENABLE_PCIE_ALLREDUCE=1
++    export VLLM_PCIE_ALLREDUCE_BACKEND=flashinfer-ipc
++    export VLLM_PCIE_ONESHOT_ALLREDUCE_MAX_SIZE=${VLLM_PCIE_ONESHOT_ALLREDUCE_MAX_SIZE:-1MB}
++    export VLLM_PCIE_ONESHOT_FUSED_ADD_RMS_NORM_MAX_SIZE=0
++    export VLLM_PCIE_DMA_MIN_BYTES=off
++    export VLLM_ALLOW_CUSTOM_ALLREDUCE_PCIE=0
++    export PYTORCH_CUDA_ALLOC_CONF=${PYTORCH_CUDA_ALLOC_CONF:-expandable_segments:True}
++    ;;
+   vllm-custom)
+     export VLLM_ENABLE_PCIE_ALLREDUCE=0
+     export VLLM_ALLOW_CUSTOM_ALLREDUCE_PCIE=1
+@@ -177,8 +229,8 @@ case "${allreduce_mode}" in
+     allreduce_args=(--disable-custom-all-reduce)
+     ;;
+   *)
+-    echo "ALLREDUCE_MODE must be b12x, vllm-custom, vllm-custom-2stage," \
+-      "or nccl; got '${allreduce_mode}'" >&2
++    echo "ALLREDUCE_MODE must be auto, b12x, flashinfer-ipc, vllm-custom," \
++      "vllm-custom-2stage, or nccl; got '${allreduce_mode}'" >&2
+     exit 2
+     ;;
+ esac
+@@ -246,6 +298,7 @@ esac
+ spec_args=()
+ spec_tokens=0
+ graph_multiplier=4
++dspark_depth_mode=disabled
+ if [[ "${mode}" == "mtp2" || "${mode}" == "mtp3" ]]; then
+   if [[ "${mode}" == "mtp2" ]]; then spec_tokens=2; else spec_tokens=3; fi
+   mtp_moe_json=
+@@ -259,7 +312,7 @@ if [[ "${mode}" == "mtp2" || "${mode}" == "mtp3" ]]; then
+   spec_args=(--speculative-config "${spec_json}")
+   graph_multiplier=8
+ elif [[ "${mode}" == "dspark" ]]; then
+-  spec_tokens=${DSPARK_TOKENS:-5}
++  spec_tokens=${DSPARK_TOKENS:-${NUM_SPECULATIVE_TOKENS:-7}}
+   require_positive_int DSPARK_TOKENS "${spec_tokens}"
+   # Target verification schedules at most one sampled token plus K drafts per
+   # request. Capturing beyond that physical row count only consumes graph
+@@ -278,9 +331,27 @@ elif [[ "${mode}" == "dspark" ]]; then
+         ;;
+     esac
+     draft_attention_json=$(printf \
+-      ',"draft_attention_backend":"%s"' "${draft_attention_backend}")
++      ',"attention_backend":"%s"' "${draft_attention_backend}")
+   fi
+-  dspark_capacity=$(bool_value DSPARK_CAPACITY "${DSPARK_CAPACITY:-0}")
++  dspark_depth_mode=${DSPARK_DEPTH_MODE:-fixed}
++  case "${dspark_depth_mode}" in
++    fixed)
++      default_dspark_capacity=0
++      default_dynamic_depth=0
++      default_activation_batch_size=0
++      ;;
++    dynamic)
++      default_dspark_capacity=1
++      default_dynamic_depth=1
++      default_activation_batch_size=1
++      ;;
++    *)
++      echo "DSPARK_DEPTH_MODE must be fixed or dynamic" >&2
++      exit 2
++      ;;
++  esac
++  dspark_capacity=$(bool_value DSPARK_CAPACITY \
++    "${DSPARK_CAPACITY:-${default_dspark_capacity}}")
+   capacity_json=
+   if [[ "${dspark_capacity}" == "1" ]]; then
+     capacity_mode=${DSPARK_CAPACITY_VERIFICATION_MODE:-}
+@@ -319,11 +390,14 @@ elif [[ "${mode}" == "dspark" ]]; then
+     "${rejection_sample_method}" "${draft_attention_json}" "${capacity_json}")
+   spec_args=(--speculative-config "${spec_json}")
+   export VLLM_DSPARK_FP8_DRAFT_HEAD=$(bool_value DSPARK_FP8_DRAFT_HEAD "${DSPARK_FP8_DRAFT_HEAD:-0}")
+-  export VLLM_DSPARK_DYNAMIC_DRAFT_DEPTH=$(bool_value DSPARK_DYNAMIC_DRAFT_DEPTH "${DSPARK_DYNAMIC_DRAFT_DEPTH:-0}")
++  dynamic_depth=${DSPARK_DYNAMIC_DRAFT_DEPTH:-${VLLM_DSPARK_DYNAMIC_DRAFT_DEPTH:-${default_dynamic_depth}}}
++  export VLLM_DSPARK_DYNAMIC_DRAFT_DEPTH=$(bool_value \
++    DSPARK_DYNAMIC_DRAFT_DEPTH "${dynamic_depth}")
+   export VLLM_DSPARK_DYNAMIC_DRAFT_DEPTH_WINDOW=${DSPARK_DYNAMIC_DRAFT_DEPTH_WINDOW:-8}
+   require_positive_int DSPARK_DYNAMIC_DRAFT_DEPTH_WINDOW \
+     "${VLLM_DSPARK_DYNAMIC_DRAFT_DEPTH_WINDOW}"
+-  export VLLM_DSPARK_CAPACITY_ACTIVATION_BATCH_SIZE=${DSPARK_CAPACITY_ACTIVATION_BATCH_SIZE:-0}
++  activation_batch_size=${DSPARK_CAPACITY_ACTIVATION_BATCH_SIZE:-${VLLM_DSPARK_CAPACITY_ACTIVATION_BATCH_SIZE:-${default_activation_batch_size}}}
++  export VLLM_DSPARK_CAPACITY_ACTIVATION_BATCH_SIZE=${activation_batch_size}
+   require_nonnegative_int DSPARK_CAPACITY_ACTIVATION_BATCH_SIZE \
+     "${VLLM_DSPARK_CAPACITY_ACTIVATION_BATCH_SIZE}"
+   export VLLM_DSPARK_CAPACITY_LOG_INTERVAL=${DSPARK_CAPACITY_LOG_INTERVAL:-0}
+@@ -358,8 +432,10 @@ if [[ "${sp_async_tp}" == "1" ]]; then
+ fi
+ 
+ if [[ -z "${gpu_memory_utilization}" ]]; then
+-  # The v10 profiler includes attention and FULL-graph allocations. These
+-  # defaults preserve the 262k serving limit used by v9 after that accounting.
++  # The 0731 DSpark draft head is larger than the historical MTP head. Its
++  # B12X TP2 profile needs 0.975 to retain the default 131k serving limit after
++  # attention and FULL-graph allocations are accounted for. At 0.97 the r15
++  # stack exposed 7.11 GiB of KV storage while this profile needs 7.37 GiB.
+   if [[ "${mode}" == "dspark" ]]; then
+     if [[ "${backend}" == "lucifer-default" ]]; then
+       # The default DeepGEMM MoE path retains more model/runtime memory than
+@@ -377,7 +453,7 @@ if [[ -z "${gpu_memory_utilization}" ]]; then
+     elif [[ "${backend}" == lucifer-* ]]; then
+       gpu_memory_utilization=0.9465
+     else
+-      gpu_memory_utilization=0.95
++      gpu_memory_utilization=0.975
+     fi
+   elif [[ "${backend}" == lucifer-* \
+     && ( "${mode}" == "mtp2" || "${mode}" == "mtp3" ) ]]; then
+@@ -398,6 +474,54 @@ if [[ "${enable_flashinfer_autotune}" == "0" ]]; then
+   autotune_args=(--no-enable-flashinfer-autotune)
+ fi
+ 
++offloading_args=()
++if [[ -n "${kv_offloading_size}" \
++  && ! "${kv_offloading_size}" =~ ^0*([.]0*)?$ ]]; then
++  # This is the total host-cache capacity across all TP ranks, matching the
++  # vLLM CLI contract. LMCache remains a separate deployment mode. Native KV
++  # offload pins/registers GPU cache allocations, so PyTorch's remappable VMM
++  # segments must be disabled while preserving any other allocator settings.
++  allocator_config=${PYTORCH_CUDA_ALLOC_CONF:-}
++  if [[ -z "${allocator_config}" ]]; then
++    allocator_config=expandable_segments:False
++  elif [[ "${allocator_config}" =~ (^|,)expandable_segments:True(,|$) ]]; then
++    allocator_config=${allocator_config//expandable_segments:True/expandable_segments:False}
++  fi
++  export PYTORCH_CUDA_ALLOC_CONF=${allocator_config}
++  offloading_args=(
++    --kv-offloading-size "${kv_offloading_size}"
++    --kv-offloading-backend native
++  )
++  if [[ "${native_l2_enabled}" == "1" ]]; then
++    export PYTHONHASHSEED=${PYTHONHASHSEED:-0}
++    native_l2_config=$(python3 - "${native_l2_path}" "${native_l2_size}" <<'PY'
++import json
++import sys
++
++root_dir, max_size_gb = sys.argv[1:]
++config = {
++    "kv_connector": "OffloadingConnector",
++    "kv_role": "kv_both",
++    "kv_connector_extra_config": {
++        "spec_name": "TieringOffloadingSpec",
++        "secondary_tiers": [
++            {
++                "type": "fs",
++                "root_dir": root_dir,
++                "n_read_threads": 32,
++                "n_write_threads": 16,
++                "gc_max_size_gb": float(max_size_gb),
++            }
++        ],
++    },
++}
++print(json.dumps(config, separators=(",", ":")))
++PY
++    )
++    offloading_args+=(--kv-transfer-config "${native_l2_config}")
++  fi
++fi
++
+ capture_args=()
+ capture_sizes=${CUDAGRAPH_CAPTURE_SIZES:-default}
+ if [[ "${capture_sizes}" == "auto" ]]; then
+@@ -465,6 +589,7 @@ command=(
+   "${autotune_args[@]}"
+   "${prefix_args[@]}"
+   "${capture_args[@]}"
++  "${offloading_args[@]}"
+   "${spec_args[@]}"
+   "${backend_args[@]}"
+   "${allreduce_args[@]}"
+@@ -478,10 +603,13 @@ if [[ -n "${EXTRA_VLLM_ARGS:-}" ]]; then
+ fi
+ command+=("$@")
+ 
+-printf 'DS4 launch: mode=%s backend=%s allreduce=%s b12x_dma=%s indexer=%s tp=%s dcp=%s max_seqs=%s graph=%s load_format=%s instanttensor_backend=%s model=%s\n' \
+-  "${mode}" "${backend}" "${allreduce_mode}" "${b12x_pcie_dma}" \
++printf 'DS4 launch: mode=%s depth=%s backend=%s allreduce=%s b12x_dma=%s indexer=%s tp=%s dcp=%s max_seqs=%s graph=%s load_format=%s instanttensor_backend=%s native_l2=%s allocator=%s model=%s\n' \
++  "${mode}" "${dspark_depth_mode}" \
++  "${backend}" "${allreduce_mode}" "${b12x_pcie_dma}" \
+   "${indexer_backend}" "${tp_size}" "${dcp_size}" "${max_num_seqs}" \
+-  "${graph_cap}" "${load_format}" "${INSTANTTENSOR_BACKEND}" "${model}" >&2
++  "${graph_cap}" "${load_format}" "${INSTANTTENSOR_BACKEND}" \
++  "${native_l2_enabled}" \
++  "${PYTORCH_CUDA_ALLOC_CONF:-<unset>}" "${model}" >&2
+ printf 'Command:' >&2
+ printf ' %q' "${command[@]}" >&2
+ printf '\n' >&2
+diff --git a/serve-glm52.sh b/serve-glm52.sh
+index 68f7501b3d618dea5c4ae93047b281cd56efd85d..8933ad62d752aabbc9f2e6a80bc3b17945afef41 100755
+--- a/serve-glm52.sh
++++ b/serve-glm52.sh
+@@ -107,6 +107,8 @@ MOE_BACKEND="${MOE_BACKEND:-b12x}"
+ MOE_SPEC_BACKEND="${MOE_SPEC_BACKEND:-b12x}"
+ ATTENTION_BACKEND="${ATTENTION_BACKEND:-B12X_MLA_SPARSE}"
+ KV_CACHE_DTYPE="${KV_CACHE_DTYPE:-fp8}"
++# Calibrated per-layer outer scales for nvfp4_ds_mla KV (empty = disabled).
++export VLLM_NVFP4_MLA_SCALES_FILE="${VLLM_NVFP4_MLA_SCALES_FILE:-}"
+ GLM51_PROFILE="${GLM51_PROFILE:-0}"
+ GLM52_CAUSAL_CASCADE="${GLM52_CAUSAL_CASCADE:-0}"
+ GLM52_DSPARK="${GLM52_DSPARK:-0}"
+diff --git a/tests/distributed/test_b12x_custom_all_reduce_warmup.py b/tests/distributed/test_b12x_custom_all_reduce_warmup.py
+new file mode 100644
+index 0000000000000000000000000000000000000000..21d1b9411c22d20c65fe2ad1f7b0962b29a8cf29
+--- /dev/null
++++ b/tests/distributed/test_b12x_custom_all_reduce_warmup.py
+@@ -0,0 +1,102 @@
++# SPDX-License-Identifier: Apache-2.0
++# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
++
++from unittest.mock import MagicMock
++
++import pytest
++import torch
++
++from vllm.distributed.device_communicators.custom_all_reduce import CustomAllreduce
++
++
++def _make_custom_allreduce(
++    *, allreduce_max_size: int
++) -> tuple[CustomAllreduce, MagicMock]:
++    """Build a minimal custom all-reduce with a mocked PCIe runtime.
++
++    Args:
++        allreduce_max_size: Largest input eligible for one-shot all-reduce.
++
++    Returns:
++        The custom all-reduce instance and its mocked PCIe runtime.
++    """
++    runtime = MagicMock()
++    runtime.for_stream.return_value.should_allreduce.return_value = True
++
++    custom_allreduce = object.__new__(CustomAllreduce)
++    custom_allreduce.disabled = False
++    custom_allreduce._pcie_runtime = runtime
++    custom_allreduce._pcie_dma = None
++    custom_allreduce._pcie_capture_stream = None
++    custom_allreduce._pcie_allreduce_max_size = allreduce_max_size
++    custom_allreduce._pcie_logged_first_allreduce = False
++    custom_allreduce._IS_CAPTURING = True
++    custom_allreduce._ptr = 0
++    custom_allreduce.max_size = allreduce_max_size
++    return custom_allreduce, runtime
++
++
++def _mock_capture_warmup(
++    monkeypatch: pytest.MonkeyPatch,
++    custom_allreduce: CustomAllreduce,
++) -> object:
++    """Place a custom all-reduce in the non-capturing graph warmup phase.
++
++    Args:
++        monkeypatch: Pytest fixture used to replace capture state helpers.
++        custom_allreduce: Instance whose PCIe stream should be mocked.
++
++    Returns:
++        The mocked PCIe capture stream.
++    """
++    capture_stream = object()
++    monkeypatch.setattr(
++        custom_allreduce,
++        "_pcie_runtime_stream",
++        lambda: capture_stream,
++    )
++    monkeypatch.setattr(torch.cuda, "is_current_stream_capturing", lambda: False)
++    monkeypatch.setattr(
++        "vllm.distributed.device_communicators.custom_all_reduce."
++        "_is_piecewise_cudagraph_runtime",
++        lambda: False,
++    )
++    return capture_stream
++
++
++def test_capture_warmup_prepares_plain_graph_allreduce(
++    monkeypatch: pytest.MonkeyPatch,
++) -> None:
++    """Verify that plain one-shot warmup prepares without communication."""
++    custom_allreduce, runtime = _make_custom_allreduce(allreduce_max_size=64)
++    capture_stream = _mock_capture_warmup(monkeypatch, custom_allreduce)
++    inp = torch.randn(2, 4)
++
++    output = custom_allreduce.custom_all_reduce(inp)
++
++    assert output is not None
++    assert output.shape == inp.shape
++    runtime.prepare_graph_all_reduce.assert_called_once_with(
++        inp,
++        stream=capture_stream,
++    )
++    runtime.all_reduce.assert_not_called()
++
++
++def test_capture_warmup_does_not_prepare_dma_only_input(
++    monkeypatch: pytest.MonkeyPatch,
++) -> None:
++    """Verify that DMA-only warmup keeps the communication-free placeholder."""
++    custom_allreduce, runtime = _make_custom_allreduce(allreduce_max_size=16)
++    custom_allreduce._pcie_dma = MagicMock()
++    custom_allreduce._pcie_dma.should_allreduce.return_value = True
++    _mock_capture_warmup(monkeypatch, custom_allreduce)
++    inp = torch.randn(4, 4)
++
++    output = custom_allreduce.custom_all_reduce(inp)
++
++    assert output is not None
++    assert output.shape == inp.shape
++    runtime.prepare_graph_all_reduce.assert_not_called()
++    runtime.all_reduce.assert_not_called()
++    custom_allreduce._pcie_dma.all_reduce.assert_not_called()
+diff --git a/tests/distributed/test_b12x_fused_all_reduce.py b/tests/distributed/test_b12x_fused_all_reduce.py
+index a79acc3afd09f4a248aa0473e5fb02209c18a4ed..5c7c0e746aa58076bcce42de4710b183d07fd81e 100644
+--- a/tests/distributed/test_b12x_fused_all_reduce.py
++++ b/tests/distributed/test_b12x_fused_all_reduce.py
+@@ -1,6 +1,7 @@
+ # SPDX-License-Identifier: Apache-2.0
+ # SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+ 
++from types import SimpleNamespace
+ from unittest.mock import MagicMock
+ 
+ import pytest
+@@ -25,6 +26,7 @@ from vllm.config import (
+     set_current_vllm_config,
+ )
+ from vllm.distributed import tensor_model_parallel_all_reduce
++from vllm.distributed.device_communicators import custom_all_reduce
+ from vllm.distributed.device_communicators.custom_all_reduce import (
+     CustomAllreduce,
+     _b12x_pcie_dma_min_bytes,
+@@ -107,8 +109,66 @@ def test_b12x_fused_allreduce_uses_independent_cutoff() -> None:
+         out=inp,
+         residual_out=residual,
+         stream=None,
+-        channel_id="eager:vllm-tp-allreduce",
++        channel_id="vllm:eager:allreduce",
+     )
++    runtime.for_stream.assert_called_with(
++        None,
++        channel_id="vllm:eager:allreduce",
++    )
++
++
++def test_b12x_eager_allreduce_forwards_stable_semantic_channel() -> None:
++    custom_allreduce, runtime = make_b12x_custom_allreduce(
++        allreduce_max_size=64,
++        fused_max_size=64,
++    )
++    inp = torch.randn(2, 4)
++    expected = torch.empty_like(inp)
++    runtime.all_reduce.return_value = expected
++
++    actual = custom_allreduce.all_reduce(inp)
++
++    assert actual is expected
++    runtime.all_reduce.assert_called_once_with(
++        inp,
++        out=None,
++        stream=None,
++        channel_id="vllm:eager:allreduce",
++    )
++
++
++def test_b12x_eager_owner_fails_closed_on_second_stream_bind() -> None:
++    custom_allreduce, runtime = make_b12x_custom_allreduce(
++        allreduce_max_size=64,
++        fused_max_size=64,
++    )
++    first_stream = object()
++    second_stream = object()
++    custom_allreduce._pcie_runtime_stream = MagicMock(  # type: ignore[method-assign]
++        side_effect=(first_stream, second_stream)
++    )
++    bound_stream = None
++
++    def for_stream(stream, *, channel_id):
++        nonlocal bound_stream
++        assert channel_id == "vllm:eager:allreduce"
++        if bound_stream is None:
++            bound_stream = stream
++        elif stream is not bound_stream:
++            raise RuntimeError("stream-affine logical owner rebound")
++        channel = MagicMock()
++        channel.should_allreduce.return_value = True
++        return channel
++
++    runtime.for_stream.side_effect = for_stream
++    inp = torch.randn(2, 4)
++
++    assert custom_allreduce.should_custom_ar(inp)
++    with pytest.raises(RuntimeError, match="stream-affine"):
++        custom_allreduce.should_custom_ar(inp)
++    assert [
++        call.kwargs["channel_id"] for call in runtime.for_stream.call_args_list
++    ] == ["vllm:eager:allreduce", "vllm:eager:allreduce"]
+ 
+ 
+ def test_b12x_fused_allreduce_falls_back_above_its_cutoff() -> None:
+@@ -144,6 +204,121 @@ def test_b12x_oneshot_defaults_to_stream_isolation(
+     assert not envs.environment_variables["VLLM_PCIE_ONESHOT_SINGLE_CHANNEL"]()
+ 
+ 
++def test_b12x_pool_prepares_single_stable_eager_owner(
++    monkeypatch: pytest.MonkeyPatch,
++) -> None:
++    captured = {}
++    runtime = MagicMock()
++
++    class FakePool:
++        @classmethod
++        def from_exchange_group(cls, **kwargs):
++            captured.update(kwargs)
++            return runtime
++
++    def fake_all_gather(gather_list, tensor, *, group):
++        for index, slot in enumerate(gather_list):
++            slot.fill_(index)
++
++    fake_config = SimpleNamespace(
++        model_config=SimpleNamespace(get_hidden_size=lambda: 4),
++        scheduler_config=SimpleNamespace(max_num_batched_tokens=8),
++    )
++    monkeypatch.setattr(custom_all_reduce, "custom_ar", True)
++    monkeypatch.setattr(custom_all_reduce.dist, "get_backend", lambda group: "gloo")
++    monkeypatch.setattr(
++        custom_all_reduce,
++        "in_the_same_node_as",
++        lambda group, source_rank=0: [True, True],
++    )
++    monkeypatch.setattr(custom_all_reduce.dist, "get_rank", lambda group=None: 0)
++    monkeypatch.setattr(custom_all_reduce.dist, "get_world_size", lambda group=None: 2)
++    monkeypatch.setattr(custom_all_reduce.dist, "all_gather", fake_all_gather)
++    monkeypatch.setattr(
++        custom_all_reduce.dist, "all_reduce", lambda *args, **kwargs: None
++    )
++    monkeypatch.setattr(
++        custom_all_reduce,
++        "_b12x_pcie_allreduce_requested",
++        lambda: True,
++    )
++    monkeypatch.setattr(custom_all_reduce, "_can_p2p", lambda *args: True)
++    monkeypatch.setattr(
++        custom_all_reduce,
++        "_is_cross_numa_topology",
++        lambda ids: False,
++    )
++    monkeypatch.setattr(
++        custom_all_reduce,
++        "_load_b12x_pcie_oneshot_pool",
++        lambda: FakePool,
++    )
++    monkeypatch.setattr(
++        custom_all_reduce,
++        "_b12x_pcie_dma_min_bytes",
++        lambda: None,
++    )
++    monkeypatch.setattr(
++        custom_all_reduce.current_platform,
++        "get_device_capability",
++        lambda: None,
++    )
++    monkeypatch.setattr(
++        custom_all_reduce.current_platform,
++        "visible_device_id_to_physical_device_id",
++        lambda index: index,
++    )
++    monkeypatch.setattr(
++        custom_all_reduce.current_platform,
++        "is_cuda_alike",
++        lambda: True,
++    )
++    monkeypatch.setattr(
++        custom_all_reduce.current_platform,
++        "is_fully_connected",
++        lambda ids: False,
++        raising=False,
++    )
++    monkeypatch.setattr(
++        custom_all_reduce.current_platform,
++        "is_cuda",
++        lambda: True,
++    )
++    monkeypatch.setattr(
++        custom_all_reduce.current_platform,
++        "is_rocm",
++        lambda: False,
++    )
++    monkeypatch.setattr(
++        "vllm.config.get_current_vllm_config",
++        lambda: fake_config,
++    )
++    monkeypatch.setattr(
++        custom_all_reduce.envs,
++        "VLLM_PCIE_ONESHOT_SINGLE_CHANNEL",
++        False,
++        raising=False,
++    )
++    monkeypatch.setattr(
++        custom_all_reduce.envs,
++        "VLLM_ALLOW_CUSTOM_ALLREDUCE_PCIE",
++        False,
++        raising=False,
++    )
++
++    built = CustomAllreduce(
++        object(),  # type: ignore[arg-type]
++        torch.device("cuda:0"),
++        nccl_group=object(),  # type: ignore[arg-type]
++    )
++
++    assert not built.disabled
++    assert captured["single_channel"] is False
++    assert captured["max_concurrent_channels"] == 2
++    runtime.prepare_channels.assert_called_once_with(("vllm:eager:allreduce",))
++    runtime.for_stream.assert_called_once_with(channel_id="vllm:eager:allreduce")
++
++
+ def test_b12x_channel_checkpoint_delegates_to_runtime() -> None:
+     custom_allreduce, runtime = make_b12x_custom_allreduce(
+         allreduce_max_size=64,
+@@ -159,6 +334,40 @@ def test_b12x_channel_checkpoint_delegates_to_runtime() -> None:
+     runtime.rollback_channels.assert_called_once_with(checkpoint)
+ 
+ 
++def test_b12x_capture_forwards_semantic_channel_id() -> None:
++    custom_allreduce, runtime = make_b12x_custom_allreduce(
++        allreduce_max_size=64,
++        fused_max_size=64,
++    )
++    stream = object()
++
++    with custom_allreduce.capture(  # type: ignore[arg-type]
++        stream,
++        channel_id="vllm:target:profile",
++    ):
++        pass
++
++    runtime.capture.assert_called_once_with(
++        stream=stream,
++        channel_id="vllm:target:profile",
++    )
++
++
++def test_b12x_capture_rejects_missing_semantic_channel_id() -> None:
++    custom_allreduce, runtime = make_b12x_custom_allreduce(
++        allreduce_max_size=64,
++        fused_max_size=64,
++    )
++
++    with (
++        pytest.raises(RuntimeError, match="semantic channel_id"),
++        custom_allreduce.capture(),
++    ):
++        pass
++
++    runtime.capture.assert_not_called()
++
++
+ def test_b12x_oneshot_buffer_tracks_dispatch_limits(
+     monkeypatch: pytest.MonkeyPatch,
+ ) -> None:
+@@ -361,7 +570,7 @@ def _run_b12x_fused_allreduce_gpu(rank: int, port: int) -> None:
+     residual.copy_(original_residual)
+     with graph_capture(
+         device=device,
+-        channel_id="graph:test-b12x-fused-allreduce",
++        channel_id="vllm:test:b12x-fused",
+     ) as capture_context:
+         graph = torch.cuda.CUDAGraph()
+         with torch.cuda.graph(graph, stream=capture_context.stream):
+diff --git a/tests/distributed/test_custom_allreduce_lifecycle.py b/tests/distributed/test_custom_allreduce_lifecycle.py
+new file mode 100644
+index 0000000000000000000000000000000000000000..c5806ccbddeb65c3af7ec2ab38a6dac2d8b79980
+--- /dev/null
++++ b/tests/distributed/test_custom_allreduce_lifecycle.py
+@@ -0,0 +1,144 @@
++# SPDX-License-Identifier: Apache-2.0
++# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
++
++import gc
++import weakref
++from unittest.mock import MagicMock
++
++import pytest
++import torch
++
++from vllm.distributed.device_communicators.cuda_communicator import CudaCommunicator
++from vllm.distributed.device_communicators.custom_all_reduce import CustomAllreduce
++from vllm.distributed.parallel_state import GroupCoordinator
++
++
++def make_b12x_custom_allreduce() -> tuple[CustomAllreduce, MagicMock]:
++    runtime = MagicMock()
++    custom_allreduce = object.__new__(CustomAllreduce)
++    custom_allreduce.disabled = False
++    custom_allreduce._pcie_runtime = runtime
++    custom_allreduce._pcie_dma = None
++    custom_allreduce._ptr = 0
++    return custom_allreduce, runtime
++
++
++def test_b12x_destructor_skips_collective_close_without_retention() -> None:
++    custom_allreduce, runtime = make_b12x_custom_allreduce()
++    dma = MagicMock()
++    custom_allreduce._pcie_dma = dma
++    custom_allreduce_ref = weakref.ref(custom_allreduce)
++
++    del custom_allreduce
++    gc.collect()
++
++    dma.close.assert_not_called()
++    runtime.close.assert_not_called()
++    assert custom_allreduce_ref() is None
++
++
++def test_b12x_explicit_close_remains_coordinated() -> None:
++    custom_allreduce, runtime = make_b12x_custom_allreduce()
++    dma = MagicMock()
++    custom_allreduce._pcie_dma = dma
++    close_order = []
++    runtime.close.side_effect = lambda: close_order.append("runtime")
++    dma.close.side_effect = lambda: close_order.append("dma")
++
++    custom_allreduce.close()
++
++    assert close_order == ["runtime", "dma"]
++    dma.close.assert_called_once_with()
++    runtime.close.assert_called_once_with()
++    assert custom_allreduce._pcie_dma is None
++    assert custom_allreduce._pcie_runtime is None
++
++
++def test_b12x_close_retains_owners_when_runtime_close_fails() -> None:
++    custom_allreduce, runtime = make_b12x_custom_allreduce()
++    dma = MagicMock()
++    runtime.close.side_effect = RuntimeError("close failed")
++    custom_allreduce._pcie_dma = dma
++
++    with pytest.raises(RuntimeError, match="close failed"):
++        custom_allreduce.close()
++
++    assert custom_allreduce._pcie_runtime is runtime
++    assert custom_allreduce._pcie_dma is dma
++    dma.close.assert_not_called()
++
++
++def test_cuda_communicator_closes_custom_allreduce_before_nccl() -> None:
++    communicator = object.__new__(CudaCommunicator)
++    communicator.ca_comm = MagicMock()
++    communicator.pynccl_comm = MagicMock()
++    communicator.aiter_ar_comm = None
++    communicator.fi_ar_comm = None
++    communicator.all2all_manager = None
++    close_order = []
++    communicator.ca_comm.close.side_effect = lambda: close_order.append("custom")
++    communicator.pynccl_comm.destroy.side_effect = lambda: close_order.append("nccl")
++
++    communicator.destroy()
++
++    assert close_order == ["custom", "nccl"]
++    assert communicator.ca_comm is None
++    assert communicator.pynccl_comm is None
++
++
++def test_cuda_communicator_retains_owners_when_custom_close_fails() -> None:
++    communicator = object.__new__(CudaCommunicator)
++    custom_allreduce = MagicMock()
++    custom_allreduce.close.side_effect = RuntimeError("close failed")
++    communicator.ca_comm = custom_allreduce
++    communicator.pynccl_comm = MagicMock()
++    communicator.aiter_ar_comm = None
++    communicator.fi_ar_comm = None
++    communicator.all2all_manager = None
++
++    with pytest.raises(RuntimeError, match="close failed"):
++        communicator.destroy()
++
++    assert communicator.ca_comm is custom_allreduce
++    communicator.pynccl_comm.destroy.assert_not_called()
++
++
++def test_group_destroy_keeps_process_groups_live_for_communicator(
++    monkeypatch: pytest.MonkeyPatch,
++) -> None:
++    coordinator = object.__new__(GroupCoordinator)
++    coordinator.device_group = object()
++    coordinator.cpu_group = object()
++    coordinator.device_communicator = MagicMock()
++    coordinator.mq_broadcaster = None
++    device_group = coordinator.device_group
++    destroy_order = []
++    coordinator.device_communicator.destroy.side_effect = lambda: destroy_order.append(
++        "communicator"
++    )
++    monkeypatch.setattr(
++        torch.distributed,
++        "destroy_process_group",
++        lambda group: destroy_order.append(
++            "device" if group is device_group else "cpu"
++        ),
++    )
++
++    coordinator.destroy()
++
++    assert destroy_order == ["communicator", "device", "cpu"]
++
++
++def test_group_destroy_retains_process_groups_when_communicator_close_fails() -> None:
++    coordinator = object.__new__(GroupCoordinator)
++    coordinator.device_group = object()
++    coordinator.cpu_group = object()
++    coordinator.device_communicator = MagicMock()
++    coordinator.device_communicator.destroy.side_effect = RuntimeError("close failed")
++    coordinator.mq_broadcaster = None
++
++    with pytest.raises(RuntimeError, match="close failed"):
++        coordinator.destroy()
++
++    assert hasattr(coordinator, "device_group")
++    assert hasattr(coordinator, "cpu_group")
+diff --git a/tests/distributed/test_dcp_a2a.py b/tests/distributed/test_dcp_a2a.py
+index 4bf1144c6fc3d3d378752dd4e36d986ec50b91e4..6a1029568a2087a1d4b373ed8080a18c59a0f73e 100644
+--- a/tests/distributed/test_dcp_a2a.py
++++ b/tests/distributed/test_dcp_a2a.py
+@@ -10,7 +10,7 @@ Tests cover:
+ 
+ import importlib.util
+ import math
+-from contextlib import contextmanager
++from contextlib import contextmanager, nullcontext
+ from typing import Any
+ 
+ import multiprocess as mp
+@@ -553,7 +553,7 @@ def test_b12x_pool_uses_independent_stream_channels(
+             return cls()
+ 
+         def prepare_channels(self, channel_ids):
+-            captured["prepared"] = channel_ids
++            captured["prepared"] = tuple(channel_ids)
+ 
+         def for_stream(self, *, channel_id):
+             captured["warmed"] = channel_id
+@@ -580,14 +580,15 @@ def test_b12x_pool_uses_independent_stream_channels(
+ 
+     assert pool is not None
+     assert captured["single_channel"] is False
+-    assert captured["prepared"] == ("eager:vllm-dcp-a2a",)
+-    assert captured["warmed"] == "eager:vllm-dcp-a2a"
++    assert captured["max_concurrent_channels"] == 2
++    assert captured["prepared"] == ("vllm:eager:dcp",)
++    assert captured["warmed"] == "vllm:eager:dcp"
+ 
+ 
+ def test_b12x_dcp_capture_selects_only_current_group_pools(monkeypatch):
+     from vllm.v1.attention.ops import dcp_alltoall
+ 
+-    events = []
++    events: list[Any] = []
+ 
+     class _FakePool:
+         def __init__(self, name):
+@@ -614,25 +615,44 @@ def test_b12x_dcp_capture_selects_only_current_group_pools(monkeypatch):
+     with dcp_alltoall.capture_b12x_dcp_a2a(  # type: ignore[arg-type]
+         group,
+         stream,
+-        channel_id="graph:test",
++        channel_id="vllm:target:profile",
+     ):
+-        events.append(("body", None, stream))
++        events.append(("body", None, stream, "vllm:target:profile"))
+ 
+     assert events == [
+-        ("enter", "output", stream, "graph:test"),
+-        ("enter", "query", stream, "graph:test"),
+-        ("body", None, stream),
+-        ("exit", "query", stream, "graph:test"),
+-        ("exit", "output", stream, "graph:test"),
++        ("enter", "output", stream, "vllm:target:profile"),
++        ("enter", "query", stream, "vllm:target:profile"),
++        ("body", None, stream, "vllm:target:profile"),
++        ("exit", "query", stream, "vllm:target:profile"),
++        ("exit", "output", stream, "vllm:target:profile"),
+     ]
+ 
+ 
++def test_b12x_dcp_capture_rejects_missing_semantic_id(monkeypatch):
++    from vllm.v1.attention.ops import dcp_alltoall
++
++    device_group = object()
++    group = _FakeCPGroup(2, device_group)  # type: ignore[arg-type]
++    key = (id(device_group), 0, 64, 512, 576, 64)
++    monkeypatch.setattr(
++        dcp_alltoall,
++        "_B12X_DCP_A2A_POOLS",
++        {key: object()},
++    )
++
++    with (
++        pytest.raises(RuntimeError, match="semantic channel_id"),
++        dcp_alltoall.capture_b12x_dcp_a2a(group),
++    ):
++        pass
++
++
+ def test_b12x_dcp_channel_rollback_restores_existing_and_closes_new_pools(
+     monkeypatch,
+ ):
+     from vllm.v1.attention.ops import dcp_alltoall
+ 
+-    events = []
++    events: list[Any] = []
+ 
+     class _FakePool:
+         def __init__(self, name):
+@@ -675,7 +695,7 @@ def test_profile_channel_checkpoint_rolls_back_all_b12x_transports(monkeypatch):
+     from vllm.distributed import parallel_state
+     from vllm.v1.attention.ops import dcp_alltoall
+ 
+-    events = []
++    events: list[Any] = []
+ 
+     class _FakeCommunicator:
+         def checkpoint_pcie_channels(self):
+@@ -699,10 +719,15 @@ def test_profile_channel_checkpoint_rolls_back_all_b12x_transports(monkeypatch):
+     monkeypatch.setattr(parallel_state, "_TP", tp_group)
+     monkeypatch.setattr(parallel_state, "_PP", pp_group)
+     monkeypatch.setattr(parallel_state, "_DCP", dcp_group)
++
++    def checkpoint_dcp(group):
++        events.append("checkpoint-dcp")
++        return "dcp-checkpoint"
++
+     monkeypatch.setattr(
+         dcp_alltoall,
+         "checkpoint_b12x_dcp_a2a_channels",
+-        lambda group: events.append("checkpoint-dcp") or "dcp-checkpoint",
++        checkpoint_dcp,
+     )
+     monkeypatch.setattr(
+         dcp_alltoall,
+@@ -725,28 +750,38 @@ def test_global_graph_capture_enters_b12x_dcp_pool(monkeypatch):
+     from vllm.distributed import parallel_state
+     from vllm.v1.attention.ops import dcp_alltoall
+ 
+-    events = []
++    events: list[Any] = []
+ 
+     class _FakeGroup:
+         world_size = 2
+ 
++        def __init__(self, name):
++            self.name = name
++
+         @contextmanager
+         def graph_capture(self, context):
+-            yield context
++            events.append(("enter-group", self.name, context.channel_id))
++            try:
++                yield context
++            finally:
++                events.append(("exit-group", self.name, context.channel_id))
+ 
+-    tp_group = _FakeGroup()
+-    pp_group = _FakeGroup()
+-    dcp_group = _FakeGroup()
++    tp_group = _FakeGroup("tp")
++    pp_group = _FakeGroup("pp")
++    dcp_group = _FakeGroup("dcp")
+     stream = object()
+     context = parallel_state.GraphCaptureContext(  # type: ignore[arg-type]
+         stream,
+-        channel_id="graph:test-global-capture",
++        channel_id="vllm:target:profile",
+     )
+ 
+     @contextmanager
+     def fake_b12x_capture(group, selected_stream, *, channel_id):
+-        events.append((group, selected_stream, channel_id))
+-        yield
++        events.append(("enter-b12x", group, selected_stream, channel_id))
++        try:
++            yield
++        finally:
++            events.append(("exit-b12x", group, selected_stream, channel_id))
+ 
+     monkeypatch.setattr(parallel_state, "_DCP", dcp_group)
+     monkeypatch.setattr(parallel_state, "get_tp_group", lambda: tp_group)
+@@ -757,7 +792,75 @@ def test_global_graph_capture_enters_b12x_dcp_pool(monkeypatch):
+     with parallel_state.graph_capture(torch.device("cpu"), context) as actual:
+         assert actual is context
+ 
+-    assert events == [(dcp_group, stream, "graph:test-global-capture")]
++    assert events == [
++        ("enter-group", "tp", "vllm:target:profile"),
++        ("enter-group", "pp", "vllm:target:profile"),
++        ("enter-group", "dcp", "vllm:target:profile"),
++        (
++            "enter-b12x",
++            dcp_group,
++            stream,
++            "vllm:target:profile",
++        ),
++        (
++            "exit-b12x",
++            dcp_group,
++            stream,
++            "vllm:target:profile",
++        ),
++        ("exit-group", "dcp", "vllm:target:profile"),
++        ("exit-group", "pp", "vllm:target:profile"),
++        ("exit-group", "tp", "vllm:target:profile"),
++    ]
++
++
++def test_group_capture_forwards_semantic_id_to_custom_allreduce(monkeypatch):
++    from vllm._aiter_ops import rocm_aiter_ops
++    from vllm.distributed import parallel_state
++    from vllm.distributed.device_communicators.cuda_communicator import (
++        CudaCommunicator,
++    )
++
++    events: list[Any] = []
++
++    class FakeCustomAllreduce:
++        @contextmanager
++        def capture(self, *, stream, channel_id):
++            events.append(("enter", stream, channel_id))
++            try:
++                yield
++            finally:
++                events.append(("exit", stream, channel_id))
++
++    communicator = object.__new__(CudaCommunicator)
++    communicator.ca_comm = FakeCustomAllreduce()
++    group = object.__new__(parallel_state.GroupCoordinator)
++    group.device_communicator = communicator
++    stream = object()
++    context = parallel_state.GraphCaptureContext(  # type: ignore[arg-type]
++        stream,
++        channel_id="vllm:draft:decode:production",
++    )
++
++    monkeypatch.setattr(rocm_aiter_ops, "is_enabled", lambda: False)
++    monkeypatch.setattr(
++        parallel_state.torch.cuda,
++        "current_stream",
++        lambda: stream,
++    )
++    monkeypatch.setattr(
++        parallel_state.torch.cuda,
++        "stream",
++        lambda selected: nullcontext(),
++    )
++
++    with parallel_state.GroupCoordinator.graph_capture(group, context) as actual:
++        assert actual is context
++
++    assert events == [
++        ("enter", stream, "vllm:draft:decode:production"),
++        ("exit", stream, "vllm:draft:decode:production"),
++    ]
+ 
+ 
+ @pytest.mark.skipif(torch.accelerator.device_count() < 1, reason="CUDA is required.")
+@@ -779,7 +882,7 @@ def test_b12x_lse_reduce_honors_token_cap(monkeypatch: pytest.MonkeyPatch):
+             is_lse_base_on_e,
+             channel_id,
+         ):
+-            assert channel_id == "eager:vllm-dcp-a2a"
++            created["channel_id"] = channel_id
+             return sentinel
+ 
+     def fake_get_pool(
+@@ -805,6 +908,7 @@ def test_b12x_lse_reduce_honors_token_cap(monkeypatch: pytest.MonkeyPatch):
+     # Batch within the cap uses B12X, with the staging pool capped too.
+     assert result is sentinel
+     assert created["max_batch_size"] == 4
++    assert created["channel_id"] == "vllm:eager:dcp"
+ 
+     out_large = torch.zeros(8, 16, 64, dtype=torch.bfloat16, device="cuda")
+     lse_large = torch.zeros(8, 16, dtype=torch.float32, device="cuda")
+@@ -832,7 +936,7 @@ def test_b12x_query_gather_honors_token_cap(monkeypatch: pytest.MonkeyPatch):
+ 
+     class _FakePool:
+         def all_gather_heads(self, local_input, *, channel_id):
+-            assert channel_id == "eager:vllm-dcp-a2a"
++            created["channel_id"] = channel_id
+             return sentinel
+ 
+     def fake_get_pool(
+@@ -853,6 +957,7 @@ def test_b12x_query_gather_honors_token_cap(monkeypatch: pytest.MonkeyPatch):
+     )
+     assert result is sentinel
+     assert created["max_batch_size"] == 4
++    assert created["channel_id"] == "vllm:eager:dcp"
+ 
+     large = torch.zeros(8, 8, 64, dtype=torch.bfloat16, device="cuda")
+     result = dcp_alltoall._try_b12x_dcp_all_gather_heads(
+@@ -919,11 +1024,9 @@ def test_b12x_lse_reduce_preserves_supported_layouts(monkeypatch: pytest.MonkeyP
+     assert received["partial"].is_contiguous()
+     assert received["lse"].is_contiguous()
+     assert received["out"].movedim(0, 1).is_contiguous()
+-    assert received["channel_id"] == "eager:vllm-dcp-a2a"
++    assert received["channel_id"] == "vllm:eager:dcp"
+ 
+-    head_major_storage = torch.zeros(
+-        16, 8, 64, dtype=torch.bfloat16, device="cuda"
+-    )
++    head_major_storage = torch.zeros(16, 8, 64, dtype=torch.bfloat16, device="cuda")
+     head_major = head_major_storage.transpose(0, 1)[:4]
+     result = dcp_alltoall._try_b12x_dcp_lse_reduce(
+         head_major,
+@@ -1298,12 +1401,12 @@ def _distributed_b12x_a2a_worker(env: dict[str, str]) -> None:
+         dcp_alltoall._dcp_a2a_send_recv_buffers = fail_packed_nccl
+         group.all_gather = fail_query_nccl  # type: ignore[attr-defined]
+         graph = torch.cuda.CUDAGraph()
+-        capture_stream = torch.cuda.Stream()
++        capture_stream = torch.cuda.Stream(device=f"cuda:{local_rank}")
+         with (
+             dcp_alltoall.capture_b12x_dcp_a2a(
+                 group,  # type: ignore[arg-type]
+                 capture_stream,
+-                channel_id="graph:test-dcp-a2a",
++                channel_id="test:dcp:graph",
+             ),
+             torch.cuda.graph(graph, stream=capture_stream),
+         ):
+diff --git a/tests/distributed/test_flashinfer_pcie_all_reduce.py b/tests/distributed/test_flashinfer_pcie_all_reduce.py
+new file mode 100644
+index 0000000000000000000000000000000000000000..181baec216cb4b316ebb52c215fa4dab87d4f256
+--- /dev/null
++++ b/tests/distributed/test_flashinfer_pcie_all_reduce.py
+@@ -0,0 +1,224 @@
++# SPDX-License-Identifier: Apache-2.0
++# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
++
++from __future__ import annotations
++
++from types import SimpleNamespace
++from typing import Any
++from unittest.mock import MagicMock
++
++import pytest
++import torch
++
++from vllm.distributed.device_communicators import custom_all_reduce
++from vllm.distributed.device_communicators import flashinfer_pcie_all_reduce as fi_pcie
++
++
++class FakeWorkspace:
++    instances: list[FakeWorkspace] = []
++
++    def __init__(self, **kwargs: Any) -> None:
++        self.kwargs = kwargs
++        self.destroyed = False
++        self.last_input: torch.Tensor | None = None
++        FakeWorkspace.instances.append(self)
++
++    def supports(self, inp: torch.Tensor) -> bool:
++        return inp.numel() <= self.kwargs["max_numel"]
++
++    def all_reduce(
++        self, inp: torch.Tensor, *, out: torch.Tensor | None = None
++    ) -> torch.Tensor:
++        self.last_input = inp
++        if out is None:
++            return inp.clone()
++        out.copy_(inp)
++        return out
++
++    def destroy(self) -> None:
++        self.destroyed = True
++
++
++@pytest.fixture(autouse=True)
++def fake_runtime(monkeypatch: pytest.MonkeyPatch) -> None:
++    FakeWorkspace.instances.clear()
++    monkeypatch.setattr(fi_pcie, "_load_workspace_class", lambda: FakeWorkspace)
++    monkeypatch.setattr(fi_pcie.dist, "get_rank", lambda group=None: 0)
++    monkeypatch.setattr(fi_pcie.dist, "get_world_size", lambda group=None: 2)
++
++    def all_gather_object(gathered, value, *, group):
++        del group
++        gathered[:] = [value, value]
++
++    monkeypatch.setattr(fi_pcie.dist, "all_gather_object", all_gather_object)
++
++
++def make_pool() -> fi_pcie.FlashInferPcieIpcAllReducePool:
++    return fi_pcie.FlashInferPcieIpcAllReducePool(
++        exchange_group=object(),  # type: ignore[arg-type]
++        device="cpu",
++        max_size=64,
++    )
++
++
++def test_each_semantic_channel_gets_an_independent_workspace() -> None:
++    pool = make_pool()
++    assert FakeWorkspace.instances == []
++    checkpoint = pool.checkpoint_channels()
++
++    pool.prepare_channels(("vllm:target:profile",))
++    assert len(FakeWorkspace.instances) == 1
++    assert pool.for_stream(channel_id="vllm:target:profile").should_allreduce(
++        torch.ones(4)
++    )
++
++    profile_workspace = FakeWorkspace.instances[-1]
++    pool.rollback_channels(checkpoint)
++    assert profile_workspace.destroyed
++    assert pool.checkpoint_channels() == ()
++
++    inp = torch.ones(4)
++    assert torch.equal(pool.all_reduce(inp), inp)
++    eager = FakeWorkspace.instances[-1]
++    pool.close()
++    assert eager.destroyed
++
++
++def test_capture_routes_graph_calls_without_reusing_eager_state() -> None:
++    pool = make_pool()
++    inp = torch.arange(4, dtype=torch.float32)
++    out = torch.empty_like(inp)
++
++    with pool.capture(channel_id="vllm:target:production"):
++        pool.prepare_graph_all_reduce(inp)
++        actual = pool.all_reduce(
++            inp,
++            out=out,
++            channel_id="vllm:target:production",
++        )
++
++    assert actual is out
++    assert torch.equal(actual, inp)
++    assert len(FakeWorkspace.instances) == 1
++    assert FakeWorkspace.instances[0].last_input is inp
++    pool.close()
++
++
++def test_channel_creation_fails_closed_when_rank_ids_differ(
++    monkeypatch: pytest.MonkeyPatch,
++) -> None:
++    pool = make_pool()
++
++    def divergent(gathered, value, *, group):
++        del group
++        gathered[:] = [value, "different-channel"]
++
++    monkeypatch.setattr(fi_pcie.dist, "all_gather_object", divergent)
++    with pytest.raises(RuntimeError, match="rank-stable"):
++        pool.prepare_channels(("vllm:target:production",))
++    pool.close()
++
++
++def test_flashinfer_ipc_is_an_explicit_integrated_backend(
++    monkeypatch: pytest.MonkeyPatch,
++) -> None:
++    monkeypatch.setenv("VLLM_ENABLE_PCIE_ALLREDUCE", "1")
++    monkeypatch.setenv("VLLM_PCIE_ALLREDUCE_BACKEND", "flashinfer-ipc")
++
++    assert custom_all_reduce._flashinfer_pcie_allreduce_requested()
++    assert not custom_all_reduce._b12x_pcie_allreduce_requested()
++    assert custom_all_reduce._get_pcie_allreduce_backend() == "flashinfer-ipc"
++
++
++def test_custom_allreduce_constructs_flashinfer_pool(
++    monkeypatch: pytest.MonkeyPatch,
++) -> None:
++    captured: dict[str, Any] = {}
++    runtime = MagicMock()
++
++    class FakePool:
++        @classmethod
++        def from_exchange_group(cls, **kwargs: Any) -> MagicMock:
++            captured.update(kwargs)
++            return runtime
++
++    def fake_all_gather(gather_list, tensor, *, group) -> None:
++        del tensor, group
++        for index, slot in enumerate(gather_list):
++            slot.fill_(index)
++
++    fake_config = SimpleNamespace(
++        model_config=SimpleNamespace(get_hidden_size=lambda: 4096),
++        scheduler_config=SimpleNamespace(max_num_batched_tokens=128),
++    )
++    monkeypatch.setattr(custom_all_reduce, "custom_ar", True)
++    monkeypatch.setattr(custom_all_reduce.dist, "get_backend", lambda group: "gloo")
++    monkeypatch.setattr(
++        custom_all_reduce,
++        "in_the_same_node_as",
++        lambda group, source_rank=0: [True, True],
++    )
++    monkeypatch.setattr(custom_all_reduce.dist, "get_rank", lambda group=None: 0)
++    monkeypatch.setattr(custom_all_reduce.dist, "get_world_size", lambda group=None: 2)
++    monkeypatch.setattr(custom_all_reduce.dist, "all_gather", fake_all_gather)
++    monkeypatch.setattr(
++        custom_all_reduce.dist, "all_reduce", lambda *args, **kwargs: None
++    )
++    monkeypatch.setattr(
++        custom_all_reduce, "_b12x_pcie_allreduce_requested", lambda: False
++    )
++    monkeypatch.setattr(
++        custom_all_reduce, "_flashinfer_pcie_allreduce_requested", lambda: True
++    )
++    monkeypatch.setattr(
++        custom_all_reduce, "_get_pcie_allreduce_backend", lambda: "flashinfer-ipc"
++    )
++    monkeypatch.setattr(custom_all_reduce, "_can_p2p", lambda *args: True)
++    monkeypatch.setattr(custom_all_reduce, "_is_cross_numa_topology", lambda ids: False)
++    monkeypatch.setattr(
++        custom_all_reduce, "_load_flashinfer_pcie_oneshot_pool", lambda: FakePool
++    )
++    monkeypatch.setattr(
++        custom_all_reduce.current_platform, "get_device_capability", lambda: None
++    )
++    monkeypatch.setattr(
++        custom_all_reduce.current_platform,
++        "visible_device_id_to_physical_device_id",
++        lambda index: index,
++    )
++    monkeypatch.setattr(
++        custom_all_reduce.current_platform, "is_cuda_alike", lambda: True
++    )
++    monkeypatch.setattr(
++        custom_all_reduce.current_platform,
++        "is_fully_connected",
++        lambda ids: False,
++        raising=False,
++    )
++    monkeypatch.setattr(custom_all_reduce.current_platform, "is_cuda", lambda: True)
++    monkeypatch.setattr(custom_all_reduce.current_platform, "is_rocm", lambda: False)
++    monkeypatch.setattr("vllm.config.get_current_vllm_config", lambda: fake_config)
++    monkeypatch.setattr(
++        custom_all_reduce.envs,
++        "VLLM_PCIE_ONESHOT_SINGLE_CHANNEL",
++        False,
++        raising=False,
++    )
++    monkeypatch.setattr(
++        custom_all_reduce.envs,
++        "VLLM_ALLOW_CUSTOM_ALLREDUCE_PCIE",
++        False,
++        raising=False,
++    )
++
++    built = custom_all_reduce.CustomAllreduce(
++        object(),  # type: ignore[arg-type]
++        torch.device("cuda:0"),
++        nccl_group=object(),  # type: ignore[arg-type]
++    )
++
++    assert not built.disabled
++    assert built.backend_name() == "FLASHINFER_PCIE_IPC"
++    assert captured["max_size"] > 0
++    runtime.prepare_channels.assert_called_once()
++    runtime.for_stream.assert_called_once()
+diff --git a/tests/distributed/test_indexer_parallel_groups.py b/tests/distributed/test_indexer_parallel_groups.py
+index 8414eb255eeccbdd5af48ccb64f60ea86983d00c..1c65833173363b70ce5e9ecf1258383389fa7ddc 100644
+--- a/tests/distributed/test_indexer_parallel_groups.py
++++ b/tests/distributed/test_indexer_parallel_groups.py
+@@ -8,6 +8,7 @@ import pytest
+ from vllm.distributed import parallel_state
+ from vllm.distributed.parallel_state import (
+     _build_indexer_replica_group_ranks,
++    _needs_indexer_replica_groups,
+     _validate_indexer_shard_count,
+ )
+ 
+@@ -54,6 +55,14 @@ def test_build_indexer_groups_cover_dcp1_partial_and_full(
+     assert query_split_groups == expected_query_split
+ 
+ 
++@pytest.mark.parametrize(
++    ("indexer_shards", "expected"),
++    [(0, False), (1, True), (2, True), (4, True), (8, False)],
++)
++def test_indexer_replica_group_gate_for_dcp8(indexer_shards, expected):
++    assert _needs_indexer_replica_groups(indexer_shards, 8) is expected
++
++
+ def test_build_indexer_replica_groups_stay_inside_each_tp_group():
+     dcp_groups, query_split_groups = _build_indexer_replica_group_ranks(
+         [list(range(8)), list(range(8, 16))], 4
+diff --git a/tests/entrypoints/test_ds4_allreduce_launcher.py b/tests/entrypoints/test_ds4_allreduce_launcher.py
+new file mode 100644
+index 0000000000000000000000000000000000000000..73ec7f630a58f78f07caadfb60e6f9d4b04e547d
+--- /dev/null
++++ b/tests/entrypoints/test_ds4_allreduce_launcher.py
+@@ -0,0 +1,58 @@
++# SPDX-License-Identifier: Apache-2.0
++# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
++
++import os
++import subprocess
++from pathlib import Path
++
++_REPO_ROOT = Path(__file__).parents[2]
++_LAUNCHER = _REPO_ROOT / "serve-ds4-flash.sh"
++
++
++def _dry_run(tmp_path: Path, **overrides: str) -> str:
++    """Run the DS4 launcher without starting a server.
++
++    Args:
++        tmp_path: Isolated home and cache root for the launcher.
++        **overrides: Environment values applied to the launcher defaults.
++
++    Returns:
++        The launcher's diagnostic stderr output.
++    """
++    env = {
++        "PATH": os.environ["PATH"],
++        "HOME": str(tmp_path),
++        "XDG_CACHE_HOME": str(tmp_path / "cache"),
++        "DRY_RUN": "1",
++        "MODE": "mtp0",
++        **overrides,
++    }
++    result = subprocess.run(
++        ["bash", str(_LAUNCHER)],
++        env=env,
++        check=True,
++        capture_output=True,
++        text=True,
++    )
++    return result.stderr
++
++
++def test_ds4_launcher_auto_selects_flashinfer_ipc_for_tp2(tmp_path: Path) -> None:
++    """Verify that automatic selection uses FlashInfer IPC at TP2."""
++    output = _dry_run(tmp_path, TP="2")
++
++    assert "allreduce=flashinfer-ipc" in output
++
++
++def test_ds4_launcher_auto_keeps_b12x_for_tp4(tmp_path: Path) -> None:
++    """Verify that automatic selection retains B12X at TP4."""
++    output = _dry_run(tmp_path, TP="4")
++
++    assert "allreduce=b12x" in output
++
++
++def test_ds4_launcher_explicit_allreduce_overrides_auto(tmp_path: Path) -> None:
++    """Verify that an explicit all-reduce mode overrides automatic selection."""
++    output = _dry_run(tmp_path, TP="2", ALLREDUCE_MODE="b12x")
++
++    assert "allreduce=b12x" in output
+diff --git a/tests/entrypoints/test_ds4_flash_launcher.py b/tests/entrypoints/test_ds4_flash_launcher.py
+new file mode 100644
+index 0000000000000000000000000000000000000000..47bcf54a2fbd4a07aeb4c7abe28f5810b14d639a
+--- /dev/null
++++ b/tests/entrypoints/test_ds4_flash_launcher.py
+@@ -0,0 +1,279 @@
++# SPDX-License-Identifier: Apache-2.0
++# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
++
++import os
++import subprocess
++from pathlib import Path
++
++_REPO_ROOT = Path(__file__).parents[2]
++_LAUNCHER = _REPO_ROOT / "serve-ds4-flash.sh"
++
++
++def _dry_run(tmp_path: Path, **overrides: str) -> str:
++    """Run the DS4 launcher in dry-run mode.
++
++    Args:
++        tmp_path: Temporary home and cache root.
++        **overrides: Environment variables that override launcher defaults.
++
++    Returns:
++        The launcher's standard-error output.
++    """
++    env = {
++        "PATH": os.environ["PATH"],
++        "HOME": str(tmp_path),
++        "XDG_CACHE_HOME": str(tmp_path / "cache"),
++        "DRY_RUN": "1",
++        **overrides,
++    }
++    result = subprocess.run(
++        ["bash", str(_LAUNCHER)],
++        env=env,
++        check=True,
++        capture_output=True,
++        text=True,
++    )
++    return result.stderr
++
++
++def test_ds4_launcher_defaults_to_0731_fixed_k7(tmp_path: Path) -> None:
++    """Verify the default 0731 fixed-K7 launch profile.
++
++    Args:
++        tmp_path: Temporary home and cache root.
++    """
++    output = _dry_run(tmp_path)
++
++    assert "mode=dspark depth=fixed" in output
++    assert "model=deepseek-ai/DeepSeek-V4-Flash-0731" in output
++    assert "9e165c30e2704aec5d9d593cce3eebd58bbef1cb" in output
++    assert 'num_speculative_tokens\\":7' in output
++    assert "max_seqs=16 graph=128" in output
++    assert "--max-model-len 131072" in output
++    assert "--gpu-memory-utilization 0.975" in output
++
++
++def test_ds4_launcher_dynamic_depth_enables_capacity_mode(tmp_path: Path) -> None:
++    """Verify that dynamic depth selects variable-capacity verification.
++
++    Args:
++        tmp_path: Temporary home and cache root.
++    """
++    output = _dry_run(tmp_path, DSPARK_DEPTH_MODE="dynamic")
++
++    assert "mode=dspark depth=dynamic" in output
++    assert 'dspark_capacity_verification_mode\\":\\"varlen' in output
++    assert 'dspark_sps_curve\\":\\"auto' in output
++
++
++def test_ds4_launcher_uses_speculative_attention_backend_field(
++    tmp_path: Path,
++) -> None:
++    """Verify the draft backend uses SpeculativeConfig's canonical field.
++
++    Args:
++        tmp_path: Temporary home and cache root.
++    """
++    output = _dry_run(
++        tmp_path,
++        DSPARK_DRAFT_ATTENTION_BACKEND="FLASHINFER_MLA_SPARSE_DSV4",
++    )
++
++    assert 'attention_backend\\":\\"FLASHINFER_MLA_SPARSE_DSV4' in output
++    assert 'draft_attention_backend\\"' not in output
++
++
++def test_ds4_launcher_accepts_cluster_style_aliases(tmp_path: Path) -> None:
++    """Verify compatibility with cluster-style environment aliases.
++
++    Args:
++        tmp_path: Temporary home and cache root.
++    """
++    output = _dry_run(
++        tmp_path,
++        DCP="1",
++        NUM_SPECULATIVE_TOKENS="5",
++    )
++
++    assert "dcp=1" in output
++    assert 'num_speculative_tokens\\":5' in output
++
++
++def test_ds4_launcher_standard_mtp_uses_standard_checkpoint(tmp_path: Path) -> None:
++    """Verify that standard MTP selects the non-DSpark checkpoint.
++
++    Args:
++        tmp_path: Temporary home and cache root.
++    """
++    output = _dry_run(tmp_path, MODE="mtp2")
++
++    assert "mode=mtp2 depth=disabled" in output
++    assert "model=deepseek-ai/DeepSeek-V4-Flash" in output
++    assert "DeepSeek-V4-Flash-0731" not in output
++    assert 'method\\":\\"mtp' in output
++    assert 'num_speculative_tokens\\":2' in output
++
++
++def test_ds4_launcher_can_disable_dspark_on_0731(tmp_path: Path) -> None:
++    """Verify target-only serving with the 0731 checkpoint.
++
++    Args:
++        tmp_path: Temporary home and cache root.
++    """
++    output = _dry_run(tmp_path, MODE="dspark-mtp0")
++
++    assert "mode=dspark-mtp0 depth=disabled" in output
++    assert "model=deepseek-ai/DeepSeek-V4-Flash-0731" in output
++    assert "--speculative-config" not in output
++
++
++def test_ds4_launcher_enables_native_kv_offload(tmp_path: Path) -> None:
++    """Verify native host-memory KV offload arguments.
++
++    Args:
++        tmp_path: Temporary home and cache root.
++    """
++    output = _dry_run(tmp_path, KV_OFFLOADING_SIZE="5.5")
++
++    assert "--kv-offloading-size 5.5" in output
++    assert "--kv-offloading-backend native" in output
++    assert "allocator=expandable_segments:False" in output
++
++
++def test_ds4_launcher_builds_bounded_native_l2_config(tmp_path: Path) -> None:
++    """Verify bounded filesystem L2 configuration generation.
++
++    Args:
++        tmp_path: Temporary home and cache root.
++    """
++    output = _dry_run(
++        tmp_path,
++        KV_OFFLOADING_SIZE="32",
++        NATIVE_L2_PATH="/cache/native-l2",
++        NATIVE_L2_GB="128",
++    )
++
++    assert "native_l2=1" in output
++    assert "--kv-transfer-config" in output
++    assert "OffloadingConnector" in output
++    assert "TieringOffloadingSpec" in output
++    assert "cache/native-l2" in output
++    assert 'gc_max_size_gb\\":128.0' in output
++
++
++def test_ds4_launcher_native_l2_requires_l1(tmp_path: Path) -> None:
++    """Verify that filesystem L2 requires native host-memory L1.
++
++    Args:
++        tmp_path: Temporary home and cache root.
++    """
++    env = {
++        "PATH": os.environ["PATH"],
++        "HOME": str(tmp_path),
++        "XDG_CACHE_HOME": str(tmp_path / "cache"),
++        "DRY_RUN": "1",
++        "NATIVE_L2_PATH": "/cache/native-l2",
++        "NATIVE_L2_GB": "128",
++    }
++    result = subprocess.run(
++        ["bash", str(_LAUNCHER)],
++        env=env,
++        check=False,
++        capture_output=True,
++        text=True,
++    )
++
++    assert result.returncode == 2
++    assert "NATIVE_L2 requires a positive KV_OFFLOADING_SIZE" in result.stderr
++
++
++def test_ds4_launcher_native_l2_requires_complete_pair(tmp_path: Path) -> None:
++    """Verify that both filesystem L2 settings are required.
++
++    Args:
++        tmp_path: Temporary home and cache root.
++    """
++    env = {
++        "PATH": os.environ["PATH"],
++        "HOME": str(tmp_path),
++        "XDG_CACHE_HOME": str(tmp_path / "cache"),
++        "DRY_RUN": "1",
++        "KV_OFFLOADING_SIZE": "32",
++        "NATIVE_L2_PATH": "/cache/native-l2",
++    }
++    result = subprocess.run(
++        ["bash", str(_LAUNCHER)],
++        env=env,
++        check=False,
++        capture_output=True,
++        text=True,
++    )
++
++    assert result.returncode == 2
++    assert "NATIVE_L2_PATH and NATIVE_L2_GB must be set together" in result.stderr
++
++
++def test_ds4_launcher_native_offload_preserves_other_allocator_settings(
++    tmp_path: Path,
++) -> None:
++    """Verify allocator normalization preserves unrelated settings.
++
++    Args:
++        tmp_path: Temporary home and cache root.
++    """
++    output = _dry_run(
++        tmp_path,
++        KV_OFFLOADING_SIZE="5.5",
++        PYTORCH_CUDA_ALLOC_CONF=("max_split_size_mb:256,expandable_segments:True"),
++    )
++
++    assert "allocator=max_split_size_mb:256,expandable_segments:False" in output
++
++
++def test_ds4_launcher_without_offload_keeps_expandable_segments(
++    tmp_path: Path,
++) -> None:
++    """Verify the default allocator when native offload is disabled.
++
++    Args:
++        tmp_path: Temporary home and cache root.
++    """
++    output = _dry_run(tmp_path)
++
++    assert "allocator=expandable_segments:True" in output
++
++
++def test_ds4_launcher_zero_kv_offload_stays_disabled(tmp_path: Path) -> None:
++    """Verify that a zero offload size does not enable native offload.
++
++    Args:
++        tmp_path: Temporary home and cache root.
++    """
++    output = _dry_run(tmp_path, KV_OFFLOADING_SIZE="0.0")
++
++    assert "--kv-offloading-size" not in output
++
++
++def test_ds4_launcher_rejects_invalid_kv_offload_size(tmp_path: Path) -> None:
++    """Verify rejection of a nonnumeric native-offload size.
++
++    Args:
++        tmp_path: Temporary home and cache root.
++    """
++    env = {
++        "PATH": os.environ["PATH"],
++        "HOME": str(tmp_path),
++        "XDG_CACHE_HOME": str(tmp_path / "cache"),
++        "DRY_RUN": "1",
++        "KV_OFFLOADING_SIZE": "five",
++    }
++    result = subprocess.run(
++        ["bash", str(_LAUNCHER)],
++        env=env,
++        check=False,
++        capture_output=True,
++        text=True,
++    )
++
++    assert result.returncode == 2
++    assert "KV_OFFLOADING_SIZE must be a non-negative GiB value" in result.stderr
+diff --git a/tests/entrypoints/unit_tests/test_chat_utils.py b/tests/entrypoints/unit_tests/test_chat_utils.py
+index 82b262321d6c12f06296a2d36b593622fd456a86..a923256daf3a63aced57f6c0ba6ea715253ab028 100644
+--- a/tests/entrypoints/unit_tests/test_chat_utils.py
++++ b/tests/entrypoints/unit_tests/test_chat_utils.py
+@@ -708,6 +708,30 @@ def test_parse_chat_messages_empty_system(
+     ]
+ 
+ 
++@pytest.mark.parametrize("role", ["system", "developer"])
++def test_parse_chat_messages_preserves_message_level_tools(
++    mistral_model_config,
++    role,
++):
++    # Message-level `tools` (as opposed to the request-level `tools`
++    # parameter) must be preserved on both "system" and "developer" role
++    # messages: chat template/encoders such as DeepSeek-V4 and DeepSeek-V3.2
++    # read message-level tools for either role.
++    tools = [{"type": "function", "function": {"name": "get_weather"}}]
++    conversation, _, _ = parse_chat_messages(
++        [
++            {"role": role, "content": "you have tools", "tools": tools},
++            {
++                "role": "user",
++                "content": [{"type": "text", "text": "Hi"}],
++            },
++        ],
++        mistral_model_config,
++        content_format="string",
++    )
++    assert conversation[0]["tools"] == tools
++
++
+ @pytest.mark.asyncio
+ async def test_parse_chat_messages_single_image_async(
+     phi3v_model_config,
+diff --git a/tests/kernels/attention/test_mla_kv_b_dtype_guard.py b/tests/kernels/attention/test_mla_kv_b_dtype_guard.py
+new file mode 100644
+index 0000000000000000000000000000000000000000..6497e1f6d0277ae05366ab28319b8c58abda64e6
+--- /dev/null
++++ b/tests/kernels/attention/test_mla_kv_b_dtype_guard.py
+@@ -0,0 +1,29 @@
++# SPDX-License-Identifier: Apache-2.0
++# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
++"""Packed-quantized kv_b_proj weights must not drive a kv_c_normed upcast.
++
++NVFP4 packs into uint8 and compressed-tensors int4/int8 packs into int32.
++Both are containers, not real activation dtypes -- casting kv_c_normed to
++either corrupts chunked prefill past ~4K prompts.
++"""
++
++import pytest
++import torch
++
++from vllm.model_executor.layers.attention.mla_attention import (
++    is_packed_quantized_dtype,
++)
++
++
++@pytest.mark.parametrize(
++    "dtype,expected",
++    [
++        (torch.uint8, True),  # NVFP4
++        (torch.int32, True),  # compressed-tensors int4/int8
++        (torch.bfloat16, False),
++        (torch.float16, False),
++        (torch.float8_e4m3fn, False),
++    ],
++)
++def test_is_packed_quantized_dtype(dtype: torch.dtype, expected: bool):
++    assert is_packed_quantized_dtype(dtype) is expected
+diff --git a/tests/kernels/quantization/test_fp8_quant_group.py b/tests/kernels/quantization/test_fp8_quant_group.py
+index 113afb3c102e666be53e50fc1c0c56f88d8fe2ce..39ddea5269269482a0d0e2b013b28b65a7dcf48b 100644
+--- a/tests/kernels/quantization/test_fp8_quant_group.py
++++ b/tests/kernels/quantization/test_fp8_quant_group.py
+@@ -7,6 +7,11 @@ import torch
+ 
+ from vllm.model_executor.layers.quantization.input_quant_fp8 import QuantFP8
+ from vllm.model_executor.layers.quantization.utils.quant_utils import GroupShape
++from vllm.utils.deep_gemm import (
++    DeepGemmQuantScaleFMT,
++    get_tma_aligned_size,
++    is_deep_gemm_supported,
++)
+ from vllm.utils.torch_utils import set_random_seed
+ 
+ 
+@@ -140,6 +145,70 @@ def test_quantfp8_group_multidimensional(
+     assert scales_4d_col.shape == (batch1, batch2, hidden_dim // group_size, batch3)
+ 
+ 
++@pytest.mark.parametrize("batch_size", [16, 17])
++@pytest.mark.parametrize("seed", [42])
++@torch.inference_mode()
++def test_quantfp8_group_packed_ue8m0_native_matches_cuda(
++    default_vllm_config, batch_size: int, seed: int
++) -> None:
++    """forward_native must emit the same scale FORMAT as forward_cuda.
++
++    When the DeepGEMM oracle selects packed UE8M0, scales are four biased e8m0
++    exponent bytes per int32 in a TMA-aligned buffer -- not float32. Since
++    CustomOp.default_on() is False under inductor, forward_native is what a
++    compiled run executes, so a float32 fallback there hands DeepGEMM the wrong
++    format with no error raised.
++
++    batch_size 17 is deliberate: it is not TMA-aligned, so it catches a layout
++    that only holds when mn happens to be a multiple of four.
++    """
++    if not is_deep_gemm_supported():
++        pytest.skip("DeepGEMM not supported on this platform")
++    try:
++        wants_packed = (
++            DeepGemmQuantScaleFMT.from_oracle() == DeepGemmQuantScaleFMT.UE8M0
++        )
++    except AssertionError:
++        pytest.skip("DeepGEMM scale-format oracle not initialized")
++    if not wants_packed:
++        pytest.skip("Oracle does not select packed UE8M0 on this platform")
++
++    set_random_seed(seed)
++
++    hidden_dim, group_size = 1024, 128
++    x = torch.randn((batch_size, hidden_dim), dtype=torch.bfloat16, device="cuda") * 8
++
++    quant_op = QuantFP8(
++        static=False,
++        group_shape=GroupShape(1, group_size),
++        column_major_scales=False,
++        use_ue8m0=True,
++    )
++
++    x_q_native, scales_native = quant_op.forward_native(x.clone())
++    x_q_cuda, scales_cuda = quant_op.forward_cuda(x.clone())
++
++    # Format, not just values: a float32 fallback fails on dtype alone.
++    assert scales_native.dtype == torch.int32
++    assert scales_native.dtype == scales_cuda.dtype
++    assert scales_native.shape == scales_cuda.shape
++    assert scales_native.stride() == scales_cuda.stride()
++
++    # DeepGEMM's layout contract, asserted directly so a refactor that keeps the
++    # values but loses the strides still fails here.
++    assert scales_native.size(-2) == batch_size
++    assert scales_native.stride(-2) == 1
++    assert scales_native.stride(-1) == get_tma_aligned_size(
++        batch_size, scales_native.element_size()
++    )
++
++    # Packed exponent bytes are integers, so they must match exactly.
++    torch.testing.assert_close(scales_native, scales_cuda, rtol=0, atol=0)
++
++    diff_ratio = (x_q_cuda != x_q_native).sum().item() / x_q_cuda.numel()
++    assert diff_ratio < 0.002, f"Too many differences: {diff_ratio:.4%}"
++
++
+ @pytest.mark.parametrize("seed", [42])
+ @torch.inference_mode()
+ def test_quantfp8_group_edge_cases(default_vllm_config, seed: int) -> None:
+diff --git a/tests/kernels/test_compressor_kv_cache.py b/tests/kernels/test_compressor_kv_cache.py
+index b8f1cb8bfa7311ce4de851088d2fbc5534488630..63607455371401445ce46697474b9315e4ee2f1b 100644
+--- a/tests/kernels/test_compressor_kv_cache.py
++++ b/tests/kernels/test_compressor_kv_cache.py
+@@ -21,6 +21,7 @@ from vllm import _custom_ops as ops
+ from vllm.models.deepseek_v4.common.ops import (
+     dequantize_and_gather_k_cache,
+     quantize_and_insert_k_cache,
++    save_partial_states,
+ )
+ from vllm.models.deepseek_v4.common.ops.fused_compress_quant_cache import (
+     _fused_kv_compress_norm_rope_insert_indexer_attn,
+@@ -61,6 +62,77 @@ def _ue8m0_reference(x: torch.Tensor, block_size: int, fp8_max: float):
+ # ── Test A: DeepseekV4 Attention path ──────────────────────────────────────────────
+ 
+ 
++@pytest.mark.parametrize("draft_tokens", [5, 7])
++def test_save_partial_states_writes_every_verifier_row(draft_tokens: int) -> None:
++    """The compressor state write covers all target rows for each request."""
++    device = "cuda"
++    verifier_width = draft_tokens + 1
++    num_reqs = 2
++    num_actual = num_reqs * verifier_width
++    head_size = 16
++    block_size = 16
++    compress_ratio = 4
++
++    kv = (
++        torch.arange(
++            (num_actual + 1) * head_size,
++            dtype=torch.float32,
++            device=device,
++        )
++        .view(num_actual + 1, head_size)
++        .to(torch.bfloat16)
++    )
++    score = (kv + 1000).to(torch.bfloat16)
++    ape = (
++        torch.arange(
++            compress_ratio * head_size,
++            dtype=torch.float32,
++            device=device,
++        )
++        .view(compress_ratio, head_size)
++        .to(torch.bfloat16)
++    )
++    positions = torch.arange(num_actual + 1, dtype=torch.int64, device=device)
++    slot_mapping = torch.cat(
++        (
++            torch.arange(verifier_width, dtype=torch.int64, device=device),
++            torch.arange(
++                block_size,
++                block_size + verifier_width,
++                dtype=torch.int64,
++                device=device,
++            ),
++            torch.tensor([-1], dtype=torch.int64, device=device),
++        )
++    )
++    state_cache = torch.full(
++        (2, block_size, 2 * head_size),
++        fill_value=-1,
++        dtype=torch.bfloat16,
++        device=device,
++    )
++
++    save_partial_states(
++        kv=kv,
++        score=score,
++        ape=ape,
++        positions=positions,
++        state_cache=state_cache,
++        slot_mapping=slot_mapping,
++        block_size=block_size,
++        state_width=head_size,
++        compress_ratio=compress_ratio,
++    )
++    torch.cuda.synchronize()
++
++    actual_slots = slot_mapping[:num_actual]
++    actual = state_cache.view(-1, 2 * head_size)[actual_slots]
++    torch.testing.assert_close(actual[:, :head_size], kv[:num_actual])
++    expected_score = score[:num_actual] + ape[positions[:num_actual] % compress_ratio]
++    torch.testing.assert_close(actual[:, head_size:], expected_score)
++    assert torch.all(state_cache.view(-1, 2 * head_size)[verifier_width] == -1)
++
++
+ @pytest.mark.parametrize("num_tokens", [1, 4, 8, 17])
+ @pytest.mark.parametrize("block_size", [16, 64])
+ def test_deepseek_v4_attention_quant_cache_roundtrip(num_tokens: int, block_size: int):
+diff --git a/tests/kernels/test_mhc_broadcast_compile.py b/tests/kernels/test_mhc_broadcast_compile.py
+new file mode 100644
+index 0000000000000000000000000000000000000000..101c3d50dbde933305e9824447baa6aea23e1fe8
+--- /dev/null
++++ b/tests/kernels/test_mhc_broadcast_compile.py
+@@ -0,0 +1,74 @@
++# SPDX-License-Identifier: Apache-2.0
++# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
++import torch
++
++from vllm.model_executor.kernels.mhc.tilelang import mhc_pre_broadcast_tilelang
++
++
++def _inputs(device: str = "meta") -> tuple[torch.Tensor, ...]:
++    num_tokens = 6
++    hidden_size = 128
++    hc_mult = 4
++    hc_mult3 = 2 * hc_mult + hc_mult * hc_mult
++    return (
++        torch.empty(num_tokens, hidden_size, dtype=torch.bfloat16, device=device),
++        torch.empty(
++            hc_mult3,
++            hc_mult * hidden_size,
++            dtype=torch.float32,
++            device=device,
++        ),
++        torch.empty(3, dtype=torch.float32, device=device),
++        torch.empty(hc_mult3, dtype=torch.float32, device=device),
++        torch.empty(hidden_size, dtype=torch.bfloat16, device=device),
++        torch.empty(
++            hc_mult3,
++            hidden_size,
++            dtype=torch.float32,
++            device=device,
++        ),
++    )
++
++
++def _run_broadcast_mhc(
++    residual: torch.Tensor,
++    fn: torch.Tensor,
++    hc_scale: torch.Tensor,
++    hc_base: torch.Tensor,
++    norm_weight: torch.Tensor,
++    fn_broadcast: torch.Tensor,
++) -> tuple[torch.Tensor, ...]:
++    return mhc_pre_broadcast_tilelang(
++        residual,
++        fn,
++        hc_scale,
++        hc_base,
++        1e-6,
++        1e-6,
++        1e-6,
++        2.0,
++        20,
++        norm_weight=norm_weight,
++        fn_broadcast=fn_broadcast,
++    )
++
++
++def _assert_output_contract(outputs: tuple[torch.Tensor, ...]) -> None:
++    residual, post_mix, res_mix, layer_input = outputs
++    assert residual.shape == (6, 4, 128)
++    assert residual.dtype == torch.bfloat16
++    assert post_mix.shape == (6, 4, 1)
++    assert post_mix.dtype == torch.float32
++    assert res_mix.shape == (6, 4, 4)
++    assert res_mix.dtype == torch.float32
++    assert layer_input.shape == (6, 128)
++    assert layer_input.dtype == torch.bfloat16
++
++
++def test_mhc_pre_broadcast_fake_output_contract() -> None:
++    _assert_output_contract(_run_broadcast_mhc(*_inputs()))
++
++
++def test_mhc_pre_broadcast_is_fullgraph_compile_boundary() -> None:
++    compiled = torch.compile(_run_broadcast_mhc, backend="eager", fullgraph=True)
++    _assert_output_contract(compiled(*_inputs()))
+diff --git a/tests/model_executor/test_flashinfer_autotune_cache.py b/tests/model_executor/test_flashinfer_autotune_cache.py
+index 65b8e8f55d2da000353a80317babdf02885096ac..dc0bf6a13e9b9ca71a332efe8d73e7f39e16ff9e 100644
+--- a/tests/model_executor/test_flashinfer_autotune_cache.py
++++ b/tests/model_executor/test_flashinfer_autotune_cache.py
+@@ -128,6 +128,53 @@ def _patch_flashinfer_autotune_deps(monkeypatch):
+     return calls
+ 
+ 
++def test_flashinfer_autotune_dummy_run_skips_pre_kv_v2_attention() -> None:
++    runner = SimpleNamespace(
++        scheduler_config=SimpleNamespace(max_num_batched_tokens=8192),
++        vllm_config=SimpleNamespace(use_v2_model_runner=True),
++    )
++
++    kwargs = kernel_warmup._flashinfer_autotune_dummy_run_kwargs(runner)
++
++    assert kwargs == {
++        "num_tokens": 8192,
++        "skip_eplb": True,
++        "is_profile": True,
++        "skip_attn": True,
++    }
++
++
++def test_flashinfer_autotune_dummy_run_keeps_attention_after_kv_init() -> None:
++    runner = SimpleNamespace(
++        scheduler_config=SimpleNamespace(max_num_batched_tokens=8192),
++        vllm_config=SimpleNamespace(use_v2_model_runner=True),
++        block_tables=object(),
++    )
++
++    kwargs = kernel_warmup._flashinfer_autotune_dummy_run_kwargs(runner)
++
++    assert kwargs == {
++        "num_tokens": 8192,
++        "skip_eplb": True,
++        "is_profile": True,
++    }
++
++
++def test_flashinfer_autotune_dummy_run_keeps_v1_signature() -> None:
++    runner = SimpleNamespace(
++        scheduler_config=SimpleNamespace(max_num_batched_tokens=8192),
++        vllm_config=SimpleNamespace(use_v2_model_runner=False),
++    )
++
++    kwargs = kernel_warmup._flashinfer_autotune_dummy_run_kwargs(runner)
++
++    assert kwargs == {
++        "num_tokens": 8192,
++        "skip_eplb": True,
++        "is_profile": True,
++    }
++
++
+ def test_b12x_dcp_warmup_finds_generic_mla_attention(monkeypatch) -> None:
+     from vllm.distributed import parallel_state
+     from vllm.model_executor.layers.attention.mla_attention import MLAAttention
+diff --git a/tests/models/deepseek_v4/test_b12x_cache_page_view.py b/tests/models/deepseek_v4/test_b12x_cache_page_view.py
+new file mode 100644
+index 0000000000000000000000000000000000000000..2a626dc73d673f4b3b70ddce3f3aae28d9e40f26
+--- /dev/null
++++ b/tests/models/deepseek_v4/test_b12x_cache_page_view.py
+@@ -0,0 +1,70 @@
++# SPDX-License-Identifier: Apache-2.0
++# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
++
++import pytest
++import torch
++
++from vllm.models.deepseek_v4.nvidia.b12x import _b12x_cache_page_view
++
++_PAGE_SIZE = 64
++_PAYLOAD_BYTES = _PAGE_SIZE * 584
++_PADDED_PAGE_BYTES = 37_440
++
++
++def test_b12x_cache_page_view_accepts_contiguous_payload_pages() -> None:
++    cache = torch.empty((3, _PAGE_SIZE, 584), dtype=torch.uint8)
++
++    view = _b12x_cache_page_view(cache, _PAGE_SIZE, "cache")
++
++    assert view.shape == (3, _PAYLOAD_BYTES)
++    assert view.stride() == (_PAYLOAD_BYTES, 1)
++
++
++def test_b12x_cache_page_view_preserves_padded_physical_stride() -> None:
++    storage = torch.empty(3 * _PADDED_PAGE_BYTES, dtype=torch.uint8)
++    cache = torch.as_strided(
++        storage,
++        size=(3, _PAGE_SIZE, 584),
++        stride=(_PADDED_PAGE_BYTES, 584, 1),
++    )
++
++    view = _b12x_cache_page_view(cache, _PAGE_SIZE, "cache")
++
++    assert view.shape == (3, _PAYLOAD_BYTES)
++    assert view.stride() == (_PADDED_PAGE_BYTES, 1)
++
++
++def test_b12x_cache_page_view_rejects_short_physical_stride() -> None:
++    storage = torch.empty(2 * _PAYLOAD_BYTES, dtype=torch.uint8)
++    cache = torch.as_strided(
++        storage,
++        size=(2, _PAGE_SIZE, 584),
++        stride=(_PAYLOAD_BYTES - 1, 584, 1),
++    )
++
++    with pytest.raises(RuntimeError, match=r"page stride .* is smaller"):
++        _b12x_cache_page_view(cache, _PAGE_SIZE, "cache")
++
++
++def test_b12x_cache_page_view_rejects_overlapping_2d_pages() -> None:
++    storage = torch.empty(2 * _PAYLOAD_BYTES, dtype=torch.uint8)
++    cache = torch.as_strided(
++        storage,
++        size=(2, _PAYLOAD_BYTES),
++        stride=(_PAYLOAD_BYTES - 1, 1),
++    )
++
++    with pytest.raises(RuntimeError, match=r"page stride .* is smaller"):
++        _b12x_cache_page_view(cache, _PAGE_SIZE, "cache")
++
++
++def test_b12x_cache_page_view_rejects_gapped_page_payload() -> None:
++    storage = torch.empty(2 * _PAYLOAD_BYTES + _PAGE_SIZE, dtype=torch.uint8)
++    cache = torch.as_strided(
++        storage,
++        size=(2, _PAGE_SIZE, 584),
++        stride=(_PAYLOAD_BYTES, 585, 1),
++    )
++
++    with pytest.raises(RuntimeError, match=r"page payload must be contiguous"):
++        _b12x_cache_page_view(cache, _PAGE_SIZE, "cache")
+diff --git a/tests/models/deepseek_v4/test_b12x_compressed_mla_workspace.py b/tests/models/deepseek_v4/test_b12x_compressed_mla_workspace.py
+new file mode 100644
+index 0000000000000000000000000000000000000000..f570a5c89a90aed3c3a0aa4935ea2aae4772fcf6
+--- /dev/null
++++ b/tests/models/deepseek_v4/test_b12x_compressed_mla_workspace.py
+@@ -0,0 +1,511 @@
++# SPDX-License-Identifier: Apache-2.0
++# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
++
++import math
++import sys
++import types
++from types import SimpleNamespace
++
++import pytest
++import torch
++
++from vllm.models.deepseek_v4 import compressor as compressor_mod
++from vllm.models.deepseek_v4.nvidia import b12x as b12x_mod
++from vllm.utils.math_utils import round_up
++from vllm.v1.attention.backend import CommonAttentionMetadata
++from vllm.v1.attention.backends.mla.compressor_utils import (
++    get_c128a_topk_width,
++    get_compressed_mla_max_q_chunks,
++    get_compressed_mla_split_cap,
++    get_dspark_swa_index_width,
++)
++
++_MAX_ROWS = 2048
++_LOCAL_HEADS = 32
++_PAGE_SIZE = 64
++_WINDOW_SIZE = 128
++_INDEX_TOPK = 2048
++
++
++class _RecordingWorkspaceManager:
++    def __init__(self) -> None:
++        self.specs: tuple[tuple[tuple[int, ...], torch.dtype], ...] | None = None
++
++    def get_simultaneous(
++        self, *specs: tuple[tuple[int, ...], torch.dtype]
++    ) -> list[torch.Tensor]:
++        self.specs = specs
++        return []
++
++
++def _install_recording_b12x(monkeypatch, caps_calls: list[SimpleNamespace]):
++    b12x = types.ModuleType("b12x")
++    b12x.__path__ = []
++    attention = types.ModuleType("b12x.attention")
++    attention.__path__ = []
++    compressed_mla = types.ModuleType("b12x.attention.compressed_mla")
++
++    def caps(**kwargs) -> SimpleNamespace:
++        return SimpleNamespace(**kwargs)
++
++    def plan(caps_value):
++        caps_calls.append(caps_value)
++        return SimpleNamespace(
++            shapes_and_dtypes=lambda: (((1,), torch.uint8),),
++        )
++
++    def split_chunks_for_contract(
++        *,
++        rows: int,
++        width: int,
++        max_chunks: int,
++        decode_row_capacity: int | None = None,
++    ) -> int:
++        del width
++        decode_split_max_rows = max(256, int(decode_row_capacity or 0))
++        return min(max_chunks, 8 if rows <= decode_split_max_rows else 1)
++
++    compressed_mla.Caps = caps  # type: ignore[attr-defined]
++    compressed_mla.plan = plan  # type: ignore[attr-defined]
++    compressed_mla.split_chunks_for_contract = (  # type: ignore[attr-defined]
++        split_chunks_for_contract
++    )
++    monkeypatch.setitem(sys.modules, "b12x", b12x)
++    monkeypatch.setitem(sys.modules, "b12x.attention", attention)
++    monkeypatch.setitem(
++        sys.modules,
++        "b12x.attention.compressed_mla",
++        compressed_mla,
++    )
++    return split_chunks_for_contract
++
++
++def _make_layer(
++    *,
++    compress_ratio: int,
++    dspark: bool,
++    dcp_world_size: int = 1,
++    max_num_batched_tokens: int = _MAX_ROWS,
++    max_num_seqs: int = 64,
++):
++    layer = object.__new__(b12x_mod.DeepseekV4B12xMLAAttention)
++    torch.nn.Module.__init__(layer)
++    layer.compress_ratio = compress_ratio
++    layer.topk_indices_buffer = (
++        torch.empty((1, _INDEX_TOPK), dtype=torch.int32)
++        if compress_ratio == 4
++        else None
++    )
++    layer.indexer = None
++    layer.max_model_len = 524288
++    layer.window_size = _WINDOW_SIZE
++    layer.max_num_batched_tokens = max_num_batched_tokens
++    layer.swa_cache_layer = SimpleNamespace(block_size=_PAGE_SIZE)
++    speculative_config = (
++        SimpleNamespace(
++            use_dspark=lambda: True,
++            num_speculative_tokens=5,
++        )
++        if dspark
++        else None
++    )
++    layer.vllm_config = SimpleNamespace(
++        speculative_config=speculative_config,
++        scheduler_config=SimpleNamespace(
++            max_num_seqs=max_num_seqs,
++            max_num_batched_tokens=max_num_batched_tokens,
++        ),
++        parallel_config=SimpleNamespace(
++            decode_context_parallel_size=dcp_world_size,
++        ),
++    )
++    return layer
++
++
++@pytest.mark.parametrize(
++    ("compress_ratio", "dspark", "expected_width"),
++    [
++        pytest.param(1, False, 128, id="swa-causal"),
++        pytest.param(1, True, 512, id="swa-dspark"),
++        pytest.param(4, False, 2176, id="c4-causal"),
++        pytest.param(4, True, 2560, id="c4-dspark"),
++        pytest.param(128, False, 4224, id="c128-causal"),
++        pytest.param(128, True, 4608, id="c128-dspark"),
++    ],
++)
++def test_reserve_uses_full_runtime_width(
++    monkeypatch,
++    compress_ratio: int,
++    dspark: bool,
++    expected_width: int,
++) -> None:
++    caps_calls: list[SimpleNamespace] = []
++    split_chunks = _install_recording_b12x(monkeypatch, caps_calls)
++    workspace = _RecordingWorkspaceManager()
++    monkeypatch.setattr(b12x_mod, "current_workspace_manager", lambda: workspace)
++    layer = _make_layer(compress_ratio=compress_ratio, dspark=dspark)
++
++    layer._reserve_dummy_compressed_mla_scratch(
++        torch.empty((1, _LOCAL_HEADS, 512), dtype=torch.bfloat16)
++    )
++
++    caps = caps_calls[-1]
++    split_cap = get_compressed_mla_split_cap(expected_width)
++    decode_row_capacity = 64 * (1 + 5) if dspark else None
++    assert caps.max_width == expected_width
++    assert caps.max_q_rows == _MAX_ROWS
++    assert caps.decode_row_capacity == decode_row_capacity
++    assert caps.max_q_chunks == get_compressed_mla_max_q_chunks(
++        _MAX_ROWS,
++        expected_width,
++        split_cap,
++        split_chunks,
++        decode_row_capacity=decode_row_capacity,
++    )
++    assert workspace.specs is not None
++
++
++def test_reserve_uses_dcp_gathered_heads(monkeypatch) -> None:
++    caps_calls: list[SimpleNamespace] = []
++    _install_recording_b12x(monkeypatch, caps_calls)
++    monkeypatch.setattr(
++        b12x_mod,
++        "current_workspace_manager",
++        lambda: _RecordingWorkspaceManager(),
++    )
++    layer = _make_layer(compress_ratio=128, dspark=False, dcp_world_size=2)
++
++    layer._reserve_dummy_compressed_mla_scratch(
++        torch.empty((1, _LOCAL_HEADS, 512), dtype=torch.bfloat16)
++    )
++
++    assert caps_calls[-1].num_q_heads == _LOCAL_HEADS * 2
++
++
++def test_workspace_width_helpers_match_reporter_geometry() -> None:
++    assert get_c128a_topk_width(524288, 128) == 4096
++    assert get_dspark_swa_index_width(128, 5) == 512
++    assert get_dspark_swa_index_width(512, 5) == 1024
++
++
++@pytest.mark.parametrize(
++    ("max_num_seqs", "num_speculative_tokens", "expected"),
++    [
++        pytest.param(24, 5, 144, id="mns24-k5"),
++        pytest.param(64, 5, 384, id="mns64-k5"),
++        pytest.param(128, 5, 768, id="mns128-k5"),
++        pytest.param(64, 7, 512, id="mns64-k7"),
++    ],
++)
++def test_dspark_decode_row_capacity_comes_from_scheduler_contract(
++    max_num_seqs: int,
++    num_speculative_tokens: int,
++    expected: int,
++) -> None:
++    vllm_config = SimpleNamespace(
++        speculative_config=SimpleNamespace(
++            use_dspark=lambda: True,
++            num_speculative_tokens=num_speculative_tokens,
++        ),
++        scheduler_config=SimpleNamespace(
++            max_num_seqs=max_num_seqs,
++            max_num_batched_tokens=8192,
++        ),
++    )
++    assert b12x_mod._get_dspark_decode_row_capacity(vllm_config) == expected
++
++
++def test_non_dspark_has_no_declared_decode_row_capacity() -> None:
++    vllm_config = SimpleNamespace(
++        speculative_config=SimpleNamespace(use_dspark=lambda: False),
++        scheduler_config=SimpleNamespace(
++            max_num_seqs=128,
++            max_num_batched_tokens=8192,
++        ),
++    )
++    assert b12x_mod._get_dspark_decode_row_capacity(vllm_config) is None
++
++
++def test_dspark_decode_row_capacity_fails_closed() -> None:
++    b12x_mod._validate_compressed_mla_decode_row_capacity(
++        rows=384,
++        mode="decode",
++        decode_row_capacity=384,
++    )
++    b12x_mod._validate_compressed_mla_decode_row_capacity(
++        rows=8192,
++        mode="extend",
++        decode_row_capacity=384,
++    )
++    with pytest.raises(ValueError, match="rows 385 exceed.*capacity 384"):
++        b12x_mod._validate_compressed_mla_decode_row_capacity(
++            rows=385,
++            mode="decode",
++            decode_row_capacity=384,
++        )
++
++
++@pytest.mark.parametrize("draft_tokens", [5, 7])
++def test_compressor_metadata_keeps_every_verifier_row(
++    monkeypatch,
++    draft_tokens: int,
++) -> None:
++    verifier_width = draft_tokens + 1
++    num_reqs = 2
++    num_tokens = num_reqs * verifier_width
++    builder = object.__new__(compressor_mod.CompressorMetadataBuilder)
++    builder.block_size = 16
++    builder.token_to_req_indices = torch.empty(num_tokens, dtype=torch.int32)
++    common = CommonAttentionMetadata(
++        query_start_loc=torch.tensor(
++            [0, verifier_width, num_tokens], dtype=torch.int32
++        ),
++        query_start_loc_cpu=torch.tensor(
++            [0, verifier_width, num_tokens], dtype=torch.int32
++        ),
++        seq_lens=torch.tensor([100, 200], dtype=torch.int32),
++        num_reqs=num_reqs,
++        num_actual_tokens=num_tokens,
++        max_query_len=verifier_width,
++        max_seq_len=200,
++        block_table_tensor=torch.zeros((num_reqs, 1), dtype=torch.int32),
++        slot_mapping=torch.arange(num_tokens, dtype=torch.int64),
++        causal=False,
++    )
++    monkeypatch.setattr(compressor_mod, "_prefer_two_stage_compressor", lambda: False)
++
++    metadata = builder.build(0, common)
++
++    assert metadata.slot_mapping.shape == (num_tokens,)
++    assert metadata.token_to_req_indices is not None
++    torch.testing.assert_close(
++        metadata.token_to_req_indices,
++        torch.repeat_interleave(
++            torch.arange(num_reqs, dtype=torch.int32),
++            verifier_width,
++        ),
++    )
++
++
++def test_q_chunk_envelope_is_cached() -> None:
++    call_count = 0
++
++    def split_chunks_for_contract(**kwargs) -> int:
++        nonlocal call_count
++        call_count += 1
++        return min(kwargs["max_chunks"], 8 if kwargs["rows"] <= 256 else 1)
++
++    get_compressed_mla_max_q_chunks.cache_clear()
++    split_cap = get_compressed_mla_split_cap(4608)
++    for _ in range(2):
++        assert (
++            get_compressed_mla_max_q_chunks(
++                _MAX_ROWS,
++                4608,
++                split_cap,
++                split_chunks_for_contract,
++            )
++            == _MAX_ROWS
++        )
++    assert call_count == _MAX_ROWS
++
++
++def test_production_q_chunk_envelope_only_reserves_declared_capacity() -> None:
++    def split_chunks_for_contract(
++        *,
++        rows: int,
++        width: int,
++        max_chunks: int,
++        decode_row_capacity: int | None = None,
++    ) -> int:
++        decode_split_max_rows = max(256, int(decode_row_capacity or 0))
++        chunk_size = 64 if rows <= decode_split_max_rows else 1024
++        return min(max_chunks, math.ceil(width / chunk_size))
++
++    max_rows = 8192
++    width = 4608
++    split_cap = get_compressed_mla_split_cap(width)
++    get_compressed_mla_max_q_chunks.cache_clear()
++
++    legacy = get_compressed_mla_max_q_chunks(
++        max_rows,
++        width,
++        split_cap,
++        split_chunks_for_contract,
++    )
++    mns24 = get_compressed_mla_max_q_chunks(
++        max_rows,
++        width,
++        split_cap,
++        split_chunks_for_contract,
++        decode_row_capacity=144,
++    )
++    mns64 = get_compressed_mla_max_q_chunks(
++        max_rows,
++        width,
++        split_cap,
++        split_chunks_for_contract,
++        decode_row_capacity=384,
++    )
++    mns128 = get_compressed_mla_max_q_chunks(
++        max_rows,
++        width,
++        split_cap,
++        split_chunks_for_contract,
++        decode_row_capacity=768,
++    )
++
++    assert legacy == 40960
++    assert mns24 == legacy
++    assert mns64 == legacy
++    assert mns128 == 55296
++
++
++def _aligned_nbytes(
++    specs: tuple[tuple[tuple[int, ...], torch.dtype], ...],
++) -> int:
++    return sum(
++        round_up(math.prod(shape) * dtype.itemsize, 256) for shape, dtype in specs
++    )
++
++
++def _runtime_plan_nbytes(compressed_mla, *, rows: int, width: int, heads: int) -> int:
++    split_cap = get_compressed_mla_split_cap(width)
++    splits = compressed_mla.split_chunks_for_contract(
++        rows=rows,
++        width=width,
++        max_chunks=split_cap,
++    )
++    runtime_plan = compressed_mla.plan(
++        compressed_mla.Caps(
++            device="cpu",
++            num_q_heads=heads,
++            max_q_rows=rows,
++            max_width=width,
++            head_dim=512,
++            v_head_dim=512,
++            page_size=_PAGE_SIZE,
++            max_chunks_per_row=splits,
++        )
++    )
++    return _aligned_nbytes(runtime_plan.shapes_and_dtypes())
++
++
++@pytest.mark.parametrize(
++    (
++        "compress_ratio",
++        "dspark",
++        "dcp_world_size",
++        "runtime_widths",
++        "expected_reserve_mib",
++    ),
++    [
++        pytest.param(1, False, 1, (128,), 64.502929688, id="swa-causal"),
++        pytest.param(1, True, 1, (128, 512), 96.627929688, id="swa-dspark"),
++        pytest.param(4, False, 1, (2176,), 273.315429688, id="c4-causal"),
++        pytest.param(
++            4,
++            True,
++            1,
++            (2176, 2560),
++            482.127929688,
++            id="c4-dspark",
++        ),
++        pytest.param(128, False, 1, (4224,), 530.315429688, id="c128-causal"),
++        pytest.param(
++            128,
++            True,
++            1,
++            (4224, 4608),
++            867.627929688,
++            id="c128-dspark",
++        ),
++        pytest.param(128, False, 2, (4224,), 1060.627929688, id="c128-dcp2"),
++    ],
++)
++def test_real_b12x_reserve_dominates_runtime_envelope(
++    monkeypatch,
++    compress_ratio: int,
++    dspark: bool,
++    dcp_world_size: int,
++    runtime_widths: tuple[int, ...],
++    expected_reserve_mib: float,
++) -> None:
++    compressed_mla = pytest.importorskip("b12x.attention.compressed_mla")
++    workspace = _RecordingWorkspaceManager()
++    monkeypatch.setattr(b12x_mod, "current_workspace_manager", lambda: workspace)
++    layer = _make_layer(
++        compress_ratio=compress_ratio,
++        dspark=dspark,
++        dcp_world_size=dcp_world_size,
++    )
++
++    layer._reserve_dummy_compressed_mla_scratch(
++        torch.empty((1, _LOCAL_HEADS, 512), dtype=torch.bfloat16)
++    )
++
++    assert workspace.specs is not None
++    reserve_bytes = _aligned_nbytes(workspace.specs)
++    assert reserve_bytes / (1 << 20) == pytest.approx(expected_reserve_mib)
++    runtime_heads = _LOCAL_HEADS * dcp_world_size
++    runtime_bytes = max(
++        _runtime_plan_nbytes(
++            compressed_mla,
++            rows=rows,
++            width=runtime_width,
++            heads=runtime_heads,
++        )
++        for runtime_width in runtime_widths
++        for rows in range(1, _MAX_ROWS + 1)
++    )
++    assert reserve_bytes >= runtime_bytes
++
++
++def test_mns64_contract_does_not_grow_production_mnb8192_scratch(
++    monkeypatch,
++) -> None:
++    compressed_mla = pytest.importorskip("b12x.attention.compressed_mla")
++    workspace = _RecordingWorkspaceManager()
++    monkeypatch.setattr(b12x_mod, "current_workspace_manager", lambda: workspace)
++    max_rows = 8192
++    layer = _make_layer(
++        compress_ratio=128,
++        dspark=True,
++        max_num_batched_tokens=max_rows,
++        max_num_seqs=64,
++    )
++
++    layer._reserve_dummy_compressed_mla_scratch(
++        torch.empty((1, _LOCAL_HEADS, 512), dtype=torch.bfloat16)
++    )
++
++    assert workspace.specs is not None
++    candidate_bytes = _aligned_nbytes(workspace.specs)
++    width = 4608
++    split_cap = get_compressed_mla_split_cap(width)
++    max_q_chunks = get_compressed_mla_max_q_chunks(
++        max_rows,
++        width,
++        split_cap,
++        compressed_mla.split_chunks_for_contract,
++    )
++    splits = compressed_mla.split_chunks_for_contract(
++        rows=max_rows,
++        width=width,
++        max_chunks=split_cap,
++    )
++    legacy_plan = compressed_mla.plan(
++        compressed_mla.Caps(
++            device="cpu",
++            num_q_heads=_LOCAL_HEADS,
++            max_q_rows=max_rows,
++            max_width=width,
++            head_dim=512,
++            v_head_dim=512,
++            page_size=_PAGE_SIZE,
++            max_chunks_per_row=splits,
++            max_q_chunks=max_q_chunks,
++        )
++    )
++
++    assert candidate_bytes == _aligned_nbytes(legacy_plan.shapes_and_dtypes())
+diff --git a/tests/quantization/test_exl3.py b/tests/quantization/test_exl3.py
+index b25e2d28d95740c1f1bdae69fe2a40164f3e556c..6b5b934d5c8eb4f5d9abdf67cc78e53e5725e6b8 100644
+--- a/tests/quantization/test_exl3.py
++++ b/tests/quantization/test_exl3.py
+@@ -1,20 +1,31 @@
+ # SPDX-License-Identifier: Apache-2.0
+ # SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+ 
++import gc
++import weakref
+ from types import SimpleNamespace
++from unittest.mock import Mock
+ 
+ import pytest
+ import torch
+ 
+ import vllm.model_executor.layers.quantization.exl3 as exl3_module
++import vllm.model_executor.layers.quantization.online.fp8 as fp8_module
+ import vllm.model_executor.parameter as parameter_module
+ from vllm.config import CompilationMode
+-from vllm.model_executor.layers.fused_moe import MoEActivation
++from vllm.config.quantization import QuantizationConfigArgs
++from vllm.model_executor.layers.fused_moe import MoEActivation, RoutedExperts
++from vllm.model_executor.layers.linear import LinearBase, UnquantizedLinearMethod
+ from vllm.model_executor.layers.quantization import get_quantization_config
+ from vllm.model_executor.layers.quantization.exl3 import (
+     Exl3Config,
++    Exl3LinearMethod,
+     Exl3MoEMethod,
+     Exl3MoEParameter,
++    Exl3OnlineLinearMethod,
++)
++from vllm.model_executor.layers.quantization.exl3_online_cache import (
++    Exl3OnlineCacheResult,
+ )
+ from vllm.model_executor.models import glm4_moe
+ 
+@@ -35,6 +46,244 @@ def _rank_sliced_metadata(**overrides):
+     return metadata
+ 
+ 
++def _set_online_overlay(monkeypatch, args: QuantizationConfigArgs) -> object:
++    current = SimpleNamespace(
++        model_config=SimpleNamespace(
++            quantization_config=args,
++            enforce_eager=True,
++        )
++    )
++    sentinel = object()
++    monkeypatch.setattr(exl3_module, "get_current_vllm_config_or_none", lambda: current)
++    monkeypatch.setattr(exl3_module, "Mxfp8OnlineLinearMethod", lambda: sentinel)
++    return sentinel
++
++
++def _mock_linear() -> Mock:
++    return Mock(spec=LinearBase)
++
++
++def test_exl3_online_overlay_quantizes_only_bf16_dense_and_shared(monkeypatch):
++    config = Exl3Config(
++        tensor_storage={"model.layers.3.self_attn.q_b_proj": {"quant_format": "exl3"}}
++    )
++    sentinel = _set_online_overlay(
++        monkeypatch,
++        QuantizationConfigArgs(linear="mxfp8", shared_experts="mxfp8"),
++    )
++
++    serialized = config.get_quant_method(
++        _mock_linear(), "model.layers.3.self_attn.q_b_proj"
++    )
++    dense_bf16 = config.get_quant_method(
++        _mock_linear(), "model.layers.3.self_attn.kv_b_proj"
++    )
++    shared_bf16 = config.get_quant_method(
++        _mock_linear(), "model.layers.3.mlp.shared_experts.down_proj"
++    )
++
++    assert isinstance(serialized, Exl3LinearMethod)
++    assert dense_bf16 is sentinel
++    assert shared_bf16 is sentinel
++
++
++def test_exl3_linear_overlay_does_not_select_shared_experts(monkeypatch):
++    config = Exl3Config()
++    sentinel = _set_online_overlay(monkeypatch, QuantizationConfigArgs(linear="mxfp8"))
++
++    dense = config.get_quant_method(
++        _mock_linear(), "model.layers.3.self_attn.kv_b_proj"
++    )
++    shared = config.get_quant_method(
++        _mock_linear(), "model.layers.3.mlp.shared_experts.down_proj"
++    )
++
++    assert dense is sentinel
++    assert isinstance(shared, UnquantizedLinearMethod)
++
++
++def test_exl3_online_overlay_honors_unfused_ignore_names(monkeypatch):
++    config = Exl3Config()
++    config.packed_modules_mapping = {
++        "fused_qkv_a_proj": ["q_a_proj", "kv_a_proj_with_mqa"]
++    }
++    sentinel = _set_online_overlay(
++        monkeypatch,
++        QuantizationConfigArgs(
++            linear="mxfp8",
++            ignore=["re:.*\\.q_a_proj$", "re:.*kv_a_proj_with_mqa"],
++        ),
++    )
++
++    ignored = config.get_quant_method(
++        _mock_linear(), "model.layers.3.self_attn.fused_qkv_a_proj"
++    )
++    kept = config.get_quant_method(_mock_linear(), "model.layers.3.self_attn.kv_b_proj")
++
++    assert isinstance(ignored, UnquantizedLinearMethod)
++    assert kept is sentinel
++
++
++def test_exl3_online_overlay_rejects_split_packed_quantization(monkeypatch):
++    config = Exl3Config()
++    config.packed_modules_mapping = {
++        "fused_qkv_a_proj": ["q_a_proj", "kv_a_proj_with_mqa"]
++    }
++    _set_online_overlay(
++        monkeypatch,
++        QuantizationConfigArgs(linear="mxfp8", ignore=["re:.*\\.q_a_proj$"]),
++    )
++
++    with pytest.raises(ValueError, match="different quantization schemes"):
++        config.get_quant_method(
++            _mock_linear(), "model.layers.3.self_attn.fused_qkv_a_proj"
++        )
++
++
++def test_exl3_online_overlay_rejects_mixed_packed_storage(monkeypatch):
++    config = Exl3Config(
++        tensor_storage={"model.layers.3.self_attn.q_a_proj": {"quant_format": "exl3"}}
++    )
++    config.packed_modules_mapping = {
++        "fused_qkv_a_proj": ["q_a_proj", "kv_a_proj_with_mqa"]
++    }
++    _set_online_overlay(monkeypatch, QuantizationConfigArgs(linear="mxfp8"))
++
++    with pytest.raises(ValueError, match="mixes EXL3 and BF16 source shards"):
++        config.get_quant_method(
++            _mock_linear(), "model.layers.3.self_attn.fused_qkv_a_proj"
++        )
++
++
++def test_exl3_online_overlay_never_quantizes_bf16_lm_head(monkeypatch):
++    config = Exl3Config()
++    _set_online_overlay(monkeypatch, QuantizationConfigArgs(linear="mxfp8"))
++    lm_head = type("ParallelLMHead", (torch.nn.Module,), {})()
++
++    method = config.get_quant_method(lm_head, "lm_head")
++
++    assert isinstance(method, UnquantizedLinearMethod)
++
++
++def test_exl3_online_overlay_preserves_rank_sliced_routed_experts(monkeypatch):
++    config = Exl3Config()
++    config.rank_sliced_metadata = _rank_sliced_metadata()
++    _set_online_overlay(
++        monkeypatch,
++        QuantizationConfigArgs(linear="mxfp8", shared_experts="mxfp8"),
++    )
++    routed = Mock(spec=RoutedExperts)
++    routed.moe_config = object()
++
++    method = config.get_quant_method(routed, "model.layers.3.mlp.experts")
++
++    assert isinstance(method, Exl3MoEMethod)
++
++
++def test_exl3_online_trellis_selects_cached_k6_method(monkeypatch):
++    config = Exl3Config()
++    config._online_model_identity = "model"  # noqa: SLF001
++    config._online_encoder_identity = "encoder"  # noqa: SLF001
++    _set_online_overlay(monkeypatch, QuantizationConfigArgs(linear="mxfp8"))
++    monkeypatch.setattr(
++        fp8_module,
++        "get_current_vllm_config",
++        lambda: SimpleNamespace(model_config=SimpleNamespace(dtype=torch.bfloat16)),
++    )
++    monkeypatch.setenv("VLLM_EXL3_ONLINE_TRELLIS_BITS", "6")
++
++    method = config.get_quant_method(_mock_linear(), "model.layers.3.self_attn.o_proj")
++
++    assert isinstance(method, Exl3OnlineLinearMethod)
++    assert method.bits == 6
++    assert method.model_identity == "model"
++    assert method.encoder_identity == "encoder"
++
++
++def test_online_trellis_cache_off_does_not_require_hub_commit(tmp_path, monkeypatch):
++    config = Exl3Config()
++    monkeypatch.setenv("VLLM_EXL3_ONLINE_CACHE_MODE", "off")
++    monkeypatch.setenv("VLLM_EXL3_ENCODER_SOURCE", str(tmp_path))
++
++    config._configure_online_cache_identity(  # noqa: SLF001
++        "org/model", hf_config=None, revision=None
++    )
++
++    assert config._online_model_identity == "cache-disabled"  # noqa: SLF001
++    assert config._online_encoder_identity == "cache-disabled"  # noqa: SLF001
++
++
++def test_online_trellis_encoder_requires_quantize_entrypoint(tmp_path, monkeypatch):
++    encoder = tmp_path / "encoder"
++    quantizer = encoder / "modules" / "quant" / "exl3_lib"
++    quantizer.mkdir(parents=True)
++    (quantizer / "quantize.py").write_text("VALUE = 1\n", encoding="utf-8")
++    monkeypatch.setenv("VLLM_EXL3_ENCODER_SOURCE", str(encoder))
++    monkeypatch.setattr(exl3_module, "_EXL3_ONLINE_QUANTIZER", None)
++    monkeypatch.setattr(
++        exl3_module.importlib,
++        "import_module",
++        lambda name: SimpleNamespace(),
++    )
++
++    with pytest.raises(RuntimeError, match="has no quantize_exl3"):
++        exl3_module._load_exl3_online_quantizer()
++    for name in tuple(exl3_module.sys.modules):
++        if name == "_vllm_exl3_encoder" or name.startswith("_vllm_exl3_encoder."):
++            monkeypatch.delitem(exl3_module.sys.modules, name, raising=False)
++
++
++def test_exl3_online_trellis_cache_hit_skips_encoder(monkeypatch):
++    monkeypatch.setattr(
++        fp8_module,
++        "get_current_vllm_config",
++        lambda: SimpleNamespace(model_config=SimpleNamespace(dtype=torch.bfloat16)),
++    )
++    method = Exl3OnlineLinearMethod(
++        bits=6,
++        prefix="model.layers.3.self_attn.o_proj",
++        model_identity="model",
++        encoder_identity="encoder",
++    )
++    layer = torch.nn.Module()
++    layer.register_parameter(
++        "weight",
++        torch.nn.Parameter(torch.zeros((256, 128), dtype=torch.float16)),
++    )
++    layer.exl3_online_input_size = 128
++    layer.exl3_online_output_size = 256
++    tensors = {
++        "trellis": torch.zeros((8, 16, 96), dtype=torch.int16),
++        "suh": torch.ones(128, dtype=torch.float16),
++        "svh": torch.ones(256, dtype=torch.float16),
++    }
++    captured = {}
++
++    def cache_hit(key, *, device, quantize):
++        del quantize
++        captured["key"] = key
++        captured["device"] = device
++        return Exl3OnlineCacheResult(tensors, 0.25, True, None)
++
++    monkeypatch.setattr(exl3_module, "load_or_quantize", cache_hit)
++    monkeypatch.setattr(
++        exl3_module,
++        "_load_exl3_online_quantizer",
++        lambda: pytest.fail("cache hit must not import the encoder"),
++    )
++    monkeypatch.setattr(exl3_module, "get_tensor_model_parallel_world_size", lambda: 4)
++    monkeypatch.setattr(exl3_module, "get_tensor_model_parallel_rank", lambda: 2)
++    monkeypatch.setattr(method, "_warm_decode_shapes", lambda layer: None)
++
++    method.process_weights_after_loading(layer)
++
++    assert captured["key"].tp_world_size == 4
++    assert captured["key"].tp_rank == 2
++    assert captured["device"] == torch.device("cpu")
++    assert layer.weight.numel() == 0
++    assert layer.exl3_online_trellis_weight is tensors["trellis"]
++
++
+ def test_rank_sliced_checkpoint_selects_exl3_override():
+     hf_config = SimpleNamespace(hybrid_tr3_tail=_rank_sliced_metadata())
+ 
+@@ -92,6 +341,8 @@ def test_glm_model_retains_quant_config_for_weight_loading(monkeypatch):
+         ({"codebook": "mul1"}, "MCG codebook"),
+         ({"moe_layers": [77, 3]}, "moe_layers"),
+         ({"tensor_schema": "unsupported"}, "tensor schema"),
++        ({"rotation_layout": "implicit_magic"}, "rotation_layout"),
++        ({"rotation_layout": "shared_h_v1"}, "shared_h_tensor_schema"),
+     ],
+ )
+ def test_rank_sliced_metadata_fails_closed(overrides, message):
+@@ -118,6 +369,28 @@ def test_rank_sliced_metadata_admits_only_declared_moe_layers():
+     )
+ 
+ 
++def test_rank_sliced_shared_h_metadata_is_explicit_and_legacy_defaults_unchanged():
++    legacy = Exl3Config()
++    legacy.maybe_update_config(
++        "unused", SimpleNamespace(hybrid_tr3_tail=_rank_sliced_metadata())
++    )
++    shared = Exl3Config()
++    shared.maybe_update_config(
++        "unused",
++        SimpleNamespace(
++            hybrid_tr3_tail=_rank_sliced_metadata(
++                rotation_layout="shared_h_v1",
++                shared_h_tensor_schema=(
++                    "model.layers.{L}.mlp.experts.shared_h.{proj}.rank{r}.{suh|svh}"
++                ),
++            )
++        ),
++    )
++
++    assert legacy.rank_sliced_rotation_layout == "per_expert_v1"
++    assert shared.rank_sliced_rotation_layout == "shared_h_v1"
++
++
+ def test_mixed_rank_sliced_metadata_hydrates_per_layer_bitrates(monkeypatch):
+     metadata = _rank_sliced_metadata(
+         bits="mixed",
+@@ -179,6 +452,49 @@ def test_rank_sliced_weight_name_keeps_only_local_tp_rank(monkeypatch):
+     )
+ 
+ 
++def test_rank_sliced_shared_h_names_map_once_and_fail_closed(monkeypatch):
++    config = Exl3Config()
++    config.maybe_update_config(
++        "unused",
++        SimpleNamespace(
++            hybrid_tr3_tail=_rank_sliced_metadata(
++                rotation_layout="shared_h_v1",
++                shared_h_tensor_schema=(
++                    "model.layers.{L}.mlp.experts.shared_h.{proj}.rank{r}.{suh|svh}"
++                ),
++            )
++        ),
++    )
++    monkeypatch.setattr(exl3_module, "get_tensor_model_parallel_rank", lambda: 2)
++    prefix = "model.layers.3.mlp.experts"
++
++    assert (
++        config.normalize_rank_sliced_weight_name(
++            f"{prefix}.shared_h.gate_proj.rank2.suh"
++        )
++        == f"{prefix}.0.gate_proj.suh"
++    )
++    assert (
++        config.normalize_rank_sliced_weight_name(
++            f"{prefix}.shared_h.down_proj.rank1.svh"
++        )
++        is None
++    )
++    with pytest.raises(ValueError, match="requires suh"):
++        config.normalize_rank_sliced_weight_name(
++            f"{prefix}.shared_h.gate_proj.rank2.svh"
++        )
++    with pytest.raises(ValueError, match="must store H-side rotations"):
++        config.normalize_rank_sliced_weight_name(f"{prefix}.7.down_proj.rank2.svh")
++
++    legacy = Exl3Config()
++    legacy.maybe_update_config(
++        "unused", SimpleNamespace(hybrid_tr3_tail=_rank_sliced_metadata())
++    )
++    with pytest.raises(ValueError, match="does not declare"):
++        legacy.normalize_rank_sliced_weight_name(f"{prefix}.shared_h.up_proj.rank2.suh")
++
++
+ def test_rank_sliced_parameter_preallocates_projection_major_slab(monkeypatch):
+     monkeypatch.setattr(parameter_module, "get_tensor_model_parallel_rank", lambda: 0)
+     monkeypatch.setattr(
+@@ -208,6 +524,70 @@ def test_rank_sliced_parameter_preallocates_projection_major_slab(monkeypatch):
+     torch.testing.assert_close(param.exl3_tensors[(2, "w3")], w3)
+ 
+ 
++def test_rank_sliced_broadcast_pointer_table_repeats_one_physical_row():
++    slab = torch.ones((1, 128), dtype=torch.float16)
++
++    table = Exl3MoEMethod._pointer_table(slab, num_experts=4)
++
++    assert table.tolist() == [slab.data_ptr()] * 4
++    with pytest.raises(RuntimeError, match="per-expert or broadcast"):
++        Exl3MoEMethod._pointer_table(
++            torch.ones((2, 128), dtype=torch.float16), num_experts=4
++        )
++
++
++def test_rank_sliced_shared_h_create_weights_allocates_one_physical_row(
++    monkeypatch,
++):
++    monkeypatch.setattr(parameter_module, "get_tensor_model_parallel_rank", lambda: 0)
++    monkeypatch.setattr(
++        parameter_module, "get_tensor_model_parallel_world_size", lambda: 4
++    )
++    config = Exl3Config()
++    config.maybe_update_config(
++        "unused",
++        SimpleNamespace(
++            hybrid_tr3_tail=_rank_sliced_metadata(
++                rotation_layout="shared_h_v1",
++                shared_h_tensor_schema=(
++                    "model.layers.{L}.mlp.experts.shared_h.{proj}.rank{r}.{suh|svh}"
++                ),
++            )
++        ),
++    )
++    monkeypatch.setattr(
++        exl3_module,
++        "get_current_vllm_config_or_none",
++        lambda: SimpleNamespace(
++            scheduler_config=SimpleNamespace(max_num_batched_tokens=8192),
++            model_config=SimpleNamespace(runner_type="generate"),
++        ),
++    )
++    layer = torch.nn.Module()
++    layer.layer_name = "model.layers.3.mlp.experts"
++    moe = SimpleNamespace(
++        moe_parallel_config=SimpleNamespace(use_ep=False, tp_rank=0, tp_size=4),
++        has_bias=False,
++    )
++    method = Exl3MoEMethod(config, moe)
++
++    method.create_weights(
++        layer,
++        num_experts=256,
++        hidden_size=6144,
++        intermediate_size_per_partition=512,
++        params_dtype=torch.bfloat16,
++    )
++
++    assert layer.exl3_shared_h_rotations
++    assert layer.w13_suh.exl3_num_experts == 1
++    assert layer.w2_svh.exl3_num_experts == 1
++    assert layer.w13_svh.exl3_num_experts == 256
++    assert layer.w2_suh.exl3_num_experts == 256
++    assert layer.w13_trellis.exl3_num_experts == 256
++    assert layer.w2_trellis.exl3_num_experts == 256
++
++
+ def test_rank_sliced_weights_use_unified_fused_moe_contract(monkeypatch):
+     experts = 2
+     hidden = intermediate = 128
+@@ -278,7 +658,66 @@ def test_rank_sliced_weights_use_unified_fused_moe_contract(monkeypatch):
+     assert api.prepare_kwargs["trellis_mcg"] is marker
+ 
+ 
+-def test_mixed_rank_sliced_weights_are_partitioned_by_declared_bitrate(monkeypatch):
++def test_rank_sliced_weights_pass_shared_h_rows_without_expansion(monkeypatch):
++    experts = 3
++    hidden = intermediate = 128
++    bits = 3
++    slabs = {
++        "w13_trellis": torch.zeros(
++            (2, experts, hidden // 16, intermediate // 16, 16 * bits),
++            dtype=torch.int16,
++        ),
++        "w2_trellis": torch.zeros(
++            (experts, intermediate // 16, hidden // 16, 16 * bits),
++            dtype=torch.int16,
++        ),
++        "w13_suh": torch.ones((2, 1, hidden), dtype=torch.float16),
++        "w13_svh": torch.ones((2, experts, intermediate), dtype=torch.float16),
++        "w2_suh": torch.ones((experts, intermediate), dtype=torch.float16),
++        "w2_svh": torch.ones((1, hidden), dtype=torch.float16),
++    }
++
++    class FakeFusedMoe:
++        @staticmethod
++        def plan_weights(**kwargs):
++            return SimpleNamespace(source_format=kwargs["source_format"])
++
++        @staticmethod
++        def prepare_weights(**kwargs):
++            return SimpleNamespace(**kwargs)
++
++    monkeypatch.setattr(
++        exl3_module, "_load_b12x_fused_moe", lambda: FakeFusedMoe()
++    )
++    method = object.__new__(Exl3MoEMethod)
++    method.quant_config = SimpleNamespace(bits=float(bits))
++    method._rank_sliced_backing = lambda _layer, name: slabs[name]
++    marker = torch.tensor(0xCBAC1FED - (1 << 32), dtype=torch.int32)
++    layer = SimpleNamespace(
++        local_num_experts=experts,
++        exl3_hidden_size=hidden,
++        exl3_intermediate_size_per_partition=intermediate,
++        exl3_params_dtype=torch.float16,
++        exl3_layer_bitrates=(bits,) * experts,
++        exl3_mixed_bitrate=False,
++        exl3_shared_h_rotations=True,
++        activation=MoEActivation.SILU,
++        w13_mcg=SimpleNamespace(exl3_tensors={(0, "w1"): marker}),
++    )
++
++    method._prepare_rank_sliced_weights(layer)
++
++    prepared = layer.exl3_trellis_weights
++    assert tuple(prepared.gate_suh.shape) == (1, hidden)
++    assert tuple(prepared.up_suh.shape) == (1, hidden)
++    assert tuple(prepared.down_svh.shape) == (1, hidden)
++    assert all(tuple(table.shape) == (experts,) for table in layer.exl3_pointer_tables)
++
++
++@pytest.mark.parametrize("shared_h", [False, True])
++def test_mixed_rank_sliced_weights_are_partitioned_by_declared_bitrate(
++    monkeypatch, shared_h
++):
+     experts = 4
+     hidden = intermediate = 128
+     bitrates = (3, 4, 3, 4)
+@@ -304,15 +743,18 @@ def test_mixed_rank_sliced_weights_are_partitioned_by_declared_bitrate(monkeypat
+         )
+ 
+     slabs = {
+-        "w13_suh": torch.ones((2, experts, hidden), dtype=torch.float16),
++        "w13_suh": torch.ones(
++            (2, 1 if shared_h else experts, hidden), dtype=torch.float16
++        ),
+         "w13_svh": torch.ones((2, experts, intermediate), dtype=torch.float16),
+         "w2_suh": torch.ones((experts, intermediate), dtype=torch.float16),
+-        "w2_svh": torch.ones((experts, hidden), dtype=torch.float16),
++        "w2_svh": torch.ones((1 if shared_h else experts, hidden), dtype=torch.float16),
+     }
+     layer = SimpleNamespace(
+         local_num_experts=experts,
+         exl3_hidden_size=hidden,
+         exl3_intermediate_size_per_partition=intermediate,
++        exl3_params_dtype=torch.float16,
+         exl3_layer_bitrates=bitrates,
+         activation=MoEActivation.SILU,
+         layer_name="model.layers.3.mlp.experts",
+@@ -353,8 +795,8 @@ def test_mixed_rank_sliced_weights_are_partitioned_by_declared_bitrate(monkeypat
+ 
+     method._prepare_mixed_rank_sliced_weights(layer)
+ 
+-    assert [entry["trellis_bits"] for entry in api.prepared] == [3, 4]
+-    assert [entry["num_experts"] for entry in api.prepared] == [2, 2]
++    assert [entry["trellis_bits"] for entry in api.prepared] == [3, 3, 4, 4]
++    assert [entry["num_experts"] for entry in api.prepared] == [2] * 4
+     for entry in api.prepared:
+         bits = entry["trellis_bits"]
+         assert tuple(entry["w13"].shape) == (
+@@ -373,9 +815,29 @@ def test_mixed_rank_sliced_weights_are_partitioned_by_declared_bitrate(monkeypat
+     assert [entry["tile_config"] for entry in api.prepared] == [
+         (128, 128, 128, 128),
+         (128, 128, 128, 128),
++        (128, 128, 128, 128),
++        (128, 128, 128, 128),
+     ]
+     assert layer.exl3_mixed_trellis["tier_ids"] == ((0, 2), (1, 3))
+     assert layer.exl3_mixed_trellis["tier_bits"] == (3, 4)
++    assert len(layer.exl3_mixed_trellis["tiers"]) == 2
++    assert len(layer.exl3_mixed_trellis["prefill_tiers"]) == 2
++    rotations = layer.exl3_mixed_trellis["rotations"]
++    expected_h_rows = 1 if shared_h else experts
++    assert rotations.gate_suh.shape[0] == expected_h_rows
++    assert rotations.up_suh.shape[0] == expected_h_rows
++    assert rotations.down_svh.shape[0] == expected_h_rows
++    assert layer.exl3_mixed_trellis["broadcast_suh"] is shared_h
++    assert layer.exl3_mixed_trellis["broadcast_svh"] is shared_h
++    for entry in api.prepared:
++        expected_tier_rows = 1 if shared_h else 2
++        assert entry["gate_suh"].shape[0] == expected_tier_rows
++        assert entry["up_suh"].shape[0] == expected_tier_rows
++        assert entry["down_svh"].shape[0] == expected_tier_rows
++        assert (
++            entry["gate_suh"].untyped_storage().data_ptr()
++            == rotations.gate_suh.untyped_storage().data_ptr()
++        )
+     assert layer.w13_trellis.exl3_tensors == {}
+     assert layer.w2_trellis.exl3_tensors == {}
+     assert layer.w13_suh.exl3_backing is None
+@@ -390,6 +852,150 @@ def test_mixed_trellis_buffer_accounting_ignores_metadata() -> None:
+     assert exl3_module._unique_tensor_storage_bytes(first, second) == 8
+ 
+ 
++def test_prepared_dense_weight_is_owned_by_source_tensor(monkeypatch) -> None:
++    class FakeApi:
++        def __init__(self):
++            self.calls = 0
++
++        def prepare_weight(self, trellis, suh, svh, **kwargs):
++            del kwargs
++            self.calls += 1
++            return SimpleNamespace(trellis=trellis, suh=suh, svh=svh)
++
++    api = FakeApi()
++    monkeypatch.setattr(exl3_module, "_load_b12x_trellis_linear", lambda: api)
++    trellis = torch.empty((8, 8, 96), dtype=torch.int16)
++    suh = torch.empty(128, dtype=torch.float16)
++    svh = torch.empty(128, dtype=torch.float16)
++
++    first = exl3_module._b12x_trellis_weight(trellis, suh, svh, torch.float16)
++    second = exl3_module._b12x_trellis_weight(trellis, suh, svh, torch.float16)
++    assert first is second
++    assert api.calls == 1
++
++    source_ref = weakref.ref(trellis)
++    del first, second, trellis
++    gc.collect()
++    assert source_ref() is None
++
++
++def test_mixed_trellis_dispatches_decode_and_one_grid_prefill(monkeypatch):
++    class FakeMixedApi:
++        def __init__(self):
++            self.calls = []
++
++        def run_mixed_trellis(self, x, *args):
++            launch = args[7]
++            self.calls.append((int(x.shape[0]), args[0], args[1], launch))
++            return torch.full_like(x, launch.value)
++
++    mixed_api = FakeMixedApi()
++    decode_tiers = (object(), object())
++    prefill_tiers = (object(), object())
++    runtime = {
++        "mixed_api": mixed_api,
++        "decode": {
++            "launch": SimpleNamespace(value=1),
++            "buffers": object(),
++        },
++        "prefill": {
++            "launch": SimpleNamespace(value=3),
++            "buffers": object(),
++        },
++        "max_decode_m": 8,
++        "max_batched_tokens": 16,
++        "prefill_capacity": 8,
++    }
++    layer = SimpleNamespace(
++        exl3_mixed_trellis={
++            "tiers": decode_tiers,
++            "prefill_tiers": prefill_tiers,
++            "global_to_combined": object(),
++            "descriptor_map": object(),
++            "rotations": object(),
++        }
++    )
++    method = object.__new__(Exl3MoEMethod)
++    monkeypatch.setattr(
++        method, "_mixed_rank_sliced_runtime", lambda layer, x, ids: runtime
++    )
++    weights = torch.ones((16, 2), dtype=torch.float32)
++    ids = torch.zeros((16, 2), dtype=torch.int64)
++
++    decode = method._apply_mixed_rank_sliced(
++        layer, torch.zeros((4, 4)), weights[:4], ids[:4]
++    )
++    prefill = method._apply_mixed_rank_sliced(layer, torch.zeros((16, 4)), weights, ids)
++
++    torch.testing.assert_close(decode, torch.ones_like(decode))
++    torch.testing.assert_close(prefill, torch.full_like(prefill, 3))
++    assert [call[0] for call in mixed_api.calls] == [4, 8, 8]
++    assert mixed_api.calls[0][1:3] == decode_tiers
++    assert all(call[1:3] == prefill_tiers for call in mixed_api.calls[1:])
++
++
++@pytest.mark.parametrize(
++    "tier_signature",
++    [
++        ((3, 192), (4, 64)),
++        ((3, 206), (4, 50)),
++        ((3, 148), (4, 108)),
++    ],
++)
++def test_mixed_trellis_prefill_block_policy_qualified_partitions(
++    tier_signature,
++) -> None:
++    common = {
++        "configured_block_m": 64,
++        "explicit_override": False,
++        "hidden_size": 6144,
++        "intermediate_size": 512,
++        "tier_signature": tier_signature,
++        "topk": 8,
++        "device_major": 12,
++        "prefill_tile_config": (128, 128, 32, 512),
++    }
++
++    assert exl3_module._resolve_mixed_trellis_prefill_block_m(**common) == 32
++    assert (
++        exl3_module._resolve_mixed_trellis_prefill_block_m(
++            **{**common, "explicit_override": True}
++        )
++        == 64
++    )
++
++
++def test_mixed_trellis_prefill_block_policy_rejects_unqualified_partition() -> None:
++    common = {
++        "configured_block_m": 64,
++        "explicit_override": False,
++        "hidden_size": 6144,
++        "intermediate_size": 512,
++        "tier_signature": ((3, 192), (4, 64)),
++        "topk": 8,
++        "device_major": 12,
++        "prefill_tile_config": (128, 128, 32, 512),
++    }
++    assert (
++        exl3_module._resolve_mixed_trellis_prefill_block_m(
++            **{**common, "tier_signature": ((3, 128), (4, 128))}
++        )
++        == 64
++    )
++    assert (
++        exl3_module._resolve_mixed_trellis_prefill_block_m(
++            **{**common, "tier_signature": ((4, 256),)}
++        )
++        == 64
++    )
++    assert (
++        exl3_module._resolve_mixed_trellis_prefill_block_m(
++            **{**common, "device_major": 11}
++        )
++        == 64
++    )
++
++
+ @pytest.mark.parametrize(
+     ("hidden", "intermediate", "expected"),
+     [
+diff --git a/tests/quantization/test_exl3_online_cache.py b/tests/quantization/test_exl3_online_cache.py
+new file mode 100644
+index 0000000000000000000000000000000000000000..7c02cc5915ed928f87c7f99441a7fe08360a745d
+--- /dev/null
++++ b/tests/quantization/test_exl3_online_cache.py
+@@ -0,0 +1,213 @@
++# SPDX-License-Identifier: Apache-2.0
++# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
++
++from __future__ import annotations
++
++from dataclasses import replace
++
++import pytest
++import torch
++
++from vllm.model_executor.layers.quantization.exl3_online_cache import (
++    Exl3OnlineCacheKey,
++    cache_mode,
++    cache_path,
++    load_or_quantize,
++    resolve_encoder_identity,
++    resolve_model_identity,
++)
++
++
++def _key() -> Exl3OnlineCacheKey:
++    return Exl3OnlineCacheKey(
++        model_identity="model-identity",
++        encoder_identity="encoder-identity",
++        prefix="model.layers.0.self_attn.o_proj",
++        bits=6,
++        seed=123,
++        tp_world_size=4,
++        tp_rank=2,
++        input_size=128,
++        output_size=256,
++    )
++
++
++def _tensors(key: Exl3OnlineCacheKey) -> dict[str, torch.Tensor]:
++    return {
++        "trellis": torch.arange(
++            key.input_size // 16 * key.output_size // 16 * key.bits * 16,
++            dtype=torch.int16,
++        ).reshape(key.input_size // 16, key.output_size // 16, key.bits * 16),
++        "suh": torch.ones(key.input_size, dtype=torch.float16),
++        "svh": torch.full((key.output_size,), 2, dtype=torch.float16),
++    }
++
++
++def test_cache_round_trip_skips_second_quantization(tmp_path, monkeypatch):
++    monkeypatch.setenv("VLLM_EXL3_ONLINE_CACHE_DIR", str(tmp_path))
++    monkeypatch.setenv("VLLM_EXL3_ONLINE_CACHE_MODE", "readwrite")
++    key = _key()
++    calls = 0
++
++    def quantize():
++        nonlocal calls
++        calls += 1
++        return _tensors(key), 0.125
++
++    first = load_or_quantize(key, device=torch.device("cpu"), quantize=quantize)
++    second = load_or_quantize(key, device=torch.device("cpu"), quantize=quantize)
++
++    assert calls == 1
++    assert not first.hit
++    assert second.hit
++    assert second.proxy_error == pytest.approx(0.125)
++    assert second.path == cache_path(key)
++    for name, expected in _tensors(key).items():
++        assert torch.equal(second.tensors[name], expected)
++
++
++def test_corrupt_cache_is_replaced_atomically(tmp_path, monkeypatch):
++    monkeypatch.setenv("VLLM_EXL3_ONLINE_CACHE_DIR", str(tmp_path))
++    monkeypatch.setenv("VLLM_EXL3_ONLINE_CACHE_MODE", "readwrite")
++    key = _key()
++    path = cache_path(key)
++    path.parent.mkdir(parents=True)
++    path.write_bytes(b"not a safetensors file")
++    calls = 0
++
++    def quantize():
++        nonlocal calls
++        calls += 1
++        return _tensors(key), None
++
++    result = load_or_quantize(key, device=torch.device("cpu"), quantize=quantize)
++    reloaded = load_or_quantize(
++        key,
++        device=torch.device("cpu"),
++        quantize=lambda: pytest.fail("valid replacement must be reused"),
++    )
++
++    assert calls == 1
++    assert not result.hit
++    assert reloaded.hit
++
++
++def test_readonly_miss_does_not_publish(tmp_path, monkeypatch):
++    monkeypatch.setenv("VLLM_EXL3_ONLINE_CACHE_DIR", str(tmp_path))
++    monkeypatch.setenv("VLLM_EXL3_ONLINE_CACHE_MODE", "readonly")
++    key = _key()
++
++    result = load_or_quantize(
++        key,
++        device=torch.device("cpu"),
++        quantize=lambda: (_tensors(key), 0.5),
++    )
++
++    assert not result.hit
++    assert result.path is None
++    assert not cache_path(key).exists()
++
++
++@pytest.mark.parametrize(
++    ("raw", "expected"),
++    [
++        ("off", "off"),
++        ("none", "off"),
++        ("readonly", "readonly"),
++        ("read-only", "readonly"),
++        ("readwrite", "readwrite"),
++        ("rw", "readwrite"),
++    ],
++)
++def test_cache_mode_aliases(raw, expected, monkeypatch):
++    monkeypatch.setenv("VLLM_EXL3_ONLINE_CACHE_MODE", raw)
++    assert cache_mode() == expected
++
++
++def test_cache_mode_rejects_unknown_value(monkeypatch):
++    monkeypatch.setenv("VLLM_EXL3_ONLINE_CACHE_MODE", "sometimes")
++    with pytest.raises(ValueError, match="must be off, readonly, or readwrite"):
++        cache_mode()
++
++
++def test_off_mode_neither_reads_nor_writes(tmp_path, monkeypatch):
++    monkeypatch.setenv("VLLM_EXL3_ONLINE_CACHE_DIR", str(tmp_path))
++    monkeypatch.setenv("VLLM_EXL3_ONLINE_CACHE_MODE", "off")
++    key = _key()
++    cache_path(key).parent.mkdir(parents=True)
++    cache_path(key).write_bytes(b"must not be read")
++
++    result = load_or_quantize(
++        key,
++        device=torch.device("cpu"),
++        quantize=lambda: (_tensors(key), 0.5),
++    )
++
++    assert not result.hit
++    assert result.path is None
++    assert cache_path(key).read_bytes() == b"must not be read"
++
++
++def test_cache_key_covers_every_rank_local_encoding_input():
++    key = _key()
++    variants = [
++        replace(key, model_identity="other-model"),
++        replace(key, encoder_identity="other-encoder"),
++        replace(key, prefix="model.layers.1.self_attn.o_proj"),
++        replace(key, bits=5),
++        replace(key, seed=456),
++        replace(key, tp_world_size=8),
++        replace(key, tp_rank=3),
++        replace(key, input_size=256),
++        replace(key, output_size=128),
++    ]
++
++    assert len({key.digest(), *(variant.digest() for variant in variants)}) == 10
++
++
++def test_local_model_identity_tracks_metadata_and_shards(tmp_path):
++    model = tmp_path / "model"
++    model.mkdir()
++    config = model / "config.json"
++    shard = model / "model-00001-of-00001.safetensors"
++    config.write_text('{"model_type":"test"}', encoding="utf-8")
++    shard.write_bytes(b"weight payload")
++
++    before = resolve_model_identity(str(model))
++    config.write_text('{"model_type":"changed"}', encoding="utf-8")
++    after = resolve_model_identity(str(model))
++
++    assert before != after
++
++
++def test_hub_model_identity_tracks_resolved_revision():
++    first = resolve_model_identity("org/model", revision="commit-a")
++    second = resolve_model_identity("org/model", revision="commit-b")
++
++    assert first != second
++
++    resolved = resolve_model_identity(
++        "org/model",
++        revision="main",
++        hf_config=type("Config", (), {"_commit_hash": "commit-a"})(),
++    )
++    assert resolved == first
++
++
++def test_hub_model_identity_rejects_unresolved_revision():
++    with pytest.raises(ValueError, match="requires a resolved revision"):
++        resolve_model_identity("org/model")
++
++
++def test_encoder_identity_tracks_source_without_explicit_revision(tmp_path):
++    package = tmp_path / "exllamav3"
++    package.mkdir()
++    source = package / "quantize.py"
++    source.write_text("VALUE = 1\n", encoding="utf-8")
++    before = resolve_encoder_identity(package)
++    source.write_text("VALUE = 2\n", encoding="utf-8")
++    after = resolve_encoder_identity(package)
++
++    assert before != after
++    explicit = resolve_encoder_identity(package, revision="abc")
++    assert explicit == resolve_encoder_identity(package, revision="abc")
+diff --git a/tests/quantization/test_exl3_prefill_plan.py b/tests/quantization/test_exl3_prefill_plan.py
+index d846ef4b25e0c317ed73c55a032347e5c20bf346..040b02cf0b666d51701a80276f48a30dec641ddb 100644
+--- a/tests/quantization/test_exl3_prefill_plan.py
++++ b/tests/quantization/test_exl3_prefill_plan.py
+@@ -7,7 +7,8 @@ The planned Trellis API and the ExLlamaV3 extension are mocked; these tests
+ prove backend policy only:
+ 
+ * decode window m in [min, max] binds the decode plan;
+-* max < m <= capacity binds the prefill plan (block_size_m=64 by default);
++* max < m <= scheduler capacity binds capacity-bounded prefill slices;
++* the opt-in prefill capacity defaults to the scheduler capacity;
+ * m < min stays on the parity path with chunk-capped staging buffers;
+ * VLLM_EXL3_PREFILL_TRELLIS=0 restores the single-plan parity behavior
+   with full-capacity staging;
+@@ -50,6 +51,7 @@ class _FakeFusedMoeApi:
+     def __init__(self):
+         self.planned = []
+         self.bound = []
++        self.routed = []
+ 
+     def Caps(self, **kwargs):
+         return kwargs
+@@ -59,13 +61,64 @@ class _FakeFusedMoeApi:
+         self.planned.append(caps)
+         return plan
+ 
+-    def bind(self, plan, *, scratch, a, experts, topk_weights, topk_ids):
+-        del scratch, experts, topk_weights, topk_ids
++    def bind(
++        self,
++        plan,
++        *,
++        scratch,
++        a,
++        experts,
++        topk_weights,
++        topk_ids,
++        route_expert_map=None,
++        output_expert_map=None,
++        output=None,
++    ):
++        del scratch, experts
+         self.bound.append((plan, int(a.shape[0])))
+-        return SimpleNamespace(plan=plan, m=int(a.shape[0]))
++        self.routed.append((topk_weights.clone(), topk_ids.clone()))
++        return SimpleNamespace(
++            plan=plan,
++            a=a,
++            route_expert_map=route_expert_map,
++            output_expert_map=output_expert_map,
++            output=output,
++        )
+ 
+     def run(self, *, binding):
+-        return torch.zeros((binding.m, HIDDEN), dtype=torch.float32)
++        if binding.route_expert_map is not None:
++            tier_output = binding.a.to(torch.float32).mul(0.5)
++            if binding.output is not None:
++                binding.output.copy_(tier_output)
++                return binding.output
++            return tier_output
++        return binding.a.to(torch.float32)
++
++
++class _FakeMixedTrellisApi:
++    def __init__(self):
++        self.compiled = []
++        self.routed = []
++        self.calls = []
++
++    def max_packed_route_slots(self, routed_rows, block_size, experts):
++        del block_size, experts
++        return routed_rows
++
++    def compile_mixed_trellis(self, **kwargs):
++        launch = SimpleNamespace(**kwargs)
++        self.compiled.append(launch)
++        return launch
++
++    def make_mixed_trellis_buffers(self, launch, **kwargs):
++        del kwargs
++        return SimpleNamespace(scratch=torch.empty(launch.size_m, dtype=torch.uint8))
++
++    def run_mixed_trellis(self, *args):
++        x, tier0, tier1, topk_weights, topk_ids = args[:5]
++        self.calls.append((int(x.shape[0]), tier0, tier1))
++        self.routed.append((topk_weights.clone(), topk_ids.clone()))
++        return x.to(torch.float32)
+ 
+ 
+ class _FakeExt:
+@@ -96,6 +149,25 @@ def _make_layer():
+     )
+ 
+ 
++def _make_mixed_layer():
++    layer = _make_layer()
++    layer.exl3_mixed_bitrate = True
++    layer.exl3_mixed_trellis = {
++        "tiers": (object(), object()),
++        "prefill_tiers": (object(), object()),
++        "tier_ids": ((0, 1, 2, 3), (4, 5, 6, 7)),
++        "tier_bits": (3, 4),
++        "global_to_combined": object(),
++        "descriptor_map": object(),
++        "rotations": object(),
++        "broadcast_suh": False,
++        "broadcast_svh": False,
++        "tile_config": (64, 128, 64, 128),
++        "prefill_tile_config": (128, 128, 128, 128),
++    }
++    return layer
++
++
+ def _make_method():
+     method = object.__new__(Exl3MoEMethod)
+     method.quant_config = SimpleNamespace(
+@@ -112,6 +184,7 @@ class _Harness:
+         self._saved_capturing = None
+         self.api = _FakeFusedMoeApi()
+         self.ext = _FakeExt()
++        self.mixed_api = _FakeMixedTrellisApi()
+ 
+     def __enter__(self):
+         for name, value in self._env.items():
+@@ -122,30 +195,41 @@ class _Harness:
+                 os.environ[name] = value
+         self._saved_loaders = (
+             exl3_module._load_b12x_fused_moe,
++            exl3_module._load_b12x_mixed_trellis,
+             exl3_module._load_exl3_ext,
+         )
+         exl3_module._load_b12x_fused_moe = lambda: self.api
++        exl3_module._load_b12x_mixed_trellis = lambda: self.mixed_api
+         exl3_module._load_exl3_ext = lambda: self.ext
+         self._saved_capturing = torch.cuda.is_current_stream_capturing
+         torch.cuda.is_current_stream_capturing = lambda: False
+         self._saved_current_device = torch.cuda.current_device
+         torch.cuda.current_device = lambda: 0
++        self._saved_device_properties = torch.cuda.get_device_properties
++        torch.cuda.get_device_properties = lambda device: SimpleNamespace(
++            multi_processor_count=1,
++            shared_memory_per_block_optin=1,
++        )
+         exl3_module._RANK_SLICED_RUNTIMES.clear()
++        exl3_module._MIXED_TRELLIS_RUNTIMES.clear()
+         return self
+ 
+     def __exit__(self, *exc):
+         (
+             exl3_module._load_b12x_fused_moe,
++            exl3_module._load_b12x_mixed_trellis,
+             exl3_module._load_exl3_ext,
+         ) = self._saved_loaders
+         torch.cuda.is_current_stream_capturing = self._saved_capturing
+         torch.cuda.current_device = self._saved_current_device
++        torch.cuda.get_device_properties = self._saved_device_properties
+         for name, value in self._saved_env.items():
+             if value is None:
+                 os.environ.pop(name, None)
+             else:
+                 os.environ[name] = value
+         exl3_module._RANK_SLICED_RUNTIMES.clear()
++        exl3_module._MIXED_TRELLIS_RUNTIMES.clear()
+         return False
+ 
+     def planned_caps(self):
+@@ -159,24 +243,24 @@ def _apply(method, layer, m):
+     return method._apply_rank_sliced(layer, x, weights, ids)
+ 
+ 
+-def test_dual_plan_construction_and_dispatch():
+-    with _Harness() as h:
++def test_opt_in_prefill_capacity_slices_dispatch():
++    with _Harness(env={"VLLM_EXL3_PREFILL_CAPACITY": "128"}) as h:
+         method = _make_method()
+         layer = _make_layer()
+ 
+         out = _apply(method, layer, 16)
+         assert out.dtype == torch.bfloat16 and out.shape == (16, HIDDEN)
+-        # Two plans: decode (32, block 8) then prefill (capacity, block 64).
++        # Two plans: decode (32, block 8), then bounded prefill (block 64).
+         assert [
+             (caps["max_tokens"], caps["w4a16_block_size_m"])
+             for caps in h.planned_caps()
+-        ] == [(32, 8), (MAX_BATCHED, 64)]
++        ] == [(32, 8), (128, 64)]
+         assert all(caps["route_num_experts"] == 0 for caps in h.planned_caps())
+         assert h.api.bound[-1][0].caps["max_tokens"] == 32
+ 
+         _apply(method, layer, 200)
+-        assert h.api.bound[-1][0].caps["max_tokens"] == MAX_BATCHED
+-        assert h.api.bound[-1][1] == 200
++        assert all(bound[0].caps["max_tokens"] == 128 for bound in h.api.bound[-2:])
++        assert [bound[1] for bound in h.api.bound[-2:]] == [128, 72]
+         assert not h.ext.moe_calls
+ 
+         _apply(method, layer, 2)
+@@ -188,6 +272,7 @@ def test_dual_plan_construction_and_dispatch():
+         assert runtime["parity_rows"] == 128
+         assert runtime["xh"].shape[0] == 128
+         assert runtime["token_sorted"].numel() == 128 * TOPK
++        assert runtime["prefill_capacity"] == 128
+ 
+         # Batches above the scheduler contract must fail before allocating a
+         # replacement runtime or a larger Trellis arena during serving.
+@@ -204,6 +289,120 @@ def test_dual_plan_construction_and_dispatch():
+         assert len(h.planned_caps()) == plan_count
+ 
+ 
++@pytest.mark.parametrize(
++    ("rows", "expected_slice_rows"),
++    ((127, [127]), (128, [128]), (129, [128, 1])),
++)
++def test_prefill_capacity_boundaries_preserve_rows_and_routing(
++    rows, expected_slice_rows
++):
++    with _Harness(env={"VLLM_EXL3_PREFILL_CAPACITY": "128"}) as h:
++        method = _make_method()
++        layer = _make_layer()
++        x = torch.arange(rows, dtype=torch.bfloat16).unsqueeze(1).expand(-1, HIDDEN)
++        weights = torch.arange(rows * TOPK, dtype=torch.float32).reshape(rows, TOPK)
++        ids = torch.arange(rows * TOPK, dtype=torch.int64).reshape(rows, TOPK)
++        ids = ids.remainder(EXPERTS)
++
++        out = method._apply_rank_sliced(layer, x, weights, ids)
++
++        assert [bound[1] for bound in h.api.bound] == expected_slice_rows
++        assert torch.equal(out, x)
++        assert torch.equal(torch.cat([route[0] for route in h.api.routed]), weights)
++        assert torch.equal(torch.cat([route[1] for route in h.api.routed]), ids)
++        assert all(bound[0] is h.api.bound[0][0] for bound in h.api.bound)
++
++
++def test_default_prefill_capacity_keeps_single_dispatch():
++    with _Harness() as h:
++        out = _apply(_make_method(), _make_layer(), 200)
++
++        assert h.planned_caps()[-1]["max_tokens"] == MAX_BATCHED
++        assert [bound[1] for bound in h.api.bound] == [200]
++        assert out.shape == (200, HIDDEN)
++
++
++def test_mixed_prefill_capacity_slices_rows_and_routing():
++    with _Harness(env={"VLLM_EXL3_PREFILL_CAPACITY": "128"}) as h:
++        method = _make_method()
++        layer = _make_mixed_layer()
++        rows = 200
++        x = torch.arange(rows, dtype=torch.bfloat16).unsqueeze(1).expand(-1, HIDDEN)
++        weights = torch.arange(rows * TOPK, dtype=torch.float32).reshape(rows, TOPK)
++        ids = torch.arange(rows * TOPK, dtype=torch.int64).reshape(rows, TOPK)
++        ids = ids.remainder(EXPERTS)
++
++        out = method._apply_rank_sliced(layer, x, weights, ids)
++
++        assert [launch.size_m for launch in h.mixed_api.compiled] == [32, 128]
++        assert [launch.moe_block_size for launch in h.mixed_api.compiled] == [8, 64]
++        assert h.mixed_api.compiled[1].force_tile_config == (128, 128, 128, 128)
++        assert not h.planned_caps()
++        assert not h.api.bound
++        assert [call[0] for call in h.mixed_api.calls] == [128, 72]
++        assert all(
++            call[1:] == layer.exl3_mixed_trellis["prefill_tiers"]
++            for call in h.mixed_api.calls
++        )
++        assert torch.equal(out, x)
++        assert torch.equal(
++            torch.cat([route[0] for route in h.mixed_api.routed]), weights
++        )
++        assert torch.equal(torch.cat([route[1] for route in h.mixed_api.routed]), ids)
++
++
++def test_mixed_runtime_policy_is_resolved_once(monkeypatch):
++    calls = 0
++
++    def properties(device):
++        nonlocal calls
++        del device
++        calls += 1
++        return SimpleNamespace(
++            major=12,
++            multi_processor_count=1,
++            shared_memory_per_block_optin=1,
++        )
++
++    with _Harness() as h:
++        monkeypatch.setattr(torch.cuda, "get_device_properties", properties)
++        method = _make_method()
++        layer = _make_mixed_layer()
++        x = torch.zeros((16, HIDDEN), dtype=torch.bfloat16)
++        ids = torch.zeros((16, TOPK), dtype=torch.int64)
++
++        first = method._mixed_rank_sliced_runtime(layer, x, ids)
++        second = method._mixed_rank_sliced_runtime(layer, x, ids)
++
++        assert first is second
++        assert calls == 1
++        assert len(h.mixed_api.compiled) == 2
++
++
++def test_mixed_runtime_forwards_shared_h_broadcast_contract():
++    with _Harness() as h:
++        method = _make_method()
++        layer = _make_mixed_layer()
++        layer.exl3_mixed_trellis["broadcast_suh"] = True
++        layer.exl3_mixed_trellis["broadcast_svh"] = True
++        x = torch.zeros((16, HIDDEN), dtype=torch.bfloat16)
++        ids = torch.zeros((16, TOPK), dtype=torch.int64)
++
++        method._mixed_rank_sliced_runtime(layer, x, ids)
++
++        assert len(h.mixed_api.compiled) == 2
++        assert all(launch.broadcast_suh is True for launch in h.mixed_api.compiled)
++        assert all(launch.broadcast_svh is True for launch in h.mixed_api.compiled)
++
++
++def test_prefill_capacity_cannot_exceed_scheduler_bound():
++    env = {"VLLM_EXL3_PREFILL_CAPACITY": str(MAX_BATCHED + 1)}
++    with _Harness(env=env) as h:
++        with pytest.raises(ValueError, match="cannot exceed max_num_batched_tokens"):
++            _apply(_make_method(), _make_layer(), 16)
++        assert not h.planned_caps()
++
++
+ def test_prefill_trellis_disabled_restores_parity():
+     with _Harness(env={"VLLM_EXL3_PREFILL_TRELLIS": "0"}) as h:
+         method = _make_method()
+@@ -221,16 +420,19 @@ def test_prefill_trellis_disabled_restores_parity():
+         runtime = next(iter(exl3_module._RANK_SLICED_RUNTIMES.values()))
+         assert runtime["prefill_plan"] is None
+         assert runtime["parity_rows"] == MAX_BATCHED
+-        assert runtime["xh"].shape[0] == MAX_BATCHED
+ 
+ 
+ def test_prefill_block_m_env_override():
+-    with _Harness(env={"VLLM_EXL3_PREFILL_BLOCK_M": "48"}) as h:
++    env = {
++        "VLLM_EXL3_PREFILL_BLOCK_M": "48",
++        "VLLM_EXL3_PREFILL_CAPACITY": "128",
++    }
++    with _Harness(env=env) as h:
+         method = _make_method()
+         layer = _make_layer()
+         _apply(method, layer, 40)
+         assert h.planned_caps()[-1]["w4a16_block_size_m"] == 48
+-        assert h.api.bound[-1][0].caps["max_tokens"] == MAX_BATCHED
++        assert h.api.bound[-1][0].caps["max_tokens"] == 128
+ 
+ 
+ def test_parity_window_capacity_is_validated_before_planning():
+@@ -259,7 +461,11 @@ def test_disabled_prefill_plan_keeps_full_parity_capacity():
+ 
+ 
+ def test_explicit_parity_path_guarded_against_capture():
+-    with _Harness(env={"VLLM_EXL3_TRELLIS_MIN_M": "4"}) as h:
++    env = {
++        "VLLM_EXL3_TRELLIS_MIN_M": "4",
++        "VLLM_EXL3_PREFILL_CAPACITY": "128",
++    }
++    with _Harness(env=env) as h:
+         method = _make_method()
+         layer = _make_layer()
+         # Plan eagerly, then flip into "capturing" state.
+@@ -268,18 +474,14 @@ def test_explicit_parity_path_guarded_against_capture():
+         # Both trellis plans stay capture-safe.
+         _apply(method, layer, 16)
+         _apply(method, layer, 200)
+-        assert h.api.bound[-1][1] == 200
++        assert [bound[1] for bound in h.api.bound[-2:]] == [128, 72]
+         # The eager parity path must refuse to be recorded.
+-        try:
++        with pytest.raises(RuntimeError, match="capture"):
+             _apply(method, layer, 2)
+-        except RuntimeError as err:
+-            assert "capture" in str(err)
+-        else:
+-            raise AssertionError("parity path must raise during capture")
+ 
+ 
+ if __name__ == "__main__":
+-    test_dual_plan_construction_and_dispatch()
++    test_opt_in_prefill_capacity_slices_dispatch()
+     test_prefill_trellis_disabled_restores_parity()
+     test_prefill_block_m_env_override()
+     test_explicit_parity_path_guarded_against_capture()
+diff --git a/tests/quantization/test_exl3_warmup.py b/tests/quantization/test_exl3_warmup.py
+new file mode 100644
+index 0000000000000000000000000000000000000000..c9b5a210f03ba8f17cd8a42546f1ffdb4b0deb86
+--- /dev/null
++++ b/tests/quantization/test_exl3_warmup.py
+@@ -0,0 +1,55 @@
++from types import SimpleNamespace
++from unittest.mock import Mock
++
++import pytest
++import torch
++
++from vllm.model_executor.layers.quantization.exl3 import (
++    warmup_exl3_mixed_trellis_route_pack,
++)
++
++
++def _model_with_mixed_trellis(mixed: dict) -> torch.nn.Module:
++    model = torch.nn.Module()
++    holder = torch.nn.Module()
++    holder.routed_experts = SimpleNamespace(
++        exl3_mixed_trellis=mixed,
++        layer_name="model.layers.3.mlp.experts",
++    )
++    model.add_module("holder", holder)
++    return model
++
++
++def test_mixed_trellis_warmup_delegates_each_runtime_state() -> None:
++    warmup = Mock(side_effect=(6, 12))
++    api = SimpleNamespace(warmup_mixed_trellis_route_pack=warmup)
++    decode = {"launch": object(), "buffers": object()}
++    prefill = {"launch": object(), "buffers": object()}
++    expert_map = object()
++    model = _model_with_mixed_trellis(
++        {
++            "runtime": {
++                "mixed_api": api,
++                "decode": decode,
++                "prefill": prefill,
++            },
++            "global_to_combined": expert_map,
++        }
++    )
++
++    assert warmup_exl3_mixed_trellis_route_pack(model) == 18
++    assert warmup.call_args_list == [
++        ((decode["launch"], decode["buffers"]), {"expert_map": expert_map}),
++        ((prefill["launch"], prefill["buffers"]), {"expert_map": expert_map}),
++    ]
++
++
++def test_mixed_trellis_warmup_fails_closed_without_profiled_runtime() -> None:
++    model = _model_with_mixed_trellis({"global_to_combined": object()})
++
++    with pytest.raises(RuntimeError, match="eager profile pass must plan"):
++        warmup_exl3_mixed_trellis_route_pack(model)
++
++
++def test_mixed_trellis_warmup_ignores_unrelated_models() -> None:
++    assert warmup_exl3_mixed_trellis_route_pack(torch.nn.Linear(4, 4)) == 0
+diff --git a/tests/quantization/test_quantization_config_args.py b/tests/quantization/test_quantization_config_args.py
+index 2ec8761fc75de25e7c156375ec67041cb74fcd66..d881f82cbe82a40d587128095cb0ed38d886fe36 100644
+--- a/tests/quantization/test_quantization_config_args.py
++++ b/tests/quantization/test_quantization_config_args.py
+@@ -187,6 +187,35 @@ def test_resolve_rejects_modelopt_moe_override():
+         )
+ 
+ 
++def test_resolve_allows_exl3_bf16_mxfp8_overlay():
++    args = resolve_quantization_config(
++        "exl3",
++        {
++            "linear": {"weight": "mxfp8"},
++            "shared_experts": "mxfp8",
++            "ignore": ["re:.*q_a_proj$", "lm_head"],
++        },
++    )
++
++    assert args.linear == QuantSpec(weight=kMxfp8Dynamic)
++    assert args.shared_experts == QuantSpec(weight=kMxfp8Dynamic)
++    assert args.ignore == ["re:.*q_a_proj$", "lm_head"]
++
++
++@pytest.mark.parametrize(
++    "config",
++    [
++        {"linear": {"weight": "fp8_per_block_static"}},
++        {"linear": {"weight": "mxfp8", "activation": "mxfp8"}},
++        {"linear": {"weight": "mxfp8"}, "moe": "mxfp8"},
++        {"shared_experts": "mxfp8", "ignore": ["lm_head"]},
++    ],
++)
++def test_resolve_rejects_unsupported_exl3_overlay(config):
++    with pytest.raises(ValueError, match="checkpoint online overlay"):
++        resolve_quantization_config("exl3", config)
++
++
+ def test_resolve_rejects_quantization_config_with_non_shorthand_quant():
+     # If --quantization names something other than an online shorthand,
+     # quantization_config is not allowed via this path (checkpoint quant
+diff --git a/tests/test_envs.py b/tests/test_envs.py
+index 56c04dd6f2e2d1005b0f2d4f925099aa88e7e7ca..e864ae549aab703ae3269c4992c1ef8eb756c821 100644
+--- a/tests/test_envs.py
++++ b/tests/test_envs.py
+@@ -48,6 +48,53 @@ def test_p2p_side_channel_defaults_and_override(monkeypatch: pytest.MonkeyPatch)
+     assert envs.VLLM_P2P_SIDE_CHANNEL_PORT == 5799
+ 
+ 
++def _clear_unknown_vllm_envs(monkeypatch: pytest.MonkeyPatch) -> None:
++    """Remove inherited VLLM variables not known by this source tree."""
++    for name in list(os.environ):
++        if name.startswith("VLLM_") and name not in environment_variables:
++            monkeypatch.delenv(name)
++
++
++@pytest.mark.parametrize(
++    ("name", "value", "expected"),
++    [
++        ("VLLM_B12X_MLA_SPEC_DECODE_MAX_Q", "12", 12),
++        ("VLLM_B12X_MLA_SPEC_EXTEND_AS_DECODE", "1", "1"),
++        ("VLLM_PCIE_DMA_FP8", "ring", "ring"),
++        ("VLLM_CPP_AR_1STAGE_NCCL_CUTOFF", "56KB", "56KB"),
++        ("VLLM_CPP_AR_IGNORE_CUTOFF_MAX_ROWS", "4", 4),
++        ("VLLM_USE_B12X_PCIE_DMA", "1", True),
++        ("VLLM_CACHE_DIR", "/cache/vllm", "/cache/vllm"),
++    ],
++)
++def test_gilded_gnosis_runtime_envs_are_registered(
++    monkeypatch: pytest.MonkeyPatch,
++    name: str,
++    value: str,
++    expected: str | int,
++) -> None:
++    """Accept every GG runtime variable consumed outside the env registry."""
++    _clear_unknown_vllm_envs(monkeypatch)
++    monkeypatch.setenv(name, value)
++
++    envs.validate_environ(hard_fail=True)
++    assert environment_variables[name]() == expected
++
++
++def test_gilded_gnosis_env_registration_keeps_unknown_detection(
++    monkeypatch: pytest.MonkeyPatch,
++) -> None:
++    """Continue rejecting misspelled VLLM variables after registration."""
++    _clear_unknown_vllm_envs(monkeypatch)
++    monkeypatch.setenv("VLLM_GILDED_GNOSIS_TYPO", "1")
++
++    with pytest.raises(
++        ValueError,
++        match="Unknown vLLM environment variable detected: VLLM_GILDED_GNOSIS_TYPO",
++    ):
++        envs.validate_environ(hard_fail=True)
++
++
+ def test_getattr_with_cache(monkeypatch: pytest.MonkeyPatch):
+     monkeypatch.setenv("VLLM_HOST_IP", "1.1.1.1")
+     monkeypatch.setenv("VLLM_PORT", "1234")
+diff --git a/tests/tokenizers_/fixtures/deepseek_v4/test_output_1.txt b/tests/tokenizers_/fixtures/deepseek_v4/test_output_1.txt
+index dbd823476c1c34156b5bff79bf493d3074098576..7e3c9bd5a394617f02d76384d613d991e60d48bd 100644
+--- a/tests/tokenizers_/fixtures/deepseek_v4/test_output_1.txt
++++ b/tests/tokenizers_/fixtures/deepseek_v4/test_output_1.txt
+@@ -1,4 +1,4 @@
+-<｜begin▁of▁sentence｜>
++<｜begin▁of▁sentence｜>You are a helpful assistant.
+ 
+ ## Tools
+ 
+@@ -26,7 +26,7 @@ Otherwise, output directly after </think> with tool calls or final response.
+ {"name": "search", "description": "Search the web for information", "parameters": {"type": "object", "properties": {"query": {"type": "string", "description": "Search query"}, "num_results": {"type": "integer", "description": "Number of results to return"}}, "required": ["query"]}}
+ 
+ You MUST strictly follow the above defined tool name and parameter schemas to invoke tool calls.
+-You are a helpful assistant.<｜User｜>What's the weather in Beijing?<｜Assistant｜><think>The user wants to know the weather in Beijing. I should use the get_weather tool.</think>
++<｜User｜>What's the weather in Beijing?<｜Assistant｜><think>The user wants to know the weather in Beijing. I should use the get_weather tool.</think>
+ 
+ <｜DSML｜tool_calls>
+ <｜DSML｜invoke name="get_weather">
+diff --git a/tests/tokenizers_/test_deepseek_v4.py b/tests/tokenizers_/test_deepseek_v4.py
+index 358732eabf40ebafc14c032c10da74dd2149a111..ea82c69c4eb793552a4ee57109ec82ab51f65123 100644
+--- a/tests/tokenizers_/test_deepseek_v4.py
++++ b/tests/tokenizers_/test_deepseek_v4.py
+@@ -126,6 +126,165 @@ def test_deepseek_v4_uses_v4_tool_prompt_from_request_tools():
+     assert prompt.endswith("<｜User｜>Weather?<｜Assistant｜></think>")
+ 
+ 
++def test_deepseek_v4_attaches_request_tools_after_existing_system_prompt():
++    tools = [
++        {
++            "type": "function",
++            "function": {
++                "name": "lookup",
++                "description": "Look things up",
++                "parameters": {"type": "object", "properties": {}},
++            },
++        }
++    ]
++
++    prompt = _tokenizer().apply_chat_template(
++        [
++            {"role": "system", "content": "Follow policy."},
++            {"role": "user", "content": "Find it."},
++        ],
++        tools=tools,
++        tokenize=False,
++        enable_thinking=True,
++        reasoning_effort="max",
++    )
++
++    max_prefix = "Reasoning Effort: Beyond maximum"
++    system = "Follow policy."
++    tool_block = "## Tools"
++    user = "<｜User｜>Find it."
++    assert prompt.index(max_prefix) < prompt.index(system)
++    assert prompt.index(system) < prompt.index(tool_block)
++    assert prompt.index(tool_block) < prompt.index(user)
++
++
++def test_deepseek_v4_attaches_request_tools_to_existing_developer_prompt():
++    tools = [
++        {
++            "type": "function",
++            "function": {
++                "name": "lookup",
++                "description": "Look things up",
++                "parameters": {"type": "object", "properties": {}},
++            },
++        }
++    ]
++
++    prompt = _tokenizer().apply_chat_template(
++        [
++            {"role": "developer", "content": "Follow policy."},
++            {"role": "user", "content": "Find it."},
++        ],
++        tools=tools,
++        tokenize=False,
++    )
++
++    assert prompt.index("Follow policy.") < prompt.index("## Tools")
++    assert prompt.index("## Tools") < prompt.index("<｜User｜>Find it.")
++    assert prompt.count("## Tools") == 1
++
++
++def test_deepseek_v4_merges_message_and_request_tools_into_one_block():
++    message_tools = [
++        {
++            "type": "function",
++            "function": {"name": "old_tool", "parameters": {"type": "object"}},
++        }
++    ]
++    request_tools = [
++        {
++            "type": "function",
++            "function": {"name": "new_tool", "parameters": {"type": "object"}},
++        }
++    ]
++
++    prompt = _tokenizer().apply_chat_template(
++        [
++            {
++                "role": "system",
++                "content": "Follow policy.",
++                "tools": message_tools,
++            },
++            {"role": "user", "content": "Find it."},
++        ],
++        tools=request_tools,
++        tokenize=False,
++    )
++
++    assert prompt.count("## Tools") == 1
++    assert '"name": "new_tool"' in prompt
++    assert '"name": "old_tool"' in prompt
++
++
++def test_deepseek_v4_request_tool_replaces_same_named_message_tool():
++    prompt = _tokenizer().apply_chat_template(
++        [
++            {
++                "role": "system",
++                "content": "Follow policy.",
++                "tools": [
++                    {
++                        "type": "function",
++                        "function": {
++                            "name": "lookup",
++                            "description": "old definition",
++                            "parameters": {"type": "object"},
++                        },
++                    }
++                ],
++            },
++            {"role": "user", "content": "Find it."},
++        ],
++        tools=[
++            {
++                "type": "function",
++                "function": {
++                    "name": "lookup",
++                    "description": "new definition",
++                    "parameters": {"type": "object"},
++                },
++            }
++        ],
++        tokenize=False,
++    )
++
++    assert prompt.count("## Tools") == 1
++    assert prompt.count('"name": "lookup"') == 1
++    assert "new definition" in prompt
++    assert "old definition" not in prompt
++
++
++def test_deepseek_v4_renders_message_level_system_tools():
++    tools = [
++        {
++            "type": "function",
++            "function": {
++                "name": "lookup",
++                "description": "Look things up",
++                "parameters": {"type": "object", "properties": {}},
++            },
++        }
++    ]
++    messages = [
++        {"role": "system", "content": "Follow policy.", "tools": tools},
++        {"role": "user", "content": "Find it."},
++    ]
++    conversation, _, _ = parse_chat_messages(
++        messages,
++        _model_config(),
++        content_format="string",
++    )
++
++    prompt = _tokenizer().apply_chat_template(
++        conversation=conversation,
++        messages=messages,
++        tokenize=False,
++    )
++
++    assert prompt.index("Follow policy.") < prompt.index("## Tools")
++    assert prompt.index("## Tools") < prompt.index("<｜User｜>Find it.")
++
++
+ def test_deepseek_v4_renders_parsed_history_tool_arguments():
+     messages = [
+         {"role": "user", "content": "List the repo"},
+@@ -183,8 +342,56 @@ def test_deepseek_v4_renders_parsed_history_tool_arguments():
+     assert 'parameter name="arguments"' not in prompt
+ 
+ 
+-@pytest.mark.parametrize("reasoning_effort", ["minimal", "low", "medium", "high"])
+-def test_deepseek_v4_accepts_openai_reasoning_effort_values(reasoning_effort):
++@pytest.mark.parametrize(
++    ("arguments", "expected_value", "is_string"),
++    [
++        ("", "", True),
++        ("not json", "not json", True),
++        ('{"unterminated": 1', '{"unterminated": 1', True),
++        (None, "null", False),
++        ([1, 2], "[1, 2]", False),
++        ("[1, 2]", "[1, 2]", False),
++    ],
++)
++def test_deepseek_v4_renders_non_object_history_tool_arguments(
++    arguments,
++    expected_value,
++    is_string,
++):
++    prompt = _tokenizer().apply_chat_template(
++        [
++            {"role": "user", "content": "Run it"},
++            {
++                "role": "assistant",
++                "tool_calls": [
++                    {
++                        "type": "function",
++                        "function": {"name": "run", "arguments": arguments},
++                    }
++                ],
++            },
++        ],
++        tokenize=False,
++    )
++
++    parameter = (
++        f'<｜DSML｜parameter name="arguments" '
++        f'string="{str(is_string).lower()}">{expected_value}'
++    )
++    assert parameter in prompt
++
++
++@pytest.mark.parametrize(
++    ("reasoning_effort", "expected_prefix"),
++    [
++        ("low", "<｜begin▁of▁sentence｜><｜User｜>Hello"),
++        ("high", "<｜begin▁of▁sentence｜>Reasoning Effort: Absolute maximum"),
++        ("max", "<｜begin▁of▁sentence｜>Reasoning Effort: Beyond maximum"),
++    ],
++)
++def test_deepseek_v4_renders_0731_reasoning_effort_prompts(
++    reasoning_effort, expected_prefix
++):
+     prompt = _tokenizer().apply_chat_template(
+         [{"role": "user", "content": "Hello"}],
+         tokenize=False,
+@@ -193,7 +400,7 @@ def test_deepseek_v4_accepts_openai_reasoning_effort_values(reasoning_effort):
+     )
+ 
+     assert prompt.endswith("<｜Assistant｜><think>")
+-    assert "Reasoning Effort: Absolute maximum" not in prompt
++    assert prompt.startswith(expected_prefix)
+ 
+ 
+ def test_deepseek_v4_none_reasoning_effort_disables_thinking():
+@@ -212,7 +419,7 @@ def test_deepseek_v4_none_reasoning_effort_disables_thinking():
+     [
+         ("none", "chat", None),
+         ("minimal", "thinking", "high"),
+-        ("low", "thinking", "high"),
++        ("low", "thinking", "low"),
+         ("medium", "thinking", "high"),
+         ("high", "thinking", "high"),
+         ("xhigh", "thinking", "max"),
+@@ -248,7 +455,7 @@ def test_deepseek_v4_maps_compatible_thinking_reasoning_effort_values(
+     assert captured_kwargs[-1]["reasoning_effort"] == expected_effort
+ 
+ 
+-def test_deepseek_v4_preserves_reference_max_reasoning_effort():
++def test_deepseek_v4_renders_0731_max_reasoning_effort():
+     prompt = _tokenizer().apply_chat_template(
+         [{"role": "user", "content": "Hello"}],
+         tokenize=False,
+@@ -256,12 +463,10 @@ def test_deepseek_v4_preserves_reference_max_reasoning_effort():
+         reasoning_effort="max",
+     )
+ 
+-    assert prompt.startswith(
+-        "<｜begin▁of▁sentence｜>Reasoning Effort: Absolute maximum"
+-    )
++    assert prompt.startswith("<｜begin▁of▁sentence｜>Reasoning Effort: Beyond maximum")
+ 
+ 
+-def test_deepseek_v4_maps_xhigh_to_reference_max_reasoning_effort():
++def test_deepseek_v4_maps_xhigh_to_0731_max_reasoning_effort():
+     prompt = _tokenizer().apply_chat_template(
+         [{"role": "user", "content": "Hello"}],
+         tokenize=False,
+@@ -269,9 +474,7 @@ def test_deepseek_v4_maps_xhigh_to_reference_max_reasoning_effort():
+         reasoning_effort="xhigh",
+     )
+ 
+-    assert prompt.startswith(
+-        "<｜begin▁of▁sentence｜>Reasoning Effort: Absolute maximum"
+-    )
++    assert prompt.startswith("<｜begin▁of▁sentence｜>Reasoning Effort: Beyond maximum")
+ 
+ 
+ @pytest.mark.parametrize(
+diff --git a/tests/v1/attention/test_flashinfer_decode_qlen_guard.py b/tests/v1/attention/test_flashinfer_decode_qlen_guard.py
+new file mode 100644
+index 0000000000000000000000000000000000000000..0f3b7eb681b4075601534cfc8227c2fb3d7f0928
+--- /dev/null
++++ b/tests/v1/attention/test_flashinfer_decode_qlen_guard.py
+@@ -0,0 +1,139 @@
++"""Persistent FlashInfer decode wrappers may only be reused when the runtime
++q_len_per_req equals the value frozen during wrapper planning (1 + K).
++
++The decode-classification ceiling (reorder_batch_threshold = 1 + 2K under
++parallel drafting) deliberately admits reduced-depth lone steps as decodes —
++spec truncation near max_tokens, short chunked-prefill tails fused with the
++spec step. Those steps must take the dynamic wrapper; routing them to a
++captured wrapper raises inside flashinfer's fast_decode_plan ("q_len_per_req
++is part of the frozen cudagraph shape: this wrapper was planned with 6,
++got 8|5") and kills the engine.
++
++These tests pin the invariant and, deliberately, the distinction between the
++classification ceiling (1 + 2K) and the planned shape (1 + K): substituting
++reorder_batch_threshold for the planned length reintroduces the crash.
++"""
++
++from types import SimpleNamespace
++
++import pytest
++import torch
++
++from vllm.v1.attention.backend import AttentionMetadataBuilder
++from vllm.v1.attention.backends.flashinfer import (
++    decode_q_len_from_indptr,
++    persistent_decode_wrapper_eligible,
++)
++from vllm.v1.attention.backends.utils import split_decodes_and_prefills
++
++K = 5
++PLANNED = 1 + K
++CEILING = 1 + 2 * K
++MAX_BS = 96
++
++
++def _threshold_for(parallel_drafting: bool) -> int:
++    stub = SimpleNamespace(
++        vllm_config=SimpleNamespace(
++            speculative_config=SimpleNamespace(
++                num_speculative_tokens=K,
++                parallel_drafting=parallel_drafting,
++            ),
++            parallel_config=SimpleNamespace(decode_context_parallel_size=1),
++        )
++    )
++    AttentionMetadataBuilder._init_reorder_batch_threshold(
++        stub, 1, supports_spec_as_decode=True
++    )
++    return stub.reorder_batch_threshold
++
++
++def _eligible(q_len, *, num_reqs=1, pure_decode=True, max_bs=MAX_BS,
++              planned=PLANNED):
++    return persistent_decode_wrapper_eligible(
++        pure_decode=pure_decode,
++        num_decode_tokens=q_len * num_reqs,
++        decode_cudagraph_max_bs=max_bs,
++        decode_q_len=q_len,
++        planned_decode_q_len=planned,
++    )
++
++
++def test_classification_ceiling_is_not_planned_shape():
++    assert _threshold_for(parallel_drafting=True) == CEILING
++    assert _threshold_for(parallel_drafting=False) == PLANNED
++    assert CEILING != PLANNED
++
++
++def test_planned_shape_selects_persistent_wrapper():
++    assert _eligible(PLANNED)
++    assert _eligible(PLANNED, num_reqs=8)
++
++
++@pytest.mark.parametrize(
++    "q_len", [q for q in range(1, CEILING + 1) if q != PLANNED]
++)
++def test_reduced_or_extended_depth_falls_back_to_dynamic(q_len):
++    # Covers both observed crash signatures: q_len=5 (spec truncation near
++    # max_tokens) and q_len=8 (chunked-prefill tail fused with spec step).
++    assert not _eligible(q_len)
++
++
++def test_above_ceiling_classifies_as_prefill():
++    meta = SimpleNamespace(
++        max_query_len=CEILING + 1,
++        num_reqs=1,
++        num_actual_tokens=CEILING + 1,
++        query_start_loc_cpu=torch.tensor([0, CEILING + 1], dtype=torch.int32),
++    )
++    nd, npf, ndt, npt = split_decodes_and_prefills(
++        meta, decode_threshold=CEILING, require_uniform=True
++    )
++    assert (nd, npf, ndt, npt) == (0, 1, 0, CEILING + 1)
++
++
++def test_other_predicate_terms_still_gate():
++    assert not _eligible(PLANNED, pure_decode=False)
++    assert not _eligible(PLANNED, num_reqs=32)  # over capacity
++
++
++def test_no_spec_planned_length_is_one():
++    assert _eligible(1, planned=1)
++    assert not _eligible(2, planned=1)
++
++
++def _indptr(*lens):
++    out = [0]
++    for n in lens:
++        out.append(out[-1] + n)
++    return torch.tensor(out, dtype=torch.int32)
++
++
++@pytest.mark.parametrize(
++    ("lens", "expected"),
++    [
++        ((PLANNED,), PLANNED),
++        ((PLANNED, 0), PLANNED),          # one active + one padding row
++        ((PLANNED, PLANNED, 0), PLANNED),
++        ((PLANNED,) * 3 + (0,), PLANNED), # total not divisible by num rows
++        ((0, 0), 0),                      # all-padding
++        ((5,), 5),                        # reduced-depth lone step
++    ],
++)
++def test_decode_q_len_ignores_zero_padding(lens, expected):
++    assert decode_q_len_from_indptr(_indptr(*lens), len(lens)) == expected
++
++
++def test_zero_padded_planned_batch_keeps_persistent_wrapper():
++    # Regression: uniform CUDA-graph batches may carry zero-length padding
++    # rows; averaging tokens over rows understated the active q_len and
++    # demoted a planned-shape batch to the dynamic wrapper.
++    lens = (PLANNED, 0)
++    q_len = decode_q_len_from_indptr(_indptr(*lens), len(lens))
++    assert persistent_decode_wrapper_eligible(
++        pure_decode=True,
++        num_decode_tokens=sum(lens),
++        decode_cudagraph_max_bs=MAX_BS,
++        decode_q_len=q_len,
++        planned_decode_q_len=PLANNED,
++    )
+diff --git a/tests/v1/cudagraph/test_breakable_cudagraph.py b/tests/v1/cudagraph/test_breakable_cudagraph.py
+index 72a9a11d3cb81cf388b7a42fc7ba7af68ae9a288..aedc99a1787da628151a439d96f7d175cce94649 100644
+--- a/tests/v1/cudagraph/test_breakable_cudagraph.py
++++ b/tests/v1/cudagraph/test_breakable_cudagraph.py
+@@ -99,6 +99,7 @@ def test_memory_profile_reuses_production_pool_and_destroys_graphs(monkeypatch):
+         def capture(self, *args, **kwargs):
+             assert self.pool is production_pool
+             assert wrapper.graph_pool is production_pool
++            assert kwargs["channel_id"] == "vllm:target:profile"
+             lazy_wrapper = FakeWrapper()
+             lazy_wrapper.graph_pool = self.pool
+             lazy_wrappers.append(lazy_wrapper)
+@@ -112,8 +113,9 @@ def test_memory_profile_reuses_production_pool_and_destroys_graphs(monkeypatch):
+         def get_cudagraph_managers(self):
+             return []
+ 
+-        def capture(self):
++        def capture(self, *, capture_phase):
+             assert workspace_module._workspace_lane.get() == 1
++            assert capture_phase == "profile"
+             events.append("spec_capture")
+ 
+     manager = FakeManager()
+@@ -235,6 +237,7 @@ def test_production_capture_releases_pool_anchor_on_failure(monkeypatch):
+ 
+         @staticmethod
+         def capture(*args, **kwargs):
++            assert kwargs["channel_id"] == "vllm:target:production"
+             events.append("capture")
+             raise RuntimeError("capture failed")
+ 
+@@ -269,6 +272,60 @@ def test_production_capture_releases_pool_anchor_on_failure(monkeypatch):
+     assert events == ["capture", "anchor_reset"]
+ 
+ 
++def test_production_capture_assigns_target_and_draft_phase_ids(monkeypatch):
++    from vllm.v1.worker.gpu import model_runner as model_runner_module
++
++    events = []
++
++    class FakeManager:
++        @staticmethod
++        def needs_capture():
++            return True
++
++        @staticmethod
++        def capture(*args, **kwargs):
++            events.append(("target", kwargs["channel_id"]))
++
++    class FakeSpeculator:
++        @staticmethod
++        def capture(*, capture_phase):
++            events.append(("draft", capture_phase))
++
++    runner = model_runner_module.GPUModelRunner.__new__(
++        model_runner_module.GPUModelRunner
++    )
++    runner.cudagraph_manager = FakeManager()
++    runner._cudagraph_pool_anchor = None
++    runner.lora_config = None
++    runner.model = object()
++    runner.model_state = object()
++    runner.input_buffers = object()
++    runner.intermediate_tensors = object()
++    runner.block_tables = object()
++    runner.attn_groups = object()
++    runner.kv_cache_config = object()
++    runner.use_aux_hidden_state_outputs = False
++    runner.speculator = FakeSpeculator()
++    runner.maybe_setup_dummy_loras = lambda _: nullcontext()
++    runner._zero_cudagraph_capture_kv_blocks = lambda: None
++
++    monkeypatch.setattr(model_runner_module.gc, "collect", lambda: None)
++    monkeypatch.setattr(torch.accelerator, "empty_cache", lambda: None)
++    monkeypatch.setattr(
++        torch.accelerator,
++        "get_memory_info",
++        lambda: (1000, 0),
++    )
++    monkeypatch.setattr(model_runner_module, "lock_workspace", lambda: None)
++
++    runner.capture_model()
++
++    assert events == [
++        ("target", "vllm:target:production"),
++        ("draft", "production"),
++    ]
++
++
+ def test_skipped_production_capture_releases_pool_anchor():
+     from vllm.v1.worker.gpu import model_runner as model_runner_module
+ 
+@@ -372,13 +429,21 @@ def test_piecewise_capture_builds_fresh_metadata_for_both_passes():
+         patch(
+             "vllm.v1.worker.gpu.cudagraph_utils.graph_capture",
+             return_value=nullcontext(),
+-        ),
++        ) as graph_capture_mock,
+         patch(
+             "vllm.v1.worker.gpu.cudagraph_utils.is_global_first_rank",
+             return_value=False,
+         ),
+     ):
+-        manager.capture(create_forward_fn)
++        manager.capture(
++            create_forward_fn,
++            channel_id="vllm:target:profile",
++        )
++
++    graph_capture_mock.assert_called_once_with(
++        device=torch.device("cpu"),
++        channel_id="vllm:target:profile",
++    )
+ 
+     assert [warmup for warmup, _ in create_calls] == [True, False]
+     assert [mode for _, mode, _ in forward_calls] == [
+diff --git a/tests/v1/kv_connector/unit/offloading_connector/test_scheduler.py b/tests/v1/kv_connector/unit/offloading_connector/test_scheduler.py
+index c783957de6717a633d46e78f210735fc6dfacd45..e1a1b4d8288e71bbb545962383a814e6b802296b 100644
+--- a/tests/v1/kv_connector/unit/offloading_connector/test_scheduler.py
++++ b/tests/v1/kv_connector/unit/offloading_connector/test_scheduler.py
+@@ -37,6 +37,10 @@ from vllm.v1.kv_offload.base import (
+     get_offload_block_hash,
+     make_offload_key,
+ )
++from vllm.v1.kv_offload.tiering.manager import (
++    CPUPrimaryTierOffloadingManager,
++    TieringOffloadingManager,
++)
+ from vllm.v1.request import RequestStatus
+ 
+ 
+@@ -53,6 +57,19 @@ def _reduce_kv_connector_stats(runner):
+     return reduced
+ 
+ 
++def test_remove_pending_job_deduplicates_lockstep_mla_block_ids() -> None:
++    """Clean one shared physical block once per transfer job."""
++    scheduler = object.__new__(OffloadingConnectorScheduler)
++    scheduler._block_id_to_pending_jobs = {
++        7: {42, 43},
++        9: {42},
++    }
++
++    scheduler._remove_pending_job(42, [7, 7, 9, 9])
++
++    assert scheduler._block_id_to_pending_jobs == {7: {43}}
++
++
+ def test_scheduler_reports_allocation_failure(request_runner):
+     runner = request_runner(
+         block_size=4,
+@@ -65,7 +82,8 @@ def test_scheduler_reports_allocation_failure(request_runner):
+     runner.run(decoded_tokens=[EOS_TOKEN_ID])
+ 
+     reduced = _reduce_kv_connector_stats(runner)
+-    assert reduced[_ConnectorMetricName.ALLOCATION_FAILURE] == 1
++    # The final scheduler step retries the failed store before finalization.
++    assert reduced[_ConnectorMetricName.ALLOCATION_FAILURE] == 2
+ 
+ 
+ @pytest.mark.parametrize("missing_metadata", ["block_ids", "offload_keys"])
+@@ -166,7 +184,7 @@ def test_abort_queued_request_does_not_build_store_job(
+ def test_last_block_offloaded_at_request_finish(
+     request_runner, async_scheduling: bool, prompt_offset: int
+ ):
+-    """EOS fills the last block at request finish — verify req_status is kept alive.
++    """EOS fills the last block at request finish and stores it before cleanup.
+ 
+     prompt = block_size + prompt_offset tokens → not a full block at schedule time,
+     so _build_store_jobs creates no store job. After EOS, request_finished
+@@ -188,19 +206,50 @@ def test_last_block_offloaded_at_request_finish(
+         generate_store_output(list(keys))
+     )
+ 
+-    # Run with one step (EOS)
+-    runner.run(
+-        decoded_tokens=[EOS_TOKEN_ID],
+-    )
++    if prompt_offset == -1:
++        runner.run(decoded_tokens=[EOS_TOKEN_ID], expected_stored=(0,))
++    else:
++        runner.run(decoded_tokens=[EOS_TOKEN_ID])
+ 
+     cs = runner.connector_scheduler
+-    # Verify req_status is kept alive for _build_store_jobs to process
+-    # regardless of whether there are storable blocks
+-    assert "0" in cs._req_status, (
+-        "req_status was deleted but should be kept alive "
+-        "for _build_store_jobs to process finished_req_ids."
++    assert "0" not in cs._req_status
++
++
++@pytest.mark.parametrize("async_scheduling", [True, False])
++def test_tiering_manager_final_store_precedes_request_finish(
++    request_runner, async_scheduling: bool
++):
++    """Regression for a final-store KeyError in TieringOffloadingManager."""
++    runner = request_runner(
++        block_size=4,
++        num_gpu_blocks=10,
++        async_scheduling=async_scheduling,
+     )
+ 
++    manager_events: list[str] = []
++    primary = MagicMock(spec=CPUPrimaryTierOffloadingManager)
++    primary.lookup.return_value = LookupResult.MISS
++    primary.get_stats.return_value = None
++    primary.take_events.return_value = []
++
++    def prepare_store(keys, req_context):
++        manager_events.append("prepare_store")
++        return generate_store_output(keys)
++
++    primary.prepare_store.side_effect = prepare_store
++    primary.on_request_finished.side_effect = lambda req_context: manager_events.append(
++        "on_request_finished"
++    )
++
++    tiering_manager = TieringOffloadingManager(primary_tier=primary)
++    runner.connector_scheduler.manager = tiering_manager
++
++    runner.new_request(token_ids=[0, 0, 0])
++    runner.run(decoded_tokens=[EOS_TOKEN_ID], expected_stored=(0,))
++
++    assert manager_events == ["prepare_store", "on_request_finished"]
++    assert tiering_manager._req_state == {}
++
+ 
+ def test_scheduler_reports_lookup_sync_delay(request_runner):
+     runner = request_runner(
+@@ -423,10 +472,10 @@ def test_request_preemption(request_runner, async_scheduling: bool):
+ 
+ 
+ @pytest.mark.parametrize("async_scheduling", [True, False])
+-def test_on_request_finished_is_not_deferred_until_store_completion(
++def test_on_request_finished_not_deferred_until_store_completion(
+     request_runner, async_scheduling: bool
+ ):
+-    """on_request_finished fires when no more stores will be submitted.
++    """on_request_finished fires after the last prepare_store is submitted.
+ 
+     A request can finish while its GPU->primary store is still in flight. The
+     manager-level hook should not wait for that completion; complete_store may
+@@ -467,8 +516,8 @@ def test_on_request_finished_is_not_deferred_until_store_completion(
+         complete_transfers=False,
+     )
+ 
+-    # Finish the request while its stores are still in flight. The hook should
+-    # fire immediately even though no complete_store has arrived yet.
++    # The following scheduler step submits the final store and fires the hook,
++    # without waiting for any complete_store callback.
+     runner.run(
+         decoded_tokens=[EOS_TOKEN_ID],
+         complete_transfers=False,
+@@ -685,7 +734,7 @@ def test_two_groups_full_and_sliding_window(request_runner, async_scheduling: bo
+     touch_calls = runner.manager.touch.call_args_list
+     assert len(touch_calls) == 6
+ 
+-    runner.run(decoded_tokens=[EOS_TOKEN_ID])
++    runner.run(decoded_tokens=[EOS_TOKEN_ID], expected_stored=(6,))
+ 
+     runner.scheduler.reset_prefix_cache()
+ 
+@@ -698,19 +747,11 @@ def test_two_groups_full_and_sliding_window(request_runner, async_scheduling: bo
+         # Group 1 (sliding window, window=2): only the last 2 blocks
+         #   are within the window → loads blocks 1,2
+         expected_loaded=((0, 0), (0, 1), (0, 2), (1, 1), (1, 2)),
+-        # The deferred store from the previous request's last block
+-        # completes during this step, and its blocks are flushed because
+-        # they were reallocated to the new request.
+-        # Only block 1 (sliding window group) is stored — block 0's
+-        # deferred store is flushed because it was reallocated.
+-        expected_stored=((0, 1),),
+-        expected_flushed=((0, 1),),
+     )
+ 
+-    # 4 touch calls: 2 from get_num_new_matched_tokens (2 groups)
+-    # + 2 from _get_reqs_to_store (2 groups)
++    # 2 touch calls from get_num_new_matched_tokens (2 groups).
+     touch_calls = runner.manager.touch.call_args_list
+-    assert len(touch_calls) == 4
++    assert len(touch_calls) == 2
+     # full attention group touched all 3 blocks
+     assert len(touch_calls[0].args[0]) == 3
+     # sliding window group touched just the last 2 blocks
+@@ -1553,16 +1594,13 @@ def test_reset_cache_finalizes_finished_request_with_pending_store(
+     assert req_status.transfer_jobs, "expected an in-flight store before finish"
+     assert any(job.is_store for job in cs._jobs.values())
+ 
+-    # Finish the request while its store is still in flight. request_finished
+-    # fires the hook eagerly, but the entry stays tracked so later completions
+-    # can still call complete_store().
++    # Finalization is deferred because the final store decision has not run.
+     req_status.req.status = RequestStatus.FINISHED_STOPPED
+     cs.request_finished(req_status.req)
+-    assert finalized == [req_id]
++    assert finalized == []
+     assert req_id in cs._req_status
+ 
+-    # reset_cache discards the in-flight store and drops the state without a
+-    # duplicate on_request_finished call.
++    # reset_cache discards pending work, signals finalization, and drops state.
+     cs.reset_cache()
+     assert finalized == [req_id]
+     assert req_id not in cs._req_status
+@@ -1783,6 +1821,288 @@ def test_swa_alignment_skip(request_runner, async_scheduling: bool):
+     )
+ 
+ 
++@pytest.mark.parametrize("async_scheduling", [True, False])
++def test_swa_alignment_skip_eagle(request_runner, async_scheduling: bool):
++    """EAGLE/MTP SWA groups store their per-segment tail run shifted one
++    block past the segment boundary.
++
++    _lookup requires sliding_window_size_in_chunks + 1 consecutive stored
++    blocks for eagle groups (the "+1 peek" block, dropped after matching).
++    Mirroring SlidingWindowManager.reachable_block_mask (shift=1), the store
++    path retains a run of tail + 1 blocks ending one block PAST each segment
++    boundary, so the post-drop hit lands exactly on the boundary.
++
++    Setup:
++      - Group 0: full attention, block_size=16
++      - Group 1: SWA + eagle, block_size=4, sliding_window=8
++
++    alignment_chunk_count = 16 / 4 = 4, tail = 2, need = 3 (incl. peek).
++    Reachable block positions: {2, 3, 4} and {6, 7, 8} (shifted by one).
++
++    With a 36-token prompt (2 full full-attn blocks, 9 SWA blocks):
++      - Group 0 stores: blocks 0, 1
++      - Group 1 stores: blocks 2, 3, 4, 6, 7, 8
++
++    A replay then hits exactly 32 tokens (the second segment boundary): the
++    eagle lookup matches the run [6, 7, 8], drops peek block 8, and the
++    load fetches window blocks [6, 7].
++    """
++    full_attn_block_size = 16
++    swa_block_size = 4
++    sliding_window = 8
++    num_gpu_blocks = 200
++
++    kv_cache_groups = [
++        KVCacheGroupSpec(
++            ["layer0"],
++            FullAttentionSpec(
++                block_size=full_attn_block_size,
++                num_kv_heads=1,
++                head_size=1,
++                dtype=torch.float32,
++            ),
++        ),
++        KVCacheGroupSpec(
++            ["layer1"],
++            SlidingWindowSpec(
++                block_size=swa_block_size,
++                num_kv_heads=1,
++                head_size=1,
++                dtype=torch.float32,
++                sliding_window=sliding_window,
++            ),
++            is_eagle_group=True,
++        ),
++    ]
++
++    runner = request_runner(
++        block_size=swa_block_size,
++        num_gpu_blocks=num_gpu_blocks,
++        async_scheduling=async_scheduling,
++        kv_cache_groups=kv_cache_groups,
++    )
++
++    kv_group_configs = runner.connector_scheduler.config.kv_group_configs
++    assert kv_group_configs[1].is_eagle_group
++    assert kv_group_configs[1].alignment_chunk_count == 4
++    assert kv_group_configs[1].sliding_window_size_in_chunks == 2
++    # No sparse retention -> no per-request replay tail.
++    assert runner.connector_scheduler.config.replay_alignment_tokens is None
++
++    # Track stored keys so lookups reflect the actual store-side filtering.
++    stored_keys: set = set()
++
++    def _prepare_store(keys, req_context):
++        keys = list(keys)
++        stored_keys.update(keys)
++        return generate_store_output(keys)
++
++    runner.manager.prepare_store.side_effect = _prepare_store
++    runner.manager.lookup.side_effect = lambda key, req_context: (
++        LookupResult.HIT if key in stored_keys else LookupResult.MISS
++    )
++
++    num_tokens = 36
++    runner.new_request(token_ids=[0] * num_tokens)
++    runner.run(decoded_tokens=[0])
++    runner.run(
++        decoded_tokens=[EOS_TOKEN_ID],
++        expected_stored=(
++            (0, 0),
++            (0, 1),
++            (1, 2),
++            (1, 3),
++            (1, 4),
++            (1, 6),
++            (1, 7),
++            (1, 8),
++        ),
++    )
++
++    # Replay the same prompt; the eagle group must hit exactly at the
++    # 32-token segment boundary via the shifted run [6, 7, 8].
++    runner.scheduler.reset_prefix_cache()
++    # Avoid re-storing the (unloaded) peek block during the replay.
++    runner.manager.prepare_store.side_effect = lambda keys, req_context: (
++        generate_store_output([])
++    )
++    runner.new_request(token_ids=[0] * num_tokens)
++    runner.run(
++        decoded_tokens=[EOS_TOKEN_ID],
++        expected_loaded=(
++            (0, 0),
++            (0, 1),
++            (1, 6),
++            (1, 7),
++        ),
++    )
++
++
++@pytest.mark.parametrize("async_scheduling", [True, False])
++def test_swa_alignment_retention_interval(
++    request_runner, monkeypatch, async_scheduling: bool
++):
++    """VLLM_PREFIX_CACHE_RETENTION_INTERVAL sets the sparsity segment size,
++    and a per-request replay-boundary tail keeps exact replays servable.
++
++    Mirrors SlidingWindowManager.reachable_block_mask: with sparse retention
++    the local GPU cache keeps SWA tails once per retention interval (not at
++    every full-attention block boundary), plus one tail run at the latest
++    full-attention-aligned boundary of the prompt (the "replay boundary") so
++    a replay of the same prompt does not fall back a whole retention segment.
++
++    Setup:
++      - retention interval = 32 tokens
++      - Group 0: full attention, block_size=16
++      - Group 1: SWA, block_size=4, sliding_window=8
++
++    alignment_chunk_count = 32 / 4 = 8 (retention-based, not 16 / 4 = 4).
++
++    With a 56-token prompt (3 full full-attn blocks, 14 SWA blocks):
++      - segment tails: blocks {6, 7} (the second segment is incomplete:
++        blocks 14, 15 never fill)
++      - replay boundary: (56 - 1) // 16 * 16 = 48 -> tail run {10, 11}
++      - Group 1 stores: blocks 6, 7, 10, 11
++
++    A replay of the prompt hits 48 tokens via the replay tail {10, 11};
++    without it, the hit would fall back to 32 (the only segment boundary).
++    """
++    monkeypatch.setenv("VLLM_PREFIX_CACHE_RETENTION_INTERVAL", "32")
++
++    full_attn_block_size = 16
++    swa_block_size = 4
++    sliding_window = 8
++    num_gpu_blocks = 200
++
++    kv_cache_groups = [
++        KVCacheGroupSpec(
++            ["layer0"],
++            FullAttentionSpec(
++                block_size=full_attn_block_size,
++                num_kv_heads=1,
++                head_size=1,
++                dtype=torch.float32,
++            ),
++        ),
++        KVCacheGroupSpec(
++            ["layer1"],
++            SlidingWindowSpec(
++                block_size=swa_block_size,
++                num_kv_heads=1,
++                head_size=1,
++                dtype=torch.float32,
++                sliding_window=sliding_window,
++            ),
++        ),
++    ]
++
++    runner = request_runner(
++        block_size=swa_block_size,
++        num_gpu_blocks=num_gpu_blocks,
++        async_scheduling=async_scheduling,
++        kv_cache_groups=kv_cache_groups,
++    )
++
++    config = runner.connector_scheduler.config
++    # Segment granularity comes from the retention interval.
++    assert config.kv_group_configs[1].alignment_chunk_count == 8
++    assert config.kv_group_configs[1].sliding_window_size_in_chunks == 2
++    # Replay tails align to the full-attention block size.
++    assert config.replay_alignment_tokens == full_attn_block_size
++
++    # Track stored keys so lookups reflect the actual store-side filtering.
++    stored_keys: set = set()
++
++    def _prepare_store(keys, req_context):
++        keys = list(keys)
++        stored_keys.update(keys)
++        return generate_store_output(keys)
++
++    runner.manager.prepare_store.side_effect = _prepare_store
++    runner.manager.lookup.side_effect = lambda key, req_context: (
++        LookupResult.HIT if key in stored_keys else LookupResult.MISS
++    )
++
++    num_tokens = 56
++    runner.new_request(token_ids=[0] * num_tokens)
++    runner.run(decoded_tokens=[0])
++    runner.run(
++        decoded_tokens=[EOS_TOKEN_ID],
++        expected_stored=(
++            (0, 0),
++            (0, 1),
++            (0, 2),
++            (1, 6),
++            (1, 7),
++            (1, 10),
++            (1, 11),
++        ),
++    )
++
++    # Replay the same prompt; the hit must reach the 48-token replay
++    # boundary served by the replay tail run {10, 11}.
++    runner.scheduler.reset_prefix_cache()
++    runner.manager.prepare_store.side_effect = lambda keys, req_context: (
++        generate_store_output([])
++    )
++    runner.new_request(token_ids=[0] * num_tokens)
++    runner.run(
++        decoded_tokens=[EOS_TOKEN_ID],
++        expected_loaded=(
++            (0, 0),
++            (0, 1),
++            (0, 2),
++            (1, 10),
++            (1, 11),
++        ),
++    )
++
++
++def test_swa_alignment_retains_shared_prefix_boundary(request_runner, monkeypatch):
++    """Native offload retains the same sparse shared-prefix tail as APC."""
++    monkeypatch.setenv("VLLM_PREFIX_CACHE_RETENTION_INTERVAL", "64")
++
++    kv_cache_groups = [
++        KVCacheGroupSpec(
++            ["layer0"],
++            FullAttentionSpec(
++                block_size=16,
++                num_kv_heads=1,
++                head_size=1,
++                dtype=torch.float32,
++            ),
++        ),
++        KVCacheGroupSpec(
++            ["layer1"],
++            SlidingWindowSpec(
++                block_size=4,
++                num_kv_heads=1,
++                head_size=1,
++                dtype=torch.float32,
++                sliding_window=8,
++            ),
++        ),
++    ]
++    runner = request_runner(
++        block_size=4,
++        num_gpu_blocks=200,
++        async_scheduling=False,
++        kv_cache_groups=kv_cache_groups,
++    )
++
++    runner.new_request(token_ids=[0] * 56)
++    request = runner.scheduler.requests[str(runner.req_id)]
++    request.shared_prefix_boundary = 32
++
++    group_config = runner.connector_scheduler.config.kv_group_configs[1]
++    assert runner.connector_scheduler._reachable_tail_end_chunks(
++        group_config, request, shift=0
++    ) == (
++        12,  # Latest replay boundary: floor((56 - 1) / 16) * 16 / 4.
++        8,  # Shared-prefix junction: 32 / 4.
++    )
++
++
+ @pytest.mark.parametrize("async_scheduling", [True, False])
+ def test_stale_sliding_window_block_after_prepare_store_failure(
+     request_runner, async_scheduling: bool
+diff --git a/tests/v1/kv_connector/unit/offloading_connector/utils.py b/tests/v1/kv_connector/unit/offloading_connector/utils.py
+index b878e294a6ef07a9fbbace001cbf0b9c76d89fd4..b335c8927971c0d736d903685c44b54f4999dc1f 100644
+--- a/tests/v1/kv_connector/unit/offloading_connector/utils.py
++++ b/tests/v1/kv_connector/unit/offloading_connector/utils.py
+@@ -482,8 +482,13 @@ class RequestRunner:
+             # Strict-always-False frees the request immediately on EOS, but
+             # the worker may still have a deferred store queued. In production
+             # the next request's step drains it; in single-request tests we
+-            # must keep stepping until the scheduler sees no in-flight jobs.
+-            if not self.scheduler.requests and not self.connector_scheduler._jobs:
++            # must keep stepping until the scheduler sees no in-flight jobs
++            # and no finished request awaiting final-store construction.
++            if (
++                not self.scheduler.requests
++                and not self.connector_scheduler._jobs
++                and not self.scheduler.finished_req_ids
++            ):
+                 break
+ 
+             scheduler_output = self.scheduler.schedule()
+@@ -544,19 +549,30 @@ class RequestRunner:
+             if (
+                 prev_token_id == EOS_TOKEN_ID
+                 and prev_token_id != token_id
+-                and (self.scheduler.requests or self.connector_scheduler._jobs)
++                and (
++                    self.scheduler.requests
++                    or self.connector_scheduler._jobs
++                    or self.scheduler.finished_req_ids
++                )
+             ):
+                 # continue for one more step to allow offloading to kick off
+                 continue
+ 
+             if token_id is None:
+                 if self.async_scheduling:
+-                    # sample last token
++                    # Flush the previous step's output.
+                     engine_outputs = self.scheduler.update_from_output(
+                         prev_scheduler_output, prev_model_runner_output
+                     )
+                     self._record_kv_connector_stats(engine_outputs)
+-                break
++                    prev_model_runner_output = None
++                if self.scheduler.requests:
++                    # The request is still running; decoded_tokens is exhausted.
++                    break
++                if not self.scheduler.finished_req_ids and (
++                    not complete_transfers or not self.connector_scheduler._jobs
++                ):
++                    break
+ 
+         self._parse_transfers()
+ 
+diff --git a/tests/v1/kv_offload/cpu/test_gpu_worker.py b/tests/v1/kv_offload/cpu/test_gpu_worker.py
+index 2f1ce67e9c4103a45ccc195683e656e6d38279d7..3dd254128a5777295f6edd806356107800869dfe 100644
+--- a/tests/v1/kv_offload/cpu/test_gpu_worker.py
++++ b/tests/v1/kv_offload/cpu/test_gpu_worker.py
+@@ -3,7 +3,10 @@
+ import random
+ import time
+ import uuid
++from types import SimpleNamespace
++from unittest.mock import MagicMock, call
+ 
++import numpy as np
+ import pytest
+ import torch
+ 
+@@ -16,8 +19,15 @@ from vllm.v1.kv_offload.base import (
+     CanonicalKVCacheTensor,
+     GPULoadStoreSpec,
+ )
++from vllm.v1.kv_offload.cpu import gpu_worker
+ from vllm.v1.kv_offload.cpu.common import CPULoadStoreSpec
+-from vllm.v1.kv_offload.cpu.gpu_worker import CPUOffloadingWorker
++from vllm.v1.kv_offload.cpu.gpu_worker import (
++    HOST_REGISTER_ALIGNMENT_BYTES,
++    HOST_REGISTER_SEGMENT_BYTES,
++    CPUOffloadingWorker,
++    _split_copy_descriptors_at_host_boundaries,
++    pin_mmap_region,
++)
+ from vllm.v1.kv_offload.cpu.shared_offload_region import SharedOffloadRegion
+ 
+ NUM_GPU_BLOCKS = [64]
+@@ -32,6 +42,179 @@ NUM_MAPPINGS = [3]
+ NUM_MAPPINGS_PER_GROUP = [2]
+ 
+ 
++def _mock_mmap_region(
++    total_size_bytes: int = 4096, row_stride: int = 4096
++) -> SimpleNamespace:
++    return SimpleNamespace(
++        rank=2,
++        total_size_bytes=total_size_bytes,
++        _row_stride=row_stride,
++        _base=SimpleNamespace(data_ptr=lambda: 0x1000),
++        _registered_host_ptrs=[],
++        _host_register_segment_bytes=None,
++        is_pinned=False,
++    )
++
++
++def test_pin_mmap_region_falls_back_after_failed_registration(monkeypatch) -> None:
++    region = _mock_mmap_region()
++    register = MagicMock(return_value=1)
++    monkeypatch.setattr(gpu_worker.current_platform, "is_cuda_alike", lambda: True)
++    monkeypatch.setattr(gpu_worker, "register_host_memory", register)
++
++    pin_mmap_region(region)
++
++    register.assert_called_once_with(0x1000, 4096)
++    assert region.is_pinned is False
++
++
++def test_pin_mmap_region_keeps_successful_registration(monkeypatch) -> None:
++    region = _mock_mmap_region()
++    register = MagicMock(return_value=0)
++    monkeypatch.setattr(gpu_worker.current_platform, "is_cuda_alike", lambda: True)
++    monkeypatch.setattr(gpu_worker, "register_host_memory", register)
++
++    pin_mmap_region(region)
++
++    register.assert_called_once_with(0x1000, 4096)
++    assert region.is_pinned is True
++    assert region._registered_host_ptrs == [0x1000]
++
++
++def test_pin_mmap_region_retries_large_mapping_as_segments(monkeypatch) -> None:
++    tail_bytes = 4096
++    total_bytes = 2 * HOST_REGISTER_SEGMENT_BYTES + tail_bytes
++    region = _mock_mmap_region(total_bytes)
++    register = MagicMock(side_effect=[1, 0, 0, 0])
++    monkeypatch.setattr(gpu_worker.current_platform, "is_cuda_alike", lambda: True)
++    monkeypatch.setattr(gpu_worker, "register_host_memory", register)
++
++    pin_mmap_region(region)
++
++    assert register.call_args_list == [
++        call(0x1000, total_bytes),
++        call(0x1000, HOST_REGISTER_SEGMENT_BYTES),
++        call(
++            0x1000 + HOST_REGISTER_SEGMENT_BYTES,
++            HOST_REGISTER_SEGMENT_BYTES,
++        ),
++        call(0x1000 + 2 * HOST_REGISTER_SEGMENT_BYTES, tail_bytes),
++    ]
++    assert region.is_pinned is True
++    assert region._registered_host_ptrs == [
++        0x1000,
++        0x1000 + HOST_REGISTER_SEGMENT_BYTES,
++        0x1000 + 2 * HOST_REGISTER_SEGMENT_BYTES,
++    ]
++    assert region._host_register_segment_bytes == HOST_REGISTER_SEGMENT_BYTES
++
++
++def test_pin_mmap_region_aligns_segments_to_kv_rows(monkeypatch) -> None:
++    row_stride = 3 * 4096
++    segment_alignment = np.lcm(row_stride, HOST_REGISTER_ALIGNMENT_BYTES)
++    segment_bytes = (
++        HOST_REGISTER_SEGMENT_BYTES // segment_alignment
++    ) * segment_alignment
++    total_bytes = 2 * segment_bytes + row_stride
++    region = _mock_mmap_region(total_bytes, row_stride)
++    register = MagicMock(side_effect=[1, 0, 0, 0])
++    monkeypatch.setattr(gpu_worker.current_platform, "is_cuda_alike", lambda: True)
++    monkeypatch.setattr(gpu_worker, "register_host_memory", register)
++
++    pin_mmap_region(region)
++
++    assert register.call_args_list == [
++        call(0x1000, total_bytes),
++        call(0x1000, segment_bytes),
++        call(0x1000 + segment_bytes, segment_bytes),
++        call(0x1000 + 2 * segment_bytes, row_stride),
++    ]
++    assert region.is_pinned is True
++    assert region._host_register_segment_bytes == segment_bytes
++    assert segment_bytes % row_stride == 0
++    assert segment_bytes % HOST_REGISTER_ALIGNMENT_BYTES == 0
++
++
++def test_pin_mmap_region_rolls_back_partial_segment_registration(
++    monkeypatch,
++) -> None:
++    total_bytes = 3 * HOST_REGISTER_SEGMENT_BYTES
++    region = _mock_mmap_region(total_bytes)
++    register = MagicMock(side_effect=[1, 0, 0, 2])
++    unregister = MagicMock(return_value=0)
++    monkeypatch.setattr(gpu_worker.current_platform, "is_cuda_alike", lambda: True)
++    monkeypatch.setattr(gpu_worker, "register_host_memory", register)
++    monkeypatch.setattr(gpu_worker, "unregister_host_memory", unregister)
++
++    pin_mmap_region(region)
++
++    assert unregister.call_args_list == [
++        call(0x1000 + HOST_REGISTER_SEGMENT_BYTES),
++        call(0x1000),
++    ]
++    assert region.is_pinned is False
++    assert region._registered_host_ptrs == []
++
++
++@pytest.mark.parametrize("host_is_src", [False, True])
++def test_split_copy_descriptors_at_host_boundaries(host_is_src: bool) -> None:
++    host_base = 10_000
++    segment_bytes = 100
++    src = np.full(6, -1, dtype=np.int64)
++    dst = np.full(6, -1, dtype=np.int64)
++    sizes = np.full(6, -1, dtype=np.int64)
++
++    host_ptrs = [host_base + 90, host_base + 196]
++    device_ptrs = [20_000, 30_000]
++    if host_is_src:
++        src[:2], dst[:2] = host_ptrs, device_ptrs
++    else:
++        src[:2], dst[:2] = device_ptrs, host_ptrs
++    sizes[:2] = [20, 12]
++
++    count = _split_copy_descriptors_at_host_boundaries(
++        src,
++        dst,
++        sizes,
++        2,
++        host_is_src=host_is_src,
++        host_base=host_base,
++        segment_bytes=segment_bytes,
++    )
++
++    assert count == 4
++    expected_host = [host_base + 90, host_base + 100, host_base + 196, host_base + 200]
++    expected_device = [20_000, 20_010, 30_000, 30_004]
++    if host_is_src:
++        assert src[:count].tolist() == expected_host
++        assert dst[:count].tolist() == expected_device
++    else:
++        assert src[:count].tolist() == expected_device
++        assert dst[:count].tolist() == expected_host
++    assert sizes[:count].tolist() == [10, 10, 4, 8]
++
++
++def test_split_copy_descriptors_keeps_in_segment_copy() -> None:
++    src = np.array([20_000], dtype=np.int64)
++    dst = np.array([10_010], dtype=np.int64)
++    sizes = np.array([20], dtype=np.int64)
++
++    count = _split_copy_descriptors_at_host_boundaries(
++        src,
++        dst,
++        sizes,
++        1,
++        host_is_src=False,
++        host_base=10_000,
++        segment_bytes=100,
++    )
++
++    assert count == 1
++    assert src.tolist() == [20_000]
++    assert dst.tolist() == [10_010]
++    assert sizes.tolist() == [20]
++
++
+ @pytest.mark.parametrize("gpu_to_cpu", [True, False])
+ @pytest.mark.parametrize("num_mappings", NUM_MAPPINGS)
+ @pytest.mark.parametrize("gpu_page_size_bytes", GPU_PAGE_SIZES)
+diff --git a/tests/v1/kv_offload/cpu/test_host_mem_ops.py b/tests/v1/kv_offload/cpu/test_host_mem_ops.py
+new file mode 100644
+index 0000000000000000000000000000000000000000..02d527c9d58ce101d69a861f87c620ab7bfed332
+--- /dev/null
++++ b/tests/v1/kv_offload/cpu/test_host_mem_ops.py
+@@ -0,0 +1,44 @@
++# SPDX-License-Identifier: Apache-2.0
++# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
++from types import SimpleNamespace
++from unittest.mock import MagicMock
++
++import torch
++
++from vllm.v1.kv_offload.cpu import host_mem_ops
++
++
++def _driver_result(code: int) -> tuple[SimpleNamespace]:
++    return (SimpleNamespace(value=code),)
++
++
++def test_cuda_registration_uses_driver_api(monkeypatch) -> None:
++    driver = MagicMock()
++    driver.cuMemHostRegister.return_value = _driver_result(2)
++    driver.cuMemHostUnregister.return_value = _driver_result(0)
++    runtime_factory = MagicMock()
++    monkeypatch.setattr(host_mem_ops.current_platform, "is_cuda", lambda: True)
++    monkeypatch.setattr(host_mem_ops, "_get_cuda_driver", lambda: driver)
++    monkeypatch.setattr(host_mem_ops, "CudaRTLibrary", runtime_factory)
++
++    assert host_mem_ops.register_host_memory(0x1000, 4096) == 2
++    assert host_mem_ops.unregister_host_memory(0x1000) == 0
++
++    driver.cuMemHostRegister.assert_called_once_with(0x1000, 4096, 0)
++    driver.cuMemHostUnregister.assert_called_once_with(0x1000)
++    runtime_factory.assert_not_called()
++
++
++def test_rocm_registration_clears_runtime_failures(monkeypatch) -> None:
++    cudart = MagicMock()
++    cudart.cudaHostRegister.return_value = SimpleNamespace(value=1)
++    cudart.cudaHostUnregister.return_value = SimpleNamespace(value=2)
++    runtime = MagicMock()
++    monkeypatch.setattr(host_mem_ops.current_platform, "is_cuda", lambda: False)
++    monkeypatch.setattr(torch.cuda, "cudart", lambda: cudart)
++    monkeypatch.setattr(host_mem_ops, "CudaRTLibrary", lambda: runtime)
++
++    assert host_mem_ops.register_host_memory(0x2000, 8192) == 1
++    assert host_mem_ops.unregister_host_memory(0x2000) == 2
++
++    assert runtime.cudaGetLastError.call_count == 2
+diff --git a/tests/v1/kv_offload/cpu/test_shared_offload_region.py b/tests/v1/kv_offload/cpu/test_shared_offload_region.py
+index ca7295f1978e1cca51ceb3dfc3fcd7c54e3c90ba..81ad7fce2aebfd852848be3ab817f230934cf8f8 100644
+--- a/tests/v1/kv_offload/cpu/test_shared_offload_region.py
++++ b/tests/v1/kv_offload/cpu/test_shared_offload_region.py
+@@ -8,10 +8,12 @@ import os
+ import threading
+ import time
+ import uuid
++from unittest.mock import MagicMock, call
+ 
+ import pytest
+ 
+ from vllm.utils.system_utils import get_mp_context
++from vllm.v1.kv_offload.cpu import shared_offload_region
+ from vllm.v1.kv_offload.cpu.shared_offload_region import (
+     SharedOffloadRegion,
+     _wait_for_file_size,
+@@ -404,6 +406,169 @@ def test_file_has_correct_size(iid):
+         assert os.path.getsize(r.mmap_path) == 4 * PAGE_SIZE
+ 
+ 
++def test_prefault_can_be_disabled_for_delayed_scheduler(iid, monkeypatch):
++    """A scheduler join must not issue MADV_POPULATE_WRITE for the full region."""
++    monkeypatch.setattr(
++        shared_offload_region.mmap,
++        "MADV_POPULATE_WRITE",
++        2**31 - 1,
++        raising=False,
++    )
++    mmap_path = f"/dev/shm/vllm_offload_{iid}.mmap"
++    region = SharedOffloadRegion(
++        engine_id=iid,
++        num_blocks=4,
++        rank=None,
++        kv_bytes_per_block=PAGE_SIZE,
++        cpu_page_size=PAGE_SIZE,
++        prefault=False,
++    )
++    try:
++        assert region.mmap_obj is not None
++    finally:
++        region.cleanup()
++        _cleanup_file(mmap_path)
++
++
++def test_unlink_after_all_workers_map_keeps_shared_mapping(iid):
++    """The production mode unlinks only after every worker owns its mmap."""
++    num_workers = 2
++    regions: list[SharedOffloadRegion | None] = [None, None]
++    errors: list[BaseException] = []
++    mmap_path = f"/dev/shm/vllm_offload_{iid}.mmap"
++
++    def create_rank0() -> None:
++        try:
++            regions[0] = SharedOffloadRegion(
++                engine_id=iid,
++                num_blocks=4,
++                rank=0,
++                kv_bytes_per_block=num_workers * PAGE_SIZE,
++                cpu_page_size=PAGE_SIZE,
++                unlink_after_workers_map=True,
++                num_workers=num_workers,
++            )
++        except BaseException as exc:
++            errors.append(exc)
++
++    rank0_thread = threading.Thread(target=create_rank0)
++    rank0_thread.start()
++    marker0 = f"{mmap_path}.mapped.0"
++    deadline = time.monotonic() + 5
++    while not os.path.exists(marker0):
++        assert time.monotonic() < deadline, "rank 0 did not publish its mmap marker"
++        time.sleep(0.005)
++
++    assert os.path.exists(mmap_path), "joiners still need the pathname"
++    regions[1] = SharedOffloadRegion(
++        engine_id=iid,
++        num_blocks=4,
++        rank=1,
++        kv_bytes_per_block=num_workers * PAGE_SIZE,
++        cpu_page_size=PAGE_SIZE,
++        unlink_after_workers_map=True,
++        num_workers=num_workers,
++    )
++    rank0_thread.join(timeout=5)
++
++    try:
++        assert not rank0_thread.is_alive()
++        assert not errors
++        assert regions[0] is not None
++        assert regions[1] is not None
++        assert not os.path.exists(mmap_path)
++        assert not os.path.exists(marker0)
++        assert not os.path.exists(f"{mmap_path}.mapped.1")
++
++        regions[0].mmap_obj[0:1] = b"\x2a"
++        assert regions[1].mmap_obj[0:1] == b"\x2a"
++    finally:
++        for region in regions:
++            if region is not None:
++                region.cleanup()
++        _cleanup_file(mmap_path)
++
++
++def test_unlink_after_workers_map_requires_worker_count(iid):
++    with pytest.raises(ValueError, match="num_workers must be positive"):
++        SharedOffloadRegion(
++            engine_id=iid,
++            num_blocks=4,
++            rank=0,
++            kv_bytes_per_block=PAGE_SIZE,
++            cpu_page_size=PAGE_SIZE,
++            unlink_after_workers_map=True,
++        )
++
++
++def test_unlink_rendezvous_timeout_cleans_resources_and_markers(iid, monkeypatch):
++    """A missing worker must not leak the creator mapping or rendezvous files."""
++    mmap_path = f"/dev/shm/vllm_offload_{iid}.mmap"
++    cleanup_state: list[tuple[int | None, mmap.mmap | None]] = []
++    original_cleanup = SharedOffloadRegion.cleanup
++
++    def tracked_cleanup(region: SharedOffloadRegion) -> None:
++        original_cleanup(region)
++        cleanup_state.append((region.fd, region.mmap_obj))
++
++    monotonic = MagicMock(side_effect=[0.0, 31.0])
++    monkeypatch.setattr(shared_offload_region.time, "monotonic", monotonic)
++    monkeypatch.setattr(SharedOffloadRegion, "cleanup", tracked_cleanup)
++
++    with pytest.raises(TimeoutError, match="worker mmap markers"):
++        SharedOffloadRegion(
++            engine_id=iid,
++            num_blocks=4,
++            rank=0,
++            kv_bytes_per_block=2 * PAGE_SIZE,
++            cpu_page_size=PAGE_SIZE,
++            unlink_after_workers_map=True,
++            num_workers=2,
++        )
++
++    assert cleanup_state == [(None, None)]
++    assert not os.path.exists(mmap_path)
++    assert not os.path.exists(f"{mmap_path}.mapped.0")
++    assert not os.path.exists(f"{mmap_path}.mapped.1")
++
++
++def test_delayed_scheduler_joins_worker_backing(iid):
++    """Tiering's delayed scheduler mapping must observe the worker backing."""
++    mmap_path = f"/dev/shm/vllm_offload_{iid}.mmap"
++    regions: list[SharedOffloadRegion] = []
++    try:
++        for rank in range(2):
++            regions.append(
++                SharedOffloadRegion(
++                    engine_id=iid,
++                    num_blocks=4,
++                    rank=rank,
++                    kv_bytes_per_block=2 * PAGE_SIZE,
++                    cpu_page_size=PAGE_SIZE,
++                )
++            )
++
++        assert os.path.exists(mmap_path)
++        scheduler = SharedOffloadRegion(
++            engine_id=iid,
++            num_blocks=4,
++            rank=None,
++            kv_bytes_per_block=2 * PAGE_SIZE,
++            cpu_page_size=PAGE_SIZE,
++            prefault=False,
++        )
++        regions.append(scheduler)
++
++        regions[0].mmap_obj[0:1] = b"\x2a"
++        assert scheduler.mmap_obj[0:1] == b"\x2a"
++        scheduler.mmap_obj[PAGE_SIZE : PAGE_SIZE + 1] = b"\x3b"
++        assert regions[1].mmap_obj[PAGE_SIZE : PAGE_SIZE + 1] == b"\x3b"
++    finally:
++        for region in reversed(regions):
++            region.cleanup()
++        _cleanup_file(mmap_path)
++
++
+ # ---------------------------------------------------------------------------
+ # Multi-worker race — concurrent construction
+ # ---------------------------------------------------------------------------
+@@ -485,26 +650,36 @@ def test_multiprocess_race_construct_and_write(iid):
+     for rank, r in results.items():
+         assert r["error"] is None, f"rank {rank}: {r['error']}"
+ 
+-    # Read the raw file while all workers still hold it open.
+-    mmap_path = f"/dev/shm/vllm_offload_{iid}.mmap"
+-    with open(mmap_path, "rb") as f:
+-        raw = f.read()
+-
+-    for blk in range(num_blocks):
+-        for w in range(num_workers):
+-            slot_start = (blk * num_workers + w) * PAGE_SIZE
+-            slot = raw[slot_start : slot_start + PAGE_SIZE]
+-            expected = w + 1  # fill_value = rank + 1
+-            assert all(b == expected for b in slot), (
+-                f"block {blk}, worker {w}: expected {expected} but got wrong bytes"
+-            )
++    # Attach through the scheduler API only after every worker has mapped and
++    # written the region. This mirrors TieringOffloadingSpec startup ordering.
++    scheduler = SharedOffloadRegion(
++        engine_id=iid,
++        num_blocks=num_blocks,
++        rank=None,
++        kv_bytes_per_block=num_workers * PAGE_SIZE,
++        cpu_page_size=PAGE_SIZE,
++        prefault=False,
++    )
++    try:
++        assert scheduler.mmap_obj is not None
++        raw = bytes(scheduler.mmap_obj)
+ 
+-    # Unblock all workers to clean up.
+-    for _ in range(num_workers):
+-        cleanup_queue.put(True)
+-    for p in procs:
+-        p.join(timeout=10)
+-        assert p.exitcode == 0
++        for blk in range(num_blocks):
++            for w in range(num_workers):
++                slot_start = (blk * num_workers + w) * PAGE_SIZE
++                slot = raw[slot_start : slot_start + PAGE_SIZE]
++                expected = w + 1  # fill_value = rank + 1
++                assert all(b == expected for b in slot), (
++                    f"block {blk}, worker {w}: expected {expected} but got wrong bytes"
++                )
++    finally:
++        scheduler.cleanup()
++        # Unblock all workers to clean up.
++        for _ in range(num_workers):
++            cleanup_queue.put(True)
++        for proc in procs:
++            proc.join(timeout=10)
++            assert proc.exitcode == 0
+ 
+ 
+ # ---------------------------------------------------------------------------
+@@ -568,6 +743,34 @@ def test_cleanup_after_create_next_view_releases_mmap(iid):
+     assert mmap_obj.closed, "mmap should be closed after releasing the tensor"
+ 
+ 
++def test_cleanup_unregisters_tracked_segments_in_reverse(iid, monkeypatch):
++    """cleanup() must unregister the exact segments accepted during pinning."""
++    r = _make_region(iid)
++    unregister = MagicMock(return_value=0)
++    monkeypatch.setattr(
++        shared_offload_region.current_platform,
++        "is_cuda_alike",
++        lambda: True,
++    )
++    monkeypatch.setattr(
++        shared_offload_region,
++        "unregister_host_memory",
++        unregister,
++    )
++    r._registered_host_ptrs = [0x1000, 0x2000, 0x3000]
++    r.is_pinned = True
++
++    r.cleanup()
++
++    assert unregister.call_args_list == [
++        call(0x3000),
++        call(0x2000),
++        call(0x1000),
++    ]
++    assert r._registered_host_ptrs == []
++    assert r.is_pinned is False
++
++
+ # ---------------------------------------------------------------------------
+ # _wait_for_file_size
+ # ---------------------------------------------------------------------------
+diff --git a/tests/v1/kv_offload/test_factory.py b/tests/v1/kv_offload/test_factory.py
+index 98191db57b735fba639f7e809ac85a47645c2482..070b74976782d02589fb0b73bc1440ec4bb04ce6 100644
+--- a/tests/v1/kv_offload/test_factory.py
++++ b/tests/v1/kv_offload/test_factory.py
+@@ -328,7 +328,8 @@ def test_create_cpu_offloading_spec_end_to_end():
+ 
+ @pytest.mark.parametrize("packed", [False, True])
+ def test_cpu_spec_sizing_preserves_tensor_layout(packed: bool):
+-    cpu_bytes_to_use = 1920
++    alignment = SharedOffloadRegion.BLOCK_SIZE_ALIGNMENT
++    cpu_bytes_to_use = alignment * 3
+     config = _make_layout_vllm_config(
+         cpu_bytes_to_use=cpu_bytes_to_use,
+         extra_config={"block_size": 32},
+@@ -340,8 +341,85 @@ def test_cpu_spec_sizing_preserves_tensor_layout(packed: bool):
+ 
+     assert isinstance(spec, CPUOffloadingSpec)
+     assert spec.cpu_page_size_per_worker == 32
+-    assert spec.kv_bytes_per_chunk == 192
+-    assert spec.num_blocks == cpu_bytes_to_use // 192
++    assert spec.kv_bytes_per_chunk == alignment
++    assert spec.num_blocks == 3
++
++
++def test_cpu_spec_create_worker_uses_shared_region_on_cuda(monkeypatch):
++    import vllm.v1.kv_offload.cpu.spec as cpu_spec_module
++
++    alignment = SharedOffloadRegion.BLOCK_SIZE_ALIGNMENT
++    config = _make_layout_vllm_config(
++        cpu_bytes_to_use=alignment * 2,
++        tensor_parallel_size=4,
++    )
++    spec = _create_spec(config, _make_sizing_kv_cache_config(packed=False))
++    assert isinstance(spec, CPUOffloadingSpec)
++
++    region = MagicMock()
++    region_ctor = MagicMock(return_value=region)
++    worker_ctor = MagicMock(return_value=MagicMock())
++    monkeypatch.setattr(cpu_spec_module.current_platform, "is_cuda_alike", lambda: True)
++    monkeypatch.setattr(cpu_spec_module, "SharedOffloadRegion", region_ctor)
++    monkeypatch.setattr(cpu_spec_module, "CPUOffloadingWorker", worker_ctor)
++    monkeypatch.setattr(
++        cpu_spec_module.torch.accelerator, "current_device_index", lambda: 5
++    )
++
++    kv_caches = MagicMock()
++    spec.create_worker(kv_caches)
++
++    region_ctor.assert_called_once_with(
++        engine_id=spec.config.engine_id,
++        num_blocks=spec.num_blocks,
++        rank=1,
++        kv_bytes_per_block=spec.kv_bytes_per_chunk,
++        cpu_page_size=spec.cpu_page_size_per_worker,
++        unlink_after_workers_map=True,
++        num_workers=4,
++    )
++    worker_ctor.assert_called_once_with(
++        kv_caches=kv_caches,
++        blocks_per_chunk=spec.blocks_per_chunk,
++        num_cpu_blocks=spec.num_blocks,
++        mmap_region=region,
++    )
++
++
++@pytest.mark.parametrize("num_blocks", [0, 2])
++def test_cpu_spec_create_worker_keeps_tensor_path_without_cuda_or_blocks(
++    monkeypatch, num_blocks: int
++):
++    import vllm.v1.kv_offload.cpu.spec as cpu_spec_module
++
++    alignment = SharedOffloadRegion.BLOCK_SIZE_ALIGNMENT
++    config = _make_layout_vllm_config(cpu_bytes_to_use=alignment * 2)
++    kv_cache_config = _make_sizing_kv_cache_config(packed=False)
++    if num_blocks == 0:
++        kv_cache_config.num_blocks = 0
++    spec = _create_spec(config, kv_cache_config)
++    assert isinstance(spec, CPUOffloadingSpec)
++
++    region_ctor = MagicMock()
++    worker_ctor = MagicMock(return_value=MagicMock())
++    monkeypatch.setattr(
++        cpu_spec_module.current_platform,
++        "is_cuda_alike",
++        lambda: num_blocks == 0,
++    )
++    monkeypatch.setattr(cpu_spec_module, "SharedOffloadRegion", region_ctor)
++    monkeypatch.setattr(cpu_spec_module, "CPUOffloadingWorker", worker_ctor)
++
++    kv_caches = MagicMock()
++    spec.create_worker(kv_caches)
++
++    region_ctor.assert_not_called()
++    worker_ctor.assert_called_once_with(
++        kv_caches=kv_caches,
++        blocks_per_chunk=spec.blocks_per_chunk,
++        num_cpu_blocks=spec.num_blocks,
++        mmap_region=None,
++    )
+ 
+ 
+ def test_cpu_spec_rejects_partially_packed_tensor_layout():
+@@ -386,6 +464,81 @@ def test_tiering_spec_aligns_row_size():
+     assert spec.num_blocks == cpu_bytes_to_use // alignment
+ 
+ 
++def test_tiering_spec_keeps_region_named_for_delayed_scheduler(monkeypatch):
++    import vllm.v1.kv_offload.tiering.spec as tiering_spec_module
++
++    alignment = SharedOffloadRegion.BLOCK_SIZE_ALIGNMENT
++    config = _make_layout_vllm_config(
++        spec_name="TieringOffloadingSpec",
++        cpu_bytes_to_use=alignment * 2,
++        tensor_parallel_size=2,
++    )
++    spec = _create_spec(config, _make_sizing_kv_cache_config(packed=False))
++    assert isinstance(spec, TieringOffloadingSpec)
++
++    scheduler_region = MagicMock()
++    region_ctor = MagicMock(return_value=scheduler_region)
++    primary_tier = MagicMock()
++    primary_tier.get_kv_memoryview.return_value = memoryview(bytearray(1))
++    primary_ctor = MagicMock(return_value=primary_tier)
++    manager_ctor = MagicMock(return_value=MagicMock())
++    monkeypatch.setattr(tiering_spec_module, "SharedOffloadRegion", region_ctor)
++    monkeypatch.setattr(
++        tiering_spec_module, "CPUPrimaryTierOffloadingManager", primary_ctor
++    )
++    monkeypatch.setattr(tiering_spec_module, "TieringOffloadingManager", manager_ctor)
++
++    spec.get_manager()
++
++    region_ctor.assert_called_once_with(
++        engine_id=spec._engine_id,
++        num_blocks=spec.num_blocks,
++        rank=None,
++        kv_bytes_per_block=spec.kv_bytes_per_chunk,
++        cpu_page_size=spec.cpu_page_size_per_worker,
++        prefault=False,
++    )
++
++
++def test_tiering_worker_keeps_region_named_for_scheduler(monkeypatch):
++    import vllm.v1.kv_offload.tiering.spec as tiering_spec_module
++
++    alignment = SharedOffloadRegion.BLOCK_SIZE_ALIGNMENT
++    config = _make_layout_vllm_config(
++        spec_name="TieringOffloadingSpec",
++        cpu_bytes_to_use=alignment * 2,
++        tensor_parallel_size=2,
++    )
++    spec = _create_spec(config, _make_sizing_kv_cache_config(packed=False))
++    assert isinstance(spec, TieringOffloadingSpec)
++
++    worker_region = MagicMock()
++    region_ctor = MagicMock(return_value=worker_region)
++    worker_ctor = MagicMock(return_value=MagicMock())
++    monkeypatch.setattr(tiering_spec_module, "SharedOffloadRegion", region_ctor)
++    monkeypatch.setattr(tiering_spec_module, "CPUOffloadingWorker", worker_ctor)
++    monkeypatch.setattr(
++        tiering_spec_module.torch.accelerator, "current_device_index", lambda: 3
++    )
++
++    kv_caches = MagicMock()
++    spec.create_worker(kv_caches)
++
++    region_ctor.assert_called_once_with(
++        engine_id=spec._engine_id,
++        num_blocks=spec.num_blocks,
++        rank=1,
++        kv_bytes_per_block=spec.kv_bytes_per_chunk,
++        cpu_page_size=spec.cpu_page_size_per_worker,
++    )
++    worker_ctor.assert_called_once_with(
++        kv_caches=kv_caches,
++        blocks_per_chunk=spec.blocks_per_chunk,
++        num_cpu_blocks=spec.num_blocks,
++        mmap_region=worker_region,
++    )
++
++
+ def test_offloading_spec_resolves_prefill_context_parallel_block_sizes():
+     config = _make_layout_vllm_config(
+         cpu_bytes_to_use=65536,
+diff --git a/tests/v1/kv_offload/tiering/test_fs_gc.py b/tests/v1/kv_offload/tiering/test_fs_gc.py
+new file mode 100644
+index 0000000000000000000000000000000000000000..fc3049c7e7466eaa20b2cc83d4c3219c4f8a9f88
+--- /dev/null
++++ b/tests/v1/kv_offload/tiering/test_fs_gc.py
+@@ -0,0 +1,257 @@
++# SPDX-License-Identifier: Apache-2.0
++# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
++"""
++Unit tests for FsGCManager, the fs secondary tier's capacity bound.
++
++These use real files on disk with explicitly set mtimes, since mtime is the
++GC's single source of truth for recency. The background thread is neutralized
++by giving every manager a very long `interval_s` and driving `sweep()` directly,
++so nothing here depends on timing except the two stamping tests, which poll.
++"""
++
++import hashlib
++import os
++import time
++
++import pytest
++
++from vllm.v1.kv_offload.base import make_offload_key
++from vllm.v1.kv_offload.file_mapper import FileMapper
++from vllm.v1.kv_offload.tiering.fs.gc_manager import FsGCManager
++
++_BLOCK_BYTES = 4096
++
++
++def _make_file_mapper(root_dir: str) -> FileMapper:
++    return FileMapper(
++        root_dir=root_dir,
++        model_name="test/model",
++        tokens_per_hash=16,
++        blocks_per_file=1,
++        tp_size=1,
++        pp_size=1,
++        pcp_size=1,
++        dcp_size=1,
++        rank=0,
++        dtype="float32",
++    )
++
++
++def _key(index: int):
++    return make_offload_key(hashlib.sha256(str(index).encode()).digest()[:16], 0)
++
++
++def _write_block(mapper: FileMapper, index: int, age_s: float) -> str:
++    """Create a block file for `index` whose mtime is `age_s` in the past."""
++    path = mapper.get_file_name(_key(index))
++    os.makedirs(os.path.dirname(path), exist_ok=True)
++    with open(path, "wb") as f:
++        f.write(b"\0" * _BLOCK_BYTES)
++    stamp = time.time() - age_s
++    os.utime(path, (stamp, stamp))
++    return path
++
++
++@pytest.fixture
++def mapper(tmp_path):
++    return _make_file_mapper(str(tmp_path))
++
++
++def _make_gc(mapper: FileMapper, **kwargs) -> FsGCManager:
++    params = dict(
++        max_bytes=10 * _BLOCK_BYTES,
++        low_watermark=0.8,
++        # Long enough that the background thread never sweeps on its own; each
++        # test calls sweep() explicitly so assertions are deterministic.
++        interval_s=3600.0,
++        stamp_interval_s=1.0,
++        grace_s=60.0,
++    )
++    params.update(kwargs)
++    return FsGCManager(mapper, **params)  # type: ignore[arg-type]
++
++
++def test_rejects_grace_not_exceeding_stamp_interval(mapper):
++    # Otherwise a block in active use can be stamped, then age past the grace
++    # window before its next stamp is due, and be swept while still hot.
++    with pytest.raises(ValueError, match="must exceed stamp_interval_s"):
++        _make_gc(mapper, stamp_interval_s=60.0, grace_s=60.0)
++
++
++def test_rejects_out_of_range_low_watermark(mapper):
++    with pytest.raises(ValueError, match="low_watermark"):
++        _make_gc(mapper, low_watermark=1.5)
++
++
++def test_under_cap_is_a_noop(mapper):
++    gc = _make_gc(mapper)
++    try:
++        paths = [_write_block(mapper, i, age_s=1000) for i in range(5)]
++        assert gc.sweep() == 0
++        assert all(os.path.exists(p) for p in paths)
++    finally:
++        gc.shutdown()
++
++
++def test_evicts_in_mtime_order_down_to_the_low_watermark(mapper):
++    gc = _make_gc(mapper)
++    try:
++        # 15 blocks over a 10-block cap, oldest first. The sweep must free down
++        # to the 8-block watermark, i.e. remove exactly the 7 oldest.
++        paths = [_write_block(mapper, i, age_s=1000 - i) for i in range(15)]
++
++        freed = gc.sweep()
++
++        assert freed == 7 * _BLOCK_BYTES
++        assert not any(os.path.exists(p) for p in paths[:7])
++        assert all(os.path.exists(p) for p in paths[7:])
++    finally:
++        gc.shutdown()
++
++
++def test_grace_window_keeps_recently_used_blocks_even_over_cap(mapper):
++    gc = _make_gc(mapper, grace_s=60.0)
++    try:
++        # Everything is inside the grace window, so the tier is knowingly left
++        # over its cap rather than evicting blocks that are still in use.
++        paths = [_write_block(mapper, i, age_s=1) for i in range(15)]
++
++        assert gc.sweep() == 0
++        assert all(os.path.exists(p) for p in paths)
++    finally:
++        gc.shutdown()
++
++
++def test_protect_keeps_an_lru_block_a_sweep_would_otherwise_evict(mapper):
++    """The one case the grace window cannot cover.
++
++    A promotion stamps its keys when the scheduler matches them, but the read
++    itself can execute much later -- queued behind other reads on a busy tier.
++    Once the mtime ages past grace_s the sweep would happily unlink the file out
++    from under the in-flight read, so submit_load/submit_store pin the keys.
++    """
++    gc = _make_gc(mapper)
++    try:
++        # All 15 are far outside the grace window, so recency protects nothing.
++        paths = [_write_block(mapper, i, age_s=1000 - i) for i in range(15)]
++
++        # The 3 oldest have reads in flight; they are exactly the blocks the
++        # sweep wants to remove first.
++        gc.protect([_key(0), _key(1), _key(2)])
++
++        freed = gc.sweep()
++
++        # Still frees the full 7 blocks needed to reach the watermark, just
++        # taking the next-oldest unprotected ones instead.
++        assert freed == 7 * _BLOCK_BYTES
++        assert all(os.path.exists(p) for p in paths[:3]), "in-flight blocks unlinked"
++        assert not any(os.path.exists(p) for p in paths[3:10])
++        assert all(os.path.exists(p) for p in paths[10:])
++
++        # Once the jobs finish the blocks become evictable again. Refill past
++        # the cap first: the previous sweep left the tier at its watermark, so
++        # another sweep would legitimately have nothing to do.
++        gc.release([_key(0), _key(1), _key(2)])
++        for i in range(15, 20):
++            _write_block(mapper, i, age_s=1)
++
++        # 13 blocks over a 10-block cap needs 5 freed, and the released blocks
++        # are still the oldest on disk, so they are now the first to go.
++        assert gc.sweep() == 5 * _BLOCK_BYTES
++        assert not any(os.path.exists(p) for p in paths[:3]), (
++            "still pinned after release"
++        )
++    finally:
++        gc.shutdown()
++
++
++def test_release_is_refcounted(mapper):
++    """Two tiers' jobs can protect the same key; one finishing must not unpin it."""
++    gc = _make_gc(mapper)
++    try:
++        paths = [_write_block(mapper, i, age_s=1000 - i) for i in range(15)]
++
++        gc.protect([_key(0)])
++        gc.protect([_key(0)])
++        gc.release([_key(0)])
++
++        gc.sweep()
++        assert os.path.exists(paths[0]), "unpinned while a job was still in flight"
++    finally:
++        gc.shutdown()
++
++
++def test_touch_stamps_mtime_so_eviction_order_follows_use(mapper):
++    gc = _make_gc(mapper)
++    try:
++        path = _write_block(mapper, 0, age_s=1000)
++        before = os.stat(path).st_mtime
++
++        gc.touch([_key(0)])
++
++        deadline = time.monotonic() + 5.0
++        while os.stat(path).st_mtime == before and time.monotonic() < deadline:
++            time.sleep(0.01)
++        assert os.stat(path).st_mtime > before
++    finally:
++        gc.shutdown()
++
++
++def test_touch_rate_limits_repeat_stamps_of_the_same_key(mapper):
++    """touch() arrives once per request per scheduling attempt with every key of
++    the request, so an unthrottled utime per call would be thousands of syscalls
++    per step."""
++    gc = _make_gc(mapper, stamp_interval_s=30.0, grace_s=60.0)
++    try:
++        path = _write_block(mapper, 0, age_s=1000)
++        gc.touch([_key(0)])
++
++        deadline = time.monotonic() + 5.0
++        while os.stat(path).st_mtime < time.time() - 900 and (
++            time.monotonic() < deadline
++        ):
++            time.sleep(0.01)
++        stamped = os.stat(path).st_mtime
++
++        # Backdate the file, then touch again well inside stamp_interval_s: the
++        # second touch must be dropped, leaving the backdated mtime in place.
++        old = time.time() - 1000
++        os.utime(path, (old, old))
++        gc.touch([_key(0)])
++        time.sleep(0.5)
++
++        assert os.stat(path).st_mtime == pytest.approx(old)
++        assert stamped > old
++    finally:
++        gc.shutdown()
++
++
++def test_touch_tolerates_keys_with_no_file(mapper):
++    """A block can live only in the DRAM primary tier, or its cascade to disk
++    can have failed; neither is an error."""
++    gc = _make_gc(mapper)
++    try:
++        gc.touch([_key(0), _key(1)])
++        time.sleep(0.2)
++        assert gc.sweep() == 0
++    finally:
++        gc.shutdown()
++
++
++def test_sweep_ignores_non_block_files(mapper):
++    """store_block writes <dest>.tmp before os.replace, and config.json must
++    survive; only .bin files are eviction candidates."""
++    gc = _make_gc(mapper, max_bytes=_BLOCK_BYTES)
++    try:
++        paths = [_write_block(mapper, i, age_s=1000 - i) for i in range(4)]
++        tmp_path = paths[0] + ".tmp"
++        with open(tmp_path, "wb") as f:
++            f.write(b"\0" * _BLOCK_BYTES)
++        stamp = time.time() - 2000
++        os.utime(tmp_path, (stamp, stamp))
++
++        gc.sweep()
++
++        assert os.path.exists(tmp_path), "in-progress store was unlinked"
++    finally:
++        gc.shutdown()
+diff --git a/tests/v1/kv_offload/tiering/test_fs_tier.py b/tests/v1/kv_offload/tiering/test_fs_tier.py
+index dcc92a4fa8bf048b419d2b871964310701643e48..873e707e8c9da7abf3834d8e3ad66a878f283be0 100644
+--- a/tests/v1/kv_offload/tiering/test_fs_tier.py
++++ b/tests/v1/kv_offload/tiering/test_fs_tier.py
+@@ -298,6 +298,45 @@ def test_failed_load_missing_file(fs_tier):
+     assert not results[0].success
+ 
+ 
++def test_failed_load_invalidates_cached_lookup(fs_tier):
++    """A block that vanished must not stay cached as a hit.
++
++    The cached existence result is what routes a promotion to this tier, and
++    nothing else clears it until every request that looked the key up has
++    finished. If a failed load left it cached as present, the scheduler would
++    re-submit the same failing promotion on every step and the request waiting
++    for those tokens would never finish, so the entry would never be cleaned
++    up either -- a livelock rather than a recompute.
++    """
++    tier, _ = fs_tier
++    tier.submit_store(make_job(1, [key(1)], [0]))
++    assert all(r.success for r in drain(tier))
++    assert lookup_and_wait(tier, [key(1)]) == [LookupResult.HIT]
++
++    # Removed behind the tier's back: by capacity management, by another
++    # instance sharing root_dir, or by any external cleanup.
++    os.unlink(tier.file_mapper.get_file_name(key(1)))
++
++    tier.submit_load(make_job(2, [key(1)], [0], is_promotion=True))
++    results = drain(tier)
++    assert not results[0].success
++
++    assert tier.lookup(key(1), _CTX) == LookupResult.MISS
++
++
++def test_successful_load_keeps_cached_lookup(fs_tier):
++    """The invalidation above must be scoped to failures."""
++    tier, _ = fs_tier
++    tier.submit_store(make_job(1, [key(1)], [0]))
++    assert all(r.success for r in drain(tier))
++    assert lookup_and_wait(tier, [key(1)]) == [LookupResult.HIT]
++
++    tier.submit_load(make_job(2, [key(1)], [0], is_promotion=True))
++    assert all(r.success for r in drain(tier))
++
++    assert tier.lookup(key(1), _CTX) == LookupResult.HIT
++
++
+ def test_multiple_jobs_tracked_independently(fs_tier):
+     tier, _ = fs_tier
+     job1 = make_job(1, [key(1)], [0])
+diff --git a/tests/v1/kv_offload/tiering/test_obj_tier.py b/tests/v1/kv_offload/tiering/test_obj_tier.py
+index 7500df8b4b94216009fa4895ffbae4d39acc4962..a110c3c3b0ca4593b55480ec05b4d7a94acd2dd7 100644
+--- a/tests/v1/kv_offload/tiering/test_obj_tier.py
++++ b/tests/v1/kv_offload/tiering/test_obj_tier.py
+@@ -437,6 +437,62 @@ class TestMockObjTierFailures:
+         assert not by_id[1].success
+         assert by_id[2].success
+ 
++    def test_failed_load_invalidates_cached_lookup(self):
++        """An object that vanished must not stay cached as a hit.
++
++        The cached existence result is what routes a promotion to this tier,
++        and nothing else clears it until every request that looked the key up
++        has finished. If a failed load left it cached as present, the
++        scheduler would re-submit the same failing promotion on every step and
++        the request waiting for those tokens would never finish, so the entry
++        would never be cleaned up either -- a livelock rather than a
++        recompute.
++        """
++        tier, agent = _make_tier(num_blocks=4)
++        tier.submit_store(make_job(1, [key(1)], [0]))
++        assert all(r.success for r in drain(tier))
++        assert lookup_and_wait(tier, [key(1)]) == [LookupResult.HIT]
++
++        # Removed behind the tier's back: a bucket lifecycle rule, another
++        # instance sharing the bucket, or any external cleanup. The probe hit
++        # is now stale and the read against it fails.
++        agent._stored_obj_keys.clear()
++        agent.check_xfer_state = lambda h: "ERR"
++
++        tier.submit_load(make_job(2, [key(1)], [0]))
++        results = drain(tier)
++        assert not results[0].success
++
++        assert tier.lookup(key(1), _CTX) == LookupResult.MISS
++
++    def test_submission_time_load_failure_invalidates_cached_lookup(self):
++        """Loads that die before the transfer starts must invalidate too;
++        re-submitting them against the same cached hit is the same livelock."""
++        tier, agent = _make_tier(num_blocks=4)
++        tier.submit_store(make_job(1, [key(1)], [0]))
++        assert all(r.success for r in drain(tier))
++        assert lookup_and_wait(tier, [key(1)]) == [LookupResult.HIT]
++
++        agent.register_memory = lambda *a, **k: None
++        tier.submit_load(make_job(2, [key(1)], [0]))
++        results = list(tier.get_finished_jobs())
++        assert len(results) == 1
++        assert not results[0].success
++
++        assert tier.lookup(key(1), _CTX) == LookupResult.MISS
++
++    def test_successful_load_keeps_cached_lookup(self):
++        """The invalidation above must be scoped to failures."""
++        tier, _ = _make_tier(num_blocks=4)
++        tier.submit_store(make_job(1, [key(1)], [0]))
++        assert all(r.success for r in drain(tier))
++        assert lookup_and_wait(tier, [key(1)]) == [LookupResult.HIT]
++
++        tier.submit_load(make_job(2, [key(1)], [0]))
++        assert all(r.success for r in drain(tier))
++
++        assert tier.lookup(key(1), _CTX) == LookupResult.HIT
++
+ 
+ class TestMockObjTierShutdown:
+     def test_shutdown_clears_in_flight_transfers(self):
+diff --git a/tests/v1/spec_decode/test_dflash_context_cudagraph.py b/tests/v1/spec_decode/test_dflash_context_cudagraph.py
+new file mode 100644
+index 0000000000000000000000000000000000000000..9374fd076a4004bb9405aea9e80fd48c4b95d4f9
+--- /dev/null
++++ b/tests/v1/spec_decode/test_dflash_context_cudagraph.py
+@@ -0,0 +1,151 @@
++# SPDX-License-Identifier: Apache-2.0
++# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
++
++from types import SimpleNamespace
++
++import numpy as np
++import pytest
++import torch
++
++from vllm.config.compilation import CUDAGraphMode
++from vllm.platforms import current_platform
++from vllm.v1.attention.backends.utils import PAD_SLOT_ID
++from vllm.v1.worker.gpu.spec_decode.dflash.cudagraph import (
++    DFlashContextCudaGraphManager,
++)
++from vllm.v1.worker.gpu.spec_decode.dflash.speculator import (
++    _DFlashInputBatch,
++    prepare_dflash_inputs,
++)
++
++
++def _make_dispatch_manager(*, captured: bool = True) -> SimpleNamespace:
++    return SimpleNamespace(
++        compilation_config=SimpleNamespace(
++            cudagraph_capture_sizes=[1, 2, 4, 8, 16],
++            max_cudagraph_capture_size=8,
++        ),
++        cudagraph_mode=CUDAGraphMode.FULL_DECODE_ONLY,
++        max_num_context_tokens=12,
++        _capture_descs={},
++        _graphs_captured=captured,
++    )
++
++
++def test_context_graph_dispatch_uses_smallest_capture_bucket():
++    manager = _make_dispatch_manager()
++
++    DFlashContextCudaGraphManager._init_candidates(manager)
++
++    assert [d.num_tokens for d in manager._capture_descs[CUDAGraphMode.FULL]] == [
++        8,
++        4,
++        2,
++        1,
++    ]
++    assert DFlashContextCudaGraphManager.dispatch_context(manager, 1).num_tokens == 1
++    assert DFlashContextCudaGraphManager.dispatch_context(manager, 3).num_tokens == 4
++    assert DFlashContextCudaGraphManager.dispatch_context(manager, 7).num_tokens == 8
++    assert (
++        DFlashContextCudaGraphManager.dispatch_context(manager, 9).cg_mode
++        == CUDAGraphMode.NONE
++    )
++
++
++def test_context_graph_dispatch_falls_back_before_capture():
++    manager = _make_dispatch_manager(captured=False)
++    DFlashContextCudaGraphManager._init_candidates(manager)
++
++    desc = DFlashContextCudaGraphManager.dispatch_context(manager, 3)
++
++    assert desc.cg_mode == CUDAGraphMode.NONE
++    assert desc.num_tokens == 3
++
++
++@pytest.mark.skipif(not current_platform.is_cuda(), reason="Requires CUDA")
++def test_prepare_dflash_inputs_makes_context_graph_padding_inert():
++    device = torch.device("cuda")
++    max_num_reqs = 4
++    max_num_tokens = 16
++    num_reqs = 2
++    num_speculative_steps = 2
++    num_query_per_req = 3
++    num_context_tokens = 3
++    padded_context_tokens = 8
++
++    input_buffers = SimpleNamespace(
++        input_ids=torch.zeros(max_num_tokens, dtype=torch.int64, device=device),
++        positions=torch.zeros(max_num_tokens, dtype=torch.int64, device=device),
++        query_start_loc=torch.zeros(max_num_reqs + 1, dtype=torch.int32, device=device),
++        seq_lens=torch.zeros(max_num_reqs, dtype=torch.int32, device=device),
++    )
++    input_batch = _DFlashInputBatch(
++        num_reqs=num_reqs,
++        num_scheduled_tokens=np.array([2, 1], dtype=np.int32),
++        positions=torch.arange(num_context_tokens, dtype=torch.int64, device=device),
++        query_start_loc=torch.tensor([0, 2, 3], dtype=torch.int32, device=device),
++        idx_mapping=torch.arange(num_reqs, dtype=torch.int32, device=device),
++    )
++
++    query_slots = torch.full((max_num_tokens,), 777, dtype=torch.int64, device=device)
++    context_positions = torch.full_like(query_slots, 777)
++    context_slots = torch.full_like(query_slots, 777)
++    sample_rows = max_num_reqs * num_speculative_steps
++    block_table = torch.arange(
++        1,
++        1 + max_num_reqs * 4,
++        dtype=torch.int32,
++        device=device,
++    ).view(max_num_reqs, 4)
++
++    prepare_dflash_inputs(
++        input_buffers,
++        query_slots,
++        context_positions,
++        context_slots,
++        torch.zeros(sample_rows, dtype=torch.int64, device=device),
++        torch.zeros(sample_rows, dtype=torch.int64, device=device),
++        torch.full((sample_rows,), -1, dtype=torch.int32, device=device),
++        input_batch,
++        torch.zeros(num_reqs, dtype=torch.int32, device=device),
++        torch.zeros(num_reqs, dtype=torch.int32, device=device),
++        torch.zeros(max_num_reqs, dtype=torch.int32, device=device),
++        torch.zeros(max_num_reqs, dtype=torch.int32, device=device),
++        block_table,
++        16,
++        torch.zeros(max_num_reqs, dtype=torch.int32, device=device),
++        1,
++        num_query_per_req,
++        num_speculative_steps,
++        max_num_reqs,
++        max_num_tokens,
++        1024,
++        context_num_tokens_padded=padded_context_tokens,
++    )
++    torch.cuda.synchronize()
++
++    torch.testing.assert_close(
++        context_positions[:num_context_tokens],
++        torch.arange(num_context_tokens, dtype=torch.int64, device=device),
++    )
++    torch.testing.assert_close(
++        context_slots[:num_context_tokens],
++        torch.tensor([16, 17, 82], dtype=torch.int64, device=device),
++    )
++    torch.testing.assert_close(
++        context_positions[num_context_tokens:padded_context_tokens],
++        torch.zeros(
++            padded_context_tokens - num_context_tokens,
++            dtype=torch.int64,
++            device=device,
++        ),
++    )
++    torch.testing.assert_close(
++        context_slots[num_context_tokens:padded_context_tokens],
++        torch.full(
++            (padded_context_tokens - num_context_tokens,),
++            PAD_SLOT_ID,
++            dtype=torch.int64,
++            device=device,
++        ),
++    )
+diff --git a/tests/v1/spec_decode/test_dflash_cudagraph_lifetime.py b/tests/v1/spec_decode/test_dflash_cudagraph_lifetime.py
+index 11fb1b66e85b09cf4f5cb74ee88a19c87dbd6a3a..95db690e834c5176809be1e84c60f87143cfc747 100644
+--- a/tests/v1/spec_decode/test_dflash_cudagraph_lifetime.py
++++ b/tests/v1/spec_decode/test_dflash_cudagraph_lifetime.py
+@@ -7,6 +7,8 @@ from unittest.mock import Mock
+ import torch
+ 
+ from vllm.config.compilation import CUDAGraphMode
++from vllm.v1.attention.backend import AttentionCGSupport
++from vllm.v1.worker.gpu.spec_decode.dflash import speculator as spec_module
+ from vllm.v1.worker.gpu.spec_decode.dflash.speculator import DFlashSpeculator
+ 
+ 
+@@ -63,3 +65,138 @@ def test_dflash_does_not_retain_eager_backbone_output(monkeypatch):
+     )
+ 
+     assert speculator._captured_backbone_outputs == []
++
++
++def test_dflash_capture_uses_phase_specific_draft_channel_ids():
++    events = []
++
++    class FakeQueryManager:
++        def capture(self, *args, **kwargs):
++            events.append(("query", kwargs["channel_id"]))
++
++    class FakeContextManager:
++        def capture_context(self, *args, **kwargs):
++            events.append(("context", kwargs["channel_id"]))
++
++    speculator = SimpleNamespace(
++        _speculator_name="DFlash",
++        sample_indices=torch.zeros(1),
++        sample_pos=torch.zeros(1),
++        sample_idx_mapping=torch.zeros(1),
++        query_cudagraph_manager=FakeQueryManager(),
++        context_cudagraph_manager=FakeContextManager(),
++        _context_slot_mappings=torch.zeros(1, 1),
++        context_positions=torch.ones(1),
++        _capture_context_kv=object(),
++        _generate_draft=object(),
++        input_buffers=object(),
++        block_tables=object(),
++        attn_groups=object(),
++        kv_cache_config=object(),
++        max_model_len=1,
++        _group_causal=True,
++    )
++
++    DFlashSpeculator.capture(speculator, capture_phase="profile")
++    DFlashSpeculator.capture(speculator, capture_phase="production")
++
++    assert events == [
++        ("query", "vllm:draft:dflash:profile"),
++        ("context", "vllm:draft:dflash:context:profile"),
++        ("query", "vllm:draft:dflash:production"),
++        ("context", "vllm:draft:dflash:context:production"),
++    ]
++
++
++def test_dflash_graph_channel_is_bound_at_capture_not_construction(monkeypatch):
++    created = []
++
++    class FakeQueryManager:
++        def __init__(self, vllm_config, device, cudagraph_mode, decode_query_len):
++            created.append(
++                ("query", vllm_config, device, cudagraph_mode, decode_query_len)
++            )
++
++    class FakeContextManager:
++        def __init__(self, vllm_config, device, max_num_context_tokens):
++            created.append(("context", vllm_config, device, max_num_context_tokens))
++
++    monkeypatch.setattr(spec_module, "DFlashCudaGraphManager", FakeQueryManager)
++    monkeypatch.setattr(
++        spec_module,
++        "DFlashContextCudaGraphManager",
++        FakeContextManager,
++    )
++
++    speculator = object.__new__(DFlashSpeculator)
++    speculator.vllm_config = object()
++    speculator.device = torch.device("cpu")
++    speculator.num_query_per_req = 6
++    speculator.max_num_tokens = 128
++    speculator._speculator_name = "DSpark"
++    speculator.attn_cg_support = SimpleNamespace(
++        min_cg_support=AttentionCGSupport.UNIFORM_BATCH,
++        min_cg_attn_backend="test",
++    )
++
++    DFlashSpeculator.init_cudagraph_manager(speculator, CUDAGraphMode.FULL)
++
++    assert created == [
++        (
++            "query",
++            speculator.vllm_config,
++            speculator.device,
++            CUDAGraphMode.FULL_DECODE_ONLY,
++            6,
++        ),
++        ("context", speculator.vllm_config, speculator.device, 128),
++    ]
++
++
++def test_dflash_context_precompute_replays_full_graph():
++    manager = Mock()
++    model = Mock()
++    speculator = SimpleNamespace(
++        context_cudagraph_manager=manager,
++        model=model,
++        hidden_states=torch.zeros(8, 4),
++        context_positions=torch.zeros(8, dtype=torch.int64),
++    )
++    desc = SimpleNamespace(cg_mode=CUDAGraphMode.FULL)
++
++    DFlashSpeculator._precompute_context_kv(
++        speculator,
++        num_target_tokens=3,
++        batch_desc=desc,
++        context_slots=torch.zeros(3, dtype=torch.int64),
++    )
++
++    manager.run_fullgraph.assert_called_once_with(desc)
++    model.precompute_and_store_context_kv.assert_not_called()
++
++
++def test_dflash_context_precompute_keeps_eager_fallback():
++    model = Mock()
++    hidden_states = torch.zeros(8, 4)
++    context_positions = torch.zeros(8, dtype=torch.int64)
++    context_slots = torch.zeros(3, dtype=torch.int64)
++    speculator = SimpleNamespace(
++        context_cudagraph_manager=None,
++        model=model,
++        hidden_states=hidden_states,
++        context_positions=context_positions,
++    )
++
++    DFlashSpeculator._precompute_context_kv(
++        speculator,
++        num_target_tokens=3,
++        batch_desc=SimpleNamespace(cg_mode=CUDAGraphMode.NONE),
++        context_slots=context_slots,
++    )
++
++    args = model.precompute_and_store_context_kv.call_args.args
++    assert args[0].data_ptr() == hidden_states.data_ptr()
++    assert args[0].shape == (3, 4)
++    assert args[1].data_ptr() == context_positions.data_ptr()
++    assert args[1].shape == (3,)
++    assert args[2] is context_slots
+diff --git a/tests/v1/worker/test_gpu_autoregressive_speculator.py b/tests/v1/worker/test_gpu_autoregressive_speculator.py
+index 89dc32ee4c68d96afc57d5e2c380657364a9f4fe..b4adbc44ca527001aadb85b3101715d51ea5899f 100644
+--- a/tests/v1/worker/test_gpu_autoregressive_speculator.py
++++ b/tests/v1/worker/test_gpu_autoregressive_speculator.py
+@@ -166,3 +166,78 @@ def test_ar_probabilistic_draft_uses_shared_sampler(monkeypatch):
+ 
+     assert captured["positions"] is positions
+     assert captured["active_rows"] is speculator.active_num_reqs
++
++
++def test_autoregressive_capture_ids_are_deterministic_and_phase_separated():
++    def capture_channel_ids() -> list[str]:
++        events = []
++
++        class FakeManager:
++            use_breakable_cg = False
++
++            def capture(self, *args, **kwargs):
++                events.append(kwargs["channel_id"])
++
++        speculator = object.__new__(_TestSpeculator)
++        speculator.last_token_indices = torch.zeros(1)
++        speculator.prefill_cudagraph_manager = FakeManager()
++        speculator.decode_cudagraph_manager = FakeManager()
++        speculator.model = object()
++        speculator._prefill = object()
++        speculator._generate_draft = object()
++        speculator.model_state = object()
++        speculator.target_input_buffers = object()
++        speculator.input_buffers = object()
++        speculator.block_tables = object()
++        speculator.target_attn_groups = object()
++        speculator.attn_groups = object()
++        speculator.kv_cache_config = object()
++        speculator.num_speculative_steps = 3
++
++        speculator.capture(capture_phase="profile")
++        speculator.capture(capture_phase="production")
++        return events
++
++    expected = [
++        "vllm:draft:prefill:profile",
++        "vllm:draft:decode:profile",
++        "vllm:draft:prefill:production",
++        "vllm:draft:decode:production",
++    ]
++    assert capture_channel_ids() == capture_channel_ids() == expected
++
++
++def test_autoregressive_graph_channel_is_bound_at_capture_not_construction(
++    monkeypatch,
++):
++    created = []
++
++    class FakeManager:
++        def __init__(self, vllm_config, device, cudagraph_mode, decode_query_len):
++            created.append((vllm_config, device, cudagraph_mode, decode_query_len))
++
++    monkeypatch.setattr(spec_module, "SpeculatorCudaGraphManager", FakeManager)
++    speculator = object.__new__(_TestSpeculator)
++    speculator.vllm_config = object()
++    speculator.device = torch.device("cpu")
++    speculator.num_speculative_steps = 3
++
++    AutoRegressiveSpeculator.init_cudagraph_manager(
++        speculator,
++        CUDAGraphMode.FULL,
++    )
++
++    assert created == [
++        (
++            speculator.vllm_config,
++            speculator.device,
++            CUDAGraphMode.FULL,
++            4,
++        ),
++        (
++            speculator.vllm_config,
++            speculator.device,
++            CUDAGraphMode.FULL_DECODE_ONLY,
++            1,
++        ),
++    ]
+diff --git a/tests/v1/worker/test_gpu_model_runner.py b/tests/v1/worker/test_gpu_model_runner.py
+index 254432312cb3209f44a504e389a67ef8a382f46d..e341d2cbe7b469d6a1e120364a7a987891c5bc54 100644
+--- a/tests/v1/worker/test_gpu_model_runner.py
++++ b/tests/v1/worker/test_gpu_model_runner.py
+@@ -1,6 +1,7 @@
+ # SPDX-License-Identifier: Apache-2.0
+ # SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+ 
++from contextlib import contextmanager, nullcontext
+ from types import SimpleNamespace
+ from unittest.mock import Mock
+ 
+@@ -12,6 +13,7 @@ import vllm.v1.worker.gpu_model_runner as gpu_model_runner_module
+ from vllm.config import (
+     AttentionConfig,
+     CacheConfig,
++    CUDAGraphMode,
+     ModelConfig,
+     ParallelConfig,
+     SchedulerConfig,
+@@ -1779,3 +1781,367 @@ def test_mamba_cache_raises_when_max_num_seqs_exceeds_blocks():
+ 
+         with pytest.raises(ValueError, match="max_num_seqs"):
+             runner.initialize_kv_cache(kv_cache_config)
++
++
++def test_v1_capture_separates_target_and_draft_semantic_channels(monkeypatch):
++    runner = GPUModelRunner.__new__(GPUModelRunner)
++    runner.compilation_config = SimpleNamespace(cudagraph_mode=CUDAGraphMode.PIECEWISE)
++    runner.speculative_config = SimpleNamespace(
++        enforce_eager=False,
++        use_eagle=lambda: False,
++        uses_draft_model=lambda: True,
++        uses_extract_hidden_states=lambda: False,
++    )
++    runner.cudagraph_dispatcher = SimpleNamespace(
++        get_capture_descs=lambda: [
++            (CUDAGraphMode.FULL, []),
++            (CUDAGraphMode.PIECEWISE, [object()]),
++        ]
++    )
++    runner.encoder_cudagraph_manager = None
++    runner.device = torch.device("cpu")
++    runner._maybe_init_encoder_cudagraph_manager = lambda: None
++    runner._freeze_gc = nullcontext
++
++    active_channel: list[str] = []
++    channel_entries: list[str] = []
++    captures: list[tuple[str, bool]] = []
++
++    @contextmanager
++    def fake_graph_capture(*, device, channel_id, **kwargs):
++        assert device == runner.device
++        active_channel.append(channel_id)
++        channel_entries.append(channel_id)
++        try:
++            yield SimpleNamespace(channel_id=channel_id)
++        finally:
++            assert active_channel.pop() == channel_id
++
++    def fake_capture_cudagraphs(*, run_drafter, **kwargs):
++        assert len(active_channel) == 1
++        captures.append((active_channel[0], run_drafter))
++
++    runner._capture_cudagraphs = fake_capture_cudagraphs
++    runner.encoder_cudagraph_manager = SimpleNamespace(
++        capture=lambda **_: captures.append((active_channel[0], True))
++    )
++    memory_info = iter(((1000, 0), (900, 0)))
++    monkeypatch.setattr(gpu_model_runner_module, "graph_capture", fake_graph_capture)
++    monkeypatch.setattr(
++        gpu_model_runner_module,
++        "set_cudagraph_capturing_enabled",
++        lambda _: None,
++    )
++    monkeypatch.setattr(gpu_model_runner_module, "lock_workspace", lambda: None)
++    monkeypatch.setattr(
++        gpu_model_runner_module,
++        "current_platform",
++        SimpleNamespace(graph_pool_handle=object),
++    )
++    monkeypatch.setattr(
++        torch.accelerator,
++        "synchronize",
++        lambda: None,
++    )
++    monkeypatch.setattr(torch.accelerator, "empty_cache", lambda: None)
++    monkeypatch.setattr(
++        torch.accelerator,
++        "get_memory_info",
++        lambda: next(memory_info),
++    )
++
++    assert runner.capture_model() == 100
++    assert captures == [
++        ("vllm:target:production", False),
++        ("vllm:draft:production", True),
++        ("vllm:encoder:production", True),
++    ]
++    assert channel_entries == [
++        "vllm:target:production",
++        "vllm:draft:production",
++        "vllm:encoder:production",
++    ]
++
++
++def test_v1_full_capture_without_speculation_is_target_only(monkeypatch):
++    runner = GPUModelRunner.__new__(GPUModelRunner)
++    runner.compilation_config = SimpleNamespace(cudagraph_mode=CUDAGraphMode.FULL)
++    runner.speculative_config = None
++    runner.cudagraph_dispatcher = SimpleNamespace(
++        get_capture_descs=lambda: [(CUDAGraphMode.FULL, [object()])]
++    )
++    runner.encoder_cudagraph_manager = None
++    runner.device = torch.device("cpu")
++    runner._maybe_init_encoder_cudagraph_manager = lambda: None
++    runner._freeze_gc = nullcontext
++
++    channels: list[str] = []
++    captures: list[bool] = []
++
++    @contextmanager
++    def fake_graph_capture(*, channel_id, **kwargs):
++        channels.append(channel_id)
++        yield SimpleNamespace(channel_id=channel_id)
++
++    runner._capture_cudagraphs = lambda *, run_drafter, **_: captures.append(
++        run_drafter
++    )
++    memory_info = iter(((1000, 0), (900, 0)))
++    monkeypatch.setattr(gpu_model_runner_module, "graph_capture", fake_graph_capture)
++    monkeypatch.setattr(
++        gpu_model_runner_module,
++        "set_cudagraph_capturing_enabled",
++        lambda _: None,
++    )
++    monkeypatch.setattr(gpu_model_runner_module, "lock_workspace", lambda: None)
++    monkeypatch.setattr(
++        torch.accelerator,
++        "synchronize",
++        lambda: None,
++    )
++    monkeypatch.setattr(torch.accelerator, "empty_cache", lambda: None)
++    monkeypatch.setattr(
++        torch.accelerator,
++        "get_memory_info",
++        lambda: next(memory_info),
++    )
++
++    assert runner.capture_model() == 100
++    assert channels == ["vllm:target:production"]
++    assert captures == [True]
++
++
++def test_v1_profile_rolls_back_distinct_target_and_draft_channels(monkeypatch):
++    runner = GPUModelRunner.__new__(GPUModelRunner)
++    runner.vllm_config = object()
++    runner.device = torch.device("cpu")
++    runner.speculative_config = SimpleNamespace(
++        enforce_eager=False,
++        use_eagle=lambda: False,
++        uses_draft_model=lambda: True,
++        uses_extract_hidden_states=lambda: False,
++    )
++    desc = SimpleNamespace(num_tokens=32)
++    runner.cudagraph_dispatcher = SimpleNamespace(
++        get_capture_descs=lambda: [
++            (CUDAGraphMode.FULL, []),
++            (CUDAGraphMode.PIECEWISE, [desc]),
++        ],
++        cudagraph_keys={},
++        keys_initialized=True,
++    )
++    runner.max_model_len = 4096
++    runner.max_num_tokens = 256
++    runner.lora_config = None
++    runner._freeze_gc = nullcontext
++    runner._init_minimal_kv_cache_for_profiling = lambda: None
++    runner._create_encoder_cudagraph_manager = lambda: None
++    runner.maybe_remove_all_loras = lambda _: None
++
++    events: list[object] = []
++    active_channel: list[str] = []
++
++    @contextmanager
++    def fake_graph_capture(*, device, channel_id, **kwargs):
++        assert device == runner.device
++        active_channel.append(channel_id)
++        events.append(("enter", channel_id))
++        try:
++            yield SimpleNamespace(channel_id=channel_id)
++        finally:
++            assert active_channel.pop() == channel_id
++            events.append(("exit", channel_id))
++
++    def fake_warmup_and_capture(*args, run_drafter, **kwargs):
++        assert len(active_channel) == 1
++        events.append(("capture", active_channel[0], run_drafter))
++
++    runner._warmup_and_capture = fake_warmup_and_capture
++    runner._cleanup_profiling_kv_cache = lambda: events.extend(
++        ("cleanup-sync", "cleanup")
++    )
++
++    checkpoint = ((lambda _: None, "checkpoint"),)
++
++    def checkpoint_graph_channels():
++        events.append("checkpoint")
++        return checkpoint
++
++    monkeypatch.setattr(
++        gpu_model_runner_module,
++        "checkpoint_b12x_graph_channels",
++        checkpoint_graph_channels,
++    )
++    monkeypatch.setattr(
++        gpu_model_runner_module,
++        "rollback_b12x_graph_channels",
++        lambda value: events.append(("rollback", value)),
++    )
++    monkeypatch.setattr(gpu_model_runner_module, "graph_capture", fake_graph_capture)
++    monkeypatch.setattr(
++        gpu_model_runner_module,
++        "set_current_vllm_config",
++        lambda _: nullcontext(),
++    )
++    monkeypatch.setattr(
++        gpu_model_runner_module,
++        "current_platform",
++        SimpleNamespace(
++            graph_pool_handle=object,
++            is_rocm=lambda: False,
++        ),
++    )
++    monkeypatch.setattr(
++        gpu_model_runner_module,
++        "set_cudagraph_capturing_enabled",
++        lambda enabled: events.append(("capture-enabled", enabled)),
++    )
++    monkeypatch.setattr(
++        gpu_model_runner_module.CUDAGraphWrapper,
++        "_all_instances",
++        [],
++    )
++    monkeypatch.setattr(
++        gpu_model_runner_module.BreakableCUDAGraphWrapper,
++        "_all_instances",
++        [],
++    )
++    monkeypatch.setattr(
++        gpu_model_runner_module.CUDAGraphWrapper,
++        "clear_all_graphs",
++        lambda: events.append("clear-target"),
++    )
++    monkeypatch.setattr(
++        gpu_model_runner_module.BreakableCUDAGraphWrapper,
++        "clear_all_graphs",
++        lambda: events.append("clear-breakable"),
++    )
++    memory_info = iter(((1000, 0), (900, 0), (900, 0), (800, 0)))
++    monkeypatch.setattr(
++        torch.accelerator,
++        "synchronize",
++        lambda: events.append("sync"),
++    )
++    monkeypatch.setattr(torch.accelerator, "empty_cache", lambda: None)
++    monkeypatch.setattr(
++        torch.accelerator,
++        "get_memory_info",
++        lambda: next(memory_info),
++    )
++
++    assert runner.profile_cudagraph_memory() == 200
++    assert ("capture", "vllm:target:profile", False) in events
++    assert ("capture", "vllm:draft:profile", True) in events
++    assert events.index("clear-target") < events.index("cleanup")
++    assert events.index("cleanup-sync") < events.index("cleanup")
++    assert events.index("cleanup") < events.index(("rollback", checkpoint))
++    assert events[-1] == ("rollback", checkpoint)
++
++
++@pytest.mark.parametrize("cleanup_fails", [False, True])
++def test_v1_profile_restores_state_when_capture_or_cleanup_fails(
++    monkeypatch,
++    cleanup_fails,
++):
++    runner = GPUModelRunner.__new__(GPUModelRunner)
++    runner.vllm_config = object()
++    runner.device = torch.device("cpu")
++    runner.speculative_config = None
++    desc = SimpleNamespace(num_tokens=32)
++    runner.cudagraph_dispatcher = SimpleNamespace(
++        get_capture_descs=lambda: [(CUDAGraphMode.FULL, [desc])],
++        cudagraph_keys={},
++        keys_initialized=True,
++    )
++    runner.max_model_len = 4096
++    runner.max_num_tokens = 256
++    runner.lora_config = None
++    runner._freeze_gc = nullcontext
++    runner._init_minimal_kv_cache_for_profiling = lambda: None
++    runner._create_encoder_cudagraph_manager = lambda: None
++    runner.maybe_remove_all_loras = lambda _: None
++
++    events: list[object] = []
++
++    @contextmanager
++    def fake_graph_capture(**kwargs):
++        yield SimpleNamespace(channel_id=kwargs["channel_id"])
++
++    def fail_capture(*args, **kwargs):
++        events.append("capture-failed")
++        raise RuntimeError("expected capture failure")
++
++    runner._warmup_and_capture = fail_capture
++    runner._cleanup_profiling_kv_cache = lambda: events.extend(
++        ("cleanup-sync", "cleanup")
++    )
++    checkpoint = ((lambda _: None, "checkpoint"),)
++
++    monkeypatch.setattr(
++        gpu_model_runner_module,
++        "checkpoint_b12x_graph_channels",
++        lambda: checkpoint,
++    )
++    monkeypatch.setattr(
++        gpu_model_runner_module,
++        "rollback_b12x_graph_channels",
++        lambda value: events.append(("rollback", value)),
++    )
++    monkeypatch.setattr(gpu_model_runner_module, "graph_capture", fake_graph_capture)
++    monkeypatch.setattr(
++        gpu_model_runner_module,
++        "set_current_vllm_config",
++        lambda _: nullcontext(),
++    )
++    monkeypatch.setattr(
++        gpu_model_runner_module,
++        "current_platform",
++        SimpleNamespace(graph_pool_handle=object, is_rocm=lambda: False),
++    )
++    monkeypatch.setattr(
++        gpu_model_runner_module,
++        "set_cudagraph_capturing_enabled",
++        lambda enabled: events.append(("capture-enabled", enabled)),
++    )
++    original_pool = object()
++    wrapper = SimpleNamespace(graph_pool=original_pool)
++    monkeypatch.setattr(
++        gpu_model_runner_module.CUDAGraphWrapper,
++        "_all_instances",
++        [wrapper],
++    )
++    monkeypatch.setattr(
++        gpu_model_runner_module.BreakableCUDAGraphWrapper,
++        "_all_instances",
++        [],
++    )
++
++    def clear_target_graphs():
++        events.append("clear-target")
++        if cleanup_fails:
++            raise RuntimeError("expected cleanup failure")
++
++    monkeypatch.setattr(
++        gpu_model_runner_module.CUDAGraphWrapper,
++        "clear_all_graphs",
++        clear_target_graphs,
++    )
++    monkeypatch.setattr(
++        gpu_model_runner_module.BreakableCUDAGraphWrapper,
++        "clear_all_graphs",
++        lambda: events.append("clear-breakable"),
++    )
++    monkeypatch.setattr(torch.accelerator, "synchronize", lambda: None)
++    monkeypatch.setattr(torch.accelerator, "empty_cache", lambda: None)
++    monkeypatch.setattr(torch.accelerator, "get_memory_info", lambda: (1000, 0))
++
++    expected_error = "expected cleanup failure" if cleanup_fails else "capture failure"
++    with pytest.raises(RuntimeError, match=expected_error):
++        runner.profile_cudagraph_memory()
++
++    assert wrapper.graph_pool is original_pool
++    if not cleanup_fails:
++        assert events.index("clear-target") < events.index("cleanup")
++        assert events.index("cleanup-sync") < events.index("cleanup")
++        assert events.index("cleanup") < events.index(("rollback", checkpoint))
++    assert events[-1] == ("rollback", checkpoint)
+diff --git a/vllm/config/quantization.py b/vllm/config/quantization.py
+index b1a42cd8bfd5527cbb1e00caef4a0bb65f2fa7cf..826704b1918f71bdde8f587db64b75237b63fd41 100644
+--- a/vllm/config/quantization.py
++++ b/vllm/config/quantization.py
+@@ -153,11 +153,14 @@ ONLINE_QUANT_SHORTHAND_NAMES: tuple[str, ...] = (
+ )
+ 
+ 
+-# Checkpoint formats that support overlaying online quantization on BF16 projections
+-# which the checkpoint explicitly leaves unquantized (shared experts via
+-# `shared_experts`, other dense linears via `linear`).
+-_MODELOPT_ONLINE_OVERLAY_NAMES = frozenset(
+-    {
++# Checkpoint formats that support overlaying online quantization on projections
++# which the checkpoint explicitly leaves in BF16 (shared experts via
++# `shared_experts`, other dense linears via `linear`). Each checkpoint backend
++# still owns the layer-level dispatch, so serialized weights always take
++# precedence over this overlay.
++_CHECKPOINT_ONLINE_OVERLAY_WEIGHTS = {
++    name: frozenset({kMxfp8Dynamic, kFp8Static128BlockSym})
++    for name in {
+         "modelopt",
+         "modelopt_fp4",
+         "modelopt_mxfp8",
+@@ -165,16 +168,15 @@ _MODELOPT_ONLINE_OVERLAY_NAMES = frozenset(
+         "mxfp4",
+         "nvfp4_nf3_hybrid",
+     }
+-)
+-
+-
+-_MODELOPT_ONLINE_OVERLAY_WEIGHTS = frozenset({kMxfp8Dynamic, kFp8Static128BlockSym})
++}
++_CHECKPOINT_ONLINE_OVERLAY_WEIGHTS["exl3"] = frozenset({kMxfp8Dynamic})
+ 
+ 
+-def _is_modelopt_online_overlay(
++def _is_checkpoint_online_overlay(
+     quantization: str | None, args: QuantizationConfigArgs
+ ) -> bool:
+-    if quantization not in _MODELOPT_ONLINE_OVERLAY_NAMES or args.moe is not None:
++    supported_weights = _CHECKPOINT_ONLINE_OVERLAY_WEIGHTS.get(quantization)
++    if supported_weights is None or args.moe is not None:
+         return False
+     specs = [s for s in (args.linear, args.shared_experts) if s is not None]
+     if not specs:
+@@ -183,8 +185,7 @@ def _is_modelopt_online_overlay(
+         # `ignore` only filters the dense-linear overlay.
+         return False
+     return all(
+-        spec.weight in _MODELOPT_ONLINE_OVERLAY_WEIGHTS and spec.activation is None
+-        for spec in specs
++        spec.weight in supported_weights and spec.activation is None for spec in specs
+     )
+ 
+ 
+@@ -192,28 +193,39 @@ def resolve_quantization_config(
+     quantization: str | None,
+     quantization_config: dict[str, Any] | QuantizationConfigArgs | None,
+ ) -> QuantizationConfigArgs | None:
+-    """Resolve `--quantization` shorthand and `--quantization-config` into a
+-    QuantizationConfigArgs.
++    """Resolve quantization CLI settings into structured arguments.
+ 
+     `quantization` may be a CLI shorthand that desugars into a base config via
+     `_ONLINE_SHORTHANDS`. `quantization_config` is a dict or pre-built args
+     object. When both are online settings, fields explicitly set in
+-    `quantization_config` take precedence over the shorthand. ModelOpt accepts
+-    online overlays for BF16 dense/shared-expert projections.
++    `quantization_config` take precedence over the shorthand. Selected
++    checkpoint formats accept online overlays for BF16 dense/shared-expert
++    projections.
++
++    Args:
++        quantization: Quantization method name or online shorthand.
++        quantization_config: Explicit online quantization fields, if any.
++
++    Returns:
++        The resolved quantization arguments, or ``None`` when no online
++        configuration was requested.
++
++    Raises:
++        ValueError: If an explicit configuration cannot overlay the selected
++            checkpoint quantization method.
+     """
+     if isinstance(quantization_config, dict):
+         quantization_config = QuantizationConfigArgs(**quantization_config)
+ 
+     if quantization is not None and quantization not in ONLINE_QUANT_SHORTHAND_NAMES:
+-        if quantization_config is not None and not _is_modelopt_online_overlay(
++        if quantization_config is not None and not _is_checkpoint_online_overlay(
+             quantization, quantization_config
+         ):
+             raise ValueError(
+                 f"quantization_config is only supported when quantization is "
+                 f"one of {sorted(ONLINE_QUANT_SHORTHAND_NAMES)}, or when "
+-                f"using the ModelOpt online overlay (weight='mxfp8' or "
+-                f"weight='fp8_per_block_static' on 'shared_experts' and/or "
+-                f"'linear', optional 'ignore'), "
++                f"using a supported checkpoint online overlay on "
++                f"'shared_experts' and/or 'linear' (optional 'ignore'), "
+                 f"got quantization={quantization!r}"
+             )
+         return quantization_config
+diff --git a/vllm/distributed/device_communicators/cuda_communicator.py b/vllm/distributed/device_communicators/cuda_communicator.py
+index 82fa3723ed1030b01c303412ca594d8ed915e7ec..60ca32c96315b29d7dfbcd6ae430faf533a7e9c4 100644
+--- a/vllm/distributed/device_communicators/cuda_communicator.py
++++ b/vllm/distributed/device_communicators/cuda_communicator.py
+@@ -662,11 +662,14 @@ class CudaCommunicator(DeviceCommunicatorBase):
+             raise ValueError("No PyNCCL communicator found")
+ 
+     def destroy(self):
++        if self.ca_comm is not None:
++            # B12X close is coordinated across ranks and must run before
++            # its NCCL exchange group is destroyed.
++            self.ca_comm.close()
++            self.ca_comm = None
+         if self.pynccl_comm is not None:
+             self.pynccl_comm.destroy()
+             self.pynccl_comm = None
+-        if self.ca_comm is not None:
+-            self.ca_comm = None
+         if self.aiter_ar_comm is not None:
+             self.aiter_ar_comm.close()
+             self.aiter_ar_comm = None
+diff --git a/vllm/distributed/device_communicators/cuda_wrapper.py b/vllm/distributed/device_communicators/cuda_wrapper.py
+index a5026163e9342506c0f04af18a652cc133034beb..188a86a401ac300363bfdd00ef67eff2e33621d2 100644
+--- a/vllm/distributed/device_communicators/cuda_wrapper.py
++++ b/vllm/distributed/device_communicators/cuda_wrapper.py
+@@ -48,6 +48,8 @@ class CudaRTLibrary:
+         Function("cudaDeviceReset", cudaError_t, []),
+         # const char* 	cudaGetErrorString ( cudaError_t error )
+         Function("cudaGetErrorString", ctypes.c_char_p, [cudaError_t]),
++        # cudaError_t cudaGetLastError ( void )
++        Function("cudaGetLastError", cudaError_t, []),
+         # ​cudaError_t 	cudaMalloc ( void** devPtr, size_t size )
+         Function(
+             "cudaMalloc",
+@@ -86,6 +88,7 @@ class CudaRTLibrary:
+         "cudaDeviceSynchronize": "hipDeviceSynchronize",
+         "cudaDeviceReset": "hipDeviceReset",
+         "cudaGetErrorString": "hipGetErrorString",
++        "cudaGetLastError": "hipGetLastError",
+         "cudaMalloc": "hipMalloc",
+         "cudaFree": "hipFree",
+         "cudaMemset": "hipMemset",
+@@ -142,6 +145,14 @@ class CudaRTLibrary:
+     def cudaGetErrorString(self, error: cudaError_t) -> str:
+         return self.funcs["cudaGetErrorString"](error).decode("utf-8")
+ 
++    def cudaGetLastError(self) -> int:
++        """Return and clear the calling thread's pending runtime error.
++
++        Returns:
++            The CUDA or HIP runtime error code that was cleared.
++        """
++        return int(self.funcs["cudaGetLastError"]())
++
+     def cudaSetDevice(self, device: int) -> None:
+         self.CUDART_CHECK(self.funcs["cudaSetDevice"](device))
+ 
+diff --git a/vllm/distributed/device_communicators/custom_all_reduce.py b/vllm/distributed/device_communicators/custom_all_reduce.py
+index 3933ef27ed57fb581113e9f2a2ca3c13df2c5cd2..0ab989c952b297ca2e73a595c846a81ec145faf7 100644
+--- a/vllm/distributed/device_communicators/custom_all_reduce.py
++++ b/vllm/distributed/device_communicators/custom_all_reduce.py
+@@ -31,15 +31,19 @@ except Exception:
+ 
+ logger = init_logger(__name__)
+ 
+-_B12X_PCIE_EAGER_CHANNEL_ID = "eager:vllm-tp-allreduce"
++# The eager scheduler has one stable all-reduce stream owner.  Never derive
++# this identity from a process-local CUDA stream handle; B12X deliberately
++# fails closed if the same logical owner is rebound to a second eager stream.
++_B12X_PCIE_EAGER_CHANNEL_ID = "vllm:eager:allreduce"
++_B12X_PCIE_MAX_CONCURRENT_CHANNELS = 2
+ 
+ 
+ def _get_pcie_allreduce_backend() -> str:
+     backend = envs.VLLM_PCIE_ALLREDUCE_BACKEND.lower()
+-    if backend not in {"b12x", "cpp"}:
++    if backend not in {"b12x", "cpp", "flashinfer-ipc"}:
+         raise ValueError(
+             "Invalid VLLM_PCIE_ALLREDUCE_BACKEND: "
+-            f"{backend!r}. Valid values: b12x, cpp."
++            f"{backend!r}. Valid values: b12x, cpp, flashinfer-ipc."
+         )
+     return backend
+ 
+@@ -48,6 +52,13 @@ def _b12x_pcie_allreduce_requested() -> bool:
+     return envs.VLLM_ENABLE_PCIE_ALLREDUCE and _get_pcie_allreduce_backend() == "b12x"
+ 
+ 
++def _flashinfer_pcie_allreduce_requested() -> bool:
++    return (
++        envs.VLLM_ENABLE_PCIE_ALLREDUCE
++        and _get_pcie_allreduce_backend() == "flashinfer-ipc"
++    )
++
++
+ def _is_piecewise_cudagraph_runtime() -> bool:
+     try:
+         from vllm.config import CUDAGraphMode
+@@ -121,6 +132,17 @@ def _load_b12x_pcie_dma() -> Any | None:
+     return PCIeDmaAllReduce
+ 
+ 
++@lru_cache(maxsize=1)
++def _load_flashinfer_pcie_oneshot_pool() -> Any | None:
++    try:
++        from vllm.distributed.device_communicators.flashinfer_pcie_all_reduce import (
++            FlashInferPcieIpcAllReducePool,
++        )
++    except Exception:
++        return None
++    return FlashInferPcieIpcAllReducePool
++
++
+ def _get_physical_device_numa_node(physical_device_id: int) -> int | None:
+     try:
+         import pynvml
+@@ -269,6 +291,7 @@ class CustomAllreduce:
+         self._cpp_ar_cutoff_size: int | None = None
+         self._cpp_ar_ignore_cutoff_max_rows = 0
+         self._pcie_cpp_backend = False
++        self._pcie_backend_name: str | None = None
+         self._pcie_logged_first_allreduce = False
+         self._ptr = 0
+ 
+@@ -304,9 +327,11 @@ class CustomAllreduce:
+             return
+ 
+         b12x_pcie_requested = _b12x_pcie_allreduce_requested()
++        flashinfer_pcie_requested = _flashinfer_pcie_allreduce_requested()
++        integrated_pcie_requested = b12x_pcie_requested or flashinfer_pcie_requested
+         if (
+             world_size not in CustomAllreduce._SUPPORTED_WORLD_SIZES
+-            and not b12x_pcie_requested
++            and not integrated_pcie_requested
+         ):
+             logger.warning(
+                 "Custom allreduce is disabled due to an unsupported world"
+@@ -363,16 +388,17 @@ class CustomAllreduce:
+         assert current_platform.is_cuda_alike()
+         fully_connected = current_platform.is_fully_connected(physical_device_ids)
+         use_pcie_oneshot = False
+-        if b12x_pcie_requested:
++        if integrated_pcie_requested:
+             if not current_platform.is_cuda():
+                 logger.warning(
+-                    "Custom allreduce is disabled because b12x PCIe oneshot "
+-                    "allreduce requires CUDA."
++                    "Custom allreduce is disabled because the integrated "
++                    "PCIe oneshot backend requires CUDA."
+                 )
+                 return
+             logger.debug(
+-                "b12x PCIe oneshot allreduce requested "
++                "%s PCIe oneshot allreduce requested "
+                 "(world_size=%d, physical_device_ids=%s, fully_connected=%s).",
++                _get_pcie_allreduce_backend(),
+                 world_size,
+                 physical_device_ids,
+                 fully_connected,
+@@ -429,21 +455,28 @@ class CustomAllreduce:
+             return
+ 
+         if use_pcie_oneshot:
++            pcie_backend = _get_pcie_allreduce_backend()
+             allow_cross_numa = envs.VLLM_PCIE_ONESHOT_ALLOW_CROSS_NUMA
+             if _is_cross_numa_topology(physical_device_ids) and not allow_cross_numa:
+                 logger.warning(
+-                    "Custom allreduce is disabled because b12x PCIe oneshot "
++                    "Custom allreduce is disabled because %s PCIe oneshot "
+                     "allreduce was requested on a cross-NUMA PCIe topology "
+                     "(physical_device_ids=%s). Set "
+                     "VLLM_PCIE_ONESHOT_ALLOW_CROSS_NUMA=1 or unset it to force it.",
++                    pcie_backend,
+                     physical_device_ids,
+                 )
+                 return
+-            pool_cls = _load_b12x_pcie_oneshot_pool()
++            pool_cls = (
++                _load_b12x_pcie_oneshot_pool()
++                if pcie_backend == "b12x"
++                else _load_flashinfer_pcie_oneshot_pool()
++            )
+             if pool_cls is None:
+                 logger.warning(
+-                    "PCIe custom allreduce was requested, but "
+-                    "b12x.comm.pcie.OneshotAllReducePool is unavailable."
++                    "%s PCIe custom allreduce was requested, but its runtime "
++                    "is unavailable.",
++                    pcie_backend,
+                 )
+                 return
+             # DMA must accommodate the largest scheduled prefill tensor. The
+@@ -461,7 +494,8 @@ class CustomAllreduce:
+                 max_num_batched_tokens = 8192
+                 logger.warning(
+                     "vLLM config unavailable during CustomAllreduce init; "
+-                    "allocating b12x PCIe buffers for hidden=%d, rows<=%d.",
++                    "allocating %s PCIe buffers for hidden=%d, rows<=%d.",
++                    pcie_backend,
+                     model_hidden_size,
+                     max_num_batched_tokens,
+                 )
+@@ -474,8 +508,9 @@ class CustomAllreduce:
+             ) = _b12x_pcie_oneshot_limits()
+             if self.nccl_group is None:
+                 logger.warning(
+-                    "Custom allreduce is disabled because b12x PCIe oneshot "
+-                    "allreduce requires a CUDA/NCCL device process group."
++                    "Custom allreduce is disabled because %s PCIe oneshot "
++                    "allreduce requires a CUDA/NCCL device process group.",
++                    pcie_backend,
+                 )
+                 return
+             self.max_size = pcie_buffer_size
+@@ -491,10 +526,15 @@ class CustomAllreduce:
+                     eager_buffer_bytes=pcie_oneshot_buffer_size,
+                     max_size=pcie_oneshot_buffer_size,
+                     single_channel=pcie_single_channel,
++                    max_concurrent_channels=_B12X_PCIE_MAX_CONCURRENT_CHANNELS,
+                 )
+                 if not pcie_single_channel:
+                     pcie_runtime.prepare_channels((_B12X_PCIE_EAGER_CHANNEL_ID,))
+-                pcie_runtime.for_stream(channel_id=_B12X_PCIE_EAGER_CHANNEL_ID)
++                pcie_runtime.for_stream(
++                    channel_id=(
++                        None if pcie_single_channel else _B12X_PCIE_EAGER_CHANNEL_ID
++                    )
++                )
+             except Exception as exc:
+                 pcie_init_error = exc
+ 
+@@ -507,25 +547,35 @@ class CustomAllreduce:
+                     pcie_runtime.close()
+                 if pcie_init_error is not None:
+                     logger.warning(
+-                        "b12x PCIe oneshot allreduce initialization failed on "
++                        "%s PCIe oneshot allreduce initialization failed on "
+                         "rank %d: %s. Falling back to PyNCCL allreduce.",
++                        pcie_backend,
+                         rank,
+                         pcie_init_error,
+                     )
+                 else:
+                     logger.warning(
+-                        "b12x PCIe oneshot allreduce initialization failed on "
+-                        "another TP rank. Falling back to PyNCCL allreduce."
++                        "%s PCIe oneshot allreduce initialization failed on "
++                        "another TP rank. Falling back to PyNCCL allreduce.",
++                        pcie_backend,
+                     )
+                 return
+             assert pcie_runtime is not None
+             self._pcie_runtime = pcie_runtime
++            self._pcie_backend_name = pcie_backend
+             # Prefill-size DMA allreduce alongside the oneshot. A deployment
+             # preflight can tune its crossover or disable it when lossless DMA
+             # never beats NCCL on the selected PCIe topology.
+-            dma_min_bytes = _b12x_pcie_dma_min_bytes()
++            dma_min_bytes = (
++                _b12x_pcie_dma_min_bytes() if pcie_backend == "b12x" else None
++            )
+             dma_cls = None if dma_min_bytes is None else _load_b12x_pcie_dma()
+-            if dma_min_bytes is None:
++            if pcie_backend != "b12x":
++                logger.info(
++                    "FlashInfer PCIe IPC handles only tuned one-shot shapes; "
++                    "larger allreduces stay on PyNCCL."
++                )
++            elif dma_min_bytes is None:
+                 logger.info(
+                     "b12x PCIe DMA allreduce disabled by "
+                     "VLLM_PCIE_DMA_MIN_BYTES=off; large allreduces stay on PyNCCL."
+@@ -579,19 +629,21 @@ class CustomAllreduce:
+ 
+             if rank == 0:
+                 logger.info(
+-                    "Configured b12x PCIe crossovers: "
++                    "Configured %s PCIe crossovers: "
+                     "oneshot max=%d, fused max=%d, DMA min=%s.",
++                    pcie_backend,
+                     self._pcie_allreduce_max_size,
+                     self._pcie_fused_add_rms_norm_max_size,
+                     dma_min_bytes if dma_min_bytes is not None else "off",
+                 )
+             self.disabled = False
+             logger.debug(
+-                "Using b12x PCIe oneshot allreduce backend "
++                "Using %s PCIe oneshot allreduce backend "
+                 "(world_size=%d, allreduce_max_size=%d, "
+                 "fused_add_rms_norm_max_size=%d, oneshot_buffer_size=%d, "
+                 "dma_buffer_size=%d, "
+                 "single_channel=%s).",
++                pcie_backend,
+                 world_size,
+                 self._pcie_allreduce_max_size,
+                 self._pcie_fused_add_rms_norm_max_size,
+@@ -670,8 +722,16 @@ class CustomAllreduce:
+ 
+         Legacy custom all-reduce registers graph buffers on exit. B12X
+         PCIe channels are instead created on the graph's owning stream and
+-        remain valid for the graph lifetime. Distributed B12X capture requires
+-        a rank-stable semantic ``channel_id``.
++        remain valid for the graph lifetime.
++
++        Args:
++            stream: CUDA stream owned by the enclosing graph capture.
++            channel_id: Stable identity shared by every rank for this graph
++                owner. Required when the B12X PCIe runtime is active.
++
++        Raises:
++            RuntimeError: If the PCIe runtime is active and ``channel_id`` is
++                ``None``.
+         """
+         old_pcie_capture_stream = self._pcie_capture_stream
+         old_pcie_capture_channel_id = self._pcie_capture_channel_id
+@@ -680,6 +740,11 @@ class CustomAllreduce:
+             if self._pcie_runtime is None:
+                 yield
+             else:
++                if channel_id is None:
++                    raise RuntimeError(
++                        "distributed PCIe graph capture requires an explicit "
++                        "semantic channel_id"
++                    )
+                 self._pcie_capture_stream = stream
+                 self._pcie_capture_channel_id = channel_id
+                 with self._pcie_runtime.capture(
+@@ -815,6 +880,8 @@ class CustomAllreduce:
+ 
+     def backend_name(self) -> str:
+         if self._pcie_runtime is not None:
++            if self._pcie_backend_name == "flashinfer-ipc":
++                return "FLASHINFER_PCIE_IPC"
+             if self._pcie_dma is not None:
+                 return "B12X_PCIE_ONESHOT_DMA"
+             return "B12X_PCIE_ONESHOT"
+@@ -949,6 +1016,24 @@ class CustomAllreduce:
+                 # all-reduce; returning a placeholder is only valid for warmup.
+                 if _is_piecewise_cudagraph_runtime():
+                     return self.all_reduce(input, registered=False)
++                # The warmup intentionally skips communication, but CuTe-based
++                # PCIe launchers still need their graph specialization loaded
++                # before the nested Inductor capture starts.
++                inp_size = input.numel() * input.element_size()
++                prepare_graph_all_reduce = getattr(
++                    self._pcie_runtime,
++                    "prepare_graph_all_reduce",
++                    None,
++                )
++                if (
++                    prepare_graph_all_reduce is not None
++                    and self._pcie_allreduce_max_size is not None
++                    and inp_size <= self._pcie_allreduce_max_size
++                ):
++                    prepare_graph_all_reduce(
++                        input,
++                        stream=self._pcie_runtime_stream(),
++                    )
+                 # If warm up, mimic the allocation pattern since custom
+                 # allreduce is out-of-place.
+                 return torch.empty_like(input)
+@@ -959,12 +1044,12 @@ class CustomAllreduce:
+             return self.all_reduce(input, registered=False)
+ 
+     def close(self):
+-        if self._pcie_dma is not None:
+-            self._pcie_dma.close()
+-            self._pcie_dma = None
+         if self._pcie_runtime is not None:
+             self._pcie_runtime.close()
+             self._pcie_runtime = None
++        if self._pcie_dma is not None:
++            self._pcie_dma.close()
++            self._pcie_dma = None
+         if not self.disabled and self._ptr:
+             if ops is not None:
+                 ops.dispose(self._ptr)
+@@ -972,7 +1057,16 @@ class CustomAllreduce:
+             self.free_shared_buffer(self.meta_ptrs, rank=self.rank)
+             self.free_shared_buffer(self.buffer_ptrs, rank=self.rank)
+ 
+-    def __del__(self):
++    def __del__(self) -> None:
++        # A finalizer cannot collectively close B12X after another rank
++        # has exited or vLLM has destroyed the process group. The backend owns
++        # abnormal resource finalization; explicit close() is coordinated by
++        # CudaCommunicator.destroy() while both process groups are still live.
++        if (
++            getattr(self, "_pcie_runtime", None) is not None
++            or getattr(self, "_pcie_dma", None) is not None
++        ):
++            return
+         self.close()
+ 
+     @staticmethod
+diff --git a/vllm/distributed/device_communicators/flashinfer_pcie_all_reduce.py b/vllm/distributed/device_communicators/flashinfer_pcie_all_reduce.py
+new file mode 100644
+index 0000000000000000000000000000000000000000..1d3b43082c028a21f45c57b88e6a218330884069
+--- /dev/null
++++ b/vllm/distributed/device_communicators/flashinfer_pcie_all_reduce.py
+@@ -0,0 +1,208 @@
++# SPDX-License-Identifier: Apache-2.0
++# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
++
++"""Stream-isolated adapter for FlashInfer's PCIe IPC all-reduce."""
++
++from __future__ import annotations
++
++from collections.abc import Iterator, Sequence
++from contextlib import contextmanager
++from functools import lru_cache
++from typing import Any
++
++import torch
++import torch.distributed as dist
++from torch.distributed import ProcessGroup
++
++
++@lru_cache(maxsize=1)
++def _load_workspace_class() -> type:
++    from flashinfer.comm import PcieIpcAllReduceWorkspace
++
++    return PcieIpcAllReduceWorkspace
++
++
++class _FlashInferPcieChannel:
++    def __init__(
++        self,
++        owner: FlashInferPcieIpcAllReducePool,
++        channel_id: str,
++    ) -> None:
++        self._owner = owner
++        self._channel_id = channel_id
++
++    def should_allreduce(self, inp: torch.Tensor) -> bool:
++        return self._owner._workspace(self._channel_id).supports(inp)
++
++    def register_graph_buffers(self) -> None:
++        # FlashInfer owns fixed IPC slabs; graph replay does not register input
++        # pointers with the legacy vLLM custom-allreduce runtime.
++        return None
++
++
++class FlashInferPcieIpcAllReducePool:
++    """Give every eager/CUDA-graph owner a distinct FlashInfer workspace.
++
++    FlashInfer's protocol state is stream-affine. vLLM may own an eager stream
++    plus independent target and draft CUDA-graph streams, so sharing one
++    workspace would permit their epochs to interleave. Semantic ``channel_id``
++    values provide a rank-stable key and one IPC workspace is allocated for
++    each live channel.
++    """
++
++    _EAGER_CHANNEL_ID = "vllm:eager:allreduce"
++
++    def __init__(
++        self,
++        *,
++        exchange_group: ProcessGroup,
++        device: torch.device | int | str,
++        max_size: int,
++        single_channel: bool = False,
++    ) -> None:
++        self.group = exchange_group
++        self.device = torch.device(device)
++        self.rank = dist.get_rank(group=exchange_group)
++        self.world_size = dist.get_world_size(group=exchange_group)
++        self.max_size = max_size
++        self.max_numel = max_size // torch.bfloat16.itemsize
++        self.single_channel = single_channel
++        self._workspaces: dict[str, Any] = {}
++        self._active_channel_id: str | None = None
++        self._closed = False
++
++        if max_size <= 0 or max_size % 16:
++            raise ValueError(
++                "FlashInfer PCIe IPC max_size must be a positive multiple "
++                f"of 16 bytes, got {max_size}"
++            )
++        # Workspace creation is collective. Keep construction allocation-free so
++        # the integration layer can prepare semantic channels at a rank-stable
++        # lifecycle point; standalone callers may still create them on first use.
++
++    @classmethod
++    def from_exchange_group(
++        cls,
++        *,
++        exchange_group: ProcessGroup,
++        device: torch.device | int | str,
++        eager_buffer_bytes: int,
++        max_size: int,
++        single_channel: bool = False,
++        max_concurrent_channels: int | None = None,
++        **_: Any,
++    ) -> FlashInferPcieIpcAllReducePool:
++        del eager_buffer_bytes, max_concurrent_channels
++        return cls(
++            exchange_group=exchange_group,
++            device=device,
++            max_size=max_size,
++            single_channel=single_channel,
++        )
++
++    def _canonical_channel_id(self, channel_id: str | None) -> str:
++        if self.single_channel or channel_id is None:
++            return self._EAGER_CHANNEL_ID
++        return channel_id
++
++    def _verify_channel_id(self, channel_id: str) -> None:
++        gathered: list[str | None] = [None] * self.world_size
++        dist.all_gather_object(gathered, channel_id, group=self.group)
++        if any(peer != channel_id for peer in gathered):
++            raise RuntimeError(
++                "FlashInfer PCIe IPC channel creation must be rank-stable; "
++                f"received {gathered}"
++            )
++
++    def _workspace(self, channel_id: str | None) -> Any:
++        if self._closed:
++            raise RuntimeError("FlashInfer PCIe IPC pool is closed")
++        key = self._canonical_channel_id(channel_id)
++        workspace = self._workspaces.get(key)
++        if workspace is None:
++            self._verify_channel_id(key)
++            workspace = _load_workspace_class()(
++                group=self.group,
++                max_numel=self.max_numel,
++                dtype=torch.bfloat16,
++            )
++            self._workspaces[key] = workspace
++        return workspace
++
++    def prepare_channels(self, channel_ids: Sequence[str]) -> None:
++        for channel_id in channel_ids:
++            self._workspace(channel_id)
++
++    def for_stream(
++        self,
++        stream: torch.cuda.Stream | None = None,
++        *,
++        channel_id: str | None = None,
++    ) -> _FlashInferPcieChannel:
++        del stream
++        key = self._canonical_channel_id(channel_id)
++        self._workspace(key)
++        return _FlashInferPcieChannel(self, key)
++
++    @contextmanager
++    def capture(
++        self,
++        stream: torch.cuda.Stream | None = None,
++        *,
++        channel_id: str | None = None,
++    ) -> Iterator[FlashInferPcieIpcAllReducePool]:
++        del stream
++        key = self._canonical_channel_id(channel_id)
++        self._workspace(key)
++        previous = self._active_channel_id
++        self._active_channel_id = key
++        try:
++            yield self
++        finally:
++            self._active_channel_id = previous
++
++    def prepare_graph_all_reduce(
++        self,
++        inp: torch.Tensor,
++        *,
++        stream: torch.cuda.Stream | None = None,
++    ) -> None:
++        del stream
++        channel_id = self._active_channel_id or self._EAGER_CHANNEL_ID
++        if not self._workspace(channel_id).supports(inp):
++            raise ValueError(
++                "FlashInfer PCIe IPC graph warmup received an unsupported "
++                f"shape {tuple(inp.shape)}"
++            )
++
++    def all_reduce(
++        self,
++        inp: torch.Tensor,
++        *,
++        out: torch.Tensor | None = None,
++        stream: torch.cuda.Stream | None = None,
++        channel_id: str | None = None,
++    ) -> torch.Tensor:
++        workspace = self._workspace(channel_id)
++        if stream is None or torch.cuda.current_stream(self.device) == stream:
++            return workspace.all_reduce(inp, out=out)
++        with torch.cuda.stream(stream):
++            return workspace.all_reduce(inp, out=out)
++
++    def checkpoint_channels(self) -> tuple[str, ...]:
++        return tuple(self._workspaces)
++
++    def rollback_channels(self, checkpoint: tuple[str, ...]) -> None:
++        retained = set(checkpoint)
++        for channel_id in reversed(tuple(self._workspaces)):
++            if channel_id in retained:
++                continue
++            self._workspaces.pop(channel_id).destroy()
++
++    def close(self) -> None:
++        if self._closed:
++            return
++        for workspace in reversed(tuple(self._workspaces.values())):
++            workspace.destroy()
++        self._workspaces.clear()
++        self._closed = True
+diff --git a/vllm/distributed/kv_transfer/kv_connector/v1/offloading/scheduler.py b/vllm/distributed/kv_transfer/kv_connector/v1/offloading/scheduler.py
+index 0d15ec22fdf9fd5cb41245495b073b0b6388f9d2..15ce871a1598eb1e81fc4f23f93067a6e7caef3a 100644
+--- a/vllm/distributed/kv_transfer/kv_connector/v1/offloading/scheduler.py
++++ b/vllm/distributed/kv_transfer/kv_connector/v1/offloading/scheduler.py
+@@ -6,6 +6,7 @@ from dataclasses import dataclass, field
+ from itertools import chain, islice
+ from typing import Any, NamedTuple
+ 
++import vllm.envs as envs
+ from vllm.config import VllmConfig
+ from vllm.distributed.kv_events import KVCacheEvent
+ from vllm.distributed.kv_transfer.kv_connector.utils import yield_req_data
+@@ -84,10 +85,11 @@ class GroupOffloadConfig(NamedTuple):
+     kv_event_group_spec: OffloadingEventGroupSpec
+     # None below means full attention
+     sliding_window_size_in_chunks: int | None
+-    # Number of this group's offloaded chunks per full-attention alignment
+-    # segment. Used to skip storing SWA chunks that can never serve a load
+-    # hit (e.g. DeepSeek V4 where SWA groups have much smaller block sizes
+-    # than the MLA full-attention group).
++    # Number of this group's offloaded chunks per sparsity segment (the
++    # full-attention alignment size, or VLLM_PREFIX_CACHE_RETENTION_INTERVAL
++    # when sparse retention is configured). Used to skip storing SWA chunks
++    # that can never serve a load hit (e.g. DeepSeek V4 where SWA groups have
++    # much smaller block sizes than the MLA full-attention group).
+     # None for full-attention groups or when the optimization doesn't apply.
+     alignment_chunk_count: int | None = None
+     # True for EAGLE/MTP draft-model attention groups. The trailing chunk
+@@ -136,6 +138,11 @@ class SchedulerOffloadConfig(NamedTuple):
+     blocks_per_chunk: int
+     num_workers: int
+     offload_prompt_only: bool
++    # Token alignment of the per-request "replay boundary" tail (see
++    # OffloadingConnectorScheduler._replay_tail_end_chunk). Set to the
++    # full-attention alignment size when sparse retention
++    # (VLLM_PREFIX_CACHE_RETENTION_INTERVAL) is enabled, else None.
++    replay_alignment_tokens: int | None = None
+ 
+     @classmethod
+     def from_spec(
+@@ -164,16 +171,34 @@ class SchedulerOffloadConfig(NamedTuple):
+         if len(full_attn_tokens_per_chunk) == 1:
+             alignment_tokens = full_attn_tokens_per_chunk.pop()
+ 
++        # Mirror SlidingWindowManager.reachable_block_mask's segment-size
++        # choice: with sparse retention (VLLM_PREFIX_CACHE_RETENTION_INTERVAL)
++        # the local GPU prefix cache keeps SWA tails once per retention
++        # segment rather than at every full-attention block boundary. Use the
++        # same granularity so stored tails sit exactly where lookups converge.
++        # An interval of 0 (latest-boundary-only retention) disables the
++        # store-side skip entirely (conservative: store all chunks).
++        retention_interval = envs.VLLM_PREFIX_CACHE_RETENTION_INTERVAL
++        segment_tokens: int | None = (
++            alignment_tokens
++            if retention_interval is None
++            else (None if retention_interval == 0 else retention_interval)
++        )
++
+         def _alignment_chunk_count(
+             tokens_per_chunk: int,
+             sliding_window_size_in_chunks: int | None,
++            is_eagle_group: bool,
+         ) -> int | None:
+-            if alignment_tokens is None or sliding_window_size_in_chunks is None:
++            if segment_tokens is None or sliding_window_size_in_chunks is None:
+                 return None
+-            if alignment_tokens <= tokens_per_chunk:
++            if segment_tokens <= tokens_per_chunk:
+                 return None
+-            per_segment = alignment_tokens // tokens_per_chunk
+-            if sliding_window_size_in_chunks >= per_segment:
++            per_segment = segment_tokens // tokens_per_chunk
++            # Contiguous chunks a hit needs at a segment boundary, including
++            # the "+1 peek" chunk for EAGLE/MTP groups (see _lookup).
++            need = sliding_window_size_in_chunks + (1 if is_eagle_group else 0)
++            if need >= per_segment:
+                 return None
+             return per_segment
+ 
+@@ -216,7 +241,9 @@ class SchedulerOffloadConfig(NamedTuple):
+                         )
+                     ),
+                     alignment_chunk_count=_alignment_chunk_count(
+-                        tokens_per_block * spec.blocks_per_chunk, sw
++                        tokens_per_block * spec.blocks_per_chunk,
++                        sw,
++                        idx in eagle_groups,
+                     ),
+                     kv_event_group_spec=get_offloading_event_group_spec(
+                         kv_cache_config.kv_cache_groups[idx]
+@@ -227,6 +254,9 @@ class SchedulerOffloadConfig(NamedTuple):
+             ),
+             blocks_per_chunk=spec.blocks_per_chunk,
+             offload_prompt_only=spec.offload_prompt_only,
++            replay_alignment_tokens=(
++                alignment_tokens if retention_interval is not None else None
++            ),
+         )
+ 
+ 
+@@ -258,6 +288,8 @@ class RequestOffloadState:
+     # time.monotonic() of this request's first deferred offload lookup;
+     # None once consumed (observed) or while no lookup is pending.
+     deferred_lookup_start_time: float | None = None
++    # True once on_request_finished has been signaled to the manager.
++    finished_signaled: bool = False
+ 
+     def __post_init__(self) -> None:
+         self.group_states = tuple(
+@@ -413,6 +445,20 @@ class OffloadingConnectorScheduler:
+             spec, kv_cache_config
+         )
+ 
++        # Tokens that must remain past a replay boundary for it to be
++        # servable: the last prompt token is always recomputed (hence the
++        # default of 1), and each EAGLE/MTP group must be able to match one
++        # complete chunk past the boundary (its "+1 peek", dropped after
++        # verification in _lookup).
++        self._replay_reserve_tokens: int = max(
++            (
++                group_config.tokens_per_chunk
++                for group_config in self.config.kv_group_configs
++                if group_config.is_eagle_group
++            ),
++            default=1,
++        )
++
+         self._req_status: dict[ReqId, RequestOffloadState] = {}
+         self._current_batch_load_jobs: dict[int, TransferJob] = {}
+         self._current_batch_jobs_to_flush: set[int] = set()
+@@ -458,7 +504,10 @@ class OffloadingConnectorScheduler:
+         return job_id
+ 
+     def _remove_pending_job(self, job_id: int, block_ids: list[int] | None) -> None:
+-        for bid in block_ids or ():
++        # Lockstep MLA groups share physical block IDs, so a transfer job may
++        # contain the same ID once per logical group. The pending-job index is
++        # set-backed and therefore registers each (block, job) pair only once.
++        for bid in set(block_ids or ()):
+             pending = self._block_id_to_pending_jobs[bid]
+             pending.remove(job_id)
+             if not pending:
+@@ -475,13 +524,6 @@ class OffloadingConnectorScheduler:
+             num = min(num, req_status.req.num_prompt_tokens)
+         return num
+ 
+-    def _maybe_cleanup_finished_req(
+-        self, req_id: str, req_status: RequestOffloadState
+-    ) -> None:
+-        """Clean up req_status if finished and no in-flight jobs."""
+-        if req_status.req.is_finished() and not req_status.transfer_jobs:
+-            del self._req_status[req_id]
+-
+     def _maximal_prefix_lookup(
+         self, keys: Iterable[OffloadKey], req_context: ReqContext
+     ) -> int | None:
+@@ -943,6 +985,37 @@ class OffloadingConnectorScheduler:
+                         ):
+                             group_state.block_ids[j] = 0
+ 
++    def _reachable_tail_end_chunks(
++        self, group_config: GroupOffloadConfig, req: Request, shift: int
++    ) -> tuple[int, ...]:
++        """End chunk indices (exclusive) of serviceable boundary tails.
++
++        Mirrors the replay-boundary handling of
++        SlidingWindowManager.reachable_block_mask: with sparse retention,
++        segment tails exist only once per retention interval. Retain tails at
++        the request replay boundary and at a detected shared-prefix junction.
++        Clamp each boundary to the latest point that every group can service,
++        including a complete EAGLE/MTP peek chunk.
++        """
++        alignment_tokens = self.config.replay_alignment_tokens
++        if alignment_tokens is None:
++            return ()
++
++        latest_serviceable = req.num_prompt_tokens - self._replay_reserve_tokens
++        boundaries = [latest_serviceable]
++        if req.shared_prefix_boundary:
++            boundaries.append(min(req.shared_prefix_boundary, latest_serviceable))
++
++        ends: list[int] = []
++        for boundary in boundaries:
++            aligned = boundary // alignment_tokens * alignment_tokens
++            if aligned <= 0 or aligned % group_config.tokens_per_chunk != 0:
++                continue
++            end = aligned // group_config.tokens_per_chunk + shift
++            if end not in ends:
++                ends.append(end)
++        return tuple(ends)
++
+     def _build_store_jobs(
+         self,
+         scheduler_output: SchedulerOutput,
+@@ -995,28 +1068,50 @@ class OffloadingConnectorScheduler:
+ 
+                 alignment_chunk_count = group_config.alignment_chunk_count
+                 tail = group_config.sliding_window_size_in_chunks
++                # Chunks reachable by _sliding_window_lookup, mirroring
++                # SlidingWindowManager.reachable_block_mask: a hit needs
++                # `need` contiguous chunks ending at a segment boundary. For
++                # EAGLE/MTP groups the run includes the "+1 peek" chunk and
++                # is shifted one chunk past the boundary, so that after
++                # _lookup drops the peek the hit lands exactly on it.
++                need = shift = 0
++                reachable_end_chunks: tuple[int, ...] = ()
++                if alignment_chunk_count is not None:
++                    assert tail is not None
++                    shift = 1 if group_config.is_eagle_group else 0
++                    need = tail + shift
++                    reachable_end_chunks = self._reachable_tail_end_chunks(
++                        group_config, req, shift
++                    )
+ 
+                 for key_idx, (offload_key, block_id) in enumerate(
+                     zip(offload_keys, offload_block_ids)
+                 ):
+                     if block_id == 0:
+                         continue
+-                    # Skip SWA chunks that can never serve a load hit:
+-                    # within each full-attention alignment segment, only the
+-                    # trailing `tail` chunks are reachable by
++                    # Skip SWA chunks that can never serve a load hit: only
++                    # the trailing `need` chunks of each alignment segment
++                    # (plus the replay-boundary tail) are reachable by
+                     # _sliding_window_lookup. For DeepSeek V4 with 100K
+                     # tokens this reduces SWA stores by ~78%.
+                     if alignment_chunk_count is not None:
+-                        assert tail is not None
+                         abs_chunk_idx = start_chunk_idx + key_idx
+-                        pos_in_segment = abs_chunk_idx % alignment_chunk_count
+-                        if pos_in_segment < alignment_chunk_count - tail:
++                        reachable = (
++                            abs_chunk_idx >= shift
++                            and (abs_chunk_idx - shift) % alignment_chunk_count
++                            >= alignment_chunk_count - need
++                        )
++                        if not reachable:
++                            reachable = any(
++                                end - need <= abs_chunk_idx < end
++                                for end in reachable_end_chunks
++                            )
++                        if not reachable:
+                             continue
+                     new_offload_keys.append(offload_key)
+ 
+             if not new_offload_keys:
+                 req_status.advance_stored_idx(num_offloadable_tokens)
+-                self._maybe_cleanup_finished_req(req_id, req_status)
+                 continue
+ 
+             store_output = self.manager.prepare_store(
+@@ -1027,12 +1122,10 @@ class OffloadingConnectorScheduler:
+                     _ConnectorMetricName.ALLOCATION_FAILURE
+                 )
+                 logger.warning("Request %s: cannot store chunks", req_id)
+-                self._maybe_cleanup_finished_req(req_id, req_status)
+                 continue
+ 
+             if not store_output.keys_to_store:
+                 req_status.advance_stored_idx(num_offloadable_tokens)
+-                self._maybe_cleanup_finished_req(req_id, req_status)
+                 continue
+ 
+             self._touch(req_status)
+@@ -1176,6 +1269,17 @@ class OffloadingConnectorScheduler:
+             store_jobs=self._build_store_jobs(scheduler_output),
+             jobs_to_flush=self._current_batch_jobs_to_flush,
+         )
++
++        # prepare_store must remain valid until every final store has been
++        # submitted. Tiering managers may release per-request state here.
++        for req_id in scheduler_output.finished_req_ids or ():
++            req_status = self._req_status.get(req_id)
++            if req_status is None:
++                continue
++            req_status.finished_signaled = True
++            self.manager.on_request_finished(req_status.req_context)
++            if not req_status.transfer_jobs:
++                del self._req_status[req_id]
+         self._current_batch_load_jobs = {}
+         self._current_batch_jobs_to_flush = set()
+         self._current_batch_allocated_block_ids = set()
+@@ -1266,7 +1370,7 @@ class OffloadingConnectorScheduler:
+ 
+             del self._jobs[job_id]
+             req_status.transfer_jobs.remove(job_id)
+-            if not req_status.transfer_jobs and req_status.req.is_finished():
++            if req_status.finished_signaled and not req_status.transfer_jobs:
+                 del self._req_status[job_status.req_id]
+ 
+     def get_stats(self) -> OffloadingConnectorStats | None:
+@@ -1308,7 +1412,6 @@ class OffloadingConnectorScheduler:
+             self.manager.on_request_finished(req_context)
+             return False, None
+ 
+-        self.manager.on_request_finished(req_status.req_context)
+         self._maybe_observe_lookup_async_delay(req_status)
+ 
+         # Update offload keys with final block hash so _build_store_jobs can
+@@ -1352,6 +1455,8 @@ class OffloadingConnectorScheduler:
+ 
+         for req_id, status in list(self._req_status.items()):
+             if status.req.is_finished():
++                if not status.finished_signaled:
++                    self.manager.on_request_finished(status.req_context)
+                 del self._req_status[req_id]
+ 
+         # Reset offloading manager cache
+diff --git a/vllm/distributed/parallel_state.py b/vllm/distributed/parallel_state.py
+index b8f4bcb087e3498ef0f6d349c2a82098eaf5448e..1a71847b7934298bbf16ff53c4256b37e6d5de12 100644
+--- a/vllm/distributed/parallel_state.py
++++ b/vllm/distributed/parallel_state.py
+@@ -1265,14 +1265,14 @@ class GroupCoordinator:
+         return self.device_communicator.recv(size, dtype, src)
+ 
+     def destroy(self):
++        if self.device_communicator is not None:
++            self.device_communicator.destroy()
+         if hasattr(self, "device_group"):
+             torch.distributed.destroy_process_group(self.device_group)
+             del self.device_group
+         if hasattr(self, "cpu_group"):
+             torch.distributed.destroy_process_group(self.cpu_group)
+             del self.cpu_group
+-        if self.device_communicator is not None:
+-            self.device_communicator.destroy()
+         if self.mq_broadcaster is not None:
+             self.mq_broadcaster = None
+ 
+@@ -1546,6 +1546,11 @@ def _validate_indexer_shard_count(indexer_shards: int, dcp_size: int) -> None:
+         )
+ 
+ 
++def _needs_indexer_replica_groups(indexer_shards: int, dcp_size: int) -> bool:
++    """Return whether the indexer needs replica-specific process groups."""
++    return 1 <= indexer_shards < dcp_size
++
++
+ _DCP_CKV_PREFETCH: GroupCoordinator | None = None
+ 
+ 
+@@ -1655,8 +1660,8 @@ def graph_capture(
+     is capturing the CUDA graph. Its main purpose is to ensure that some
+     operations will be run after the graph is captured, before the graph
+     is replayed. It returns a `GraphCaptureContext` object which contains the
+-    necessary data for the graph capture. Currently, it only contains the
+-    stream that the graph capture is running on. This stream is set to the
++    necessary data for the graph capture: its stream and an optional semantic
++    channel identity for distributed capture resources. The stream is set to the
+     current CUDA stream when the context manager is entered and reset to the
+     default stream when the context manager is exited. This is to ensure that
+     the graph capture is running on a separate stream from the default stream,
+@@ -1666,9 +1671,14 @@ def graph_capture(
+     A caller may pass an explicit ``graph_capture_context`` to control the
+     stream used (e.g. to capture on the default stream).
+ 
+-    ``channel_id`` identifies the graph semantically to distributed transports.
+-    It must be stable and identical across ranks; CUDA stream handles are local
+-    process state and are not valid distributed identities.
++    Args:
++        device: Device that owns a newly created capture stream.
++        graph_capture_context: Existing capture context to reuse.
++        channel_id: Stable distributed identity for this graph owner.
++
++    Raises:
++        ValueError: If ``channel_id`` conflicts with the identity stored on
++            ``graph_capture_context``.
+     """
+     if graph_capture_context is None:
+         context = GraphCaptureContext(
+@@ -1683,12 +1693,14 @@ def graph_capture(
+                     "graph capture context and argument specify different "
+                     "semantic channel IDs"
+                 )
+-            context.channel_id = channel_id
++            if context.channel_id is None:
++                context = GraphCaptureContext(context.stream, channel_id=channel_id)
+     maybe_dcp_capture = (
+         get_dcp_group().graph_capture(context)
+         if _DCP is not None and get_dcp_group().world_size > 1
+         else nullcontext()
+     )
++    maybe_b12x_dcp_capture: contextlib.AbstractContextManager[Any]
+     if _DCP is not None and get_dcp_group().world_size > 1:
+         # Import locally to avoid making distributed initialization depend on
+         # attention modules. The helper is a no-op until DCP warmup creates a
+@@ -2126,7 +2138,9 @@ def initialize_model_parallel(
+     )
+     indexer_shards = int(envs.VLLM_DCP_INDEXER_SHARDS)
+     _validate_indexer_shard_count(indexer_shards, decode_context_model_parallel_size)
+-    if 1 < indexer_shards < decode_context_model_parallel_size:
++    if _needs_indexer_replica_groups(
++        indexer_shards, decode_context_model_parallel_size
++    ):
+         indexer_dcp_ranks, indexer_query_split_ranks = (
+             _build_indexer_replica_group_ranks(tp_group_ranks, indexer_shards)
+         )
+diff --git a/vllm/entrypoints/chat_utils.py b/vllm/entrypoints/chat_utils.py
+index 61244a3e164b6fb34ff2f6f6e68f84cbdd550a88..5e8f909ce5e18dd330dde886398066e04ea1b486 100644
+--- a/vllm/entrypoints/chat_utils.py
++++ b/vllm/entrypoints/chat_utils.py
+@@ -359,7 +359,12 @@ class CustomChatCompletionMessageParam(TypedDict, total=False):
+     """The reasoning content for interleaved thinking."""
+ 
+     tools: list[ChatCompletionFunctionToolParam] | None
+-    """The tools for developer role."""
++    """Message-level tools, preserved for "system" and "developer" roles.
++
++    Used by chat templates/encoders (e.g. DeepSeek-V4, DeepSeek-V3.2) that
++    accept tools attached directly to a system or developer message, as
++    opposed to (or in addition to) the request-level `tools` parameter.
++    """
+ 
+     task: str | None
+     """Model-specific task marker. Currently passed through for DeepSeek V4."""
+@@ -396,7 +401,12 @@ class ConversationMessage(TypedDict, total=False):
+     """Deprecated: The reasoning content for interleaved thinking."""
+ 
+     tools: list[ChatCompletionFunctionToolParam] | None
+-    """The tools for developer role."""
++    """Message-level tools, preserved for "system" and "developer" roles.
++
++    Used by chat templates/encoders (e.g. DeepSeek-V4, DeepSeek-V3.2) that
++    accept tools attached directly to a system or developer message, as
++    opposed to (or in addition to) the request-level `tools` parameter.
++    """
+ 
+     task: str | None
+     """Model-specific task marker. Currently passed through for DeepSeek V4."""
+@@ -1857,8 +1867,8 @@ def _parse_chat_message_content(
+         if "task" in message and isinstance(message["task"], str):
+             result_msg["task"] = message["task"]
+ 
+-        if role == "developer":
+-            result_msg["tools"] = message.get("tools", None)
++        if role in ("system", "developer") and message.get("tools") is not None:
++            result_msg["tools"] = message["tools"]
+     return result
+ 
+ 
+diff --git a/vllm/envs.py b/vllm/envs.py
+index 96226926fc5532b41a05eff5526aac922acccd83..e31ada8006c924295e43d1683290f19808abfb3a 100755
+--- a/vllm/envs.py
++++ b/vllm/envs.py
+@@ -87,6 +87,8 @@ if TYPE_CHECKING:
+     VLLM_B12X_MLA_CKV_GATHER_MAX_TOKENS: int = 524288
+     VLLM_B12X_MLA_CKV_PREFETCH_DEPTH: int = 1
+     VLLM_B12X_MLA_CKV_PREFETCH_WORKSPACE_MIB: int = 1024
++    VLLM_B12X_MLA_SPEC_DECODE_MAX_Q: int = 8
++    VLLM_B12X_MLA_SPEC_EXTEND_AS_DECODE: str = "auto"
+     VLLM_MINIMAX_M3_ENABLE_TORCH_COMPILE: bool = False
+     VLLM_B12X_CUDAGRAPH_PIECEWISE_PREWARM: bool = False
+     VLLM_B12X_MOE_FORCE_MODELOPT_PREP: bool = False
+@@ -234,12 +236,17 @@ if TYPE_CHECKING:
+     VLLM_FLASHINFER_AUTOTUNE_SKIP_OPS: list[str] | None = None
+     VLLM_FLASHINFER_ALLREDUCE_BACKEND: Literal["auto", "trtllm", "mnnvl"] = "auto"
+     VLLM_ENABLE_PCIE_ALLREDUCE: bool = False
+-    VLLM_PCIE_ALLREDUCE_BACKEND: Literal["b12x", "cpp"] = "cpp"
++    VLLM_PCIE_ALLREDUCE_BACKEND: Literal["b12x", "cpp", "flashinfer-ipc"] = "cpp"
+     VLLM_PCIE_ONESHOT_ALLREDUCE_MAX_SIZE: str = "84KB"
+     VLLM_PCIE_ONESHOT_FUSED_ADD_RMS_NORM_MAX_SIZE: str = "84KB"
+     VLLM_PCIE_DMA_MIN_BYTES: str = "6MB"
+     VLLM_PCIE_ONESHOT_ALLOW_CROSS_NUMA: bool = True
+     VLLM_PCIE_ONESHOT_SINGLE_CHANNEL: bool = False
++    VLLM_PCIE_DMA_FP8: str | None = None
++    VLLM_CPP_AR_1STAGE_NCCL_CUTOFF: str | None = None
++    VLLM_CPP_AR_IGNORE_CUTOFF_MAX_ROWS: int | None = None
++    VLLM_USE_B12X_PCIE_DMA: bool = False
++    VLLM_CACHE_DIR: str | None = None
+     VLLM_FLASHINFER_WORKSPACE_BUFFER_SIZE: int = 394 * 1024 * 1024
+     VLLM_XGRAMMAR_CACHE_MB: int = 0
+     VLLM_REGEX_COMPILATION_TIMEOUT_S: int = 5
+@@ -1225,6 +1232,15 @@ environment_variables: dict[str, Callable[[], Any]] = {
+     "VLLM_B12X_MLA_CKV_PREFETCH_WORKSPACE_MIB": lambda: int(
+         os.getenv("VLLM_B12X_MLA_CKV_PREFETCH_WORKSPACE_MIB", "1024")
+     ),
++    # Short speculative extends may use the B12X sparse-MLA decode kernel.
++    # Backend validation remains authoritative because eligibility also
++    # depends on the active speculative configuration.
++    "VLLM_B12X_MLA_SPEC_DECODE_MAX_Q": lambda: int(
++        os.getenv("VLLM_B12X_MLA_SPEC_DECODE_MAX_Q", "8")
++    ),
++    "VLLM_B12X_MLA_SPEC_EXTEND_AS_DECODE": lambda: os.getenv(
++        "VLLM_B12X_MLA_SPEC_EXTEND_AS_DECODE", "auto"
++    ),
+     # Diagnostic flag retained for local experiments. MiniMax M3 compile is
+     # fail-closed in the model until the no-break path is validated.
+     "VLLM_MINIMAX_M3_ENABLE_TORCH_COMPILE": lambda: bool(
+@@ -1852,7 +1868,7 @@ environment_variables: dict[str, Callable[[], Any]] = {
+     "VLLM_PCIE_ALLREDUCE_BACKEND": env_with_choices(
+         "VLLM_PCIE_ALLREDUCE_BACKEND",
+         "cpp",
+-        ["b12x", "cpp"],
++        ["b12x", "cpp", "flashinfer-ipc"],
+     ),
+     # Max input size for the b12x PCIe oneshot allreduce dispatch.
+     # Accepts raw bytes or a KB/MB suffix (e.g. "84KB").
+@@ -1878,6 +1894,23 @@ environment_variables: dict[str, Callable[[], Any]] = {
+         os.getenv("VLLM_PCIE_ONESHOT_SINGLE_CHANNEL", "0").strip().lower()
+         not in ("", "0", "false", "no", "off")
+     ),
++    # Optional wire format and crossover tuning read by the custom-allreduce
++    # integration. Unset values delegate to backend-owned defaults.
++    "VLLM_PCIE_DMA_FP8": lambda: os.getenv("VLLM_PCIE_DMA_FP8"),
++    "VLLM_CPP_AR_1STAGE_NCCL_CUTOFF": lambda: os.getenv(
++        "VLLM_CPP_AR_1STAGE_NCCL_CUTOFF"
++    ),
++    "VLLM_CPP_AR_IGNORE_CUTOFF_MAX_ROWS": lambda: (
++        int(value)
++        if (value := os.getenv("VLLM_CPP_AR_IGNORE_CUTOFF_MAX_ROWS")) is not None
++        else None
++    ),
++    # The DS4 launcher exports these for B12X and compiler-cache consumers.
++    # Register them so vLLM validation does not reject a supported launch.
++    "VLLM_USE_B12X_PCIE_DMA": lambda: bool(
++        int(os.getenv("VLLM_USE_B12X_PCIE_DMA", "0"))
++    ),
++    "VLLM_CACHE_DIR": lambda: os.getenv("VLLM_CACHE_DIR"),
+     # Control the workspace buffer size for the FlashInfer backend.
+     "VLLM_FLASHINFER_WORKSPACE_BUFFER_SIZE": lambda: int(
+         os.getenv("VLLM_FLASHINFER_WORKSPACE_BUFFER_SIZE", str(394 * 1024 * 1024))
+@@ -2287,12 +2320,18 @@ environment_variables: dict[str, Callable[[], Any]] = {
+     "VLLM_EXL3_TRELLIS_MAX_M": lambda: os.getenv("VLLM_EXL3_TRELLIS_MAX_M"),
+     "VLLM_EXL3_TRELLIS_BLOCK_M": lambda: os.getenv("VLLM_EXL3_TRELLIS_BLOCK_M"),
+     "VLLM_EXL3_PREFILL_CHUNK": lambda: os.getenv("VLLM_EXL3_PREFILL_CHUNK"),
++    "VLLM_EXL3_PREFILL_CAPACITY": lambda: os.getenv("VLLM_EXL3_PREFILL_CAPACITY"),
+     "VLLM_EXL3_PREFILL_TRELLIS": lambda: os.getenv("VLLM_EXL3_PREFILL_TRELLIS"),
+     "VLLM_EXL3_PREFILL_BLOCK_M": lambda: os.getenv("VLLM_EXL3_PREFILL_BLOCK_M"),
++    # Deterministic online EXL3 encoding and its persistent rank-local cache.
++    "VLLM_EXL3_ONLINE_TRELLIS_BITS": lambda: os.getenv("VLLM_EXL3_ONLINE_TRELLIS_BITS"),
++    "VLLM_EXL3_ENCODER_SOURCE": lambda: os.getenv("VLLM_EXL3_ENCODER_SOURCE"),
++    "VLLM_EXL3_ENCODER_REVISION": lambda: os.getenv("VLLM_EXL3_ENCODER_REVISION"),
++    "VLLM_EXL3_ONLINE_CACHE_DIR": lambda: os.getenv("VLLM_EXL3_ONLINE_CACHE_DIR"),
++    "VLLM_EXL3_ONLINE_CACHE_MODE": lambda: os.getenv("VLLM_EXL3_ONLINE_CACHE_MODE"),
+     # Prebuilt exllamav3 extension location and torch-ABI compatibility shim.
+     "VLLM_EXL3_EXT_PATH": lambda: os.getenv("VLLM_EXL3_EXT_PATH"),
+     "VLLM_EXL3_ABI_SHIM": lambda: os.getenv("VLLM_EXL3_ABI_SHIM"),
+-
+ }
+ 
+ 
+diff --git a/vllm/model_executor/kernels/mhc/tilelang.py b/vllm/model_executor/kernels/mhc/tilelang.py
+index 885ec74f91e3957f32efda5b083257d735d498a8..639f6e059766f943b98615796b8ad8242770842d 100644
+--- a/vllm/model_executor/kernels/mhc/tilelang.py
++++ b/vllm/model_executor/kernels/mhc/tilelang.py
+@@ -407,6 +407,67 @@ def mhc_pre_broadcast_tilelang(
+     )
+ 
+ 
++def _mhc_pre_broadcast_tilelang_fake(
++    residual: torch.Tensor,
++    fn: torch.Tensor,
++    hc_scale: torch.Tensor,
++    hc_base: torch.Tensor,
++    rms_eps: float,
++    hc_pre_eps: float,
++    hc_sinkhorn_eps: float,
++    hc_post_mult_value: float,
++    sinkhorn_repeat: int,
++    n_splits: int = 1,
++    norm_weight: torch.Tensor | None = None,
++    norm_eps: float = 1e-6,
++    fn_broadcast: torch.Tensor | None = None,
++) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor, torch.Tensor]:
++    del (
++        hc_scale,
++        hc_base,
++        rms_eps,
++        hc_pre_eps,
++        hc_sinkhorn_eps,
++        hc_post_mult_value,
++        sinkhorn_repeat,
++        n_splits,
++        norm_weight,
++        norm_eps,
++        fn_broadcast,
++    )
++    num_tokens, hidden_size = residual.shape
++    hc_mult = fn.shape[1] // hidden_size
++    return (
++        torch.empty(
++            num_tokens,
++            hc_mult,
++            hidden_size,
++            dtype=torch.bfloat16,
++            device=residual.device,
++        ),
++        torch.empty(
++            num_tokens,
++            hc_mult,
++            1,
++            dtype=torch.float32,
++            device=residual.device,
++        ),
++        torch.empty(
++            num_tokens,
++            hc_mult,
++            hc_mult,
++            dtype=torch.float32,
++            device=residual.device,
++        ),
++        torch.empty(
++            num_tokens,
++            hidden_size,
++            dtype=torch.bfloat16,
++            device=residual.device,
++        ),
++    )
++
++
+ def mhc_post_tilelang(
+     x: torch.Tensor,
+     residual: torch.Tensor,
+@@ -782,6 +843,7 @@ def _hc_head_fused_kernel_tilelang_fake(
+ 
+ 
+ _mhc_pre_tilelang_impl = mhc_pre_tilelang
++_mhc_pre_broadcast_tilelang_impl = mhc_pre_broadcast_tilelang
+ _mhc_post_tilelang_impl = mhc_post_tilelang
+ _mhc_fused_post_pre_tilelang_impl = mhc_fused_post_pre_tilelang
+ 
+@@ -791,6 +853,12 @@ direct_register_custom_op(
+     mutates_args=[],
+     fake_impl=_mhc_pre_tilelang_fake,
+ )
++direct_register_custom_op(
++    op_name="mhc_pre_broadcast_tilelang",
++    op_func=_mhc_pre_broadcast_tilelang_impl,
++    mutates_args=[],
++    fake_impl=_mhc_pre_broadcast_tilelang_fake,
++)
+ direct_register_custom_op(
+     op_name="mhc_post_tilelang",
+     op_func=_mhc_post_tilelang_impl,
+@@ -816,6 +884,17 @@ def mhc_pre_tilelang(*args, **kwargs):
+     return torch.ops.vllm.mhc_pre_tilelang(*args, **kwargs)
+ 
+ 
++def mhc_pre_broadcast_tilelang(*args, **kwargs):
++    """Call broadcast MHC pre through the registered custom op.
++
++    The implementation invokes DeepGEMM through a pybind extension, which
++    cannot be traced by Dynamo. Keeping that call behind a custom-op boundary
++    lets full-graph compilation represent the operation without entering its
++    Python implementation.
++    """
++    return torch.ops.vllm.mhc_pre_broadcast_tilelang(*args, **kwargs)
++
++
+ def mhc_post_tilelang(*args, **kwargs):
+     """Call MHC post through the registered custom op."""
+     return torch.ops.vllm.mhc_post_tilelang(*args, **kwargs)
+@@ -825,6 +904,7 @@ def mhc_fused_post_pre_tilelang(*args, **kwargs):
+     """Call fused MHC post/pre through the registered custom op."""
+     return torch.ops.vllm.mhc_fused_post_pre_tilelang(*args, **kwargs)
+ 
++
+ direct_register_custom_op(
+     op_name="hc_head_fused_kernel_tilelang",
+     op_func=_hc_head_fused_kernel_tilelang,
+diff --git a/vllm/model_executor/layers/attention/mla_attention.py b/vllm/model_executor/layers/attention/mla_attention.py
+index 9fefa3dd4f194f25c788630795e2835a869247a3..1931df061abaa20779c4bf73d4acc8d104c2d7ec 100644
+--- a/vllm/model_executor/layers/attention/mla_attention.py
++++ b/vllm/model_executor/layers/attention/mla_attention.py
+@@ -333,6 +333,22 @@ def _run_mla_query_bmm(
+     torch.bmm(query.contiguous() if use_safe_op else query, weight, out=output)
+ 
+ 
++def is_packed_quantized_dtype(dtype: torch.dtype) -> bool:
++    """Return whether ``dtype`` is a packed quantized-weight container.
++
++    NVFP4 packs into ``uint8``; compressed-tensors int4/int8 packs into
++    ``int32``. Neither is a real activation dtype, so ``kv_c_normed`` must not
++    be cast to them -- the linear layer unpacks and quantizes internally.
++
++    Args:
++        dtype: Data type to classify.
++
++    Returns:
++        Whether the data type stores packed quantized weights.
++    """
++    return dtype in (torch.uint8, torch.int32)
++
++
+ @functools.cache
+ def _b12x_absorb_bmm_enabled() -> bool:
+     return envs.VLLM_B12X_ABSORB_BMM
+@@ -3178,12 +3194,13 @@ class MLACommonBaseImpl(MLAAttentionImpl[A], Generic[A]):
+                 if hasattr(self.kv_b_proj, "weight")
+                 else self.kv_b_proj.params_dtype
+             )
+-            # For NVFP4, weights are packed uint8 — keep input in model dtype
+-            # since the NVFP4 linear layer quantizes internally.
++            # Packed quantized weights (NVFP4 → uint8, compressed-tensors
++            # int4/int8 → int32) are containers, not activation dtypes — keep
++            # the input in model dtype; the linear layer quantizes internally.
+             if (
+                 use_fp8_prefill or _kv_b_proj_w_dtype != current_platform.fp8_dtype()
+-            ) and _kv_b_proj_w_dtype != torch.uint8:
+-                kv_c_normed = kv_c_normed.to(self.kv_b_proj.weight.dtype)
++            ) and not is_packed_quantized_dtype(_kv_b_proj_w_dtype):
++                kv_c_normed = kv_c_normed.to(_kv_b_proj_w_dtype)
+ 
+             k_pe = workspace[:toks][..., self.kv_lora_rank :].unsqueeze(1)
+             kv_nope = self.kv_b_proj(kv_c_normed)[0].view(
+@@ -3334,9 +3351,11 @@ class MLACommonBaseImpl(MLAAttentionImpl[A], Generic[A]):
+                 if hasattr(self.kv_b_proj, "weight")
+                 else self.kv_b_proj.params_dtype
+             )
++            # Same packed-container rule as _compute_prefill_context above; this
++            # is the branch forward_mha takes when dcp_world_size > 1.
+             if (
+                 use_fp8_prefill or kv_b_proj_w_dtype != current_platform.fp8_dtype()
+-            ) and kv_b_proj_w_dtype != torch.uint8:
++            ) and not is_packed_quantized_dtype(kv_b_proj_w_dtype):
+                 kv_c_normed = kv_c_normed.to(kv_b_proj_w_dtype)
+ 
+             kv_nope = self.kv_b_proj(kv_c_normed)[0].view(
+diff --git a/vllm/model_executor/layers/quantization/exl3.py b/vllm/model_executor/layers/quantization/exl3.py
+index 39932667b1da2017e9500f37b7587479b04acb41..36bd8c525b3bdada590480628856801f56a6e2a2 100644
+--- a/vllm/model_executor/layers/quantization/exl3.py
++++ b/vllm/model_executor/layers/quantization/exl3.py
+@@ -24,13 +24,16 @@ import importlib
+ import os
+ import re
+ import sys
+-from types import SimpleNamespace
++import zlib
++from pathlib import Path
++from types import ModuleType, SimpleNamespace
+ from typing import TYPE_CHECKING, Any
+ 
+ import torch
+ from transformers import PretrainedConfig
+ 
+ from vllm.config import get_current_vllm_config_or_none
++from vllm.config.quantization import QuantizationConfigArgs
+ from vllm.distributed import (
+     get_tensor_model_parallel_rank,
+     get_tensor_model_parallel_world_size,
+@@ -53,7 +56,24 @@ from vllm.model_executor.layers.quantization.base_config import (
+     QuantizationConfig,
+     QuantizeMethodBase,
+ )
++from vllm.model_executor.layers.quantization.compressed_tensors.utils import (
++    should_ignore_layer,
++)
++from vllm.model_executor.layers.quantization.exl3_online_cache import (
++    Exl3OnlineCacheKey,
++    cache_mode,
++    load_or_quantize,
++    resolve_encoder_identity,
++    resolve_model_identity,
++)
++from vllm.model_executor.layers.quantization.online.fp8 import _Fp8OnlineLinearBase
++from vllm.model_executor.layers.quantization.online.mxfp8 import (
++    Mxfp8OnlineLinearMethod,
++    is_shared_expert_projection,
++)
++from vllm.model_executor.layers.quantization.utils.quant_utils import kMxfp8Dynamic
+ from vllm.model_executor.parameter import BasevLLMParameter
++from vllm.model_executor.utils import replace_parameter
+ from vllm.transformers_utils.repo_utils import get_hf_file_to_dict
+ 
+ if TYPE_CHECKING:
+@@ -70,10 +90,62 @@ _HADAMARD_BLOCK = 128
+ _EXL3_EXT: Any | None = None
+ _B12X_FUSED_MOE_API: Any | None = None
+ _B12X_MIXED_TRELLIS_API: Any | None = None
++_B12X_TRELLIS_LINEAR_API: Any | None = None
++_EXL3_ONLINE_QUANTIZER: Any | None = None
++_EXL3_ONLINE_WARMED_SIGNATURES: set[tuple[int, int, int, int]] = set()
++_B12X_TRELLIS_WARMED_DEVICES: set[int] = set()
++# The dense W4A16 kernel caps its temporary accumulation arena at
++# SMs * 4 * block_m * 256 fp32 elements.  SM120/SM121 devices supported by
++# this path have at most 192 SMs, and block_m never exceeds 64.  Keeping this
++# architecture bound here lets Inductor own and reuse the temporary across
++# layers instead of allocating inside CUDA graph capture.
++_B12X_TRELLIS_C_TMP_CAP = 192 * 4 * 64 * 256
+ _RANK_SLICED_RUNTIMES: dict[tuple[Any, ...], dict[str, Any]] = {}
+ _MIXED_TRELLIS_RUNTIMES: dict[tuple[Any, ...], dict[str, Any]] = {}
+ _NEXT_RUNTIME_SCOPE_ID = 0
+ _MIXED_TRELLIS_ROUTE_BLOCK_SIZE = 8
++_GLM52_MIXED_TRELLIS_PREFILL_BLOCK_SIZE = 32
++_GLM52_MIXED_TRELLIS_BLOCK32_SIGNATURES = frozenset(
++    {
++        ((3, 192), (4, 64)),
++        ((3, 206), (4, 50)),
++        ((3, 148), (4, 108)),
++    }
++)
++
++
++def _resolve_mixed_trellis_prefill_block_m(
++    *,
++    configured_block_m: int,
++    explicit_override: bool,
++    hidden_size: int,
++    intermediate_size: int,
++    tier_signature: tuple[tuple[int, int], ...],
++    topk: int,
++    device_major: int,
++    prefill_tile_config: tuple[int, int, int, int],
++) -> int:
++    """Select the qualified GLM-5.2 mixed-K prefill route block.
++
++    B12X's paired-M8 FC2 schedule makes block-32 numerically equivalent
++    to the established block-64 path while reducing scratch and improving the
++    dominant large-prefill kernel on SM12x. The allowlist contains only tier
++    partitions qualified end-to-end on GLM-5.2 checkpoints. Explicit operator
++    tuning and every other model geometry retain the configured value.
++    """
++
++    qualified = (
++        not explicit_override
++        and int(device_major) == 12
++        and int(hidden_size) == 6144
++        and int(intermediate_size) == 512
++        and tier_signature in _GLM52_MIXED_TRELLIS_BLOCK32_SIGNATURES
++        and int(topk) == 8
++        and tuple(int(value) for value in prefill_tile_config) == (128, 128, 32, 512)
++    )
++    if qualified:
++        return _GLM52_MIXED_TRELLIS_PREFILL_BLOCK_SIZE
++    return int(configured_block_m)
+ 
+ 
+ # Smallest m the Trellis kernel path can service, and therefore the smallest
+@@ -88,6 +160,75 @@ MIN_CAPTURABLE_TRELLIS_M = 1
+ _DEFAULT_TRELLIS_MIN_M = MIN_CAPTURABLE_TRELLIS_M
+ 
+ 
++def _online_trellis_bits() -> int | None:
++    raw = os.environ.get("VLLM_EXL3_ONLINE_TRELLIS_BITS")
++    if raw is None or not raw.strip():
++        return None
++    try:
++        bits = int(raw)
++    except ValueError:
++        raise ValueError(
++            f"VLLM_EXL3_ONLINE_TRELLIS_BITS must be an integer from 3 to 8, got {raw!r}"
++        ) from None
++    if bits not in range(3, 9):
++        raise ValueError(
++            f"VLLM_EXL3_ONLINE_TRELLIS_BITS must be from 3 to 8, got {bits}"
++        )
++    return bits
++
++
++def _online_trellis_shape_supported(input_size: int, output_size: int) -> bool:
++    return input_size % _HADAMARD_BLOCK == 0 and output_size % _HADAMARD_BLOCK == 0
++
++
++def _load_exl3_online_quantizer() -> Any:
++    """Load the encoder without importing ExLlamaV3's serving front end."""
++
++    global _EXL3_ONLINE_QUANTIZER
++    if _EXL3_ONLINE_QUANTIZER is not None:
++        return _EXL3_ONLINE_QUANTIZER
++
++    raw_root = os.environ.get("VLLM_EXL3_ENCODER_SOURCE")
++    if raw_root is None or not raw_root.strip():
++        raise RuntimeError(
++            "online EXL3 Trellis requires VLLM_EXL3_ENCODER_SOURCE to point "
++            "to the exllamav3 Python package directory"
++        )
++    package_root = Path(raw_root).resolve()
++    quantizer_path = package_root / "modules" / "quant" / "exl3_lib"
++    if not (quantizer_path / "quantize.py").is_file():
++        raise RuntimeError(
++            "VLLM_EXL3_ENCODER_SOURCE does not contain the ExLlamaV3 encoder: "
++            f"{package_root}"
++        )
++
++    package_name = "_vllm_exl3_encoder"
++    packages = {
++        package_name: package_root,
++        f"{package_name}.modules": package_root / "modules",
++        f"{package_name}.modules.quant": package_root / "modules" / "quant",
++        f"{package_name}.modules.quant.exl3_lib": quantizer_path,
++    }
++    for name, path in packages.items():
++        if name in sys.modules:
++            continue
++        module = ModuleType(name)
++        module.__path__ = [str(path)]
++        module.__package__ = name
++        sys.modules[name] = module
++
++    quantize = importlib.import_module(
++        f"{package_name}.modules.quant.exl3_lib.quantize"
++    )
++    if not hasattr(quantize, "quantize_exl3"):
++        raise RuntimeError(
++            "VLLM_EXL3_ENCODER_SOURCE points to an incompatible ExLlamaV3 "
++            "encoder: modules.quant.exl3_lib.quantize has no quantize_exl3"
++        )
++    _EXL3_ONLINE_QUANTIZER = quantize.quantize_exl3
++    return _EXL3_ONLINE_QUANTIZER
++
++
+ def _is_draft_layer(layer: Any) -> bool:
+     """True for a rank-sliced MTP/nextn/eagle draft MoE layer.
+ 
+@@ -154,10 +295,23 @@ def _runtime_scope_id(quant_config: Any) -> int:
+ 
+ 
+ _RANK_SLICED_FORMAT = "exl3-trellis"
++_PER_EXPERT_ROTATION_LAYOUT = "per_expert_v1"
++_SHARED_H_ROTATION_LAYOUT = "shared_h_v1"
++_SHARED_H_TENSOR_SCHEMA = (
++    "model.layers.{L}.mlp.experts.shared_h.{proj}.rank{r}.{suh|svh}"
++)
+ _RANK_SLICED_WEIGHT_RE = re.compile(
+     r"^(?P<prefix>.+)\.rank(?P<rank>\d+)\."
+     r"(?P<field>trellis|suh|svh|mcg|mul1)$"
+ )
++_SHARED_H_WEIGHT_RE = re.compile(
++    r"^(?P<experts_prefix>.+\.experts)\.shared_h\."
++    r"(?P<projection>gate_proj|up_proj|down_proj)\.rank(?P<rank>\d+)\."
++    r"(?P<field>suh|svh)$"
++)
++_EXPERT_PROJECTION_RE = re.compile(
++    r"^.+\.experts\.\d+\.(?P<projection>gate_proj|up_proj|down_proj)$"
++)
+ 
+ ShardId = str | int | tuple[int, ...] | None
+ 
+@@ -242,11 +396,29 @@ def _load_b12x_mixed_trellis() -> Any:
+         max_packed_route_slots=host.max_packed_route_slots,
+         prepare_weights=prepare.prepare_trellis256_moe_weights,
+         run_mixed_trellis=module.run_mixed_trellis,
++        warmup_mixed_trellis_route_pack=module.warmup_mixed_trellis_route_pack,
+     )
+     _B12X_MIXED_TRELLIS_API = api
+     return api
+ 
+ 
++def _load_b12x_trellis_linear() -> Any:
++    """Resolve the native dense Trellis API lazily."""
++
++    global _B12X_TRELLIS_LINEAR_API
++    if _B12X_TRELLIS_LINEAR_API is not None:
++        return _B12X_TRELLIS_LINEAR_API
++    try:
++        from b12x.gemm import trellis_linear
++    except Exception as exc:
++        raise RuntimeError(
++            "Online EXL3 prefill requires b12x.gemm.trellis_linear. "
++            "Install a matching B12X build."
++        ) from exc
++    _B12X_TRELLIS_LINEAR_API = trellis_linear
++    return trellis_linear
++
++
+ def _unique_tensor_storage_bytes(*buffers: Any) -> int:
+     """Count unique tensor storage while ignoring buffer metadata fields."""
+ 
+@@ -264,6 +436,15 @@ def _unique_tensor_storage_bytes(*buffers: Any) -> int:
+     return total
+ 
+ 
++def _scratch_view(backing: torch.Tensor, spec: Any) -> torch.Tensor:
++    """Return a typed plan-scratch view over a shared byte arena."""
++
++    nbytes = int(spec.dtype.itemsize)
++    for dim in spec.shape:
++        nbytes *= int(dim)
++    return backing.narrow(0, 0, nbytes).view(spec.dtype).view(tuple(spec.shape))
++
++
+ def _positive_env_int(name: str, default: int) -> int:
+     # An env var that is present but blank means "unset". Compose and Kubernetes
+     # both render an unset variable as the empty string, so int("") would abort
+@@ -284,6 +465,21 @@ def _positive_env_int(name: str, default: int) -> int:
+     return value
+ 
+ 
++def _resolve_prefill_capacity(max_batched_tokens: int) -> int:
++    """Resolve the optional EXL3 arena bound within the scheduler contract."""
++
++    prefill_capacity = _positive_env_int(
++        "VLLM_EXL3_PREFILL_CAPACITY", max_batched_tokens
++    )
++    if prefill_capacity > max_batched_tokens:
++        raise ValueError(
++            "VLLM_EXL3_PREFILL_CAPACITY cannot exceed "
++            "max_num_batched_tokens: "
++            f"capacity={prefill_capacity}, max={max_batched_tokens}"
++        )
++    return prefill_capacity
++
++
+ @torch.library.custom_op(
+     "vllm::exl3_gemm",
+     mutates_args=(),
+@@ -338,6 +534,166 @@ def _exl3_gemm_fake(
+     )
+ 
+ 
++def _b12x_trellis_weight(
++    trellis: torch.Tensor,
++    suh: torch.Tensor,
++    svh: torch.Tensor,
++    dtype: torch.dtype,
++) -> Any:
++    """Prepare each online weight before capture and retain its native views."""
++
++    api = _load_b12x_trellis_linear()
++    # Keep prepared views on the owning tensor. A process-global pointer-keyed
++    # cache can alias after allocator address reuse and retains released models
++    # forever. This small reference cycle is collected with the tensor.
++    cache = getattr(trellis, "_vllm_b12x_prepared_weights", None)
++    if cache is None:
++        cache = {}
++        trellis._vllm_b12x_prepared_weights = cache
++    key = (id(suh), id(svh), dtype)
++    weight = cache.get(key)
++    if weight is None:
++        weight = api.prepare_weight(
++            trellis,
++            suh,
++            svh,
++            codebook="mcg",
++            params_dtype=dtype,
++        )
++        cache[key] = weight
++    return weight
++
++
++def _b12x_trellis_k6_supported(
++    trellis: torch.Tensor,
++    *,
++    has_mcg: bool,
++    has_mul1: bool,
++) -> bool:
++    """Gate the native path to the exact K6/MCG contract it implements."""
++
++    return bool(
++        has_mcg
++        and not has_mul1
++        and trellis.dtype == torch.int16
++        and trellis.ndim == 3
++        and int(trellis.shape[2]) == 96
++        and int(trellis.shape[0]) % 8 == 0
++        and int(trellis.shape[1]) % 8 == 0
++    )
++
++
++def _warm_b12x_trellis_device(
++    trellis: torch.Tensor,
++    suh: torch.Tensor,
++    svh: torch.Tensor,
++) -> None:
++    """Build the runtime extension before any CUDA graph starts capturing."""
++
++    device_index = trellis.device.index
++    if device_index is None:
++        device_index = torch.cuda.current_device()
++    if device_index in _B12X_TRELLIS_WARMED_DEVICES:
++        return
++    source = torch.zeros(
++        (1, int(trellis.shape[0]) * 16),
++        dtype=torch.float16,
++        device=trellis.device,
++    )
++    _b12x_trellis_linear(source, trellis, suh, svh)
++    torch.cuda.synchronize(trellis.device)
++    _B12X_TRELLIS_WARMED_DEVICES.add(device_index)
++
++
++def _b12x_trellis_c_tmp_elements(rows: int, columns: int) -> int:
++    """Return graph-safe dense-W4A16 scratch capacity for one static shape."""
++
++    rows = int(rows)
++    columns = int(columns)
++    if rows <= 128:
++        # The cooperative K6 small-M kernel does not consume W4A16 scratch.
++        return 1
++    padded_rows = max(
++        ((rows + 47) // 48) * 48,
++        ((rows + 63) // 64) * 64,
++    )
++    return min(columns * padded_rows, _B12X_TRELLIS_C_TMP_CAP)
++
++
++@torch.library.custom_op(
++    "vllm::b12x_trellis_linear_out",
++    mutates_args=("output", "gemm_output", "c_tmp", "rotated_f16"),
++    device_types="cuda",
++)
++def _b12x_trellis_linear_out(
++    x: torch.Tensor,
++    trellis: torch.Tensor,
++    suh: torch.Tensor,
++    svh: torch.Tensor,
++    output: torch.Tensor,
++    gemm_output: torch.Tensor,
++    c_tmp: torch.Tensor,
++    rotated_f16: torch.Tensor,
++) -> None:
++    """Execute dense Trellis into graph-owned output and scratch tensors."""
++
++    api = _load_b12x_trellis_linear()
++    weight = _b12x_trellis_weight(trellis, suh, svh, x.dtype)
++    api.run(
++        x,
++        weight,
++        output=output,
++        gemm_output=gemm_output,
++        c_tmp=c_tmp,
++        rotated_f16=rotated_f16,
++    )
++
++
++@_b12x_trellis_linear_out.register_fake
++def _b12x_trellis_linear_out_fake(
++    x: torch.Tensor,
++    trellis: torch.Tensor,
++    suh: torch.Tensor,
++    svh: torch.Tensor,
++    output: torch.Tensor,
++    gemm_output: torch.Tensor,
++    c_tmp: torch.Tensor,
++    rotated_f16: torch.Tensor,
++) -> None:
++    del x, trellis, suh, svh, output, gemm_output, c_tmp, rotated_f16
++
++
++def _b12x_trellis_linear(
++    x: torch.Tensor,
++    trellis: torch.Tensor,
++    suh: torch.Tensor,
++    svh: torch.Tensor,
++) -> torch.Tensor:
++    """Run every online-K6 batch through B12X with explicit storage."""
++
++    output = torch.empty(
++        (x.shape[0], trellis.shape[1] * 16), dtype=x.dtype, device=x.device
++    )
++    gemm_output = torch.empty_like(output)
++    c_tmp = torch.empty(
++        (_b12x_trellis_c_tmp_elements(x.shape[0], output.shape[1]),),
++        dtype=torch.float32,
++        device=x.device,
++    )
++    rotated_f16 = torch.empty_like(x)
++    _b12x_trellis_linear_out(
++        x,
++        trellis,
++        suh,
++        svh,
++        output,
++        gemm_output,
++        c_tmp,
++        rotated_f16,
++    )
++    return output
++
++
+ class Exl3Config(QuantizationConfig):
+     """Configuration for modern and legacy EXL3 trellis checkpoints."""
+ 
+@@ -357,8 +713,11 @@ class Exl3Config(QuantizationConfig):
+         self.tensor_storage = tensor_storage or {}
+         self._eager_checked = False
+         self.rank_sliced_metadata: dict[str, Any] | None = None
++        self.rank_sliced_rotation_layout = _PER_EXPERT_ROTATION_LAYOUT
+         self.rank_sliced_k_values: tuple[int, ...] | None = None
+         self.rank_sliced_bits_by_layer: dict[int, tuple[int, ...]] = {}
++        self._online_model_identity: str | None = None
++        self._online_encoder_identity: str | None = None
+ 
+     def get_name(self) -> str:
+         return "exl3"
+@@ -407,6 +766,12 @@ class Exl3Config(QuantizationConfig):
+         hf_config: PretrainedConfig | None = None,
+         revision: str | None = None,
+     ) -> None:
++        if _online_trellis_bits() is not None:
++            self._configure_online_cache_identity(
++                model_name,
++                hf_config=hf_config,
++                revision=revision,
++            )
+         rank_sliced = getattr(hf_config, "hybrid_tr3_tail", None)
+         if (
+             isinstance(rank_sliced, dict)
+@@ -449,6 +814,36 @@ class Exl3Config(QuantizationConfig):
+         self._validate_storage_metadata()
+         self._force_independent_lm_head(hf_config)
+ 
++    def _configure_online_cache_identity(
++        self,
++        model_name: str,
++        *,
++        hf_config: PretrainedConfig | None,
++        revision: str | None,
++    ) -> None:
++        if self._online_model_identity is not None:
++            return
++        encoder_source = os.getenv("VLLM_EXL3_ENCODER_SOURCE")
++        if encoder_source is None or not encoder_source.strip():
++            raise ValueError(
++                "VLLM_EXL3_ENCODER_SOURCE is required when "
++                "VLLM_EXL3_ONLINE_TRELLIS_BITS is enabled"
++            )
++        if cache_mode() == "off":
++            self._online_model_identity = "cache-disabled"
++            self._online_encoder_identity = "cache-disabled"
++            return
++        resolved_revision = revision or getattr(hf_config, "_commit_hash", None)
++        self._online_model_identity = resolve_model_identity(
++            model_name,
++            revision=resolved_revision,
++            hf_config=hf_config,
++        )
++        self._online_encoder_identity = resolve_encoder_identity(
++            encoder_source,
++            revision=os.getenv("VLLM_EXL3_ENCODER_REVISION"),
++        )
++
+     def _configure_rank_sliced(self, metadata: dict[str, Any]) -> None:
+         required = {
+             "bits",
+@@ -484,7 +879,30 @@ class Exl3Config(QuantizationConfig):
+                 "unsupported rank-sliced EXL3 tensor schema: "
+                 f"{metadata['tensor_schema']!r}"
+             )
++        rotation_layout = str(
++            metadata.get("rotation_layout", _PER_EXPERT_ROTATION_LAYOUT)
++        )
++        if rotation_layout not in {
++            _PER_EXPERT_ROTATION_LAYOUT,
++            _SHARED_H_ROTATION_LAYOUT,
++        }:
++            raise ValueError(
++                f"unsupported rank-sliced EXL3 rotation_layout: {rotation_layout!r}"
++            )
++        shared_schema = metadata.get("shared_h_tensor_schema")
++        if rotation_layout == _SHARED_H_ROTATION_LAYOUT:
++            if shared_schema != _SHARED_H_TENSOR_SCHEMA:
++                raise ValueError(
++                    "shared_h_v1 rank-sliced EXL3 requires "
++                    f"shared_h_tensor_schema={_SHARED_H_TENSOR_SCHEMA!r}"
++                )
++        elif shared_schema is not None:
++            raise ValueError(
++                "shared_h_tensor_schema is only valid with "
++                "rotation_layout='shared_h_v1'"
++            )
+         self.rank_sliced_metadata = dict(metadata)
++        self.rank_sliced_rotation_layout = rotation_layout
+         bits_field = metadata["bits"]
+         if isinstance(bits_field, str) and bits_field.strip().lower() == "mixed":
+             k_values = tuple(
+@@ -658,15 +1076,105 @@ class Exl3Config(QuantizationConfig):
+         if is_lm_head and not prefix:
+             prefix = "lm_head"
+         if isinstance(layer, LinearBase) or is_lm_head:
+-            if not self._linear_prefix_is_exl3(prefix):
+-                return UnquantizedLinearMethod()
+-            return Exl3LinearMethod(self)
++            if self._linear_prefix_is_exl3(prefix):
++                return Exl3LinearMethod(self)
++            if not is_lm_head and (
++                method := self._get_bf16_online_linear_method(layer, prefix)
++            ):
++                return method
++            return UnquantizedLinearMethod()
+         if isinstance(layer, RoutedExperts):
+             if not self._moe_prefix_is_exl3(prefix, layer):
+                 return None
+             return Exl3MoEMethod(self, layer.moe_config)
+         return None
+ 
++    def _get_bf16_online_linear_method(
++        self, layer: torch.nn.Module, prefix: str
++    ) -> QuantizeMethodBase | None:
++        """Overlay online quantization on linears absent from EXL3 storage.
++
++        EXL3-owned dense matrices are selected before this method and routed
++        experts never enter it. Shared-expert projections have an independent
++        spec so a broad ``linear`` overlay cannot quantize them accidentally.
++        When ``VLLM_EXL3_ONLINE_TRELLIS_BITS`` is set, eligible projections use
++        online EXL3 Trellis encoding instead of MXFP8.
++
++        Args:
++            layer: Candidate module for the online overlay.
++            prefix: Fully qualified checkpoint module name.
++
++        Returns:
++            An online Trellis or MXFP8 method for an eligible BF16 projection,
++            otherwise ``None``.
++
++        Raises:
++            ValueError: If the EXL3 overlay requests an unsupported weight or
++                activation format.
++        """
++        if not isinstance(layer, LinearBase):
++            return None
++
++        vllm_config = get_current_vllm_config_or_none()
++        if vllm_config is None:
++            return None
++        args = vllm_config.model_config.quantization_config
++        if not isinstance(args, QuantizationConfigArgs):
++            return None
++
++        shared_expert = is_shared_expert_projection(prefix)
++        spec = args.shared_experts if shared_expert else args.linear
++        if spec is None:
++            return None
++        if (
++            not shared_expert
++            and args.ignore
++            and should_ignore_layer(
++                prefix,
++                ignore=args.ignore,
++                fused_mapping=self.packed_modules_mapping,
++            )
++        ):
++            return None
++        if spec.weight != kMxfp8Dynamic or spec.activation is not None:
++            raise ValueError(
++                "EXL3 BF16 online overlay only supports weight='mxfp8' "
++                "with no activation override."
++            )
++
++        if (bits := _online_trellis_bits()) is not None:
++            if self._online_model_identity is None:
++                model_config = vllm_config.model_config
++                self._configure_online_cache_identity(
++                    model_config.model,
++                    hf_config=model_config.hf_config,
++                    revision=model_config.revision,
++                )
++            assert self._online_model_identity is not None
++            assert self._online_encoder_identity is not None
++            logger.warning_once(
++                "EXL3 BF16 online Trellis: encoding eligible non-EXL3 "
++                "linear weights at K=%d; 128-unaligned matrices retain the "
++                "configured MXFP8 path (module example: %s).",
++                bits,
++                prefix,
++            )
++            return Exl3OnlineLinearMethod(
++                bits=bits,
++                prefix=prefix,
++                model_identity=self._online_model_identity,
++                encoder_identity=self._online_encoder_identity,
++            )
++
++        logger.info_once(
++            "EXL3 BF16 online overlay: quantizing non-EXL3 %s projections "
++            "to MXFP8 at load time (module example: %s).",
++            "shared-expert" if shared_expert else "dense-linear",
++            prefix,
++        )
++        logger.debug("EXL3 BF16 MXFP8 overlay applied to %s", prefix)
++        return Mxfp8OnlineLinearMethod()
++
+     def _storage_entry(self, prefix: str) -> dict[str, Any] | None:
+         candidates = [prefix]
+         if prefix.startswith("model."):
+@@ -706,10 +1214,17 @@ class Exl3Config(QuantizationConfig):
+         if not source_leaves:
+             return False
+         base = prefix.rsplit(".", 1)[0] if "." in prefix else ""
+-        return all(
++        source_is_exl3 = [
+             self._is_exl3_prefix(f"{base}.{source}" if base else source)
+             for source in source_leaves
+-        )
++        ]
++        if any(source_is_exl3) and not all(source_is_exl3):
++            raise ValueError(
++                f"Packed EXL3 projection {prefix!r} mixes EXL3 and BF16 "
++                "source shards; a fused module must use one quantization "
++                "scheme."
++            )
++        return all(source_is_exl3)
+ 
+     def _moe_prefix_is_exl3(
+         self, prefix: str, layer: torch.nn.Module | None = None
+@@ -765,9 +1280,40 @@ class Exl3Config(QuantizationConfig):
+         """Drop non-local TP payloads and remove the serialized rank segment."""
+         if self.rank_sliced_metadata is None:
+             return name
++        shared_match = _SHARED_H_WEIGHT_RE.match(name)
++        if shared_match is not None:
++            if self.rank_sliced_rotation_layout != _SHARED_H_ROTATION_LAYOUT:
++                raise ValueError(
++                    "rank-sliced EXL3 contains shared-H tensors but metadata "
++                    "does not declare rotation_layout='shared_h_v1'"
++                )
++            projection = shared_match.group("projection")
++            field = shared_match.group("field")
++            expected_field = "svh" if projection == "down_proj" else "suh"
++            if field != expected_field:
++                raise ValueError(
++                    "invalid shared-H EXL3 tensor: "
++                    f"projection={projection!r} requires {expected_field}, got {field}"
++                )
++            if int(shared_match.group("rank")) != get_tensor_model_parallel_rank():
++                return None
++            return f"{shared_match.group('experts_prefix')}.0.{projection}.{field}"
+         match = _RANK_SLICED_WEIGHT_RE.match(name)
+         if match is None:
+             return name
++        if self.rank_sliced_rotation_layout == _SHARED_H_ROTATION_LAYOUT:
++            projection_match = _EXPERT_PROJECTION_RE.match(match.group("prefix"))
++            if projection_match is not None:
++                projection = projection_match.group("projection")
++                field = match.group("field")
++                is_h_side = (
++                    projection in {"gate_proj", "up_proj"} and field == "suh"
++                ) or (projection == "down_proj" and field == "svh")
++                if is_h_side:
++                    raise ValueError(
++                        "shared_h_v1 must store H-side rotations under "
++                        "experts.shared_h, not under an expert id"
++                    )
+         if int(match.group("rank")) != get_tensor_model_parallel_rank():
+             return None
+         return f"{match.group('prefix')}.{match.group('field')}"
+@@ -800,6 +1346,218 @@ def _exl3_weight_loader(
+     param.load_exl3_weight(loaded_weight, loaded_shard_id)
+ 
+ 
++class Exl3OnlineLinearMethod(_Fp8OnlineLinearBase):
++    """Encode eligible BF16 linear shards to cached dense EXL3 weights."""
++
++    def __init__(
++        self,
++        *,
++        bits: int,
++        prefix: str,
++        model_identity: str,
++        encoder_identity: str,
++    ) -> None:
++        super().__init__()
++        self.bits = bits
++        self.prefix = prefix
++        self.model_identity = model_identity
++        self.encoder_identity = encoder_identity
++        self.fallback: Mxfp8OnlineLinearMethod | None = None
++
++    def create_weights(
++        self,
++        layer: torch.nn.Module,
++        input_size_per_partition: int,
++        output_partition_sizes: list[int],
++        input_size: int,
++        output_size: int,
++        params_dtype: torch.dtype,
++        **extra_weight_attrs,
++    ) -> None:
++        output_size_per_partition = sum(output_partition_sizes)
++        layer.exl3_online_trellis = _online_trellis_shape_supported(
++            input_size_per_partition, output_size_per_partition
++        )
++        if not layer.exl3_online_trellis:
++            self.fallback = Mxfp8OnlineLinearMethod()
++            self.fallback.create_weights(
++                layer,
++                input_size_per_partition,
++                output_partition_sizes,
++                input_size,
++                output_size,
++                params_dtype,
++                **extra_weight_attrs,
++            )
++            logger.info_once(
++                "EXL3 online Trellis retains MXFP8 for 128-unaligned shards "
++                "(example %s: K=%d, N=%d).",
++                self.prefix,
++                input_size_per_partition,
++                output_size_per_partition,
++            )
++            return
++
++        super().create_weights(
++            layer,
++            input_size_per_partition,
++            output_partition_sizes,
++            input_size,
++            output_size,
++            params_dtype,
++            **extra_weight_attrs,
++        )
++        layer.exl3_online_input_size = input_size_per_partition
++        layer.exl3_online_output_size = output_size_per_partition
++
++    @staticmethod
++    def _h_data(input_size: int, device: torch.device) -> dict[str, Any]:
++        return {
++            "H": torch.zeros(
++                input_size, input_size, dtype=torch.float32, device="meta"
++            ),
++            "first_key": "vllm-online",
++            "count": 0,
++            "finalized": False,
++            "num_total": 0,
++            "inf_nan": torch.zeros(2, dtype=torch.long, device=device),
++            "device": device,
++        }
++
++    def _warm_decode_shapes(self, layer: torch.nn.Module) -> None:
++        device = layer.exl3_online_trellis_weight.device
++        _b12x_trellis_weight(
++            layer.exl3_online_trellis_weight,
++            layer.exl3_online_suh,
++            layer.exl3_online_svh,
++            torch.float16,
++        )
++        device_index = device.index
++        if device_index is None:
++            device_index = torch.cuda.current_device()
++        signature = (
++            device_index,
++            layer.exl3_online_input_size,
++            layer.exl3_online_output_size,
++            self.bits,
++        )
++        if signature in _EXL3_ONLINE_WARMED_SIGNATURES:
++            return
++        for rows in range(1, 7):
++            source = torch.zeros(
++                (rows, layer.exl3_online_input_size),
++                dtype=torch.float16,
++                device=device,
++            )
++            _b12x_trellis_linear(
++                source,
++                layer.exl3_online_trellis_weight,
++                layer.exl3_online_suh,
++                layer.exl3_online_svh,
++            )
++        torch.cuda.synchronize(device)
++        _EXL3_ONLINE_WARMED_SIGNATURES.add(signature)
++
++    def process_weights_after_loading(self, layer: torch.nn.Module) -> None:
++        if self.fallback is not None:
++            self.fallback.process_weights_after_loading(layer)
++            return
++        if getattr(layer, "_already_called_process_weights_after_loading", False):
++            return
++
++        device = layer.weight.device
++        seed = zlib.crc32(self.prefix.encode("utf-8")) & 0x7FFFFFFF
++        cache_key = Exl3OnlineCacheKey(
++            model_identity=self.model_identity,
++            encoder_identity=self.encoder_identity,
++            prefix=self.prefix,
++            bits=self.bits,
++            seed=seed,
++            tp_world_size=get_tensor_model_parallel_world_size(),
++            tp_rank=get_tensor_model_parallel_rank(),
++            input_size=layer.exl3_online_input_size,
++            output_size=layer.exl3_online_output_size,
++        )
++
++        def encode() -> tuple[dict[str, torch.Tensor], float]:
++            source = layer.weight.detach().t().float().contiguous()
++            quant_args = {
++                "K": self.bits,
++                "seed": seed,
++                "devices": [device],
++                "apply_out_scales": True,
++                "mcg": True,
++            }
++            quantize_exl3 = _load_exl3_online_quantizer()
++            _, proxy_error, tensors = quantize_exl3(
++                source,
++                self._h_data(layer.exl3_online_input_size, device),
++                quant_args,
++                return_weight_q=False,
++                verbose=False,
++            )
++            if not quant_args.get("q_fallback", False):
++                raise RuntimeError(
++                    "online EXL3 Trellis unexpectedly used calibrated LDLQ"
++                )
++            return {name: tensors[name] for name in ("trellis", "suh", "svh")}, float(
++                proxy_error
++            )
++
++        result = load_or_quantize(cache_key, device=device, quantize=encode)
++
++        layer.register_buffer(
++            "exl3_online_trellis_weight",
++            result.tensors["trellis"],
++            persistent=False,
++        )
++        layer.register_buffer(
++            "exl3_online_suh", result.tensors["suh"], persistent=False
++        )
++        layer.register_buffer(
++            "exl3_online_svh", result.tensors["svh"], persistent=False
++        )
++        replace_parameter(
++            layer,
++            "weight",
++            torch.empty(0, dtype=torch.uint8, device=device),
++        )
++        layer._already_called_process_weights_after_loading = True
++        self._warm_decode_shapes(layer)
++        logger.info(
++            "Online EXL3 K%d %s %s%s",
++            self.bits,
++            "cache hit for" if result.hit else "encoded",
++            self.prefix,
++            ""
++            if result.proxy_error is None
++            else f" (fallback proxy error {result.proxy_error:.8f})",
++        )
++
++    def apply(
++        self,
++        layer: torch.nn.Module,
++        x: torch.Tensor,
++        bias: torch.Tensor | None = None,
++    ) -> torch.Tensor:
++        if self.fallback is not None:
++            return self.fallback.apply(layer, x, bias)
++
++        original_shape = x.shape[:-1]
++        original_dtype = x.dtype
++        x_2d = x.reshape(-1, x.shape[-1]).to(torch.float16).contiguous()
++        output = _b12x_trellis_linear(
++            x_2d,
++            layer.exl3_online_trellis_weight,
++            layer.exl3_online_suh,
++            layer.exl3_online_svh,
++        )
++        if bias is not None:
++            output = output + bias.to(dtype=output.dtype)
++        output = output.reshape(*original_shape, layer.exl3_online_output_size)
++        return output if output.dtype == original_dtype else output.to(original_dtype)
++
++
+ class Exl3LinearMethod(LinearMethodBase):
+     def __init__(self, quant_config: Exl3Config) -> None:
+         self.quant_config = quant_config
+@@ -905,6 +1663,24 @@ class Exl3LinearMethod(LinearMethodBase):
+                     device=device, non_blocking=True
+                 ).contiguous()
+ 
++        for shard_id in layer.exl3_shard_ids:
++            trellis = layer.trellis.exl3_tensors[shard_id]
++            if not _b12x_trellis_k6_supported(
++                trellis,
++                has_mcg=shard_id in layer.mcg.exl3_tensors,
++                has_mul1=shard_id in layer.mul1.exl3_tensors,
++            ):
++                continue
++            suh = layer.suh.exl3_tensors[shard_id]
++            svh = layer.svh.exl3_tensors[shard_id]
++            _b12x_trellis_weight(
++                trellis,
++                suh,
++                svh,
++                torch.float16,
++            )
++            _warm_b12x_trellis_device(trellis, suh, svh)
++
+     def apply(
+         self,
+         layer: torch.nn.Module,
+@@ -1158,14 +1934,28 @@ class Exl3LinearMethod(LinearMethodBase):
+             )
+         if x.shape[-1] < packed_k:
+             x = torch.nn.functional.pad(x, (0, packed_k - x.shape[-1]))
+-        output = _exl3_gemm(
+-            x,
++        has_mcg = shard_id in layer.mcg.exl3_tensors
++        has_mul1 = shard_id in layer.mul1.exl3_tensors
++        if _b12x_trellis_k6_supported(
+             trellis,
+-            layer.suh.exl3_tensors[shard_id],
+-            layer.svh.exl3_tensors[shard_id],
+-            shard_id in layer.mcg.exl3_tensors,
+-            shard_id in layer.mul1.exl3_tensors,
+-        )
++            has_mcg=has_mcg,
++            has_mul1=has_mul1,
++        ):
++            output = _b12x_trellis_linear(
++                x,
++                trellis,
++                layer.suh.exl3_tensors[shard_id],
++                layer.svh.exl3_tensors[shard_id],
++            )
++        else:
++            output = _exl3_gemm(
++                x,
++                trellis,
++                layer.suh.exl3_tensors[shard_id],
++                layer.svh.exl3_tensors[shard_id],
++                has_mcg,
++                has_mul1,
++            )
+         logical_n = Exl3LinearMethod._output_shard_size(layer, shard_id)
+         if output.shape[-1] < logical_n:
+             raise ValueError(
+@@ -1308,6 +2098,12 @@ class Exl3MoEMethod(FusedMoEMethodBase):
+         layer.exl3_intermediate_size_per_partition = intermediate_size_per_partition
+         layer.exl3_params_dtype = params_dtype
+         rank_sliced = self.quant_config.rank_sliced_metadata is not None
++        shared_h = (
++            rank_sliced
++            and self.quant_config.rank_sliced_rotation_layout
++            == _SHARED_H_ROTATION_LAYOUT
++        )
++        layer.exl3_shared_h_rotations = shared_h
+         if rank_sliced:
+             checkpoint_tp = int(self.quant_config.rank_sliced_metadata["tp"])
+             if checkpoint_tp != layer.exl3_tp_size:
+@@ -1360,11 +2156,15 @@ class Exl3MoEMethod(FusedMoEMethodBase):
+             layer.exl3_mixed_bitrate = len(set(layer.exl3_layer_bitrates)) > 1
+         for prefix, shard_ids in (("w13", ("w1", "w3")), ("w2", ("w2",))):
+             for suffix in ("suh", "svh", "trellis", "mcg", "mul1"):
++                shared_parameter = shared_h and (
++                    (prefix == "w13" and suffix == "suh")
++                    or (prefix == "w2" and suffix == "svh")
++                )
+                 layer.register_parameter(
+                     f"{prefix}_{suffix}",
+                     Exl3MoEParameter(
+                         weight_loader=_exl3_moe_weight_loader,
+-                        num_experts=num_experts,
++                        num_experts=1 if shared_parameter else num_experts,
+                         shard_ids=shard_ids,
+                         preallocate=rank_sliced
+                         and suffix
+@@ -1382,7 +2182,16 @@ class Exl3MoEMethod(FusedMoEMethodBase):
+         for prefix, shard_ids in required.items():
+             for attr in ("suh", "svh", "trellis"):
+                 tensors = getattr(layer, f"{prefix}_{attr}").exl3_tensors
+-                for expert_id in range(layer.local_num_experts):
++                shared_parameter = getattr(
++                    layer, "exl3_shared_h_rotations", False
++                ) and (
++                    (prefix == "w13" and attr == "suh")
++                    or (prefix == "w2" and attr == "svh")
++                )
++                expert_ids = (
++                    (0,) if shared_parameter else range(layer.local_num_experts)
++                )
++                for expert_id in expert_ids:
+                     for shard_id in shard_ids:
+                         if (expert_id, shard_id) not in tensors:
+                             missing.append(f"{prefix}_{attr}[{expert_id},{shard_id}]")
+@@ -1484,8 +2293,20 @@ class Exl3MoEMethod(FusedMoEMethodBase):
+                 for shard_id in shard_ids:
+                     key = (expert_id, shard_id)
+                     trellis = getattr(layer, f"{group}_trellis").exl3_tensors[key]
+-                    suh = getattr(layer, f"{group}_suh").exl3_tensors[key]
+-                    svh = getattr(layer, f"{group}_svh").exl3_tensors[key]
++                    suh_key = (
++                        (0, shard_id)
++                        if getattr(layer, "exl3_shared_h_rotations", False)
++                        and group == "w13"
++                        else key
++                    )
++                    svh_key = (
++                        (0, shard_id)
++                        if getattr(layer, "exl3_shared_h_rotations", False)
++                        and group == "w2"
++                        else key
++                    )
++                    suh = getattr(layer, f"{group}_suh").exl3_tensors[suh_key]
++                    svh = getattr(layer, f"{group}_svh").exl3_tensors[svh_key]
+                     if (
+                         trellis.dtype != torch.int16
+                         or trellis.ndim != 3
+@@ -1531,17 +2352,40 @@ class Exl3MoEMethod(FusedMoEMethodBase):
+         return backing
+ 
+     @staticmethod
+-    def _pointer_table(slab: torch.Tensor) -> torch.Tensor:
++    def _pointer_table(
++        slab: torch.Tensor,
++        *,
++        num_experts: int | None = None,
++    ) -> torch.Tensor:
+         if slab.ndim < 2 or not slab[0].is_contiguous():
+             raise RuntimeError("EXL3 pointer-table rows must be contiguous")
++        rows = int(slab.shape[0])
++        entries = rows if num_experts is None else int(num_experts)
++        if rows not in {1, entries}:
++            raise RuntimeError(
++                "EXL3 pointer-table rows must be per-expert or broadcast: "
++                f"rows={rows}, experts={entries}"
++            )
+         step = slab.stride(0) * slab.element_size()
+         base = slab.data_ptr()
+         return torch.tensor(
+-            [base + expert_id * step for expert_id in range(slab.shape[0])],
++            [
++                base + (0 if rows == 1 else expert_id) * step
++                for expert_id in range(entries)
++            ],
+             dtype=torch.int64,
+             device=slab.device,
+         )
+ 
++    @staticmethod
++    def _select_rotation_rows(
++        rotations: torch.Tensor,
++        expert_ids: torch.Tensor,
++    ) -> torch.Tensor:
++        if int(rotations.shape[0]) == 1:
++            return rotations
++        return rotations.index_select(0, expert_ids).contiguous()
++
+     @staticmethod
+     def _trellis_tile_config(hidden_size: int, intermediate_size: int):
+         if hidden_size % 128 or intermediate_size % 128:
+@@ -1569,8 +2413,16 @@ class Exl3MoEMethod(FusedMoEMethodBase):
+             return (128, 128, 64, 256)
+         return (128, 128, 128, 128)
+ 
++    @staticmethod
++    def _mixed_trellis_prefill_tile_config(hidden_size: int, intermediate_size: int):
++        # Route packing stays block-64, while B12X's mixed-kernel ABI v2
++        # executes FC2 as arithmetic-equivalent 8-row subtiles.  Reuse the
++        # checkpoint's original one-grid tile geometry so prefill has the same
++        # reduction order as the stock-r16 quality reference.
++        return Exl3MoEMethod._mixed_trellis_tile_config(hidden_size, intermediate_size)
++
+     def _prepare_mixed_rank_sliced_weights(self, layer: RoutedExperts) -> None:
+-        api = _load_b12x_mixed_trellis()
++        mixed_api = _load_b12x_mixed_trellis()
+         num_experts = int(layer.local_num_experts)
+         hidden_size = int(layer.exl3_hidden_size)
+         intermediate_size = int(layer.exl3_intermediate_size_per_partition)
+@@ -1609,9 +2461,44 @@ class Exl3MoEMethod(FusedMoEMethodBase):
+         down_suh = self._rank_sliced_backing(layer, "w2_suh")
+         down_svh = self._rank_sliced_backing(layer, "w2_svh")
+         device = gate_suh.device
+-        tile_config = self._mixed_trellis_tile_config(hidden_size, intermediate_size)
++        mixed_tile_config = self._mixed_trellis_tile_config(
++            hidden_size, intermediate_size
++        )
++        prefill_tile_config = self._mixed_trellis_prefill_tile_config(
++            hidden_size, intermediate_size
++        )
++        tier_order = tuple(
++            expert_id for expert_ids in tiers.values() for expert_id in expert_ids
++        )
++        tier_index = torch.tensor(tier_order, dtype=torch.long, device=device)
++        combined_gate_suh = self._select_rotation_rows(gate_suh, tier_index)
++        combined_up_suh = self._select_rotation_rows(up_suh, tier_index)
++        broadcast_suh = int(combined_gate_suh.shape[0]) == 1
++        if broadcast_suh != (int(combined_up_suh.shape[0]) == 1):
++            raise ValueError(
++                "mixed EXL3 gate/up SUH rotations must both be per-expert "
++                "or both broadcast"
++            )
++        combined_intermediate_rotations = torch.cat(
++            (
++                gate_svh.index_select(0, tier_index),
++                up_svh.index_select(0, tier_index),
++                down_suh.index_select(0, tier_index),
++            ),
++            dim=1,
++        ).contiguous()
++        combined_down_svh = self._select_rotation_rows(down_svh, tier_index)
++        broadcast_svh = int(combined_down_svh.shape[0]) == 1
++        combined_rotations = SimpleNamespace(
++            intermediate=combined_intermediate_rotations,
++            gate_suh=combined_gate_suh,
++            up_suh=combined_up_suh,
++            down_svh=combined_down_svh,
++        )
+         prepared_tiers = []
++        prefill_tiers = []
+         tier_ids = []
++        tier_offset = 0
+         for bits, expert_ids in tiers.items():
+             expected_last = 16 * bits
+             w13 = torch.stack(
+@@ -1650,25 +2537,42 @@ class Exl3MoEMethod(FusedMoEMethodBase):
+                     f"expected={expected_w13}/{expected_w2}"
+                 )
+ 
+-            index = torch.tensor(expert_ids, dtype=torch.long, device=device)
+-            tier_gate_suh = gate_suh.index_select(0, index).contiguous()
+-            tier_up_suh = up_suh.index_select(0, index).contiguous()
+-            intermediate_rotations = torch.cat(
+-                (
+-                    gate_svh.index_select(0, index),
+-                    up_svh.index_select(0, index),
+-                    down_suh.index_select(0, index),
+-                ),
+-                dim=1,
+-            ).contiguous()
+-            tier_down_svh = down_svh.index_select(0, index).contiguous()
+-            prepared_tiers.append(
+-                api.prepare_weights(
++            tier_slice = slice(tier_offset, tier_offset + len(expert_ids))
++            tier_gate_suh = (
++                combined_gate_suh
++                if int(combined_gate_suh.shape[0]) == 1
++                else combined_gate_suh[tier_slice]
++            )
++            tier_up_suh = (
++                combined_up_suh
++                if int(combined_up_suh.shape[0]) == 1
++                else combined_up_suh[tier_slice]
++            )
++            intermediate_rotations = combined_intermediate_rotations[tier_slice]
++            tier_down_svh = (
++                combined_down_svh
++                if int(combined_down_svh.shape[0]) == 1
++                else combined_down_svh[tier_slice]
++            )
++
++            def prepare_tier(
++                tile_config: tuple[int, int, int, int],
++                *,
++                w13: torch.Tensor = w13,
++                w2: torch.Tensor = w2,
++                expert_count: int = len(expert_ids),
++                bits: int = bits,
++                tier_gate_suh: torch.Tensor = tier_gate_suh,
++                tier_up_suh: torch.Tensor = tier_up_suh,
++                intermediate_rotations: torch.Tensor = intermediate_rotations,
++                tier_down_svh: torch.Tensor = tier_down_svh,
++            ):
++                return mixed_api.prepare_weights(
+                     w13=w13,
+                     w2=w2,
+                     hidden_size=hidden_size,
+                     intermediate_size=intermediate_size,
+-                    num_experts=len(expert_ids),
++                    num_experts=expert_count,
+                     activation=layer.activation.value,
+                     fc1_tile_n=tile_config[1],
+                     fc2_tile_n=tile_config[3],
+@@ -1683,22 +2587,29 @@ class Exl3MoEMethod(FusedMoEMethodBase):
+                     tile_config=tile_config,
+                     workspace=w13.view(torch.int32).reshape(-1)[:1],
+                 )
+-            )
++
++            prepared_tiers.append(prepare_tier(mixed_tile_config))
++            prefill_tiers.append(prepare_tier(prefill_tile_config))
+             tier_ids.append(expert_ids)
++            tier_offset += len(expert_ids)
+ 
+-        global_to_combined, descriptor_map = api.build_tiered_maps(
++        global_to_combined, descriptor_map = mixed_api.build_tiered_maps(
+             tier_ids[0], tier_ids[1], device=device
+         )
+         layer.exl3_mixed_trellis = {
+             "tiers": tuple(prepared_tiers),
++            "prefill_tiers": tuple(prefill_tiers),
+             "tier_ids": tuple(tier_ids),
+             "tier_bits": tuple(tiers),
+             "global_to_combined": global_to_combined,
+             "descriptor_map": descriptor_map,
+-            "rotations": api.combine_trellis_rotations(*prepared_tiers),
+-            "tile_config": tile_config,
++            "rotations": combined_rotations,
++            "broadcast_suh": broadcast_suh,
++            "broadcast_svh": broadcast_svh,
++            "tile_config": mixed_tile_config,
++            "prefill_tile_config": prefill_tile_config,
+         }
+-        layer.exl3_trellis_tile_config = tile_config
++        layer.exl3_trellis_tile_config = mixed_tile_config
+ 
+         # The prepared tier objects own compact, tier-ordered copies. Release
+         # per-expert source tensors and the original rotation slabs now rather
+@@ -1807,13 +2718,22 @@ class Exl3MoEMethod(FusedMoEMethodBase):
+             down_suh,
+             down_svh,
+         )
+-        layer.exl3_pointer_tables = tuple(self._pointer_table(slab) for slab in slabs)
++        layer.exl3_pointer_tables = tuple(
++            self._pointer_table(slab, num_experts=num_experts) for slab in slabs
++        )
+         layer.exl3_expert_map = torch.arange(
+             num_experts,
+             dtype=torch.int64,
+             device=w13.device,
+         )
+         layer.exl3_trellis_tile_config = tile_config
++        if getattr(layer, "exl3_shared_h_rotations", False):
++            saved_bytes = (num_experts - 1) * 3 * hidden_size * 2
++            logger.info_once(
++                "EXL3 shared-H rotation layout active; saving %.2f MiB per "
++                "routed-expert layer and TP rank",
++                saved_bytes / (1024 * 1024),
++            )
+ 
+     def get_fused_moe_quant_config(
+         self, layer: RoutedExperts
+@@ -1832,15 +2752,73 @@ class Exl3MoEMethod(FusedMoEMethodBase):
+         topk_ids: torch.Tensor,
+     ) -> dict[str, Any]:
+         mixed = layer.exl3_mixed_trellis
+-        max_decode_m = _positive_env_int("VLLM_EXL3_TRELLIS_MAX_M", 32)
+-        max_batched_tokens = int(layer.exl3_max_num_batched_tokens)
+-        if max_decode_m > max_batched_tokens:
+-            max_decode_m = max_batched_tokens
+         topk = int(topk_ids.shape[1])
+-        tier_signature = tuple(
+-            (int(bits), len(ids))
+-            for bits, ids in zip(mixed["tier_bits"], mixed["tier_ids"], strict=True)
+-        )
++        policy = mixed.get("runtime_policy")
++        if policy is None:
++            max_decode_m = _positive_env_int("VLLM_EXL3_TRELLIS_MAX_M", 32)
++            max_batched_tokens = int(layer.exl3_max_num_batched_tokens)
++            prefill_capacity = _resolve_prefill_capacity(max_batched_tokens)
++            prefill_block_raw = os.environ.get("VLLM_EXL3_PREFILL_BLOCK_M")
++            configured_block_m = _positive_env_int("VLLM_EXL3_PREFILL_BLOCK_M", 64)
++            max_decode_m = min(max_decode_m, max_batched_tokens)
++            tier_signature = tuple(
++                (int(bits), len(ids))
++                for bits, ids in zip(mixed["tier_bits"], mixed["tier_ids"], strict=True)
++            )
++            props = torch.cuda.get_device_properties(x.device)
++            explicit_block_m = bool(
++                prefill_block_raw is not None and prefill_block_raw.strip()
++            )
++            prefill_block_m = _resolve_mixed_trellis_prefill_block_m(
++                configured_block_m=configured_block_m,
++                explicit_override=explicit_block_m,
++                hidden_size=int(layer.exl3_hidden_size),
++                intermediate_size=int(layer.exl3_intermediate_size_per_partition),
++                tier_signature=tier_signature,
++                topk=topk,
++                device_major=int(getattr(props, "major", 0)),
++                prefill_tile_config=mixed["prefill_tile_config"],
++            )
++            policy = {
++                "device_index": x.device.index,
++                "topk": topk,
++                "max_decode_m": max_decode_m,
++                "max_batched_tokens": max_batched_tokens,
++                "prefill_capacity": prefill_capacity,
++                "prefill_block_m": prefill_block_m,
++                "tier_signature": tier_signature,
++                "sms": int(props.multi_processor_count),
++                "max_shared_mem": int(props.shared_memory_per_block_optin),
++            }
++            mixed["runtime_policy"] = policy
++            logger.info_once(
++                "EXL3 mixed Trellis prefill block policy: selected=%d "
++                "configured=%d explicit=%s shape=%dx%d tiers=%s topk=%d "
++                "sm=%d tile=%s",
++                prefill_block_m,
++                configured_block_m,
++                explicit_block_m,
++                int(layer.exl3_hidden_size),
++                int(layer.exl3_intermediate_size_per_partition),
++                tier_signature,
++                topk,
++                int(getattr(props, "major", 0)),
++                mixed["prefill_tile_config"],
++            )
++        elif policy["device_index"] != x.device.index or policy["topk"] != topk:
++            raise RuntimeError(
++                "mixed-bitrate EXL3 runtime geometry changed after planning: "
++                f"device/topk={x.device.index}/{topk}, expected "
++                f"{policy['device_index']}/{policy['topk']}"
++            )
++
++        max_decode_m = policy["max_decode_m"]
++        max_batched_tokens = policy["max_batched_tokens"]
++        prefill_capacity = policy["prefill_capacity"]
++        prefill_block_m = policy["prefill_block_m"]
++        tier_signature = policy["tier_signature"]
++        broadcast_suh = bool(mixed["broadcast_suh"])
++        broadcast_svh = bool(mixed["broadcast_svh"])
+         key = (
+             _runtime_owner_token(self.quant_config, layer),
+             x.device.index,
+@@ -1852,10 +2830,16 @@ class Exl3MoEMethod(FusedMoEMethodBase):
+             topk,
+             max_decode_m,
+             max_batched_tokens,
++            prefill_capacity,
+             mixed["tile_config"],
++            mixed["prefill_tile_config"],
++            prefill_block_m,
++            broadcast_suh,
++            broadcast_svh,
+         )
+         runtime = _MIXED_TRELLIS_RUNTIMES.get(key)
+         if runtime is not None:
++            mixed["runtime"] = runtime
+             return runtime
+         if torch.cuda.is_current_stream_capturing():
+             raise RuntimeError(
+@@ -1868,18 +2852,21 @@ class Exl3MoEMethod(FusedMoEMethodBase):
+                 f"{topk_ids.dtype}"
+             )
+ 
+-        api = _load_b12x_mixed_trellis()
++        mixed_api = _load_b12x_mixed_trellis()
+         device = x.device
+-        props = torch.cuda.get_device_properties(device)
+         total_experts = sum(experts for _, experts in tier_signature)
+ 
+-        def make_state(capacity: int) -> dict[str, Any]:
+-            route_slots = api.max_packed_route_slots(
++        def make_state(
++            capacity: int,
++            block_size_m: int,
++            tile_config: tuple[int, int, int, int],
++        ) -> dict[str, Any]:
++            route_slots = mixed_api.max_packed_route_slots(
+                 capacity * topk,
+-                _MIXED_TRELLIS_ROUTE_BLOCK_SIZE,
++                block_size_m,
+                 total_experts,
+             )
+-            launch = api.compile_mixed_trellis(
++            launch = mixed_api.compile_mixed_trellis(
+                 size_m=capacity,
+                 hidden_size=int(layer.exl3_hidden_size),
+                 intermediate_size=int(layer.exl3_intermediate_size_per_partition),
+@@ -1888,49 +2875,64 @@ class Exl3MoEMethod(FusedMoEMethodBase):
+                 tier0_bits=tier_signature[0][0],
+                 tier1_bits=tier_signature[1][0],
+                 top_k=topk,
+-                max_m_blocks=(route_slots + _MIXED_TRELLIS_ROUTE_BLOCK_SIZE - 1)
+-                // _MIXED_TRELLIS_ROUTE_BLOCK_SIZE,
+-                moe_block_size=_MIXED_TRELLIS_ROUTE_BLOCK_SIZE,
+-                sms=int(props.multi_processor_count),
+-                max_shared_mem=int(props.shared_memory_per_block_optin),
+-                force_tile_config=mixed["tile_config"],
++                max_m_blocks=(route_slots + block_size_m - 1) // block_size_m,
++                moe_block_size=block_size_m,
++                sms=policy["sms"],
++                max_shared_mem=policy["max_shared_mem"],
++                force_tile_config=tile_config,
+                 rotation_input_dtype=("bf16" if x.dtype == torch.bfloat16 else "fp16"),
+                 route_ids_dtype=topk_ids.dtype,
++                broadcast_suh=broadcast_suh,
++                broadcast_svh=broadcast_svh,
+             )
+             return {
+                 "capacity": capacity,
+                 "launch": launch,
+-                "buffers": api.make_mixed_trellis_buffers(
++                "buffers": mixed_api.make_mixed_trellis_buffers(
+                     launch,
+                     device=device,
+-                    sms=int(props.multi_processor_count),
++                    sms=policy["sms"],
+                 ),
+             }
+ 
+-        decode = make_state(max_decode_m)
+-        prefill = (
+-            make_state(max_batched_tokens)
+-            if max_batched_tokens > max_decode_m
+-            else decode
++        decode = make_state(
++            max_decode_m,
++            _MIXED_TRELLIS_ROUTE_BLOCK_SIZE,
++            mixed["tile_config"],
+         )
++        prefill = None
++        if max_batched_tokens > max_decode_m:
++            if os.environ.get("VLLM_EXL3_PREFILL_TRELLIS", "1") != "1":
++                raise ValueError("mixed-K EXL3 requires VLLM_EXL3_PREFILL_TRELLIS=1")
++            prefill = make_state(
++                prefill_capacity,
++                prefill_block_m,
++                mixed["prefill_tile_config"],
++            )
+         runtime = {
+-            "api": api,
++            "mixed_api": mixed_api,
+             "decode": decode,
+             "prefill": prefill,
+             "max_decode_m": max_decode_m,
+             "max_batched_tokens": max_batched_tokens,
++            "prefill_capacity": prefill_capacity,
+         }
+         _MIXED_TRELLIS_RUNTIMES[key] = runtime
+-        buffer_bytes = _unique_tensor_storage_bytes(
+-            decode["buffers"], prefill["buffers"]
++        mixed["runtime"] = runtime
++        decode_bytes = _unique_tensor_storage_bytes(decode["buffers"])
++        prefill_bytes = (
++            0 if prefill is None else _unique_tensor_storage_bytes(prefill["buffers"])
+         )
+         logger.info_once(
+-            "EXL3 mixed Trellis runtime planned: tiers=%s decode_capacity=%d "
+-            "prefill_capacity=%d buffers=%.1f MiB",
++            "EXL3 mixed Trellis runtime planned: tiers=%s one-grid decode=%d "
++            "one-grid prefill=%d/%d block_m=%d buffers=%.1f+%.1f MiB",
+             tier_signature,
+             max_decode_m,
++            prefill_capacity,
+             max_batched_tokens,
+-            buffer_bytes / (1 << 20),
++            prefill_block_m,
++            decode_bytes / (1 << 20),
++            prefill_bytes / (1 << 20),
+         )
+         return runtime
+ 
+@@ -1948,23 +2950,65 @@ class Exl3MoEMethod(FusedMoEMethodBase):
+                 "mixed-bitrate EXL3 batch exceeds planned capacity: "
+                 f"m={m}, capacity={runtime['max_batched_tokens']}"
+             )
+-        state = (
+-            runtime["decode"] if m <= runtime["max_decode_m"] else runtime["prefill"]
+-        )
+         mixed = layer.exl3_mixed_trellis
+-        output = runtime["api"].run_mixed_trellis(
+-            x,
+-            mixed["tiers"][0],
+-            mixed["tiers"][1],
+-            topk_weights,
+-            topk_ids,
+-            mixed["global_to_combined"],
+-            mixed["descriptor_map"],
+-            mixed["rotations"],
+-            state["launch"],
+-            state["buffers"],
+-        )
+-        return output.to(x.dtype)
++
++        def run_state(
++            slice_x: torch.Tensor,
++            slice_weights: torch.Tensor,
++            slice_ids: torch.Tensor,
++            state: dict[str, Any],
++            tiers: tuple[Any, Any],
++        ) -> torch.Tensor:
++            return (
++                runtime["mixed_api"]
++                .run_mixed_trellis(
++                    slice_x,
++                    tiers[0],
++                    tiers[1],
++                    slice_weights,
++                    slice_ids,
++                    mixed["global_to_combined"],
++                    mixed["descriptor_map"],
++                    mixed["rotations"],
++                    state["launch"],
++                    state["buffers"],
++                )
++                .to(slice_x.dtype)
++            )
++
++        if m <= runtime["max_decode_m"]:
++            return run_state(
++                x,
++                topk_weights,
++                topk_ids,
++                runtime["decode"],
++                mixed["tiers"],
++            )
++
++        if runtime["prefill"] is None:
++            raise RuntimeError("mixed-K EXL3 one-grid prefill plan is unavailable")
++        prefill_capacity = int(runtime["prefill_capacity"])
++        if m <= prefill_capacity:
++            return run_state(
++                x,
++                topk_weights,
++                topk_ids,
++                runtime["prefill"],
++                mixed["prefill_tiers"],
++            )
++
++        output = torch.empty_like(x)
++        for start in range(0, m, prefill_capacity):
++            stop = min(start + prefill_capacity, m)
++            slice_output = run_state(
++                x[start:stop],
++                topk_weights[start:stop],
++                topk_ids[start:stop],
++                runtime["prefill"],
++                mixed["prefill_tiers"],
++            )
++            output[start:stop].copy_(slice_output)
++        return output
+ 
+     def _rank_sliced_runtime(
+         self,
+@@ -1996,12 +3040,11 @@ class Exl3MoEMethod(FusedMoEMethodBase):
+             raise ValueError(
+                 "VLLM_EXL3_TRELLIS_MIN_M cannot exceed VLLM_EXL3_TRELLIS_MAX_M"
+             )
+-        # Batch-INVARIANT capacity. Including x.shape[0] here made the runtime
+-        # cache key depend on the live batch, so any m above the planned capacity
+-        # produced a cache MISS -- silently planning a fresh ~1 GiB arena mid-serve
+-        # and making the capacity guard in _apply_rank_sliced unreachable. The
+-        # planned capacity is a property of the layer, not of one forward pass.
++        # Both capacities are batch-invariant runtime properties. The scheduler
++        # bound remains fail-closed while a smaller opt-in Trellis capacity is
++        # handled by slicing at dispatch.
+         max_batched_tokens = int(layer.exl3_max_num_batched_tokens)
++        prefill_capacity = _resolve_prefill_capacity(max_batched_tokens)
+         prefill_plan_enabled = prefill_trellis and max_batched_tokens > max_trellis_m
+         parity_rows = (
+             min(chunk, max_batched_tokens)
+@@ -2036,6 +3079,7 @@ class Exl3MoEMethod(FusedMoEMethodBase):
+             prefill_trellis,
+             prefill_block_m,
+             layer.exl3_trellis_tile_config,
++            prefill_capacity,
+         )
+         runtime = _RANK_SLICED_RUNTIMES.get(key)
+         if runtime is not None:
+@@ -2079,7 +3123,7 @@ class Exl3MoEMethod(FusedMoEMethodBase):
+         prefill_scratch = None
+         if prefill_plan_enabled:
+             prefill_plan, prefill_scratch = _plan_with_scratch(
+-                max_batched_tokens, prefill_block_m
++                prefill_capacity, prefill_block_m
+             )
+ 
+         ext = _load_exl3_ext()
+@@ -2110,6 +3154,7 @@ class Exl3MoEMethod(FusedMoEMethodBase):
+             "min_trellis_m": min_trellis_m,
+             "max_trellis_m": max_trellis_m,
+             "max_batched_tokens": max_batched_tokens,
++            "prefill_capacity": prefill_capacity,
+             "parity_rows": parity_rows,
+             "topk": topk,
+             "chunk": chunk,
+@@ -2182,12 +3227,13 @@ class Exl3MoEMethod(FusedMoEMethodBase):
+         )
+         logger.info_once(
+             "EXL3 rank-sliced runtime planned: Trellis m=%d..%d block_m=%d, "
+-            "prefill %s capacity=%d chunk=%d topk=%d",
++            "prefill %s scheduler_capacity=%d chunk=%d topk=%d",
+             min_trellis_m,
+             max_trellis_m,
+             block_m,
+             (
+-                f"trellis block_m={prefill_block_m} arena={prefill_arena_mib:.1f}MiB"
++                f"trellis block_m={prefill_block_m} "
++                f"capacity={prefill_capacity} arena={prefill_arena_mib:.1f}MiB"
+                 if prefill_plan is not None
+                 else "parity"
+             ),
+@@ -2231,16 +3277,33 @@ class Exl3MoEMethod(FusedMoEMethodBase):
+                     "EXL3 batch exceeds its planned capacity: "
+                     f"m={m}, capacity={runtime['max_batched_tokens']}"
+                 )
+-            binding = runtime["api"].bind(
+-                runtime["prefill_plan"],
+-                scratch=runtime["prefill_scratch"],
+-                a=x,
+-                experts=layer.exl3_trellis_weights,
+-                topk_weights=topk_weights,
+-                topk_ids=topk_ids,
+-            )
+-            output = runtime["api"].run(binding=binding)
+-            return output.to(x.dtype)
++            prefill_capacity = int(runtime["prefill_capacity"])
++            if m <= prefill_capacity:
++                binding = runtime["api"].bind(
++                    runtime["prefill_plan"],
++                    scratch=runtime["prefill_scratch"],
++                    a=x,
++                    experts=layer.exl3_trellis_weights,
++                    topk_weights=topk_weights,
++                    topk_ids=topk_ids,
++                )
++                output = runtime["api"].run(binding=binding)
++                return output.to(x.dtype)
++
++            output = torch.empty_like(x)
++            for start in range(0, m, prefill_capacity):
++                stop = min(start + prefill_capacity, m)
++                binding = runtime["api"].bind(
++                    runtime["prefill_plan"],
++                    scratch=runtime["prefill_scratch"],
++                    a=x[start:stop],
++                    experts=layer.exl3_trellis_weights,
++                    topk_weights=topk_weights[start:stop],
++                    topk_ids=topk_ids[start:stop],
++                )
++                slice_output = runtime["api"].run(binding=binding)
++                output[start:stop].copy_(slice_output)
++            return output
+ 
+         if torch.cuda.is_current_stream_capturing():
+             raise RuntimeError(
+@@ -2444,4 +3507,57 @@ class Exl3MoEMethod(FusedMoEMethodBase):
+         return output[..., :logical_n]
+ 
+ 
+-__all__ = ["Exl3Config", "Exl3LinearMethod", "Exl3MoEMethod"]
++def warmup_exl3_mixed_trellis_route_pack(model: torch.nn.Module) -> int:
++    """Materialize mixed-Trellis route-pack modules before KV sizing.
++
++    The first profile pass creates every layer's immutable mixed-Trellis
++    runtime. Route packing itself has power-of-two capacity specializations,
++    however, so profiling only the maximum batch leaves smaller decode,
++    speculative, and final-prefill-chunk modules lazy. Delegate enumeration to
++    B12X while those persistent CUDA allocations can still be measured by the
++    worker's second profile pass.
++    """
++    warmed = 0
++    seen_layers: set[int] = set()
++    for module in model.modules():
++        routed_experts = getattr(module, "routed_experts", module)
++        mixed = getattr(routed_experts, "exl3_mixed_trellis", None)
++        if not isinstance(mixed, dict) or id(routed_experts) in seen_layers:
++            continue
++        seen_layers.add(id(routed_experts))
++
++        runtime = mixed.get("runtime")
++        if runtime is None:
++            layer_name = getattr(routed_experts, "layer_name", "<unknown>")
++            raise RuntimeError(
++                "mixed-bitrate EXL3 route-pack warmup found no runtime for "
++                f"{layer_name}; the eager profile pass must plan the runtime "
++                "before kernel warmup"
++            )
++        api = runtime["mixed_api"]
++        warmup = getattr(api, "warmup_mixed_trellis_route_pack", None)
++        if not callable(warmup):
++            raise RuntimeError(
++                "mixed-bitrate EXL3 route-pack warmup requires a matching B12X build"
++            )
++
++        for state_name in ("decode", "prefill"):
++            state = runtime.get(state_name)
++            if state is None:
++                continue
++            warmed += int(
++                warmup(
++                    state["launch"],
++                    state["buffers"],
++                    expert_map=mixed["global_to_combined"],
++                )
++            )
++    return warmed
++
++
++__all__ = [
++    "Exl3Config",
++    "Exl3LinearMethod",
++    "Exl3MoEMethod",
++    "warmup_exl3_mixed_trellis_route_pack",
++]
+diff --git a/vllm/model_executor/layers/quantization/exl3_online_cache.py b/vllm/model_executor/layers/quantization/exl3_online_cache.py
+new file mode 100644
+index 0000000000000000000000000000000000000000..2855f2b1a43fb6b6d7eeed5a933e042cdc76b80d
+--- /dev/null
++++ b/vllm/model_executor/layers/quantization/exl3_online_cache.py
+@@ -0,0 +1,339 @@
++# SPDX-License-Identifier: Apache-2.0
++# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
++
++"""Persistent cache for deterministic online EXL3 weight encoding."""
++
++from __future__ import annotations
++
++import hashlib
++import json
++import os
++import tempfile
++from collections.abc import Callable, Mapping
++from dataclasses import asdict, dataclass
++from pathlib import Path
++from typing import Any, Literal
++
++import filelock
++import torch
++from safetensors import safe_open
++from safetensors.torch import save_file
++
++from vllm.logger import init_logger
++
++logger = init_logger(__name__)
++
++_CACHE_SCHEMA = 1
++_CACHE_TENSORS = frozenset({"trellis", "suh", "svh"})
++CacheMode = Literal["off", "readonly", "readwrite"]
++QuantizeFn = Callable[[], tuple[Mapping[str, torch.Tensor], float | None]]
++
++
++@dataclass(frozen=True)
++class Exl3OnlineCacheKey:
++    """All inputs that can change one rank-local online EXL3 payload."""
++
++    model_identity: str
++    encoder_identity: str
++    prefix: str
++    bits: int
++    seed: int
++    tp_world_size: int
++    tp_rank: int
++    input_size: int
++    output_size: int
++    codebook: str = "mcg"
++    apply_out_scales: bool = True
++    schema: int = _CACHE_SCHEMA
++
++    def canonical_json(self) -> str:
++        return json.dumps(asdict(self), sort_keys=True, separators=(",", ":"))
++
++    def digest(self) -> str:
++        return hashlib.sha256(self.canonical_json().encode()).hexdigest()
++
++
++@dataclass(frozen=True)
++class Exl3OnlineCacheResult:
++    tensors: dict[str, torch.Tensor]
++    proxy_error: float | None
++    hit: bool
++    path: Path | None
++
++
++def _sha256_file(path: Path) -> str:
++    digest = hashlib.sha256()
++    with path.open("rb") as source:
++        while chunk := source.read(1024 * 1024):
++            digest.update(chunk)
++    return digest.hexdigest()
++
++
++def resolve_model_identity(
++    model_name: str,
++    *,
++    revision: str | None = None,
++    hf_config: Any | None = None,
++) -> str:
++    """Fingerprint a Hub revision or a local checkpoint without reading weights."""
++
++    resolved_revision = getattr(hf_config, "_commit_hash", None) or revision
++    model_path = Path(model_name).expanduser()
++    if not model_path.exists():
++        if not resolved_revision:
++            raise ValueError(
++                "online EXL3 caching requires a resolved revision for Hub "
++                f"checkpoint {model_name!r}; pass --revision or set "
++                "VLLM_EXL3_ONLINE_CACHE_MODE=off"
++            )
++        payload = {
++            "kind": "hub",
++            "model": model_name,
++            "revision": resolved_revision,
++        }
++        return hashlib.sha256(json.dumps(payload, sort_keys=True).encode()).hexdigest()
++
++    model_path = model_path.resolve()
++    if model_path.is_file():
++        stat = model_path.stat()
++        payload = {
++            "kind": "file",
++            "path": str(model_path),
++            "size": stat.st_size,
++            "mtime_ns": stat.st_mtime_ns,
++        }
++        if stat.st_size <= 16 * 1024 * 1024:
++            payload["sha256"] = _sha256_file(model_path)
++        return hashlib.sha256(json.dumps(payload, sort_keys=True).encode()).hexdigest()
++
++    markers: list[tuple[str, str]] = []
++    for name in (
++        "config.json",
++        "quantization_config.json",
++        "model.safetensors.index.json",
++        "pytorch_model.bin.index.json",
++        "tier_bitmap.json",
++    ):
++        path = model_path / name
++        if path.is_file():
++            markers.append((name, _sha256_file(path)))
++
++    shards: list[tuple[str, str, int, int]] = []
++    for pattern in ("*.safetensors", "*.bin", "*.gguf"):
++        for path in sorted(model_path.glob(pattern)):
++            resolved = path.resolve()
++            stat = resolved.stat()
++            shards.append(
++                (
++                    path.name,
++                    str(resolved),
++                    stat.st_size,
++                    stat.st_mtime_ns,
++                )
++            )
++    payload = {
++        "kind": "directory",
++        "path": str(model_path),
++        "revision": resolved_revision,
++        "markers": markers,
++        "shards": shards,
++    }
++    return hashlib.sha256(
++        json.dumps(payload, sort_keys=True, separators=(",", ":")).encode()
++    ).hexdigest()
++
++
++def resolve_encoder_identity(
++    package_root: str | Path,
++    *,
++    revision: str | None = None,
++) -> str:
++    """Identify the encoder implementation used to produce cached tensors."""
++
++    root = Path(package_root).expanduser().resolve()
++    if revision and revision.strip():
++        payload = {"root": str(root), "revision": revision.strip()}
++    else:
++        files = [
++            (str(path.relative_to(root)), _sha256_file(path))
++            for path in sorted(root.rglob("*.py"))
++            if path.is_file()
++        ]
++        if not files:
++            raise ValueError(f"EXL3 encoder source contains no Python files: {root}")
++        payload = {"root": str(root), "files": files}
++    return hashlib.sha256(
++        json.dumps(payload, sort_keys=True, separators=(",", ":")).encode()
++    ).hexdigest()
++
++
++def cache_mode() -> CacheMode:
++    raw = os.getenv("VLLM_EXL3_ONLINE_CACHE_MODE", "readwrite").strip().lower()
++    aliases = {"read-only": "readonly", "rw": "readwrite", "none": "off"}
++    raw = aliases.get(raw, raw)
++    if raw not in {"off", "readonly", "readwrite"}:
++        raise ValueError(
++            "VLLM_EXL3_ONLINE_CACHE_MODE must be off, readonly, or readwrite; "
++            f"got {raw!r}"
++        )
++    return raw  # type: ignore[return-value]
++
++
++def cache_root() -> Path:
++    """Return the trusted online-weight cache directory.
++
++    Cached payloads become model weights after schema validation. The directory
++    must therefore be writable only by the serving user and trusted to the same
++    degree as the source checkpoint.
++    """
++
++    configured = os.getenv("VLLM_EXL3_ONLINE_CACHE_DIR")
++    if configured and configured.strip():
++        return Path(configured).expanduser()
++    vllm_root = Path(os.getenv("VLLM_CACHE_ROOT", "~/.cache/vllm")).expanduser()
++    return vllm_root / "exl3_online"
++
++
++def cache_path(key: Exl3OnlineCacheKey) -> Path:
++    digest = key.digest()
++    model_dir = key.model_identity[:20]
++    rank_dir = f"tp{key.tp_world_size}-rank{key.tp_rank}"
++    return (
++        cache_root()
++        / f"v{_CACHE_SCHEMA}"
++        / model_dir
++        / rank_dir
++        / f"{digest}.safetensors"
++    )
++
++
++def _validate_tensors(
++    tensors: Mapping[str, torch.Tensor], key: Exl3OnlineCacheKey
++) -> None:
++    if set(tensors) != _CACHE_TENSORS:
++        raise ValueError(
++            f"online EXL3 cache tensor set is {sorted(tensors)}, "
++            f"expected {sorted(_CACHE_TENSORS)}"
++        )
++    expected = {
++        "trellis": (
++            torch.int16,
++            (key.input_size // 16, key.output_size // 16, key.bits * 16),
++        ),
++        "suh": (torch.float16, (key.input_size,)),
++        "svh": (torch.float16, (key.output_size,)),
++    }
++    for name, (dtype, shape) in expected.items():
++        tensor = tensors[name]
++        if tensor.dtype != dtype or tuple(tensor.shape) != shape:
++            raise ValueError(
++                f"online EXL3 cache {name} has {tensor.dtype}/{tuple(tensor.shape)}, "
++                f"expected {dtype}/{shape}"
++            )
++        if not tensor.is_contiguous():
++            raise ValueError(f"online EXL3 cache {name} must be contiguous")
++
++
++def _load(path: Path, key: Exl3OnlineCacheKey) -> Exl3OnlineCacheResult:
++    with safe_open(path, framework="pt", device="cpu") as handle:
++        metadata = handle.metadata() or {}
++        if metadata.get("cache_key") != key.canonical_json():
++            raise ValueError("online EXL3 cache key metadata does not match")
++        # ``safe_open`` exposes ``keys()`` but is not itself iterable.
++        tensors = {name: handle.get_tensor(name) for name in handle.keys()}  # noqa: SIM118
++    _validate_tensors(tensors, key)
++    raw_error = metadata.get("proxy_error")
++    proxy_error = None if raw_error in (None, "") else float(raw_error)
++    return Exl3OnlineCacheResult(dict(tensors), proxy_error, True, path)
++
++
++def _to_device(
++    result: Exl3OnlineCacheResult, device: torch.device
++) -> Exl3OnlineCacheResult:
++    tensors = {
++        name: tensor.to(device=device, non_blocking=False).contiguous()
++        for name, tensor in result.tensors.items()
++    }
++    return Exl3OnlineCacheResult(tensors, result.proxy_error, result.hit, result.path)
++
++
++def _quantize(
++    key: Exl3OnlineCacheKey,
++    quantize: QuantizeFn,
++    *,
++    path: Path | None,
++) -> Exl3OnlineCacheResult:
++    tensors, proxy_error = quantize()
++    tensors = {name: tensor.contiguous() for name, tensor in tensors.items()}
++    _validate_tensors(tensors, key)
++    return Exl3OnlineCacheResult(tensors, proxy_error, False, path)
++
++
++def _save(path: Path, key: Exl3OnlineCacheKey, result: Exl3OnlineCacheResult) -> None:
++    path.parent.mkdir(parents=True, exist_ok=True)
++    cpu_tensors = {
++        name: tensor.detach().to(device="cpu").contiguous()
++        for name, tensor in result.tensors.items()
++    }
++    metadata = {
++        "cache_key": key.canonical_json(),
++        "proxy_error": "" if result.proxy_error is None else repr(result.proxy_error),
++    }
++    fd, temporary_name = tempfile.mkstemp(
++        prefix=f".{path.name}.", suffix=".tmp", dir=path.parent
++    )
++    os.close(fd)
++    temporary = Path(temporary_name)
++    try:
++        save_file(cpu_tensors, temporary, metadata=metadata)
++        with temporary.open("rb") as output:
++            os.fsync(output.fileno())
++        os.replace(temporary, path)
++    finally:
++        temporary.unlink(missing_ok=True)
++
++
++def load_or_quantize(
++    key: Exl3OnlineCacheKey,
++    *,
++    device: torch.device,
++    quantize: QuantizeFn,
++) -> Exl3OnlineCacheResult:
++    """Load one rank-local payload or encode and atomically publish it."""
++
++    mode = cache_mode()
++    if mode == "off":
++        return _quantize(key, quantize, path=None)
++
++    path = cache_path(key)
++    if path.is_file():
++        try:
++            return _to_device(_load(path, key), device)
++        except Exception as exc:
++            logger.warning("Ignoring invalid online EXL3 cache %s: %s", path, exc)
++
++    if mode == "readonly":
++        return _quantize(key, quantize, path=None)
++
++    try:
++        path.parent.mkdir(parents=True, exist_ok=True)
++        lock = filelock.FileLock(f"{path}.lock")
++        with lock:
++            if path.is_file():
++                try:
++                    return _to_device(_load(path, key), device)
++                except Exception as exc:
++                    logger.warning(
++                        "Replacing invalid online EXL3 cache %s: %s", path, exc
++                    )
++                    path.unlink(missing_ok=True)
++            result = _quantize(key, quantize, path=path)
++            _save(path, key, result)
++            return result
++    except OSError as exc:
++        logger.warning(
++            "Online EXL3 cache is unavailable at %s; encoding without cache: %s",
++            path,
++            exc,
++        )
++        return _quantize(key, quantize, path=None)
+diff --git a/vllm/model_executor/layers/quantization/input_quant_fp8.py b/vllm/model_executor/layers/quantization/input_quant_fp8.py
+index e8810919c2046ffe672e9eea675a80f62c28375a..60d348687e0534fe3b3ee413420ed4cd7cf1d4c4 100644
+--- a/vllm/model_executor/layers/quantization/input_quant_fp8.py
++++ b/vllm/model_executor/layers/quantization/input_quant_fp8.py
+@@ -16,6 +16,7 @@ from vllm.model_executor.layers.quantization.utils.quant_utils import (
+ from vllm.platforms import current_platform
+ from vllm.utils.deep_gemm import (
+     DeepGemmQuantScaleFMT,
++    get_tma_aligned_size,
+     is_deep_gemm_e8m0_used,
+     is_deep_gemm_supported,
+ )
+@@ -90,12 +91,7 @@ class QuantFP8(CustomOp):
+     ) -> tuple[torch.Tensor, torch.Tensor]:
+         from vllm.model_executor.layers.quantization.utils import fp8_utils
+ 
+-        if (
+-            self.is_group_quant
+-            and self.use_ue8m0
+-            and self.use_deep_gemm_supported
+-            and (DeepGemmQuantScaleFMT.from_oracle() == DeepGemmQuantScaleFMT.UE8M0)
+-        ):
++        if self.is_group_quant and self._deepgemm_wants_packed_scales():
+             return fp8_utils.per_token_group_quant_fp8_packed_for_deepgemm(
+                 x,
+                 group_size=self.group_size,
+@@ -190,6 +186,13 @@ class QuantFP8(CustomOp):
+     ):
+         if self.is_group_quant and not self.static:
+             assert scale is None, "Dynamic group quantization does not use scale"
++            # Must mirror forward_cuda's choice exactly. When DeepGEMM wants
++            # packed UE8M0, plain float32 scales are the wrong *format*, not
++            # merely a different layout, and CustomOp.default_on() is False
++            # under inductor -- so this is the path a compiled run takes and
++            # DeepGEMM silently receives unpacked scales.
++            if self._deepgemm_wants_packed_scales():
++                return self._quantize_group_native_packed(x)
+             return self._quantize_group_native(x)
+ 
+         assert (scale is not None) == self.static
+@@ -230,6 +233,70 @@ class QuantFP8(CustomOp):
+ 
+         return out, scale
+ 
++    def _deepgemm_wants_packed_scales(self) -> bool:
++        """Whether the consumer expects DeepGEMM's packed UE8M0 scale format.
++
++        Shared by forward_cuda and forward_native so the two cannot disagree
++        about the scale format they emit. The oracle only answers UE8M0 on the
++        SM120 family; elsewhere it answers FLOAT32_CEIL_UE8M0 and both paths
++        return plain float32 scales.
++        """
++        return (
++            self.use_ue8m0
++            and self.use_deep_gemm_supported
++            and DeepGemmQuantScaleFMT.from_oracle() == DeepGemmQuantScaleFMT.UE8M0
++        )
++
++    def _quantize_group_native_packed(
++        self, x: torch.Tensor
++    ) -> tuple[torch.Tensor, torch.Tensor]:
++        """Native equivalent of per_token_group_quant_fp8_packed_for_deepgemm.
++
++        Verified bit-identical to the C++ op (values, shape and TMA-aligned
++        stride) across square, wide and ragged-row shapes. Expressed in plain
++        torch ops so inductor can fuse it with neighbouring work, which a custom
++        op cannot be.
++        """
++        hidden_dim = x.shape[-1]
++        assert hidden_dim % self.group_size == 0, (
++            f"hidden dim {hidden_dim} must be divisible by group {self.group_size}"
++        )
++        mn = x.numel() // hidden_dim
++        num_groups = hidden_dim // self.group_size
++        k_packed = (num_groups + 3) // 4
++
++        xg = x.reshape(mn, num_groups, self.group_size).float()
++        absmax = xg.abs().amax(dim=-1).clamp(min=_FP8_MIN_SCALING_FACTOR)
++
++        # UE8M0 keeps only a power-of-two scale, so the exponent is the payload.
++        exponent = torch.ceil(torch.log2(absmax / _FP8_MAX))
++        quantized = (xg / torch.exp2(exponent).unsqueeze(-1)).clamp(_FP8_MIN, _FP8_MAX)
++        x_q = quantized.to(_FP8_DTYPE).reshape(x.shape)
++
++        # e8m0 byte is the biased exponent; four bytes pack into one int32.
++        byte = (exponent + 127.0).clamp(0, 255).to(torch.int32)
++        pad = k_packed * 4 - num_groups
++        if pad:
++            byte = F.pad(byte, (0, pad))
++        b = byte.reshape(mn, k_packed, 4)
++        packed = b[..., 0] | (b[..., 1] << 8) | (b[..., 2] << 16) | (b[..., 3] << 24)
++
++        # DeepGEMM requires size(-2) == mn, stride(-2) == 1 and
++        # stride(-1) == get_tma_aligned_size(mn): the mn dim must be the fast
++        # one, with the slow stride padded out to the TMA-aligned size.
++        #
++        # Build it by padding the transposed buffer, materializing, transposing
++        # back and slicing -- NOT via empty_strided + copy_. Inductor is free to
++        # ignore an empty_strided layout request and materialize row-major,
++        # which trips the assertion, but it does preserve a transpose-derived
++        # view, and slicing the leading dim afterwards keeps the strides intact.
++        #
++        # A bare transpose-of-contiguous is correct only when mn is already
++        # TMA-aligned and silently yields stride(-1) == mn otherwise.
++        tma_aligned_mn = get_tma_aligned_size(mn, packed.element_size())
++        packed_t = F.pad(packed.transpose(0, 1), (0, tma_aligned_mn - mn))
++        return x_q, packed_t.contiguous().transpose(0, 1)[:mn]
++
+     def _quantize_group_native(
+         self, x: torch.Tensor
+     ) -> tuple[torch.Tensor, torch.Tensor]:
+diff --git a/vllm/model_executor/warmup/kernel_warmup.py b/vllm/model_executor/warmup/kernel_warmup.py
+index 36a17fa8aa263009adc60acc5bf8ca172fa49645..87e1f5be2b93ce125fd479b39712c1252b16db86 100644
+--- a/vllm/model_executor/warmup/kernel_warmup.py
++++ b/vllm/model_executor/warmup/kernel_warmup.py
+@@ -23,6 +23,9 @@ from vllm.model_executor.kernels.linear.scaled_mm.b12x_tensor import (
+     warmup_b12x_tensor_fp8_linear,
+ )
+ from vllm.model_executor.layers.fused_moe.b12x_moe import warmup_b12x_moe_dynamic
++from vllm.model_executor.layers.quantization.exl3 import (
++    warmup_exl3_mixed_trellis_route_pack,
++)
+ from vllm.model_executor.warmup.b12x_sparse_indexer_warmup import (
+     warmup_b12x_sparse_indexer,
+ )
+@@ -366,6 +369,16 @@ def kernel_warmup(worker: "Worker"):
+         max_tokens=max(moe_token_counts),
+         token_counts=moe_token_counts,
+     )
++    free_before_exl3_warmup = torch.cuda.mem_get_info()[0]
++    warmed_exl3_route_pack = warmup_exl3_mixed_trellis_route_pack(worker.get_model())
++    if warmed_exl3_route_pack:
++        free_after_exl3_warmup = torch.cuda.mem_get_info()[0]
++        logger.info(
++            "Warmed up %d EXL3 mixed-Trellis route-pack variant(s); "
++            "free-memory delta %.1f MiB.",
++            warmed_exl3_route_pack,
++            (free_before_exl3_warmup - free_after_exl3_warmup) / (1 << 20),
++        )
+ 
+     minimax_m3_msa_warmup(worker)
+ 
+@@ -442,6 +455,28 @@ def _flashinfer_autotune_skip_ops(runner: "GPUModelRunner") -> set[str] | None:
+     return None
+ 
+ 
++def _flashinfer_autotune_dummy_run_kwargs(
++    runner: "GPUModelRunner",
++) -> dict[str, object]:
++    kwargs = dict(
++        num_tokens=runner.scheduler_config.max_num_batched_tokens,
++        skip_eplb=True,
++        is_profile=True,
++    )
++
++    # V2 initializes attention backends and block tables only after the initial
++    # memory profile.  Kernel autotuning runs during that profile, so execute
++    # the model kernels without attention until those tables exist.  Attention
++    # backends have their own warmup after KV-cache initialization.
++    if (
++        getattr(runner.vllm_config, "use_v2_model_runner", False)
++        and not hasattr(runner, "block_tables")
++    ):
++        kwargs["skip_attn"] = True
++
++    return kwargs
++
++
+ def flashinfer_autotune(runner: "GPUModelRunner") -> None:
+     """
+     Autotune FlashInfer operations.
+@@ -475,11 +510,7 @@ def flashinfer_autotune(runner: "GPUModelRunner") -> None:
+ 
+     if not use_persistent_cache:
+         with torch.inference_mode(), fi_utils.autotune(**autotune_kwargs):
+-            runner._dummy_run(
+-                num_tokens=runner.scheduler_config.max_num_batched_tokens,
+-                skip_eplb=True,
+-                is_profile=True,
+-            )
++            runner._dummy_run(**_flashinfer_autotune_dummy_run_kwargs(runner))
+         get_world_group().barrier()
+         return
+ 
+@@ -494,11 +525,7 @@ def flashinfer_autotune(runner: "GPUModelRunner") -> None:
+     # When autotuning with number of tokens m, flashinfer will autotune
+     # operations for all number of tokens up to m, so we only need to
+     # run with the max number of tokens.
+-    dummy_run_kwargs = dict(
+-        num_tokens=runner.scheduler_config.max_num_batched_tokens,
+-        skip_eplb=True,
+-        is_profile=True,
+-    )
++    dummy_run_kwargs = _flashinfer_autotune_dummy_run_kwargs(runner)
+ 
+     with torch.inference_mode():
+         if is_leader:
+diff --git a/vllm/models/deepseek_v4/nvidia/b12x.py b/vllm/models/deepseek_v4/nvidia/b12x.py
+index 6f5e3113da5e73ffdcb44c954faccd7e8981e3ba..2893589fd62d13244c7f17790acb63ec7299309d 100644
+--- a/vllm/models/deepseek_v4/nvidia/b12x.py
++++ b/vllm/models/deepseek_v4/nvidia/b12x.py
+@@ -20,6 +20,7 @@ from typing import TYPE_CHECKING, ClassVar, Literal, cast
+ 
+ import torch
+ 
++from vllm.config import VllmConfig
+ from vllm.forward_context import get_forward_context
+ from vllm.models.deepseek_v4.common.ops import (
+     compute_dcp_global_topk_indices_and_lens,
+@@ -30,6 +31,12 @@ from vllm.models.deepseek_v4.nvidia.flashmla import (
+     DeepseekV4FlashMLABackend,
+ )
+ from vllm.models.deepseek_v4.sparse_mla import DeepseekV4FlashMLAMetadata
++from vllm.v1.attention.backends.mla.compressor_utils import (
++    get_c128a_topk_width,
++    get_compressed_mla_max_q_chunks,
++    get_compressed_mla_split_cap,
++    get_dspark_swa_index_width,
++)
+ from vllm.v1.attention.ops.common import cp_lse_ag_out_rs
+ from vllm.v1.attention.ops.dcp_alltoall import (
+     dcp_a2a_lse_reduce,
+@@ -44,22 +51,58 @@ if TYPE_CHECKING:
+ _DSV4_HEAD_DIM = 512
+ _DSV4_V_HEAD_DIM = 512
+ _DSV4_CACHE_BYTES_PER_TOKEN = 584
+-_DSV4_CACHE_PAD_ALIGNMENT_BYTES = 576
+-_DECODE_SPLIT_TILE = 64
+-_C128A_TOPK_ALIGNMENT = 128
+ _VALIDATE_DCP_INDICES_ENV = "VLLM_DSV4_DCP_VALIDATE_INDICES"
+ 
+ 
++def _get_dspark_decode_row_capacity(vllm_config: VllmConfig) -> int | None:
++    """Return the largest target-verifier row count the scheduler can emit."""
++    speculative_config = vllm_config.speculative_config
++    if speculative_config is None or not speculative_config.use_dspark():
++        return None
++    num_speculative_tokens = int(speculative_config.num_speculative_tokens or 0)
++    if num_speculative_tokens <= 0:
++        return None
++    scheduler_config = vllm_config.scheduler_config
++    return min(
++        int(scheduler_config.max_num_batched_tokens),
++        int(scheduler_config.max_num_seqs) * (1 + num_speculative_tokens),
++    )
++
++
++def _validate_compressed_mla_decode_row_capacity(
++    *,
++    rows: int,
++    mode: Literal["decode", "extend"],
++    decode_row_capacity: int | None,
++) -> None:
++    if mode != "decode" or decode_row_capacity is None:
++        return
++    if int(rows) > int(decode_row_capacity):
++        raise ValueError(
++            f"compressed MLA decode rows {rows} exceed the declared "
++            f"capacity {decode_row_capacity}"
++        )
++
++
+ def _cdiv(x: int, y: int) -> int:
+     return (int(x) + int(y) - 1) // int(y)
+ 
+ 
+ def _dsv4_b12x_page_nbytes(page_size: int) -> int:
+-    payload_nbytes = int(page_size) * _DSV4_CACHE_BYTES_PER_TOKEN
+-    return (
+-        _cdiv(payload_nbytes, _DSV4_CACHE_PAD_ALIGNMENT_BYTES)
+-        * _DSV4_CACHE_PAD_ALIGNMENT_BYTES
+-    )
++    """Return the logical DSV4 payload bytes in one cache page.
++
++    vLLM may place padding between physical pages, but the padding is not part
++    of the compressed-MLA payload.  Keeping it out of the exported view also
++    supports standalone contiguous allocations, whose physical page stride is
++    exactly ``page_size * 584`` bytes.
++
++    Args:
++        page_size: Number of tokens stored in one cache page.
++
++    Returns:
++        The logical compressed-MLA payload size in bytes.
++    """
++    return int(page_size) * _DSV4_CACHE_BYTES_PER_TOKEN
+ 
+ 
+ def _b12x_cache_page_view(
+@@ -67,7 +110,25 @@ def _b12x_cache_page_view(
+     page_size: int,
+     name: str,
+ ) -> torch.Tensor:
+-    """Return a uint8 ``[pages, padded_page_bytes]`` view for b12x kernels."""
++    """Return a uint8 ``[pages, payload_bytes]`` view for SparkInfer kernels.
++
++    Preserve the physical page stride so both padded packed allocations and
++    contiguous per-layer allocations follow the same runtime contract.
++
++    Args:
++        cache: Source paged cache tensor.
++        page_size: Number of tokens stored in one cache page.
++        name: Cache name used in validation errors.
++
++    Returns:
++        A logical byte view that preserves the source physical page stride.
++
++    Raises:
++        ValueError: If ``page_size`` is not positive.
++        RuntimeError: If the cache is not paged, a page cannot contain the
++            logical payload, pages overlap, or the payload within a page is
++            not contiguous.
++    """
+     page_nbytes = _dsv4_b12x_page_nbytes(page_size)
+     if page_nbytes <= 0:
+         raise ValueError(f"{name} page_size must be positive, got {page_size}")
+@@ -77,11 +138,19 @@ def _b12x_cache_page_view(
+         if int(byte_cache.shape[1]) < page_nbytes:
+             raise RuntimeError(
+                 f"{name} page width {int(byte_cache.shape[1])} is smaller than "
+-                f"DSV4 padded page width {page_nbytes}"
++                f"DSV4 payload width {page_nbytes}"
++            )
++        if int(byte_cache.stride(1)) != 1:
++            raise RuntimeError(
++                f"{name} page payload must be contiguous, got stride "
++                f"{tuple(byte_cache.stride())}"
+             )
+-        if not byte_cache.is_contiguous():
+-            raise RuntimeError(f"{name} page cache must be contiguous")
+-        return byte_cache
++        if int(byte_cache.stride(0)) < page_nbytes:
++            raise RuntimeError(
++                f"{name} page stride {int(byte_cache.stride(0))} is smaller than "
++                f"DSV4 page payload {page_nbytes}"
++            )
++        return byte_cache[:, :page_nbytes]
+ 
+     if byte_cache.ndim < 2:
+         raise RuntimeError(
+@@ -93,13 +162,22 @@ def _b12x_cache_page_view(
+     if page_stride_nbytes < page_nbytes:
+         raise RuntimeError(
+             f"{name} page stride {page_stride_nbytes} is smaller than DSV4 page "
+-            f"width {page_nbytes}"
++            f"payload {page_nbytes}"
+         )
+ 
++    expected_stride = 1
++    for dim in range(byte_cache.ndim - 1, 0, -1):
++        if int(byte_cache.stride(dim)) != expected_stride:
++            raise RuntimeError(
++                f"{name} page payload must be contiguous, got stride "
++                f"{tuple(byte_cache.stride())}"
++            )
++        expected_stride *= int(byte_cache.shape[dim])
++
+     # Packed DS4 KV cache views have a storage offset for this layer and a
+-    # larger per-block stride for the whole packed block. Expose only this
+-    # layer's page payload while preserving stride(0), so B12X can use the
+-    # packed block stride without materializing/copying.
++    # larger per-block stride for the whole packed block. Expose only the
++    # logical payload while preserving stride(0), so SparkInfer can use the
++    # physical block stride without materializing/copying.
+     page_view = torch.as_strided(
+         byte_cache,
+         size=(pages, page_nbytes),
+@@ -239,6 +317,7 @@ def _run_compressed_mla(
+     indexed_lens: torch.Tensor | None,
+     indexed_page_size: int | None,
+     mode: Literal["decode", "extend"] = "decode",
++    decode_row_capacity: int | None = None,
+     return_lse: bool = False,
+     lse_scale: Literal["natural", "base2"] = "natural",
+ ) -> torch.Tensor | None:
+@@ -262,6 +341,11 @@ def _run_compressed_mla(
+     )
+ 
+     rows, heads = int(q.shape[0]), int(q.shape[1])
++    _validate_compressed_mla_decode_row_capacity(
++        rows=rows,
++        mode=mode,
++        decode_row_capacity=decode_row_capacity,
++    )
+     q = q.contiguous()
+     swa_indices = swa_indices.contiguous()
+     swa_lens = swa_lens.contiguous()
+@@ -287,13 +371,14 @@ def _run_compressed_mla(
+     width = int(swa_indices.shape[-1])
+     if indexed_indices is not None:
+         width += int(indexed_indices.shape[-1])
+-    decode_split_cap = max(1, _cdiv(width, _DECODE_SPLIT_TILE))
++    decode_split_cap = get_compressed_mla_split_cap(width)
+     # Keep the legacy 64-wide split cap for decode, but let the b12x contract
+     # select the smaller batched-prefill split count when rows > decode max.
+     num_splits_cap = compressed_mla_split_chunks_for_contract(
+         rows=max(1, rows),
+         width=width,
+         max_chunks=decode_split_cap,
++        decode_row_capacity=decode_row_capacity,
+     )
+ 
+     plan = plan_compressed_mla_scratch(
+@@ -306,6 +391,7 @@ def _run_compressed_mla(
+             v_head_dim=_DSV4_V_HEAD_DIM,
+             page_size=int(swa_page_size),
+             max_chunks_per_row=num_splits_cap,
++            decode_row_capacity=decode_row_capacity,
+         )
+     )
+     scratch = current_workspace_manager().get_simultaneous(*plan.shapes_and_dtypes())
+@@ -364,6 +450,7 @@ def _run_dcp_compressed_mla(
+     indexed_lens: torch.Tensor | None,
+     indexed_page_size: int | None,
+     mode: Literal["decode", "extend"] = "decode",
++    decode_row_capacity: int | None = None,
+ ) -> None:
+     from vllm.distributed.parallel_state import get_dcp_group
+ 
+@@ -396,6 +483,7 @@ def _run_dcp_compressed_mla(
+         indexed_lens=indexed_lens,
+         indexed_page_size=indexed_page_size,
+         mode=mode,
++        decode_row_capacity=decode_row_capacity,
+         return_lse=True,
+         lse_scale="natural",
+     )
+@@ -493,28 +581,57 @@ class DeepseekV4B12xMLAAttention(DeepseekV4FlashMLAAttention):
+             elif self.indexer is not None:
+                 indexed_width = int(self.indexer.topk_tokens)
+         elif self.compress_ratio > 1:
+-            indexed_width = _cdiv(self.max_model_len, self.compress_ratio)
+-            indexed_width = _cdiv(indexed_width, _C128A_TOPK_ALIGNMENT)
+-            indexed_width *= _C128A_TOPK_ALIGNMENT
++            indexed_width = get_c128a_topk_width(
++                self.max_model_len,
++                self.compress_ratio,
++            )
+ 
+-        width = max(int(self.window_size) + indexed_width, 1)
++        swa_width = int(self.window_size)
++        speculative_config = self.vllm_config.speculative_config
++        decode_row_capacity = _get_dspark_decode_row_capacity(self.vllm_config)
++        if speculative_config is not None and speculative_config.use_dspark():
++            swa_width = max(
++                swa_width,
++                get_dspark_swa_index_width(
++                    swa_width,
++                    speculative_config.num_speculative_tokens or 0,
++                ),
++            )
++
++        width = max(swa_width + indexed_width, 1)
+         rows = max(int(self.max_num_batched_tokens), 1)
+-        decode_split_cap = max(1, _cdiv(width, _DECODE_SPLIT_TILE))
++        decode_split_cap = get_compressed_mla_split_cap(width)
+         num_splits_cap = compressed_mla_split_chunks_for_contract(
+             rows=rows,
+             width=width,
+             max_chunks=decode_split_cap,
++            decode_row_capacity=decode_row_capacity,
++        )
++        max_q_chunks = get_compressed_mla_max_q_chunks(
++            rows,
++            width,
++            decode_split_cap,
++            compressed_mla_split_chunks_for_contract,
++            decode_row_capacity=decode_row_capacity,
++        )
++        dcp_world_size = max(
++            int(self.vllm_config.parallel_config.decode_context_parallel_size),
++            1,
+         )
++        # max_q_rows covers final row-sized buffers; max_q_chunks covers split
++        # intermediates whose peak can occur below max_q_rows.
+         plan = plan_compressed_mla_scratch(
+             B12XCompressedMLAScratchCaps(
+                 device=q.device,
+-                num_q_heads=int(q.shape[1]),
++                num_q_heads=int(q.shape[1]) * dcp_world_size,
+                 max_q_rows=rows,
+                 max_width=width,
+                 head_dim=_DSV4_HEAD_DIM,
+                 v_head_dim=_DSV4_V_HEAD_DIM,
+                 page_size=int(self.swa_cache_layer.block_size),
+                 max_chunks_per_row=num_splits_cap,
++                max_q_chunks=max_q_chunks,
++                decode_row_capacity=decode_row_capacity,
+             )
+         )
+         current_workspace_manager().get_simultaneous(*plan.shapes_and_dtypes())
+@@ -549,6 +666,7 @@ class DeepseekV4B12xMLAAttention(DeepseekV4FlashMLAAttention):
+         if attn_metadata is None:
+             # Warmup dummy run: no metadata, so reserve the largest compressed
+             # MLA scratch this layer can request before vLLM locks workspace.
++            # Its config-derived geometry is identical on later dummy calls.
+             output.zero_()
+             self._reserve_dummy_compressed_mla_scratch(q)
+             return
+@@ -620,6 +738,7 @@ class DeepseekV4B12xMLAAttention(DeepseekV4FlashMLAAttention):
+         num_decodes = swa_metadata.num_decodes
+         num_decode_tokens = swa_metadata.num_decode_tokens
+         dcp_world_size = vllm_config.parallel_config.decode_context_parallel_size
++        decode_row_capacity = _get_dspark_decode_row_capacity(vllm_config)
+         dcp_rank = 0
+         if dcp_world_size > 1:
+             from vllm.distributed.parallel_state import get_dcp_group
+@@ -697,6 +816,7 @@ class DeepseekV4B12xMLAAttention(DeepseekV4FlashMLAAttention):
+                 indexed_lens=topk_lens,
+                 indexed_page_size=indexed_page_size,
+                 mode="decode",
++                decode_row_capacity=decode_row_capacity,
+             )
+         else:
+             _run_compressed_mla(
+@@ -713,6 +833,7 @@ class DeepseekV4B12xMLAAttention(DeepseekV4FlashMLAAttention):
+                 indexed_lens=topk_lens,
+                 indexed_page_size=indexed_page_size,
+                 mode="decode",
++                decode_row_capacity=decode_row_capacity,
+             )
+ 
+     def _forward_b12x_prefill(
+diff --git a/vllm/models/deepseek_v4/sparse_mla.py b/vllm/models/deepseek_v4/sparse_mla.py
+index 623bff0828d59ff275e39fb738ef66368c4d3987..d53b732b1ef9e122137eac343cf588f792b9ae01 100644
+--- a/vllm/models/deepseek_v4/sparse_mla.py
++++ b/vllm/models/deepseek_v4/sparse_mla.py
+@@ -11,7 +11,6 @@ from vllm.config import VllmConfig
+ from vllm.config.cache import CacheDType
+ from vllm.platforms.interface import DeviceCapability
+ from vllm.triton_utils import tl, triton
+-from vllm.utils.math_utils import cdiv
+ from vllm.v1.attention.backend import (
+     AttentionBackend,
+     AttentionCGSupport,
+@@ -20,17 +19,13 @@ from vllm.v1.attention.backend import (
+     CommonAttentionMetadata,
+     MultipleOf,
+ )
+-from vllm.v1.attention.backends.mla.compressor_utils import get_compressed_slot_mapping
++from vllm.v1.attention.backends.mla.compressor_utils import (
++    get_c128a_topk_width,
++    get_compressed_slot_mapping,
++)
+ from vllm.v1.attention.backends.utils import split_decodes_and_prefills
+ from vllm.v1.kv_cache_interface import AttentionSpec
+ 
+-# Pad C128A topk width to this alignment. 128 covers both h_q=64 (B_TOPK=64) and
+-# h_q=128 (B_TOPK=128). FlashMLA decode asserts extra_topk % B_TOPK == 0;
+-# unaligned widths (e.g. 17 = ceil(2136/128)) crash the sm100 head64 kernel.
+-# Padded slots stay -1 and decode_lens caps them via topk_length, so the pad is a
+-# no-op at kernel level. Mirrors _SPARSE_PREFILL_TOPK_ALIGNMENT in cache_utils.py.
+-_C128A_TOPK_ALIGNMENT = 128
+-
+ 
+ class DeepseekV4FlashMLABackend(AttentionBackend):
+     """DeepSeek-V4 sparse-MLA backend.
+@@ -191,12 +186,9 @@ class DeepseekV4FlashMLAMetadataBuilder(
+ 
+         # Pre-allocate C128A topk buffers for CUDA graph address stability.
+         if self.compress_ratio == 128:
+-            c128a_max_compressed = cdiv(
+-                self.model_config.max_model_len, self.compress_ratio
+-            )
+-            c128a_max_compressed = (
+-                cdiv(c128a_max_compressed, _C128A_TOPK_ALIGNMENT)
+-                * _C128A_TOPK_ALIGNMENT
++            c128a_max_compressed = get_c128a_topk_width(
++                self.model_config.max_model_len,
++                self.compress_ratio,
+             )
+             # Stored so _build_c128a_metadata passes it as the kernel's
+             # max_compressed_tokens, matching the buffer stride. Otherwise the
+diff --git a/vllm/tokenizers/deepseek_v4.py b/vllm/tokenizers/deepseek_v4.py
+index 3897149626f87d6dd1c23e4520d49e037cd40f8e..3cf84de82312520d6669137789fd47f7ba9db75c 100644
+--- a/vllm/tokenizers/deepseek_v4.py
++++ b/vllm/tokenizers/deepseek_v4.py
+@@ -37,8 +37,26 @@ def get_deepseek_v4_tokenizer(tokenizer: HfTokenizer) -> HfTokenizer:
+             conversation = kwargs.get("conversation", messages)
+             messages = conversation.copy()
+             if tools is not None and len(tools) > 0:
+-                messages.insert(0, {"role": "system"})
+-                messages[0]["tools"] = tools  # type: ignore[typeddict-unknown-key]
++                for index, message in enumerate(messages):
++                    if message.get("role") in ("system", "developer"):
++                        prompt_message = message.copy()
++                        message_tools = prompt_message.get("tools")
++                        request_tool_names = {
++                            tool.get("function", {}).get("name") for tool in tools
++                        }
++                        merged_tools = [
++                            tool
++                            for tool in message_tools or []
++                            if tool.get("function", {}).get("name")
++                            not in request_tool_names
++                        ]
++                        merged_tools.extend(tools)
++                        prompt_message["tools"] = merged_tools  # type: ignore[typeddict-unknown-key]
++                        messages[index] = prompt_message
++                        break
++                else:
++                    messages.insert(0, {"role": "system"})
++                    messages[0]["tools"] = tools  # type: ignore[typeddict-unknown-key]
+ 
+             reasoning_effort = kwargs.get("reasoning_effort")
+             if not isinstance(reasoning_effort, str):
+@@ -48,6 +66,8 @@ def get_deepseek_v4_tokenizer(tokenizer: HfTokenizer) -> HfTokenizer:
+                 reasoning_effort = None
+             elif reasoning_effort in ("max", "xhigh"):
+                 reasoning_effort = "max"
++            elif reasoning_effort == "low":
++                reasoning_effort = "low"
+             else:
+                 reasoning_effort = "high"
+ 
+diff --git a/vllm/tokenizers/deepseek_v4_encoding.py b/vllm/tokenizers/deepseek_v4_encoding.py
+index 16bfa1a99a1bdd52104f6440af12b6c197ca3741..e69c530317fcb7be0fe2989c8b04c4523876fccf 100644
+--- a/vllm/tokenizers/deepseek_v4_encoding.py
++++ b/vllm/tokenizers/deepseek_v4_encoding.py
+@@ -65,11 +65,31 @@ tool_output_template: str = (
+     "<tool_result>{content}</tool_result>"
+ )
+ 
+-REASONING_EFFORT_MAX = (
+-    "Reasoning Effort: Absolute maximum with no shortcuts permitted.\n"
+-    "You MUST be very thorough in your thinking and comprehensively decompose the problem to resolve the root cause, rigorously stress-testing your logic against all potential paths, edge cases, and adversarial scenarios.\n"
+-    "Explicitly write out your entire deliberation process, documenting every intermediate step, considered alternative, and rejected hypothesis to ensure absolutely no assumption is left unchecked.\n\n"
+-)
++REASONING_EFFORT_PROMPTS: Dict[str, str] = {
++    "low": "",
++    "high": (
++        "Reasoning Effort: Absolute maximum with no shortcuts permitted.\n"
++        "You MUST be very thorough in your thinking and comprehensively "
++        "decompose the problem to resolve the root cause, rigorously "
++        "stress-testing your logic against all potential paths, edge cases, "
++        "and adversarial scenarios.\n"
++        "Explicitly write out your entire deliberation process, documenting "
++        "every intermediate step, considered alternative, and rejected "
++        "hypothesis to ensure absolutely no assumption is left unchecked.\n\n"
++    ),
++    "max": (
++        "Reasoning Effort: Beyond maximum — exhaustive, relentless, and "
++        "uncompromising.\n"
++        "You MUST reason with the utmost depth and rigor, leaving absolutely "
++        "nothing to chance: exhaustively decompose the problem into its most "
++        "fundamental components, trace every causal chain to its root, and "
++        "resolve the underlying cause rather than any surface symptom.\n"
++        "Do not stop reasoning until you have independently verified the "
++        "solution from multiple angles and are certain that no assumption "
++        "remains unchecked and no error remains undiscovered.\n\n"
++    ),
++}
++DEFAULT_REASONING_EFFORT = "low"
+ 
+ TOOLS_TEMPLATE = """## Tools
+ 
+@@ -139,10 +159,19 @@ def encode_arguments_to_dsml(tool_call: Dict[str, Any]) -> str:
+     p_dsml_template = '<{dsml_token}parameter name="{key}" string="{is_str}">{value}</{dsml_token}parameter>'
+     P_dsml_strs = []
+ 
+-    if isinstance(tool_call["arguments"], str):
+-        arguments = json.loads(tool_call["arguments"])
++    raw_arguments = tool_call.get("arguments")
++    if isinstance(raw_arguments, str):
++        try:
++            arguments = json.loads(raw_arguments)
++        except (TypeError, ValueError):
++            arguments = {"arguments": raw_arguments}
+     else:
+-        arguments = tool_call["arguments"]
++        arguments = raw_arguments
++
++    # Historical tool calls are not always normalized to an object. Preserve
++    # those values as one explicit parameter instead of failing prompt render.
++    if not isinstance(arguments, dict):
++        arguments = {"arguments": arguments}
+ 
+     for k, v in arguments.items():
+         p_dsml_str = p_dsml_template.format(
+@@ -202,7 +231,8 @@ def render_message(index: int, messages: List[Dict[str, Any]], thinking_mode: st
+         messages: Full list of messages in the conversation.
+         thinking_mode: Either "chat" or "thinking".
+         drop_thinking: Whether to drop reasoning content from earlier turns.
+-        reasoning_effort: Optional reasoning effort level ("max", "high", or None).
++        reasoning_effort: Reasoning effort level, one of "low", "high", "max".
++            None is treated as "low".
+ 
+     Returns:
+         Encoded string for this message.
+@@ -227,10 +257,13 @@ def render_message(index: int, messages: List[Dict[str, Any]], thinking_mode: st
+     if tool_calls:
+         tool_calls = tool_calls_from_openai_format(tool_calls)
+ 
+-    # Reasoning effort prefix (only at index 0 in thinking mode with max effort)
+-    assert reasoning_effort in ['max', None, 'high'], f"Invalid reasoning effort: {reasoning_effort}"
+-    if index == 0 and thinking_mode == "thinking" and reasoning_effort == 'max':
+-        prompt += REASONING_EFFORT_MAX
++    reasoning_effort = reasoning_effort or DEFAULT_REASONING_EFFORT
++    assert reasoning_effort in REASONING_EFFORT_PROMPTS, (
++        f"Invalid reasoning effort: {reasoning_effort}, expected one of "
++        f"{list(REASONING_EFFORT_PROMPTS)}"
++    )
++    if index == 0 and thinking_mode == "thinking":
++        prompt += REASONING_EFFORT_PROMPTS[reasoning_effort]
+ 
+     if role == "system":
+         prompt += system_msg_template.format(content=content or "")
+@@ -497,7 +530,8 @@ def encode_messages(
+         drop_thinking: If True, drop reasoning from earlier assistant turns
+                       (only keep reasoning for messages after the last user message).
+         add_default_bos_token: Whether to prepend BOS token at conversation start.
+-        reasoning_effort: Optional reasoning effort level ("max", "high", or None).
++        reasoning_effort: Reasoning effort level, one of "low", "high", "max".
++            Only takes effect in thinking mode. None is treated as "low".
+ 
+     Returns:
+         The encoded prompt string.
+diff --git a/vllm/v1/attention/backends/flashinfer.py b/vllm/v1/attention/backends/flashinfer.py
+index 816a8a7aa117689b2d9a064a41dc35f4ff36138b..1724f3db7819e65ad7c43266e6d934b8927f9f7c 100755
+--- a/vllm/v1/attention/backends/flashinfer.py
++++ b/vllm/v1/attention/backends/flashinfer.py
+@@ -617,6 +617,77 @@ class FlashInferMetadata:
+     cascade_wrapper: MultiLevelCascadeAttentionWrapper | None
+ 
+ 
++def persistent_decode_wrapper_eligible(
++    *,
++    pure_decode: bool,
++    num_decode_tokens: int,
++    decode_cudagraph_max_bs: int,
++    decode_q_len: int,
++    planned_decode_q_len: int,
++) -> bool:
++    """Whether a decode-classified batch may reuse a persistent (CUDA-graph)
++    FlashInfer decode wrapper.
++
++    Persistent wrappers are planned once, during graph capture, with a frozen
++    ``q_len_per_req`` of exactly ``planned_decode_q_len`` (1 + num_spec_tokens;
++    1 without speculative decoding). Reuse is only sound when the runtime
++    per-request query length matches that frozen shape — FlashInfer's
++    ``fast_decode_plan`` hard-errors otherwise ("q_len_per_req is part of the
++    frozen cudagraph shape").
++
++    WARNING: ``planned_decode_q_len`` is NOT ``reorder_batch_threshold``. With
++    parallel drafting the decode-classification ceiling is
++    ``1 + 2 * num_spec_tokens``, which deliberately admits reduced-depth steps
++    (spec truncation near ``max_tokens``, short chunked-prefill tails fused
++    with the spec step). Those are valid decode batches, but they must take
++    the dynamic wrapper, which replans for the current shape on every call.
++
++    Args:
++        pure_decode: True when the batch contains no prefill requests.
++        num_decode_tokens: Total scheduled tokens across the decode requests.
++        decode_cudagraph_max_bs: Token capacity the persistent wrappers were
++            sized for ((1 + num_spec_tokens) * max_num_reqs, capped by
++            ``max_cudagraph_capture_size``).
++        decode_q_len: Runtime per-request query length of the active
++            (non-padding) decode requests.
++        planned_decode_q_len: Frozen per-request query length the persistent
++            wrappers were planned with (1 + num_spec_tokens).
++
++    Returns:
++        True when the batch may be routed to the persistent (CUDA-graph)
++        decode wrapper; False when it must use the dynamic wrapper.
++    """
++    return (
++        pure_decode
++        and num_decode_tokens <= decode_cudagraph_max_bs
++        and decode_q_len == planned_decode_q_len
++    )
++
++
++def decode_q_len_from_indptr(qo_indptr_cpu: torch.Tensor, num_decodes: int) -> int:
++    """Per-request query length of the active decode requests in a batch.
++
++    Uniform CUDA-graph decode batches may carry zero-length padding rows
++    (``split_decodes_and_prefills`` classifies ``q_len == 0`` padding as
++    decode so ``num_decodes`` matches the captured size). Averaging
++    ``num_decode_tokens`` over ``num_decodes`` would understate the active
++    query length for such batches and wrongly demote them to the dynamic
++    wrapper, so the length is taken as the maximum per-request span instead
++    (decode rows are uniform-or-zero by construction).
++
++    Args:
++        qo_indptr_cpu: CPU query-start-loc tensor for the batch.
++        num_decodes: Number of decode-classified requests, including any
++            zero-length padding rows.
++
++    Returns:
++        The uniform query length of the active decode requests, or 0 when
++        every row is padding.
++    """
++    lens = qo_indptr_cpu[1 : num_decodes + 1] - qo_indptr_cpu[:num_decodes]
++    return int(lens.max().item()) if num_decodes > 0 else 0
++
++
+ class FlashInferMetadataBuilder(AttentionMetadataBuilder[FlashInferMetadata]):
+     reorder_batch_threshold: int = 1
+ 
+@@ -664,6 +735,10 @@ class FlashInferMetadataBuilder(AttentionMetadataBuilder[FlashInferMetadata]):
+             if speculative_config is not None
+             else 0
+         )
++        # The frozen per-request query length persistent decode wrappers are
++        # planned with during capture. See persistent_decode_wrapper_eligible
++        # for why this must never be conflated with reorder_batch_threshold.
++        self._planned_decode_q_len = 1 + num_spec_tokens
+         self.enable_cuda_graph = (
+             self.compilation_config.cudagraph_mode.decode_mode() == CUDAGraphMode.FULL
+         )
+@@ -1507,16 +1582,21 @@ class FlashInferMetadataBuilder(AttentionMetadataBuilder[FlashInferMetadata]):
+             else:
+                 assert seq_lens_cpu is not None
+                 pure_decode = num_prefills == 0
++                # Spec-as-decode verify batches carry a uniform per-request
++                # query length; uniform CUDA-graph batches may additionally
++                # carry zero-length padding rows, so the active length comes
++                # from the per-request spans, not an average.
++                decode_q_len = decode_q_len_from_indptr(qo_indptr_cpu, num_decodes)
+                 use_cudagraph = (
+                     self.enable_cuda_graph
+-                    and pure_decode
+-                    and num_decode_tokens <= self._decode_cudagraph_max_bs
++                    and persistent_decode_wrapper_eligible(
++                        pure_decode=pure_decode,
++                        num_decode_tokens=num_decode_tokens,
++                        decode_cudagraph_max_bs=self._decode_cudagraph_max_bs,
++                        decode_q_len=decode_q_len,
++                        planned_decode_q_len=self._planned_decode_q_len,
++                    )
+                 )
+-                # Spec-as-decode verify batches carry a uniform
+-                # num_decode_tokens // num_decodes tokens per request; the
+-                # wrapper's batch size and kv metadata are per request.
+-                assert num_decode_tokens % num_decodes == 0
+-                decode_q_len = num_decode_tokens // num_decodes
+ 
+                 decode_wrapper = self._get_decode_wrapper(num_decodes, use_cudagraph)
+                 # Use the persistent buffer with padding length,
+diff --git a/vllm/v1/attention/backends/mla/compressor_utils.py b/vllm/v1/attention/backends/mla/compressor_utils.py
+index 9ec2085e8d180b0d40dd06f692db7d29916cbb54..cfa5f62d0748f10e62be38c17253bd0fb71adf4a 100644
+--- a/vllm/v1/attention/backends/mla/compressor_utils.py
++++ b/vllm/v1/attention/backends/mla/compressor_utils.py
+@@ -1,8 +1,94 @@
+ # SPDX-License-Identifier: Apache-2.0
+ # SPDX-FileCopyrightText: Copyright contributors to the vLLM project
++from collections.abc import Callable
++from functools import cache
++
+ import torch
+ 
+ from vllm.triton_utils import tl, triton
++from vllm.utils.math_utils import cdiv
++
++_C128A_TOPK_ALIGNMENT = 128
++_COMPRESSED_MLA_SPLIT_ALIGNMENT = 64
++_DSPARK_SWA_INDEX_ALIGNMENT = 512
++
++
++def get_c128a_topk_width(max_model_len: int, compress_ratio: int) -> int:
++    """Return C128 indexed width padded for FlashMLA B_TOPK divisibility.
++
++    Args:
++        max_model_len: Maximum model context length in tokens.
++        compress_ratio: Ratio used to compress the indexed KV cache.
++
++    Returns:
++        The aligned compressed top-k width.
++    """
++    compressed_width = cdiv(max_model_len, compress_ratio)
++    return cdiv(compressed_width, _C128A_TOPK_ALIGNMENT) * _C128A_TOPK_ALIGNMENT
++
++
++def get_dspark_swa_index_width(
++    window_size: int,
++    num_speculative_tokens: int,
++) -> int:
++    """Return the padded width of non-causal DSpark SWA indices.
++
++    Args:
++        window_size: Sliding-window attention width.
++        num_speculative_tokens: Number of DSpark draft tokens.
++
++    Returns:
++        The aligned non-causal index width.
++    """
++    width = max(int(window_size), 0) + max(int(num_speculative_tokens), 0)
++    return cdiv(width, _DSPARK_SWA_INDEX_ALIGNMENT) * _DSPARK_SWA_INDEX_ALIGNMENT
++
++
++def get_compressed_mla_split_cap(width: int) -> int:
++    """Return the maximum compressed-MLA split count for ``width``.
++
++    Args:
++        width: Combined SWA and indexed width.
++
++    Returns:
++        The split count capped by the kernel tile width.
++    """
++    return max(1, cdiv(max(int(width), 1), _COMPRESSED_MLA_SPLIT_ALIGNMENT))
++
++
++@cache
++def get_compressed_mla_max_q_chunks(
++    max_rows: int,
++    width: int,
++    max_chunks: int,
++    split_chunks_for_contract: Callable[..., int],
++    decode_row_capacity: int | None = None,
++) -> int:
++    """Return the q-chunk cap over every reachable row count.
++
++    Args:
++        max_rows: Maximum number of query rows in one scheduler step.
++        width: Combined SWA and indexed width.
++        max_chunks: Maximum chunks allowed for each row.
++        split_chunks_for_contract: Kernel contract split-count function.
++        decode_row_capacity: Integration-declared decode/verifier row capacity.
++
++    Returns:
++        The largest reachable product of rows and chunks per row.
++    """
++    max_rows = max(int(max_rows), 1)
++    width = max(int(width), 1)
++    max_chunks = max(int(max_chunks), 1)
++    return max(
++        rows
++        * split_chunks_for_contract(
++            rows=rows,
++            width=width,
++            max_chunks=max_chunks,
++            decode_row_capacity=decode_row_capacity,
++        )
++        for rows in range(1, max_rows + 1)
++    )
+ 
+ 
+ @triton.jit
+@@ -48,15 +134,12 @@ def _compressed_slot_mapping_kernel(
+         else:
+             virtual_block_size = block_size * DCP_WORLD_SIZE
+             block_ids = pos_after_compress // virtual_block_size
+-            virtual_block_offsets = (
+-                pos_after_compress - block_ids * virtual_block_size
+-            )
++            virtual_block_offsets = pos_after_compress - block_ids * virtual_block_size
+             is_local = (
+                 virtual_block_offsets // CP_KV_CACHE_INTERLEAVE_SIZE
+             ) % DCP_WORLD_SIZE == DCP_RANK
+             block_offsets = (
+-                virtual_block_offsets
+-                // (DCP_WORLD_SIZE * CP_KV_CACHE_INTERLEAVE_SIZE)
++                virtual_block_offsets // (DCP_WORLD_SIZE * CP_KV_CACHE_INTERLEAVE_SIZE)
+             ) * CP_KV_CACHE_INTERLEAVE_SIZE + (
+                 virtual_block_offsets % CP_KV_CACHE_INTERLEAVE_SIZE
+             )
+diff --git a/vllm/v1/attention/backends/mla/sparse_swa.py b/vllm/v1/attention/backends/mla/sparse_swa.py
+index 5c23e98d3bb136b3776b1302649e6d3c24897f11..45bdf5d2e6964127e570aacec849c193bb1f34c9 100644
+--- a/vllm/v1/attention/backends/mla/sparse_swa.py
++++ b/vllm/v1/attention/backends/mla/sparse_swa.py
+@@ -17,6 +17,9 @@ from vllm.v1.attention.backend import (
+     CommonAttentionMetadata,
+     MultipleOf,
+ )
++from vllm.v1.attention.backends.mla.compressor_utils import (
++    get_dspark_swa_index_width,
++)
+ from vllm.v1.attention.ops.flashmla import FlashMLASchedMeta, get_mla_metadata
+ from vllm.v1.kv_cache_interface import (
+     KVCacheSpec,
+@@ -416,7 +419,10 @@ class DeepseekSparseSWAMetadataBuilder(AttentionMetadataBuilder):
+         # width. decode_swa_lens keeps the padding out of the attention result.
+         self.is_dspark = spec_config is not None and spec_config.use_dspark()
+         self.noncausal_index_width = (
+-            cdiv(self.window_size + self.num_speculative_tokens, 512) * 512
++            get_dspark_swa_index_width(
++                self.window_size,
++                self.num_speculative_tokens,
++            )
+             if self.is_dspark
+             else 0
+         )
+diff --git a/vllm/v1/attention/ops/dcp_alltoall.py b/vllm/v1/attention/ops/dcp_alltoall.py
+index e371cf22e442a163bce41dcfe046c791ab1323a7..6fc3036ea8bce0f80b241e5a39fbe645842a552e 100644
+--- a/vllm/v1/attention/ops/dcp_alltoall.py
++++ b/vllm/v1/attention/ops/dcp_alltoall.py
+@@ -41,11 +41,14 @@ logger = init_logger(__name__)
+ 
+ _B12X_DCP_A2A_POOLS: dict[tuple[int, int, int, int, int, int], Any] = {}
+ _B12X_DCP_A2A_DISABLED: set[tuple[int, int, int, int, int, int]] = set()
++# DCP likewise has one stable eager scheduler owner.  Graph target/draft/encoder
++# identities are supplied separately by their GraphCaptureContext.
++_B12X_DCP_EAGER_CHANNEL_ID = "vllm:eager:dcp"
++_B12X_DCP_MAX_CONCURRENT_CHANNELS = 2
+ _DCP_A2A_GRAPH_BUFFERS: dict[
+     tuple[tuple[int, ...], torch.device, torch.dtype],
+     tuple[torch.Tensor, torch.Tensor],
+ ] = {}
+-_B12X_DCP_A2A_EAGER_CHANNEL_ID = "eager:vllm-dcp-a2a"
+ 
+ 
+ def _is_supported_bhd_layout(tensor: torch.Tensor) -> bool:
+@@ -54,9 +57,7 @@ def _is_supported_bhd_layout(tensor: torch.Tensor) -> bool:
+         return False
+     batch, heads, head_dim = (int(value) for value in tensor.shape)
+     stride_batch, stride_head, _ = (int(value) for value in tensor.stride())
+-    packed_token_major = (
+-        stride_batch == heads * head_dim and stride_head == head_dim
+-    )
++    packed_token_major = stride_batch == heads * head_dim and stride_head == head_dim
+     capacity_strided_head_major = (
+         stride_batch == head_dim and stride_head >= batch * head_dim
+     )
+@@ -131,9 +132,10 @@ def _get_b12x_dcp_a2a_pool(
+             head_dim=head_dim,
+             query_head_dim=query_head_dim,
+             single_channel=False,
++            max_concurrent_channels=_B12X_DCP_MAX_CONCURRENT_CHANNELS,
+         )
+-        pool.prepare_channels((_B12X_DCP_A2A_EAGER_CHANNEL_ID,))
+-        pool.for_stream(channel_id=_B12X_DCP_A2A_EAGER_CHANNEL_ID)
++        pool.prepare_channels((_B12X_DCP_EAGER_CHANNEL_ID,))
++        pool.for_stream(channel_id=_B12X_DCP_EAGER_CHANNEL_ID)
+     except Exception as exc:
+         init_error = exc
+ 
+@@ -195,6 +197,11 @@ def capture_b12x_dcp_a2a(
+         ),
+         key=lambda item: item[0][1:],
+     )
++    if matching_pools and channel_id is None:
++        raise RuntimeError(
++            "distributed PCIe DCP graph capture requires an explicit semantic "
++            "channel_id"
++        )
+     with ExitStack() as stack:
+         for _, pool in matching_pools:
+             stack.enter_context(pool.capture(stream=stream, channel_id=channel_id))
+@@ -318,7 +325,7 @@ def _try_b12x_dcp_lse_reduce(
+         cp_attn_lse,
+         out=reduced,
+         is_lse_base_on_e=is_lse_base_on_e,
+-        channel_id=_B12X_DCP_A2A_EAGER_CHANNEL_ID,
++        channel_id=_B12X_DCP_EAGER_CHANNEL_ID,
+     )
+ 
+ 
+@@ -371,7 +378,7 @@ def _try_b12x_dcp_all_gather_heads(
+         return None
+     return pool.all_gather_heads(
+         local_input,
+-        channel_id=_B12X_DCP_A2A_EAGER_CHANNEL_ID,
++        channel_id=_B12X_DCP_EAGER_CHANNEL_ID,
+     )
+ 
+ 
+diff --git a/vllm/v1/kv_offload/cpu/gpu_worker.py b/vllm/v1/kv_offload/cpu/gpu_worker.py
+index baf9a66719a05c4d69969406ccf3e64e87bb9693..94448857963e21225c4bd97888e0dc46618c5917 100644
+--- a/vllm/v1/kv_offload/cpu/gpu_worker.py
++++ b/vllm/v1/kv_offload/cpu/gpu_worker.py
+@@ -4,6 +4,7 @@ import functools
+ import time
+ from collections import deque
+ from dataclasses import dataclass
++from math import lcm
+ 
+ import numpy as np
+ import torch
+@@ -23,6 +24,10 @@ from vllm.v1.kv_offload.base import (
+     OffloadingWorker,
+     TransferResult,
+ )
++from vllm.v1.kv_offload.cpu.host_mem_ops import (
++    register_host_memory,
++    unregister_host_memory,
++)
+ from vllm.v1.kv_offload.cpu.shared_offload_region import SharedOffloadRegion
+ from vllm.v1.kv_offload.cpu.swap_blocks_triton import (
+     THRESHOLD_BYTES,
+@@ -31,6 +36,75 @@ from vllm.v1.kv_offload.cpu.swap_blocks_triton import (
+ 
+ logger = init_logger(__name__)
+ 
++HOST_REGISTER_SEGMENT_BYTES = 256 << 20
++HOST_REGISTER_ALIGNMENT_BYTES = 64 << 10
++
++
++def _split_copy_descriptors_at_host_boundaries(
++    src: np.ndarray,
++    dst: np.ndarray,
++    sizes: np.ndarray,
++    count: int,
++    *,
++    host_is_src: bool,
++    host_base: int,
++    segment_bytes: int,
++) -> int:
++    """Split raw copies that cross separately registered host segments.
++
++    ``cuMemcpyBatchAsync`` rejects a single descriptor spanning two adjacent
++    ``cudaHostRegister`` regions. Expand only those descriptors in place;
++    processing backwards keeps unread inputs intact.
++    """
++    assert segment_bytes > 0
++    host_ptrs = src if host_is_src else dst
++    host_offsets = host_ptrs[:count] - host_base
++    copy_sizes = sizes[:count]
++    assert np.all(host_offsets >= 0) and np.all(copy_sizes > 0)
++    part_counts = np.floor_divide(
++        np.remainder(host_offsets, segment_bytes) + copy_sizes + segment_bytes - 1,
++        segment_bytes,
++    )
++    expanded_count = int(part_counts.sum())
++
++    if expanded_count == count:
++        return count
++
++    assert expanded_count <= len(src)
++    write_idx = expanded_count
++    for read_idx in range(count - 1, -1, -1):
++        src_ptr = int(src[read_idx])
++        dst_ptr = int(dst[read_idx])
++        size = int(sizes[read_idx])
++        host_ptr = src_ptr if host_is_src else dst_ptr
++        part_count = int(part_counts[read_idx])
++        if part_count == 1:
++            write_idx -= 1
++            src[write_idx] = src_ptr
++            dst[write_idx] = dst_ptr
++            sizes[write_idx] = size
++            continue
++
++        parts: list[tuple[int, int]] = []
++        copied = 0
++        while copied < size:
++            host_offset = host_ptr + copied - host_base
++            bytes_to_boundary = segment_bytes - host_offset % segment_bytes
++            part_size = min(size - copied, bytes_to_boundary)
++            parts.append((copied, part_size))
++            copied += part_size
++
++        assert len(parts) == part_count
++        write_idx -= len(parts)
++        for part_idx, (offset, part_size) in enumerate(parts):
++            out_idx = write_idx + part_idx
++            src[out_idx] = src_ptr + offset
++            dst[out_idx] = dst_ptr + offset
++            sizes[out_idx] = part_size
++
++    assert write_idx == 0
++    return expanded_count
++
+ 
+ def _select_swap_blocks_fn(
+     kv_cache_groups_data_refs: list[list[CanonicalKVCacheRef]],
+@@ -121,7 +195,12 @@ def compute_sub_block_ptrs(
+ 
+ 
+ def pin_mmap_region(region: SharedOffloadRegion) -> None:
+-    """Register the entire mmap as CUDA pinned memory via cudaHostRegister."""
++    """Register the mmap as CUDA pinned memory.
++
++    Large virtual mappings can be rejected by ``cudaHostRegister`` even when
++    enough host memory is available. Preserve the single-registration fast
++    path, then retry large mappings as bounded, non-overlapping segments.
++    """
+     if not current_platform.is_cuda_alike():
+         logger.info(
+             "Skipping mmap host registration on %s; cudaHostRegister is only "
+@@ -133,21 +212,83 @@ def pin_mmap_region(region: SharedOffloadRegion) -> None:
+     rank = region.rank
+ 
+     base_ptr = region._base.data_ptr()
+-    result = torch.cuda.cudart().cudaHostRegister(base_ptr, region.total_size_bytes, 0)
+-    if result.value != 0:
+-        logger.warning(
+-            "cudaHostRegister failed for rank=%d (code=%d) — "
+-            "transfers will still work but may be slower (unpinned DMA)",
+-            rank,
+-            result,
++    region._registered_host_ptrs.clear()
++    region._host_register_segment_bytes = None
++    result = register_host_memory(base_ptr, region.total_size_bytes)
++    if result != 0:
++        if region.total_size_bytes <= HOST_REGISTER_SEGMENT_BYTES:
++            logger.warning(
++                "cudaHostRegister failed for rank=%d (code=%d); "
++                "transfers will continue with unpinned memory",
++                rank,
++                result,
++            )
++            return
++
++        # Keep every canonical KV row inside one registration. CUDA's batched
++        # memcpy API rejects a descriptor spanning two adjacent registrations.
++        row_stride = region._row_stride
++        # CUDA 13 rejects adjacent registrations when their split offset does
++        # not preserve its 64 KiB host-registration granularity. Align to both
++        # that boundary and a full KV row so neither registration ranges nor
++        # batch-copy descriptors straddle a split.
++        segment_alignment = lcm(row_stride, HOST_REGISTER_ALIGNMENT_BYTES)
++        alignments_per_segment = max(
++            1, HOST_REGISTER_SEGMENT_BYTES // segment_alignment
+         )
+-    else:
+-        logger.debug(
+-            "cudaHostRegister rank=%d %.2f GB",
++        segment_bytes = alignments_per_segment * segment_alignment
++        registered_ptrs: list[int] = []
++        for offset in range(0, region.total_size_bytes, segment_bytes):
++            ptr = base_ptr + offset
++            size = min(
++                segment_bytes,
++                region.total_size_bytes - offset,
++            )
++            segment_result = register_host_memory(ptr, size)
++            if segment_result == 0:
++                registered_ptrs.append(ptr)
++                continue
++
++            for registered_ptr in reversed(registered_ptrs):
++                unregister_result = unregister_host_memory(registered_ptr)
++                if unregister_result != 0:
++                    logger.warning(
++                        "cudaHostUnregister rollback failed for rank=%d "
++                        "ptr=%#x (code=%d)",
++                        rank,
++                        registered_ptr,
++                        unregister_result,
++                    )
++            logger.warning(
++                "Segmented cudaHostRegister failed for rank=%d offset=%d "
++                "size=%d (code=%d); transfers will continue with unpinned memory",
++                rank,
++                offset,
++                size,
++                segment_result,
++            )
++            return
++
++        region._registered_host_ptrs.extend(registered_ptrs)
++        region._host_register_segment_bytes = segment_bytes
++        region.is_pinned = True
++        logger.info(
++            "Registered rank=%d mmap as %d row-aligned host-memory segments "
++            "(segment=%d bytes, total=%.2f GB)",
+             rank,
++            len(registered_ptrs),
++            segment_bytes,
+             region.total_size_bytes / 1e9,
+         )
+-        region.is_pinned = True
++        return
++
++    region._registered_host_ptrs.append(base_ptr)
++    region.is_pinned = True
++    logger.debug(
++        "cudaHostRegister rank=%d %.2f GB",
++        rank,
++        region.total_size_bytes / 1e9,
++    )
+ 
+ 
+ def _new_descriptor_buffers(
+@@ -179,6 +320,8 @@ class SingleDirectionOffloadingHandler:
+         kv_cache_groups_data_refs: list[list[CanonicalKVCacheRef]],
+         gpu_to_cpu: bool,
+         mmap_region: SharedOffloadRegion | None = None,
++        segmented_host_base: int | None = None,
++        segmented_host_bytes: int | None = None,
+     ):
+         """
+         Initialize a SingleDirectionOffloadingHandler.
+@@ -218,6 +361,21 @@ class SingleDirectionOffloadingHandler:
+         self._swap_blocks_batch = _select_swap_blocks_fn(
+             kv_cache_groups_data_refs, gpu_to_cpu
+         )
++        self._segmented_host_base = segmented_host_base
++        self._segmented_host_bytes = segmented_host_bytes
++        assert (segmented_host_base is None) == (segmented_host_bytes is None)
++        page_sizes = [
++            data_ref.page_size_bytes
++            for group in kv_cache_groups_data_refs
++            for data_ref in group
++        ]
++        self._descriptor_capacity_multiplier = 1
++        if segmented_host_base is not None and page_sizes:
++            assert segmented_host_bytes is not None
++            max_page_size = max(page_sizes)
++            self._descriptor_capacity_multiplier = 1 + cdiv(
++                max_page_size - 1, segmented_host_bytes
++            )
+ 
+         # GPU blocks may be smaller
+         # cpu_page_size = gpu_page_size * blocks_per_chunk.
+@@ -287,13 +445,16 @@ class SingleDirectionOffloadingHandler:
+             num_copy_ops += group_size * len(group_data_refs)
+ 
+         # reuse a pooled buffer set, growing it if this transfer needs more room
++        descriptor_capacity = num_copy_ops * self._descriptor_capacity_multiplier
+         batch_src, batch_dst, batch_sizes = (
+             self._buffer_pool.pop()
+             if self._buffer_pool
+-            else _new_descriptor_buffers(num_copy_ops)
++            else _new_descriptor_buffers(descriptor_capacity)
+         )
+-        if batch_src.numel() < num_copy_ops:
+-            batch_src, batch_dst, batch_sizes = _new_descriptor_buffers(num_copy_ops)
++        if batch_src.numel() < descriptor_capacity:
++            batch_src, batch_dst, batch_sizes = _new_descriptor_buffers(
++                descriptor_capacity
++            )
+ 
+         src = batch_src[:num_copy_ops]
+         dst = batch_dst[:num_copy_ops]
+@@ -359,6 +520,21 @@ class SingleDirectionOffloadingHandler:
+         assert dst_offset == num_dst_blocks
+         assert op_idx == num_copy_ops
+ 
++        if self._segmented_host_base is not None and num_copy_ops > 0:
++            assert self._segmented_host_bytes is not None
++            num_copy_ops = _split_copy_descriptors_at_host_boundaries(
++                batch_src.numpy(),
++                batch_dst.numpy(),
++                batch_sizes.numpy(),
++                num_copy_ops,
++                host_is_src=not self.gpu_to_cpu,
++                host_base=self._segmented_host_base,
++                segment_bytes=self._segmented_host_bytes,
++            )
++            src = batch_src[:num_copy_ops]
++            dst = batch_dst[:num_copy_ops]
++            sizes = batch_sizes[:num_copy_ops]
++
+         stream = (
+             self._stream_pool.pop() if self._stream_pool else current_platform.Stream()
+         )
+@@ -480,6 +656,8 @@ class CPUOffloadingWorker(OffloadingWorker):
+         logger.info("Allocating %d CPU tensors...", len(kv_caches.tensors))
+         if mmap_region is not None and pin_memory:
+             pin_mmap_region(mmap_region)
++        segmented_host_base = None
++        segmented_host_bytes = None
+ 
+         gpu_tensors: list[torch.Tensor] = []
+         cpu_tensors: list[torch.Tensor] = []
+@@ -511,6 +689,15 @@ class CPUOffloadingWorker(OffloadingWorker):
+             gpu_tensors.append(gpu_tensor)
+             cpu_tensors.append(cpu_tensor)
+ 
++        if mmap_region is not None and len(mmap_region._registered_host_ptrs) > 1:
++            registration_bytes = mmap_region._host_register_segment_bytes
++            assert registration_bytes is not None
++            # Row-aligned registrations are the zero-overhead fast path. Keep
++            # the descriptor splitter only for alternate layouts.
++            if any(registration_bytes % tensor.stride(0) for tensor in cpu_tensors):
++                segmented_host_base = mmap_region._base.data_ptr()
++                segmented_host_bytes = registration_bytes
++
+         self._store_handler = SingleDirectionOffloadingHandler(
+             gpu_tensors=gpu_tensors,
+             cpu_tensors=cpu_tensors,
+@@ -518,6 +705,8 @@ class CPUOffloadingWorker(OffloadingWorker):
+             kv_cache_groups_data_refs=kv_caches.group_data_refs,
+             gpu_to_cpu=True,
+             mmap_region=mmap_region,
++            segmented_host_base=segmented_host_base,
++            segmented_host_bytes=segmented_host_bytes,
+         )
+ 
+         self._load_handler = SingleDirectionOffloadingHandler(
+@@ -526,6 +715,8 @@ class CPUOffloadingWorker(OffloadingWorker):
+             blocks_per_chunk=blocks_per_chunk,
+             kv_cache_groups_data_refs=kv_caches.group_data_refs,
+             gpu_to_cpu=False,
++            segmented_host_base=segmented_host_base,
++            segmented_host_bytes=segmented_host_bytes,
+         )
+ 
+     def submit_store(
+diff --git a/vllm/v1/kv_offload/cpu/host_mem_ops.py b/vllm/v1/kv_offload/cpu/host_mem_ops.py
+new file mode 100644
+index 0000000000000000000000000000000000000000..a6e6d4f59b89d16161d5fb2e66415f794e69a862
+--- /dev/null
++++ b/vllm/v1/kv_offload/cpu/host_mem_ops.py
+@@ -0,0 +1,65 @@
++# SPDX-License-Identifier: Apache-2.0
++# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
++"""Low-level host-memory registration helpers for CPU KV offload."""
++
++import torch
++
++from vllm.distributed.device_communicators.cuda_wrapper import CudaRTLibrary
++from vllm.platforms import current_platform
++
++
++def _get_cuda_driver():
++    from cuda.bindings import driver
++
++    return driver
++
++
++def register_host_memory(ptr: int, size: int) -> int:
++    """Register host memory and return a CUDA/HIP error code.
++
++    CUDA uses the driver API deliberately. A failed runtime
++    ``cudaHostRegister`` updates the calling thread's last-error state, which
++    can make a later unrelated PyTorch operation fail even when offload falls
++    back to pageable memory. Driver API failures are returned directly and do
++    not contaminate that runtime state.
++
++    Args:
++        ptr: Base address of the host-memory region.
++        size: Region size in bytes.
++
++    Returns:
++        The CUDA or HIP registration error code.
++    """
++    if current_platform.is_cuda():
++        (result,) = _get_cuda_driver().cuMemHostRegister(ptr, size, 0)
++        return int(result.value)
++
++    cudart = torch.cuda.cudart()
++    result = cudart.cudaHostRegister(ptr, size, 0)
++    code = int(result.value)
++    if code != 0:
++        # HIP uses the runtime API, so consume its expected registration error
++        # before the caller continues with pageable memory.
++        CudaRTLibrary().cudaGetLastError()
++    return code
++
++
++def unregister_host_memory(ptr: int) -> int:
++    """Unregister host memory and return a CUDA/HIP error code.
++
++    Args:
++        ptr: Base address passed to :func:`register_host_memory`.
++
++    Returns:
++        The CUDA or HIP unregistration error code.
++    """
++    if current_platform.is_cuda():
++        (result,) = _get_cuda_driver().cuMemHostUnregister(ptr)
++        return int(result.value)
++
++    cudart = torch.cuda.cudart()
++    result = cudart.cudaHostUnregister(ptr)
++    code = int(result.value)
++    if code != 0:
++        CudaRTLibrary().cudaGetLastError()
++    return code
+diff --git a/vllm/v1/kv_offload/cpu/shared_offload_region.py b/vllm/v1/kv_offload/cpu/shared_offload_region.py
+index 290c0d5107d4d7298b0bea86f35608da527f25b1..1fd3594f66578fa1d0a634f88c5b6e8cf4e192e6 100644
+--- a/vllm/v1/kv_offload/cpu/shared_offload_region.py
++++ b/vllm/v1/kv_offload/cpu/shared_offload_region.py
+@@ -1,5 +1,6 @@
+ # SPDX-License-Identifier: Apache-2.0
+ # SPDX-FileCopyrightText: Copyright contributors to the vLLM project
++import contextlib
+ import mmap
+ import os
+ import time
+@@ -8,6 +9,7 @@ import torch
+ 
+ from vllm.logger import init_logger
+ from vllm.platforms import current_platform
++from vllm.v1.kv_offload.cpu.host_mem_ops import unregister_host_memory
+ 
+ logger = init_logger(__name__)
+ 
+@@ -45,16 +47,36 @@ class SharedOffloadRegion:
+         rank: int | None,
+         kv_bytes_per_block: int,
+         cpu_page_size: int,
++        *,
++        unlink_after_workers_map: bool = False,
++        num_workers: int | None = None,
++        prefault: bool = True,
+     ) -> None:
+         self.page_size = mmap.PAGESIZE
+         assert kv_bytes_per_block % self.page_size == 0
++        if unlink_after_workers_map:
++            if num_workers is None or num_workers <= 0:
++                raise ValueError(
++                    "num_workers must be positive when "
++                    "unlink_after_workers_map is enabled"
++                )
++            if rank is not None and not 0 <= rank < num_workers:
++                raise ValueError(f"rank {rank} is outside num_workers={num_workers}")
+ 
+         self.num_blocks = num_blocks
+         self._row_stride = kv_bytes_per_block
+         self.total_size_bytes = self.num_blocks * self._row_stride
+ 
+         self.mmap_path = f"/dev/shm/vllm_offload_{engine_id}.mmap"
++        self._mapping_marker: str | None = None
+         self._creator = False  # set True only if this worker creates the file
++        self.fd: int | None = None
++        self.mmap_obj: mmap.mmap | None = None
++        self._base: torch.Tensor | None = None
++        self._views: list[torch.Tensor] = []
++        self._registered_host_ptrs: list[int] = []
++        self._host_register_segment_bytes: int | None = None
++        self.is_pinned: bool = False
+         self.rank = rank
+         if rank is not None:
+             # byte offset to this worker's first slot within each block row
+@@ -62,60 +84,123 @@ class SharedOffloadRegion:
+             # exclusive upper bound for this worker's area within each row
+             self._worker_area_end = (rank + 1) * cpu_page_size
+         try:
+-            # Exclusive create — only one worker succeeds
+-            self.fd: int | None = os.open(
+-                self.mmap_path, os.O_CREAT | os.O_EXCL | os.O_RDWR, 0o600
+-            )
+-            os.ftruncate(self.fd, self.total_size_bytes)
+-            self._creator = True
+-            logger.info(
+-                "Created mmap file %s (%.2f GB)",
+-                self.mmap_path,
+-                self.total_size_bytes / 1e9,
+-            )
+-        except FileExistsError:
+-            self.fd = os.open(self.mmap_path, os.O_RDWR)
+-            _wait_for_file_size(self.fd, self.total_size_bytes)
+-            logger.info("Opened existing mmap file %s", self.mmap_path)
+-
+-        self.mmap_obj: mmap.mmap | None = mmap.mmap(
+-            self.fd,
+-            self.total_size_bytes,
+-            flags=mmap.MAP_SHARED,
+-            prot=mmap.PROT_READ | mmap.PROT_WRITE,
+-        )
+-
+-        # MADV_POPULATE_WRITE was added in Linux 5.14 (value 23).
+-        _MADV_POPULATE_WRITE = getattr(mmap, "MADV_POPULATE_WRITE", 23)
+-        if rank is not None:
+-            # Populate only this worker's pages (one slot per block row).
+-            worker_offset = rank * cpu_page_size
+-            _t0 = time.perf_counter()
+-            page_size = self.page_size
+-            for block in range(num_blocks):
+-                raw_offset = block * self._row_stride + worker_offset
+-                aligned_offset = (raw_offset // page_size) * page_size
+-                end = raw_offset + cpu_page_size
+-                aligned_length = end - aligned_offset
+-                self.mmap_obj.madvise(
+-                    _MADV_POPULATE_WRITE, aligned_offset, aligned_length
++            try:
++                # Exclusive create — only one worker succeeds.
++                self.fd = os.open(
++                    self.mmap_path, os.O_CREAT | os.O_EXCL | os.O_RDWR, 0o600
+                 )
+-            logger.debug(
+-                "MADV_POPULATE_WRITE loop: %d blocks in %.3f s",
+-                num_blocks,
+-                time.perf_counter() - _t0,
+-            )
+-        else:
+-            # No rank — populate the entire shared region in one call.
+-            _t0 = time.perf_counter()
+-            self.mmap_obj.madvise(_MADV_POPULATE_WRITE, 0, self.total_size_bytes)
+-            logger.debug(
+-                "MADV_POPULATE_WRITE entire region: %.3f s", time.perf_counter() - _t0
++                os.ftruncate(self.fd, self.total_size_bytes)
++                self._creator = True
++                logger.info(
++                    "Created mmap file %s (%.2f GB)",
++                    self.mmap_path,
++                    self.total_size_bytes / 1e9,
++                )
++            except FileExistsError:
++                self.fd = os.open(self.mmap_path, os.O_RDWR)
++                _wait_for_file_size(self.fd, self.total_size_bytes)
++                logger.info("Opened existing mmap file %s", self.mmap_path)
++
++            assert self.fd is not None
++            mmap_obj = mmap.mmap(
++                self.fd,
++                self.total_size_bytes,
++                flags=mmap.MAP_SHARED,
++                prot=mmap.PROT_READ | mmap.PROT_WRITE,
+             )
++            self.mmap_obj = mmap_obj
+ 
+-        self._base = torch.frombuffer(memoryview(self.mmap_obj), dtype=torch.int8)
+-        self._views: list[torch.Tensor] = []
+-        self.is_pinned: bool = False
++            if unlink_after_workers_map and rank is not None:
++                assert num_workers is not None
++                self._unlink_after_worker_mappings(num_workers)
++
++            if prefault:
++                # MADV_POPULATE_WRITE was added in Linux 5.14 (value 23).
++                populate_write = getattr(mmap, "MADV_POPULATE_WRITE", 23)
++                if rank is not None:
++                    # Populate only this worker's pages (one slot per block row).
++                    worker_offset = rank * cpu_page_size
++                    start = time.perf_counter()
++                    page_size = self.page_size
++                    for block in range(num_blocks):
++                        raw_offset = block * self._row_stride + worker_offset
++                        aligned_offset = (raw_offset // page_size) * page_size
++                        end = raw_offset + cpu_page_size
++                        aligned_length = end - aligned_offset
++                        mmap_obj.madvise(populate_write, aligned_offset, aligned_length)
++                    logger.debug(
++                        "MADV_POPULATE_WRITE loop: %d blocks in %.3f s",
++                        num_blocks,
++                        time.perf_counter() - start,
++                    )
++                else:
++                    start = time.perf_counter()
++                    mmap_obj.madvise(populate_write, 0, self.total_size_bytes)
++                    logger.debug(
++                        "MADV_POPULATE_WRITE entire region: %.3f s",
++                        time.perf_counter() - start,
++                    )
++
++            self._base = torch.frombuffer(memoryview(mmap_obj), dtype=torch.int8)
++        except BaseException:
++            self.cleanup()
++            raise
++
++    def _unlink_after_worker_mappings(
++        self, num_workers: int, timeout: float = 30.0
++    ) -> None:
++        """Make the mmap anonymous after every worker has mapped the file.
++
++        The pathname is needed only while workers rendezvous during startup.
++        Once every rank owns a mapping, unlinking is safe: POSIX keeps the
++        pages alive until the last mapping closes and releases them even when
++        a worker is terminated before Python cleanup runs.
++
++        Raises:
++            TimeoutError: If not every worker publishes its mapping marker.
++        """
++        assert self.rank is not None
++        marker_prefix = f"{self.mmap_path}.mapped."
++        marker_path = f"{marker_prefix}{self.rank}"
++        marker_fd = os.open(marker_path, os.O_CREAT | os.O_EXCL | os.O_WRONLY, 0o600)
++        os.close(marker_fd)
++        self._mapping_marker = marker_path
++
++        # Rank 0 is the coordinator, independent of which rank created the
++        # backing file. Other ranks can continue as soon as their mapping is
++        # established; rank 0 keeps the pathname available until all markers
++        # are visible.
++        if self.rank != 0:
++            return
++
++        marker_paths = [f"{marker_prefix}{rank}" for rank in range(num_workers)]
++        try:
++            deadline = time.monotonic() + timeout
++            while not all(os.path.exists(path) for path in marker_paths):
++                if time.monotonic() > deadline:
++                    missing = [
++                        path for path in marker_paths if not os.path.exists(path)
++                    ]
++                    raise TimeoutError(
++                        "Timed out waiting for worker mmap markers: "
++                        + ", ".join(missing)
++                    )
++                time.sleep(0.005)
++
++            try:
++                os.unlink(self.mmap_path)
++                logger.info(
++                    "Unlinked mmap file %s after %d workers mapped it",
++                    self.mmap_path,
++                    num_workers,
++                )
++            except FileNotFoundError:
++                pass
++        finally:
++            for path in marker_paths:
++                with contextlib.suppress(FileNotFoundError):
++                    os.unlink(path)
++            self._mapping_marker = None
+ 
+     def create_next_view(self, tensor_page_size: int) -> torch.Tensor:
+         """Allocate a strided int8 view for this worker, one canonical tensor.
+@@ -140,6 +225,7 @@ class SharedOffloadRegion:
+             tensor_page_size: Bytes per block for this  tensor.
+         """
+         assert self.rank is not None
++        assert self._base is not None
+         new_offset = self._worker_offset + tensor_page_size
+         assert new_offset <= self._worker_area_end, (
+             f"Worker offset {new_offset} exceeds worker area end "
+@@ -162,6 +248,7 @@ class SharedOffloadRegion:
+         Shape: (num_blocks, row_stride_bytes). Secondary tiers address
+         block *b* as ``view[b]``.
+         """
++        assert self._base is not None
+         kv_tensor = self._base.view(self.num_blocks, self._row_stride)
+         np_arr = kv_tensor.numpy()
+         assert np_arr.ctypes.data == self._base.data_ptr(), (
+@@ -173,14 +260,18 @@ class SharedOffloadRegion:
+     def cleanup(self) -> None:
+         if self.is_pinned and self._base is not None:
+             if current_platform.is_cuda_alike():
+-                base_ptr = self._base.data_ptr()
+-                result = torch.cuda.cudart().cudaHostUnregister(base_ptr)
+-                if result.value != 0:
+-                    logger.warning(
+-                        "cudaHostUnregister failed for rank=%d (code=%d)",
+-                        self.rank,
+-                        result,
+-                    )
++                registered_ptrs = self._registered_host_ptrs or [self._base.data_ptr()]
++                for ptr in reversed(registered_ptrs):
++                    result = unregister_host_memory(ptr)
++                    if result != 0:
++                        logger.warning(
++                            "cudaHostUnregister failed for rank=%d ptr=%#x (code=%d)",
++                            self.rank,
++                            ptr,
++                            result,
++                        )
++            self._registered_host_ptrs.clear()
++            self._host_register_segment_bytes = None
+             self.is_pinned = False
+         # Release views before _base: each view holds a _base reference and a
+         # direct StorageImpl reference.  Freeing views first lets both refcounts
+@@ -201,10 +292,16 @@ class SharedOffloadRegion:
+             except Exception:
+                 logger.warning("Failed to close fd %s", self.fd, exc_info=True)
+             self.fd = None
++        if self._mapping_marker is not None:
++            with contextlib.suppress(FileNotFoundError):
++                os.unlink(self._mapping_marker)
++            self._mapping_marker = None
+         if self._creator and getattr(self, "mmap_path", None):
+             try:
+                 os.unlink(self.mmap_path)
+                 logger.info("Removed mmap file %s", self.mmap_path)
++            except FileNotFoundError:
++                pass
+             except Exception:
+                 logger.warning(
+                     "Failed to unlink path %s", self.mmap_path, exc_info=True
+diff --git a/vllm/v1/kv_offload/cpu/spec.py b/vllm/v1/kv_offload/cpu/spec.py
+index f6d1c29aff930bf485354a45478040261fa68205..cbd857670faa5770764ce690044c1f831df0fd1a 100644
+--- a/vllm/v1/kv_offload/cpu/spec.py
++++ b/vllm/v1/kv_offload/cpu/spec.py
+@@ -2,6 +2,7 @@
+ # SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+ from typing import Any
+ 
++import torch
+ from typing_extensions import override
+ 
+ from vllm.platforms import current_platform
+@@ -20,10 +21,11 @@ from vllm.v1.kv_offload.config import OffloadingConfig
+ from vllm.v1.kv_offload.cpu.common import CPUOffloadingMetrics
+ from vllm.v1.kv_offload.cpu.gpu_worker import CPUOffloadingWorker
+ from vllm.v1.kv_offload.cpu.manager import CPUOffloadingManager
++from vllm.v1.kv_offload.cpu.shared_offload_region import SharedOffloadRegion
+ 
+ 
+ class CPUOffloadingSpec(OffloadingSpec):
+-    BLOCK_SIZE_ALIGNMENT = 1
++    BLOCK_SIZE_ALIGNMENT = SharedOffloadRegion.BLOCK_SIZE_ALIGNMENT
+ 
+     @classmethod
+     def build_metric_definitions(
+@@ -133,10 +135,24 @@ class CPUOffloadingSpec(OffloadingSpec):
+         return self._manager
+ 
+     def create_worker(self, kv_caches: CanonicalKVCaches) -> CPUOffloadingWorker:
++        mmap_region: SharedOffloadRegion | None = None
++        if current_platform.is_cuda_alike() and self.num_blocks > 0:
++            world_size = self.config.parallel.world_size
++            rank = torch.accelerator.current_device_index() % world_size
++            mmap_region = SharedOffloadRegion(
++                engine_id=self.config.engine_id,
++                num_blocks=self.num_blocks,
++                rank=rank,
++                kv_bytes_per_block=self.kv_bytes_per_chunk,
++                cpu_page_size=self.cpu_page_size_per_worker,
++                unlink_after_workers_map=True,
++                num_workers=world_size,
++            )
+         return CPUOffloadingWorker(
+             kv_caches=kv_caches,
+             blocks_per_chunk=self.blocks_per_chunk,
+             num_cpu_blocks=self.num_blocks,
++            mmap_region=mmap_region,
+         )
+ 
+     @override
+diff --git a/vllm/v1/kv_offload/tiering/async_lookup.py b/vllm/v1/kv_offload/tiering/async_lookup.py
+index c75a9604009b9a4336e0064aa07f991879541e37..64645bbf4508973a011bda250c3b54c7669560e0 100644
+--- a/vllm/v1/kv_offload/tiering/async_lookup.py
++++ b/vllm/v1/kv_offload/tiering/async_lookup.py
+@@ -172,6 +172,33 @@ class AsyncLookupManager(ABC):
+                 if state is not None:
+                     state.result = result
+ 
++    def invalidate(self, keys: Iterable[OffloadKey]) -> None:
++        """Mark keys as absent so the next lookup() stops reporting a hit.
++
++        A cached ``True`` is only a snapshot of the tier at the time of the
++        existence check; the block can disappear afterwards (evicted by this
++        instance's own capacity management, by another instance sharing
++        ``root_dir``, or by any external cleanup). Nothing else clears the
++        entry until every request that looked the key up has finished, so a
++        transfer that fails on a vanished block would otherwise be retried
++        against the same stale ``True`` on every subsequent step, and the
++        request that is waiting for it never finishes -- a livelock, with the
++        failing job re-submitted forever.
++
++        ``False`` rather than ``None``: a fresh lookup is only ever queued for a
++        key with no state at all, so ``None`` would make lookup() report RETRY
++        forever instead of recomputing. Whether absence is also literally true
++        depends on the tier -- the fs tier's ``load_block`` unlinks any file it
++        could not read, while a failed object-store read leaves the object in
++        place -- but a pessimistic ``False`` is always safe: it costs at most a
++        recompute, and it expires with the requests that looked the key up,
++        after which a fresh existence check can hit again.
++        """
++        for key in keys:
++            state = self._lookup_state.get(key)
++            if state is not None:
++                state.result = False
++
+     def cleanup(self, req_id: str) -> None:
+         """Remove entries no longer needed by any active request.
+ 
+diff --git a/vllm/v1/kv_offload/tiering/fs/gc_manager.py b/vllm/v1/kv_offload/tiering/fs/gc_manager.py
+new file mode 100644
+index 0000000000000000000000000000000000000000..fc4c92e718c93cc74156d5aec26a06af98c296e2
+--- /dev/null
++++ b/vllm/v1/kv_offload/tiering/fs/gc_manager.py
+@@ -0,0 +1,324 @@
++# SPDX-License-Identifier: Apache-2.0
++# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
++"""
++Garbage collection for the fs secondary tier.
++
++The fs tier keeps no index of its own -- the filesystem *is* the index, since
++`lookup()` is a plain existence check -- so out of the box it has neither a
++capacity limit nor eviction, and grows until the filesystem fills.
++
++`FsGCManager` adds both, using file mtime as the single source of truth for
++recency:
++
++  - `touch()` stamps mtime when the scheduler marks a block recently used.
++    `TieringOffloadingManager` calls this on every secondary tier, including
++    for blocks served from the DRAM primary tier -- which never read this
++    tier's files and would otherwise age out while still hot. Reads cannot
++    supply this signal on their own: `store_block` sets mtime once at write
++    time, reads never update file metadata, and `load_block` opens O_DIRECT so
++    a read need not touch the device at all.
++  - A background sweep walks the tree, and when the total exceeds `max_bytes`
++    unlinks in mtime order until it is back under the low watermark.
++
++Keeping recency on disk rather than in a private dict means the ordering
++survives a restart (the fs tier's contents are reusable across runs when
++PYTHONHASHSEED is pinned), the accounting cannot drift from reality since every
++sweep re-measures it, and external tooling (`du`, `find -newermt`, a separate
++reaper) sees the same truth.
++
++Both `touch()` and the sweep run off the scheduler thread. `touch()` is called
++once per request per scheduling attempt with *all* of the request's offload keys
++(~1.9k keys for a 200k-token context), so stamping inline would cost
++milliseconds of syscalls per call and dirty thousands of inodes; instead a key
++is stamped at most once per `stamp_interval_s` and the `os.utime` calls happen
++on a daemon thread.
++
++Deleting a file that a promotion is about to read is not a correctness problem
++-- the failed promotion frees the DRAM block and the tokens get recomputed --
++but it wastes work and silently drops the block from disk, so the sweep protects
++any key with an in-flight job (`protect`/`release`) and any file whose mtime is
++within `grace_s`. Because `stamp_interval_s < grace_s`, every key used within
++`grace_s - stamp_interval_s` is guaranteed to have a protected mtime. That
++margin is eroded by clock skew wherever mtimes are not set by this host's
++clock -- on NFS or a network PVC the server stamps them while the sweep cutoff
++comes from local `time.time()` -- so on shared storage keep it well above the
++sweep duration rather than tightening the two intervals toward each other.
++
++Known limitation: sweeps do not emit KV events. When the owning tier publishes
++BlockStored events (enable_kv_events), a sweep's unlinks have no removed=True
++counterpart, so an external consumer of the event stream can believe evicted
++blocks still exist. Emitting removals would require reconstructing OffloadKeys
++from the swept paths and handing them across threads to the scheduler-owned
++events list -- and the stream would still be incomplete, because failed-load
++unlinks, peer instances sharing root_dir, and external reapers also remove
++files without events. MEDIUM_FS presence events are best-effort by design;
++consumers must tolerate a BlockStored block that is no longer there. This
++instance's own scheduler already does: a failed load invalidates its cached
++lookup and the tokens are recomputed.
++"""
++
++import os
++import threading
++import time
++from collections import OrderedDict
++from collections.abc import Collection, Iterator
++
++from vllm.logger import init_logger
++from vllm.v1.kv_offload.base import OffloadKey
++from vllm.v1.kv_offload.file_mapper import FileMapper
++
++logger = init_logger(__name__)
++
++# Bound the wait so shutdown() stays responsive when no work arrives.
++_WAKE_TIMEOUT_S = 1.0
++
++# Only block files are candidates. In particular `store_block` writes to
++# "<dest>.tmp" before os.replace, and config.json must never be removed. A
++# writer killed mid-store therefore leaks a .tmp that no sweep counts or
++# reaps; the window is one block write wide, so this is bounded in practice.
++_BLOCK_SUFFIX = ".bin"
++
++
++class FsGCManager:
++    """Bounds the fs tier's on-disk size, evicting least-recently-used blocks."""
++
++    def __init__(
++        self,
++        file_mapper: FileMapper,
++        max_bytes: int,
++        low_watermark: float = 0.9,
++        interval_s: float = 60.0,
++        stamp_interval_s: float = 60.0,
++        grace_s: float = 300.0,
++        max_tracked: int = 200_000,
++    ) -> None:
++        if not 0.0 < low_watermark <= 1.0:
++            raise ValueError(f"low_watermark must be in (0, 1], got {low_watermark}")
++        if grace_s <= stamp_interval_s:
++            raise ValueError(
++                f"grace_s ({grace_s}) must exceed stamp_interval_s "
++                f"({stamp_interval_s}), otherwise a block in active use can "
++                f"have an mtime old enough to be swept"
++            )
++
++        self.file_mapper = file_mapper
++        self.max_bytes = max_bytes
++        self.target_bytes = int(max_bytes * low_watermark)
++        self.interval_s = interval_s
++        self.stamp_interval_s = stamp_interval_s
++        self.grace_s = grace_s
++        self.max_tracked = max_tracked
++
++        # Blocks live under a per-rank sibling of the digest directory.
++        self.block_root = f"{file_mapper.base_path}_r{file_mapper.rank}"
++
++        # key -> monotonic time of last stamp, in LRU order so it can be
++        # trimmed. Losing an entry only costs one redundant utime later.
++        self._last_stamped: OrderedDict[OffloadKey, float] = OrderedDict()
++        # Dedup set of keys awaiting a stamp; dict preserves insertion order.
++        self._pending_stamps: dict[OffloadKey, None] = {}
++        # Keys with in-flight store/load jobs, which must not be unlinked.
++        self._protected: dict[OffloadKey, int] = {}
++
++        self._lock = threading.Lock()
++        self._wake = threading.Event()
++        self._stopping = False
++        self._stamped = 0
++        self._stamp_errors = 0
++
++        self._thread = threading.Thread(
++            target=self._run, name="vllm_kv_fs_gc", daemon=True
++        )
++        self._thread.start()
++        logger.info(
++            "fs tier GC enabled: cap %.1f GiB, sweeping to %.1f GiB every %gs "
++            "(mtime tracks last use, so eviction is LRU and survives restarts)",
++            max_bytes / 2**30,
++            self.target_bytes / 2**30,
++            interval_s,
++        )
++
++    # ------------------------------------------------------------------
++    # Scheduler-thread entry points
++    # ------------------------------------------------------------------
++
++    def touch(self, keys: Collection[OffloadKey]) -> None:
++        """Record keys as recently used. Cheap: one dict lookup per key."""
++        now = time.monotonic()
++        with self._lock:
++            if self._stopping:
++                return
++            for key in keys:
++                last = self._last_stamped.get(key)
++                if last is not None and now - last < self.stamp_interval_s:
++                    continue
++                self._last_stamped[key] = now
++                self._last_stamped.move_to_end(key)
++                self._pending_stamps[key] = None
++            while len(self._last_stamped) > self.max_tracked:
++                self._last_stamped.popitem(last=False)
++            has_work = bool(self._pending_stamps)
++        if has_work:
++            self._wake.set()
++
++    def protect(self, keys: Collection[OffloadKey]) -> None:
++        """Pin keys with an in-flight job so the sweep cannot unlink them."""
++        with self._lock:
++            for key in keys:
++                self._protected[key] = self._protected.get(key, 0) + 1
++
++    def release(self, keys: Collection[OffloadKey]) -> None:
++        """Undo one `protect` for each key."""
++        with self._lock:
++            for key in keys:
++                count = self._protected.get(key)
++                if count is None:
++                    continue
++                if count <= 1:
++                    del self._protected[key]
++                else:
++                    self._protected[key] = count - 1
++
++    # ------------------------------------------------------------------
++    # Background thread
++    # ------------------------------------------------------------------
++
++    def _run(self) -> None:
++        next_sweep = time.monotonic() + self.interval_s
++        while True:
++            self._wake.wait(_WAKE_TIMEOUT_S)
++            self._wake.clear()
++
++            with self._lock:
++                stopping = self._stopping
++                batch = list(self._pending_stamps)
++                self._pending_stamps.clear()
++            try:
++                self._stamp(batch)
++            except Exception:
++                # _stamp handles the expected per-key OSError itself; anything
++                # else escaping here would kill this daemon thread and
++                # silently un-bound the tier again, with no signal beyond the
++                # absence of sweep logs.
++                logger.exception("fs tier GC stamping failed")
++
++            if stopping:
++                return
++            now = time.monotonic()
++            if now >= next_sweep:
++                next_sweep = now + self.interval_s
++                try:
++                    self.sweep()
++                except Exception:
++                    logger.exception("fs tier GC sweep failed")
++
++    def _stamp(self, keys: list[OffloadKey]) -> None:
++        for key in keys:
++            # A key legitimately may have no file: the block can live only in
++            # the DRAM primary tier, or its cascade may have failed.
++            try:
++                os.utime(self.file_mapper.get_file_name(key), None)
++                self._stamped += 1
++            except OSError:
++                self._stamp_errors += 1
++
++    def _iter_blocks(self, path: str) -> Iterator[tuple[str, int, float]]:
++        """Yield (path, size, mtime) for every block file under `path`."""
++        try:
++            entries = list(os.scandir(path))
++        except FileNotFoundError:
++            return
++        for entry in entries:
++            try:
++                if entry.is_dir(follow_symlinks=False):
++                    yield from self._iter_blocks(entry.path)
++                elif entry.name.endswith(_BLOCK_SUFFIX):
++                    stat = entry.stat(follow_symlinks=False)
++                    yield entry.path, stat.st_size, stat.st_mtime
++            except OSError:
++                # Raced with a store or another sweep; skip it.
++                continue
++
++    def sweep(self) -> int:
++        """Unlink LRU blocks until under the low watermark. Returns bytes freed."""
++        started = time.monotonic()
++        blocks = list(self._iter_blocks(self.block_root))
++        total = sum(size for _, size, _ in blocks)
++        if total <= self.max_bytes:
++            logger.debug(
++                "fs tier GC: %.2f GiB in %d blocks, under the %.2f GiB cap",
++                total / 2**30,
++                len(blocks),
++                self.max_bytes / 2**30,
++            )
++            return 0
++
++        with self._lock:
++            protected_paths = {
++                self.file_mapper.get_file_name(key) for key in self._protected
++            }
++        cutoff = time.time() - self.grace_s
++
++        blocks.sort(key=lambda block: block[2])
++        freed = 0
++        removed = 0
++        in_flight = 0
++        within_grace = 0
++        for path, size, mtime in blocks:
++            if total - freed <= self.target_bytes:
++                break
++            # Check protection before recency: a block with an in-flight job must
++            # survive however old its mtime is, and the two reasons are worth
++            # telling apart. in_flight > 0 means the grace window alone was not
++            # enough and protect() is doing real work; within_grace > 0 means the
++            # working set itself is at least as large as the cap.
++            if path in protected_paths:
++                in_flight += 1
++                continue
++            if mtime > cutoff:
++                within_grace += 1
++                continue
++            try:
++                os.unlink(path)
++            except OSError:
++                continue
++            freed += size
++            removed += 1
++
++        logger.info(
++            "fs tier GC: %.2f GiB over the %.2f GiB cap, freed %.2f GiB in %d "
++            "blocks, kept %d with jobs in flight and %d used within the %gs "
++            "grace window, now %.2f GiB, took %.2fs",
++            total / 2**30,
++            self.max_bytes / 2**30,
++            freed / 2**30,
++            removed,
++            in_flight,
++            within_grace,
++            self.grace_s,
++            (total - freed) / 2**30,
++            time.monotonic() - started,
++        )
++        return freed
++
++    def shutdown(self) -> None:
++        """Stop the sweep thread. Best-effort, and nothing depends on it.
++
++        The engine reaches this through scheduler -> connector -> tier only if
++        it gets that far: EngineCore.shutdown() tears the executor down first,
++        and the API server's SIGTERM path force-kills the engine core with
++        timeout=0s, so in practice this often does not run at all. That is
++        safe -- the thread is a daemon, mtimes are already committed on disk
++        and sweeps are idempotent -- but it means queued stamps can be dropped
++        (costing at most `stamp_interval_s` of recency) and the summary below
++        should not be relied on as a shutdown signal.
++        """
++        with self._lock:
++            self._stopping = True
++        self._wake.set()
++        self._thread.join(timeout=5.0)
++        logger.info(
++            "fs tier GC stopped (%d mtime stamps, %d failed)",
++            self._stamped,
++            self._stamp_errors,
++        )
+diff --git a/vllm/v1/kv_offload/tiering/fs/manager.py b/vllm/v1/kv_offload/tiering/fs/manager.py
+index f12ef2c6d4d3daddefbc6ced42309e6ff83b7fa4..7229afb640cf91eac4e9ae9b17045acf40460eb3 100644
+--- a/vllm/v1/kv_offload/tiering/fs/manager.py
++++ b/vllm/v1/kv_offload/tiering/fs/manager.py
+@@ -18,7 +18,7 @@ File naming:  <base_path>_r<rank>/<hhh>/<hh>_g<group_idx>/<hash_hex>.bin
+ import functools
+ import json
+ import os
+-from collections.abc import Iterable
++from collections.abc import Collection, Iterable
+ from typing import TYPE_CHECKING, ClassVar
+ 
+ try:
+@@ -49,6 +49,7 @@ from vllm.v1.kv_offload.tiering.base import (
+     ScheduleEndContext,
+     SecondaryTierManager,
+ )
++from vllm.v1.kv_offload.tiering.fs.gc_manager import FsGCManager
+ from vllm.v1.kv_offload.tiering.fs.io import load_block, store_block
+ from vllm.v1.kv_offload.tiering.fs.thread_pool import DualQueueThreadPool
+ 
+@@ -112,6 +113,12 @@ class FileSystemTierManager(SecondaryTierManager):
+         n_write_threads: int = 16,
+         enable_kv_events: bool = False,
+         locality: str | None = None,
++        gc_max_size_gb: float | None = None,
++        gc_low_watermark: float = 0.9,
++        gc_interval_s: float = 60.0,
++        gc_stamp_interval_s: float = 60.0,
++        gc_grace_s: float = 300.0,
++        gc_max_tracked: int = 200_000,
+     ):
+         """
+         Args:
+@@ -127,6 +134,28 @@ class FileSystemTierManager(SecondaryTierManager):
+                 cache events are enabled globally (kv_events_config).
+             locality: Whether this tier's storage is LOCAL or REMOTE relative
+                 to the publishing vLLM instance.
++            gc_max_size_gb: On-disk budget for this tier, in GiB. None (the
++                default) leaves the tier unbounded, as before. When set, a
++                background sweep evicts least-recently-used blocks to stay under
++                it; see FsGCManager. The budget is per engine rather than per
++                rank: the tier is constructed once on the scheduler side
++                (get_manager), so TP and PP ranks share a single
++                <base_path>_r<rank> subtree and a single budget. Engines sharing
++                a root_dir enforce the budget independently over the same
++                subtree and so evict each other's blocks, and blocks written
++                under a different layout fingerprint (a different <base_path>)
++                are never swept at all. Note that sweeps emit no removed=True KV
++                events (see FsGCManager for why), so with enable_kv_events an
++                external consumer must treat BlockStored as best-effort.
++            gc_low_watermark: Fraction of gc_max_size_gb a sweep evicts down to,
++                so eviction is batched rather than continuous.
++            gc_interval_s: Seconds between sweeps.
++            gc_stamp_interval_s: Minimum seconds between mtime stamps of the
++                same block. Must be less than gc_grace_s.
++            gc_grace_s: Blocks used within this many seconds are never swept,
++                which keeps a sweep from racing a promotion that is about to
++                read the file.
++            gc_max_tracked: Cap on keys tracked for the stamp rate limit.
+         """
+         super().__init__(offloading_spec, primary_kv_view, tier_type)
+         self.locality = Locality(locality) if locality is not None else None
+@@ -176,6 +205,23 @@ class FileSystemTierManager(SecondaryTierManager):
+ 
+         self._lookup_manager = FsAsyncLookupManager(tier=self, tier_type=self.tier_type)
+ 
++        # Keys of in-flight load jobs, so a failed load can invalidate the
++        # cached existence results that sent it here.
++        self._load_job_keys: dict[JobId, list[OffloadKey]] = {}
++
++        self._gc_manager: FsGCManager | None = None
++        self._gc_job_keys: dict[JobId, list[OffloadKey]] = {}
++        if gc_max_size_gb is not None:
++            self._gc_manager = FsGCManager(
++                self.file_mapper,
++                max_bytes=int(gc_max_size_gb * 2**30),
++                low_watermark=gc_low_watermark,
++                interval_s=gc_interval_s,
++                stamp_interval_s=gc_stamp_interval_s,
++                grace_s=gc_grace_s,
++                max_tracked=gc_max_tracked,
++            )
++
+     @override
+     def on_new_request(self, req_context: ReqContext) -> RequestOffloadingContext:
+         return RequestOffloadingContext()
+@@ -191,6 +237,7 @@ class FileSystemTierManager(SecondaryTierManager):
+     def submit_store(self, job_metadata: JobMetadata) -> None:
+         if self.events is not None:
+             self._store_job_keys[job_metadata.job_id] = list(job_metadata.keys)
++        self._gc_protect(job_metadata)
+         tasks = (
+             functools.partial(
+                 store_block,
+@@ -205,6 +252,8 @@ class FileSystemTierManager(SecondaryTierManager):
+ 
+     @override
+     def submit_load(self, job_metadata: JobMetadata) -> None:
++        self._gc_protect(job_metadata)
++        self._load_job_keys[job_metadata.job_id] = list(job_metadata.keys)
+         tasks = (
+             functools.partial(
+                 load_block,
+@@ -224,6 +273,18 @@ class FileSystemTierManager(SecondaryTierManager):
+         """
+         results = []
+         for job_id, success in self._pool.get_finished():
++            if self._gc_manager is not None:
++                keys = self._gc_job_keys.pop(job_id, None)
++                if keys is not None:
++                    self._gc_manager.release(keys)
++            load_keys = self._load_job_keys.pop(job_id, None)
++            if load_keys is not None and not success:
++                # The blocks this load needed are gone or unreadable, and
++                # load_block has unlinked whatever it could not read. Drop the
++                # cached existence results so the next lookup reports a miss and
++                # the tokens are recomputed; leaving them cached as present
++                # would re-submit this same failing load on every step.
++                self._lookup_manager.invalidate(load_keys)
+             if self.events is not None:
+                 keys = self._store_job_keys.pop(job_id, None)
+                 if success and keys:
+@@ -256,6 +317,26 @@ class FileSystemTierManager(SecondaryTierManager):
+     def on_schedule_end(self, context: ScheduleEndContext) -> None:
+         self._lookup_manager.flush()
+ 
++    @override
++    def touch(self, keys: Collection[OffloadKey], req_context: ReqContext) -> None:
++        """Refresh on-disk recency so GC evicts least-recently-used blocks.
++
++        Called by TieringOffloadingManager for every tier whenever the scheduler
++        matches a request's blocks -- including blocks served from the DRAM
++        primary tier, which never read this tier's files and would otherwise age
++        out while still hot. No-op unless a GC budget is configured.
++        """
++        if self._gc_manager is not None:
++            self._gc_manager.touch(keys)
++
++    def _gc_protect(self, job_metadata: JobMetadata) -> None:
++        """Pin a job's keys for as long as its transfers are in flight."""
++        if self._gc_manager is None:
++            return
++        keys = list(job_metadata.keys)
++        self._gc_job_keys[job_metadata.job_id] = keys
++        self._gc_manager.protect(keys)
++
+     @override
+     def shutdown(self) -> None:
+         """
+@@ -264,5 +345,7 @@ class FileSystemTierManager(SecondaryTierManager):
+         Shuts down the lookup manager and the thread pool,
+         clearing pending tasks and waiting for active threads to complete.
+         """
++        if self._gc_manager is not None:
++            self._gc_manager.shutdown()
+         self._lookup_manager.shutdown()
+         self._pool.shutdown(wait=True)
+diff --git a/vllm/v1/kv_offload/tiering/obj/manager.py b/vllm/v1/kv_offload/tiering/obj/manager.py
+index f4af8c44c53146918a3677854c96d6e1b3cc4830..c8fb9b7a147be5e7131dca3f7f665a6c2c58eced 100644
+--- a/vllm/v1/kv_offload/tiering/obj/manager.py
++++ b/vllm/v1/kv_offload/tiering/obj/manager.py
+@@ -141,6 +141,9 @@ class ObjectStoreSecondaryTierManager(SecondaryTierManager):
+                 )
+         # Keys of in-flight store jobs, tracked only when events are enabled.
+         self._store_job_keys: dict[JobId, list[OffloadKey]] = {}
++        # Keys of in-flight load jobs, so a failed load can invalidate the
++        # cached existence results that sent it here.
++        self._load_job_keys: dict[JobId, list[OffloadKey]] = {}
+ 
+         agent_config = nixl_agent_config(backends=[])
+         self._agent = nixl_agent("ObjAgent", agent_config)
+@@ -281,6 +284,11 @@ class ObjectStoreSecondaryTierManager(SecondaryTierManager):
+         )
+ 
+     def submit_load(self, job_metadata: JobMetadata) -> None:
++        # Recorded before _submit_transfer so its submission-time failure
++        # paths (register_memory, prep_xfer_dlist, make_prepped_xfer,
++        # transfer) also invalidate the cached lookups that routed this
++        # load here, not just transfers that fail in flight.
++        self._load_job_keys[job_metadata.job_id] = list(job_metadata.keys)
+         obj_keys = (self._file_mapper.get_file_name(k) for k in job_metadata.keys)
+         self._submit_transfer(
+             job_metadata.job_id, job_metadata.block_ids, obj_keys, NIXL_READ
+@@ -323,8 +331,20 @@ class ObjectStoreSecondaryTierManager(SecondaryTierManager):
+         self._poll_active_transfers()
+         results = self._pending_results
+         self._pending_results = []
+-        if self.events is not None:
+-            for result in results:
++        for result in results:
++            load_keys = self._load_job_keys.pop(result.job_id, None)
++            if load_keys is not None and not result.success:
++                # The store no longer answers for these keys (vanished object
++                # or persistently failing read). Drop the cached existence
++                # results so the next lookup reports a miss and the tokens are
++                # recomputed; leaving them cached as present would re-submit
++                # this same failing load on every step. Unlike the fs tier's
++                # load_block, a failed read does not remove the object, so
++                # this can be pessimistic -- but only until the requests that
++                # looked the keys up finish, after which a fresh existence
++                # probe can hit again.
++                self._lookup_manager.invalidate(load_keys)
++            if self.events is not None:
+                 keys = self._store_job_keys.pop(result.job_id, None)
+                 if result.success and keys:
+                     self.events.append(
+diff --git a/vllm/v1/kv_offload/tiering/spec.py b/vllm/v1/kv_offload/tiering/spec.py
+index 964699968c9b7630fd8375e15dbb7bd4dc1e2253..6190b0486af17c9783aae5bc80303727b237e942 100644
+--- a/vllm/v1/kv_offload/tiering/spec.py
++++ b/vllm/v1/kv_offload/tiering/spec.py
+@@ -179,6 +179,10 @@ class TieringOffloadingSpec(CPUOffloadingSpec):
+                 rank=None,
+                 kv_bytes_per_block=self.kv_bytes_per_chunk,
+                 cpu_page_size=self.cpu_page_size_per_worker,
++                # Workers already prefault every row. Repeating that work over
++                # the full region can fail for very large L1 tiers and provides
++                # no benefit to the scheduler's zero-copy secondary-tier view.
++                prefault=False,
+             )
+             self._scheduler_mmap = scheduler_mmap
+ 
+diff --git a/vllm/v1/worker/gpu/cudagraph_utils.py b/vllm/v1/worker/gpu/cudagraph_utils.py
+index 53042f71fda561d6570f37bf4a55e1e3dc66f8fa..1f4cc19e3b4fbf70c26a88f6a9ff5aed7f1d6bfa 100644
+--- a/vllm/v1/worker/gpu/cudagraph_utils.py
++++ b/vllm/v1/worker/gpu/cudagraph_utils.py
+@@ -123,7 +123,6 @@ class CudaGraphManager:
+         decode_query_len: int,
+         lora_capture_cases: list[int] | None = None,
+         varlen_spec_decode: bool = False,
+-        channel_id: str = "graph:vllm-model",
+     ):
+         self.vllm_config = vllm_config
+         self.device = device
+@@ -133,7 +132,6 @@ class CudaGraphManager:
+         self.cudagraph_mode = cudagraph_mode
+         self.decode_query_len = decode_query_len
+         self.varlen_spec_decode = varlen_spec_decode
+-        self.channel_id = channel_id
+ 
+         self.dp_size = vllm_config.parallel_config.data_parallel_size
+         self.tp_size = vllm_config.parallel_config.tensor_parallel_size
+@@ -448,6 +446,8 @@ class CudaGraphManager:
+     def capture(
+         self,
+         create_forward_fn: CreateForwardFn,
++        *,
++        channel_id: str,
+         progress_bar_desc: str = "Capturing CUDA graphs",
+     ) -> None:
+         """Capture CUDA graphs.
+@@ -458,13 +458,14 @@ class CudaGraphManager:
+                 it is invoked once with warmup=True and again with warmup=False
+                 because attention backends may mutate or lazily initialize
+                 metadata during warmup.
++            channel_id: Stable distributed identity for this graph owner.
+         """
+         # Keep event handles created by descriptor warmups alive together with
+         # the graph artifacts captured below. Some multi-stream custom ops run
+         # on joined auxiliary streams where CUDA's per-current-stream capture
+         # query is false even though later graph nodes retain those handles.
+         with (
+-            graph_capture(device=self.device, channel_id=self.channel_id),
++            graph_capture(device=self.device, channel_id=channel_id),
+             vllm_cudagraph_capture_scope(),
+         ):
+             # Capture in order: PIECEWISE first, then FULL. PIECEWISE has larger
+@@ -643,6 +644,8 @@ class ModelCudaGraphManager(CudaGraphManager):
+         has_lora: bool = False,
+         use_aux_hidden_state_outputs: bool = False,
+         lora_capture_hook: Callable[[int, int, int], None] | None = None,
++        *,
++        channel_id: str,
+         progress_bar_desc: str = "Capturing CUDA graphs",
+     ) -> None:
+         """Capture CUDA graphs for model forward pass."""
+@@ -757,7 +760,11 @@ class ModelCudaGraphManager(CudaGraphManager):
+ 
+             return forward_fn
+ 
+-        super().capture(create_forward_fn, progress_bar_desc)
++        super().capture(
++            create_forward_fn,
++            channel_id=channel_id,
++            progress_bar_desc=progress_bar_desc,
++        )
+ 
+     def clear(self) -> None:
+         super().clear()
+diff --git a/vllm/v1/worker/gpu/model_runner.py b/vllm/v1/worker/gpu/model_runner.py
+index 423df0dd2cee33796508f30ca89cd6cd995f6c4b..ea5340100e69745a88e4720edf299d691aac9d17 100644
+--- a/vllm/v1/worker/gpu/model_runner.py
++++ b/vllm/v1/worker/gpu/model_runner.py
+@@ -967,11 +967,12 @@ class GPUModelRunner(LoRAModelRunnerMixin):
+                     has_lora=self.lora_config is not None,
+                     use_aux_hidden_state_outputs=self.use_aux_hidden_state_outputs,
+                     lora_capture_hook=create_lora_capture_hook(self.lora_config, self),
++                    channel_id="vllm:target:profile",
+                     progress_bar_desc="Profiling CUDA graph memory",
+                 )
+                 if self.speculator is not None:
+                     with use_workspace_lane(1):
+-                        self.speculator.capture()
++                        self.speculator.capture(capture_phase="profile")
+                 self._zero_cudagraph_capture_kv_blocks()
+             end_free_gpu_memory = torch.accelerator.get_memory_info()[0]
+             gross_cuda_graph_size = max(start_free_gpu_memory - end_free_gpu_memory, 0)
+@@ -1050,10 +1051,11 @@ class GPUModelRunner(LoRAModelRunnerMixin):
+                     has_lora=self.lora_config is not None,
+                     use_aux_hidden_state_outputs=self.use_aux_hidden_state_outputs,
+                     lora_capture_hook=create_lora_capture_hook(self.lora_config, self),
++                    channel_id="vllm:target:production",
+                 )
+                 if self.speculator is not None:
+                     with use_workspace_lane(1):
+-                        self.speculator.capture()
++                        self.speculator.capture(capture_phase="production")
+                 self._zero_cudagraph_capture_kv_blocks()
+         finally:
+             self._release_cudagraph_pool_anchor()
+diff --git a/vllm/v1/worker/gpu/spec_decode/autoregressive/cudagraph_utils.py b/vllm/v1/worker/gpu/spec_decode/autoregressive/cudagraph_utils.py
+index 19919043c831574b73c8617615a352e885c648f8..c625d91aee8496d3f518361fff2d234ecdf8329a 100644
+--- a/vllm/v1/worker/gpu/spec_decode/autoregressive/cudagraph_utils.py
++++ b/vllm/v1/worker/gpu/spec_decode/autoregressive/cudagraph_utils.py
+@@ -35,6 +35,8 @@ class SpeculatorCudaGraphManager(CudaGraphManager):
+         block_tables: BlockTables,
+         attn_groups: list[list[AttentionGroup]],
+         kv_cache_config: KVCacheConfig,
++        *,
++        channel_id: str,
+         progress_bar_desc: str = "Capturing CUDA graphs",
+     ) -> None:
+         def create_forward_fn(
+@@ -71,4 +73,8 @@ class SpeculatorCudaGraphManager(CudaGraphManager):
+                 cg_mode,
+             )
+ 
+-        super().capture(create_forward_fn, progress_bar_desc)
++        super().capture(
++            create_forward_fn,
++            channel_id=channel_id,
++            progress_bar_desc=progress_bar_desc,
++        )
+diff --git a/vllm/v1/worker/gpu/spec_decode/autoregressive/speculator.py b/vllm/v1/worker/gpu/spec_decode/autoregressive/speculator.py
+index ea21ff9756b3ae6392558a3d7308575acb697419..d9ab74a28fb9bd1d0f288829f35a5446c5185255 100644
+--- a/vllm/v1/worker/gpu/spec_decode/autoregressive/speculator.py
++++ b/vllm/v1/worker/gpu/spec_decode/autoregressive/speculator.py
+@@ -21,7 +21,10 @@ from vllm.v1.worker.gpu.input_batch import InputBatch, InputBuffers
+ from vllm.v1.worker.gpu.spec_decode.autoregressive.cudagraph_utils import (
+     SpeculatorCudaGraphManager,
+ )
+-from vllm.v1.worker.gpu.spec_decode.speculator import DraftModelSpeculator
++from vllm.v1.worker.gpu.spec_decode.speculator import (
++    CUDAGraphCapturePhase,
++    DraftModelSpeculator,
++)
+ 
+ logger = init_logger(__name__)
+ 
+@@ -71,7 +74,6 @@ class AutoRegressiveSpeculator(DraftModelSpeculator):
+             self.device,
+             cudagraph_mode,
+             self.num_speculative_steps + 1,
+-            channel_id="graph:vllm-speculator-prefill",
+         )
+ 
+         # PIECEWISE cudagraphs are not supported for draft decodes.
+@@ -86,10 +88,9 @@ class AutoRegressiveSpeculator(DraftModelSpeculator):
+             self.device,
+             cudagraph_mode,
+             decode_query_len=1,
+-            channel_id="graph:vllm-speculator-decode",
+         )
+ 
+-    def capture(self) -> None:
++    def capture(self, *, capture_phase: CUDAGraphCapturePhase) -> None:
+         logger.info("Capturing model for speculator...")
+         # Reset indices to zeros to prevent stale values from prior
+         # dummy runs to cause out-of-bounds indexing during capture.
+@@ -113,6 +114,7 @@ class AutoRegressiveSpeculator(DraftModelSpeculator):
+             self.block_tables,
+             self.target_attn_groups,
+             self.kv_cache_config,
++            channel_id=f"vllm:draft:prefill:{capture_phase}",
+             progress_bar_desc="Capturing prefill CUDA graphs",
+         )
+ 
+@@ -130,6 +132,7 @@ class AutoRegressiveSpeculator(DraftModelSpeculator):
+             self.block_tables,
+             self.attn_groups,
+             self.kv_cache_config,
++            channel_id=f"vllm:draft:decode:{capture_phase}",
+             progress_bar_desc="Capturing decode CUDA graphs",
+         )
+ 
+diff --git a/vllm/v1/worker/gpu/spec_decode/dflash/cudagraph.py b/vllm/v1/worker/gpu/spec_decode/dflash/cudagraph.py
+index 5b36fee76eb227cd735648b9e31ac97ff1aabbec..21165755a8343e03ab1cf088c5e662b4255d9210 100644
+--- a/vllm/v1/worker/gpu/spec_decode/dflash/cudagraph.py
++++ b/vllm/v1/worker/gpu/spec_decode/dflash/cudagraph.py
+@@ -4,6 +4,7 @@ from collections.abc import Callable, Mapping
+ 
+ import torch
+ 
++from vllm.config import VllmConfig
+ from vllm.config.compilation import CUDAGraphMode
+ from vllm.v1.kv_cache_interface import KVCacheConfig
+ from vllm.v1.worker.gpu.attn_utils import (
+@@ -72,6 +73,8 @@ class DFlashCudaGraphManager(CudaGraphManager):
+         kv_cache_config: KVCacheConfig,
+         max_model_len: int,
+         causal: bool | Mapping[int, bool],
++        *,
++        channel_id: str,
+         progress_bar_desc: str = "Capturing CUDA graphs",
+     ) -> None:
+         def create_forward_fn(
+@@ -108,4 +111,106 @@ class DFlashCudaGraphManager(CudaGraphManager):
+                 num_query_per_req=desc.uniform_token_count,
+             )
+ 
+-        super().capture(create_forward_fn, progress_bar_desc)
++        super().capture(
++            create_forward_fn,
++            channel_id=channel_id,
++            progress_bar_desc=progress_bar_desc,
++        )
++
++
++class DFlashContextCudaGraphManager(CudaGraphManager):
++    """CUDA graphs for the variable-size DFlash context-KV projection.
++
++    The draft-query graph is keyed by request count, while the context rows
++    depend on how many target tokens survived verification. Keeping a second
++    manager avoids padding every request to the full speculative width. Each
++    real row count is mapped to the smallest configured capture bucket.
++    """
++
++    def _init_candidates(self) -> None:
++        capture_sizes = self.compilation_config.cudagraph_capture_sizes
++        if not (self.cudagraph_mode and capture_sizes):
++            return
++
++        max_capture_size = self.compilation_config.max_cudagraph_capture_size
++        capture_sizes = sorted(
++            {
++                size
++                for size in capture_sizes
++                if 0 < size <= self.max_num_context_tokens and size <= max_capture_size
++            }
++        )
++        if not capture_sizes:
++            return
++
++        descs = [
++            BatchExecutionDescriptor(
++                cg_mode=CUDAGraphMode.FULL,
++                num_tokens=size,
++                num_reqs=None,
++            )
++            for size in reversed(capture_sizes)
++        ]
++        self._capture_descs[CUDAGraphMode.FULL] = descs
++
++        self._context_candidates = {}
++        previous = 0
++        for size in capture_sizes:
++            desc = BatchExecutionDescriptor(
++                cg_mode=CUDAGraphMode.FULL,
++                num_tokens=size,
++                num_reqs=None,
++            )
++            for num_tokens in range(previous + 1, size + 1):
++                self._context_candidates[num_tokens] = desc
++            previous = size
++
++    def __init__(
++        self,
++        vllm_config: VllmConfig,
++        device: torch.device,
++        max_num_context_tokens: int,
++    ) -> None:
++        self.max_num_context_tokens = max_num_context_tokens
++        self._context_candidates: dict[int, BatchExecutionDescriptor] = {}
++        super().__init__(
++            vllm_config,
++            device,
++            CUDAGraphMode.FULL_DECODE_ONLY,
++            decode_query_len=1,
++        )
++
++    def dispatch_context(self, num_tokens: int) -> BatchExecutionDescriptor:
++        if self._graphs_captured:
++            desc = self._context_candidates.get(num_tokens)
++            if desc is not None:
++                return desc
++        return BatchExecutionDescriptor(
++            cg_mode=CUDAGraphMode.NONE,
++            num_tokens=num_tokens,
++            num_reqs=None,
++        )
++
++    def capture_context(
++        self,
++        forward_fn: Callable[[int], None],
++        *,
++        channel_id: str,
++    ) -> None:
++        def create_forward_fn(
++            desc: BatchExecutionDescriptor,
++            warmup: bool,
++        ) -> Callable[[CUDAGraphMode], None]:
++            del warmup
++
++            def run_context(cg_mode: CUDAGraphMode) -> None:
++                del cg_mode
++                forward_fn(desc.num_tokens)
++
++            return run_context
++
++        super().capture(
++            create_forward_fn,
++            channel_id=channel_id,
++            progress_bar_desc="Capturing DFlash context-KV CUDA graphs",
++        )
+diff --git a/vllm/v1/worker/gpu/spec_decode/dflash/speculator.py b/vllm/v1/worker/gpu/spec_decode/dflash/speculator.py
+index a3cefda68bfb53aa4677d028b1ae6329bdab44b0..b997f045b9d28b115f9bc88574458d8448615592 100644
+--- a/vllm/v1/worker/gpu/spec_decode/dflash/speculator.py
++++ b/vllm/v1/worker/gpu/spec_decode/dflash/speculator.py
+@@ -27,15 +27,25 @@ from vllm.v1.attention.backends.utils import PAD_SLOT_ID
+ from vllm.v1.kv_cache_interface import KVCacheConfig
+ from vllm.v1.worker.gpu.attn_utils import build_slot_mappings_by_layer
+ from vllm.v1.worker.gpu.block_table import BlockTables
++from vllm.v1.worker.gpu.cudagraph_utils import (
++    BatchExecutionDescriptor,
++    CudaGraphManager,
++)
+ from vllm.v1.worker.gpu.dp_utils import dispatch_cg_and_sync_dp
+ from vllm.v1.worker.gpu.input_batch import InputBatch, InputBuffers
+ from vllm.v1.worker.gpu.model_states.interface import ModelState
+-from vllm.v1.worker.gpu.spec_decode.dflash.cudagraph import DFlashCudaGraphManager
++from vllm.v1.worker.gpu.spec_decode.dflash.cudagraph import (
++    DFlashContextCudaGraphManager,
++    DFlashCudaGraphManager,
++)
+ from vllm.v1.worker.gpu.spec_decode.dflash.utils import (
+     load_dflash_model,
+     maybe_load_mask_embedding,
+ )
+-from vllm.v1.worker.gpu.spec_decode.speculator import DraftModelSpeculator
++from vllm.v1.worker.gpu.spec_decode.speculator import (
++    CUDAGraphCapturePhase,
++    DraftModelSpeculator,
++)
+ from vllm.v1.worker.gpu.spec_decode.utils import get_parallel_drafting_token_id
+ from vllm.v1.worker.utils import AttentionGroup
+ 
+@@ -128,6 +138,7 @@ class DFlashSpeculator(DraftModelSpeculator):
+         ).repeat(self.max_num_reqs)
+ 
+         self.query_cudagraph_manager: DFlashCudaGraphManager | None = None
++        self.context_cudagraph_manager: DFlashContextCudaGraphManager | None = None
+         self.draft_kv_cache_group_id: int = -1
+         # Manual CUDA graphs keep raw addresses for model intermediates. Retain
+         # each captured backbone output so its storage cannot be recycled while
+@@ -182,10 +193,15 @@ class DFlashSpeculator(DraftModelSpeculator):
+             self.device,
+             cudagraph_mode,
+             decode_query_len=self.num_query_per_req,
+-            channel_id="graph:vllm-dflash-query",
+         )
++        if wants_full and supports_full and self._speculator_name == "DSpark":
++            self.context_cudagraph_manager = DFlashContextCudaGraphManager(
++                self.vllm_config,
++                self.device,
++                max_num_context_tokens=self.max_num_tokens,
++            )
+ 
+-    def capture(self) -> None:
++    def capture(self, *, capture_phase: CUDAGraphCapturePhase) -> None:
+         logger.info("Capturing model for %s speculator...", self._speculator_name)
+         # Reset sampling indices to prevent stale values from prior dummy runs
+         # from being baked into the captured graph. Mapping rows stay inert.
+@@ -201,13 +217,24 @@ class DFlashSpeculator(DraftModelSpeculator):
+             self.kv_cache_config,
+             self.max_model_len,
+             causal=self._group_causal,
++            channel_id=f"vllm:draft:dflash:{capture_phase}",
+             progress_bar_desc=f"Capturing {self._speculator_name.lower()} CUDA graphs",
+         )
++        if self.context_cudagraph_manager is not None:
++            self._context_slot_mappings.fill_(PAD_SLOT_ID)
++            self.context_positions.zero_()
++            self.context_cudagraph_manager.capture_context(
++                self._capture_context_kv,
++                channel_id=f"vllm:draft:dflash:context:{capture_phase}",
++            )
+ 
+-    def get_cudagraph_managers(self) -> tuple[DFlashCudaGraphManager, ...]:
+-        if self.query_cudagraph_manager is None:
+-            return ()
+-        return (self.query_cudagraph_manager,)
++    def get_cudagraph_managers(self) -> tuple[CudaGraphManager, ...]:
++        managers: list[CudaGraphManager] = []
++        if self.query_cudagraph_manager is not None:
++            managers.append(self.query_cudagraph_manager)
++        if self.context_cudagraph_manager is not None:
++            managers.append(self.context_cudagraph_manager)
++        return tuple(managers)
+ 
+     def clear_cudagraphs(self) -> None:
+         super().clear_cudagraphs()
+@@ -372,9 +399,9 @@ class DFlashSpeculator(DraftModelSpeculator):
+         )
+ 
+         # Per-group context slot buffers for the precompute (one row per group).
+-        self._context_slot_mappings = torch.zeros(
+-            len(self.draft_kv_cache_group_ids),
+-            self.max_num_tokens,
++        self._context_slot_mappings = torch.full(
++            (len(self.draft_kv_cache_group_ids), self.max_num_tokens),
++            PAD_SLOT_ID,
+             dtype=torch.int64,
+             device=self.device,
+         )
+@@ -430,6 +457,40 @@ class DFlashSpeculator(DraftModelSpeculator):
+             )
+         return last_hidden_states
+ 
++    def _context_slots_for_layers(
++        self,
++        num_tokens: int,
++    ) -> torch.Tensor | list[torch.Tensor]:
++        if self._layer_group_idx is not None:
++            return [
++                self._context_slot_mappings[gidx][:num_tokens]
++                for gidx in self._layer_group_idx
++            ]
++        return self._context_slot_mappings[0][:num_tokens]
++
++    def _capture_context_kv(self, num_tokens: int) -> None:
++        self.model.precompute_and_store_context_kv(
++            self.hidden_states[:num_tokens],
++            self.context_positions[:num_tokens],
++            self._context_slots_for_layers(num_tokens),
++        )
++
++    def _precompute_context_kv(
++        self,
++        num_target_tokens: int,
++        batch_desc: BatchExecutionDescriptor,
++        context_slots: torch.Tensor | list[torch.Tensor | None] | None,
++    ) -> None:
++        if batch_desc.cg_mode == CUDAGraphMode.FULL:
++            assert self.context_cudagraph_manager is not None
++            self.context_cudagraph_manager.run_fullgraph(batch_desc)
++            return
++        self.model.precompute_and_store_context_kv(
++            self.hidden_states[:num_target_tokens],
++            self.context_positions[:num_target_tokens],
++            context_slots,
++        )
++
+     def _generate_draft(
+         self,
+         num_reqs: int,
+@@ -594,6 +655,17 @@ class DFlashSpeculator(DraftModelSpeculator):
+         # The query slot mapping is written into the shared BlockTables slot_mappings.
+         # That buffer's address is what the captured CUDA graph reads from at replay.
+         assert self.draft_kv_cache_group_id >= 0
++        if self.context_cudagraph_manager is not None and not (dummy_run or is_profile):
++            context_batch_desc = self.context_cudagraph_manager.dispatch_context(
++                num_target_tokens
++            )
++        else:
++            context_batch_desc = BatchExecutionDescriptor(
++                cg_mode=CUDAGraphMode.NONE,
++                num_tokens=num_target_tokens,
++                num_reqs=None,
++            )
++        context_num_tokens_padded = context_batch_desc.num_tokens
+         # Support multiple draft KV cache groups by preparing inputs once for each
+         for i, gid in enumerate(self.draft_kv_cache_group_ids):
+             prepare_dflash_inputs(
+@@ -619,6 +691,7 @@ class DFlashSpeculator(DraftModelSpeculator):
+                 self.max_num_tokens,
+                 self.max_model_len,
+                 self.sample_from_anchor,
++                context_num_tokens_padded=context_num_tokens_padded,
+             )
+ 
+         # Cache-restored tokens (e.g. prefix-cache hits) never flowed through
+@@ -642,9 +715,8 @@ class DFlashSpeculator(DraftModelSpeculator):
+                     self.block_tables.kernel_block_sizes[gid],
+                 )
+ 
+-        # Pre-insert context K/V into the cache. Runs eagerly outside the captured graph
+-        # because the context shape varies per step. During dummy runs the block tables
+-        # are placeholders, so we skip the cache write to avoid clobbering real entries.
++        # Pre-insert context K/V into the cache. Decode replays a row-bucketed
++        # FULL graph; profiling, dummy, and out-of-envelope shapes remain eager.
+         # Each layer uses the context slots of its own kv-cache group.
+         if dummy_run:
+             context_slots: torch.Tensor | list[torch.Tensor | None] | None = None
+@@ -655,9 +727,9 @@ class DFlashSpeculator(DraftModelSpeculator):
+             ]
+         else:
+             context_slots = self._context_slot_mappings[0][:num_target_tokens]
+-        self.model.precompute_and_store_context_kv(
+-            self.hidden_states[:num_target_tokens],
+-            self.context_positions[:num_target_tokens],
++        self._precompute_context_kv(
++            num_target_tokens,
++            context_batch_desc,
+             context_slots,
+         )
+ 
+@@ -746,6 +818,7 @@ def _prepare_dflash_inputs_kernel(
+     max_num_reqs,
+     max_num_tokens,
+     max_model_len,
++    context_num_tokens_padded,
+     SAMPLE_FROM_ANCHOR: tl.constexpr,
+     PAD_SLOT_ID: tl.constexpr,
+     BLOCK_SIZE: tl.constexpr,
+@@ -897,6 +970,13 @@ def _prepare_dflash_inputs_kernel(
+                 tl.store(out_input_ids_ptr + block, 0, mask=mask)
+                 tl.store(out_query_positions_ptr + block, 0, mask=mask)
+                 tl.store(out_query_slot_mapping_ptr + block, PAD_SLOT_ID, mask=mask)
++            # Context-KV graphs round the actual target rows up to a capture
++            # bucket. Keep padded rows in-range and suppress their cache writes.
++            for i in range(ctx_end, context_num_tokens_padded, BLOCK_SIZE):
++                block = i + tl.arange(0, BLOCK_SIZE)
++                mask = block < context_num_tokens_padded
++                tl.store(out_context_positions_ptr + block, 0, mask=mask)
++                tl.store(out_context_slot_mapping_ptr + block, PAD_SLOT_ID, mask=mask)
+ 
+ 
+ def prepare_dflash_inputs(
+@@ -928,6 +1008,7 @@ def prepare_dflash_inputs(
+     max_num_tokens: int,
+     max_model_len: int,
+     sample_from_anchor: bool = False,
++    context_num_tokens_padded: int | None = None,
+ ) -> None:
+     num_reqs = input_batch.num_reqs
+     assert num_reqs > 0
+@@ -937,6 +1018,15 @@ def prepare_dflash_inputs(
+     max_tokens_per_req = max_target_query_len + num_query_per_req
+     BLOCK_SIZE = min(256, triton.next_power_of_2(max(1, max_tokens_per_req)))
+     num_blocks = triton.cdiv(max_tokens_per_req, BLOCK_SIZE)
++    num_context_tokens = int(input_batch.num_scheduled_tokens.sum())
++    if context_num_tokens_padded is None:
++        context_num_tokens_padded = num_context_tokens
++    if not num_context_tokens <= context_num_tokens_padded <= max_num_tokens:
++        raise ValueError(
++            "DFlash context graph padding must cover the actual context rows "
++            f"without exceeding the input buffer: actual={num_context_tokens}, "
++            f"padded={context_num_tokens_padded}, max={max_num_tokens}."
++        )
+     _prepare_dflash_inputs_kernel[(num_reqs, num_blocks)](
+         input_buffers.input_ids,
+         input_buffers.positions,
+@@ -965,6 +1055,7 @@ def prepare_dflash_inputs(
+         max_num_reqs,
+         max_num_tokens,
+         max_model_len,
++        context_num_tokens_padded,
+         SAMPLE_FROM_ANCHOR=sample_from_anchor,
+         PAD_SLOT_ID=PAD_SLOT_ID,
+         BLOCK_SIZE=BLOCK_SIZE,
+diff --git a/vllm/v1/worker/gpu/spec_decode/speculator.py b/vllm/v1/worker/gpu/spec_decode/speculator.py
+index 0784f580ac0106849ec5f56aa6750d3784979695..a59cd1270bdd030f2beed072d5f1f4b726d6d916 100644
+--- a/vllm/v1/worker/gpu/spec_decode/speculator.py
++++ b/vllm/v1/worker/gpu/spec_decode/speculator.py
+@@ -2,7 +2,7 @@
+ # SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+ from abc import ABC, abstractmethod
+ from collections.abc import Mapping
+-from typing import TYPE_CHECKING, Any
++from typing import TYPE_CHECKING, Any, Literal
+ 
+ import torch
+ import torch.nn as nn
+@@ -32,6 +32,8 @@ if TYPE_CHECKING:
+ 
+ logger = init_logger(__name__)
+ 
++CUDAGraphCapturePhase = Literal["profile", "production"]
++
+ 
+ class BaseSpeculator(ABC):
+     # Draft-token capacity surface, implemented by speculators with a
+@@ -51,7 +53,7 @@ class BaseSpeculator(ABC):
+         pass
+ 
+     @abstractmethod
+-    def capture(self) -> None:
++    def capture(self, *, capture_phase: CUDAGraphCapturePhase) -> None:
+         pass
+ 
+     def get_cudagraph_managers(self) -> tuple["CudaGraphManager", ...]:
+diff --git a/vllm/v1/worker/gpu_model_runner.py b/vllm/v1/worker/gpu_model_runner.py
+index f6053f52bb01f21fc9dd131c183d758d504128ee..7d1216710fd4a4e7e6ac5c13b17934d04aa273ab 100644
+--- a/vllm/v1/worker/gpu_model_runner.py
++++ b/vllm/v1/worker/gpu_model_runner.py
+@@ -44,12 +44,14 @@ from vllm.distributed.kv_transfer import get_kv_transfer_group, has_kv_transfer_
+ from vllm.distributed.kv_transfer.kv_connector.utils import copy_kv_blocks
+ from vllm.distributed.parallel_state import (
+     GraphCaptureContext,
++    checkpoint_b12x_graph_channels,
+     get_dcp_group,
+     get_pp_group,
+     get_tp_group,
+     graph_capture,
+     is_global_first_rank,
+     prepare_communication_buffer_for_model,
++    rollback_b12x_graph_channels,
+ )
+ from vllm.forward_context import (
+     BatchDescriptor,
+@@ -4643,11 +4645,7 @@ class GPUModelRunner(
+             )
+             # Whether the drafter runs a GPU model forward (and thus carries
+             # TP/EP/DP collectives), independent of padded-batch timing.
+-            drafter_runs_model_forward = (
+-                spec_config.use_eagle()
+-                or spec_config.uses_draft_model()
+-                or spec_config.uses_extract_hidden_states()
+-            )
++            drafter_runs_model_forward = self._drafter_runs_model_forward()
+             use_gpu_toks = (
+                 drafter_runs_model_forward
+                 and not spec_config.disable_padded_drafter_batch
+@@ -5845,6 +5843,7 @@ class GPUModelRunner(
+         profile_seq_lens: int | None = None,
+         include_mm_inputs: bool = True,
+         single_request_prefill: bool = False,
++        run_drafter: bool = True,
+     ) -> tuple[torch.Tensor, torch.Tensor]:
+         """
+         Run a dummy forward pass to warm up/profile run or capture the
+@@ -5878,6 +5877,7 @@ class GPUModelRunner(
+             single_request_prefill: If True, create one prefill request with
+                 `num_tokens` tokens. This covers text-only single-request
+                 prefill kernels without keying warmup on a live prompt length.
++            run_drafter: Whether to execute the draft-model portion of the run.
+         """
+         mm_config = self.vllm_config.model_config.multimodal_config
+         if mm_config and mm_config.mm_encoder_only:
+@@ -6177,11 +6177,7 @@ class GPUModelRunner(
+             else:
+                 hidden_states = outputs
+ 
+-            if self.speculative_config and (
+-                self.speculative_config.use_eagle()
+-                or self.speculative_config.uses_draft_model()
+-                or self.speculative_config.uses_extract_hidden_states()
+-            ):
++            if run_drafter and self._drafter_runs_model_forward():
+                 assert isinstance(
+                     self.drafter,
+                     EagleProposer
+@@ -6672,7 +6668,7 @@ class GPUModelRunner(
+ 
+         saved_num_cudagraph_captured = compilation_counter.num_cudagraph_captured
+ 
+-        capture_descs = self.cudagraph_dispatcher.get_capture_descs()
++        capture_descs = list(self.cudagraph_dispatcher.get_capture_descs())
+         # Use a temporary manager for memory profiling. The persistent manager
+         # is initialized later so it does not keep profiling-only graph state.
+         encoder_cudagraph_manager = self._create_encoder_cudagraph_manager()
+@@ -6715,88 +6711,117 @@ class GPUModelRunner(
+             original_pools[id(instance)] = instance.graph_pool
+             instance.graph_pool = profiling_pool
+ 
+-        shared_memory_estimate = {}
+-        per_graph_estimate = {}
++        shared_memory_estimate: dict[CUDAGraphMode, int] = {}
++        per_graph_estimate: dict[CUDAGraphMode, int] = {}
+         encoder_memory_estimate = 0
+ 
+-        # On ROCm, capture these throwaway profiling graphs on vLLM's dedicated
+-        # compute stream instead of the fresh side stream graph_capture()
+-        # allocates by default. torch's allocator pools free blocks per stream,
+-        # so a side-stream forward strands a persistent aiter scratch buffer in
+-        # a separate pool, shifting the physical placement of the real KV cache
+-        # allocated afterward and slowing bandwidth-bound decode ~20%. The
+-        # graphs are discarded, so a side stream is unnecessary here.
+-        # Use current_stream(), not torch.cuda.current_stream(): before vLLM
+-        # initializes its dedicated stream, torch returns the per-thread default
+-        # stream (cuda_stream=0), which cannot be used for cudagraph capture.
+-        # cap_ctx=None keeps the side-stream path on CUDA.
+-        cap_ctx = (
+-            GraphCaptureContext(
+-                current_stream(),
+-                channel_id="graph:vllm-model",
+-            )
+-            if current_platform.is_rocm()
+-            else None
+-        )
+-
+         # Cleanup-only guard: CUDA graph capture errors should still propagate
+         # because encoder graph capture is opt-in.
++        graph_channel_checkpoints: tuple[tuple[Callable[[Any], None], Any], ...] = ()
+         try:
++            graph_channel_checkpoints = checkpoint_b12x_graph_channels()
+             set_cudagraph_capturing_enabled(True)
+-            with (
+-                self._freeze_gc(),
+-                graph_capture(
+-                    device=self.device,
+-                    graph_capture_context=cap_ctx,
+-                    channel_id="graph:vllm-model",
+-                ),
+-            ):
+-                torch.accelerator.synchronize()
+-                torch.accelerator.empty_cache()
+-
+-                for mode, descs in capture_descs:
+-                    profile_descs = descs[:2]
+-                    mem_samples: list[int] = []
+-
+-                    for i, desc in enumerate(profile_descs):
+-                        mem_before = torch.accelerator.get_memory_info()[0]
+-                        self._warmup_and_capture(
+-                            desc,
+-                            cudagraph_runtime_mode=mode,
+-                            profile_seq_lens=(
+-                                min(
+-                                    self.max_model_len,
+-                                    self.max_num_tokens // desc.num_tokens,
+-                                )
+-                                if mode == CUDAGraphMode.FULL and i == 0
+-                                else None
+-                            ),
++            with self._freeze_gc():
++                for component, channel_id in (
++                    ("target", "vllm:target:profile"),
++                    ("draft", "vllm:draft:profile"),
++                ):
++                    component_descs = [
++                        (mode, descs)
++                        for mode, descs in capture_descs
++                        if descs
++                        and (
++                            component == "target"
++                            or self._captures_independent_drafter_graphs(mode)
+                         )
+-                        torch.accelerator.synchronize()
+-                        free_after = torch.accelerator.get_memory_info()[0]
+-                        mem_samples.append(mem_before - free_after)
++                    ]
++                    if not component_descs:
++                        continue
+ 
+-                    first_capture = mem_samples[0]
+-                    # Use at least 1 MiB per graph for driver overhead
+-                    per_graph = max(
+-                        mem_samples[1] if len(mem_samples) > 1 else 0, 1 << 20
++                    # ROCm profiles on vLLM's dedicated compute stream to avoid
++                    # stranding allocator pages in a disposable side stream.
++                    cap_ctx = (
++                        GraphCaptureContext(current_stream(), channel_id=channel_id)
++                        if current_platform.is_rocm()
++                        else None
+                     )
++                    with graph_capture(
++                        device=self.device,
++                        graph_capture_context=cap_ctx,
++                        channel_id=channel_id,
++                    ):
++                        torch.accelerator.synchronize()
++                        torch.accelerator.empty_cache()
+ 
+-                    shared_memory_estimate[mode] = first_capture
+-                    per_graph_estimate[mode] = per_graph * (len(descs) - 1)
++                        for mode, descs in component_descs:
++                            profile_descs = descs[:2]
++                            mem_samples: list[int] = []
++                            captures_drafter = (
++                                self._captures_independent_drafter_graphs(mode)
++                            )
+ 
+-                    logger.debug(
+-                        "Estimated %s CUDA graph memory: "
+-                        "%.2f MiB first-capture + (%d-1) × %.2f MiB per-graph",
+-                        mode.name,
+-                        first_capture / (1 << 20),
+-                        len(descs),
+-                        per_graph / (1 << 20),
+-                    )
++                            for i, desc in enumerate(profile_descs):
++                                mem_before = torch.accelerator.get_memory_info()[0]
++                                self._warmup_and_capture(
++                                    desc,
++                                    cudagraph_runtime_mode=mode,
++                                    profile_seq_lens=(
++                                        min(
++                                            self.max_model_len,
++                                            self.max_num_tokens // desc.num_tokens,
++                                        )
++                                        if mode == CUDAGraphMode.FULL and i == 0
++                                        else None
++                                    ),
++                                    run_drafter=(
++                                        component == "draft" or not captures_drafter
++                                    ),
++                                )
++                                torch.accelerator.synchronize()
++                                free_after = torch.accelerator.get_memory_info()[0]
++                                mem_samples.append(max(mem_before - free_after, 0))
++
++                            first_capture = mem_samples[0]
++                            # Use at least 1 MiB per graph for driver overhead.
++                            per_graph = max(
++                                mem_samples[1] if len(mem_samples) > 1 else 0,
++                                1 << 20,
++                            )
++
++                            shared_memory_estimate[mode] = (
++                                shared_memory_estimate.get(mode, 0) + first_capture
++                            )
++                            per_graph_estimate[mode] = per_graph_estimate.get(
++                                mode, 0
++                            ) + per_graph * (len(descs) - 1)
++
++                            logger.debug(
++                                "Estimated %s %s CUDA graph memory: "
++                                "%.2f MiB first-capture + (%d-1) x %.2f MiB "
++                                "per-graph",
++                                component,
++                                mode.name,
++                                first_capture / (1 << 20),
++                                len(descs),
++                                per_graph / (1 << 20),
++                            )
+ 
+                 if encoder_cudagraph_manager is not None:
++                    channel_id = "vllm:encoder:profile"
++                    cap_ctx = (
++                        GraphCaptureContext(current_stream(), channel_id=channel_id)
++                        if current_platform.is_rocm()
++                        else None
++                    )
+                     mem_before = torch.accelerator.get_memory_info()[0]
+-                    encoder_cudagraph_manager.capture(graph_pool=encoder_profiling_pool)
++                    with graph_capture(
++                        device=self.device,
++                        graph_capture_context=cap_ctx,
++                        channel_id=channel_id,
++                    ):
++                        encoder_cudagraph_manager.capture(
++                            graph_pool=encoder_profiling_pool
++                        )
+                     torch.accelerator.synchronize()
+                     free_after = torch.accelerator.get_memory_info()[0]
+                     encoder_memory_estimate = max(mem_before - free_after, 0)
+@@ -6807,23 +6832,26 @@ class GPUModelRunner(
+                         encoder_graphs,
+                     )
+         finally:
+-            set_cudagraph_capturing_enabled(False)
+-            CUDAGraphWrapper.clear_all_graphs()
+-            BreakableCUDAGraphWrapper.clear_all_graphs()
+-            if encoder_cudagraph_manager is not None:
+-                encoder_cudagraph_manager.clear()
+-            all_wrappers = list(CUDAGraphWrapper._all_instances) + list(
+-                BreakableCUDAGraphWrapper._all_instances
+-            )
+-            for instance in all_wrappers:
+-                if id(instance) in original_pools:
+-                    instance.graph_pool = original_pools[id(instance)]
+-            for key_set in self.cudagraph_dispatcher.cudagraph_keys.values():
+-                key_set.clear()
+-            self.cudagraph_dispatcher.keys_initialized = False
+-            self.maybe_remove_all_loras(self.lora_config)
+-            self._cleanup_profiling_kv_cache()
+-            compilation_counter.num_cudagraph_captured = saved_num_cudagraph_captured
++            try:
++                try:
++                    set_cudagraph_capturing_enabled(False)
++                    CUDAGraphWrapper.clear_all_graphs()
++                    BreakableCUDAGraphWrapper.clear_all_graphs()
++                    if encoder_cudagraph_manager is not None:
++                        encoder_cudagraph_manager.clear()
++                finally:
++                    for instance in all_wrappers:
++                        instance.graph_pool = original_pools[id(instance)]
++                for key_set in self.cudagraph_dispatcher.cudagraph_keys.values():
++                    key_set.clear()
++                self.cudagraph_dispatcher.keys_initialized = False
++                self.maybe_remove_all_loras(self.lora_config)
++                self._cleanup_profiling_kv_cache()
++                compilation_counter.num_cudagraph_captured = (
++                    saved_num_cudagraph_captured
++                )
++            finally:
++                rollback_b12x_graph_channels(graph_channel_checkpoints)
+ 
+         # FULL and PIECEWISE graphs share the global pool at runtime and are
+         # never replayed concurrently, so the pool overlays their memory.
+@@ -6860,42 +6888,58 @@ class GPUModelRunner(
+         # Trigger CUDA graph capture for specific shapes.
+         # Capture the large shapes first so that the smaller shapes
+         # can reuse the memory pool allocated for the large shapes.
++        capture_descs = list(self.cudagraph_dispatcher.get_capture_descs())
+         set_cudagraph_capturing_enabled(True)
+-        with (
+-            self._freeze_gc(),
+-            graph_capture(
+-                device=self.device,
+-                channel_id="graph:vllm-model",
+-            ),
+-        ):
+-            torch.accelerator.synchronize()
+-            torch.accelerator.empty_cache()
+-            start_free_gpu_memory = torch.accelerator.get_memory_info()[0]
+-
+-            for (
+-                runtime_mode,
+-                batch_descs,
+-            ) in self.cudagraph_dispatcher.get_capture_descs():
+-                self._capture_cudagraphs(
+-                    batch_descriptors=batch_descs,
+-                    cudagraph_runtime_mode=runtime_mode,
+-                )
++        try:
++            with self._freeze_gc():
+                 torch.accelerator.synchronize()
++                torch.accelerator.empty_cache()
++                start_free_gpu_memory = torch.accelerator.get_memory_info()[0]
+ 
+-            # Capture encoder CUDA graphs if enabled
+-            if self.encoder_cudagraph_manager is not None:
+-                encoder_graph_pool = current_platform.graph_pool_handle()
+-                self.encoder_cudagraph_manager.capture(graph_pool=encoder_graph_pool)
++                for component, channel_id in (
++                    ("target", "vllm:target:production"),
++                    ("draft", "vllm:draft:production"),
++                ):
++                    component_descs = [
++                        (mode, descs)
++                        for mode, descs in capture_descs
++                        if descs
++                        and (
++                            component == "target"
++                            or self._captures_independent_drafter_graphs(mode)
++                        )
++                    ]
++                    if not component_descs:
++                        continue
++                    with graph_capture(device=self.device, channel_id=channel_id):
++                        for runtime_mode, batch_descs in component_descs:
++                            captures_drafter = (
++                                self._captures_independent_drafter_graphs(runtime_mode)
++                            )
++                            self._capture_cudagraphs(
++                                batch_descriptors=batch_descs,
++                                cudagraph_runtime_mode=runtime_mode,
++                                run_drafter=(
++                                    component == "draft" or not captures_drafter
++                                ),
++                            )
++                            torch.accelerator.synchronize()
+ 
+-            torch.accelerator.synchronize()
+-            end_free_gpu_memory = torch.accelerator.get_memory_info()[0]
++                if self.encoder_cudagraph_manager is not None:
++                    encoder_graph_pool = current_platform.graph_pool_handle()
++                    with graph_capture(
++                        device=self.device,
++                        channel_id="vllm:encoder:production",
++                    ):
++                        self.encoder_cudagraph_manager.capture(
++                            graph_pool=encoder_graph_pool
++                        )
+ 
+-        # Disable cudagraph capturing globally, so any unexpected cudagraph
+-        # capturing will be detected and raise an error after here.
+-        # Note: We don't put it into graph_capture context manager because
+-        # we may do lazy capturing in future that still allows capturing
+-        # after here.
+-        set_cudagraph_capturing_enabled(False)
++                torch.accelerator.synchronize()
++                end_free_gpu_memory = torch.accelerator.get_memory_info()[0]
++        finally:
++            # Leave capture mode disabled even when one graph owner fails.
++            set_cudagraph_capturing_enabled(False)
+ 
+         torch.accelerator.synchronize()
+         torch.accelerator.empty_cache()
+@@ -6915,6 +6959,35 @@ class GPUModelRunner(
+         )
+         return cuda_graph_size
+ 
++    def _captures_independent_drafter_graphs(
++        self,
++        cudagraph_runtime_mode: CUDAGraphMode,
++    ) -> bool:
++        """Return whether PIECEWISE capture needs a separate drafter pass.
++
++        Args:
++            cudagraph_runtime_mode: CUDA graph mode being captured.
++
++        Returns:
++            Whether the mode owns independently replayable drafter graphs.
++        """
++        spec_config = self.speculative_config
++        return (
++            cudagraph_runtime_mode == CUDAGraphMode.PIECEWISE
++            and spec_config is not None
++            and not spec_config.enforce_eager
++            and self._drafter_runs_model_forward()
++        )
++
++    def _drafter_runs_model_forward(self) -> bool:
++        """Return whether the configured drafter executes a model forward."""
++        spec_config = self.speculative_config
++        return spec_config is not None and (
++            spec_config.use_eagle()
++            or spec_config.uses_draft_model()
++            or spec_config.uses_extract_hidden_states()
++        )
++
+     def _warmup_and_capture(
+         self,
+         desc: BatchDescriptor,
+@@ -6922,6 +6995,7 @@ class GPUModelRunner(
+         profile_seq_lens: int | None = None,
+         allow_microbatching: bool = False,
+         num_warmups: int | None = None,
++        run_drafter: bool = True,
+     ):
+         if num_warmups is None:
+             num_warmups = self.compilation_config.cudagraph_num_of_warmups
+@@ -6937,6 +7011,7 @@ class GPUModelRunner(
+                 remove_lora=False,
+                 num_active_loras=desc.num_active_loras,
+                 profile_seq_lens=profile_seq_lens,
++                run_drafter=run_drafter,
+             )
+         self._dummy_run(
+             desc.num_tokens,
+@@ -6948,12 +7023,15 @@ class GPUModelRunner(
+             num_active_loras=desc.num_active_loras,
+             is_graph_capturing=True,
+             profile_seq_lens=profile_seq_lens,
++            run_drafter=run_drafter,
+         )
+ 
+     def _capture_cudagraphs(
+         self,
+         batch_descriptors: list[BatchDescriptor],
+         cudagraph_runtime_mode: CUDAGraphMode,
++        *,
++        run_drafter: bool = True,
+     ):
+         assert (
+             cudagraph_runtime_mode != CUDAGraphMode.NONE
+@@ -6996,6 +7074,7 @@ class GPUModelRunner(
+                 batch_desc,
+                 cudagraph_runtime_mode=cudagraph_runtime_mode,
+                 allow_microbatching=allow_microbatching,
++                run_drafter=run_drafter,
+             )
+             torch.accelerator.synchronize()
+         self.maybe_remove_all_loras(self.lora_config)

--- a/tests/test-gilded-gnosis-release-composition.sh
+++ b/tests/test-gilded-gnosis-release-composition.sh
@@ -345,16 +345,16 @@ output_r32="$(
 
 grep -Fxq 'composition=reproduce-r32' <<<"${output_r32}"
 grep -Fxq \
-  'image=voipmonitor/vllm:gilded-gnosis-v20-vllmfa13d33-b12xe90b8af-fi1ac6942-cu132-20260809-r32' \
+  'image=voipmonitor/vllm:gilded-gnosis-v20-vllmfa13d33-b12x817fb3d-fi1ac6942-cu132-20260809-r32' \
   <<<"${output_r32}"
 grep -Fxq \
-  'version=0.11.2.dev280+gilded.gnosis.v20.vllmfa13d33.b12xe90b8af.fi1ac6942.cu132.20260809.r32' \
+  'version=0.11.2.dev280+gilded.gnosis.v20.vllmfa13d33.b12x817fb3d.fi1ac6942.cu132.20260809.r32' \
   <<<"${output_r32}"
 grep -Fxq \
   'vllm_tree=fa13d334a2962756f9f7e9b562deb85387359f42' \
   <<<"${output_r32}"
 grep -Fxq \
-  'b12x_tree=e90b8af95d906ff21764814633ac5259d1c0cb4f' \
+  'b12x_tree=817fb3da19a4592a54e79571128e83b702be9e0a' \
   <<<"${output_r32}"
 grep -Fxq \
   'flashinfer_commit=1ac6942776b383c6b03c7a5805a22e72a3e3349f' \
@@ -371,7 +371,7 @@ grep -Fxq \
 
 r32_compose="${repo_root}/examples/docker-compose-ds4-v20-r32.yml"
 grep -Fq \
-  'gilded-gnosis-v20-vllmfa13d33-b12xe90b8af-fi1ac6942-cu132-20260809-r32' \
+  'gilded-gnosis-v20-vllmfa13d33-b12x817fb3d-fi1ac6942-cu132-20260809-r32' \
   "${r32_compose}"
 grep -Fq 'B12X_PCIE_TP2_REMOTE_PUSH: ${B12X_PCIE_TP2_REMOTE_PUSH:-0}' \
   "${r32_compose}"
@@ -721,16 +721,16 @@ output_clean="$(
 
 grep -Fxq 'composition=clean' <<<"${output_clean}"
 grep -Eq \
-  '^image=voipmonitor/vllm:gilded-gnosis-v20-vllmfa13d33-b12xe90b8af-fi1ac6942-cu132-[0-9]{8}-r32$' \
+  '^image=voipmonitor/vllm:gilded-gnosis-v20-vllmfa13d33-b12x817fb3d-fi1ac6942-cu132-[0-9]{8}-r32$' \
   <<<"${output_clean}"
 grep -Eq \
-  '^version=0[.]11[.]2[.]dev280[+]gilded[.]gnosis[.]v20[.]vllmfa13d33[.]b12xe90b8af[.]fi1ac6942[.]cu132[.][0-9]{8}[.]r32$' \
+  '^version=0[.]11[.]2[.]dev280[+]gilded[.]gnosis[.]v20[.]vllmfa13d33[.]b12x817fb3d[.]fi1ac6942[.]cu132[.][0-9]{8}[.]r32$' \
   <<<"${output_clean}"
 grep -Fxq \
   'vllm_tree=fa13d334a2962756f9f7e9b562deb85387359f42' \
   <<<"${output_clean}"
 grep -Fxq \
-  'b12x_tree=e90b8af95d906ff21764814633ac5259d1c0cb4f' \
+  'b12x_tree=817fb3da19a4592a54e79571128e83b702be9e0a' \
   <<<"${output_clean}"
 grep -Fxq \
   'flashinfer_commit=1ac6942776b383c6b03c7a5805a22e72a3e3349f' \

--- a/tests/test-gilded-gnosis-release-composition.sh
+++ b/tests/test-gilded-gnosis-release-composition.sh
@@ -360,7 +360,7 @@ grep -Fxq \
   'flashinfer_commit=1ac6942776b383c6b03c7a5805a22e72a3e3349f' \
   <<<"${output_r33}"
 grep -Fxq \
-  'launcher_commit=6b3456a6485d55898534b87a4a07353e434b23b3' \
+  'launcher_commit=47ac813334e094090d5fd85b317d13b2e932ef09' \
   <<<"${output_r33}"
 grep -Fxq \
   'lmcache_tree=9a05c8818bae48d15b79c7e876418bb813c08cd0' \
@@ -779,7 +779,7 @@ grep -Fxq \
   'flashinfer_commit=1ac6942776b383c6b03c7a5805a22e72a3e3349f' \
   <<<"${output_clean}"
 grep -Fxq \
-  'launcher_commit=6b3456a6485d55898534b87a4a07353e434b23b3' \
+  'launcher_commit=47ac813334e094090d5fd85b317d13b2e932ef09' \
   <<<"${output_clean}"
 grep -Fxq \
   'instanttensor_repo=https://github.com/voipmonitor/InstantTensor.git' \

--- a/tests/test-gilded-gnosis-release-composition.sh
+++ b/tests/test-gilded-gnosis-release-composition.sh
@@ -337,6 +337,49 @@ grep -Fxq 'lmcache_version=0.5.2+glm52dcp.4' <<<"${output_r18}"
 grep -Fxq 'xgrammar_ref=v0.2.5' <<<"${output_r18}"
 grep -Fxq 'xgrammar_transformers5_compat=1' <<<"${output_r18}"
 
+output_r32="$(
+  cd "${repo_root}"
+  PRINT_RELEASE_CONFIG=1 VLLM_RELEASE_COMPOSITION=reproduce-r32 \
+    ./build-gilded-gnosis-v20-final-cu132.sh
+)"
+
+grep -Fxq 'composition=reproduce-r32' <<<"${output_r32}"
+grep -Fxq \
+  'image=voipmonitor/vllm:gilded-gnosis-v20-vllmfa13d33-b12xe90b8af-fi1ac6942-cu132-20260809-r32' \
+  <<<"${output_r32}"
+grep -Fxq \
+  'version=0.11.2.dev280+gilded.gnosis.v20.vllmfa13d33.b12xe90b8af.fi1ac6942.cu132.20260809.r32' \
+  <<<"${output_r32}"
+grep -Fxq \
+  'vllm_tree=fa13d334a2962756f9f7e9b562deb85387359f42' \
+  <<<"${output_r32}"
+grep -Fxq \
+  'b12x_tree=e90b8af95d906ff21764814633ac5259d1c0cb4f' \
+  <<<"${output_r32}"
+grep -Fxq \
+  'flashinfer_commit=1ac6942776b383c6b03c7a5805a22e72a3e3349f' \
+  <<<"${output_r32}"
+grep -Fxq \
+  'launcher_commit=3d3b94a7f2493c50aa677fdf6d799cc224db5785' \
+  <<<"${output_r32}"
+grep -Fxq \
+  'lmcache_tree=9a05c8818bae48d15b79c7e876418bb813c08cd0' \
+  <<<"${output_r32}"
+grep -Fxq \
+  'lmcache_patch=releases/gilded-gnosis-v20-r32/lmcache/integration.patch' \
+  <<<"${output_r32}"
+
+r32_compose="${repo_root}/examples/docker-compose-ds4-v20-r32.yml"
+grep -Fq \
+  'gilded-gnosis-v20-vllmfa13d33-b12xe90b8af-fi1ac6942-cu132-20260809-r32' \
+  "${r32_compose}"
+grep -Fq 'B12X_PCIE_TP2_REMOTE_PUSH: ${B12X_PCIE_TP2_REMOTE_PUSH:-0}' \
+  "${r32_compose}"
+grep -Fq 'B12X_PCIE_TP4_REMOTE_PUSH: ${B12X_PCIE_TP4_REMOTE_PUSH:-0}' \
+  "${r32_compose}"
+grep -Fq 'B12X_PCIE_TP8_OWNER_REDUCE: ${B12X_PCIE_TP8_OWNER_REDUCE:-1}' \
+  "${r32_compose}"
+
 output_r31="$(
   cd "${repo_root}"
   PRINT_RELEASE_CONFIG=1 VLLM_RELEASE_COMPOSITION=reproduce-r31 \
@@ -678,16 +721,16 @@ output_clean="$(
 
 grep -Fxq 'composition=clean' <<<"${output_clean}"
 grep -Eq \
-  '^image=voipmonitor/vllm:gilded-gnosis-v20-vllmfa13d33-b12xacee6e5-fi1ac6942-cu132-[0-9]{8}-r31$' \
+  '^image=voipmonitor/vllm:gilded-gnosis-v20-vllmfa13d33-b12xe90b8af-fi1ac6942-cu132-[0-9]{8}-r32$' \
   <<<"${output_clean}"
 grep -Eq \
-  '^version=0[.]11[.]2[.]dev280[+]gilded[.]gnosis[.]v20[.]vllmfa13d33[.]b12xacee6e5[.]fi1ac6942[.]cu132[.][0-9]{8}[.]r31$' \
+  '^version=0[.]11[.]2[.]dev280[+]gilded[.]gnosis[.]v20[.]vllmfa13d33[.]b12xe90b8af[.]fi1ac6942[.]cu132[.][0-9]{8}[.]r32$' \
   <<<"${output_clean}"
 grep -Fxq \
   'vllm_tree=fa13d334a2962756f9f7e9b562deb85387359f42' \
   <<<"${output_clean}"
 grep -Fxq \
-  'b12x_tree=acee6e504209068bd0cbb01cb2b98966bddcf042' \
+  'b12x_tree=e90b8af95d906ff21764814633ac5259d1c0cb4f' \
   <<<"${output_clean}"
 grep -Fxq \
   'flashinfer_commit=1ac6942776b383c6b03c7a5805a22e72a3e3349f' \

--- a/tests/test-gilded-gnosis-release-composition.sh
+++ b/tests/test-gilded-gnosis-release-composition.sh
@@ -360,7 +360,7 @@ grep -Fxq \
   'flashinfer_commit=1ac6942776b383c6b03c7a5805a22e72a3e3349f' \
   <<<"${output_r32}"
 grep -Fxq \
-  'launcher_commit=3d3b94a7f2493c50aa677fdf6d799cc224db5785' \
+  'launcher_commit=306d4d25185ca069721400545b40aa2a309477e5' \
   <<<"${output_r32}"
 grep -Fxq \
   'lmcache_tree=9a05c8818bae48d15b79c7e876418bb813c08cd0' \
@@ -736,7 +736,7 @@ grep -Fxq \
   'flashinfer_commit=1ac6942776b383c6b03c7a5805a22e72a3e3349f' \
   <<<"${output_clean}"
 grep -Fxq \
-  'launcher_commit=3d3b94a7f2493c50aa677fdf6d799cc224db5785' \
+  'launcher_commit=306d4d25185ca069721400545b40aa2a309477e5' \
   <<<"${output_clean}"
 grep -Fxq \
   'instanttensor_repo=https://github.com/voipmonitor/InstantTensor.git' \

--- a/tests/test-gilded-gnosis-release-composition.sh
+++ b/tests/test-gilded-gnosis-release-composition.sh
@@ -360,7 +360,7 @@ grep -Fxq \
   'flashinfer_commit=1ac6942776b383c6b03c7a5805a22e72a3e3349f' \
   <<<"${output_r32}"
 grep -Fxq \
-  'launcher_commit=306d4d25185ca069721400545b40aa2a309477e5' \
+  'launcher_commit=6b3456a6485d55898534b87a4a07353e434b23b3' \
   <<<"${output_r32}"
 grep -Fxq \
   'lmcache_tree=9a05c8818bae48d15b79c7e876418bb813c08cd0' \
@@ -736,7 +736,7 @@ grep -Fxq \
   'flashinfer_commit=1ac6942776b383c6b03c7a5805a22e72a3e3349f' \
   <<<"${output_clean}"
 grep -Fxq \
-  'launcher_commit=306d4d25185ca069721400545b40aa2a309477e5' \
+  'launcher_commit=6b3456a6485d55898534b87a4a07353e434b23b3' \
   <<<"${output_clean}"
 grep -Fxq \
   'instanttensor_repo=https://github.com/voipmonitor/InstantTensor.git' \

--- a/tests/test-gilded-gnosis-release-composition.sh
+++ b/tests/test-gilded-gnosis-release-composition.sh
@@ -337,6 +337,49 @@ grep -Fxq 'lmcache_version=0.5.2+glm52dcp.4' <<<"${output_r18}"
 grep -Fxq 'xgrammar_ref=v0.2.5' <<<"${output_r18}"
 grep -Fxq 'xgrammar_transformers5_compat=1' <<<"${output_r18}"
 
+output_r33="$(
+  cd "${repo_root}"
+  PRINT_RELEASE_CONFIG=1 VLLM_RELEASE_COMPOSITION=reproduce-r33 \
+    ./build-gilded-gnosis-v20-final-cu132.sh
+)"
+
+grep -Fxq 'composition=reproduce-r33' <<<"${output_r33}"
+grep -Fxq \
+  'image=voipmonitor/vllm:gilded-gnosis-v20-vllmfa13d33-b12x06db0f4-fi1ac6942-cu132-20260809-r33' \
+  <<<"${output_r33}"
+grep -Fxq \
+  'version=0.11.2.dev280+gilded.gnosis.v20.vllmfa13d33.b12x06db0f4.fi1ac6942.cu132.20260809.r33' \
+  <<<"${output_r33}"
+grep -Fxq \
+  'vllm_tree=fa13d334a2962756f9f7e9b562deb85387359f42' \
+  <<<"${output_r33}"
+grep -Fxq \
+  'b12x_tree=06db0f4b27dbd19eb934da0da27eff7a7c49d8c4' \
+  <<<"${output_r33}"
+grep -Fxq \
+  'flashinfer_commit=1ac6942776b383c6b03c7a5805a22e72a3e3349f' \
+  <<<"${output_r33}"
+grep -Fxq \
+  'launcher_commit=6b3456a6485d55898534b87a4a07353e434b23b3' \
+  <<<"${output_r33}"
+grep -Fxq \
+  'lmcache_tree=9a05c8818bae48d15b79c7e876418bb813c08cd0' \
+  <<<"${output_r33}"
+grep -Fxq \
+  'lmcache_patch=releases/gilded-gnosis-v20-r33/lmcache/integration.patch' \
+  <<<"${output_r33}"
+
+r33_compose="${repo_root}/examples/docker-compose-ds4-v20-r33.yml"
+grep -Fq \
+  'gilded-gnosis-v20-vllmfa13d33-b12x06db0f4-fi1ac6942-cu132-20260809-r33' \
+  "${r33_compose}"
+grep -Fq 'B12X_PCIE_TP2_REMOTE_PUSH: ${B12X_PCIE_TP2_REMOTE_PUSH:-0}' \
+  "${r33_compose}"
+grep -Fq 'B12X_PCIE_TP4_REMOTE_PUSH: ${B12X_PCIE_TP4_REMOTE_PUSH:-0}' \
+  "${r33_compose}"
+grep -Fq 'B12X_PCIE_TP8_OWNER_REDUCE: ${B12X_PCIE_TP8_OWNER_REDUCE:-1}' \
+  "${r33_compose}"
+
 output_r32="$(
   cd "${repo_root}"
   PRINT_RELEASE_CONFIG=1 VLLM_RELEASE_COMPOSITION=reproduce-r32 \
@@ -721,16 +764,16 @@ output_clean="$(
 
 grep -Fxq 'composition=clean' <<<"${output_clean}"
 grep -Eq \
-  '^image=voipmonitor/vllm:gilded-gnosis-v20-vllmfa13d33-b12x817fb3d-fi1ac6942-cu132-[0-9]{8}-r32$' \
+  '^image=voipmonitor/vllm:gilded-gnosis-v20-vllmfa13d33-b12x06db0f4-fi1ac6942-cu132-[0-9]{8}-r33$' \
   <<<"${output_clean}"
 grep -Eq \
-  '^version=0[.]11[.]2[.]dev280[+]gilded[.]gnosis[.]v20[.]vllmfa13d33[.]b12x817fb3d[.]fi1ac6942[.]cu132[.][0-9]{8}[.]r32$' \
+  '^version=0[.]11[.]2[.]dev280[+]gilded[.]gnosis[.]v20[.]vllmfa13d33[.]b12x06db0f4[.]fi1ac6942[.]cu132[.][0-9]{8}[.]r33$' \
   <<<"${output_clean}"
 grep -Fxq \
   'vllm_tree=fa13d334a2962756f9f7e9b562deb85387359f42' \
   <<<"${output_clean}"
 grep -Fxq \
-  'b12x_tree=817fb3da19a4592a54e79571128e83b702be9e0a' \
+  'b12x_tree=06db0f4b27dbd19eb934da0da27eff7a7c49d8c4' \
   <<<"${output_clean}"
 grep -Fxq \
   'flashinfer_commit=1ac6942776b383c6b03c7a5805a22e72a3e3349f' \

--- a/tests/test-release-manifest-fail-fast.sh
+++ b/tests/test-release-manifest-fail-fast.sh
@@ -76,7 +76,7 @@ assert_pr_set \
   '145 188 213 214 217 218 228 229 230 234 235 245 248 251 252 253 254 255 256'
 assert_pr_set \
   manifests/b12x/gilded-gnosis-v20.json \
-  '125 126 133 135'
+  '125 126 133 135 136 137'
 assert_pr_set \
   manifests/lmcache/gilded-gnosis-v20.json \
   '7 8 9 10 11 12 13 14 15 16 17'

--- a/tests/test-release-manifest-fail-fast.sh
+++ b/tests/test-release-manifest-fail-fast.sh
@@ -76,7 +76,7 @@ assert_pr_set \
   '145 188 213 214 217 218 228 229 230 234 235 245 248 251 252 253 254 255 256'
 assert_pr_set \
   manifests/b12x/gilded-gnosis-v20.json \
-  '125 126'
+  '125 126 133'
 assert_pr_set \
   manifests/lmcache/gilded-gnosis-v20.json \
   '7 8 9 10 11 12 13 14 15 16 17'

--- a/tests/test-release-manifest-fail-fast.sh
+++ b/tests/test-release-manifest-fail-fast.sh
@@ -76,7 +76,7 @@ assert_pr_set \
   '145 188 213 214 217 218 228 229 230 234 235 245 248 251 252 253 254 255 256'
 assert_pr_set \
   manifests/b12x/gilded-gnosis-v20.json \
-  '125 126 133'
+  '125 126 133 135'
 assert_pr_set \
   manifests/lmcache/gilded-gnosis-v20.json \
   '7 8 9 10 11 12 13 14 15 16 17'

--- a/validation/gilded-gnosis-v20-r33-remote-gpu.json
+++ b/validation/gilded-gnosis-v20-r33-remote-gpu.json
@@ -1,0 +1,127 @@
+{
+  "schema_version": 1,
+  "image": "voipmonitor/vllm:gilded-gnosis-v20-vllmfa13d33-b12x06db0f4-fi1ac6942-cu132-20260809-r33",
+  "image_id": "sha256:60944a4ea1fbb2d1f35d7972f685d8fb0b91e77dd5aeca1dcafa3bcc29846d12",
+  "vllm_base": "e2666d9a65f41fc376607531453cbd57c4c71016",
+  "vllm_tree": "fa13d334a2962756f9f7e9b562deb85387359f42",
+  "vllm_patch_sha256": "c03a83a6cf81c213caa435ec6190f61b6b10c02ab8cc3d5b24fe6d291a121b39",
+  "b12x_base": "9bbae67841e4818e7472e1edcdca8ebcbda68611",
+  "b12x_tree": "06db0f4b27dbd19eb934da0da27eff7a7c49d8c4",
+  "b12x_patch_sha256": "6ee9f0b437379fd8246781b5a99da10eed2ad47eb8d7426272d3f8bff1553303",
+  "flashinfer_commit": "1ac6942776b383c6b03c7a5805a22e72a3e3349f",
+  "lmcache_tree": "9a05c8818bae48d15b79c7e876418bb813c08cd0",
+  "launcher_commit": "47ac813334e094090d5fd85b317d13b2e932ef09",
+  "validator_host": "192.168.0.69",
+  "validator_topology": "eight RTX PRO 6000 Blackwell GPUs on direct CPU root ports; only physical GPUs 4-7 were used",
+  "reference_topology": "same validator host and GPU set; no result from the local switched 16-GPU host is used as a performance reference",
+  "gpu_ids": [
+    4,
+    5,
+    6,
+    7
+  ],
+  "validated_at": "2026-08-09T10:00:26Z",
+  "profiles": {
+    "glm52_exl3": {
+      "model": "willfalco/GLM-5.2-EXL3-TR3-3.36bpw@8d9aa923a17502675ca23737349b67f2e66bb69d",
+      "parallelism": "TP4/DCP1/MTP3",
+      "quantization": "EXL3 checkpoint plus online EXL3 K6 dense path",
+      "kv_cache": "NVFP4 DS-MLA",
+      "scheduler": "MNS1, graph cap 6, max model length 131072",
+      "load_format": "InstantTensor BUFFERED"
+    },
+    "ds4_flash": {
+      "model": "deepseek-ai/DeepSeek-V4-Flash-0731@9e165c30e2704aec5d9d593cce3eebd58bbef1cb",
+      "parallelism": "TP2 and TP4, DCP1",
+      "target_backend": "B12X W4A8",
+      "all_reduce": "FlashInfer PCIe IPC at TP2 auto; B12X at TP4 auto",
+      "speculation": "fixed probabilistic DSpark K5",
+      "kv_cache": "FP8 DS-MLA",
+      "load_format": "InstantTensor BUFFERED"
+    }
+  },
+  "tests": {
+    "source_contracts": "pass",
+    "runtime_contracts": "pass",
+    "model_startup": "pass",
+    "correctness": "pass",
+    "decode": "pass",
+    "prefill": "pass",
+    "release_composition": "pass",
+    "docker_release_tests": "pass",
+    "lmcache_tests": "pass: 222 passed, 131 skipped",
+    "focused_b12x_tests": "pass: 9 passed, 59 deselected",
+    "cuda_graphs": "pass: FULL+PIECEWISE target and speculative graph capture through each configured scheduler envelope",
+    "engine_health": "pass"
+  },
+  "evidence": {
+    "glm52_exl3_tp4_dcp1_mtp3_standard": {
+      "prompt": "llm_decode_bench default encyclopedia prompt",
+      "decode_c1_runs_tps": [
+        116.20981073209954,
+        112.02957747360817
+      ],
+      "decode_c1_median_tps": 114.11969410285386,
+      "same_profile_historical_tps": 113.397,
+      "gpu_kv_cache_tokens": 202304,
+      "note": "A separate synthetic MTP-friendly prompt reached about 144 tok/s; it is deliberately excluded from the standard comparison."
+    },
+    "ds4_k5_tp4_b12x": {
+      "decode_c1_tps": 247.0248264544163,
+      "decode_c4_tps": 541.9472533507881,
+      "decode_c8_tps": 804.4637861699726,
+      "strict_draft_acceptance_c1": 0.37411764705882355,
+      "strict_draft_acceptance_c4": 0.347,
+      "strict_draft_acceptance_c8": 0.31987179487179485,
+      "gpu_kv_cache_tokens": 188320
+    },
+    "ds4_k5_tp2_flashinfer_pcie_ipc": {
+      "decode_c1_tps": 180.58589777719473,
+      "decode_c4_tps": 397.0906333375556,
+      "decode_c8_tps": 580.6711853523535,
+      "strict_draft_acceptance_c1": 0.29393939393939394,
+      "strict_draft_acceptance_c4": 0.34459459459459457,
+      "strict_draft_acceptance_c8": 0.33303571428571427,
+      "prefill_8k_tps": 12849,
+      "correctness_response": "42"
+    },
+    "b12x_remote_push_policy": {
+      "decision": "TP2 and TP4 remain opt-in; TP8 owner reduction remains the automatic path",
+      "tp2_stock_c1_c4_c8_tps": [
+        170.2,
+        401.2,
+        588.1
+      ],
+      "tp2_remote_push_c1_c4_c8_tps": [
+        171.3,
+        391.7,
+        595.3
+      ],
+      "tp4_stock_c1_c4_c8_c16_c32_tps": [
+        217.2,
+        545.7,
+        785.9,
+        1113.4,
+        1750.1
+      ],
+      "tp4_remote_push_c1_c4_c8_c16_c32_tps": [
+        239.7,
+        534.0,
+        793.1,
+        1132.9,
+        1718.5
+      ],
+      "note": "Same-host matched runs showed workload-dependent gains and losses rather than a consistent end-to-end win."
+    }
+  },
+  "artifacts": {
+    "glm52_standard_run1": "99a4b9ce0570eefae137cde9223ae0cd3611b4fa62dc11fc141701832c3f211c",
+    "glm52_standard_run2": "2ca337fdc6dbe169efa7ac6e72608185513da86479a712005d8d9d80a4c489ab",
+    "ds4_tp4_k5_decode": "55ce3ca9ce94fb551ad0102e6594feed50efee935aec6a91c65201a4c2db223d",
+    "ds4_tp2_k5_decode_c1": "de0d664fe1dbfda7eef8fff6aa5ac75f56c8fb8d42a44d68eec5b9f52c716c47",
+    "ds4_tp2_k5_decode_c4_c8": "aa0d3f32a00f2a6682e096b09908770f058c174585b3800971b4044a65c9ee06",
+    "ds4_tp2_k5_prefill8k": "b093961d3a25f5836e28222b4199b82582cce1dfa2edb0b3174d2d5ef5bc3080",
+    "ds4_tp2_correctness": "c714ff3d18f8d9ef25afccb602bfd6815e7009326d7fff5a08d202af2b019add"
+  },
+  "issue": "https://github.com/local-inference-lab/rtx6kpro/issues/33"
+}


### PR DESCRIPTION
## Summary

- compose r33 from clean GG, B12X master, and LMCache release bases using immutable PR heads and archived integration locks
- add B12X #133 topology-scoped all-reduce, #135 dense API compatibility, #136 capture-safe SM120 K6 small-M dispatch, and #137 mixed-Trellis QSRT ABI alignment
- keep TP2/TP4 remote-push all-reduce opt-in; matched E2E measurements did not show a consistent win, while TP8 owner reduction remains automatic
- add a DS4 r33 compose, exact reproduction mode, and an immutable remote-GPU qualification receipt

## Validation

The exact image `voipmonitor/vllm:gilded-gnosis-v20-vllmfa13d33-b12x06db0f4-fi1ac6942-cu132-20260809-r33` (`sha256:60944a4ea1fbb2d1f35d7972f685d8fb0b91e77dd5aeca1dcafa3bcc29846d12`) was tested on GPUs 4-7 of `192.168.0.69`.

- release source, manifest, helper, image-label, launcher-hash, and dry-run gates: pass
- LMCache: 222 passed, 131 skipped
- focused B12X #136 tests: 9 passed, 59 deselected
- GLM-5.2 EXL3 3.36, TP4/DCP1/MTP3 standard C1: 116.2 / 112.0 tok/s, median 114.1 versus historical 113.4
- DS4 0731 fixed probabilistic K5 TP2 C1/C4/C8: 180.6 / 397.1 / 580.7 tok/s; 8k prefill 12,849 tok/s
- DS4 0731 fixed probabilistic K5 TP4 C1/C4/C8: 247.0 / 541.9 / 804.5 tok/s
- FULL+PIECEWISE CUDA graph capture: pass
- TP2 correctness response: exactly `42`

The separate ~144 tok/s GLM observation used a synthetic MTP-friendly prompt and is explicitly excluded from the standard regression comparison. Full source identity and artifact hashes are in `validation/gilded-gnosis-v20-r33-remote-gpu.json`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added r32 and r33 release profiles for DeepSeek-V4-Flash-0731.
  * Added support for topology-aware fused all-reduce, capture-safe small-batch dispatch, and mixed-execution compatibility.
  * Added reproducible release composition and validation workflows.

* **Documentation**
  * Added r33 release documentation, setup instructions, validated configurations, benchmark results, and correctness status.

* **Validation**
  * Added release checks covering runtime behavior, remote-push settings, hardware profiles, and benchmark evidence for GLM and DeepSeek workloads.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->