### PR TITLE
feat(lmcache): reset incompatible L2 layouts

### DIFF
--- a/Dockerfile.kimi-k3-qsrt-tp16-runtime
+++ b/Dockerfile.kimi-k3-qsrt-tp16-runtime
@@ -127,6 +127,7 @@ COPY --chmod=0755 launchers/serve-kimi-k3-full-mxfp4-dflash-ii /usr/local/bin/se
 COPY --chmod=0755 launchers/serve-kimi-k3-qsrt-nospec /usr/local/bin/serve-kimi-k3-qsrt-nospec
 COPY --chmod=0755 launchers/serve-kimi-k3-qsrt-dspark /usr/local/bin/serve-kimi-k3-qsrt-dspark
 COPY --chmod=0755 launchers/lmcache-mp-wrapper.sh /usr/local/bin/lmcache-mp-wrapper.sh
+COPY --chmod=0755 launchers/lmcache-layout-fingerprint.py /usr/local/bin/lmcache-layout-fingerprint.py
 COPY --chmod=0755 launchers/serve-kimi-k3-production-dspark-ii /usr/local/bin/serve-kimi-k3-production-dspark-ii
 
 RUN set -eux; \

--- a/launchers/lmcache-layout-fingerprint.py
+++ b/launchers/lmcache-layout-fingerprint.py
@@ -1,0 +1,242 @@
+#!/usr/bin/env python3
+"""Version a persistent LMCache L2 directory by cache-layout inputs."""
+
+from __future__ import annotations
+
+import argparse
+import fcntl
+import hashlib
+import json
+import os
+import shutil
+from pathlib import Path
+from typing import Any
+
+SCHEMA_VERSION = 1
+STATE_FILE = ".lmcache-layout-fingerprint.json"
+LOCK_FILE = ".lmcache-layout-fingerprint.lock"
+STATE_TEMP_PREFIX = f"{STATE_FILE}.tmp."
+_IGNORED_SOURCE_DIRS = frozenset(
+    {".git", ".mypy_cache", ".pytest_cache", ".ruff_cache", "__pycache__"}
+)
+_IGNORED_SOURCE_SUFFIXES = frozenset({".pyc", ".pyo"})
+
+
+def _sha256_file(path: Path) -> str:
+    digest = hashlib.sha256()
+    with path.open("rb") as handle:
+        for chunk in iter(lambda: handle.read(1024 * 1024), b""):
+            digest.update(chunk)
+    return digest.hexdigest()
+
+
+def _path_manifest(path: Path) -> dict[str, Any]:
+    if not path.exists():
+        raise FileNotFoundError(path)
+    if path.is_symlink():
+        return {"path": str(path), "kind": "symlink", "target": os.readlink(path)}
+    if path.is_file():
+        return {"path": str(path), "kind": "file", "sha256": _sha256_file(path)}
+    if not path.is_dir():
+        raise ValueError(f"unsupported fingerprint input: {path}")
+
+    members: list[dict[str, str]] = []
+    for member in sorted(path.rglob("*"), key=lambda item: str(item.relative_to(path))):
+        relative_path = member.relative_to(path)
+        if any(part in _IGNORED_SOURCE_DIRS for part in relative_path.parts):
+            continue
+        if member.suffix in _IGNORED_SOURCE_SUFFIXES:
+            continue
+        relative = str(relative_path)
+        if member.is_symlink():
+            members.append(
+                {"path": relative, "kind": "symlink", "target": os.readlink(member)}
+            )
+        elif member.is_file():
+            members.append(
+                {"path": relative, "kind": "file", "sha256": _sha256_file(member)}
+            )
+    return {"path": str(path), "kind": "directory", "members": members}
+
+
+def build_manifest(
+    *,
+    config_paths: list[Path],
+    software_paths: list[Path],
+    values: dict[str, str],
+) -> tuple[dict[str, Any], str]:
+    """Build a canonical manifest and its SHA-256 layout identity."""
+    payload: dict[str, Any] = {
+        "schema": SCHEMA_VERSION,
+        "inputs": {
+            "configs": [_path_manifest(path) for path in sorted(config_paths, key=str)],
+            "software": [
+                _path_manifest(path) for path in sorted(software_paths, key=str)
+            ],
+            "values": dict(sorted(values.items())),
+        },
+    }
+    encoded = json.dumps(payload, sort_keys=True, separators=(",", ":")).encode()
+    digest = hashlib.sha256(encoded).hexdigest()
+    return {**payload, "digest": digest}, digest
+
+
+def _read_state(path: Path) -> dict[str, Any] | None:
+    try:
+        state = json.loads(path.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError):
+        return None
+    if not isinstance(state, dict) or state.get("schema") != SCHEMA_VERSION:
+        return None
+    digest = state.get("digest")
+    if not isinstance(digest, str) or len(digest) != 64:
+        return None
+    return state
+
+
+def _write_state(path: Path, manifest: dict[str, Any]) -> None:
+    temporary = path.with_name(f"{path.name}.tmp.{os.getpid()}")
+    encoded = json.dumps(manifest, indent=2, sort_keys=True) + "\n"
+    try:
+        with temporary.open("w", encoding="utf-8") as handle:
+            handle.write(encoded)
+            handle.flush()
+            os.fsync(handle.fileno())
+        os.replace(temporary, path)
+    finally:
+        temporary.unlink(missing_ok=True)
+
+
+def _data_entries(path: Path) -> list[Path]:
+    metadata = {STATE_FILE, LOCK_FILE}
+    return [entry for entry in path.iterdir() if entry.name not in metadata]
+
+
+def _remove_stale_state_temps(path: Path) -> None:
+    for entry in path.iterdir():
+        if entry.name.startswith(STATE_TEMP_PREFIX) and (
+            entry.is_file() or entry.is_symlink()
+        ):
+            entry.unlink()
+
+
+def _clear_data(path: Path) -> None:
+    for entry in _data_entries(path):
+        if entry.is_symlink() or not entry.is_dir():
+            entry.unlink()
+        else:
+            shutil.rmtree(entry)
+    (path / STATE_FILE).unlink(missing_ok=True)
+
+
+def reconcile(
+    l2_path: Path,
+    manifest: dict[str, Any],
+    *,
+    policy: str,
+    adopt_unmarked: bool = False,
+) -> str:
+    """Preserve or reset one dedicated L2 directory under an exclusive lock."""
+    if policy not in {"auto", "always", "never"}:
+        raise ValueError(f"invalid L2 reset policy: {policy!r}")
+    digest = manifest.get("digest")
+    if not isinstance(digest, str) or len(digest) != 64:
+        raise ValueError("manifest digest must be a SHA-256 hex string")
+
+    l2_path.mkdir(parents=True, exist_ok=True)
+    resolved = l2_path.resolve()
+    if resolved == Path(resolved.anchor):
+        raise ValueError(
+            f"refusing to manage filesystem root as LMCache L2: {resolved}"
+        )
+
+    lock_path = resolved / LOCK_FILE
+    state_path = resolved / STATE_FILE
+    with lock_path.open("a+", encoding="utf-8") as lock:
+        fcntl.flock(lock, fcntl.LOCK_EX)
+        _remove_stale_state_temps(resolved)
+        previous = _read_state(state_path)
+        compatible = previous is not None and previous.get("digest") == digest
+
+        if policy == "never":
+            return "compatible" if compatible else "mismatch-preserved"
+        if policy == "always":
+            _clear_data(resolved)
+            _write_state(state_path, manifest)
+            return "reset"
+        if compatible:
+            return "compatible"
+
+        had_data = bool(_data_entries(resolved))
+        had_state = state_path.exists()
+        if had_data and not had_state and not adopt_unmarked:
+            raise RuntimeError(
+                "refusing to reset an unversioned non-empty L2 directory; "
+                "pass --adopt-unmarked once after confirming that the path is "
+                "dedicated to LMCache"
+            )
+        if had_data or had_state:
+            _clear_data(resolved)
+            result = "reset"
+        else:
+            result = "initialized"
+        _write_state(state_path, manifest)
+        return result
+
+
+def _parse_values(raw_values: list[str]) -> dict[str, str]:
+    values: dict[str, str] = {}
+    for raw in raw_values:
+        key, separator, value = raw.partition("=")
+        if not separator or not key:
+            raise ValueError(f"layout value must be key=value: {raw!r}")
+        if key in values:
+            raise ValueError(f"duplicate layout value: {key}")
+        values[key] = value
+    return values
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--l2-path", type=Path, required=True)
+    parser.add_argument("--policy", choices=("auto", "always", "never"), required=True)
+    parser.add_argument(
+        "--adopt-unmarked",
+        action="store_true",
+        help="allow auto policy to reset a non-empty directory with no state file",
+    )
+    parser.add_argument("--config-path", type=Path, action="append", default=[])
+    parser.add_argument("--software-path", type=Path, action="append", default=[])
+    parser.add_argument("--value", action="append", default=[])
+    args = parser.parse_args()
+
+    try:
+        values = _parse_values(args.value)
+        manifest, digest = build_manifest(
+            config_paths=args.config_path,
+            software_paths=args.software_path,
+            values=values,
+        )
+        result = reconcile(
+            args.l2_path,
+            manifest,
+            policy=args.policy,
+            adopt_unmarked=args.adopt_unmarked,
+        )
+    except (OSError, RuntimeError, ValueError) as error:
+        parser.error(str(error))
+    print(
+        json.dumps(
+            {
+                "digest": digest,
+                "l2_path": str(args.l2_path.resolve()),
+                "policy": args.policy,
+                "result": result,
+            },
+            sort_keys=True,
+        )
+    )
+
+
+if __name__ == "__main__":
+    main()

