### PR TITLE
fix(kimi): use temporary L2 prefetch staging

### DIFF
--- a/launchers/lmcache-mp-wrapper.sh
+++ b/launchers/lmcache-mp-wrapper.sh
@@ -75,6 +75,15 @@ lmcache_l1_init_gb="${LMCACHE_L1_INIT_GB:-${lmcache_l1_gb}}"
 lmcache_gpu_workers="${LMCACHE_MAX_GPU_WORKERS:-${TP_SIZE:-${TP:-1}}}"
 lmcache_cpu_workers="${LMCACHE_MAX_CPU_WORKERS:-4}"
 lmcache_log="${LMCACHE_LOG:-/tmp/lmcache-mp-${service_port}.log}"
+lmcache_l2_prefetch_policy="${LMCACHE_L2_PREFETCH_POLICY:-retain}"
+lmcache_l2_prefetch_policy="${lmcache_l2_prefetch_policy,,}"
+case "${lmcache_l2_prefetch_policy}" in
+  default|retain) ;;
+  *)
+    echo "ERROR: LMCACHE_L2_PREFETCH_POLICY must be default or retain; got ${lmcache_l2_prefetch_policy}" >&2
+    exit 2
+    ;;
+esac
 lmcache_transfer_mode="${LMCACHE_TRANSFER_MODE:-auto}"
 lmcache_transfer_mode="${lmcache_transfer_mode,,}"
 case "${lmcache_transfer_mode}" in
@@ -112,7 +121,7 @@ server_args=(
   --eviction-trigger-watermark 0.90
   --eviction-ratio 0.10
   --l2-store-policy default
-  --l2-prefetch-policy retain
+  --l2-prefetch-policy "${lmcache_l2_prefetch_policy}"
   --http-port "${lmcache_http_port}"
 )
 

--- a/launchers/serve-kimi-k3-production-dspark-ii
+++ b/launchers/serve-kimi-k3-production-dspark-ii
@@ -14,6 +14,10 @@ export LMCACHE_EXPECTED_SOURCE_ROOT="${LMCACHE_EXPECTED_SOURCE_ROOT:-/opt/kimi-k
 export LMCACHE_SHM_NAME="${LMCACHE_SHM_NAME-}"
 export LMCACHE_SEPARATE_OBJECT_GROUPS="${LMCACHE_SEPARATE_OBJECT_GROUPS:-1}"
 export LMCACHE_SERVER_ENV="${LMCACHE_SERVER_ENV-CUDA_VISIBLE_DEVICES= CUDA_MODULE_LOADING=LAZY}"
+# Kimi's large recurrent-cache objects make retained L2 prefetched buffers
+# accumulate L1 pressure across restores. Use temporary L1 staging by default;
+# operators can opt back into retain for a separately qualified workload.
+export LMCACHE_L2_PREFETCH_POLICY="${LMCACHE_L2_PREFETCH_POLICY:-default}"
 # Kimi-K3 DCP16 exposes 768-token scheduler blocks and 12,288-token MLA
 # transfer groups. LMCache chunks must preserve both granularities.
 export LMCACHE_CHUNK_SIZE="${LMCACHE_CHUNK_SIZE:-12288}"

--- a/tests/test-glm52-lmcache-helper.sh
+++ b/tests/test-glm52-lmcache-helper.sh
@@ -173,6 +173,30 @@ bash "${lmcache_wrapper}" \
 grep -Fq -- '--max-gpu-workers 2' "${tmp_root}/override-server.args"
 grep -Fq -- '--chunk-size 768' "${tmp_root}/override-server.args"
 
+# The prefetch policy is independently configurable. Retain remains the
+# generic wrapper default; profiles with sustained L1 pressure can select the
+# temporary-staging policy explicitly.
+PATH="${tmp_root}/bin:${PATH}" \
+LMCACHE_MODE=ram \
+LMCACHE_L2_PREFETCH_POLICY=default \
+LMCACHE_L1_GB=2 \
+LMCACHE_LOG="${tmp_root}/prefetch.log" \
+LMCACHE_TEST_SERVER_ARGS="${tmp_root}/prefetch-server.args" \
+LMCACHE_TEST_MODEL_ARGS="${tmp_root}/prefetch-model.args" \
+bash "${lmcache_wrapper}" \
+  "${tmp_root}/model-server"
+grep -Fq -- '--l2-prefetch-policy default' \
+  "${tmp_root}/prefetch-server.args"
+
+if PATH="${tmp_root}/bin:${PATH}" \
+  LMCACHE_MODE=ram \
+  LMCACHE_L2_PREFETCH_POLICY=invalid \
+  bash "${lmcache_wrapper}" \
+    "${tmp_root}/model-server"; then
+  echo 'Invalid LMCache L2 prefetch policy unexpectedly succeeded' >&2
+  exit 1
+fi
+
 PATH="${tmp_root}/bin:${PATH}" \
 LMCACHE_MODE=ram \
 PORT=8005 \
@@ -212,6 +236,7 @@ fi
 grep -Fq -- 'fs_native' "${tmp_root}/disk-server.args"
 grep -Fq -- 'use_odirect' "${tmp_root}/disk-server.args"
 grep -Fq -- 'max_capacity_gb' "${tmp_root}/disk-server.args"
+grep -Fq -- '--l2-prefetch-policy retain' "${tmp_root}/disk-server.args"
 
 if PATH="${tmp_root}/bin:${PATH}" \
   LMCACHE_MODE=invalid \

--- a/tests/test-kimi-source-overlay.sh
+++ b/tests/test-kimi-source-overlay.sh
@@ -8,6 +8,10 @@ scratch_dir="$(mktemp -d)"
 trap 'rm -rf "${scratch_dir}"' EXIT
 missing_source="${scratch_dir}/missing-vllm-source"
 
+grep -Fq \
+  'export LMCACHE_L2_PREFETCH_POLICY="${LMCACHE_L2_PREFETCH_POLICY:-default}"' \
+  "${repo_root}/launchers/serve-kimi-k3-production-dspark-ii"
+
 output="$({
   PYTHONPATH="${overlay_dir}" \
     VLLM_SOURCE_OVERLAY_ROOT="${missing_source}" \


### PR DESCRIPTION
## Summary
- make LMCache L2 prefetch policy configurable as `default` or `retain`
- preserve `retain` as the generic wrapper default
- select `default` in the Kimi production profile
- reject invalid policy values before starting LMCache

## Why
`retain` keeps prefetched L2 objects resident in L1 and can create cumulative L1 pressure during long Kimi prefix replay. `default` uses L1 as temporary staging for the load and avoids `l2_prefetch_failure{reason=l1_oom}` while preserving explicit override support.

## Validation
- wrapper regression covers default override, retained generic default, and invalid-value rejection
- `tests/test-glm52-lmcache-helper.sh`: PASS
- `tests/test-kimi-source-overlay.sh`: PASS
- shell syntax, static security scan, and `git diff --check` pass

## Compatibility
Non-Kimi launchers keep the existing `retain` behavior unless the new environment variable is set.
