### PR TITLE
fix(lmcache): preflight named shared-memory pools

### DIFF
--- a/Dockerfile.kimi-k3-qsrt-tp16-runtime
+++ b/Dockerfile.kimi-k3-qsrt-tp16-runtime
@@ -127,6 +127,7 @@ COPY --chmod=0755 launchers/serve-kimi-k3-full-mxfp4-dflash-ii /usr/local/bin/se
 COPY --chmod=0755 launchers/serve-kimi-k3-qsrt-nospec /usr/local/bin/serve-kimi-k3-qsrt-nospec
 COPY --chmod=0755 launchers/serve-kimi-k3-qsrt-dspark /usr/local/bin/serve-kimi-k3-qsrt-dspark
 COPY --chmod=0755 launchers/lmcache-mp-wrapper.sh /usr/local/bin/lmcache-mp-wrapper.sh
+COPY --chmod=0755 launchers/lmcache-shm-preflight.py /usr/local/bin/lmcache-shm-preflight.py
 COPY --chmod=0755 launchers/serve-kimi-k3-production-dspark-ii /usr/local/bin/serve-kimi-k3-production-dspark-ii
 
 RUN set -eux; \

--- a/launchers/lmcache-mp-wrapper.sh
+++ b/launchers/lmcache-mp-wrapper.sh
@@ -119,8 +119,39 @@ server_args=(
 # An explicitly empty shared-memory name selects bounded per-request transfer
 # buffers. This avoids mapping and pinning the entire L1 pool in every vLLM
 # worker when the engine-driven transfer path is used.
+lmcache_shm_lock_fd=""
 if [[ -v LMCACHE_SHM_NAME ]]; then
   server_args+=(--shm-name "${LMCACHE_SHM_NAME}")
+  if [[ -n "${LMCACHE_SHM_NAME}" ]]; then
+    if [[ ! "${LMCACHE_SHM_NAME}" =~ ^[[:alnum:]][[:alnum:]_.-]{0,254}$ ]]; then
+      echo "ERROR: invalid LMCACHE_SHM_NAME: ${LMCACHE_SHM_NAME}" >&2
+      exit 2
+    fi
+    shm_lock_root="${LMCACHE_SHM_LOCK_ROOT:-/dev/shm}"
+    if [[ -L "${shm_lock_root}" || ! -d "${shm_lock_root}" ]]; then
+      echo "ERROR: LMCache SHM lock root must be a non-symlink directory: ${shm_lock_root}" >&2
+      exit 2
+    fi
+    if ! command -v flock >/dev/null 2>&1; then
+      echo "ERROR: flock is required for named LMCache SHM startup" >&2
+      exit 2
+    fi
+    # Lock the already-existing SHM directory inode. This avoids creating a
+    # lock pathname in a world-writable directory, where a pre-placed symlink
+    # could redirect a shell redirection to an unrelated file.
+    exec {lmcache_shm_lock_fd}<"${shm_lock_root}"
+    flock -x "${lmcache_shm_lock_fd}"
+
+    wrapper_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+    shm_preflight="${LMCACHE_SHM_PREFLIGHT_BIN:-${wrapper_dir}/lmcache-shm-preflight.py}"
+    if [[ ! -x "${shm_preflight}" ]]; then
+      echo "ERROR: LMCache SHM preflight helper is not executable: ${shm_preflight}" >&2
+      exit 2
+    fi
+    "${shm_preflight}" \
+      --name "${LMCACHE_SHM_NAME}" \
+      --expected-gb "${lmcache_l1_init_gb}"
+  fi
 fi
 if [[ "${lmcache_separate_object_groups}" == 1 ]]; then
   server_args+=(--separate-object-groups)
@@ -259,6 +290,14 @@ if [[ "${ready}" != 1 ]]; then
   stop_children
   wait "${lmcache_pid}" 2>/dev/null || true
   exit 1
+fi
+
+# The named segment now exists and the LMCache server is healthy. Releasing
+# here serializes cooperating wrappers across both stale cleanup and creation.
+if [[ -n "${lmcache_shm_lock_fd}" ]]; then
+  flock -u "${lmcache_shm_lock_fd}"
+  exec {lmcache_shm_lock_fd}>&-
+  lmcache_shm_lock_fd=""
 fi
 
 printf 'LMCache ready: mode=%s transfer=%s L1=%sGB chunk=%s L2=%s health=http://%s:%s/healthcheck metrics=http://%s:%s/metrics log=%s\n' \

--- a/launchers/lmcache-shm-preflight.py
+++ b/launchers/lmcache-shm-preflight.py
@@ -1,0 +1,198 @@
+#!/usr/bin/env python3
+"""Validate a named LMCache shared-memory region before server startup."""
+
+from __future__ import annotations
+
+import argparse
+import os
+import re
+import sys
+from decimal import Decimal, InvalidOperation
+from pathlib import Path
+
+_GIB = 1024**3
+_SAFE_NAME = re.compile(r"[A-Za-z0-9][A-Za-z0-9_.-]{0,254}\Z")
+
+
+def required_bytes(size_gb: str) -> int:
+    """Convert a positive GiB capacity to bytes without float rounding."""
+    if len(size_gb) > 128:
+        raise ValueError("shared-memory capacity input is unreasonably long")
+    try:
+        size = Decimal(size_gb)
+    except InvalidOperation as exc:
+        raise ValueError(f"invalid shared-memory capacity: {size_gb!r}") from exc
+    if not size.is_finite() or size <= 0:
+        raise ValueError(f"shared-memory capacity must be positive: {size_gb!r}")
+    if size.adjusted() > 9:
+        raise ValueError(
+            f"shared-memory capacity is too large to represent: {size_gb!r}"
+        )
+    numerator, denominator = size.as_integer_ratio()
+    result = (numerator * _GIB + denominator - 1) // denominator
+    if result > sys.maxsize:
+        raise ValueError(
+            f"shared-memory capacity is too large to represent: {size_gb!r}"
+        )
+    return result
+
+
+def shm_path(name: str, *, root: Path = Path("/dev/shm")) -> Path:
+    """Return a path below ``root`` for one POSIX-style shared-memory name."""
+    if name in {"", ".", ".."} or _SAFE_NAME.fullmatch(name) is None:
+        raise ValueError(
+            "shared-memory name must start with an alphanumeric character and "
+            "contain only alphanumerics, dot, underscore, or hyphen"
+        )
+    return root / name
+
+
+def _normalized_proc_target(value: str) -> str:
+    deleted_suffix = " (deleted)"
+    return value.removesuffix(deleted_suffix)
+
+
+def holders(path: Path, *, proc_root: Path = Path("/proc")) -> list[str]:
+    """Return process IDs that map or hold an FD for ``path``."""
+    target = str(path)
+    found: set[str] = set()
+    try:
+        processes = list(proc_root.iterdir())
+    except OSError as exc:
+        raise RuntimeError(f"cannot inspect process table {proc_root}: {exc}") from exc
+
+    for process in processes:
+        if not process.name.isdigit():
+            continue
+        # ``preflight`` holds the candidate inode open while scanning so a
+        # replacement cannot reuse its inode. Ignore that deliberate self-FD.
+        if process.name == str(os.getpid()):
+            continue
+        try:
+            for line in (
+                (process / "maps")
+                .read_text(encoding="utf-8", errors="replace")
+                .splitlines()
+            ):
+                fields = line.split(maxsplit=5)
+                if len(fields) == 6 and _normalized_proc_target(fields[5]) == target:
+                    found.add(process.name)
+                    break
+        except (FileNotFoundError, ProcessLookupError):
+            pass
+        except OSError as exc:
+            raise RuntimeError(
+                f"cannot inspect process {process.name} mappings: {exc}"
+            ) from exc
+
+        try:
+            for descriptor in (process / "fd").iterdir():
+                try:
+                    linked = _normalized_proc_target(os.readlink(descriptor))
+                except (FileNotFoundError, ProcessLookupError):
+                    continue
+                except OSError as exc:
+                    raise RuntimeError(
+                        f"cannot inspect process {process.name} descriptor "
+                        f"{descriptor.name}: {exc}"
+                    ) from exc
+                if linked == target:
+                    found.add(process.name)
+                    break
+        except (FileNotFoundError, ProcessLookupError):
+            pass
+        except OSError as exc:
+            raise RuntimeError(
+                f"cannot inspect process {process.name} descriptors: {exc}"
+            ) from exc
+
+    return sorted(found, key=int)
+
+
+def available_bytes(path: Path) -> int:
+    """Return bytes available to unprivileged allocations in ``path``'s FS."""
+    stats = os.statvfs(path)
+    return stats.f_bavail * stats.f_frsize
+
+
+def preflight(
+    name: str,
+    *,
+    expected_bytes: int,
+    root: Path = Path("/dev/shm"),
+) -> Path:
+    """Remove an unheld stale region and verify capacity for a new one."""
+    if expected_bytes <= 0:
+        raise ValueError("expected_bytes must be positive")
+    if not root.is_dir():
+        raise RuntimeError(f"shared-memory root is not a directory: {root}")
+
+    path = shm_path(name, root=root)
+    if os.path.lexists(path):
+        if path.is_symlink() or not path.is_file():
+            raise RuntimeError(
+                f"shared-memory entry is not a regular file and will not be removed: {path}"
+            )
+        try:
+            descriptor = os.open(
+                path,
+                os.O_RDONLY | os.O_CLOEXEC | getattr(os, "O_NOFOLLOW", 0),
+            )
+        except OSError as exc:
+            raise RuntimeError(
+                f"shared-memory entry changed during holder inspection: {path}"
+            ) from exc
+        try:
+            inspected = os.fstat(descriptor)
+            active = holders(path)
+            if active:
+                raise RuntimeError(
+                    f"shared-memory entry {path} is held by an active process: "
+                    + ", ".join(active)
+                )
+            try:
+                current = path.stat(follow_symlinks=False)
+            except FileNotFoundError as exc:
+                raise RuntimeError(
+                    f"shared-memory entry changed during holder inspection: {path}"
+                ) from exc
+            if (current.st_dev, current.st_ino) != (
+                inspected.st_dev,
+                inspected.st_ino,
+            ):
+                raise RuntimeError(
+                    f"shared-memory entry changed during holder inspection: {path}"
+                )
+            path.unlink()
+        finally:
+            os.close(descriptor)
+
+    available = available_bytes(root)
+    if available < expected_bytes:
+        raise RuntimeError(
+            "insufficient capacity in "
+            f"{root}: need {expected_bytes} bytes, available {available} bytes"
+        )
+    return path
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--name", required=True)
+    parser.add_argument("--expected-gb", required=True)
+    parser.add_argument("--root", type=Path, default=Path("/dev/shm"))
+    args = parser.parse_args()
+
+    try:
+        expected = required_bytes(args.expected_gb)
+        path = preflight(args.name, expected_bytes=expected, root=args.root)
+    except (OSError, RuntimeError, ValueError) as error:
+        parser.error(str(error))
+    print(
+        f"LMCache shared-memory preflight passed: path={path} "
+        f"expected_bytes={expected} available_bytes={available_bytes(args.root)}"
+    )
+
+
+if __name__ == "__main__":
+    main()

--- a/launchers/serve-kimi-k3-production-dspark-ii
+++ b/launchers/serve-kimi-k3-production-dspark-ii
@@ -8,7 +8,10 @@ export LMCACHE_MODE="${LMCACHE_MODE:-ram}"
 export LMCACHE_L1_GB="${LMCACHE_L1_GB:-32}"
 # The standalone cache server has no CUDA context. Existing vLLM workers own
 # GPU gather/scatter operations and exchange bounded per-request CPU buffers
-# with the server.
+# with the server by default. Whole-pool direct SHM is opt-in: for a 48 GiB
+# pool set LMCACHE_SHM_NAME together with LMCACHE_L1_GB=48 and
+# LMCACHE_L1_INIT_GB=48. The wrapper validates stale holders and /dev/shm
+# capacity before starting a named pool.
 export LMCACHE_TRANSFER_MODE="${LMCACHE_TRANSFER_MODE:-engine_driven}"
 export LMCACHE_EXPECTED_SOURCE_ROOT="${LMCACHE_EXPECTED_SOURCE_ROOT:-/opt/kimi-k3-qsrt/lmcache}"
 export LMCACHE_SHM_NAME="${LMCACHE_SHM_NAME-}"

--- a/tests/test-glm52-lmcache-helper.sh
+++ b/tests/test-glm52-lmcache-helper.sh
@@ -40,6 +40,18 @@ exit 22
 SH
 chmod +x "${tmp_root}/bin/curl"
 
+cat >"${tmp_root}/bin/lmcache-shm-preflight.py" <<'SH'
+#!/usr/bin/env bash
+set -euo pipefail
+printf '%s\n' "$@" >"${LMCACHE_TEST_SHM_PREFLIGHT_ARGS}"
+if [[ -n "${LMCACHE_TEST_SHM_LOCK_TARGET:-}" ]] && \
+    flock -n "${LMCACHE_TEST_SHM_LOCK_TARGET}" -c true; then
+  echo "named SHM startup lock was not held during preflight" >&2
+  exit 91
+fi
+SH
+chmod +x "${tmp_root}/bin/lmcache-shm-preflight.py"
+
 cat >"${tmp_root}/model-server" <<'SH'
 #!/usr/bin/env bash
 set -euo pipefail
@@ -127,6 +139,30 @@ grep -Fq -- '"lmcache.mp.mp_transfer_mode":"engine_driven"' \
 sed -n '1p' "${tmp_root}/engine-server.env" | grep -Fxq ''
 sed -n '2p' "${tmp_root}/engine-server.env" | grep -Fxq 'LAZY'
 grep -Fxq '0,1' "${tmp_root}/engine-model-cuda.env"
+
+# A non-empty name selects direct shared-memory transfer and must pass a
+# capacity/stale-holder preflight before LMCache creates the region.
+mkdir -p "${tmp_root}/shm-locks"
+PATH="${tmp_root}/bin:${PATH}" \
+LMCACHE_MODE=ram \
+LMCACHE_SHM_NAME=direct-l1 \
+LMCACHE_L1_GB=2 \
+LMCACHE_L1_INIT_GB=1.5 \
+LMCACHE_SHM_LOCK_ROOT="${tmp_root}/shm-locks" \
+LMCACHE_SHM_PREFLIGHT_BIN="${tmp_root}/bin/lmcache-shm-preflight.py" \
+LMCACHE_TEST_SHM_LOCK_TARGET="${tmp_root}/shm-locks" \
+LMCACHE_TEST_SHM_PREFLIGHT_ARGS="${tmp_root}/shm-preflight.args" \
+LMCACHE_LOG="${tmp_root}/shm.log" \
+LMCACHE_TEST_SERVER_ARGS="${tmp_root}/shm-server.args" \
+LMCACHE_TEST_MODEL_ARGS="${tmp_root}/shm-model.args" \
+bash "${lmcache_wrapper}" \
+  "${tmp_root}/model-server" direct-shm
+grep -Fq -- '--shm-name direct-l1' "${tmp_root}/shm-server.args"
+grep -Fxq -- '--name' < <(sed -n '1p' "${tmp_root}/shm-preflight.args")
+grep -Fxq -- 'direct-l1' < <(sed -n '2p' "${tmp_root}/shm-preflight.args")
+grep -Fxq -- '--expected-gb' < <(sed -n '3p' "${tmp_root}/shm-preflight.args")
+grep -Fxq -- '1.5' < <(sed -n '4p' "${tmp_root}/shm-preflight.args")
+flock -n "${tmp_root}/shm-locks" -c true
 
 # HTTP health is the primary readiness contract; this test intentionally uses
 # a log string that cannot satisfy the fallback.

--- a/tests/test-kimi-source-overlay.sh
+++ b/tests/test-kimi-source-overlay.sh
@@ -8,6 +8,10 @@ scratch_dir="$(mktemp -d)"
 trap 'rm -rf "${scratch_dir}"' EXIT
 missing_source="${scratch_dir}/missing-vllm-source"
 
+grep -Fq \
+  'COPY --chmod=0755 launchers/lmcache-shm-preflight.py /usr/local/bin/lmcache-shm-preflight.py' \
+  "${repo_root}/Dockerfile.kimi-k3-qsrt-tp16-runtime"
+
 output="$({
   PYTHONPATH="${overlay_dir}" \
     VLLM_SOURCE_OVERLAY_ROOT="${missing_source}" \

--- a/tests/test_lmcache_shm_preflight.py
+++ b/tests/test_lmcache_shm_preflight.py
@@ -1,0 +1,153 @@
+from __future__ import annotations
+
+import importlib.util
+from decimal import Decimal
+from pathlib import Path
+
+import pytest
+
+MODULE_PATH = (
+    Path(__file__).resolve().parents[1] / "launchers" / "lmcache-shm-preflight.py"
+)
+SPEC = importlib.util.spec_from_file_location("lmcache_shm_preflight", MODULE_PATH)
+assert SPEC is not None and SPEC.loader is not None
+MODULE = importlib.util.module_from_spec(SPEC)
+SPEC.loader.exec_module(MODULE)
+
+
+def test_required_bytes_converts_gib_exactly() -> None:
+    assert MODULE.required_bytes("48") == 48 * 1024**3
+    assert MODULE.required_bytes("0.5") == 512 * 1024**2
+
+
+def test_required_bytes_ceil_is_exact_beyond_decimal_context_precision() -> None:
+    value = "1.00000000000000000000000000001"
+    numerator, denominator = Decimal(value).as_integer_ratio()
+    expected = (numerator * 1024**3 + denominator - 1) // denominator
+
+    assert MODULE.required_bytes(value) == expected
+
+
+@pytest.mark.parametrize("value", ["0", "-1", "nan", "inf", "not-a-number"])
+def test_required_bytes_rejects_invalid_capacity(value: str) -> None:
+    with pytest.raises(ValueError):
+        MODULE.required_bytes(value)
+
+
+def test_required_bytes_rejects_unrepresentable_capacity() -> None:
+    with pytest.raises(ValueError):
+        MODULE.required_bytes("1e1000000")
+
+
+@pytest.mark.parametrize("name", ["", ".", "..", "../escape", "a/b", " name"])
+def test_shm_path_rejects_unsafe_names(tmp_path: Path, name: str) -> None:
+    with pytest.raises(ValueError):
+        MODULE.shm_path(name, root=tmp_path)
+
+
+def test_preflight_removes_unheld_stale_file(monkeypatch, tmp_path: Path) -> None:
+    stale = tmp_path / "lmcache-l1"
+    stale.write_bytes(b"stale")
+    monkeypatch.setattr(MODULE, "holders", lambda _path: [])
+    monkeypatch.setattr(MODULE, "available_bytes", lambda _path: 4096)
+
+    result = MODULE.preflight("lmcache-l1", expected_bytes=1024, root=tmp_path)
+
+    assert result == stale
+    assert not stale.exists()
+
+
+def test_preflight_rejects_live_holder(monkeypatch, tmp_path: Path) -> None:
+    segment = tmp_path / "lmcache-l1"
+    segment.write_bytes(b"active")
+    monkeypatch.setattr(MODULE, "holders", lambda _path: ["1234"])
+
+    with pytest.raises(RuntimeError, match="active process"):
+        MODULE.preflight("lmcache-l1", expected_bytes=1024, root=tmp_path)
+
+    assert segment.exists()
+
+
+def test_preflight_refuses_path_replaced_during_holder_scan(
+    monkeypatch, tmp_path: Path
+) -> None:
+    segment = tmp_path / "lmcache-l1"
+    segment.write_bytes(b"stale")
+
+    def replace_segment(path: Path) -> list[str]:
+        path.unlink()
+        path.write_bytes(b"new live segment")
+        return []
+
+    monkeypatch.setattr(MODULE, "holders", replace_segment)
+    monkeypatch.setattr(MODULE, "available_bytes", lambda _path: 4096)
+
+    with pytest.raises(RuntimeError, match="changed during holder inspection"):
+        MODULE.preflight("lmcache-l1", expected_bytes=1024, root=tmp_path)
+
+    assert segment.read_bytes() == b"new live segment"
+
+
+def test_preflight_rejects_non_file_entry(monkeypatch, tmp_path: Path) -> None:
+    (tmp_path / "lmcache-l1").mkdir()
+    monkeypatch.setattr(MODULE, "holders", lambda _path: [])
+
+    with pytest.raises(RuntimeError, match="regular file"):
+        MODULE.preflight("lmcache-l1", expected_bytes=1024, root=tmp_path)
+
+
+def test_preflight_rejects_insufficient_capacity(monkeypatch, tmp_path: Path) -> None:
+    monkeypatch.setattr(MODULE, "available_bytes", lambda _path: 1023)
+
+    with pytest.raises(RuntimeError, match="insufficient capacity"):
+        MODULE.preflight("lmcache-l1", expected_bytes=1024, root=tmp_path)
+
+
+def test_preflight_accepts_exact_capacity(monkeypatch, tmp_path: Path) -> None:
+    monkeypatch.setattr(MODULE, "available_bytes", lambda _path: 1024)
+
+    result = MODULE.preflight("lmcache-l1", expected_bytes=1024, root=tmp_path)
+
+    assert result == tmp_path / "lmcache-l1"
+
+
+def test_holders_detects_maps_and_file_descriptors(tmp_path: Path) -> None:
+    proc_root = tmp_path / "proc"
+    shm_root = tmp_path / "shm"
+    shm_root.mkdir()
+    segment = shm_root / "lmcache-l1"
+    segment.write_bytes(b"")
+
+    maps_pid = proc_root / "100"
+    maps_pid.mkdir(parents=True)
+    (maps_pid / "maps").write_text(f"0-1 rw-s 0 00:00 0 {segment}\n", encoding="utf-8")
+    (maps_pid / "fd").mkdir()
+
+    fd_pid = proc_root / "200"
+    (fd_pid / "fd").mkdir(parents=True)
+    (fd_pid / "maps").write_text("", encoding="utf-8")
+    (fd_pid / "fd" / "7").symlink_to(segment)
+
+    assert MODULE.holders(segment, proc_root=proc_root) == ["100", "200"]
+
+
+def test_holders_fails_closed_when_proc_metadata_is_unreadable(
+    monkeypatch, tmp_path: Path
+) -> None:
+    proc_root = tmp_path / "proc"
+    process = proc_root / "100"
+    process.mkdir(parents=True)
+    maps = process / "maps"
+    maps.write_text("", encoding="utf-8")
+    (process / "fd").mkdir()
+    original_read_text = Path.read_text
+
+    def deny_maps(path: Path, *args, **kwargs):
+        if path == maps:
+            raise PermissionError("denied")
+        return original_read_text(path, *args, **kwargs)
+
+    monkeypatch.setattr(Path, "read_text", deny_maps)
+
+    with pytest.raises(RuntimeError, match="cannot inspect process 100"):
+        MODULE.holders(tmp_path / "lmcache-l1", proc_root=proc_root)


### PR DESCRIPTION
## Summary
- add a preflight helper for opt-in named LMCache shared-memory pools
- reject unsafe names, symlinks, non-regular segments, live holders, and insufficient `/dev/shm` capacity
- remove only the exact stale unheld segment before server startup
- hold the inspected inode open and serialize cooperating wrappers through segment creation
- package the helper in the Kimi runtime image and document a 48 GiB direct-SHM opt-in

## Why
Named whole-pool SHM can reduce transfer overhead, but a stale segment or an undersized `/dev/shm` otherwise fails late and can leave confusing restart behavior. The default per-request path remains unchanged.

## Validation
- `tests/test_lmcache_shm_preflight.py`: 22 passed
- `tests/test-glm52-lmcache-helper.sh`: PASS
- `tests/test-kimi-source-overlay.sh`: PASS
- `ruff check`, `ruff format --check`, shell syntax, static security scan, and `git diff --check` pass

## Compatibility and safety
- no preflight runs when `LMCACHE_SHM_NAME` is unset or explicitly empty
- live segments are never unlinked
- a read-only `flock` on the existing SHM root spans preflight through server readiness, closing the cleanup/create race for cooperating launchers without creating a lock pathname
- `/proc` inspection failures are fail-closed; only vanished processes or file descriptors are ignored
- the packaged Kimi runtime runs the helper as root; non-root deployments without `/proc` inspection permission fail safely before unlinking
- path traversal is rejected by a strict POSIX SHM-name grammar
- direct SHM remains an explicit deployment choice