--- a/launchers/lmcache-mp-wrapper.sh
+++ b/launchers/lmcache-mp-wrapper.sh
@@ -75,6 +75,25 @@ lmcache_l1_init_gb="${LMCACHE_L1_INIT_GB:-${lmcache_l1_gb}}"
 lmcache_gpu_workers="${LMCACHE_MAX_GPU_WORKERS:-${TP_SIZE:-${TP:-1}}}"
 lmcache_cpu_workers="${LMCACHE_MAX_CPU_WORKERS:-4}"
 lmcache_log="${LMCACHE_LOG:-/tmp/lmcache-mp-${service_port}.log}"
+lmcache_reset_l2="${LMCACHE_RESET_L2_ON_START:-never}"
+lmcache_reset_l2="${lmcache_reset_l2,,}"
+case "${lmcache_reset_l2}" in
+  auto|always|never) ;;
+  *)
+    echo "ERROR: LMCACHE_RESET_L2_ON_START must be auto, always, or never; got ${lmcache_reset_l2}" >&2
+    exit 2
+    ;;
+esac
+lmcache_layout_adopt_unmarked="${LMCACHE_LAYOUT_ADOPT_UNMARKED:-0}"
+lmcache_layout_adopt_unmarked="${lmcache_layout_adopt_unmarked,,}"
+case "${lmcache_layout_adopt_unmarked}" in
+  1|true|yes|on) lmcache_layout_adopt_unmarked=1 ;;
+  0|false|no|off) lmcache_layout_adopt_unmarked=0 ;;
+  *)
+    echo "ERROR: LMCACHE_LAYOUT_ADOPT_UNMARKED must be a boolean; got ${lmcache_layout_adopt_unmarked}" >&2
+    exit 2
+    ;;
+esac
 lmcache_transfer_mode="${LMCACHE_TRANSFER_MODE:-auto}"
 lmcache_transfer_mode="${lmcache_transfer_mode,,}"
 case "${lmcache_transfer_mode}" in
@@ -155,6 +174,41 @@ print(
 PY
   )"
   server_args+=(--l2-adapter "${l2_config}")
+
+  if [[ "${lmcache_reset_l2}" != never ]]; then
+    wrapper_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+    layout_fingerprint="${LMCACHE_LAYOUT_FINGERPRINT_BIN:-${wrapper_dir}/lmcache-layout-fingerprint.py}"
+    if [[ ! -x "${layout_fingerprint}" ]]; then
+      echo "ERROR: LMCache layout fingerprint helper is not executable: ${layout_fingerprint}" >&2
+      exit 2
+    fi
+    layout_args=(
+      --l2-path "${lmcache_l2_path}"
+      --policy "${lmcache_reset_l2}"
+      --value "runtime_fingerprint=${LOCAL_INFERENCE_CACHE_FINGERPRINT:-unknown}"
+      --value "model=${MODEL:-}"
+      --value "draft_model=${DRAFT_MODEL:-}"
+      --value "tp_size=${TP_SIZE:-${TP:-1}}"
+      --value "dcp_size=${DCP_SIZE:-${DCP:-1}}"
+      --value "chunk_size=${lmcache_chunk_size}"
+      --value "transfer_mode=${lmcache_transfer_mode}"
+      --value "separate_object_groups=${lmcache_separate_object_groups}"
+    )
+    if [[ "${lmcache_layout_adopt_unmarked}" == 1 ]]; then
+      layout_args+=(--adopt-unmarked)
+    fi
+    IFS=: read -r -a layout_config_paths \
+      <<< "${LMCACHE_LAYOUT_CONFIG_PATHS:-}"
+    for path in "${layout_config_paths[@]}"; do
+      [[ -n "${path}" ]] && layout_args+=(--config-path "${path}")
+    done
+    IFS=: read -r -a layout_software_paths \
+      <<< "${LMCACHE_LAYOUT_SOFTWARE_PATHS:-}"
+    for path in "${layout_software_paths[@]}"; do
+      [[ -n "${path}" ]] && layout_args+=(--software-path "${path}")
+    done
+    "${layout_fingerprint}" "${layout_args[@]}"
+  fi
 fi
 
 transfer_config="$(

--- a/launchers/serve-kimi-k3-production-dspark-ii
+++ b/launchers/serve-kimi-k3-production-dspark-ii
@@ -4,6 +4,8 @@
 # control, or LMCACHE_MODE=disk with a persistent /cache mount for an L2 tier.
 set -euo pipefail
 
+export MODEL="${MODEL:-/root/.cache/huggingface/hub/models--moonshotai--Kimi-K3/snapshots/2496450e92e425c886db095102a52a6682ca3970}"
+export DRAFT_MODEL="${DRAFT_MODEL:-/root/.cache/huggingface/hub/models--Inferact--Kimi-K3-DSpark/snapshots/cf6b8244620e7ea4b0651d214f28e89eac75bed6}"
 export LMCACHE_MODE="${LMCACHE_MODE:-ram}"
 export LMCACHE_L1_GB="${LMCACHE_L1_GB:-32}"
 # The standalone cache server has no CUDA context. Existing vLLM workers own
@@ -14,6 +16,12 @@ export LMCACHE_EXPECTED_SOURCE_ROOT="${LMCACHE_EXPECTED_SOURCE_ROOT:-/opt/kimi-k
 export LMCACHE_SHM_NAME="${LMCACHE_SHM_NAME-}"
 export LMCACHE_SEPARATE_OBJECT_GROUPS="${LMCACHE_SEPARATE_OBJECT_GROUPS:-1}"
 export LMCACHE_SERVER_ENV="${LMCACHE_SERVER_ENV-CUDA_VISIBLE_DEVICES= CUDA_MODULE_LOADING=LAZY}"
+export LMCACHE_RESET_L2_ON_START="${LMCACHE_RESET_L2_ON_START:-auto}"
+# Auto mode refuses to erase a non-empty directory that predates fingerprint
+# metadata. Set this to 1 for one confirmed migration of a dedicated L2 path.
+export LMCACHE_LAYOUT_ADOPT_UNMARKED="${LMCACHE_LAYOUT_ADOPT_UNMARKED:-0}"
+export LMCACHE_LAYOUT_CONFIG_PATHS="${LMCACHE_LAYOUT_CONFIG_PATHS:-${MODEL}/config.json:${DRAFT_MODEL}/config.json}"
+export LMCACHE_LAYOUT_SOFTWARE_PATHS="${LMCACHE_LAYOUT_SOFTWARE_PATHS:-/opt/kimi-k3-qsrt/lmcache/lmcache/integration/vllm:/opt/kimi-k3-qsrt/lmcache/lmcache/v1/multiprocess}"
 # Kimi-K3 DCP16 exposes 768-token scheduler blocks and 12,288-token MLA
 # transfer groups. LMCache chunks must preserve both granularities.
 export LMCACHE_CHUNK_SIZE="${LMCACHE_CHUNK_SIZE:-12288}"

--- a/tests/test-glm52-lmcache-helper.sh
+++ b/tests/test-glm52-lmcache-helper.sh
@@ -40,6 +40,13 @@ exit 22
 SH
 chmod +x "${tmp_root}/bin/curl"
 
+cat >"${tmp_root}/bin/lmcache-layout-fingerprint.py" <<'SH'
+#!/usr/bin/env bash
+set -euo pipefail
+printf '%s\n' "$@" >"${LMCACHE_TEST_LAYOUT_ARGS}"
+SH
+chmod +x "${tmp_root}/bin/lmcache-layout-fingerprint.py"
+
 cat >"${tmp_root}/model-server" <<'SH'
 #!/usr/bin/env bash
 set -euo pipefail
@@ -196,6 +203,15 @@ PORT=8003 \
 LMCACHE_L1_GB=2 \
 LMCACHE_L2_GB=7 \
 LMCACHE_L2_PATH="${tmp_root}/l2" \
+LMCACHE_RESET_L2_ON_START=auto \
+LMCACHE_LAYOUT_FINGERPRINT_BIN="${tmp_root}/bin/lmcache-layout-fingerprint.py" \
+LMCACHE_LAYOUT_CONFIG_PATHS='/models/target/config.json:/models/draft/config.json' \
+LMCACHE_LAYOUT_SOFTWARE_PATHS='/opt/runtime/lmcache:/opt/runtime/vllm' \
+LMCACHE_LAYOUT_ADOPT_UNMARKED=1 \
+LMCACHE_TEST_LAYOUT_ARGS="${tmp_root}/layout.args" \
+LOCAL_INFERENCE_CACHE_FINGERPRINT=runtime-tree \
+MODEL=/models/target \
+DRAFT_MODEL=/models/draft \
 LMCACHE_HTTP_PORT=8181 \
 LMCACHE_LOG="${tmp_root}/disk.log" \
 LMCACHE_TEST_SERVER_ARGS="${tmp_root}/disk-server.args" \
@@ -212,6 +228,25 @@ fi
 grep -Fq -- 'fs_native' "${tmp_root}/disk-server.args"
 grep -Fq -- 'use_odirect' "${tmp_root}/disk-server.args"
 grep -Fq -- 'max_capacity_gb' "${tmp_root}/disk-server.args"
+grep -Fxq -- '--l2-path' < <(sed -n '1p' "${tmp_root}/layout.args")
+grep -Fxq -- "${tmp_root}/l2" < <(sed -n '2p' "${tmp_root}/layout.args")
+grep -Fq -- '--policy' "${tmp_root}/layout.args"
+grep -Fq -- 'auto' "${tmp_root}/layout.args"
+grep -Fq -- '--adopt-unmarked' "${tmp_root}/layout.args"
+grep -Fq -- '/models/target/config.json' "${tmp_root}/layout.args"
+grep -Fq -- '/models/draft/config.json' "${tmp_root}/layout.args"
+grep -Fq -- '/opt/runtime/lmcache' "${tmp_root}/layout.args"
+grep -Fq -- 'runtime_fingerprint=runtime-tree' "${tmp_root}/layout.args"
+grep -Fq -- 'chunk_size=512' "${tmp_root}/layout.args"
+
+if PATH="${tmp_root}/bin:${PATH}" \
+  LMCACHE_MODE=disk \
+  LMCACHE_RESET_L2_ON_START=invalid \
+  bash "${lmcache_wrapper}" \
+    "${tmp_root}/model-server"; then
+  echo 'Invalid LMCache L2 reset policy unexpectedly succeeded' >&2
+  exit 1
+fi
 
 if PATH="${tmp_root}/bin:${PATH}" \
   LMCACHE_MODE=invalid \

--- a/tests/test-kimi-source-overlay.sh
+++ b/tests/test-kimi-source-overlay.sh
@@ -8,6 +8,15 @@ scratch_dir="$(mktemp -d)"
 trap 'rm -rf "${scratch_dir}"' EXIT
 missing_source="${scratch_dir}/missing-vllm-source"
 
+grep -Fq \
+  'COPY --chmod=0755 launchers/lmcache-layout-fingerprint.py /usr/local/bin/lmcache-layout-fingerprint.py' \
+  "${repo_root}/Dockerfile.kimi-k3-qsrt-tp16-runtime"
+grep -Fq \
+  'export LMCACHE_RESET_L2_ON_START="${LMCACHE_RESET_L2_ON_START:-auto}"' \
+  "${repo_root}/launchers/serve-kimi-k3-production-dspark-ii"
+grep -Fq 'LMCACHE_LAYOUT_CONFIG_PATHS' \
+  "${repo_root}/launchers/serve-kimi-k3-production-dspark-ii"
+
 output="$({
   PYTHONPATH="${overlay_dir}" \
     VLLM_SOURCE_OVERLAY_ROOT="${missing_source}" \

--- a/tests/test_lmcache_layout_fingerprint.py
+++ b/tests/test_lmcache_layout_fingerprint.py
@@ -1,0 +1,215 @@
+from __future__ import annotations
+
+import importlib.util
+import json
+from pathlib import Path
+
+import pytest
+
+MODULE_PATH = (
+    Path(__file__).resolve().parents[1] / "launchers" / "lmcache-layout-fingerprint.py"
+)
+SPEC = importlib.util.spec_from_file_location("lmcache_layout_fingerprint", MODULE_PATH)
+assert SPEC is not None and SPEC.loader is not None
+MODULE = importlib.util.module_from_spec(SPEC)
+SPEC.loader.exec_module(MODULE)
+
+
+def test_build_manifest_is_stable_and_content_addressed(tmp_path: Path) -> None:
+    config = tmp_path / "config.json"
+    source = tmp_path / "source.py"
+    config.write_text('{"layers": 61}\n', encoding="utf-8")
+    source.write_text("LAYOUT_VERSION = 1\n", encoding="utf-8")
+
+    first_manifest, first_digest = MODULE.build_manifest(
+        config_paths=[config],
+        software_paths=[source],
+        values={"chunk_size": "12288", "dcp_size": "8"},
+    )
+    second_manifest, second_digest = MODULE.build_manifest(
+        config_paths=[config],
+        software_paths=[source],
+        values={"dcp_size": "8", "chunk_size": "12288"},
+    )
+
+    assert first_manifest == second_manifest
+    assert first_digest == second_digest
+
+    config.write_text('{"layers": 62}\n', encoding="utf-8")
+    _, changed_digest = MODULE.build_manifest(
+        config_paths=[config],
+        software_paths=[source],
+        values={"chunk_size": "12288", "dcp_size": "8"},
+    )
+    assert changed_digest != first_digest
+
+
+def test_build_manifest_hashes_directory_members(tmp_path: Path) -> None:
+    source = tmp_path / "source"
+    source.mkdir()
+    (source / "a.py").write_text("A = 1\n", encoding="utf-8")
+    _, first = MODULE.build_manifest(
+        config_paths=[], software_paths=[source], values={}
+    )
+    (source / "b.py").write_text("B = 2\n", encoding="utf-8")
+    _, second = MODULE.build_manifest(
+        config_paths=[], software_paths=[source], values={}
+    )
+    assert first != second
+
+
+def test_build_manifest_ignores_generated_python_artifacts(tmp_path: Path) -> None:
+    source = tmp_path / "source"
+    source.mkdir()
+    (source / "a.py").write_text("A = 1\n", encoding="utf-8")
+    _, before = MODULE.build_manifest(
+        config_paths=[], software_paths=[source], values={}
+    )
+
+    pycache = source / "__pycache__"
+    pycache.mkdir()
+    (pycache / "a.cpython-312.pyc").write_bytes(b"runtime bytecode")
+    (source / ".ruff_cache").mkdir()
+    (source / ".ruff_cache" / "state").write_bytes(b"runtime cache")
+    _, after_runtime_files = MODULE.build_manifest(
+        config_paths=[], software_paths=[source], values={}
+    )
+
+    assert after_runtime_files == before
+
+    (source / "b.py").write_text("B = 2\n", encoding="utf-8")
+    _, after_source_change = MODULE.build_manifest(
+        config_paths=[], software_paths=[source], values={}
+    )
+    assert after_source_change != before
+
+
+def test_build_manifest_rejects_missing_input(tmp_path: Path) -> None:
+    with pytest.raises(FileNotFoundError):
+        MODULE.build_manifest(
+            config_paths=[tmp_path / "missing.json"],
+            software_paths=[],
+            values={},
+        )
+
+
+def _manifest(digest: str) -> dict[str, object]:
+    return {"schema": 1, "digest": digest * 64, "inputs": {"test": digest}}
+
+
+def test_auto_initializes_empty_l2_directory(tmp_path: Path) -> None:
+    l2 = tmp_path / "l2"
+    l2.mkdir()
+
+    result = MODULE.reconcile(l2, _manifest("a"), policy="auto")
+
+    assert result == "initialized"
+    state = json.loads((l2 / MODULE.STATE_FILE).read_text(encoding="utf-8"))
+    assert state["digest"] == "a" * 64
+
+
+def test_auto_removes_stale_state_temporary_files(tmp_path: Path) -> None:
+    l2 = tmp_path / "l2"
+    l2.mkdir()
+    stale = l2 / f"{MODULE.STATE_FILE}.tmp.123"
+    stale.write_text("partial", encoding="utf-8")
+
+    result = MODULE.reconcile(l2, _manifest("a"), policy="auto")
+
+    assert result == "initialized"
+    assert not stale.exists()
+
+
+def test_auto_preserves_matching_objects(tmp_path: Path) -> None:
+    l2 = tmp_path / "l2"
+    l2.mkdir()
+    MODULE.reconcile(l2, _manifest("a"), policy="auto")
+    cached = l2 / "object-1"
+    cached.write_bytes(b"cache")
+
+    result = MODULE.reconcile(l2, _manifest("a"), policy="auto")
+
+    assert result == "compatible"
+    assert cached.read_bytes() == b"cache"
+
+
+def test_auto_clears_mismatched_objects(tmp_path: Path) -> None:
+    l2 = tmp_path / "l2"
+    l2.mkdir()
+    MODULE.reconcile(l2, _manifest("a"), policy="auto")
+    (l2 / "object-1").write_bytes(b"cache")
+    nested = l2 / "nested"
+    nested.mkdir()
+    (nested / "object-2").write_bytes(b"cache")
+
+    result = MODULE.reconcile(l2, _manifest("b"), policy="auto")
+
+    assert result == "reset"
+    assert not (l2 / "object-1").exists()
+    assert not nested.exists()
+    state = json.loads((l2 / MODULE.STATE_FILE).read_text(encoding="utf-8"))
+    assert state["digest"] == "b" * 64
+
+
+def test_auto_refuses_unversioned_objects_without_adoption(tmp_path: Path) -> None:
+    l2 = tmp_path / "l2"
+    l2.mkdir()
+    legacy = l2 / "legacy-object"
+    legacy.write_bytes(b"cache")
+
+    with pytest.raises(RuntimeError, match="unversioned"):
+        MODULE.reconcile(l2, _manifest("a"), policy="auto")
+
+    assert legacy.read_bytes() == b"cache"
+
+
+def test_auto_adopts_and_clears_unversioned_objects(tmp_path: Path) -> None:
+    l2 = tmp_path / "l2"
+    l2.mkdir()
+    (l2 / "legacy-object").write_bytes(b"cache")
+
+    result = MODULE.reconcile(l2, _manifest("a"), policy="auto", adopt_unmarked=True)
+
+    assert result == "reset"
+    assert not (l2 / "legacy-object").exists()
+
+
+def test_never_preserves_mismatch_and_original_state(tmp_path: Path) -> None:
+    l2 = tmp_path / "l2"
+    l2.mkdir()
+    MODULE.reconcile(l2, _manifest("a"), policy="auto")
+    cached = l2 / "object-1"
+    cached.write_bytes(b"cache")
+
+    result = MODULE.reconcile(l2, _manifest("b"), policy="never")
+
+    assert result == "mismatch-preserved"
+    assert cached.exists()
+    state = json.loads((l2 / MODULE.STATE_FILE).read_text(encoding="utf-8"))
+    assert state["digest"] == "a" * 64
+
+
+def test_always_clears_even_when_fingerprint_matches(tmp_path: Path) -> None:
+    l2 = tmp_path / "l2"
+    l2.mkdir()
+    MODULE.reconcile(l2, _manifest("a"), policy="auto")
+    cached = l2 / "object-1"
+    cached.write_bytes(b"cache")
+
+    result = MODULE.reconcile(l2, _manifest("a"), policy="always")
+
+    assert result == "reset"
+    assert not cached.exists()
+
+
+@pytest.mark.parametrize("policy", ["", "sometimes", "AUTO"])
+def test_reconcile_rejects_invalid_policy(tmp_path: Path, policy: str) -> None:
+    l2 = tmp_path / "l2"
+    l2.mkdir()
+    with pytest.raises(ValueError):
+        MODULE.reconcile(l2, _manifest("a"), policy=policy)
+
+
+def test_reconcile_rejects_filesystem_root() -> None:
+    with pytest.raises(ValueError, match="filesystem root"):
+        MODULE.reconcile(Path("/"), _manifest("a"), policy="auto")


### PR DESCRIPTION
## Summary
- fingerprint persistent LMCache L2 layout inputs before server startup
- include model configs, selected runtime source trees, and TP/DCP/chunk/transfer values
- exclude generated Python caches from source hashing so restarts remain stable
- preserve compatible L2 data and atomically reset mismatched dedicated paths
- fail closed on non-empty unversioned paths unless one-time adoption is explicit

## Why
LMCache object keys do not encode every tensor-layout or runtime-ABI input. Reusing an L2 directory across incompatible model, DCP, chunk, or source layouts can return structurally wrong cache objects without an obvious startup error.

## Validation
- `tests/test_lmcache_layout_fingerprint.py`: 16 passed
- `tests/test-glm52-lmcache-helper.sh`: PASS
- `tests/test-kimi-source-overlay.sh`: PASS
- `ruff check`, `ruff format --check`, shell syntax, static security scan, and `git diff --check` pass

## Safety
- generic wrapper default remains `never`; the Kimi production profile opts into `auto`
- filesystem root is rejected
- `auto` refuses an unversioned non-empty directory unless `LMCACHE_LAYOUT_ADOPT_UNMARKED=1` is explicitly set once
- `always` is the only unconditional reset policy
- an exclusive lock and atomic state replacement serialize fingerprint decisions
- each L2 path must be dedicated to one active LMCache server instance; startup serialization does not make concurrent writers supported
