### PR TITLE
fix(kimi): align QSRT DSpark scheduler budget

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,1 +1,2 @@
 patches/releases/**/integration.patch -whitespace
+manifests/**/patches/*.patch -whitespace

--- a/Dockerfile.kimi-k3-qsrt-tp16-runtime
+++ b/Dockerfile.kimi-k3-qsrt-tp16-runtime
@@ -127,6 +127,8 @@ COPY --chmod=0755 launchers/serve-kimi-k3-full-mxfp4-dspark-ii /usr/local/bin/se
 COPY --chmod=0755 launchers/serve-kimi-k3-full-mxfp4-dflash-ii /usr/local/bin/serve-kimi-k3-full-mxfp4-dflash-ii
 COPY --chmod=0755 launchers/serve-kimi-k3-qsrt-nospec /usr/local/bin/serve-kimi-k3-qsrt-nospec
 COPY --chmod=0755 launchers/serve-kimi-k3-qsrt-dspark /usr/local/bin/serve-kimi-k3-qsrt-dspark
+COPY --chmod=0755 launchers/serve-kimi-k3-qsrt-dspark-tp8 /usr/local/bin/serve-kimi-k3-qsrt-dspark-tp8
+COPY --chmod=0755 scripts/validate_kimi_k3_qsrt_runtime.py /usr/local/bin/validate-kimi-k3-qsrt-runtime.py
 COPY --chmod=0755 launchers/lmcache-mp-wrapper.sh /usr/local/bin/lmcache-mp-wrapper.sh
 COPY --chmod=0755 launchers/serve-kimi-k3-production-dspark-ii /usr/local/bin/serve-kimi-k3-production-dspark-ii
 
@@ -145,12 +147,14 @@ RUN set -eux; \
     /opt/venv/bin/python -c 'from lmcache.v1.multiprocess.transfer_context.worker_transfer import _collapse_chunks_for_single_destination; chunks=[object(), object()]; selected, ids=_collapse_chunks_for_single_destination(chunks, [7, 7], 1, 1); assert selected == chunks[-1:] and ids == [7]'; \
     /opt/venv/bin/python -c 'from b12x.comm.pcie.pcie_allreduce import recommended_max_bytes; assert recommended_max_bytes(16, default=86016) == 86016'; \
     B12X_PCIE_ALLREDUCE_ALGORITHM=island_rs /opt/venv/bin/python -c 'from b12x.comm.pcie.pcie_allreduce import recommended_max_bytes; assert recommended_max_bytes(16, default=86016) == 163840'; \
+    /opt/venv/bin/python /usr/local/bin/validate-kimi-k3-qsrt-runtime.py; \
     for launcher in \
       /usr/local/bin/serve-kimi-k3-full-mxfp4-nospec-ii \
       /usr/local/bin/serve-kimi-k3-full-mxfp4-dspark-ii \
       /usr/local/bin/serve-kimi-k3-full-mxfp4-dflash-ii \
       /usr/local/bin/serve-kimi-k3-qsrt-nospec \
       /usr/local/bin/serve-kimi-k3-qsrt-dspark \
+      /usr/local/bin/serve-kimi-k3-qsrt-dspark-tp8 \
       /usr/local/bin/lmcache-mp-wrapper.sh \
       /usr/local/bin/serve-kimi-k3-production-dspark-ii; do \
       bash -n "${launcher}"; \

--- a/README.md
+++ b/README.md
@@ -185,14 +185,15 @@ different graph shapes and generated kernels; sharing a writable JIT directory
 between them is unsupported.
 
 The source-locked production image also includes the language-only QSRT-K2
-launcher. For eight 96 GiB GPUs, use
+launcher. Build its immutable vLLM/B12X/LMCache source bundle with
+`./build-kimi-k3-qsrt-tp16-runtime.sh`. For eight 96 GiB GPUs, use
 `/usr/local/bin/serve-kimi-k3-qsrt-dspark-tp8`. It reserves four worker batch
 slots for DSpark depth 3 while keeping the target scheduler aligned to Kimi's
 1,536-token recurrent block (`1540` total / `1536` target / two sequences).
 The generic QSRT launcher validates this reserve before starting and verifies
 that the active B12X package supports both QSRT atoms-v2 and inactive W4A16
 routes. See `docs/kimi-k3-qsrt-tp8-scheduler-safety.md` for the failure analysis,
-compatibility limits, and qualification evidence.
+source identities, compatibility limits, and qualification evidence.
 
 ### Infernal Invocation CUDA 13.3 runtime for DeepSeek-V4-Flash and GLM-5.2
 

--- a/README.md
+++ b/README.md
@@ -184,6 +184,16 @@ Use a distinct `/cache/jit` volume for each entrypoint. The three profiles have
 different graph shapes and generated kernels; sharing a writable JIT directory
 between them is unsupported.
 
+The source-locked production image also includes the language-only QSRT-K2
+launcher. For eight 96 GiB GPUs, use
+`/usr/local/bin/serve-kimi-k3-qsrt-dspark-tp8`. It reserves four worker batch
+slots for DSpark depth 3 while keeping the target scheduler aligned to Kimi's
+1,536-token recurrent block (`1540` total / `1536` target / two sequences).
+The generic QSRT launcher validates this reserve before starting and verifies
+that the active B12X package supports both QSRT atoms-v2 and inactive W4A16
+routes. See `docs/kimi-k3-qsrt-tp8-scheduler-safety.md` for the failure analysis,
+compatibility limits, and qualification evidence.
+
 ### Infernal Invocation CUDA 13.3 runtime for DeepSeek-V4-Flash and GLM-5.2
 
 Status: **qualified for the DeepSeek-V4-Flash profile and source-qualified for

--- a/build-kimi-k3-qsrt-tp16-runtime.sh
+++ b/build-kimi-k3-qsrt-tp16-runtime.sh
@@ -5,14 +5,14 @@ set -euo pipefail
 repo_root="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 cd "${repo_root}"
 
-release_root=patches/releases/kimi-k3-production-lmcache-sampler-overlay
+release_root=patches/releases/kimi-k3-qsrt-tp8-safety
 vllm_lock="${release_root}/vllm/integration.lock.json"
 b12x_lock="${release_root}/b12x/integration.lock.json"
 lmcache_lock="${release_root}/lmcache/integration.lock.json"
 base_image="${BASE_IMAGE:-voipmonitor/vllm@sha256:01b973d1ae132882bcc1bf62ea232f6aabe649dd4a89b961d81f3c41cc53f971}"
 release_name="${RELEASE_NAME:-kimi-k3-production-dspark-lmcache}"
 release_date="${RELEASE_DATE:-20260819}"
-revision="${REVISION:-source-overlay}"
+revision="${REVISION:-qsrt-tp8-safety}"
 
 for path in \
   "${vllm_lock}" \

--- a/docs/kimi-k3-qsrt-tp8-scheduler-safety.md
+++ b/docs/kimi-k3-qsrt-tp8-scheduler-safety.md
@@ -1,0 +1,121 @@
+# Kimi-K3 QSRT TP8 DSpark scheduler safety
+
+Status: **qualified** for QSRT-K2 TP8/DCP8 with Inferact DSpark depth 3.
+
+## Runtime contract
+
+Kimi-K3 TP8/DCP8 exposes a 1,536-token recurrent scheduler block. Parallel
+DSpark drafting adds `depth - 1` batch slots per active request. The total
+worker batch capacity and target scheduler budget are therefore different
+quantities:
+
+```text
+parallel draft reserve = (3 - 1) * 2 = 4 slots
+max_num_scheduled_tokens = 1536
+max_num_batched_tokens = 1536 + 4 = 1540
+```
+
+`serve-kimi-k3-qsrt-dspark-tp8` applies this profile. The generic QSRT DSpark
+launcher accepts an explicit `MAX_NUM_SCHEDULED_TOKENS` and rejects a total
+batch budget that cannot hold both the target scheduler batch and every draft
+slot.
+
+The generic launcher's historical defaults remain unchanged: TP16/DCP8,
+DSpark depth 7, 4,096 total batch tokens, and eight active sequences. Operators
+who do not select an explicit target scheduler budget retain vLLM's automatic
+budget derivation.
+
+## Failure mode
+
+The prior TP8 adaptation set `max_num_batched_tokens=1536` with depth 3 and two
+sequences. vLLM reserved four draft slots and silently reduced the target
+scheduler budget to 1,532 tokens. A 1,536-token prompt was split as `1532 + 4`.
+The four-token partial-prefill tail entered fixed-M W4A16 execution with graph
+padding routes.
+
+A B12X compatibility overlay provided the Kimi QSRT atoms-v2 planner ABI but
+predated the inactive-route behavior tracked by B12X PR #227. The fixed-M
+kernel could therefore address an inactive expert route instead of giving it
+zero effective weight. Direct vLLM SSE already contained Kimi control markers,
+low-entropy repetition, or token salad; the gateway only preserved those
+bytes.
+
+Greedy, unique-salt boundary probes isolated the failure:
+
+| Prompt tokens | Pre-fix result |
+|---:|---|
+| 1,532 | stable |
+| 1,533 | stable |
+| 1,534 | stable |
+| 1,536 | 4/4 NaN logprobs, HTTP 400 |
+
+The API error was:
+
+```text
+Out of range float values are not JSON compliant: nan
+```
+
+## Fail-closed package validation
+
+The image now installs `validate-kimi-k3-qsrt-runtime.py`. The build and the
+QSRT launcher require all of these contracts from the active imported B12X
+tree:
+
+- weight planning accepts `qsrt_storage_format` and `qsrt_profile`;
+- weight preparation accepts the atoms-v2 payload, first-slot, and layer index;
+- fixed-M W4A16 phase 0/1 stages inactive routes;
+- FC2-only runtime-M phase 2 validates routes inline rather than staging a
+  fixed route table.
+
+This catches the packaging class where image labels describe a safe B12X tree
+but a later bind mount or replacement Python package shadows it with an older
+compatibility tree.
+
+The B12X product correction remains owned by B12X PR #227. The QSRT
+compatibility-base port is B12X PR #237. This deployment change does not
+duplicate either kernel patch; it validates the behavior at the image and
+launcher boundary.
+
+## Qualification
+
+The exact four-token tail was re-exercised at 1,540 prompt tokens after keeping
+the target scheduler budget at 1,536. Ten unique-salt greedy runs completed,
+all selected the same first token, and none emitted NaN, control markers, or
+token salad.
+
+The captured production incident payload then passed five direct-vLLM runs and
+five llmconduit runs. Same-process local-prefix replay reused 1,536 tokens and
+matched cold output.
+
+A 14,505-token deterministic cache fixture returned `K3_CACHE_OK` across all
+three cache arms:
+
+| Arm | Local hit | External hit | Result |
+|---|---:|---:|---|
+| cold producer | 0 | 0 | `K3_CACHE_OK` |
+| APC reset / LMCache L1 | 0 | 12,288 | byte-equivalent |
+| same-image restart / LMCache L2 | 0 | 12,288 | byte-equivalent |
+
+The final runtime had zero restarts, no OOM, no NaN/nonfinite/CUBLAS/illegal
+memory/worker-death markers, and no thermal slowdown.
+
+Machine-readable receipt:
+
+```text
+validation/kimi-k3-qsrt-tp8-scheduler-inactive-routes-20260819.json
+```
+
+## Compatibility and limits
+
+- This qualification covers the language-only QSRT-K2 target, not the official
+  MXFP4 native-vision TP16 contract.
+- The scheduler invariant is generic, but the provided TP8 defaults are
+  specific to a 1,536-token recurrent block, depth 3, and two active sequences.
+- Changing speculative depth or sequence count requires recomputing the draft
+  reserve and re-running exact boundary probes.
+- Repetition detection and client retry remain containment only; they do not
+  repair the first corrupt logit.
+
+AI assistance was used for root-cause analysis, implementation, test design,
+and PR drafting. The submitting human must review every changed line and be
+able to defend the scheduler and B12X contracts before merge.

--- a/docs/kimi-k3-qsrt-tp8-scheduler-safety.md
+++ b/docs/kimi-k3-qsrt-tp8-scheduler-safety.md
@@ -76,6 +76,17 @@ compatibility-base port is B12X PR #237. This deployment change does not
 duplicate either kernel patch; it validates the behavior at the image and
 launcher boundary.
 
+The build composes one immutable source bundle under
+`patches/releases/kimi-k3-qsrt-tp8-safety`: vLLM tree `12776c0`, LMCache tree
+`e045d729`, and B12X tree `64dc2cb`. The B12X tree starts from the pinned QSRT
+compatibility branch, applies PR #237, and then applies a SHA-256-locked patch
+for the remaining qualified Kimi PCIe and atoms-v2 runtime files. Reproduce it
+with:
+
+```bash
+./build-kimi-k3-qsrt-tp16-runtime.sh
+```
+
 ## Qualification
 
 The exact four-token tail was re-exercised at 1,540 prompt tokens after keeping

--- a/launchers/serve-kimi-k3-qsrt-dspark
+++ b/launchers/serve-kimi-k3-qsrt-dspark
@@ -12,14 +12,48 @@ DCP_SIZE="${DCP_SIZE:-8}"
 KV_CACHE_MEMORY_BYTES="${KV_CACHE_MEMORY_BYTES:-2300000000}"
 MAX_MODEL_LEN="${MAX_MODEL_LEN:-1048576}"
 MAX_NUM_BATCHED_TOKENS="${MAX_NUM_BATCHED_TOKENS:-4096}"
+MAX_NUM_SCHEDULED_TOKENS="${MAX_NUM_SCHEDULED_TOKENS:-}"
 MAX_NUM_SEQS="${MAX_NUM_SEQS:-8}"
+DSPARK_SPECULATIVE_TOKENS="${DSPARK_SPECULATIVE_TOKENS:-7}"
 GPU_MEMORY_UTILIZATION="${GPU_MEMORY_UTILIZATION:-0.98}"
 SERVED_MODEL_NAME="${SERVED_MODEL_NAME:-Kimi-K3-QSRT-K2-DSpark7-TP${TP_SIZE}-DCP${DCP_SIZE}}"
+
+require_positive_integer() {
+  local name=$1 value=$2
+  if [[ ! "${value}" =~ ^[1-9][0-9]*$ ]]; then
+    printf '%s must be a positive integer: %q\n' "${name}" "${value}" >&2
+    exit 2
+  fi
+}
 
 if (( TP_SIZE < 1 || DCP_SIZE < 1 || TP_SIZE % DCP_SIZE != 0 )); then
   printf 'TP_SIZE must be positive and divisible by DCP_SIZE: TP_SIZE=%s DCP_SIZE=%s\n' \
     "${TP_SIZE}" "${DCP_SIZE}" >&2
   exit 2
+fi
+
+require_positive_integer MAX_NUM_BATCHED_TOKENS "${MAX_NUM_BATCHED_TOKENS}"
+require_positive_integer MAX_NUM_SEQS "${MAX_NUM_SEQS}"
+require_positive_integer DSPARK_SPECULATIVE_TOKENS "${DSPARK_SPECULATIVE_TOKENS}"
+
+# Parallel DSpark drafting reserves depth-1 additional batch slots per active
+# request. Keep those slots outside an explicitly selected target scheduler
+# budget; otherwise a recurrent block boundary can be split by the reserve.
+dspark_slots_per_request=$((DSPARK_SPECULATIVE_TOKENS - 1))
+dspark_reserve=$((dspark_slots_per_request * MAX_NUM_SEQS))
+if [[ -n "${MAX_NUM_SCHEDULED_TOKENS}" ]]; then
+  require_positive_integer MAX_NUM_SCHEDULED_TOKENS "${MAX_NUM_SCHEDULED_TOKENS}"
+  required_batch_slots=$((MAX_NUM_SCHEDULED_TOKENS + dspark_reserve))
+  if (( MAX_NUM_BATCHED_TOKENS < required_batch_slots )); then
+    printf 'MAX_NUM_SCHEDULED_TOKENS=%s with DSpark depth %s and max_num_seqs=%s requires at least %s total batch slots; got %s\n' \
+      "${MAX_NUM_SCHEDULED_TOKENS}" "${DSPARK_SPECULATIVE_TOKENS}" \
+      "${MAX_NUM_SEQS}" "${required_batch_slots}" \
+      "${MAX_NUM_BATCHED_TOKENS}" >&2
+    exit 2
+  fi
+  printf 'DSpark reserve: %s; target scheduler budget: %s; total batch slots: %s\n' \
+    "${dspark_reserve}" "${MAX_NUM_SCHEDULED_TOKENS}" \
+    "${MAX_NUM_BATCHED_TOKENS}" >&2
 fi
 
 required=(
@@ -28,16 +62,25 @@ required=(
   /opt/kimi-k3-qsrt/vllm/vllm/__init__.py
   /opt/kimi-k3-qsrt/b12x/b12x/attention/dense_mla/__init__.py
 )
-for path in "${required[@]}"; do
-  [[ -e "${path}" ]] || {
-    printf 'Required Kimi-K3 artifact is missing: %s\n' "${path}" >&2
+if [[ "${DRY_RUN:-0}" != 1 ]]; then
+  for path in "${required[@]}"; do
+    [[ -e "${path}" ]] || {
+      printf 'Required Kimi-K3 artifact is missing: %s\n' "${path}" >&2
+      exit 1
+    }
+  done
+  runtime_validator="${KIMI_K3_QSRT_RUNTIME_VALIDATOR:-/usr/local/bin/validate-kimi-k3-qsrt-runtime.py}"
+  [[ -f "${runtime_validator}" ]] || {
+    printf 'Kimi-K3 QSRT runtime validator is missing: %s\n' \
+      "${runtime_validator}" >&2
     exit 1
   }
-done
+  /opt/venv/bin/python "${runtime_validator}"
+fi
 
 printf -v speculative_config \
-  '{"method":"dspark","model":"%s","num_speculative_tokens":7,"attention_backend":"B12X_MLA","kv_cache_dtype":"fp8","draft_sample_method":"greedy","rejection_sample_method":"block","quantization":"mxfp8","quantization_config":{"linear":"mxfp8","ignore":["re:.*fused_qkv_a_proj$"]}}' \
-  "${DRAFT_MODEL}"
+  '{"method":"dspark","model":"%s","num_speculative_tokens":%s,"attention_backend":"B12X_MLA","kv_cache_dtype":"fp8","draft_sample_method":"greedy","rejection_sample_method":"block","quantization":"mxfp8","quantization_config":{"linear":"mxfp8","ignore":["re:.*fused_qkv_a_proj$"]}}' \
+  "${DRAFT_MODEL}" "${DSPARK_SPECULATIVE_TOKENS}"
 
 export HF_MODULES_CACHE="${HF_MODULES_CACHE:-/tmp/huggingface-modules}"
 export VLLM_SOURCE_OVERLAY_ACTIVE=1
@@ -90,35 +133,52 @@ export INSTANTTENSOR_MAX_FREE_MEM_USAGE="${INSTANTTENSOR_MAX_FREE_MEM_USAGE:-0.6
 export SAFETENSORS_FAST_GPU="${SAFETENSORS_FAST_GPU:-1}"
 unset NCCL_GRAPH_FILE
 
-exec /opt/venv/bin/python -m vllm.entrypoints.cli.main serve "${MODEL}" \
-  --served-model-name "${SERVED_MODEL_NAME}" \
-  --trust-remote-code \
-  --language-model-only \
-  --host 0.0.0.0 \
-  --port "${PORT}" \
-  --tensor-parallel-size "${TP_SIZE}" \
-  --decode-context-parallel-size "${DCP_SIZE}" \
-  --dcp-comm-backend a2a \
-  --dcp-kv-cache-interleave-size 1 \
-  --load-format instanttensor \
-  --moe-backend b12x \
-  --linear-backend b12x \
-  --attention-backend B12X_MLA \
-  --kda-prefill-backend triton \
-  --dtype bfloat16 \
-  --kv-cache-dtype fp8 \
-  --kv-cache-memory-bytes "${KV_CACHE_MEMORY_BYTES}" \
-  --max-model-len "${MAX_MODEL_LEN}" \
-  --max-num-batched-tokens "${MAX_NUM_BATCHED_TOKENS}" \
-  --max-num-seqs "${MAX_NUM_SEQS}" \
-  --gpu-memory-utilization "${GPU_MEMORY_UTILIZATION}" \
-  --enable-chunked-prefill \
-  --no-enable-prefix-caching \
-  --speculative-config "${speculative_config}" \
-  --compilation-config '{"mode":0,"cudagraph_mode":"FULL_AND_PIECEWISE","custom_ops":["all"],"cudagraph_capture_sizes":[8,16,24,32,40,48,56,64],"pass_config":{"fuse_allreduce_rms":true}}' \
-  --generation-config vllm \
-  --reasoning-parser kimi_k3 \
-  --tool-call-parser kimi_k3 \
-  --enable-auto-tool-choice \
-  --attention-config.flash_attn_version=2 \
-  "$@"
+cmd=(
+  /opt/venv/bin/python -m vllm.entrypoints.cli.main serve "${MODEL}"
+  --served-model-name "${SERVED_MODEL_NAME}"
+  --trust-remote-code
+  --language-model-only
+  --host 0.0.0.0
+  --port "${PORT}"
+  --tensor-parallel-size "${TP_SIZE}"
+  --decode-context-parallel-size "${DCP_SIZE}"
+  --dcp-comm-backend a2a
+  --dcp-kv-cache-interleave-size 1
+  --load-format instanttensor
+  --moe-backend b12x
+  --linear-backend b12x
+  --attention-backend B12X_MLA
+  --kda-prefill-backend triton
+  --dtype bfloat16
+  --kv-cache-dtype fp8
+  --kv-cache-memory-bytes "${KV_CACHE_MEMORY_BYTES}"
+  --max-model-len "${MAX_MODEL_LEN}"
+  --max-num-batched-tokens "${MAX_NUM_BATCHED_TOKENS}"
+  --max-num-seqs "${MAX_NUM_SEQS}"
+  --gpu-memory-utilization "${GPU_MEMORY_UTILIZATION}"
+  --enable-chunked-prefill
+  --no-enable-prefix-caching
+  --speculative-config "${speculative_config}"
+  --compilation-config '{"mode":0,"cudagraph_mode":"FULL_AND_PIECEWISE","custom_ops":["all"],"cudagraph_capture_sizes":[8,16,24,32,40,48,56,64],"pass_config":{"fuse_allreduce_rms":true}}'
+  --generation-config vllm
+  --reasoning-parser kimi_k3
+  --tool-call-parser kimi_k3
+  --enable-auto-tool-choice
+  --attention-config.flash_attn_version=2
+)
+if [[ -n "${MAX_NUM_SCHEDULED_TOKENS}" ]]; then
+  cmd+=(--max-num-scheduled-tokens "${MAX_NUM_SCHEDULED_TOKENS}")
+fi
+cmd+=("$@")
+
+if [[ "${DRY_RUN:-0}" == 1 ]]; then
+  printf 'TP_SIZE=%q\n' "${TP_SIZE}"
+  printf 'DCP_SIZE=%q\n' "${DCP_SIZE}"
+  printf 'Speculative config: %s\n' "${speculative_config}"
+  printf 'Command:'
+  printf ' %q' "${cmd[@]}"
+  printf '\n'
+  exit 0
+fi
+
+exec "${cmd[@]}"

--- a/launchers/serve-kimi-k3-qsrt-dspark-tp8
+++ b/launchers/serve-kimi-k3-qsrt-dspark-tp8
@@ -1,0 +1,24 @@
+#!/usr/bin/env bash
+# TP8/DCP8 QSRT-K2 profile with a 1,536-token recurrent scheduler boundary.
+set -euo pipefail
+
+export TP_SIZE="${TP_SIZE:-8}"
+export DCP_SIZE="${DCP_SIZE:-8}"
+export SERVED_MODEL_NAME="${SERVED_MODEL_NAME:-Kimi-K3}"
+export MAX_MODEL_LEN="${MAX_MODEL_LEN:-512000}"
+export KV_CACHE_MEMORY_BYTES="${KV_CACHE_MEMORY_BYTES:-2348810240}"
+export MAX_NUM_SEQS="${MAX_NUM_SEQS:-2}"
+export DSPARK_SPECULATIVE_TOKENS="${DSPARK_SPECULATIVE_TOKENS:-3}"
+export MAX_NUM_SCHEDULED_TOKENS="${MAX_NUM_SCHEDULED_TOKENS:-1536}"
+export MAX_NUM_BATCHED_TOKENS="${MAX_NUM_BATCHED_TOKENS:-1540}"
+export GPU_MEMORY_UTILIZATION="${GPU_MEMORY_UTILIZATION:-0.985}"
+
+launcher="${KIMI_K3_QSRT_DSPARK_LAUNCHER:-/usr/local/bin/serve-kimi-k3-qsrt-dspark}"
+if [[ ! -x "${launcher}" ]]; then
+  sibling="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)/serve-kimi-k3-qsrt-dspark"
+  if [[ -x "${sibling}" ]]; then
+    launcher="${sibling}"
+  fi
+fi
+
+exec "${launcher}" "$@"

--- a/manifests/b12x/kimi-k3-qsrt-tp8-safety.json
+++ b/manifests/b12x/kimi-k3-qsrt-tp8-safety.json
@@ -1,0 +1,21 @@
+{
+  "schema_version": 1,
+  "name": "kimi-k3-qsrt-tp8-safety-b12x",
+  "repository": "https://github.com/local-inference-lab/b12x.git",
+  "base_ref": "refs/heads/agent/pr197-base-glm52-sqg",
+  "composition_strategy": "merge",
+  "pull_requests": [
+    {
+      "number": 237,
+      "head": "7917d618a09cb01cde7df31ac6696dbe86dd72ab",
+      "title": "Sanitize inactive QSRT W4A16 routes"
+    }
+  ],
+  "source_patches": [
+    {
+      "path": "patches/kimi-k3-qsrt-tp8-qualified-compat.patch",
+      "sha256": "3937584294c689de1a2507ff420d0554a3e93bc4dfe39a208790fbe07c84bd55",
+      "title": "Restore the qualified Kimi-K3 QSRT atoms-v2 and PCIe runtime contracts"
+    }
+  ]
+}

--- a/manifests/b12x/patches/kimi-k3-qsrt-tp8-qualified-compat.patch
+++ b/manifests/b12x/patches/kimi-k3-qsrt-tp8-qualified-compat.patch
@@ -1,0 +1,6615 @@
+diff --git a/b12x/attention/__init__.py b/b12x/attention/__init__.py
+index 40e6066fa41b3da36880f0451bdaf279d9eb84d7..c5d4a69ce0b3c9e99e0792370bcd6c9bf90da93a 100644
+--- a/b12x/attention/__init__.py
++++ b/b12x/attention/__init__.py
+@@ -2,9 +2,8 @@
+ 
+ - ``paged``: paged-KV self-attention (decode + extend, FP8 KV, MSA
+   block-sparse variant) with on-device graph-replay metadata staging.
+-- ``dense_mla``: dense compressed-cache MLA with strided physical records and
+-  optional causal sliding-window masking.
+-- ``sparse_mla``: top-k-selected MLA, including strided physical records.
++- ``dense_mla``: dense compressed-cache MLA for Kimi K3 geometry.
++- ``sparse_mla``: top-k-selected MLA decode/extend (DeepSeek-V3.2 / GLM NSA).
+ - ``compressed_mla``: MLA decode directly from compressed KV pages (DSV4).
+ - ``nsa_indexer``: the NSA index stage — quantize -> score -> select.
+ - ``varlen``: contiguous batched/varlen attention (reduced-assurance tier).
+diff --git a/b12x/attention/_shared/contiguous/api.py b/b12x/attention/_shared/contiguous/api.py
+index b293c49ae30657484d4664d61467c8ba34bcb62a..3b2bf678d01e5b206b39baaba70bae76e231a89e 100644
+--- a/b12x/attention/_shared/contiguous/api.py
++++ b/b12x/attention/_shared/contiguous/api.py
+@@ -75,12 +75,6 @@ def _lse_shape(q_shape: tuple[int, ...]) -> tuple[int, ...]:
+     return (batch, q_heads, seqlen_q)
+ 
+ 
+-def _output_shape(
+-    q_shape: tuple[int, ...], v_shape: tuple[int, ...]
+-) -> tuple[int, ...]:
+-    return (*q_shape[:-1], int(v_shape[-1]))
+-
+-
+ def _seq_dims(shape: tuple[int, ...]) -> tuple[tuple[int, ...], int, int, int]:
+     if len(shape) == 3:
+         seqlen, num_heads, head_dim = shape
+@@ -230,10 +224,10 @@ def _validate_forward_inputs(
+     batch_v, _, v_heads, v_head_dim = _seq_dims(v_shape)
+     if batch_q != batch_k or batch_q != batch_v:
+         raise ValueError("q, k, and v must have matching batch dimensions")
+-    if q_head_dim != k_head_dim:
+-        raise ValueError("q and k must have matching head dimensions")
+-    if v_head_dim <= 0:
+-        raise ValueError("v head dimension must be positive")
++    if q_head_dim != k_head_dim or q_head_dim != v_head_dim:
++        raise ValueError(
++            "q, k, and v must have matching head dimensions in the initial path"
++        )
+     if kv_heads != v_heads:
+         raise ValueError("k and v must have the same number of KV heads")
+     if q_heads % kv_heads != 0:
+@@ -736,13 +730,13 @@ class _AttentionForwardLaunch:
+         self._q_shape = q_shape
+         self._k_shape = k_shape
+         self._v_shape = v_shape
+-        self._o_shape = _output_shape(q_shape, v_shape)
++        self._o_shape = q_shape
+         self._lse_shape = _lse_shape(q_shape)
+         self._attention_sink_bias_shape = (q_shape[-2],)
+         self._q_stride = _contiguous_stride(q_shape)
+         self._k_stride = _contiguous_stride(k_shape)
+         self._v_stride = _contiguous_stride(v_shape)
+-        self._o_stride = _contiguous_stride(self._o_shape)
++        self._o_stride = _contiguous_stride(q_shape)
+         self._lse_stride = _contiguous_stride(self._lse_shape)
+         self._attention_sink_bias_stride = _contiguous_stride(
+             self._attention_sink_bias_shape
+@@ -876,7 +870,7 @@ class _VarlenAttentionForwardLaunch:
+         self._v_shape = v_shape
+         self._cu_seqlens_q_shape = cu_seqlens_q_shape
+         self._cu_seqlens_k_shape = cu_seqlens_k_shape
+-        self._o_shape = _output_shape(q_shape, v_shape)
++        self._o_shape = q_shape
+         self._lse_shape = _lse_shape(q_shape)
+         self._attention_sink_bias_shape = (q_shape[-2],)
+         self._q_stride = _contiguous_stride(q_shape)
+@@ -884,7 +878,7 @@ class _VarlenAttentionForwardLaunch:
+         self._v_stride = _contiguous_stride(v_shape)
+         self._cu_seqlens_q_stride = _contiguous_stride(cu_seqlens_q_shape)
+         self._cu_seqlens_k_stride = _contiguous_stride(cu_seqlens_k_shape)
+-        self._o_stride = _contiguous_stride(self._o_shape)
++        self._o_stride = _contiguous_stride(q_shape)
+         self._lse_stride = _contiguous_stride(self._lse_shape)
+         self._attention_sink_bias_stride = _contiguous_stride(
+             self._attention_sink_bias_shape
+@@ -942,7 +936,9 @@ class _VarlenAttentionForwardLaunch:
+             # existing unpacked-head kernel as the static fallback for those
+             # shapes; this choice depends only on plan geometry and is graph
+             # capture safe.
+-            pack_gqa=(qhead_per_kvhead != 1 and tile_m % qhead_per_kvhead == 0),
++            pack_gqa=(
++                qhead_per_kvhead != 1 and tile_m % qhead_per_kvhead == 0
++            ),
+             tile_m=tile_m,
+             tile_n=tile_n,
+         )
+@@ -1396,11 +1392,9 @@ def _validate_attention_output_lse(
+     lse: torch.Tensor,
+     plan: AttentionPlan | VarlenAttentionPlan,
+ ) -> None:
+-    expected_output_shape = _output_shape(plan.q_shape, plan.v_shape)
+-    if output.shape != expected_output_shape:
++    if output.shape != plan.q_shape:
+         raise ValueError(
+-            "attention output must have shape "
+-            f"{expected_output_shape}, got {tuple(output.shape)}"
++            f"attention output must have shape {plan.q_shape}, got {tuple(output.shape)}"
+         )
+     if output.device != plan.device:
+         raise ValueError(
+@@ -1428,13 +1422,12 @@ def _validate_attention_output_lse(
+ def _attention_scratch_layout(
+     *,
+     q_shape: tuple[int, ...],
+-    v_shape: tuple[int, ...],
+     dtype: torch.dtype,
+ ) -> _AttentionScratchLayout:
+     cursor = 0
+     cursor = _align_up(cursor, _ARENA_ALIGN_BYTES)
+     output_offset_bytes = cursor
+-    cursor += _shape_numel(_output_shape(q_shape, v_shape)) * _dtype_nbytes(dtype)
++    cursor += _shape_numel(q_shape) * _dtype_nbytes(dtype)
+     cursor = _align_up(cursor, _ARENA_ALIGN_BYTES)
+     lse_offset_bytes = cursor
+     cursor += _shape_numel(_lse_shape(q_shape)) * _dtype_nbytes(torch.float32)
+@@ -1493,7 +1486,7 @@ def _attention_scratch_views_from_arena(
+     output = _arena_view(
+         arena,
+         offset_bytes=layout.output_offset_bytes,
+-        shape=_output_shape(plan.q_shape, plan.v_shape),
++        shape=plan.q_shape,
+         dtype=plan.dtype,
+     )
+     lse = _arena_view(
+@@ -1547,7 +1540,7 @@ def _varlen_attention_scratch_views_from_arena(
+     output = _arena_view(
+         arena,
+         offset_bytes=layout.output_offset_bytes,
+-        shape=_output_shape(plan.q_shape, plan.v_shape),
++        shape=plan.q_shape,
+         dtype=plan.dtype,
+     )
+     lse = _arena_view(
+@@ -1962,9 +1955,7 @@ def _build_varlen_attention_binding_from_views(
+ 
+ 
+ def plan_attention_scratch(plan: AttentionPlan) -> AttentionScratchPlan:
+-    layout = _attention_scratch_layout(
+-        q_shape=plan.q_shape, v_shape=plan.v_shape, dtype=plan.dtype
+-    )
++    layout = _attention_scratch_layout(q_shape=plan.q_shape, dtype=plan.dtype)
+     return AttentionScratchPlan(
+         plan=plan,
+         _layout=layout,
+@@ -1981,9 +1972,7 @@ def plan_attention_scratch(plan: AttentionPlan) -> AttentionScratchPlan:
+ def plan_varlen_attention_scratch(
+     plan: VarlenAttentionPlan,
+ ) -> VarlenAttentionScratchPlan:
+-    layout = _attention_scratch_layout(
+-        q_shape=plan.q_shape, v_shape=plan.v_shape, dtype=plan.dtype
+-    )
++    layout = _attention_scratch_layout(q_shape=plan.q_shape, dtype=plan.dtype)
+     return VarlenAttentionScratchPlan(
+         plan=plan,
+         _layout=layout,
+@@ -1999,11 +1988,7 @@ def plan_varlen_attention_scratch(
+ 
+ def allocate_attention_workspace_for_plan(plan: AttentionPlan) -> AttentionWorkspace:
+     """Allocate reusable scratch for one exact contiguous attention plan."""
+-    output = torch.empty(
+-        _output_shape(plan.q_shape, plan.v_shape),
+-        dtype=plan.dtype,
+-        device=plan.device,
+-    )
++    output = torch.empty(plan.q_shape, dtype=plan.dtype, device=plan.device)
+     lse = torch.empty(_lse_shape(plan.q_shape), dtype=torch.float32, device=plan.device)
+     return AttentionWorkspace(
+         q_shape=plan.q_shape,
+@@ -2027,11 +2012,7 @@ def allocate_varlen_attention_workspace_for_plan(
+     plan: VarlenAttentionPlan,
+ ) -> VarlenAttentionWorkspace:
+     """Allocate reusable scratch for one exact packed varlen attention plan."""
+-    output = torch.empty(
+-        _output_shape(plan.q_shape, plan.v_shape),
+-        dtype=plan.dtype,
+-        device=plan.device,
+-    )
++    output = torch.empty(plan.q_shape, dtype=plan.dtype, device=plan.device)
+     lse = torch.empty(_lse_shape(plan.q_shape), dtype=torch.float32, device=plan.device)
+     return VarlenAttentionWorkspace(
+         q_shape=plan.q_shape,
+diff --git a/b12x/attention/_shared/static_fp8_quant.py b/b12x/attention/_shared/static_fp8_quant.py
+deleted file mode 100644
+index d1714437d414595dff3d82ae7d76e0a8ae649ea6..0000000000000000000000000000000000000000
+--- a/b12x/attention/_shared/static_fp8_quant.py
++++ /dev/null
+@@ -1,188 +0,0 @@
+-"""Graph-safe BF16 to per-tensor E4M3 query quantization."""
+-
+-from __future__ import annotations
+-
+-from dataclasses import dataclass
+-from threading import RLock
+-
+-import cuda.bindings.driver as cuda
+-import cutlass
+-import cutlass.cute as cute
+-import torch
+-from cutlass import Float32, Int32, Int64
+-from cutlass.cute.runtime import from_dlpack
+-
+-from b12x._lib.compiler import KernelCompileSpec, compile as compile_cute
+-from b12x._lib.compiler import key_field, run_compiled
+-from b12x._lib.intrinsics import (
+-    bfloat2_to_float2_scaled,
+-    cvt_f32x4_to_e4m3x4,
+-    get_ptr_as_int64,
+-    ld_global_v2_u32,
+-    st_global_u32,
+-)
+-
+-FP8 = torch.float8_e4m3fn
+-_THREADS = 128
+-_VALUES_PER_THREAD = 4
+-_LOCK = RLock()
+-_CACHE: dict[tuple[int, int], object] = {}
+-
+-
+-def _byte_base_pointer(tensor: torch.Tensor) -> torch.Tensor:
+-    byte_view = tensor.view(torch.uint8)
+-    return torch.as_strided(byte_view, size=(1,), stride=(1,))
+-
+-
+-def _to_cute(tensor: torch.Tensor, dtype, *, align: int):
+-    converted = from_dlpack(tensor, assumed_align=align)
+-    converted.element_type = dtype
+-    return converted.mark_layout_dynamic(leading_dim=0)
+-
+-
+-class _StaticFp8QuantKernel:
+-    def __init__(self, max_numel: int):
+-        self.max_numel = int(max_numel)
+-
+-    @cute.jit
+-    def __call__(
+-        self,
+-        source_bytes: cute.Tensor,
+-        output_bytes: cute.Tensor,
+-        scale: cute.Tensor,
+-        active_numel: Int32,
+-        stream: cuda.CUstream,
+-    ):
+-        grid = (self.max_numel + _THREADS * _VALUES_PER_THREAD - 1) // (
+-            _THREADS * _VALUES_PER_THREAD
+-        )
+-        self.kernel(source_bytes, output_bytes, scale, active_numel).launch(
+-            grid=(grid, 1, 1),
+-            block=(_THREADS, 1, 1),
+-            stream=stream,
+-        )
+-
+-    @cute.kernel
+-    def kernel(
+-        self,
+-        source_bytes: cute.Tensor,
+-        output_bytes: cute.Tensor,
+-        scale: cute.Tensor,
+-        active_numel: Int32,
+-    ):
+-        thread, _, _ = cute.arch.thread_idx()
+-        block, _, _ = cute.arch.block_idx()
+-        word = Int32(block) * Int32(_THREADS) + Int32(thread)
+-        element = word * Int32(_VALUES_PER_THREAD)
+-        if element < active_numel:
+-            inverse_scale = Float32(1.0) / Float32(scale[0])
+-            lo, hi = ld_global_v2_u32(
+-                get_ptr_as_int64(source_bytes, element.to(Int64) * Int64(2))
+-            )
+-            value0, value1 = bfloat2_to_float2_scaled(lo, inverse_scale)
+-            value2, value3 = bfloat2_to_float2_scaled(hi, inverse_scale)
+-            packed = cvt_f32x4_to_e4m3x4(value0, value1, value2, value3)
+-            st_global_u32(
+-                get_ptr_as_int64(output_bytes, element.to(Int64)),
+-                packed,
+-            )
+-
+-
+-@dataclass(frozen=True)
+-class Binding:
+-    source: torch.Tensor
+-    output: torch.Tensor
+-    scale: torch.Tensor
+-    max_numel: int
+-
+-
+-def bind(
+-    *,
+-    source: torch.Tensor,
+-    output: torch.Tensor,
+-    scale: torch.Tensor,
+-    max_numel: int,
+-) -> Binding:
+-    if source.dtype != torch.bfloat16 or not source.is_contiguous():
+-        raise TypeError("query source must be contiguous BF16")
+-    if output.dtype != FP8 or tuple(output.shape) != tuple(source.shape):
+-        raise TypeError("query quant output must be E4M3 with the source shape")
+-    if not output.is_contiguous() or output.device != source.device:
+-        raise ValueError("query quant output must be contiguous on the source device")
+-    if scale.dtype != torch.float32 or scale.numel() != 1:
+-        raise TypeError("query quant scale must be a scalar float32 tensor")
+-    if scale.device != source.device:
+-        raise ValueError("query quant scale must be on the source device")
+-    if source.numel() % _VALUES_PER_THREAD:
+-        raise ValueError("query element count must be divisible by four")
+-    if not 0 < source.numel() <= int(max_numel):
+-        raise ValueError("query element count exceeds the planned quant capacity")
+-    return Binding(
+-        source=source.detach(),
+-        output=output.detach(),
+-        scale=scale.detach(),
+-        max_numel=int(max_numel),
+-    )
+-
+-
+-def _launch(binding: Binding):
+-    source_bytes = _byte_base_pointer(binding.source)
+-    output_bytes = _byte_base_pointer(binding.output)
+-    stream = cuda.CUstream(torch.cuda.current_stream().cuda_stream)
+-    entry = _StaticFp8QuantKernel(binding.max_numel)
+-    args = (
+-        _to_cute(source_bytes, cutlass.Uint8, align=16),
+-        _to_cute(output_bytes, cutlass.Uint8, align=16),
+-        _to_cute(binding.scale.reshape(1), cutlass.Float32, align=4),
+-        Int32(binding.source.numel()),
+-        stream,
+-    )
+-    spec = KernelCompileSpec.from_fields(
+-        "attention.static_fp8_query_quant",
+-        1,
+-        key_field("max_numel", binding.max_numel),
+-    )
+-    return entry, args, spec
+-
+-
+-def _signature(binding: Binding) -> tuple[int, int]:
+-    index = binding.source.device.index
+-    if index is None:
+-        index = torch.cuda.current_device()
+-    return int(index), int(binding.max_numel)
+-
+-
+-def compile(*, binding: Binding) -> None:
+-    signature = _signature(binding)
+-    with _LOCK:
+-        compiled = _CACHE.get(signature)
+-    if compiled is None:
+-        entry, args, spec = _launch(binding)
+-        compiled = compile_cute(entry, *args, compile_spec=spec)
+-        with _LOCK:
+-            _CACHE[signature] = compiled
+-
+-
+-def run(*, binding: Binding) -> torch.Tensor:
+-    signature = _signature(binding)
+-    with _LOCK:
+-        compiled = _CACHE.get(signature)
+-    if compiled is None:
+-        if torch.cuda.is_current_stream_capturing():
+-            raise RuntimeError(
+-                "query quant compile miss during CUDA graph capture; call compile first"
+-            )
+-        compile(binding=binding)
+-        with _LOCK:
+-            compiled = _CACHE[signature]
+-    _, args, _ = _launch(binding)
+-    run_compiled(compiled, args)
+-    return binding.output
+-
+-
+-def clear_caches() -> None:
+-    with _LOCK:
+-        _CACHE.clear()
+-
+-
+-__all__ = ["Binding", "bind", "clear_caches", "compile", "run"]
+diff --git a/b12x/attention/dense_mla/__init__.py b/b12x/attention/dense_mla/__init__.py
+index 46361faf5110eedb0c07ac8c2dfb003bb15cc777..50a8f9a6bcd438a48a00cfedf3651ccdea9365fd 100644
+--- a/b12x/attention/dense_mla/__init__.py
++++ b/b12x/attention/dense_mla/__init__.py
+@@ -1,25 +1,22 @@
+-"""Paged dense Multi-head Latent Attention on SM12x.
++"""Dense Multi-head Latent Attention for Kimi K3 on SM12x.
+ 
+-The operator consumes absorbed queries and combined compressed-cache records
+-directly. Logical Q/K width, logical value width, and physical-record width
+-are planned independently. Supported logical widths are ``(576, 512)`` and
+-``(1088, 1024)``.
++The operator consumes the absorbed K3 query and the combined compressed-cache
++record directly:
+ 
+-* query: ``[total_q, local_heads, logical_qk_width]``;
+-* cache: ``[pages, page_size, physical_record_width]`` (or a singleton-head
+-  rank-4 view), where the logical key prefix is read directly;
+-* value: the logical value prefix of each record.
++* query: ``[total_q, local_heads, 576]``;
++* cache: ``[pages, page_size, 576]`` (or a singleton-head rank-4 view);
++* key: all 576 record elements;
++* value: the first 512 record elements.
+ 
+-``window_size=None`` attends to the full causal context. A positive
+-``window_size`` restricts query position ``p`` to the inclusive interval
+-``[max(0, p - window_size + 1), p]``. The attention scale is caller-provided.
+-BF16 and E4M3 records are supported. For E4M3 cache with BF16 query input,
+-``q_dtype=torch.bfloat16`` plans fixed query-quantization storage in the same
+-caller-owned scratch buffer.
++The attention scale is based on K3's *raw* 192-wide QK head
++(``1 / sqrt(192)``), not the 576-wide absorbed record.  BF16 and standard
++E4M3 combined records are supported; E4M3 uses one caller-provided FP32 scalar
++scale for the whole record.
+ 
+ Planned lifecycle: ``plan(Caps(...))`` -> caller allocates ``scratch_specs`` ->
+-``bind`` (views and validation only) -> ``compile``/``run``. Decode and extend
+-share the same graph-safe dense core. No selected-index array is materialized.
++``bind`` (views and validation only) -> ``compile``/``run``.  Decode and
++single-request prefill share the same graph-safe dense core.  No selected-index
++array is materialized.
+ """
+ 
+ from __future__ import annotations
+@@ -48,7 +45,7 @@ META = OpMeta(
+         "clear_caches",
+     ),
+     dtypes=("bf16", "fp8_e4m3"),
+-    recipes=("strided_paged_dense_mla",),
++    recipes=("kimi_k3_dense_mla",),
+     requires=(),
+     provenance=Provenance(
+         repo="https://github.com/lukealonso/b12x",
+@@ -62,8 +59,9 @@ META = OpMeta(
+     test_path="tests/attention/test_dense_mla.py",
+     since="0.8.0",
+     notes=(
+-        "Physical page and record addressing is 64-bit. Optional BF16-to-E4M3 "
+-        "query conversion uses planned caller-owned storage."
++        "K3 TP12 uses eight local heads, a 576-element absorbed Q/K record, "
++        "a 512-element latent value, and 1/sqrt(192) scaling. Pool-scaled "
++        "addressing is 64-bit and the runtime owns no allocations."
+     ),
+ )
+ 
+diff --git a/b12x/attention/dense_mla/_forward.py b/b12x/attention/dense_mla/_forward.py
+index 64316b37125e29927e43e902c32e8e8ca8c32e88..f244b18b2ce8749af6a6b6691273fb35d56caaa5 100644
+--- a/b12x/attention/dense_mla/_forward.py
++++ b/b12x/attention/dense_mla/_forward.py
+@@ -60,9 +60,6 @@ class DenseMlaForwardKernel:
+         chunks_per_split: int,
+         query_tile: int,
+         fp8: bool,
+-        qk_dim: int,
+-        value_dim: int,
+-        window_size: int | None,
+     ):
+         self.layout = layout
+         self.page_size = int(page_size)
+@@ -72,9 +69,6 @@ class DenseMlaForwardKernel:
+         self.chunks_per_split = int(chunks_per_split)
+         self.query_tile = int(query_tile)
+         self.fp8 = bool(fp8)
+-        self.qk_dim = int(qk_dim)
+-        self.value_dim = int(value_dim)
+-        self.window_size = None if window_size is None else int(window_size)
+         self.kv_stages = int(layout.kv_stages)
+         self.math_warps = MATH_WARPS_PER_QUERY * self.query_tile
+         self.math_threads = self.math_warps * 32
+@@ -98,7 +92,6 @@ class DenseMlaForwardKernel:
+         q_stride_row_bytes: Int64,
+         q_stride_head_bytes: Int64,
+         page_stride_bytes: Int64,
+-        cache_record_stride_bytes: Int64,
+         page_table_stride: Int64,
+         total_q: Int32,
+         batch: Int32,
+@@ -122,7 +115,6 @@ class DenseMlaForwardKernel:
+             q_stride_row_bytes,
+             q_stride_head_bytes,
+             page_stride_bytes,
+-            cache_record_stride_bytes,
+             page_table_stride,
+             total_q,
+             batch,
+@@ -146,7 +138,6 @@ class DenseMlaForwardKernel:
+         mbar_base,
+         active_chunks: Int32,
+         split_first_chunk: Int32,
+-        visible_begin: Int32,
+         visible_end: Int32,
+         query_row: Int32,
+         head_base: Int32,
+@@ -165,10 +156,10 @@ class DenseMlaForwardKernel:
+         *,
+         barrier_id: cutlass.Constexpr,
+     ):
+-        accumulator_fragment = cute.make_rmem_tensor(self.value_dim // 16, Float32)
++        accumulator_fragment = cute.make_rmem_tensor(32, Float32)
+         global_max_fragment = cute.make_rmem_tensor(2, Float32)
+         global_sum_fragment = cute.make_rmem_tensor(2, Float32)
+-        for idx in cutlass.range_constexpr(self.value_dim // 16):
++        for idx in cutlass.range_constexpr(32):
+             accumulator_fragment[idx] = Float32(0.0)
+         global_max_fragment[0] = Float32(-1.0e30)
+         global_max_fragment[1] = Float32(-1.0e30)
+@@ -201,7 +192,7 @@ class DenseMlaForwardKernel:
+                         accumulator_fragment[tile * 2],
+                         accumulator_fragment[tile * 2 + 1],
+                     ]
+-                    for tile in range(self.value_dim // 32)
++                    for tile in range(16)
+                 ]
+                 global_max = [
+                     global_max_fragment[0],
+@@ -225,7 +216,6 @@ class DenseMlaForwardKernel:
+                         local_warp,
+                         lane,
+                         record_stride_bytes=self.layout.record_stride_bytes,
+-                        qk_dim=self.qk_dim,
+                     )
+                 else:
+                     qk = qk_bf16(
+@@ -235,12 +225,10 @@ class DenseMlaForwardKernel:
+                         local_warp,
+                         lane,
+                         record_stride_bytes=self.layout.record_stride_bytes,
+-                        qk_dim=self.qk_dim,
+                     )
+                 qk = mask_and_scale(
+                     qk,
+                     chunk_begin,
+-                    visible_begin,
+                     visible_end,
+                     score_scale_log2,
+                     local_warp,
+@@ -264,7 +252,6 @@ class DenseMlaForwardKernel:
+                     lane,
+                     local_tid,
+                     barrier_id=barrier_id,
+-                    value_dim=self.value_dim,
+                 )
+                 weights = [
+                     probability[0] * warp_scale0,
+@@ -284,7 +271,6 @@ class DenseMlaForwardKernel:
+                         local_tid,
+                         record_stride_bytes=self.layout.record_stride_bytes,
+                         barrier_id=barrier_id,
+-                        value_dim=self.value_dim,
+                     )
+                 else:
+                     accumulator = pv_bf16(
+@@ -296,9 +282,8 @@ class DenseMlaForwardKernel:
+                         lane,
+                         record_stride_bytes=self.layout.record_stride_bytes,
+                         barrier_id=barrier_id,
+-                        value_dim=self.value_dim,
+                     )
+-                for tile in cutlass.range_constexpr(self.value_dim // 32):
++                for tile in cutlass.range_constexpr(16):
+                     accumulator_fragment[tile * 2] = accumulator[tile][0]
+                     accumulator_fragment[tile * 2 + 1] = accumulator[tile][1]
+                 global_max_fragment[0] = global_max[0]
+@@ -324,7 +309,7 @@ class DenseMlaForwardKernel:
+                 accumulator_fragment[tile * 2],
+                 accumulator_fragment[tile * 2 + 1],
+             ]
+-            for tile in range(self.value_dim // 32)
++            for tile in range(16)
+         ]
+         global_max = [
+             global_max_fragment[0],
+@@ -353,7 +338,6 @@ class DenseMlaForwardKernel:
+                     has_splits=True,
+                     fp8=self.fp8,
+                     ln2=0.6931471805599453,
+-                    value_dim=self.value_dim,
+                 )
+             else:
+                 write_partial_or_final(
+@@ -373,7 +357,6 @@ class DenseMlaForwardKernel:
+                     has_splits=False,
+                     fp8=self.fp8,
+                     ln2=0.6931471805599453,
+-                    value_dim=self.value_dim,
+                 )
+         else:
+             write_partial_or_final(
+@@ -393,7 +376,6 @@ class DenseMlaForwardKernel:
+                 has_splits=False,
+                 fp8=self.fp8,
+                 ln2=0.6931471805599453,
+-                value_dim=self.value_dim,
+             )
+ 
+     @cute.kernel
+@@ -414,7 +396,6 @@ class DenseMlaForwardKernel:
+         q_stride_row_bytes: Int64,
+         q_stride_head_bytes: Int64,
+         page_stride_bytes: Int64,
+-        cache_record_stride_bytes: Int64,
+         page_table_stride: Int64,
+         total_q: Int32,
+         batch: Int32,
+@@ -446,25 +427,10 @@ class DenseMlaForwardKernel:
+         query_length = query_end - query_begin
+         cache_length = Int32(cache_seqlens[request])
+ 
+-        first_valid_chunk = Int32(0)
+-        visible_chunks_end = cache_length
+-        if cutlass.const_expr(self.window_size is not None):
+-            tile_local_query = query_start - query_begin
+-            visible_chunks_end = (
+-                cache_length - query_length + tile_local_query + Int32(1)
+-            )
+-            if visible_chunks_end < Int32(0):
+-                visible_chunks_end = Int32(0)
+-            if visible_chunks_end > cache_length:
+-                visible_chunks_end = cache_length
+-            visible_chunks_begin = visible_chunks_end - Int32(self.window_size)
+-            if visible_chunks_begin < Int32(0):
+-                visible_chunks_begin = Int32(0)
+-            first_valid_chunk = visible_chunks_begin // Int32(CANDIDATES_PER_CHUNK)
+-        valid_chunks = (visible_chunks_end + Int32(CANDIDATES_PER_CHUNK - 1)) // Int32(
++        valid_chunks = (cache_length + Int32(CANDIDATES_PER_CHUNK - 1)) // Int32(
+             CANDIDATES_PER_CHUNK
+         )
+-        split_first_chunk = first_valid_chunk + split * Int32(self.chunks_per_split)
++        split_first_chunk = split * Int32(self.chunks_per_split)
+         split_last_chunk = split_first_chunk + Int32(self.chunks_per_split)
+         if split_last_chunk > valid_chunks:
+             split_last_chunk = valid_chunks
+@@ -478,8 +444,9 @@ class DenseMlaForwardKernel:
+                 query_slot = entry // Int32(HEADS_PER_TILE)
+                 local_head = entry - query_slot * Int32(HEADS_PER_TILE)
+                 query_row = query_start + query_slot
+-                if query_row < total_q and head_base + local_head < Int32(
+-                    self.num_heads
++                if (
++                    query_row < total_q
++                    and head_base + local_head < Int32(self.num_heads)
+                 ):
+                     if cutlass.const_expr(self.num_splits > 1):
+                         if active_splits > Int32(1):
+@@ -546,7 +513,6 @@ class DenseMlaForwardKernel:
+                     cache_length,
+                     io_lane,
+                     page_stride_bytes,
+-                    cache_record_stride_bytes,
+                     page_table_stride,
+                     page_size=self.page_size,
+                     record_bytes=self.layout.record_bytes,
+@@ -589,11 +555,6 @@ class DenseMlaForwardKernel:
+                 visible_end = Int32(0)
+             if visible_end > cache_length:
+                 visible_end = cache_length
+-            visible_begin = Int32(0)
+-            if cutlass.const_expr(self.window_size is not None):
+-                visible_begin = visible_end - Int32(self.window_size)
+-                if visible_begin < Int32(0):
+-                    visible_begin = Int32(0)
+ 
+             score_scale = sm_scale_log2
+             value_scale = Float32(1.0)
+@@ -628,7 +589,6 @@ class DenseMlaForwardKernel:
+                     mbar_base,
+                     active_chunks,
+                     split_first_chunk,
+-                    visible_begin,
+                     visible_end,
+                     query_row,
+                     head_base,
+@@ -657,7 +617,6 @@ class DenseMlaForwardKernel:
+                     mbar_base,
+                     active_chunks,
+                     split_first_chunk,
+-                    visible_begin,
+                     visible_end,
+                     query_row,
+                     head_base,
+@@ -686,7 +645,6 @@ class DenseMlaForwardKernel:
+                     mbar_base,
+                     active_chunks,
+                     split_first_chunk,
+-                    visible_begin,
+                     visible_end,
+                     query_row,
+                     head_base,
+@@ -715,7 +673,6 @@ class DenseMlaForwardKernel:
+                     mbar_base,
+                     active_chunks,
+                     split_first_chunk,
+-                    visible_begin,
+                     visible_end,
+                     query_row,
+                     head_base,
+diff --git a/b12x/attention/dense_mla/_io.py b/b12x/attention/dense_mla/_io.py
+index f6e082bac27a68c5a0cc01752e65e1086f3e7222..5f91aaf6d7888b0c49bca31561b54ce4757fae4a 100644
+--- a/b12x/attention/dense_mla/_io.py
++++ b/b12x/attention/dense_mla/_io.py
+@@ -26,7 +26,6 @@ def issue_dense_page_gather(
+     token_end: Int32,
+     io_lane: Int32,
+     page_stride_bytes: Int64,
+-    record_stride_bytes_global: Int64,
+     page_table_stride: Int64,
+     *,
+     page_size: cutlass.Constexpr,
+@@ -61,10 +60,9 @@ def issue_dense_page_gather(
+ 
+         # Load-bearing Int64 conversions. Neither multiplication is allowed to
+         # occur in Int32, even when benchmark page ids happen to be small.
+-        source_offset = (
+-            physical_page.to(Int64) * page_stride_bytes
+-            + in_page.to(Int64) * record_stride_bytes_global
+-        )
++        source_offset = physical_page.to(Int64) * page_stride_bytes + in_page.to(
++            Int64
++        ) * Int64(record_bytes)
+         cp_async_bulk_g2s_mbar(
+             kv_dst_addr + entry * Int32(record_stride_bytes),
+             get_ptr_as_int64(cache_bytes, source_offset),
+diff --git a/b12x/attention/dense_mla/_kernel.py b/b12x/attention/dense_mla/_kernel.py
+index 6f14d2470052da209dcf7567883d20b1c249e61d..12bae04d9c33d022434a637f9ac1fe5c3fe5f726 100644
+--- a/b12x/attention/dense_mla/_kernel.py
++++ b/b12x/attention/dense_mla/_kernel.py
+@@ -21,7 +21,6 @@ from b12x._lib.compiler import (
+     tensor_key,
+ )
+ 
+-from .._shared import static_fp8_quant
+ from ._forward import DenseMlaForwardKernel
+ from ._layout import make_smem_layout
+ from ._merge import DenseMlaMergeKernel
+@@ -83,10 +82,6 @@ def _signature(binding: Binding) -> tuple[object, ...]:
+         scratch.query_tile,
+         scratch.num_splits,
+         scratch.chunks_per_split,
+-        scratch.physical_record_width,
+-        scratch.head_dim,
+-        scratch.v_head_dim,
+-        scratch.window_size,
+         tuple(int(value) for value in binding.q.stride()),
+         tuple(int(value) for value in binding.kv_cache.stride()),
+         tuple(int(value) for value in binding.output.stride()),
+@@ -118,7 +113,6 @@ def _forward_launch(binding: Binding) -> _ForwardLaunch:
+     layout = make_smem_layout(
+         query_tile=scratch.query_tile,
+         fp8=fp8,
+-        qk_dim=scratch.head_dim,
+     )
+     entry = DenseMlaForwardKernel(
+         layout=layout,
+@@ -128,9 +122,6 @@ def _forward_launch(binding: Binding) -> _ForwardLaunch:
+         chunks_per_split=scratch.chunks_per_split,
+         query_tile=scratch.query_tile,
+         fp8=fp8,
+-        qk_dim=scratch.head_dim,
+-        value_dim=scratch.v_head_dim,
+-        window_size=scratch.window_size,
+     )
+ 
+     q_bytes = _byte_base_pointer(binding.q)
+@@ -194,7 +185,6 @@ def _forward_launch(binding: Binding) -> _ForwardLaunch:
+         Int64(int(binding.q.stride(0)) * binding.q.element_size()),
+         Int64(int(binding.q.stride(1)) * binding.q.element_size()),
+         Int64(int(binding.kv_cache.stride(0)) * binding.kv_cache.element_size()),
+-        Int64(int(binding.kv_cache.stride(1)) * binding.kv_cache.element_size()),
+         Int64(int(binding.page_table.stride(0))),
+         Int32(int(binding.q.shape[0])),
+         Int32(int(binding.cache_seqlens.shape[0])),
+@@ -203,7 +193,7 @@ def _forward_launch(binding: Binding) -> _ForwardLaunch:
+     )
+     spec = KernelCompileSpec.from_fields(
+         "attention.dense_mla.forward",
+-        4,
++        3,
+         key_field("dtype", "fp8" if fp8 else "bf16"),
+         key_field("heads", scratch.num_q_heads),
+         key_field("page_size", scratch.page_size),
+@@ -212,10 +202,6 @@ def _forward_launch(binding: Binding) -> _ForwardLaunch:
+         key_field("query_tile", scratch.query_tile),
+         key_field("num_splits", scratch.num_splits),
+         key_field("chunks_per_split", scratch.chunks_per_split),
+-        key_field("physical_record_width", scratch.physical_record_width),
+-        key_field("head_dim", scratch.head_dim),
+-        key_field("v_head_dim", scratch.v_head_dim),
+-        key_field("window_size", scratch.window_size),
+         key_field("record_stride_bytes", layout.record_stride_bytes),
+         tensor_key(
+             "q",
+@@ -223,7 +209,7 @@ def _forward_launch(binding: Binding) -> _ForwardLaunch:
+             dims=(
+                 DimKey.dynamic(),
+                 DimKey.exact(scratch.num_q_heads),
+-                DimKey.exact(scratch.head_dim),
++                DimKey.exact(576),
+             ),
+         ),
+         tensor_key(
+@@ -232,7 +218,7 @@ def _forward_launch(binding: Binding) -> _ForwardLaunch:
+             dims=(
+                 DimKey.dynamic(),
+                 DimKey.exact(scratch.page_size),
+-                DimKey.exact(scratch.physical_record_width),
++                DimKey.exact(576),
+             ),
+         ),
+         tensor_key(
+@@ -241,7 +227,7 @@ def _forward_launch(binding: Binding) -> _ForwardLaunch:
+             dims=(
+                 DimKey.dynamic(),
+                 DimKey.exact(scratch.num_q_heads),
+-                DimKey.exact(scratch.v_head_dim),
++                DimKey.exact(512),
+             ),
+         ),
+     )
+@@ -254,7 +240,7 @@ def _merge_launch(binding: Binding) -> _MergeLaunch | None:
+         return None
+     assert scratch.partial_output is not None
+     assert scratch.partial_lse is not None
+-    entry = DenseMlaMergeKernel(scratch.num_splits, scratch.v_head_dim)
++    entry = DenseMlaMergeKernel(scratch.num_splits)
+     stream = cuda.CUstream(torch.cuda.current_stream().cuda_stream)
+     args = (
+         _to_cute(
+@@ -278,7 +264,6 @@ def _merge_launch(binding: Binding) -> _MergeLaunch | None:
+         4,
+         key_field("num_splits", scratch.num_splits),
+         key_field("heads", scratch.num_q_heads),
+-        key_field("v_head_dim", scratch.v_head_dim),
+         tensor_key(
+             "partial_output",
+             scratch.partial_output,
+@@ -286,7 +271,7 @@ def _merge_launch(binding: Binding) -> _MergeLaunch | None:
+                 DimKey.capacity(scratch.max_total_q),
+                 DimKey.exact(scratch.num_q_heads),
+                 DimKey.exact(scratch.num_splits),
+-                DimKey.exact(scratch.v_head_dim),
++                DimKey.exact(512),
+             ),
+         ),
+         tensor_key(
+@@ -295,7 +280,7 @@ def _merge_launch(binding: Binding) -> _MergeLaunch | None:
+             dims=(
+                 DimKey.dynamic(),
+                 DimKey.exact(scratch.num_q_heads),
+-                DimKey.exact(scratch.v_head_dim),
++                DimKey.exact(512),
+             ),
+         ),
+     )
+@@ -333,8 +318,6 @@ def compile_dense_mla(*, binding: Binding) -> None:
+     """Compile the exact native forward/merge entries without launching."""
+     if not binding.q.is_cuda:
+         raise ValueError("dense MLA native compilation requires CUDA tensors")
+-    if binding.query_quant is not None:
+-        static_fp8_quant.compile(binding=binding.query_quant)
+     _compile_entries(binding)
+ 
+ 
+@@ -345,8 +328,6 @@ def run_dense_mla(
+     """Launch only previously planned storage; no device allocation occurs."""
+     if not binding.q.is_cuda:
+         raise ValueError("dense MLA native execution requires CUDA tensors")
+-    if binding.query_quant is not None:
+-        static_fp8_quant.run(binding=binding.query_quant)
+     signature = _signature(binding)
+     with _LOCK:
+         compiled_forward = _FORWARD_CACHE.get(signature)
+@@ -374,7 +355,6 @@ def run_dense_mla(
+ 
+ 
+ def clear_dense_mla_kernel_caches() -> None:
+-    static_fp8_quant.clear_caches()
+     with _LOCK:
+         _FORWARD_CACHE.clear()
+         _MERGE_CACHE.clear()
+diff --git a/b12x/attention/dense_mla/_layout.py b/b12x/attention/dense_mla/_layout.py
+index ab6f417d78e32f3f3bf78a2d2125d9750ea134cb..4b5856771f84ad36317bef9aa8ebc0bf81fe1933 100644
+--- a/b12x/attention/dense_mla/_layout.py
++++ b/b12x/attention/dense_mla/_layout.py
+@@ -33,9 +33,7 @@ class SmemLayout:
+     total_bytes: int
+ 
+ 
+-def make_smem_layout(
+-    *, query_tile: int, fp8: bool, qk_dim: int = K3_QK_DIM
+-) -> SmemLayout:
++def make_smem_layout(*, query_tile: int, fp8: bool) -> SmemLayout:
+     query_tile = int(query_tile)
+     if query_tile not in (1, 2, 4):
+         raise ValueError("dense MLA query_tile must be 1, 2, or 4")
+@@ -47,11 +45,8 @@ def make_smem_layout(
+     # opt-in SMEM limit exposed by RTX PRO 6000 Blackwell.  BF16 retains the
+     # same producer/consumer transaction protocol with one stage; the primary
+     # E4M3 serving path keeps the latency-hiding double buffer.
+-    qk_dim = int(qk_dim)
+-    if qk_dim <= 0 or qk_dim % 32:
+-        raise ValueError("dense MLA qk_dim must be a positive multiple of 32")
+-    kv_stages = KV_STAGES if fp8 and qk_dim <= K3_QK_DIM else 1
+-    record_bytes = qk_dim * element_bytes
++    kv_stages = KV_STAGES if fp8 else 1
++    record_bytes = K3_QK_DIM * element_bytes
+     # The extra 16 bytes rotate successive rows across banks while making
+     # every row a legal cp.async.bulk destination.
+     record_stride_bytes = record_bytes + 16
+diff --git a/b12x/attention/dense_mla/_math.py b/b12x/attention/dense_mla/_math.py
+index ae8d92925cdd6ca43bb7d95a24f40cdd4109c6d2..e40b02b4c58703146cf0cec30b8b8d9ba068b472 100644
+--- a/b12x/attention/dense_mla/_math.py
++++ b/b12x/attention/dense_mla/_math.py
+@@ -39,6 +39,8 @@ from b12x._lib.intrinsics import (
+ from ._layout import (
+     CANDIDATES_PER_CHUNK,
+     HEADS_PER_TILE,
++    K3_QK_DIM,
++    K3_VALUE_DIM,
+     MATH_WARPS_PER_QUERY,
+ )
+ 
+@@ -155,7 +157,6 @@ def qk_fp8(
+     lane: Int32,
+     *,
+     record_stride_bytes: cutlass.Constexpr,
+-    qk_dim: cutlass.Constexpr,
+ ):
+     """Raw E4M3 K-by-Q MMA for one 16-candidate warp tile."""
+     a_row = (lane & Int32(7)) + ((lane >> Int32(3)) & Int32(1)) * Int32(8)
+@@ -164,7 +165,7 @@ def qk_fp8(
+     b_col = ((lane >> Int32(3)) & Int32(1)) * Int32(16)
+     first_candidate = local_warp * Int32(16)
+ 
+-    for ks in cutlass.range_constexpr(qk_dim // 32):
++    for ks in cutlass.range_constexpr(K3_QK_DIM // 32):
+         ko = Int32(ks * 32)
+         a_addr = (
+             kv_smem_addr
+@@ -199,7 +200,6 @@ def qk_bf16(
+     lane: Int32,
+     *,
+     record_stride_bytes: cutlass.Constexpr,
+-    qk_dim: cutlass.Constexpr,
+ ):
+     """Raw BF16 K-by-Q MMA for one 16-candidate warp tile."""
+     gid = lane >> Int32(2)
+@@ -208,7 +208,7 @@ def qk_bf16(
+     a_col = (lane >> Int32(4)) * Int32(8)
+     first_candidate = local_warp * Int32(16)
+ 
+-    for ks in cutlass.range_constexpr(qk_dim // 16):
++    for ks in cutlass.range_constexpr(K3_QK_DIM // 16):
+         ko = Int32(ks * 16)
+         a_addr = (
+             kv_smem_addr
+@@ -238,7 +238,6 @@ def qk_bf16(
+ def mask_and_scale(
+     qk,
+     chunk_begin: Int32,
+-    visible_begin: Int32,
+     visible_end: Int32,
+     scale_log2: Float32,
+     local_warp: Int32,
+@@ -248,10 +247,10 @@ def mask_and_scale(
+     gid = lane >> Int32(2)
+     candidate0 = chunk_begin + local_warp * Int32(16) + gid
+     candidate1 = candidate0 + Int32(8)
+-    if candidate0 < visible_begin or candidate0 >= visible_end:
++    if candidate0 >= visible_end:
+         qk[0] = Float32(_MASK)
+         qk[1] = Float32(_MASK)
+-    if candidate1 < visible_begin or candidate1 >= visible_end:
++    if candidate1 >= visible_end:
+         qk[2] = Float32(_MASK)
+         qk[3] = Float32(_MASK)
+     for idx in cutlass.range_constexpr(4):
+@@ -273,7 +272,6 @@ def online_softmax(
+     local_tid: Int32,
+     *,
+     barrier_id: cutlass.Constexpr,
+-    value_dim: cutlass.Constexpr,
+ ):
+     """Update a base-2 online softmax and rescale persistent PV registers."""
+     gid = lane >> Int32(2)
+@@ -368,7 +366,7 @@ def online_softmax(
+     row_alpha = row_alpha0
+     if (gid & Int32(1)) != Int32(0):
+         row_alpha = row_alpha1
+-    for tile in cutlass.range_constexpr(value_dim // 32):
++    for tile in cutlass.range_constexpr(16):
+         acc[tile][0] = acc[tile][0] * row_alpha
+         acc[tile][1] = acc[tile][1] * row_alpha
+ 
+@@ -474,7 +472,6 @@ def pv_fp8(
+     *,
+     record_stride_bytes: cutlass.Constexpr,
+     barrier_id: cutlass.Constexpr,
+-    value_dim: cutlass.Constexpr,
+ ):
+     """HIGH/LOW E4M3 probability MMA against the raw K3 value prefix."""
+     gid = lane >> Int32(2)
+@@ -566,7 +563,7 @@ def pv_fp8(
+     a_row = (lane & Int32(7)) + ((lane >> Int32(3)) & Int32(1)) * Int32(8)
+     a_col = (lane >> Int32(4)) * Int32(16)
+     row_scale = ld_shared_f32(weight_scale_addr + gid * Int32(4))
+-    for value_chunk in cutlass.range_constexpr(value_dim // 64):
++    for value_chunk in cutlass.range_constexpr(K3_VALUE_DIM // 64):
+         for n_tile in cutlass.range_constexpr(2):
+             dimension = Int32(value_chunk * 64) + (
+                 Int32(n_tile * MATH_WARPS_PER_QUERY) + local_warp
+@@ -615,7 +612,6 @@ def pv_bf16(
+     *,
+     record_stride_bytes: cutlass.Constexpr,
+     barrier_id: cutlass.Constexpr,
+-    value_dim: cutlass.Constexpr,
+ ):
+     """BF16 probability/value MMA for the K3 value prefix."""
+     gid = lane >> Int32(2)
+@@ -648,7 +644,7 @@ def pv_bf16(
+ 
+     a_row = (lane & Int32(7)) + ((lane >> Int32(3)) & Int32(1)) * Int32(8)
+     a_col = (lane >> Int32(4)) * Int32(8)
+-    for value_chunk in cutlass.range_constexpr(value_dim // 64):
++    for value_chunk in cutlass.range_constexpr(K3_VALUE_DIM // 64):
+         for n_tile in cutlass.range_constexpr(2):
+             column = (
+                 Int32(value_chunk * 64)
+@@ -725,7 +721,6 @@ def write_partial_or_final(
+     has_splits: cutlass.Constexpr,
+     fp8: cutlass.Constexpr,
+     ln2: cutlass.Constexpr,
+-    value_dim: cutlass.Constexpr,
+ ):
+     """Write a normalized split partial, or the final one-split result."""
+     gid = lane >> Int32(2)
+@@ -749,7 +744,7 @@ def write_partial_or_final(
+         scale = scale * value_scale
+ 
+     if query_valid != Int32(0) and head_base + gid < Int32(num_heads):
+-        for value_chunk in cutlass.range_constexpr(value_dim // 64):
++        for value_chunk in cutlass.range_constexpr(K3_VALUE_DIM // 64):
+             for n_tile in cutlass.range_constexpr(2):
+                 tile = value_chunk * 2 + n_tile
+                 dimension = (
+diff --git a/b12x/attention/dense_mla/_merge.py b/b12x/attention/dense_mla/_merge.py
+index 5f26c5aa2d46751b0134662b3341e0bb2430f5a8..afe93603ed25bab6d65013533b5b30fe8e7f28cd 100644
+--- a/b12x/attention/dense_mla/_merge.py
++++ b/b12x/attention/dense_mla/_merge.py
+@@ -21,9 +21,8 @@ from ._math import exp2_approx, log2_approx
+ class DenseMlaMergeKernel:
+     """Merge normalized BF16 split partials and emit natural-log LSE."""
+ 
+-    def __init__(self, num_splits: int, value_dim: int):
++    def __init__(self, num_splits: int):
+         self.num_splits = int(num_splits)
+-        self.value_dim = int(value_dim)
+ 
+     def _get_shared_storage_cls(self):
+         """Return the per-CTA split-weight storage.
+@@ -149,57 +148,55 @@ class DenseMlaMergeKernel:
+ 
+         cute.arch.barrier()
+ 
+-        while dimension < Int32(self.value_dim):
+-            accumulator = cute.make_rmem_tensor(4, Float32)
+-            for idx in cutlass.range_constexpr(4):
+-                accumulator[idx] = Float32(0.0)
+-
+-            split = Int32(0)
+-            while split < active_splits:
+-                weight = Float32(split_weight[split])
+-                # Capture-static tail splits deliberately leave their partial
+-                # vectors undefined and publish -inf LSE.  Do not load those
+-                # vectors: NaN * 0 would otherwise poison the merged output.
+-                if weight > Float32(0.0):
+-                    partial_offset = (
+-                        (Int64(query) * Int64(partial_output.shape[1]) + Int64(head))
+-                        * Int64(self.num_splits)
+-                        + Int64(split)
+-                    ) * Int64(self.value_dim) + Int64(dimension)
+-                    packed0, packed1 = ld_global_v2_u32(
+-                        get_ptr_as_int64(partial_output, partial_offset)
+-                    )
+-                    value0, value1 = bfloat2_to_float2_scaled(
+-                        packed0,
+-                        weight,
+-                    )
+-                    value2, value3 = bfloat2_to_float2_scaled(
+-                        packed1,
+-                        weight,
+-                    )
+-                    accumulator[0] += value0
+-                    accumulator[1] += value1
+-                    accumulator[2] += value2
+-                    accumulator[3] += value3
+-                split += Int32(1)
+-
+-            inverse = Float32(inverse_storage[0])
+-            output_offset = cute.crd2idx(
+-                (query, head, dimension),
+-                output.layout,
+-            )
+-            st_global_v2_u32(
+-                get_ptr_as_int64(output, output_offset),
+-                pack_f32x2_to_bfloat2(
+-                    accumulator[0] * inverse,
+-                    accumulator[1] * inverse,
+-                ),
+-                pack_f32x2_to_bfloat2(
+-                    accumulator[2] * inverse,
+-                    accumulator[3] * inverse,
+-                ),
+-            )
+-            dimension += Int32(128 * 4)
++        accumulator = cute.make_rmem_tensor(4, Float32)
++        for idx in cutlass.range_constexpr(4):
++            accumulator[idx] = Float32(0.0)
++
++        split = Int32(0)
++        while split < active_splits:
++            weight = Float32(split_weight[split])
++            # Capture-static tail splits deliberately leave their partial
++            # vectors undefined and publish -inf LSE.  Do not load those
++            # vectors: NaN * 0 would otherwise poison the merged output.
++            if weight > Float32(0.0):
++                partial_offset = (
++                    (Int64(query) * Int64(partial_output.shape[1]) + Int64(head))
++                    * Int64(self.num_splits)
++                    + Int64(split)
++                ) * Int64(512) + Int64(dimension)
++                packed0, packed1 = ld_global_v2_u32(
++                    get_ptr_as_int64(partial_output, partial_offset)
++                )
++                value0, value1 = bfloat2_to_float2_scaled(
++                    packed0,
++                    weight,
++                )
++                value2, value3 = bfloat2_to_float2_scaled(
++                    packed1,
++                    weight,
++                )
++                accumulator[0] += value0
++                accumulator[1] += value1
++                accumulator[2] += value2
++                accumulator[3] += value3
++            split += Int32(1)
++
++        inverse = Float32(inverse_storage[0])
++        output_offset = cute.crd2idx(
++            (query, head, dimension),
++            output.layout,
++        )
++        st_global_v2_u32(
++            get_ptr_as_int64(output, output_offset),
++            pack_f32x2_to_bfloat2(
++                accumulator[0] * inverse,
++                accumulator[1] * inverse,
++            ),
++            pack_f32x2_to_bfloat2(
++                accumulator[2] * inverse,
++                accumulator[3] * inverse,
++            ),
++        )
+ 
+ 
+ __all__ = ["DenseMlaMergeKernel"]
+diff --git a/b12x/attention/dense_mla/_reference.py b/b12x/attention/dense_mla/_reference.py
+index 21a10e6c7729c4ec660a493828a0cf903e3b65ef..1d6b329cc45b91e04893db3e528b405c4a053b2d 100644
+--- a/b12x/attention/dense_mla/_reference.py
++++ b/b12x/attention/dense_mla/_reference.py
+@@ -1,4 +1,4 @@
+-"""High-precision paged dense-MLA oracle."""
++"""High-precision paged dense-MLA oracle for the Kimi-K3 contract."""
+ 
+ from __future__ import annotations
+ 
+@@ -12,20 +12,17 @@ K3_RAW_QK_DIM = 192
+ K3_SM_SCALE = 1.0 / math.sqrt(K3_RAW_QK_DIM)
+ 
+ 
+-def _cache_rank3(cache: torch.Tensor, *, head_dim: int) -> torch.Tensor:
++def _cache_rank3(cache: torch.Tensor) -> torch.Tensor:
+     if cache.ndim == 4:
+         if int(cache.shape[2]) != 1:
+             raise ValueError("rank-4 dense MLA cache must have one KV head")
+         cache = cache[:, :, 0, :]
+     if cache.ndim != 3:
+         raise ValueError(
+-            "cache must be [pages,page_size,physical_record_width] or its "
+-            "singleton-head rank-4 form"
+-        )
+-    if int(cache.shape[-1]) < head_dim:
+-        raise ValueError(
+-            f"dense MLA cache record must contain at least {head_dim} elements"
++            "cache must be [pages,page_size,576] or [pages,page_size,1,576]"
+         )
++    if int(cache.shape[-1]) != K3_ABSORBED_DIM:
++        raise ValueError(f"dense MLA cache record must be {K3_ABSORBED_DIM} wide")
+     return cache
+ 
+ 
+@@ -49,29 +46,16 @@ def dense_mla_reference(
+     kv_scale: torch.Tensor | float | None = None,
+     q_scale: torch.Tensor | float | None = None,
+     sm_scale: float = K3_SM_SCALE,
+-    v_head_dim: int | None = None,
+-    window_size: int | None = None,
+ ) -> tuple[torch.Tensor, torch.Tensor]:
+-    """Compute right-aligned causal dense MLA with an optional local window.
++    """Compute the exact right-aligned causal K3 dense MLA definition.
+ 
+     The cache already contains the current query chunk.  Query row ``i`` in a
+     request of length ``Q`` therefore sees keys through
+     ``cache_len - Q + i`` (inclusive).
+     """
+-    if q.ndim != 3:
+-        raise ValueError("q must have shape [total_q, heads, head_dim]")
+-    head_dim = int(q.shape[-1])
+-    default_value_dims = {K3_ABSORBED_DIM: K3_VALUE_DIM, 1088: 1024}
+-    if head_dim not in default_value_dims:
+-        raise ValueError(f"unsupported dense MLA query width {head_dim}")
+-    if v_head_dim is None:
+-        v_head_dim = default_value_dims[head_dim]
+-    v_head_dim = int(v_head_dim)
+-    if not 0 < v_head_dim <= head_dim:
+-        raise ValueError("v_head_dim must be in [1, head_dim]")
+-    if window_size is not None and int(window_size) <= 0:
+-        raise ValueError("window_size must be positive or None")
+-    cache = _cache_rank3(kv_cache, head_dim=head_dim)
++    cache = _cache_rank3(kv_cache)
++    if q.ndim != 3 or tuple(q.shape[1:])[-1:] != (K3_ABSORBED_DIM,):
++        raise ValueError("q must have shape [total_q, heads, 576]")
+     if q.dtype not in (torch.bfloat16, torch.float8_e4m3fn):
+         raise TypeError("q must be BF16 or E4M3")
+     if cache.dtype not in (torch.bfloat16, torch.float8_e4m3fn):
+@@ -98,22 +82,6 @@ def dense_mla_reference(
+         raise ValueError("E4M3 kv_cache requires kv_scale")
+     if q.dtype == torch.float8_e4m3fn and q_scale is None:
+         raise ValueError("E4M3 q requires q_scale")
+-    if cache.dtype == torch.bfloat16 and (kv_scale is not None or q_scale is not None):
+-        raise ValueError("BF16 dense MLA does not accept quantization scales")
+-    if q.dtype != cache.dtype and not (
+-        q.dtype == torch.bfloat16 and cache.dtype == torch.float8_e4m3fn
+-    ):
+-        raise TypeError(
+-            "dense MLA reference supports matching query/cache dtypes or a "
+-            "BF16 query with an E4M3 cache"
+-        )
+-    if q.dtype == torch.bfloat16 and cache.dtype == torch.float8_e4m3fn:
+-        if q_scale is None:
+-            raise ValueError("BF16 query quantization for E4M3 cache requires q_scale")
+-        quantized_q = (q.float() / q_mul).to(torch.float8_e4m3fn)
+-        q_f32 = quantized_q.float() * q_mul
+-    else:
+-        q_f32 = q.float() * q_mul
+ 
+     cu_host = [int(v) for v in cu_seqlens_q.detach().cpu().tolist()]
+     lens_host = [int(v) for v in cache_seqlens.detach().cpu().tolist()]
+@@ -121,7 +89,7 @@ def dense_mla_reference(
+         raise ValueError("cu_seqlens_q must span exactly q.shape[0] rows")
+     page_size = int(cache.shape[1])
+     output = torch.empty(
+-        (int(q.shape[0]), int(q.shape[1]), v_head_dim),
++        (int(q.shape[0]), int(q.shape[1]), K3_VALUE_DIM),
+         dtype=torch.float32,
+         device=q.device,
+     )
+@@ -143,24 +111,18 @@ def dense_mla_reference(
+         if pages_needed > int(page_table.shape[1]):
+             raise ValueError("page_table is too narrow for cache_seqlens")
+         physical_pages = page_table[request, :pages_needed].to(torch.long)
+-        records = cache.index_select(0, physical_pages).reshape(
+-            -1, int(cache.shape[-1])
+-        )
+-        records = records[:, :head_dim]
++        records = cache.index_select(0, physical_pages).reshape(-1, K3_ABSORBED_DIM)
+         records = records[:kv_len].float() * kv_mul
+ 
+-        q_rows = q_f32[q_begin:q_end]
++        q_rows = q[q_begin:q_end].float() * q_mul
+         for local_q in range(q_len):
+             visible = kv_len - q_len + local_q + 1
+-            visible_begin = (
+-                0 if window_size is None else max(0, visible - int(window_size))
+-            )
+-            key = records[visible_begin:visible]
++            key = records[:visible]
+             logits = torch.einsum("hd,kd->hk", q_rows[local_q], key)
+             logits = logits * float(sm_scale)
+             probs = torch.softmax(logits, dim=-1)
+             output[q_begin + local_q] = torch.einsum(
+-                "hk,kd->hd", probs, key[:, :v_head_dim]
++                "hk,kd->hd", probs, key[:, :K3_VALUE_DIM]
+             )
+             lse[q_begin + local_q] = torch.logsumexp(logits, dim=-1)
+ 
+diff --git a/b12x/attention/dense_mla/_scratch.py b/b12x/attention/dense_mla/_scratch.py
+index 37235c1d46caa37d4ecab8bcb44cf85b872c2d14..ba4362bf6b6035e6046285036a4ac21d31ce317e 100644
+--- a/b12x/attention/dense_mla/_scratch.py
++++ b/b12x/attention/dense_mla/_scratch.py
+@@ -20,7 +20,6 @@ from b12x._lib.scratch_layout import (
+     materialize_scratch_view,
+ )
+ 
+-from .._shared import static_fp8_quant
+ from .planner import Budget, choose_num_splits
+ from ._layout import make_smem_layout
+ from ._reference import (
+@@ -30,7 +29,7 @@ from ._reference import (
+ )
+ 
+ _FP8 = torch.float8_e4m3fn
+-_MAX_Q_ROWS = 65_536
++_MAX_Q_ROWS = 1_024
+ _MAX_CACHE_TOKENS = 1_048_576
+ 
+ 
+@@ -42,20 +41,13 @@ def _canonical_device(device: torch.device | str) -> torch.device:
+ 
+ 
+ def _query_tile(caps: Caps) -> int:
+-    if caps.mode == "decode" or caps.max_batch != 1 or caps.window_size is not None:
++    if caps.mode == "decode" or caps.max_batch != 1:
+         return 1
+     if caps.kv_dtype == _FP8 and caps.max_total_q >= 3:
+         return 4
+     return 2
+ 
+ 
+-def _max_attended_tokens(caps: Caps) -> int:
+-    if caps.window_size is None:
+-        return caps.max_cache_tokens
+-    # A local interval can begin and end in partial physical pages.
+-    return min(caps.max_cache_tokens, caps.window_size + caps.page_size - 1)
+-
+-
+ @dataclass(frozen=True, kw_only=True)
+ class Caps:
+     device: torch.device | str
+@@ -69,11 +61,8 @@ class Caps:
+     max_page_table_width: int
+     num_cache_pages: int
+     dtype: torch.dtype = torch.bfloat16
+-    q_dtype: torch.dtype | None = None
+     head_dim: int = K3_ABSORBED_DIM
+     v_head_dim: int = K3_VALUE_DIM
+-    physical_record_width: int = K3_ABSORBED_DIM
+-    window_size: int | None = None
+     use_cuda_graph: bool = False
+     budget: Budget | None = None
+ 
+@@ -82,35 +71,19 @@ class Caps:
+         if self.mode not in ("decode", "extend", "verify"):
+             raise ValueError(f"unsupported dense MLA mode {self.mode!r}")
+         if self.dtype != torch.bfloat16:
+-            raise TypeError("dense MLA output must be torch.bfloat16")
++            raise TypeError("K3 dense MLA activations/output must be torch.bfloat16")
+         if self.kv_dtype not in (torch.bfloat16, _FP8):
+-            raise TypeError("dense MLA KV must be BF16 or E4M3")
+-        q_dtype = self.kv_dtype if self.q_dtype is None else self.q_dtype
+-        if q_dtype not in (torch.bfloat16, _FP8):
+-            raise TypeError("dense MLA query must be BF16 or E4M3")
+-        if q_dtype != self.kv_dtype and not (
+-            q_dtype == torch.bfloat16 and self.kv_dtype == _FP8
+-        ):
+-            raise TypeError(
+-                "dense MLA supports matching query/cache dtypes or a BF16 "
+-                "query with an E4M3 cache"
+-            )
+-        object.__setattr__(self, "q_dtype", q_dtype)
+-        geometry = (int(self.head_dim), int(self.v_head_dim))
+-        if geometry not in ((K3_ABSORBED_DIM, K3_VALUE_DIM), (1088, 1024)):
+-            raise ValueError(
+-                "dense MLA supports logical (QK, V) widths (576, 512) and (1088, 1024)"
+-            )
+-        if int(self.physical_record_width) < int(self.head_dim):
+-            raise ValueError("physical_record_width must cover the logical key record")
+-        if self.window_size is not None and int(self.window_size) <= 0:
+-            raise ValueError("window_size must be positive or None")
++            raise TypeError("K3 dense MLA KV must be BF16 or E4M3")
++        if int(self.head_dim) != K3_ABSORBED_DIM:
++            raise ValueError(f"K3 dense MLA head_dim must be {K3_ABSORBED_DIM}")
++        if int(self.v_head_dim) != K3_VALUE_DIM:
++            raise ValueError(f"K3 dense MLA v_head_dim must be {K3_VALUE_DIM}")
+         heads = int(self.num_q_heads)
+         if heads <= 0:
+             raise ValueError("num_q_heads must be positive")
+         page_size = int(self.page_size)
+-        if page_size <= 0 or (page_size != 1 and page_size % 16):
+-            raise ValueError("page_size must be 1 or a positive multiple of 16")
++        if page_size <= 0 or page_size % 16:
++            raise ValueError("page_size must be a positive multiple of 16")
+         max_total_q = int(self.max_total_q)
+         if not 1 <= max_total_q <= _MAX_Q_ROWS:
+             raise ValueError(f"max_total_q must be in [1, {_MAX_Q_ROWS}]")
+@@ -140,12 +113,9 @@ class Caps:
+             "num_cache_pages",
+             "head_dim",
+             "v_head_dim",
+-            "physical_record_width",
+         ):
+             object.__setattr__(self, name, int(getattr(self, name)))
+         object.__setattr__(self, "use_cuda_graph", bool(self.use_cuda_graph))
+-        if self.window_size is not None:
+-            object.__setattr__(self, "window_size", int(self.window_size))
+ 
+ 
+ @dataclass(frozen=True)
+@@ -156,21 +126,18 @@ class _ScratchLayout:
+     partial_output_offset_bytes: int | None
+     partial_lse_offset_bytes: int | None
+     final_lse_offset_bytes: int
+-    quantized_q_offset_bytes: int | None
+ 
+ 
+ def _dense_mla_scratch_layout(
+     caps: Caps,
+ ) -> _ScratchLayout:
+     query_tile = _query_tile(caps)
+-    max_attended_tokens = _max_attended_tokens(caps)
+     if caps.device.type == "cuda":
+         properties = torch.cuda.get_device_properties(caps.device)
+         sm_count = int(properties.multi_processor_count)
+         shared_layout = make_smem_layout(
+             query_tile=query_tile,
+             fp8=caps.kv_dtype == _FP8,
+-            qk_dim=caps.head_dim,
+         )
+         shared_limit = int(properties.shared_memory_per_block_optin)
+         if shared_layout.total_bytes > shared_limit:
+@@ -182,14 +149,14 @@ def _dense_mla_scratch_layout(
+     else:
+         sm_count = 1
+     num_splits = choose_num_splits(
+-        max_cache_tokens=max_attended_tokens,
++        max_cache_tokens=caps.max_cache_tokens,
+         max_total_q=caps.max_total_q,
+         num_q_heads=caps.num_q_heads,
+         query_tile=query_tile,
+         sm_count=sm_count,
+         budget=caps.budget,
+     )
+-    num_chunks = (max_attended_tokens + 63) // 64
++    num_chunks = (caps.max_cache_tokens + 63) // 64
+     chunks_per_split = (num_chunks + num_splits - 1) // num_splits
+     partial_rows = caps.max_total_q * num_splits
+     if (
+@@ -213,7 +180,7 @@ def _dense_mla_scratch_layout(
+             caps.max_total_q
+             * caps.num_q_heads
+             * num_splits
+-            * caps.v_head_dim
++            * K3_VALUE_DIM
+             * dtype_nbytes(torch.bfloat16)
+         )
+         cursor = align_up(cursor, SCRATCH_ALIGN_BYTES)
+@@ -228,13 +195,6 @@ def _dense_mla_scratch_layout(
+     cursor = align_up(cursor, SCRATCH_ALIGN_BYTES)
+     final_lse_offset_bytes = cursor
+     cursor += caps.max_total_q * caps.num_q_heads * dtype_nbytes(torch.float32)
+-    quantized_q_offset_bytes = None
+-    if caps.q_dtype != caps.kv_dtype:
+-        cursor = align_up(cursor, SCRATCH_ALIGN_BYTES)
+-        quantized_q_offset_bytes = cursor
+-        cursor += (
+-            caps.max_total_q * caps.num_q_heads * caps.head_dim * dtype_nbytes(_FP8)
+-        )
+     cursor = align_up(cursor, SCRATCH_ALIGN_BYTES)
+     return _ScratchLayout(
+         nbytes=max(cursor, SCRATCH_ALIGN_BYTES),
+@@ -243,7 +203,6 @@ def _dense_mla_scratch_layout(
+         partial_output_offset_bytes=partial_output_offset_bytes,
+         partial_lse_offset_bytes=partial_lse_offset_bytes,
+         final_lse_offset_bytes=final_lse_offset_bytes,
+-        quantized_q_offset_bytes=quantized_q_offset_bytes,
+     )
+ 
+ 
+@@ -252,7 +211,6 @@ class Scratch:
+     shared_scratch: torch.Tensor
+     device: torch.device
+     mode: str
+-    q_dtype: torch.dtype
+     kv_dtype: torch.dtype
+     num_q_heads: int
+     page_size: int
+@@ -261,10 +219,6 @@ class Scratch:
+     max_cache_tokens: int
+     max_page_table_width: int
+     num_cache_pages: int
+-    physical_record_width: int
+-    head_dim: int
+-    v_head_dim: int
+-    window_size: int | None
+     num_splits: int
+     chunks_per_split: int
+     query_tile: int
+@@ -272,7 +226,6 @@ class Scratch:
+     partial_output: torch.Tensor | None
+     partial_lse: torch.Tensor | None
+     final_lse: torch.Tensor
+-    quantized_q: torch.Tensor | None
+ 
+ 
+ @dataclass(frozen=True, kw_only=True)
+@@ -288,7 +241,6 @@ class Binding:
+     q_scale: torch.Tensor | None
+     sm_scale: float
+     active_splits: int
+-    query_quant: static_fp8_quant.Binding | None
+ 
+ 
+ def _storage_bounds(tensor: torch.Tensor, *, name: str) -> None:
+@@ -350,8 +302,7 @@ def _rank3_cache(
+         cache = cache[:, :, 0, :]
+     if cache.ndim != 3:
+         raise ValueError(
+-            "kv_cache must be [pages,page_size,physical_record_width] or "
+-            "[pages,page_size,1,physical_record_width]"
++            "kv_cache must be [pages,page_size,576] or [pages,page_size,1,576]"
+         )
+     if cache.dtype != scratch.kv_dtype:
+         raise TypeError(
+@@ -359,26 +310,18 @@ def _rank3_cache(
+         )
+     if cache.device != scratch.device:
+         raise ValueError("kv_cache device does not match dense MLA plan")
+-    if tuple(cache.shape[1:]) != (
+-        scratch.page_size,
+-        scratch.physical_record_width,
+-    ):
++    if tuple(cache.shape[1:]) != (scratch.page_size, K3_ABSORBED_DIM):
+         raise ValueError(
+             "kv_cache inner shape must be "
+-            f"({scratch.page_size}, {scratch.physical_record_width}), got "
+-            f"{tuple(cache.shape[1:])}"
++            f"({scratch.page_size}, {K3_ABSORBED_DIM}), got {tuple(cache.shape[1:])}"
+         )
+     if int(cache.shape[0]) > scratch.num_cache_pages:
+         raise ValueError("kv_cache page count exceeds planned capacity")
+-    if (
+-        int(cache.stride(2)) != 1
+-        or int(cache.stride(1)) < scratch.physical_record_width
+-    ):
++    if int(cache.stride(2)) != 1 or int(cache.stride(1)) != K3_ABSORBED_DIM:
+         raise ValueError(
+-            "kv_cache requires contiguous elements and a token stride covering "
+-            "physical_record_width"
++            "kv_cache requires contiguous records/tokens (stride[-1]=1, stride[-2]=576)"
+         )
+-    if int(cache.stride(0)) < scratch.page_size * int(cache.stride(1)):
++    if int(cache.stride(0)) < scratch.page_size * K3_ABSORBED_DIM:
+         raise ValueError("kv_cache page stride is smaller than one page payload")
+     _require_16_byte_records(
+         cache,
+@@ -405,23 +348,21 @@ def _validate_binding(
+ ) -> Binding:
+     if q.ndim != 3 or tuple(q.shape[1:]) != (
+         scratch.num_q_heads,
+-        scratch.head_dim,
++        K3_ABSORBED_DIM,
+     ):
+         raise ValueError(
+             "q must have shape "
+-            f"[total_q,{scratch.num_q_heads},{scratch.head_dim}], got {tuple(q.shape)}"
+-        )
+-    if q.dtype != scratch.q_dtype:
+-        raise TypeError(
+-            f"q dtype {q.dtype} does not match planned query dtype {scratch.q_dtype}"
++            f"[total_q,{scratch.num_q_heads},{K3_ABSORBED_DIM}], got {tuple(q.shape)}"
+         )
++    if q.dtype not in (torch.bfloat16, _FP8):
++        raise TypeError("q must be BF16 or E4M3")
+     if q.device != scratch.device:
+         raise ValueError("q device does not match dense MLA plan")
+     if not 1 <= int(q.shape[0]) <= scratch.max_total_q:
+         raise ValueError("q rows exceed planned capacity")
+-    if int(q.stride(2)) != 1 or int(q.stride(1)) != scratch.head_dim:
++    if int(q.stride(2)) != 1 or int(q.stride(1)) != K3_ABSORBED_DIM:
+         raise ValueError("q requires contiguous absorbed head records")
+-    if int(q.stride(0)) < scratch.num_q_heads * scratch.head_dim:
++    if int(q.stride(0)) < scratch.num_q_heads * K3_ABSORBED_DIM:
+         raise ValueError("q row stride overlaps absorbed head records")
+     _require_16_byte_records(
+         q,
+@@ -431,21 +372,26 @@ def _validate_binding(
+     _storage_bounds(q, name="q")
+ 
+     cache = _rank3_cache(kv_cache, scratch=scratch)
++    if q.dtype != cache.dtype:
++        raise TypeError(
++            "q and kv_cache must use the same native dense MLA format "
++            "(BF16/BF16 or E4M3/E4M3)"
++        )
+     if output.ndim != 3 or tuple(output.shape) != (
+         int(q.shape[0]),
+         scratch.num_q_heads,
+-        scratch.v_head_dim,
++        K3_VALUE_DIM,
+     ):
+         raise ValueError(
+             "output must have shape "
+-            f"{(int(q.shape[0]), scratch.num_q_heads, scratch.v_head_dim)}, "
++            f"{(int(q.shape[0]), scratch.num_q_heads, K3_VALUE_DIM)}, "
+             f"got {tuple(output.shape)}"
+         )
+     if output.dtype != torch.bfloat16 or output.device != scratch.device:
+         raise TypeError("output must be BF16 on the plan device")
+-    if int(output.stride(2)) != 1 or int(output.stride(1)) != scratch.v_head_dim:
++    if int(output.stride(2)) != 1 or int(output.stride(1)) != K3_VALUE_DIM:
+         raise ValueError("output requires contiguous latent head records")
+-    if int(output.stride(0)) < scratch.num_q_heads * scratch.v_head_dim:
++    if int(output.stride(0)) < scratch.num_q_heads * K3_VALUE_DIM:
+         raise ValueError("output row stride overlaps latent head records")
+     _require_16_byte_records(
+         output,
+@@ -488,24 +434,10 @@ def _validate_binding(
+         q_scale,
+         name="q_scale",
+         device=scratch.device,
+-        required=cache.dtype == _FP8,
++        required=q.dtype == _FP8,
+     )
+-    if cache.dtype != _FP8 and (kv_scale is not None or q_scale is not None):
++    if q.dtype != _FP8 and (kv_scale is not None or q_scale is not None):
+         raise ValueError("BF16 dense MLA does not accept quantization scales")
+-    query_quant = None
+-    native_q = q
+-    if q.dtype != cache.dtype:
+-        if scratch.quantized_q is None:
+-            raise RuntimeError("dense MLA query quantization scratch is missing")
+-        if q_scale is None:
+-            raise RuntimeError("dense MLA query quantization scale is missing")
+-        native_q = scratch.quantized_q[: int(q.shape[0])]
+-        query_quant = static_fp8_quant.bind(
+-            source=q,
+-            output=native_q,
+-            scale=q_scale,
+-            max_numel=(scratch.max_total_q * scratch.num_q_heads * scratch.head_dim),
+-        )
+     sm_scale = float(sm_scale)
+     if not (sm_scale > 0.0):
+         raise ValueError("sm_scale must be positive")
+@@ -517,7 +449,7 @@ def _validate_binding(
+         )
+     return Binding(
+         scratch=scratch,
+-        q=native_q.detach(),
++        q=q.detach(),
+         kv_cache=cache,
+         output=output,
+         page_table=page_table.detach(),
+@@ -527,7 +459,6 @@ def _validate_binding(
+         q_scale=q_scale,
+         sm_scale=sm_scale,
+         active_splits=active_splits,
+-        query_quant=query_quant,
+     )
+ 
+ 
+@@ -548,7 +479,7 @@ def _materialize(
+                 caps.max_total_q,
+                 caps.num_q_heads,
+                 layout.num_splits,
+-                caps.v_head_dim,
++                K3_VALUE_DIM,
+             ),
+             dtype=torch.bfloat16,
+         )
+@@ -564,20 +495,11 @@ def _materialize(
+         shape=(caps.max_total_q, caps.num_q_heads),
+         dtype=torch.float32,
+     )
+-    quantized_q = None
+-    if layout.quantized_q_offset_bytes is not None:
+-        quantized_q, _ = materialize_scratch_view(
+-            scratch_storage,
+-            offset_bytes=layout.quantized_q_offset_bytes,
+-            shape=(caps.max_total_q, caps.num_q_heads, caps.head_dim),
+-            dtype=_FP8,
+-        )
+     query_tile = _query_tile(caps)
+     return Scratch(
+         shared_scratch=scratch_storage,
+         device=caps.device,
+         mode=caps.mode,
+-        q_dtype=caps.q_dtype,
+         kv_dtype=caps.kv_dtype,
+         num_q_heads=caps.num_q_heads,
+         page_size=caps.page_size,
+@@ -586,10 +508,6 @@ def _materialize(
+         max_cache_tokens=caps.max_cache_tokens,
+         max_page_table_width=caps.max_page_table_width,
+         num_cache_pages=caps.num_cache_pages,
+-        physical_record_width=caps.physical_record_width,
+-        head_dim=caps.head_dim,
+-        v_head_dim=caps.v_head_dim,
+-        window_size=caps.window_size,
+         num_splits=layout.num_splits,
+         chunks_per_split=layout.chunks_per_split,
+         query_tile=query_tile,
+@@ -597,7 +515,6 @@ def _materialize(
+         partial_output=partial_output,
+         partial_lse=partial_lse,
+         final_lse=final_lse,
+-        quantized_q=quantized_q,
+     )
+ 
+ 
+diff --git a/b12x/attention/dense_mla/api.py b/b12x/attention/dense_mla/api.py
+index 198d69dcd216e3d8e8ef2b0cef84684a084195a7..90c438972932c023e5e4c3a9da2c5fd73f1894be 100644
+--- a/b12x/attention/dense_mla/api.py
++++ b/b12x/attention/dense_mla/api.py
+@@ -1,4 +1,4 @@
+-"""Public planned API for paged dense MLA."""
++"""Public planned API for dense Kimi-K3 MLA."""
+ 
+ from __future__ import annotations
+ 
+@@ -43,7 +43,7 @@ def run(*, binding: Binding) -> tuple[torch.Tensor, torch.Tensor]:
+ 
+ 
+ def reference(*args, **kwargs):
+-    """Run the FP32 paged dense-MLA oracle."""
++    """Run the FP32 paged K3 dense-MLA oracle."""
+     return dense_mla_reference(*args, **kwargs)
+ 
+ 
+@@ -55,10 +55,9 @@ def is_supported(device=None) -> bool:
+     """True only for the fail-closed SM120/SM121 production envelope."""
+     if not default_is_supported(device, requires=META.requires):
+         return False
+-    if device is None:
+-        device = torch.device("cuda", torch.cuda.current_device())
+-    else:
+-        device = torch.device(device)
++    device = torch.device(
++        device if device is not None else ("cuda", torch.cuda.current_device())
++    )
+     return tuple(torch.cuda.get_device_capability(device)) in ((12, 0), (12, 1))
+ 
+ 
+diff --git a/b12x/attention/sparse_mla/_paged_index_remap.py b/b12x/attention/sparse_mla/_paged_index_remap.py
+deleted file mode 100644
+index e6d4674252e6b523e69e60687699a561f2f2bba3..0000000000000000000000000000000000000000
+--- a/b12x/attention/sparse_mla/_paged_index_remap.py
++++ /dev/null
+@@ -1,376 +0,0 @@
+-"""Native request-relative to physical-slot remapping for paged sparse MLA."""
+-
+-from __future__ import annotations
+-
+-from dataclasses import dataclass
+-from threading import RLock
+-
+-import cuda.bindings.driver as cuda
+-import cutlass
+-import cutlass.cute as cute
+-import torch
+-from cutlass import Int32, Int64
+-from cutlass.cute.runtime import from_dlpack
+-
+-from b12x._lib.compiler import KernelCompileSpec, compile as compile_cute
+-from b12x._lib.compiler import key_field, run_compiled
+-from b12x._lib.utils import current_cuda_stream
+-
+-_LOCK = RLock()
+-_CACHE: dict[tuple[int, int, bool], object] = {}
+-BLOCK_SIZE = 64
+-TOPK = 2048
+-THREADS = 32
+-INDICES_PER_THREAD = TOPK // THREADS
+-
+-
+-def _flat_i32(tensor: torch.Tensor):
+-    converted = from_dlpack(tensor.reshape(-1), assumed_align=4)
+-    converted.element_type = cutlass.Int32
+-    return converted.mark_layout_dynamic(leading_dim=0)
+-
+-
+-class _RemapKernel:
+-    def __init__(self, max_q_rows: int, request_relative: bool):
+-        self.max_q_rows = int(max_q_rows)
+-        self.request_relative = bool(request_relative)
+-
+-    @cute.jit
+-    def __call__(
+-        self,
+-        request_ids: cute.Tensor,
+-        block_table: cute.Tensor,
+-        logical_indices: cute.Tensor,
+-        physical_indices: cute.Tensor,
+-        input_counts: cute.Tensor,
+-        selected_counts: cute.Tensor,
+-        active_rows: Int32,
+-        request_count: Int32,
+-        table_width: Int32,
+-        num_cache_blocks: Int32,
+-        block_stride_records: Int64,
+-        token_stride_records: Int64,
+-        stream: cuda.CUstream,
+-    ):
+-        self.kernel(
+-            request_ids,
+-            block_table,
+-            logical_indices,
+-            physical_indices,
+-            input_counts,
+-            selected_counts,
+-            active_rows,
+-            request_count,
+-            table_width,
+-            num_cache_blocks,
+-            block_stride_records,
+-            token_stride_records,
+-        ).launch(
+-            grid=(self.max_q_rows, 1, 1),
+-            block=(THREADS, 1, 1),
+-            stream=stream,
+-        )
+-
+-    @cute.kernel
+-    def kernel(
+-        self,
+-        request_ids: cute.Tensor,
+-        block_table: cute.Tensor,
+-        logical_indices: cute.Tensor,
+-        physical_indices: cute.Tensor,
+-        input_counts: cute.Tensor,
+-        selected_counts: cute.Tensor,
+-        active_rows: Int32,
+-        request_count: Int32,
+-        table_width: Int32,
+-        num_cache_blocks: Int32,
+-        block_stride_records: Int64,
+-        token_stride_records: Int64,
+-    ):
+-        row_idx, _, _ = cute.arch.block_idx()
+-        row = Int32(row_idx)
+-        if row < active_rows:
+-            thread = Int32(cute.arch.thread_idx()[0])
+-            request = Int32(0)
+-            if cutlass.const_expr(self.request_relative):
+-                request = request_ids[row].to(Int32)
+-            column_begin = thread * Int32(INDICES_PER_THREAD)
+-            count = Int32(0)
+-            for offset in cutlass.range(Int32(INDICES_PER_THREAD), unroll=1):
+-                column = column_begin + offset
+-                logical_offset = Int64(row) * Int64(TOPK) + Int64(column)
+-                logical_slot = logical_indices[logical_offset].to(Int32)
+-                logical_block = logical_slot // Int32(BLOCK_SIZE)
+-                valid = (logical_slot >= Int32(0)) & (logical_block >= Int32(0))
+-                if cutlass.const_expr(self.request_relative):
+-                    valid = (
+-                        valid
+-                        & (request >= Int32(0))
+-                        & (request < request_count)
+-                        & (logical_block < table_width)
+-                    )
+-                else:
+-                    valid = valid & (column < input_counts[row].to(Int32))
+-                if valid:
+-                    physical_block = logical_block
+-                    if cutlass.const_expr(self.request_relative):
+-                        table_offset = request.to(Int64) * table_width.to(
+-                            Int64
+-                        ) + logical_block.to(Int64)
+-                        physical_block = block_table[table_offset].to(Int32)
+-                    if (physical_block >= Int32(0)) & (
+-                        physical_block < num_cache_blocks
+-                    ):
+-                        count += Int32(1)
+-
+-            # The first warp of the output row is temporary storage for the
+-            # per-thread counts. Every thread loads its stable prefix before
+-            # any thread overwrites the temporary values.
+-            row_offset = Int64(row) * Int64(TOPK)
+-            physical_indices[row_offset + thread.to(Int64)] = count
+-            cute.arch.sync_threads()
+-            output_base = Int32(0)
+-            total = Int32(0)
+-            for peer in cutlass.range_constexpr(THREADS):
+-                peer_count = physical_indices[row_offset + Int64(peer)].to(Int32)
+-                if Int32(peer) < thread:
+-                    output_base += peer_count
+-                total += peer_count
+-            cute.arch.sync_threads()
+-            if thread == Int32(0):
+-                selected_counts[row] = total
+-
+-            local_output = Int32(0)
+-            for offset in cutlass.range(Int32(INDICES_PER_THREAD), unroll=1):
+-                column = column_begin + offset
+-                logical_offset = row_offset + column.to(Int64)
+-                logical_slot = logical_indices[logical_offset].to(Int32)
+-                logical_block = logical_slot // Int32(BLOCK_SIZE)
+-                valid = (logical_slot >= Int32(0)) & (logical_block >= Int32(0))
+-                if cutlass.const_expr(self.request_relative):
+-                    valid = (
+-                        valid
+-                        & (request >= Int32(0))
+-                        & (request < request_count)
+-                        & (logical_block < table_width)
+-                    )
+-                else:
+-                    valid = valid & (column < input_counts[row].to(Int32))
+-                if valid:
+-                    physical_block = logical_block
+-                    if cutlass.const_expr(self.request_relative):
+-                        table_offset = request.to(Int64) * table_width.to(
+-                            Int64
+-                        ) + logical_block.to(Int64)
+-                        physical_block = block_table[table_offset].to(Int32)
+-                    if (physical_block >= Int32(0)) & (
+-                        physical_block < num_cache_blocks
+-                    ):
+-                        physical_record = (
+-                            physical_block.to(Int64) * block_stride_records
+-                            + (logical_slot % Int32(BLOCK_SIZE)).to(Int64)
+-                            * token_stride_records
+-                        )
+-                        output_offset = (
+-                            row_offset + output_base.to(Int64) + local_output.to(Int64)
+-                        )
+-                        physical_indices[output_offset] = physical_record.to(Int32)
+-                        local_output += Int32(1)
+-
+-
+-@dataclass(frozen=True)
+-class Binding:
+-    request_ids: torch.Tensor
+-    block_table: torch.Tensor
+-    logical_indices: torch.Tensor
+-    physical_indices: torch.Tensor
+-    input_counts: torch.Tensor
+-    selected_counts: torch.Tensor
+-    max_q_rows: int
+-    num_cache_blocks: int
+-    block_stride_records: int
+-    token_stride_records: int
+-    request_relative: bool
+-
+-
+-def bind(
+-    *,
+-    request_ids: torch.Tensor,
+-    block_table: torch.Tensor,
+-    logical_indices: torch.Tensor,
+-    physical_indices: torch.Tensor,
+-    selected_counts: torch.Tensor,
+-    max_q_rows: int,
+-    num_cache_blocks: int,
+-    block_stride_records: int,
+-    token_stride_records: int,
+-) -> Binding:
+-    rows = int(logical_indices.shape[0])
+-    tensors = (
+-        request_ids,
+-        block_table,
+-        logical_indices,
+-        physical_indices,
+-        selected_counts,
+-    )
+-    if any(tensor.dtype != torch.int32 for tensor in tensors):
+-        raise TypeError("sparse index metadata must use int32 tensors")
+-    if any(not tensor.is_contiguous() for tensor in tensors):
+-        raise ValueError("sparse index metadata must be contiguous")
+-    if any(tensor.device != logical_indices.device for tensor in tensors):
+-        raise ValueError("sparse index metadata must share one device")
+-    if tuple(logical_indices.shape) != (rows, TOPK):
+-        raise ValueError(f"logical_indices must have shape ({rows}, {TOPK})")
+-    if tuple(physical_indices.shape) != (rows, TOPK):
+-        raise ValueError(f"physical_indices must have shape ({rows}, {TOPK})")
+-    if tuple(request_ids.shape) != (rows,):
+-        raise ValueError(f"request_ids must have shape ({rows},)")
+-    if tuple(selected_counts.shape) != (rows,):
+-        raise ValueError(f"selected_counts must have shape ({rows},)")
+-    if block_table.ndim != 2 or block_table.shape[0] <= 0 or block_table.shape[1] <= 0:
+-        raise ValueError("block_table must be a non-empty two-dimensional tensor")
+-    if not 0 < rows <= int(max_q_rows):
+-        raise ValueError("logical index rows exceed the planned capacity")
+-    if not 0 < int(num_cache_blocks) <= torch.iinfo(torch.int32).max // BLOCK_SIZE:
+-        raise ValueError("num_cache_blocks exceeds the physical-slot int32 range")
+-    if int(block_stride_records) <= 0 or int(token_stride_records) <= 0:
+-        raise ValueError("physical record strides must be positive")
+-    return Binding(
+-        request_ids=request_ids.detach(),
+-        block_table=block_table.detach(),
+-        logical_indices=logical_indices.detach(),
+-        physical_indices=physical_indices.detach(),
+-        input_counts=selected_counts.detach(),
+-        selected_counts=selected_counts.detach(),
+-        max_q_rows=int(max_q_rows),
+-        num_cache_blocks=int(num_cache_blocks),
+-        block_stride_records=int(block_stride_records),
+-        token_stride_records=int(token_stride_records),
+-        request_relative=True,
+-    )
+-
+-
+-def bind_physical_slots(
+-    *,
+-    physical_slots: torch.Tensor,
+-    input_counts: torch.Tensor,
+-    physical_indices: torch.Tensor,
+-    selected_counts: torch.Tensor,
+-    max_q_rows: int,
+-    num_cache_blocks: int,
+-    block_stride_records: int,
+-    token_stride_records: int,
+-) -> Binding:
+-    rows = int(physical_slots.shape[0])
+-    tensors = (physical_slots, input_counts, physical_indices, selected_counts)
+-    if any(tensor.dtype != torch.int32 for tensor in tensors):
+-        raise TypeError("sparse index metadata must use int32 tensors")
+-    if any(not tensor.is_contiguous() for tensor in tensors):
+-        raise ValueError("sparse index metadata must be contiguous")
+-    if any(tensor.device != physical_slots.device for tensor in tensors):
+-        raise ValueError("sparse index metadata must share one device")
+-    if tuple(physical_slots.shape) != (rows, TOPK):
+-        raise ValueError(f"physical_slots must have shape ({rows}, {TOPK})")
+-    if tuple(physical_indices.shape) != (rows, TOPK):
+-        raise ValueError(f"physical_indices must have shape ({rows}, {TOPK})")
+-    if tuple(input_counts.shape) != (rows,) or tuple(selected_counts.shape) != (rows,):
+-        raise ValueError(f"sparse counts must have shape ({rows},)")
+-    if not 0 < rows <= int(max_q_rows):
+-        raise ValueError("physical slot rows exceed the planned capacity")
+-    if not 0 < int(num_cache_blocks) <= torch.iinfo(torch.int32).max // BLOCK_SIZE:
+-        raise ValueError("num_cache_blocks exceeds the physical-slot int32 range")
+-    if int(block_stride_records) <= 0 or int(token_stride_records) <= 0:
+-        raise ValueError("physical record strides must be positive")
+-    placeholder = input_counts
+-    return Binding(
+-        request_ids=placeholder.detach(),
+-        block_table=placeholder.detach(),
+-        logical_indices=physical_slots.detach(),
+-        physical_indices=physical_indices.detach(),
+-        input_counts=input_counts.detach(),
+-        selected_counts=selected_counts.detach(),
+-        max_q_rows=int(max_q_rows),
+-        num_cache_blocks=int(num_cache_blocks),
+-        block_stride_records=int(block_stride_records),
+-        token_stride_records=int(token_stride_records),
+-        request_relative=False,
+-    )
+-
+-
+-def _signature(binding: Binding) -> tuple[int, int, bool]:
+-    index = binding.logical_indices.device.index
+-    if index is None:
+-        index = torch.cuda.current_device()
+-    return int(index), int(binding.max_q_rows), bool(binding.request_relative)
+-
+-
+-def _launch(binding: Binding):
+-    entry = _RemapKernel(binding.max_q_rows, binding.request_relative)
+-    request_count = int(binding.block_table.shape[0]) if binding.request_relative else 1
+-    table_width = int(binding.block_table.shape[1]) if binding.request_relative else 1
+-    args = (
+-        _flat_i32(binding.request_ids),
+-        _flat_i32(binding.block_table),
+-        _flat_i32(binding.logical_indices),
+-        _flat_i32(binding.physical_indices),
+-        _flat_i32(binding.input_counts),
+-        _flat_i32(binding.selected_counts),
+-        Int32(binding.logical_indices.shape[0]),
+-        Int32(request_count),
+-        Int32(table_width),
+-        Int32(binding.num_cache_blocks),
+-        Int64(binding.block_stride_records),
+-        Int64(binding.token_stride_records),
+-        current_cuda_stream(),
+-    )
+-    spec = KernelCompileSpec.from_fields(
+-        "attention.paged_sparse_index_remap",
+-        2,
+-        key_field("max_q_rows", binding.max_q_rows),
+-        key_field("request_relative", binding.request_relative),
+-    )
+-    return entry, args, spec
+-
+-
+-def compile(*, binding: Binding) -> None:
+-    signature = _signature(binding)
+-    with _LOCK:
+-        compiled = _CACHE.get(signature)
+-    if compiled is None:
+-        entry, args, spec = _launch(binding)
+-        compiled = compile_cute(entry, *args, compile_spec=spec)
+-        with _LOCK:
+-            _CACHE[signature] = compiled
+-
+-
+-def run(*, binding: Binding) -> tuple[torch.Tensor, torch.Tensor]:
+-    signature = _signature(binding)
+-    with _LOCK:
+-        compiled = _CACHE.get(signature)
+-    if compiled is None:
+-        if torch.cuda.is_current_stream_capturing():
+-            raise RuntimeError(
+-                "sparse index remap compile miss during CUDA graph capture; "
+-                "call compile first"
+-            )
+-        compile(binding=binding)
+-        with _LOCK:
+-            compiled = _CACHE[signature]
+-    _, args, _ = _launch(binding)
+-    run_compiled(compiled, args)
+-    return binding.physical_indices, binding.selected_counts
+-
+-
+-def clear_caches() -> None:
+-    with _LOCK:
+-        _CACHE.clear()
+-
+-
+-__all__ = [
+-    "Binding",
+-    "bind",
+-    "bind_physical_slots",
+-    "clear_caches",
+-    "compile",
+-    "run",
+-]
+diff --git a/b12x/attention/sparse_mla/strided.py b/b12x/attention/sparse_mla/strided.py
+deleted file mode 100644
+index a961dfa2d68f6e35bdf45d4ed6b22bd6ba6abdf1..0000000000000000000000000000000000000000
+--- a/b12x/attention/sparse_mla/strided.py
++++ /dev/null
+@@ -1,503 +0,0 @@
+-"""Planned strided-record sparse-MLA API."""
+-
+-from __future__ import annotations
+-
+-import math
+-from dataclasses import dataclass
+-
+-import torch
+-
+-from ..._lib.gating import default_is_supported
+-from ..._lib.scratch import ScratchBufferSpec, scratch_buffer_spec, scratch_tensor
+-from ..._lib.scratch_layout import (
+-    SCRATCH_ALIGN_BYTES,
+-    align_up,
+-    materialize_scratch_view,
+-)
+-from .._shared import static_fp8_quant
+-from ..dense_mla._kernel import (
+-    clear_dense_mla_kernel_caches,
+-    compile_dense_mla,
+-    run_dense_mla,
+-)
+-from ..dense_mla._scratch import Binding as _NativeBinding
+-from ..dense_mla._scratch import Caps as _NativeCaps
+-from ..dense_mla._scratch import Plan as _NativePlan
+-from ..dense_mla._scratch import Scratch
+-from ..dense_mla._scratch import plan_dense_mla_scratch
+-from ..dense_mla.planner import Budget
+-from . import _paged_index_remap
+-
+-FP8 = torch.float8_e4m3fn
+-BLOCK_SIZE = 64
+-TOTAL_HEADS = 128
+-QK_DIM = 576
+-VALUE_DIM = 512
+-PHYSICAL_RECORD_WIDTH = 1088
+-TOPK = 2048
+-SM_SCALE = 1.0 / math.sqrt(192)
+-
+-
+-@dataclass(frozen=True, kw_only=True)
+-class Caps:
+-    device: torch.device | str
+-    num_q_heads: int
+-    tp_size: int
+-    max_q_rows: int
+-    num_cache_blocks: int
+-    max_physical_records: int | None = None
+-    block_size: int = BLOCK_SIZE
+-    topk: int = TOPK
+-    kv_dtype: torch.dtype = FP8
+-    use_cuda_graph: bool = False
+-    budget: Budget | None = None
+-
+-    def __post_init__(self) -> None:
+-        if int(self.tp_size) != 8:
+-            raise ValueError("strided sparse MLA is qualified only for TP8")
+-        if int(self.num_q_heads) != TOTAL_HEADS // int(self.tp_size):
+-            raise ValueError("num_q_heads must equal total_heads / tp_size")
+-        if int(self.block_size) != BLOCK_SIZE:
+-            raise ValueError(f"strided sparse MLA block_size must be {BLOCK_SIZE}")
+-        if int(self.topk) != TOPK:
+-            raise ValueError(f"strided sparse MLA topk must be {TOPK}")
+-        if self.kv_dtype != FP8:
+-            raise TypeError("strided sparse MLA requires E4M3 KV cache")
+-        if int(self.max_q_rows) <= 0:
+-            raise ValueError("max_q_rows must be positive")
+-        if int(self.num_cache_blocks) <= 0:
+-            raise ValueError("num_cache_blocks must be positive")
+-        if int(self.num_cache_blocks) > torch.iinfo(torch.int32).max // BLOCK_SIZE:
+-            raise ValueError("num_cache_blocks exceeds the physical-slot int32 range")
+-        max_physical_records = (
+-            int(self.num_cache_blocks) * BLOCK_SIZE
+-            if self.max_physical_records is None
+-            else int(self.max_physical_records)
+-        )
+-        if not int(self.num_cache_blocks) * BLOCK_SIZE <= max_physical_records:
+-            raise ValueError(
+-                "max_physical_records must cover all contiguous physical slots"
+-            )
+-        if max_physical_records > torch.iinfo(torch.int32).max:
+-            raise ValueError("max_physical_records exceeds the index int32 range")
+-        object.__setattr__(self, "max_physical_records", max_physical_records)
+-
+-
+-@dataclass(frozen=True)
+-class Binding:
+-    native: _NativeBinding
+-    query_quant: static_fp8_quant.Binding
+-    index_remap: _paged_index_remap.Binding | None
+-    kv_cache: torch.Tensor
+-    selected_indices: torch.Tensor
+-    selected_counts: torch.Tensor
+-
+-
+-@dataclass(frozen=True)
+-class Plan:
+-    caps: Caps
+-    native: _NativePlan
+-    query_offset_bytes: int
+-    physical_indices_offset_bytes: int
+-    selected_counts_offset_bytes: int
+-    _scratch_specs: tuple[ScratchBufferSpec, ...]
+-
+-    def scratch_specs(self):
+-        return self._scratch_specs
+-
+-    def shapes_and_dtypes(self):
+-        return tuple((spec.shape, spec.dtype) for spec in self._scratch_specs)
+-
+-    @property
+-    def num_splits(self) -> int:
+-        return self.native.num_splits
+-
+-
+-def plan(caps: Caps) -> Plan:
+-    native_caps = _NativeCaps(
+-        device=caps.device,
+-        mode="decode",
+-        kv_dtype=FP8,
+-        num_q_heads=int(caps.num_q_heads),
+-        page_size=1,
+-        max_total_q=int(caps.max_q_rows),
+-        max_batch=int(caps.max_q_rows),
+-        max_cache_tokens=TOPK,
+-        max_page_table_width=TOPK,
+-        num_cache_pages=int(caps.max_physical_records),
+-        head_dim=QK_DIM,
+-        v_head_dim=VALUE_DIM,
+-        physical_record_width=PHYSICAL_RECORD_WIDTH,
+-        use_cuda_graph=bool(caps.use_cuda_graph),
+-        budget=caps.budget,
+-    )
+-    native = plan_dense_mla_scratch(native_caps)
+-    native_spec = native.scratch_specs()[0]
+-    query_offset_bytes = align_up(native_spec.nbytes, SCRATCH_ALIGN_BYTES)
+-    query_nbytes = int(caps.max_q_rows) * int(caps.num_q_heads) * QK_DIM
+-    physical_indices_offset_bytes = align_up(
+-        query_offset_bytes + query_nbytes,
+-        SCRATCH_ALIGN_BYTES,
+-    )
+-    physical_indices_nbytes = int(caps.max_q_rows) * TOPK * torch.int32.itemsize
+-    selected_counts_offset_bytes = align_up(
+-        physical_indices_offset_bytes + physical_indices_nbytes,
+-        SCRATCH_ALIGN_BYTES,
+-    )
+-    selected_counts_nbytes = int(caps.max_q_rows) * torch.int32.itemsize
+-    total_nbytes = align_up(
+-        selected_counts_offset_bytes + selected_counts_nbytes,
+-        SCRATCH_ALIGN_BYTES,
+-    )
+-    return Plan(
+-        caps=caps,
+-        native=native,
+-        query_offset_bytes=query_offset_bytes,
+-        physical_indices_offset_bytes=physical_indices_offset_bytes,
+-        selected_counts_offset_bytes=selected_counts_offset_bytes,
+-        _scratch_specs=(
+-            scratch_buffer_spec(
+-                "sparse_mla.strided.scratch",
+-                nbytes=total_nbytes,
+-                device=native_spec.device,
+-            ),
+-        ),
+-    )
+-
+-
+-def _physical_record_view(
+-    plan: Plan,
+-    kv_cache: torch.Tensor,
+-) -> tuple[torch.Tensor, int, int]:
+-    expected_record_shape = (BLOCK_SIZE, PHYSICAL_RECORD_WIDTH)
+-    if (
+-        kv_cache.dtype != FP8
+-        or kv_cache.ndim != 3
+-        or tuple(kv_cache.shape[1:]) != expected_record_shape
+-        or not 0 < int(kv_cache.shape[0]) <= int(plan.caps.num_cache_blocks)
+-    ):
+-        raise ValueError(
+-            "kv_cache must be E4M3 with shape "
+-            f"[1..{plan.caps.num_cache_blocks}, {BLOCK_SIZE}, "
+-            f"{PHYSICAL_RECORD_WIDTH}], got "
+-            f"dtype={kv_cache.dtype}, shape={tuple(kv_cache.shape)}"
+-        )
+-    block_stride, token_stride, element_stride = map(int, kv_cache.stride())
+-    if (
+-        element_stride != 1
+-        or token_stride < PHYSICAL_RECORD_WIDTH
+-        or block_stride < BLOCK_SIZE * token_stride
+-        or token_stride % PHYSICAL_RECORD_WIDTH
+-        or block_stride % PHYSICAL_RECORD_WIDTH
+-    ):
+-        raise ValueError(
+-            "kv_cache must use non-overlapping, whole 1088-element physical "
+-            f"record strides, got stride={tuple(kv_cache.stride())}"
+-        )
+-    block_stride_records = block_stride // PHYSICAL_RECORD_WIDTH
+-    token_stride_records = token_stride // PHYSICAL_RECORD_WIDTH
+-    physical_records = (
+-        (int(kv_cache.shape[0]) - 1) * block_stride_records
+-        + (BLOCK_SIZE - 1) * token_stride_records
+-        + 1
+-    )
+-    if physical_records > int(plan.caps.max_physical_records):
+-        raise ValueError(
+-            "kv_cache physical record span exceeds planned capacity: "
+-            f"need {physical_records}, planned {plan.caps.max_physical_records}"
+-        )
+-    flat_cache = torch.as_strided(
+-        kv_cache,
+-        size=(physical_records, 1, PHYSICAL_RECORD_WIDTH),
+-        stride=(PHYSICAL_RECORD_WIDTH, PHYSICAL_RECORD_WIDTH, 1),
+-    )
+-    return flat_cache, block_stride_records, token_stride_records
+-
+-
+-def _bind_native(
+-    plan: Plan,
+-    *,
+-    scratch_storage: torch.Tensor,
+-    q: torch.Tensor,
+-    flat_cache: torch.Tensor,
+-    original_cache: torch.Tensor,
+-    output: torch.Tensor,
+-    record_indices: torch.Tensor,
+-    selected_counts: torch.Tensor,
+-    cu_seqlens_q: torch.Tensor,
+-    kv_scale: torch.Tensor,
+-    q_scale: torch.Tensor,
+-    active_splits: int | None = None,
+-) -> Binding:
+-    if q.dtype != torch.bfloat16:
+-        raise TypeError("strided sparse MLA absorbed query must be BF16")
+-    rows = int(q.shape[0])
+-    if record_indices.dtype != torch.int32 or tuple(record_indices.shape) != (
+-        rows,
+-        TOPK,
+-    ):
+-        raise ValueError(f"record_indices must be int32 with shape ({rows}, {TOPK})")
+-    if selected_counts.dtype != torch.int32 or tuple(selected_counts.shape) != (rows,):
+-        raise ValueError(f"selected_counts must be int32 with shape ({rows},)")
+-    if tuple(cu_seqlens_q.shape) != (rows + 1,):
+-        raise ValueError(f"cu_seqlens_q must have shape ({rows + 1},)")
+-    q_fp8, _ = materialize_scratch_view(
+-        scratch_storage,
+-        offset_bytes=plan.query_offset_bytes,
+-        shape=tuple(q.shape),
+-        dtype=FP8,
+-    )
+-    query_quant = static_fp8_quant.bind(
+-        source=q,
+-        output=q_fp8,
+-        scale=q_scale,
+-        max_numel=int(plan.caps.max_q_rows) * int(plan.caps.num_q_heads) * QK_DIM,
+-    )
+-    native = plan.native.bind(
+-        scratch=scratch_storage,
+-        q=q_fp8,
+-        kv_cache=flat_cache,
+-        output=output,
+-        page_table=record_indices,
+-        cache_seqlens=selected_counts,
+-        cu_seqlens_q=cu_seqlens_q,
+-        kv_scale=kv_scale,
+-        q_scale=q_scale,
+-        sm_scale=SM_SCALE,
+-        active_splits=active_splits,
+-    )
+-    return Binding(
+-        native=native,
+-        query_quant=query_quant,
+-        index_remap=None,
+-        kv_cache=original_cache,
+-        selected_indices=record_indices,
+-        selected_counts=selected_counts,
+-    )
+-
+-
+-def _index_scratch(
+-    plan: Plan,
+-    scratch_storage: torch.Tensor,
+-    rows: int,
+-) -> tuple[torch.Tensor, torch.Tensor]:
+-    physical_indices, _ = materialize_scratch_view(
+-        scratch_storage,
+-        offset_bytes=plan.physical_indices_offset_bytes,
+-        shape=(rows, TOPK),
+-        dtype=torch.int32,
+-    )
+-    selected_counts, _ = materialize_scratch_view(
+-        scratch_storage,
+-        offset_bytes=plan.selected_counts_offset_bytes,
+-        shape=(rows,),
+-        dtype=torch.int32,
+-    )
+-    return physical_indices, selected_counts
+-
+-
+-def bind(
+-    plan: Plan,
+-    *,
+-    scratch,
+-    q: torch.Tensor,
+-    kv_cache: torch.Tensor,
+-    output: torch.Tensor,
+-    selected_indices: torch.Tensor,
+-    selected_counts: torch.Tensor,
+-    cu_seqlens_q: torch.Tensor,
+-    kv_scale: torch.Tensor,
+-    q_scale: torch.Tensor,
+-    active_splits: int | None = None,
+-) -> Binding:
+-    scratch_storage = scratch_tensor(
+-        scratch,
+-        plan.scratch_specs(),
+-        owner="strided sparse MLA",
+-    )
+-    rows = int(q.shape[0])
+-    record_indices, remapped_counts = _index_scratch(plan, scratch_storage, rows)
+-    flat_cache, block_stride_records, token_stride_records = _physical_record_view(
+-        plan, kv_cache
+-    )
+-    binding = _bind_native(
+-        plan,
+-        scratch_storage=scratch_storage,
+-        q=q,
+-        flat_cache=flat_cache,
+-        original_cache=kv_cache,
+-        output=output,
+-        record_indices=record_indices,
+-        selected_counts=remapped_counts,
+-        cu_seqlens_q=cu_seqlens_q,
+-        kv_scale=kv_scale,
+-        q_scale=q_scale,
+-        active_splits=active_splits,
+-    )
+-    remap = _paged_index_remap.bind_physical_slots(
+-        physical_slots=selected_indices,
+-        input_counts=selected_counts,
+-        physical_indices=record_indices,
+-        selected_counts=remapped_counts,
+-        max_q_rows=int(plan.caps.max_q_rows),
+-        num_cache_blocks=int(kv_cache.shape[0]),
+-        block_stride_records=block_stride_records,
+-        token_stride_records=token_stride_records,
+-    )
+-    return Binding(
+-        native=binding.native,
+-        query_quant=binding.query_quant,
+-        index_remap=remap,
+-        kv_cache=binding.kv_cache,
+-        selected_indices=binding.selected_indices,
+-        selected_counts=binding.selected_counts,
+-    )
+-
+-
+-def bind_indexed(
+-    plan: Plan,
+-    *,
+-    scratch,
+-    q: torch.Tensor,
+-    kv_cache: torch.Tensor,
+-    output: torch.Tensor,
+-    logical_indices: torch.Tensor,
+-    request_ids: torch.Tensor,
+-    block_table: torch.Tensor,
+-    cu_seqlens_q: torch.Tensor,
+-    kv_scale: torch.Tensor,
+-    q_scale: torch.Tensor,
+-    active_splits: int | None = None,
+-) -> Binding:
+-    scratch_storage = scratch_tensor(
+-        scratch,
+-        plan.scratch_specs(),
+-        owner="strided sparse MLA",
+-    )
+-    rows = int(q.shape[0])
+-    physical_indices, selected_counts = _index_scratch(plan, scratch_storage, rows)
+-    flat_cache, block_stride_records, token_stride_records = _physical_record_view(
+-        plan, kv_cache
+-    )
+-    binding = _bind_native(
+-        plan,
+-        scratch_storage=scratch_storage,
+-        q=q,
+-        flat_cache=flat_cache,
+-        original_cache=kv_cache,
+-        output=output,
+-        record_indices=physical_indices,
+-        selected_counts=selected_counts,
+-        cu_seqlens_q=cu_seqlens_q,
+-        kv_scale=kv_scale,
+-        q_scale=q_scale,
+-        active_splits=active_splits,
+-    )
+-    remap = _paged_index_remap.bind(
+-        request_ids=request_ids,
+-        block_table=block_table,
+-        logical_indices=logical_indices,
+-        physical_indices=physical_indices,
+-        selected_counts=selected_counts,
+-        max_q_rows=int(plan.caps.max_q_rows),
+-        num_cache_blocks=int(kv_cache.shape[0]),
+-        block_stride_records=block_stride_records,
+-        token_stride_records=token_stride_records,
+-    )
+-    return Binding(
+-        native=binding.native,
+-        query_quant=binding.query_quant,
+-        index_remap=remap,
+-        kv_cache=binding.kv_cache,
+-        selected_indices=binding.selected_indices,
+-        selected_counts=binding.selected_counts,
+-    )
+-
+-
+-def compile(*, binding: Binding) -> None:
+-    if binding.index_remap is not None:
+-        _paged_index_remap.compile(binding=binding.index_remap)
+-    static_fp8_quant.compile(binding=binding.query_quant)
+-    compile_dense_mla(binding=binding.native)
+-
+-
+-def run_decode(*, binding: Binding) -> tuple[torch.Tensor, torch.Tensor]:
+-    if binding.index_remap is not None:
+-        _paged_index_remap.run(binding=binding.index_remap)
+-    static_fp8_quant.run(binding=binding.query_quant)
+-    return run_dense_mla(binding=binding.native)
+-
+-
+-def run_extend(*, binding: Binding) -> tuple[torch.Tensor, torch.Tensor]:
+-    if binding.index_remap is not None:
+-        _paged_index_remap.run(binding=binding.index_remap)
+-    static_fp8_quant.run(binding=binding.query_quant)
+-    return run_dense_mla(binding=binding.native)
+-
+-
+-def reference(
+-    q: torch.Tensor,
+-    kv_cache: torch.Tensor,
+-    selected_indices: torch.Tensor,
+-    selected_counts: torch.Tensor,
+-    *,
+-    kv_scale: torch.Tensor | float,
+-    q_scale: torch.Tensor | float,
+-) -> tuple[torch.Tensor, torch.Tensor]:
+-    def scalar(value: torch.Tensor | float) -> float:
+-        if isinstance(value, torch.Tensor):
+-            return float(value.detach().cpu().item())
+-        return float(value)
+-
+-    count_host = [int(value) for value in selected_counts.detach().cpu().tolist()]
+-    q_mul = scalar(q_scale)
+-    q_f32 = (q.float() / q_mul).to(FP8).float() * q_mul
+-    kv_mul = scalar(kv_scale)
+-    output = torch.empty(
+-        q.shape[0], q.shape[1], VALUE_DIM, dtype=torch.float32, device=q.device
+-    )
+-    lse = torch.empty(q.shape[:2], dtype=torch.float32, device=q.device)
+-    for row, count in enumerate(count_host):
+-        ids = selected_indices[row, :count].to(torch.long)
+-        blocks = torch.div(ids, BLOCK_SIZE, rounding_mode="floor")
+-        tokens = ids.remainder(BLOCK_SIZE)
+-        records = kv_cache[blocks, tokens, :QK_DIM].float() * kv_mul
+-        logits = torch.einsum("hd,kd->hk", q_f32[row], records) * SM_SCALE
+-        probability = torch.softmax(logits, dim=-1)
+-        output[row] = torch.einsum("hk,kd->hd", probability, records[:, :VALUE_DIM])
+-        lse[row] = torch.logsumexp(logits, dim=-1)
+-    return output.to(torch.bfloat16), lse
+-
+-
+-def is_supported(device=None) -> bool:
+-    if not default_is_supported(device, requires=()):
+-        return False
+-    if device is None:
+-        device = torch.device("cuda", torch.cuda.current_device())
+-    else:
+-        device = torch.device(device)
+-    return tuple(torch.cuda.get_device_capability(device)) in ((12, 0), (12, 1))
+-
+-
+-def clear_caches() -> None:
+-    _paged_index_remap.clear_caches()
+-    static_fp8_quant.clear_caches()
+-    clear_dense_mla_kernel_caches()
+-
+-
+-__all__ = [
+-    "Binding",
+-    "Budget",
+-    "Caps",
+-    "Plan",
+-    "Scratch",
+-    "bind",
+-    "bind_indexed",
+-    "clear_caches",
+-    "compile",
+-    "is_supported",
+-    "plan",
+-    "reference",
+-    "run_decode",
+-    "run_extend",
+-]
+diff --git a/b12x/attention/varlen/__init__.py b/b12x/attention/varlen/__init__.py
+index d5c078f90d91a8388e50e6b7da5a838f90dd357b..ea66aa0308ec9d4afc28c19c28642eec89cfd522 100644
+--- a/b12x/attention/varlen/__init__.py
++++ b/b12x/attention/varlen/__init__.py
+@@ -1,8 +1,7 @@
+ """Contiguous (non-paged) attention for SM12x: batched and varlen forward.
+ 
+-BF16/FP16 Q/K/V, including different Q/K and V head dimensions, causal +
+-sliding-window + attention-sink; tile shapes auto-selected by Q/K head
+-dimension and causality. ``run`` is the varlen (cu_seqlens)
++BF16/FP16 Q/K/V, causal + sliding-window + attention-sink; tile shapes
++auto-selected by head_dim/causality. ``run`` is the varlen (cu_seqlens)
+ entry, ``run_batched`` the fixed-shape batched entry; each has its own
+ plan/scratch/binding family (``create_plan*`` for the per-shape kernel plan,
+ ``plan*`` for scratch sizing).
+diff --git a/b12x/comm/pcie/__init__.py b/b12x/comm/pcie/__init__.py
+index 216310e44c775a422d3dec494fac60673b309760..bbcb1d834c1871d33a948db26e40cd47c446e170 100644
+--- a/b12x/comm/pcie/__init__.py
++++ b/b12x/comm/pcie/__init__.py
+@@ -15,8 +15,10 @@ pools via ``<Class>Pool``.
+   per-token FP8-e4m3 transport.
+ - ``DcpAllToAll``: DCP attention exchange with fused LSE reduce-scatter.
+ - ``DcpTopKOwnerExchange``: exact DCP candidate owner staging.
++- ``VocabParallelArgmax``: TP8/TP12/TP16 fused BF16 add and exact global
++  greedy argmax.
+ 
+-Every device kernel is authored in Python with CuTe DSL.  Host-side CUDA
++Every device kernel is authored in Python with CuTe DSL. Host-side CUDA
+ Runtime/Driver calls are also made from Python; this package contains no
+ repo-authored C++ or CUDA source and never invokes a native extension build.
+ """
+@@ -40,13 +42,16 @@ META = OpMeta(
+         "DcpAllToAll",
+         "DcpAllToAllPool",
+         "DcpTopKOwnerExchange",
++        "VocabParallelArgmax",
++        "kimi_topk16",
++        "prepare_kimi_topk16",
+         "autotune_dma_crossovers",
+         "parse_oneshot_max_size",
+         "lse_reduce_scatter_reference",
+         "owner_stage_reference",
+         "is_supported",
+     ),
+-    dtypes=("bf16", "fp32", "fp8_e4m3", "int32"),
++    dtypes=("bf16", "fp32", "fp8_e4m3", "int32", "int64"),
+     requires=("multi_gpu",),
+     provenance=Provenance(
+         repo="https://github.com/lukealonso/b12x",
+@@ -68,11 +73,14 @@ if TYPE_CHECKING:  # static analysis only; runtime resolution is lazy
+         OneshotAllReduce,
+         OneshotAllReducePool,
+         TwoShotReduceScatter,
++        VocabParallelArgmax,
+         autotune_dma_crossovers,
+         is_supported,
++        kimi_topk16,
+         lse_reduce_scatter_reference,
+         owner_stage_reference,
+         parse_oneshot_max_size,
++        prepare_kimi_topk16,
+     )
+ 
+ install_lazy_api(globals(), META)
+diff --git a/b12x/comm/pcie/_cute_intrinsics.py b/b12x/comm/pcie/_cute_intrinsics.py
+index 6f2daab78ea857079cdbc74cec904b54aa0688a2..f65c60211700800186d467edc249f43037df3b78 100644
+--- a/b12x/comm/pcie/_cute_intrinsics.py
++++ b/b12x/comm/pcie/_cute_intrinsics.py
+@@ -501,3 +501,57 @@ def rsqrt_approx_f32(value: Float32, *, loc=None, ip=None) -> Float32:
+             ip=ip,
+         )
+     )
++
++
++@dsl_user_op
++def float_order_key(value: Float32, *, loc=None, ip=None) -> Uint32:
++    """Map a float onto a u32 whose unsigned order matches float order.
++
++    Lets a (score, expert) pair be packed into one integer key, so "better
++    candidate" becomes a plain integer max and the tie-break stops costing a
++    second comparison.
++    """
++    return Uint32(
++        llvm.inline_asm(
++            T.i32(),
++            [Float32(value).ir_value(loc=loc, ip=ip)],
++            """
++            {
++                .reg .u32 bits, mask;
++                mov.b32 bits, $1;
++                shr.u32 mask, bits, 31;
++                mul.lo.u32 mask, mask, 0x7fffffff;
++                or.b32 mask, mask, 0x80000000;
++                xor.b32 $0, bits, mask;
++            }
++            """,
++            "=r,f",
++            has_side_effects=False,
++            is_align_stack=False,
++            asm_dialect=llvm.AsmDialect.AD_ATT,
++            loc=loc,
++            ip=ip,
++        )
++    )
++
++
++@dsl_user_op
++def redux_max_u32(value: Uint32, *, loc=None, ip=None) -> Uint32:
++    """Warp-wide unsigned max in one instruction.
++
++    ``cute.arch.warp_redux_sync`` exposes the float variant, which libNVVM
++    rejects for sm_120a; the integer one is what the kernel actually needs.
++    """
++    return Uint32(
++        llvm.inline_asm(
++            T.i32(),
++            [Uint32(value).ir_value(loc=loc, ip=ip)],
++            "redux.sync.max.u32 $0, $1, 0xffffffff;",
++            "=r,r",
++            has_side_effects=True,
++            is_align_stack=False,
++            asm_dialect=llvm.AsmDialect.AD_ATT,
++            loc=loc,
++            ip=ip,
++        )
++    )
+diff --git a/b12x/comm/pcie/_dcp_a2a_cute.py b/b12x/comm/pcie/_dcp_a2a_cute.py
+index 0dea2609cbb9a6e337ea54b2be37002c989c405c..e64169abe1fb97cda3b6c75e850622d44e9ac4be 100644
+--- a/b12x/comm/pcie/_dcp_a2a_cute.py
++++ b/b12x/comm/pcie/_dcp_a2a_cute.py
+@@ -17,12 +17,15 @@ from b12x._lib.intrinsics import (
+     fmax_f32,
+     ld_global_v4_u32,
+     st_global_v4_u32,
++    u32_as_f32,
+ )
+ from b12x._lib.runtime_control import raise_if_kernel_resolution_frozen
+ from b12x._lib.utils import current_cuda_stream, make_ptr
+ 
+ from ._dcp_cute_common import block_pair_barrier
+ from ._cute_intrinsics import (
++    float_order_key,
++    redux_max_u32,
+     ld_generic_f32,
+     ld_relaxed_gpu_u32,
+     pack_f32x2_to_bf16x2,
+@@ -45,6 +48,7 @@ _GRAPH_ARRIVED_INDEX = _SELF_COUNTER_WORDS + 2
+ _PREPARED_LSE_LAUNCHERS: set[tuple[object, ...]] = set()
+ _PREPARED_GATHER_LAUNCHERS: set[tuple[object, ...]] = set()
+ _PREPARED_PAIR_LAUNCHERS: set[tuple[object, ...]] = set()
++_PREPARED_KIMI_TOPK_LAUNCHERS: set[int] = set()
+ 
+ 
+ @dsl_user_op
+@@ -106,6 +110,89 @@ def _copy_16b(source: cute.Pointer, destination: cute.Pointer) -> None:
+     st_global_v4_u32(destination.toint(), *values)
+ 
+ 
++@dsl_user_op
++def _select_if_eq_u32(
++    lhs: Uint32,
++    rhs: Uint32,
++    on_equal: Uint32,
++    otherwise: Uint32,
++    *,
++    loc=None,
++    ip=None,
++) -> Uint32:
++    """``lhs == rhs ? on_equal : otherwise`` as one predicated select."""
++
++    return Uint32(
++        llvm.inline_asm(
++            T.i32(),
++            [
++                Uint32(lhs).ir_value(loc=loc, ip=ip),
++                Uint32(rhs).ir_value(loc=loc, ip=ip),
++                Uint32(on_equal).ir_value(loc=loc, ip=ip),
++                Uint32(otherwise).ir_value(loc=loc, ip=ip),
++            ],
++            "{ .reg .pred p; setp.eq.u32 p, $1, $2; selp.b32 $0, $3, $4, p; }",
++            "=r,r,r,r,r",
++            has_side_effects=False,
++            is_align_stack=False,
++            asm_dialect=llvm.AsmDialect.AD_ATT,
++            loc=loc,
++            ip=ip,
++        )
++    )
++
++
++@dsl_user_op
++def _select_if_eq_u64(
++    lhs: cutlass.Uint64,
++    rhs: cutlass.Uint64,
++    on_equal: cutlass.Uint64,
++    otherwise: cutlass.Uint64,
++    *,
++    loc=None,
++    ip=None,
++) -> cutlass.Uint64:
++    """``lhs == rhs ? on_equal : otherwise`` as one predicated select.
++
++    A Python ``if`` on a runtime condition becomes a branch region. The top-16
++    rounds update a register-held key array, so a divergent branch can spill the
++    array to local memory. A ternary chain emits straight-line predicated code
++    and lets ptxas fold repeated ``setp`` operations.
++    """
++
++    return cutlass.Uint64(
++        llvm.inline_asm(
++            T.i64(),
++            [
++                cutlass.Uint64(lhs).ir_value(loc=loc, ip=ip),
++                cutlass.Uint64(rhs).ir_value(loc=loc, ip=ip),
++                cutlass.Uint64(on_equal).ir_value(loc=loc, ip=ip),
++                cutlass.Uint64(otherwise).ir_value(loc=loc, ip=ip),
++            ],
++            "{ .reg .pred p; setp.eq.u64 p, $1, $2; selp.b64 $0, $3, $4, p; }",
++            "=l,l,l,l,l",
++            has_side_effects=False,
++            is_align_stack=False,
++            asm_dialect=llvm.AsmDialect.AD_ATT,
++            loc=loc,
++            ip=ip,
++        )
++    )
++
++
++@cute.jit
++def _copy_16b_addr(source: Int64, destination: Int64) -> None:
++    """Copy 16B between two byte addresses already resolved by the caller.
++
++    The gather loops pick their source rank at runtime.  Selecting the address
++    first and issuing one copy keeps a single load in flight per thread; cloning
++    the copy once per peer inside a constexpr chain makes a warp that straddles
++    two source ranks issue its loads in two serialised batches.
++    """
++    values = ld_global_v4_u32(source)
++    st_global_v4_u32(destination, *values)
++
++
+ @dsl_user_op
+ def _fma_rn_f32(
+     a: Float32,
+@@ -168,7 +255,7 @@ def _add_u64_opaque(
+     loc=None,
+     ip=None,
+ ) -> Int64:
+-    """Add a payload offset without CSE into the earlier LSE address phase."""
++    """Add a payload offset without CSE into the LSE-address calculation."""
+ 
+     return Int64(
+         llvm.inline_asm(
+@@ -188,6 +275,70 @@ def _add_u64_opaque(
+     )
+ 
+ 
++
++_KIMI_NEG_INF = float("-inf")
++
++
++@cute.jit
++def _kimi_pack_key(score: Float32, expert: Int32) -> cutlass.Uint64:
++    """Pack (score, expert) so that a plain integer max picks the winner.
++
++    The expert index goes in complemented, so a tie on score resolves to the
++    lower index -- the same order the native reference produces, without a
++    second comparison at every step.
++    """
++    return (cutlass.Uint64(float_order_key(score)) << cutlass.Uint64(32)) | (
++        cutlass.Uint64(0xFFFF) - cutlass.Uint64(expert)
++    )
++
++
++@cute.jit
++def _kimi_key_expert(key: cutlass.Uint64) -> Int32:
++    return Int32(cutlass.Uint64(0xFFFF) - (key & cutlass.Uint64(0xFFFF)))
++
++
++@cute.jit
++def _kimi_warp_max_key(key: cutlass.Uint64) -> cutlass.Uint64:
++    """Warp-wide max of a 64-bit key in two instructions.
++
++    Reduces the high words, then only the low words of the lanes that tied on
++    the high word, which is cheaper than carrying a 64-bit value through a
++    shuffle chain.
++    """
++    hi = cutlass.Uint32(key >> cutlass.Uint64(32))
++    lo = cutlass.Uint32(key & cutlass.Uint64(0xFFFFFFFF))
++    max_hi = redux_max_u32(hi)
++    contribution = _select_if_eq_u32(hi, max_hi, lo, Uint32(0))
++    max_lo = redux_max_u32(contribution)
++    return (cutlass.Uint64(max_hi) << cutlass.Uint64(32)) | cutlass.Uint64(max_lo)
++
++
++def _kimi_sort_desc(keys, count: int) -> None:
++    """Descending bitonic sort over a compile-time number of packed keys.
++
++    Every index is a Python constant, so the whole network unrolls and the
++    per-round selection can just read ``keys[0]``.
++    """
++    width = 2
++    while width <= count:
++        stride = width // 2
++        while stride > 0:
++            for index in range(count):
++                peer = index ^ stride
++                if peer <= index:
++                    continue
++                descending = (index & width) == 0
++                lower = keys[index]
++                upper = keys[peer]
++                if descending:
++                    keys[index] = cutlass.max(lower, upper)
++                    keys[peer] = cutlass.min(lower, upper)
++                else:
++                    keys[index] = cutlass.min(lower, upper)
++                    keys[peer] = cutlass.max(lower, upper)
++            stride //= 2
++        width *= 2
++
+ class _DCPA2ABase:
+     def __init__(
+         self,
+@@ -902,23 +1053,31 @@ class _AllGatherHeadsLaunch(_DCPA2ABase):
+                 * Int64(packs_per_head)
+             )
+             output_base = Int64(row) * Int64(packs_per_head)
++            # Resolve the peer's base address first and copy once. Cloning the
++            # whole pack loop into all sixteen arms of the constexpr chain
++            # bloats the kernel and pays the chain on every row.
++            source_address = Int64(
++                (local_input + source_base * Int64(4)).toint()
++            )
+             for source in cutlass.range_constexpr(self._world_size):
+                 if source_rank == Int32(source):
+                     if cutlass.const_expr(source == self._rank):
+                         source_words = local_input
+                     else:
+                         source_words = self._staging_words(staging[source])
+-                    pack = lane
+-                    while pack < packs_per_head:
+-                        _copy_16b(
+-                            source_words
+-                            + source_base * Int64(4)
+-                            + Int64(pack) * Int64(4),
+-                            output
+-                            + output_base * Int64(4)
+-                            + Int64(pack) * Int64(4),
+-                        )
+-                        pack += Int32(32)
++                    source_address = Int64(
++                        (source_words + source_base * Int64(4)).toint()
++                    )
++            output_address = Int64(
++                (output + output_base * Int64(4)).toint()
++            )
++            pack = lane
++            while pack < packs_per_head:
++                _copy_16b_addr(
++                    source_address + Int64(pack) * Int64(16),
++                    output_address + Int64(pack) * Int64(16),
++                )
++                pack += Int32(32)
+             row += warp_stride
+ 
+         if cutlass.const_expr(self._device_slot_selection):
+@@ -1188,6 +1347,19 @@ class _AllGatherPairLaunch(_DCPA2ABase):
+             )
+             source_rank = row_pack // first_packs
+             pack = row_pack - source_rank * first_packs
++            # Default to this rank's own slice so the address is always
++            # mappable; the chain below always overwrites it, because
++            # source_rank is derived from row_pack and is in range.
++            source_address = Int64(
++                (
++                    local_first
++                    + (
++                        Int64(batch_index) * Int64(first_packs)
++                        + Int64(pack)
++                    )
++                    * Int64(4)
++                ).toint()
++            )
+             for source in cutlass.range_constexpr(self._world_size):
+                 if source_rank == Int32(source):
+                     if cutlass.const_expr(source == self._rank):
+@@ -1200,11 +1372,16 @@ class _AllGatherPairLaunch(_DCPA2ABase):
+                         source_base = (
+                             Int64(batch_index) * Int64(combined_packs)
+                         )
+-                    _copy_16b(
+-                        source_words
+-                        + (source_base + Int64(pack)) * Int64(4),
+-                        output_first + Int64(linear) * Int64(4),
++                    source_address = Int64(
++                        (
++                            source_words
++                            + (source_base + Int64(pack)) * Int64(4)
++                        ).toint()
+                     )
++            _copy_16b_addr(
++                source_address,
++                Int64((output_first + Int64(linear) * Int64(4)).toint()),
++            )
+             linear += Int32(self._threads)
+ 
+         if cutlass.const_expr(not self._kimi_topk):
+@@ -1221,6 +1398,16 @@ class _AllGatherPairLaunch(_DCPA2ABase):
+                 )
+                 source_rank = row_pack // second_packs
+                 pack = row_pack - source_rank * second_packs
++                source_address = Int64(
++                    (
++                        local_second
++                        + (
++                            Int64(batch_index) * Int64(second_packs)
++                            + Int64(pack)
++                        )
++                        * Int64(4)
++                    ).toint()
++                )
+                 for source in cutlass.range_constexpr(self._world_size):
+                     if source_rank == Int32(source):
+                         if cutlass.const_expr(source == self._rank):
+@@ -1236,11 +1423,18 @@ class _AllGatherPairLaunch(_DCPA2ABase):
+                                 Int64(batch_index) * Int64(combined_packs)
+                                 + Int64(first_packs)
+                             )
+-                        _copy_16b(
+-                            source_words
+-                            + (source_base + Int64(pack)) * Int64(4),
+-                            output_second + Int64(linear) * Int64(4),
++                        source_address = Int64(
++                            (
++                                source_words
++                                + (source_base + Int64(pack)) * Int64(4)
++                            ).toint()
+                         )
++                _copy_16b_addr(
++                    source_address,
++                    Int64(
++                        (output_second + Int64(linear) * Int64(4)).toint()
++                    ),
++                )
+                 linear += Int32(self._threads)
+         else:
+             smem_alloc = cutlass.utils.SmemAllocator()
+@@ -1253,6 +1447,10 @@ class _AllGatherPairLaunch(_DCPA2ABase):
+                 unbiased_scores: cute.struct.Align[
+                     cute.struct.MemRange[Float32, 896], 16
+                 ]
++                # The 64 survivors of the warp-local rounds, as packed keys.
++                reduce_keys: cute.struct.Align[
++                    cute.struct.MemRange[cutlass.Uint64, 64], 16
++                ]
+ 
+             storage = smem_alloc.allocate(SharedStorage)
+             selection_scores = storage.selection_scores.get_tensor(
+@@ -1261,30 +1459,52 @@ class _AllGatherPairLaunch(_DCPA2ABase):
+             unbiased_scores = storage.unbiased_scores.get_tensor(
+                 cute.make_layout((896,), stride=(1,))
+             )
++            reduce_keys = storage.reduce_keys.get_tensor(
++                cute.make_layout((64,), stride=(1,))
++            )
+ 
+-            expert = Int32(tidx)
+-            while expert < Int32(896):
+-                source_rank = expert // Int32(56)
+-                local_expert = expert - source_rank * Int32(56)
+-                router_value = Float32(0.0)
++            # Pull the 3,584-byte router row in 16-byte packs. This uses 224
++            # peer transactions instead of 896 scalar transactions; PCIe
++            # transaction count dominates router-row transfer time.
++            router_pack = Int32(tidx)
++            router_packs_total = Int32(self._world_size) * second_packs
++            while router_pack < router_packs_total:
++                source_rank = router_pack // second_packs
++                pack = router_pack - source_rank * second_packs
++                source_address = Int64(
++                    (local_second + Int64(pack) * Int64(4)).toint()
++                )
+                 for source in cutlass.range_constexpr(self._world_size):
+                     if source_rank == Int32(source):
+                         if cutlass.const_expr(source == self._rank):
+-                            source_router = cute.recast_ptr(
+-                                local_second.align(4), dtype=Float32
+-                            )
++                            source_words = local_second
++                            source_base = Int64(0)
+                         else:
+-                            source_router = cute.recast_ptr(
+-                                (
+-                                    staging[source]
+-                                    + slot_offset
+-                                    + Int64(first_packs) * Int64(16)
+-                                ).align(4),
+-                                dtype=Float32,
++                            source_words = self._staging_words(
++                                staging[source] + slot_offset
+                             )
+-                        router_value = cute.arch.load(
+-                            source_router + Int64(local_expert), Float32
++                            source_base = Int64(first_packs)
++                        source_address = Int64(
++                            (
++                                source_words
++                                + (source_base + Int64(pack)) * Int64(4)
++                            ).toint()
+                         )
++                word0, word1, word2, word3 = ld_global_v4_u32(source_address)
++                # router_pack counts packs in rank-major order, so multiplying
++                # it by four yields the first global expert index in the pack
++                # for every supported world size.
++                base_expert = router_pack * Int32(4)
++                selection_scores[base_expert] = u32_as_f32(word0)
++                selection_scores[base_expert + Int32(1)] = u32_as_f32(word1)
++                selection_scores[base_expert + Int32(2)] = u32_as_f32(word2)
++                selection_scores[base_expert + Int32(3)] = u32_as_f32(word3)
++                router_pack += Int32(self._threads)
++            cute.arch.sync_threads()
++
++            expert = Int32(tidx)
++            while expert < Int32(896):
++                router_value = selection_scores[expert]
+                 bias = cute.arch.load(
+                     correction_bias + Int64(expert), Float32
+                 )
+@@ -1306,43 +1526,89 @@ class _AllGatherPairLaunch(_DCPA2ABase):
+                 expert += Int32(self._threads)
+             cute.arch.sync_threads()
+ 
+-            if Int32(tidx) == Int32(0):
+-                selected_ids = cute.make_rmem_tensor((16,), Int32)
+-                selected_weights = cute.make_rmem_tensor((16,), Float32)
++            # Two-level top-16 over packed (score, expert) keys. Four warps each
++            # reduce 256 experts held in registers (8 per lane); warp 0 then
++            # merges the 64 survivors.
++            # A round costs one warp reduction -- two instructions -- because the
++            # tie-break lives in the key rather than in a second comparison.
++            lane = Int32(tidx) % Int32(32)
++            warp = Int32(tidx) // Int32(32)
++            lane_key = cutlass.Uint64(0)
++            keys = cute.make_rmem_tensor((8,), cutlass.Uint64)
++            if warp < Int32(4):
++                for item in cutlass.range_constexpr(8):
++                    expert_id = warp * Int32(256) + Int32(item * 32) + lane
++                    value = Float32(_KIMI_NEG_INF)
++                    if expert_id < Int32(896):
++                        value = selection_scores[expert_id]
++                    keys[item] = _kimi_pack_key(value, expert_id)
++                _kimi_sort_desc(keys, 8)
++                previous = cutlass.Uint64(0)
+                 for selected in cutlass.range_constexpr(16):
+-                    selected_ids[selected] = Int32(-1)
+-                    selected_weights[selected] = Float32(0.0)
+-                weight_sum = Float32(0.0)
++                    if cutlass.const_expr(selected > 0):
++                        # Hold the head before the shift overwrites it, so
++                        # every element selects on the same condition.
++                        head = keys[0]
++                        tail_key = _kimi_pack_key(
++                            Float32(_KIMI_NEG_INF), _kimi_key_expert(keys[7])
++                        )
++                        for item in cutlass.range_constexpr(7):
++                            keys[item] = _select_if_eq_u64(
++                                previous, head, keys[item + 1], keys[item]
++                            )
++                        keys[7] = _select_if_eq_u64(
++                            previous, head, tail_key, keys[7]
++                        )
++                    previous = _kimi_warp_max_key(keys[0])
++                    lane_key = _select_if_eq_u64(
++                        cutlass.Uint64(lane),
++                        cutlass.Uint64(selected),
++                        previous,
++                        lane_key,
++                    )
++                if lane < Int32(16):
++                    reduce_keys[warp * Int32(16) + lane] = lane_key
++            cute.arch.sync_threads()
++            selected_ids = cute.make_rmem_tensor((16,), Int32)
++            selected_weights = cute.make_rmem_tensor((16,), Float32)
++            weight_sum = Float32(0.0)
++            if warp == Int32(0):
++                merge_keys = cute.make_rmem_tensor((2,), cutlass.Uint64)
++                for item in cutlass.range_constexpr(2):
++                    merge_keys[item] = reduce_keys[Int32(item * 32) + lane]
++                _kimi_sort_desc(merge_keys, 2)
++                previous = cutlass.Uint64(0)
+                 for selected in cutlass.range_constexpr(16):
+-                    best_score = Float32(float("-inf"))
+-                    best_expert = Int32(-1)
+-                    candidate = Int32(0)
+-                    while candidate < Int32(896):
+-                        already_selected = False
+-                        for prior in cutlass.range_constexpr(selected):
+-                            if selected_ids[prior] == candidate:
+-                                already_selected = True
+-                        score = selection_scores[candidate]
+-                        if not already_selected:
+-                            if (
+-                                score > best_score
+-                                or (
+-                                    score == best_score
+-                                    and (
+-                                        best_expert < Int32(0)
+-                                        or candidate < best_expert
+-                                    )
+-                                )
+-                            ):
+-                                best_score = score
+-                                best_expert = candidate
+-                        candidate += Int32(1)
+-                    selected_ids[selected] = best_expert
+-                    weight = Float32(0.0)
+-                    if best_expert >= Int32(0):
+-                        weight = unbiased_scores[best_expert]
++                    if cutlass.const_expr(selected > 0):
++                        head = merge_keys[0]
++                        tail_key = _kimi_pack_key(
++                            Float32(_KIMI_NEG_INF),
++                            _kimi_key_expert(merge_keys[1]),
++                        )
++                        merge_keys[0] = _select_if_eq_u64(
++                            previous, head, merge_keys[1], merge_keys[0]
++                        )
++                        merge_keys[1] = _select_if_eq_u64(
++                            previous, head, tail_key, merge_keys[1]
++                        )
++                    previous = _kimi_warp_max_key(merge_keys[0])
++                    # The reduction broadcasts, so every lane agrees here.
++                    final_expert = _kimi_key_expert(previous)
++                    selected_ids[selected] = final_expert
++                    weight = unbiased_scores[final_expert]
+                     selected_weights[selected] = weight
+-                    weight_sum += weight
++                # The native kernel renormalises with cg::reduce over the warp,
++                # which folds by halves (lane l adds lane l+stride, stride
++                # halving from 16). Summing left to right instead lands a ULP
++                # away, so fold in the same order. Same fifteen adds.
++                eight = [
++                    selected_weights[item] + selected_weights[item + 8]
++                    for item in range(8)
++                ]
++                four = [eight[item] + eight[item + 4] for item in range(4)]
++                two = [four[item] + four[item + 2] for item in range(2)]
++                weight_sum = two[0] + two[1]
++            if Int32(tidx) == Int32(0):
+                 scale = Float32(1.0) / (weight_sum + Float32(1.0e-20))
+                 for selected in cutlass.range_constexpr(16):
+                     cute.arch.store(
+@@ -1363,6 +1629,165 @@ class _AllGatherPairLaunch(_DCPA2ABase):
+                 )
+ 
+ 
++class _KimiTopK16Launch:
++    """Select Kimi-K3's 16 routed experts in one CTA per token."""
++
++    def __init__(self, threads: int) -> None:
++        self._threads = int(threads)
++
++    @cute.jit
++    def __call__(
++        self,
++        router_logits: cute.Pointer,
++        correction_bias: cute.Pointer,
++        output_weights: cute.Pointer,
++        output_ids: cute.Pointer,
++        rows: Int32,
++        stream: cuda.CUstream,
++    ) -> None:
++        self.kernel(
++            router_logits,
++            correction_bias,
++            output_weights,
++            output_ids,
++        ).launch(
++            grid=(rows, 1, 1),
++            block=(self._threads, 1, 1),
++            max_number_threads=(512, 1, 1),
++            min_blocks_per_mp=1,
++            cluster=(1, 1, 1),
++            stream=stream,
++        )
++
++    @cute.kernel
++    def kernel(
++        self,
++        router_logits: cute.Pointer,
++        correction_bias: cute.Pointer,
++        output_weights: cute.Pointer,
++        output_ids: cute.Pointer,
++    ) -> None:
++        tidx, _, _ = cute.arch.thread_idx()
++        bidx, _, _ = cute.arch.block_idx()
++        smem_alloc = cutlass.utils.SmemAllocator()
++
++        @cute.struct
++        class SharedStorage:
++            selection_scores: cute.struct.Align[
++                cute.struct.MemRange[Float32, 896], 16
++            ]
++            unbiased_scores: cute.struct.Align[
++                cute.struct.MemRange[Float32, 896], 16
++            ]
++            active_experts: cute.struct.Align[
++                cute.struct.MemRange[Int32, 896], 16
++            ]
++            warp_keys: cute.struct.Align[
++                cute.struct.MemRange[cutlass.Uint64, 16], 16
++            ]
++
++        storage = smem_alloc.allocate(SharedStorage)
++        selection_scores = storage.selection_scores.get_tensor(
++            cute.make_layout((896,), stride=(1,))
++        )
++        unbiased_scores = storage.unbiased_scores.get_tensor(
++            cute.make_layout((896,), stride=(1,))
++        )
++        active_experts = storage.active_experts.get_tensor(
++            cute.make_layout((896,), stride=(1,))
++        )
++        warp_keys = storage.warp_keys.get_tensor(
++            cute.make_layout((16,), stride=(1,))
++        )
++
++        row_offset = Int64(bidx) * Int64(896)
++        expert = Int32(tidx)
++        while expert < Int32(896):
++            router_value = cute.arch.load(
++                router_logits + row_offset + Int64(expert), Float32
++            )
++            bias = cute.arch.load(
++                correction_bias + Int64(expert), Float32
++            )
++            unbiased = Float32(1.0) / (
++                Float32(1.0) + cute.math.exp(-router_value, fastmath=True)
++            )
++            if not cute.math.isfinite(unbiased):
++                unbiased = Float32(0.0)
++            selection = unbiased + bias
++            if not cute.math.isfinite(selection):
++                if selection > Float32(0.0):
++                    selection = Float32(float("inf"))
++                else:
++                    selection = Float32(float("-inf"))
++            # Canonicalize signed zero because packed keys distinguish -0.0
++            # from +0.0 and expert ties require one deterministic ordering.
++            if selection == Float32(0.0):
++                selection = Float32(0.0)
++            selection_scores[expert] = selection
++            unbiased_scores[expert] = unbiased
++            active_experts[expert] = Int32(1)
++            expert += Int32(self._threads)
++        cute.arch.sync_threads()
++
++        # Each round reduces one candidate per thread, then merges the warp
++        # winners. The selected key is invalidated in shared memory before the
++        # following round. Packed keys preserve lower-ID tie-breaking.
++        lane = Int32(tidx) % Int32(32)
++        warp = Int32(tidx) // Int32(32)
++        selected_ids = cute.make_rmem_tensor((16,), Int32)
++        selected_weights = cute.make_rmem_tensor((16,), Float32)
++        for selected in cutlass.range_constexpr(16):
++            thread_key = cutlass.Uint64(0)
++            candidate = Int32(tidx)
++            while candidate < Int32(896):
++                candidate_key = cutlass.Uint64(0)
++                if active_experts[candidate] != Int32(0):
++                    candidate_key = _kimi_pack_key(
++                        selection_scores[candidate], candidate
++                    )
++                thread_key = cutlass.max(thread_key, candidate_key)
++                candidate += Int32(self._threads)
++            warp_key = _kimi_warp_max_key(thread_key)
++            if lane == Int32(0):
++                warp_keys[warp] = warp_key
++            cute.arch.sync_threads()
++            if Int32(tidx) == Int32(0):
++                selected_key = warp_keys[0]
++                for source_warp in cutlass.range_constexpr(
++                    1, self._threads // 32
++                ):
++                    selected_key = cutlass.max(
++                        selected_key, warp_keys[source_warp]
++                    )
++                final_expert = _kimi_key_expert(selected_key)
++                selected_ids[selected] = final_expert
++                selected_weights[selected] = unbiased_scores[final_expert]
++                active_experts[final_expert] = Int32(0)
++            cute.arch.sync_threads()
++
++        weight_sum = Float32(0.0)
++        if Int32(tidx) == Int32(0):
++            for selected in cutlass.range_constexpr(16):
++                weight_sum += selected_weights[selected]
++
++        if Int32(tidx) == Int32(0):
++            output_offset = Int64(bidx) * Int64(16)
++            denominator = Float32(1.0)
++            if weight_sum > Float32(0.0):
++                denominator = weight_sum
++            scale = Float32(1.0) / denominator
++            for selected in cutlass.range_constexpr(16):
++                cute.arch.store(
++                    output_weights + output_offset + Int64(selected),
++                    selected_weights[selected] * scale,
++                )
++                cute.arch.store(
++                    output_ids + output_offset + Int64(selected),
++                    selected_ids[selected],
++                )
++
++
+ def _pad_ptrs(values: Sequence[int], world_size: int) -> tuple[int, ...]:
+     if len(values) != world_size:
+         raise ValueError("pointer bundle does not match DCP world size")
+@@ -1776,6 +2201,59 @@ def _get_compiled_all_gather_pair(
+     return run
+ 
+ 
++def is_kimi_topk16_prepared(threads: int = 256) -> bool:
++    return int(threads) in _PREPARED_KIMI_TOPK_LAUNCHERS
++
++
++@functools.cache
++def _get_compiled_kimi_topk16(threads: int = 256) -> Callable:
++    normalized_threads = int(threads)
++    if normalized_threads not in (128, 256, 512):
++        raise ValueError("Kimi top-16 threads must be 128, 256, or 512")
++    launch = _KimiTopK16Launch(normalized_threads)
++    raise_if_kernel_resolution_frozen(
++        "cute.compile",
++        target=launch,
++        cache_key=(normalized_threads,),
++    )
++    p_f32 = _f32_ptr(16)
++    p_i32 = _i32_ptr(16)
++    raw = b12x_compile(
++        launch,
++        p_f32,
++        p_f32,
++        p_f32,
++        p_i32,
++        1,
++        current_cuda_stream(),
++        compile_spec=KernelCompileSpec.from_key(
++            "comm.pcie.dcp_a2a.kimi_topk16",
++            1,
++            (normalized_threads,),
++            labels=("threads",),
++        ),
++    )
++
++    def run(
++        router_logits_ptr: int,
++        correction_bias_ptr: int,
++        output_weights_ptr: int,
++        output_ids_ptr: int,
++        rows: int,
++    ) -> None:
++        raw(
++            _f32_ptr(router_logits_ptr),
++            _f32_ptr(correction_bias_ptr),
++            _f32_ptr(output_weights_ptr),
++            _i32_ptr(output_ids_ptr),
++            int(rows),
++            current_cuda_stream(),
++        )
++
++    _PREPARED_KIMI_TOPK_LAUNCHERS.add(normalized_threads)
++    return run
++
++
+ def lse_reduce_scatter(
+     *,
+     world_size: int,
+@@ -1928,6 +2406,7 @@ def all_gather_pair(
+ 
+ def all_gather_pair_kimi_topk(
+     *,
++    world_size: int,
+     rank: int,
+     local_down_ptr: int,
+     local_router_ptr: int,
+@@ -1942,14 +2421,16 @@ def all_gather_pair_kimi_topk(
+ ) -> None:
+     slot_delta_256b = _slot_delta_256b(slot_delta_bytes)
+     launcher = _get_compiled_all_gather_pair(
+-        16,
++        world_size,
+         rank,
+         512,
+         device_slot_selection,
+         True,
+     )
+     if not device_slot_selection:
+-        _get_compiled_all_gather_pair(16, rank, 512, True, True)
++        _get_compiled_all_gather_pair(
++            world_size, rank, 512, True, True
++        )
+     launcher(
+         local_down_ptr,
+         local_router_ptr,
+@@ -1960,15 +2441,34 @@ def all_gather_pair_kimi_topk(
+         staging_ptrs,
+         signal_ptrs,
+         1,
+-        28,
+-        14,
++        448 // world_size,
++        224 // world_size,
+         slot_delta_256b,
+     )
+ 
+ 
++def kimi_topk16(
++    *,
++    router_logits_ptr: int,
++    correction_bias_ptr: int,
++    output_weights_ptr: int,
++    output_ids_ptr: int,
++    rows: int,
++    threads: int = 256,
++) -> None:
++    _get_compiled_kimi_topk16(threads)(
++        router_logits_ptr,
++        correction_bias_ptr,
++        output_weights_ptr,
++        output_ids_ptr,
++        rows,
++    )
++
++
+ __all__ = [
+     "all_gather_heads",
+     "all_gather_pair",
+     "all_gather_pair_kimi_topk",
++    "kimi_topk16",
+     "lse_reduce_scatter",
+ ]
+diff --git a/b12x/comm/pcie/_island_rs_cute.py b/b12x/comm/pcie/_island_rs_cute.py
+new file mode 100644
+index 0000000000000000000000000000000000000000..460755463d59762238f6b8af3df7cf671b58f761
+--- /dev/null
++++ b/b12x/comm/pcie/_island_rs_cute.py
+@@ -0,0 +1,683 @@
++"""CuTeDSL pull-based island reduce-scatter TP16 collective.
++
++Rank ``island * 4 + lane`` owns one equal quarter of the vector. Each rank
++pulls from six peers: the three other lanes of its four-rank island and the
++same lane in the three other islands. This bounds peer degree at six while
++distributing inter-island traffic across every rank. The three protocol rounds
++move 2.25 times the BF16 payload per rank.
++"""
++
++from __future__ import annotations
++
++import functools
++from collections.abc import Callable, Sequence
++from typing import Tuple
++
++import cuda.bindings.driver as cuda
++import cutlass
++import cutlass.cute as cute
++import cutlass.utils
++from cutlass import Float32, Int32, Int64, Uint32
++from cutlass._mlir.dialects import llvm
++from cutlass.cutlass_dsl import T, dsl_user_op
++
++from b12x._lib.compiler import KernelCompileSpec
++from b12x._lib.compiler import compile as b12x_compile
++from b12x._lib.runtime_control import raise_if_kernel_resolution_frozen
++from b12x._lib.utils import (
++    cuda_stream_from_int_or_current,
++    cuda_stream_to_int,
++    current_cuda_stream,
++    make_ptr,
++)
++
++
++@dsl_user_op
++def _atomic_add_global_u32(
++    address: Int64, value: Uint32, *, loc=None, ip=None
++) -> Uint32:
++    return Uint32(
++        llvm.inline_asm(
++            T.i32(),
++            [
++                Int64(address).ir_value(loc=loc, ip=ip),
++                Uint32(value).ir_value(loc=loc, ip=ip),
++            ],
++            "atom.global.add.u32 $0, [$1], $2;",
++            "=r,l,r",
++            has_side_effects=True,
++            is_align_stack=False,
++            asm_dialect=llvm.AsmDialect.AD_ATT,
++            loc=loc,
++            ip=ip,
++        )
++    )
++
++
++@dsl_user_op
++def _load_acquire_sys_u32(address: Int64, *, loc=None, ip=None) -> Uint32:
++    return Uint32(
++        llvm.inline_asm(
++            T.i32(),
++            [Int64(address).ir_value(loc=loc, ip=ip)],
++            "ld.acquire.sys.global.u32 $0, [$1];",
++            "=r,l",
++            has_side_effects=True,
++            is_align_stack=False,
++            asm_dialect=llvm.AsmDialect.AD_ATT,
++            loc=loc,
++            ip=ip,
++        )
++    )
++
++
++@dsl_user_op
++def _store_release_sys_u32(address: Int64, value: Uint32, *, loc=None, ip=None) -> None:
++    llvm.inline_asm(
++        None,
++        [
++            Int64(address).ir_value(loc=loc, ip=ip),
++            Uint32(value).ir_value(loc=loc, ip=ip),
++        ],
++        "st.release.sys.global.u32 [$0], $1;",
++        "l,r",
++        has_side_effects=True,
++        is_align_stack=False,
++        asm_dialect=llvm.AsmDialect.AD_ATT,
++        loc=loc,
++        ip=ip,
++    )
++
++
++@dsl_user_op
++def _fence_sc_sys(*, loc=None, ip=None) -> None:
++    llvm.inline_asm(
++        None,
++        [],
++        "fence.sc.sys;",
++        "",
++        has_side_effects=True,
++        is_align_stack=False,
++        asm_dialect=llvm.AsmDialect.AD_ATT,
++        loc=loc,
++        ip=ip,
++    )
++
++
++@dsl_user_op
++def _nanosleep(cycles: Uint32, *, loc=None, ip=None) -> None:
++    llvm.inline_asm(
++        None,
++        [Uint32(cycles).ir_value(loc=loc, ip=ip)],
++        "nanosleep.u32 $0;",
++        "r",
++        has_side_effects=True,
++        is_align_stack=False,
++        asm_dialect=llvm.AsmDialect.AD_ATT,
++        loc=loc,
++        ip=ip,
++    )
++
++
++@cute.jit
++def _wait_for(address: Int64, generation: Uint32, cycles: int) -> None:
++    observed = _load_acquire_sys_u32(address)
++    while observed < generation:
++        if cutlass.const_expr(cycles > 0):
++            _nanosleep(Uint32(cycles))
++        observed = _load_acquire_sys_u32(address)
++
++
++@cute.jit
++def _flag_address(base: Int64, region: int, block: Int32, index: Int32) -> Int64:
++    return (
++        base
++        + Int64(region)
++        + (Int64(block) * Int64(_ISLAND_SIZE) + Int64(index)) * Int64(128)
++    )
++
++
++@dsl_user_op
++def unpack_bf16x2(value: Uint32, *, loc=None, ip=None) -> Tuple[Float32, Float32]:
++    result = llvm.inline_asm(
++        llvm.StructType.get_literal([T.f32(), T.f32()]),
++        [Uint32(value).ir_value(loc=loc, ip=ip)],
++        """
++        {
++            .reg .b16 lo, hi;
++            mov.b32 {lo, hi}, $2;
++            cvt.f32.bf16 $0, lo;
++            cvt.f32.bf16 $1, hi;
++        }
++        """,
++        "=f,=f,r",
++        has_side_effects=False,
++        is_align_stack=False,
++        asm_dialect=llvm.AsmDialect.AD_ATT,
++        loc=loc,
++        ip=ip,
++    )
++    return (
++        Float32(llvm.extractvalue(T.f32(), result, [0], loc=loc, ip=ip)),
++        Float32(llvm.extractvalue(T.f32(), result, [1], loc=loc, ip=ip)),
++    )
++
++
++@dsl_user_op
++def pack_f32x2_to_bf16x2(lo: Float32, hi: Float32, *, loc=None, ip=None) -> Uint32:
++    """Match two scalar ``__float2bfloat16`` conversions without saturation."""
++    return Uint32(
++        llvm.inline_asm(
++            T.i32(),
++            [
++                Float32(lo).ir_value(loc=loc, ip=ip),
++                Float32(hi).ir_value(loc=loc, ip=ip),
++            ],
++            """
++            {
++                .reg .b16 blo, bhi;
++                cvt.rn.bf16.f32 blo, $1;
++                cvt.rn.bf16.f32 bhi, $2;
++                mov.b32 $0, {blo, bhi};
++            }
++            """,
++            "=r,f,f",
++            has_side_effects=False,
++            is_align_stack=False,
++            asm_dialect=llvm.AsmDialect.AD_ATT,
++            loc=loc,
++            ip=ip,
++        )
++    )
++
++
++_ISLAND_SIZE = 4
++_MAX_ISLANDS = 4
++_MAX_WORLD_SIZE = _ISLAND_SIZE * _MAX_ISLANDS
++
++# One 128-byte line per (block, slot); 32 blocks x 4 slots per region.
++_RS_ARRIVED = 256
++_XS_ARRIVED = 16_640
++_AG_ARRIVED = 33_024
++HEADER_BYTES = 49_408
++MAX_BLOCKS = 32
++
++
++def island_rs_peers(rank: int, world_size: int) -> tuple[int, ...]:
++    """Slabs this rank maps: three island lanes, three same-lane partners."""
++
++    if world_size != _MAX_WORLD_SIZE:
++        raise ValueError(f"island reduce-scatter requires TP16, got TP{world_size}")
++    if not 0 <= rank < world_size:
++        raise ValueError(f"invalid rank {rank} for TP{world_size}")
++    island, lane = divmod(rank, _ISLAND_SIZE)
++    lanes = {island * _ISLAND_SIZE + p for p in range(_ISLAND_SIZE)}
++    partners = {j * _ISLAND_SIZE + lane for j in range(_MAX_ISLANDS)}
++    return tuple(sorted((lanes | partners) - {rank}))
++
++
++class _IslandRSLaunch:
++    """Rank-specialized launcher; every peer index folds away at compile time."""
++
++    def __init__(
++        self,
++        world_size: int,
++        rank: int,
++        *,
++        threads: int = 128,
++        wait_nanosleep_cycles: int = 24,
++    ) -> None:
++        if world_size != _MAX_WORLD_SIZE:
++            raise ValueError(f"unsupported world size {world_size}")
++        if not 0 <= rank < world_size:
++            raise ValueError(f"invalid rank {rank} for world size {world_size}")
++        if not 32 <= threads <= 1024 or threads % 32:
++            raise ValueError("threads must be a multiple of 32 in [32, 1024]")
++        self._world_size = int(world_size)
++        self._rank = int(rank)
++        self._threads = int(threads)
++        self._wait_nanosleep_cycles = int(wait_nanosleep_cycles)
++        self._island = self._rank // _ISLAND_SIZE
++        self._lane = self._rank % _ISLAND_SIZE
++
++    @cute.jit
++    def __call__(
++        self,
++        slab0: cute.Pointer,
++        slab1: cute.Pointer,
++        slab2: cute.Pointer,
++        slab3: cute.Pointer,
++        slab4: cute.Pointer,
++        slab5: cute.Pointer,
++        slab6: cute.Pointer,
++        slab7: cute.Pointer,
++        slab8: cute.Pointer,
++        slab9: cute.Pointer,
++        slab10: cute.Pointer,
++        slab11: cute.Pointer,
++        slab12: cute.Pointer,
++        slab13: cute.Pointer,
++        slab14: cute.Pointer,
++        slab15: cute.Pointer,
++        input_ptr: cute.Pointer,
++        output_ptr: cute.Pointer,
++        stage_offset: Int64,
++        part_offset: Int64,
++        final_offset: Int64,
++        quarter_capacity: Int64,
++        elements: Int64,
++        blocks: Int32,
++        stream: cuda.CUstream,
++    ) -> None:
++        self.kernel(
++            slab0,
++            slab1,
++            slab2,
++            slab3,
++            slab4,
++            slab5,
++            slab6,
++            slab7,
++            slab8,
++            slab9,
++            slab10,
++            slab11,
++            slab12,
++            slab13,
++            slab14,
++            slab15,
++            input_ptr,
++            output_ptr,
++            stage_offset,
++            part_offset,
++            final_offset,
++            quarter_capacity,
++            elements,
++        ).launch(
++            grid=(blocks, 1, 1),
++            block=[self._threads, 1, 1],
++            cluster=(1, 1, 1),
++            stream=stream,
++        )
++
++    @cute.kernel
++    def kernel(
++        self,
++        slab0: cute.Pointer,
++        slab1: cute.Pointer,
++        slab2: cute.Pointer,
++        slab3: cute.Pointer,
++        slab4: cute.Pointer,
++        slab5: cute.Pointer,
++        slab6: cute.Pointer,
++        slab7: cute.Pointer,
++        slab8: cute.Pointer,
++        slab9: cute.Pointer,
++        slab10: cute.Pointer,
++        slab11: cute.Pointer,
++        slab12: cute.Pointer,
++        slab13: cute.Pointer,
++        slab14: cute.Pointer,
++        slab15: cute.Pointer,
++        input_ptr: cute.Pointer,
++        output_ptr: cute.Pointer,
++        stage_offset: Int64,
++        part_offset: Int64,
++        final_offset: Int64,
++        quarter_capacity: Int64,
++        elements: Int64,
++    ) -> None:
++        slabs = (
++            slab0,
++            slab1,
++            slab2,
++            slab3,
++            slab4,
++            slab5,
++            slab6,
++            slab7,
++            slab8,
++            slab9,
++            slab10,
++            slab11,
++            slab12,
++            slab13,
++            slab14,
++            slab15,
++        )
++        tidx, _, _ = cute.arch.thread_idx()
++        bidx, _, _ = cute.arch.block_idx()
++        gdim, _, _ = cute.arch.grid_dim()
++        self_base = Int64(slabs[self._rank].toint())
++
++        allocator = cutlass.utils.SmemAllocator()
++        shared_generation = allocator.allocate_tensor(
++            element_type=cutlass.Uint32,
++            layout=cute.make_layout((1,)),
++            byte_alignment=4,
++        )
++        if tidx == Int32(0):
++            shared_generation[0] = _atomic_add_global_u32(
++                self_base + Int64(bidx) * Int64(4), Uint32(1)
++            ) + Uint32(1)
++        cute.arch.barrier()
++        generation = Uint32(shared_generation[0])
++        if generation % Uint32(2) != Uint32(0):
++            stage_offset += quarter_capacity * Int64(_ISLAND_SIZE * 4)
++            part_offset += quarter_capacity * Int64(4)
++            final_offset += quarter_capacity * Int64(_ISLAND_SIZE * 4)
++
++        # Everything below counts in bf16x2 words; callers guarantee an even
++        # element count so there is no scalar tail to chase.
++        pairs = elements // Int64(2)
++        quarter = (pairs + Int64(_ISLAND_SIZE - 1)) // Int64(_ISLAND_SIZE)
++        stride = Int64(gdim) * Int64(self._threads)
++        start = Int64(bidx) * Int64(self._threads) + Int64(tidx)
++
++        input_words = cute.recast_ptr(input_ptr.align(4), dtype=Uint32)
++        output_words = cute.recast_ptr(output_ptr.align(4), dtype=Uint32)
++
++        # Every remote transfer is a read. The equal-quarter ownership keeps
++        # any rank from moving the complete vector on behalf of its island.
++
++        # Phase 1 -- publish my whole input locally, then reduce my quarter by
++        # pulling it out of the four island stages.
++        self_stage = cute.recast_ptr(
++            cute.make_ptr(
++                cutlass.BFloat16,
++                self_base + stage_offset,
++                cute.AddressSpace.gmem,
++                assumed_align=16,
++            ).align(4),
++            dtype=Uint32,
++        )
++        # A block publishes the same shifted residue class that the matching
++        # block on each destination lane consumes after its per-block arrival
++        # flag. This keeps data ownership aligned with synchronization even
++        # when a quarter boundary is not divisible by the launch stride.
++        for lane in cutlass.range_constexpr(_ISLAND_SIZE):
++            begin = Int64(lane) * quarter
++            stop = begin + quarter
++            if stop > pairs:
++                stop = pairs
++            index = start
++            while index < stop - begin:
++                self_stage[begin + index] = input_words[begin + index]
++                index += stride
++        cute.arch.barrier()
++        if tidx == Int32(0):
++            _fence_sc_sys()
++            for p in cutlass.range_constexpr(_ISLAND_SIZE):
++                if cutlass.const_expr(p != self._lane):
++                    peer = self._island * _ISLAND_SIZE + p
++                    _store_release_sys_u32(
++                        _flag_address(
++                            Int64(slabs[peer].toint()),
++                            _RS_ARRIVED,
++                            bidx,
++                            Int32(self._lane),
++                        ),
++                        generation,
++                    )
++            for p in cutlass.range_constexpr(_ISLAND_SIZE):
++                if cutlass.const_expr(p != self._lane):
++                    _wait_for(
++                        _flag_address(self_base, _RS_ARRIVED, bidx, Int32(p)),
++                        generation,
++                        self._wait_nanosleep_cycles,
++                    )
++        cute.arch.barrier()
++
++        mine_begin = Int64(self._lane) * quarter
++        mine_stop = mine_begin + quarter
++        if mine_stop > pairs:
++            mine_stop = pairs
++        mine_length = mine_stop - mine_begin
++
++        self_part = cute.recast_ptr(
++            cute.make_ptr(
++                cutlass.BFloat16,
++                self_base + part_offset,
++                cute.AddressSpace.gmem,
++                assumed_align=16,
++            ).align(4),
++            dtype=Uint32,
++        )
++        index = start
++        while index < mine_length:
++            total_lo = Float32(0.0)
++            total_hi = Float32(0.0)
++            for p in cutlass.range_constexpr(_ISLAND_SIZE):
++                peer = self._island * _ISLAND_SIZE + p
++                peer_stage = cute.recast_ptr(
++                    cute.make_ptr(
++                        cutlass.BFloat16,
++                        Int64(slabs[peer].toint()) + stage_offset,
++                        cute.AddressSpace.gmem,
++                        assumed_align=16,
++                    ).align(4),
++                    dtype=Uint32,
++                )
++                lo, hi = unpack_bf16x2(peer_stage[mine_begin + index])
++                total_lo += lo
++                total_hi += hi
++            self_part[index] = pack_f32x2_to_bf16x2(total_lo, total_hi)
++            index += stride
++        cute.arch.barrier()
++
++        # Phase 2 -- combine the four island partials for my quarter, again by
++        # pulling, from the same lane in every island.
++        if tidx == Int32(0):
++            _fence_sc_sys()
++            for j in cutlass.range_constexpr(_MAX_ISLANDS):
++                if cutlass.const_expr(j != self._island):
++                    partner = j * _ISLAND_SIZE + self._lane
++                    _store_release_sys_u32(
++                        _flag_address(
++                            Int64(slabs[partner].toint()),
++                            _XS_ARRIVED,
++                            bidx,
++                            Int32(self._island),
++                        ),
++                        generation,
++                    )
++            for j in cutlass.range_constexpr(_MAX_ISLANDS):
++                if cutlass.const_expr(j != self._island):
++                    _wait_for(
++                        _flag_address(self_base, _XS_ARRIVED, bidx, Int32(j)),
++                        generation,
++                        self._wait_nanosleep_cycles,
++                    )
++        cute.arch.barrier()
++
++        self_final = cute.recast_ptr(
++            cute.make_ptr(
++                cutlass.BFloat16,
++                self_base + final_offset,
++                cute.AddressSpace.gmem,
++                assumed_align=16,
++            ).align(4),
++            dtype=Uint32,
++        )
++        index = start
++        while index < mine_length:
++            total_lo = Float32(0.0)
++            total_hi = Float32(0.0)
++            for j in cutlass.range_constexpr(_MAX_ISLANDS):
++                partner = j * _ISLAND_SIZE + self._lane
++                partner_part = cute.recast_ptr(
++                    cute.make_ptr(
++                        cutlass.BFloat16,
++                        Int64(slabs[partner].toint()) + part_offset,
++                        cute.AddressSpace.gmem,
++                        assumed_align=16,
++                    ).align(4),
++                    dtype=Uint32,
++                )
++                lo, hi = unpack_bf16x2(partner_part[index])
++                total_lo += lo
++                total_hi += hi
++            value = pack_f32x2_to_bf16x2(total_lo, total_hi)
++            self_final[mine_begin + index] = value
++            output_words[mine_begin + index] = value
++            index += stride
++        cute.arch.barrier()
++
++        # Phase 3 -- island all-gather, pulling the three quarters I do not own
++        # straight into my output.
++        if tidx == Int32(0):
++            _fence_sc_sys()
++            for p in cutlass.range_constexpr(_ISLAND_SIZE):
++                if cutlass.const_expr(p != self._lane):
++                    peer = self._island * _ISLAND_SIZE + p
++                    _store_release_sys_u32(
++                        _flag_address(
++                            Int64(slabs[peer].toint()),
++                            _AG_ARRIVED,
++                            bidx,
++                            Int32(self._lane),
++                        ),
++                        generation,
++                    )
++            for p in cutlass.range_constexpr(_ISLAND_SIZE):
++                if cutlass.const_expr(p != self._lane):
++                    _wait_for(
++                        _flag_address(self_base, _AG_ARRIVED, bidx, Int32(p)),
++                        generation,
++                        self._wait_nanosleep_cycles,
++                    )
++        cute.arch.barrier()
++
++        for p in cutlass.range_constexpr(_ISLAND_SIZE):
++            if cutlass.const_expr(p != self._lane):
++                peer = self._island * _ISLAND_SIZE + p
++                peer_final = cute.recast_ptr(
++                    cute.make_ptr(
++                        cutlass.BFloat16,
++                        Int64(slabs[peer].toint()) + final_offset,
++                        cute.AddressSpace.gmem,
++                        assumed_align=16,
++                    ).align(4),
++                    dtype=Uint32,
++                )
++                begin = Int64(p) * quarter
++                stop = begin + quarter
++                if stop > pairs:
++                    stop = pairs
++                index = start
++                while index < stop - begin:
++                    output_words[begin + index] = peer_final[begin + index]
++                    index += stride
++
++
++@functools.lru_cache(maxsize=None)
++def get_island_rs_launcher(
++    world_size: int,
++    rank: int,
++    device_index: int,
++    *,
++    threads: int = 128,
++    wait_nanosleep_cycles: int = 24,
++) -> Callable[..., None]:
++    """Return the rank-specialized TP16 island reduce-scatter launcher."""
++
++    del device_index  # retained in the process-local cache key
++    launch = _IslandRSLaunch(
++        world_size,
++        rank,
++        threads=threads,
++        wait_nanosleep_cycles=wait_nanosleep_cycles,
++    )
++    cache_key = (
++        int(world_size),
++        int(rank),
++        int(threads),
++        int(wait_nanosleep_cycles),
++    )
++    raise_if_kernel_resolution_frozen(
++        "cute.compile", target=launch, cache_key=cache_key
++    )
++    slab_placeholder = make_ptr(
++        cutlass.Uint8,
++        256,
++        cute.AddressSpace.gmem,
++        assumed_align=256,
++    )
++    raw = b12x_compile(
++        launch,
++        *(slab_placeholder for _ in range(_MAX_WORLD_SIZE)),
++        make_ptr(cutlass.BFloat16, 16, cute.AddressSpace.gmem, assumed_align=2),
++        make_ptr(cutlass.BFloat16, 16, cute.AddressSpace.gmem, assumed_align=2),
++        1,
++        1,
++        1,
++        1,
++        1,
++        1,
++        current_cuda_stream(),
++        compile_spec=KernelCompileSpec.from_key(
++            "comm.pcie.island_rs.bf16",
++            1,
++            cache_key,
++            labels=(
++                "world_size",
++                "rank",
++                "threads",
++                "wait_nanosleep_cycles",
++            ),
++        ),
++    )
++
++    def run(
++        slab_addresses: Sequence[int],
++        input_address: int,
++        output_address: int,
++        stage_offset: int,
++        part_offset: int,
++        final_offset: int,
++        quarter_capacity: int,
++        elements: int,
++        blocks: int,
++        stream: object = None,
++    ) -> None:
++        if len(slab_addresses) != world_size:
++            raise ValueError(
++                f"expected {world_size} slab addresses, got {len(slab_addresses)}"
++            )
++        if not 1 <= int(blocks) <= MAX_BLOCKS:
++            raise ValueError(f"blocks must be in [1, {MAX_BLOCKS}], got {blocks}")
++        raw(
++            *(
++                make_ptr(
++                    cutlass.Uint8,
++                    int(address),
++                    cute.AddressSpace.gmem,
++                    assumed_align=256,
++                )
++                for address in slab_addresses
++            ),
++            make_ptr(
++                cutlass.BFloat16,
++                input_address,
++                cute.AddressSpace.gmem,
++                assumed_align=2,
++            ),
++            make_ptr(
++                cutlass.BFloat16,
++                output_address,
++                cute.AddressSpace.gmem,
++                assumed_align=2,
++            ),
++            stage_offset,
++            part_offset,
++            final_offset,
++            quarter_capacity,
++            elements,
++            blocks,
++            cuda_stream_from_int_or_current(cuda_stream_to_int(stream)),
++        )
++
++    return run
++
++
++__all__ = ["HEADER_BYTES", "MAX_BLOCKS", "get_island_rs_launcher", "island_rs_peers"]
+diff --git a/b12x/comm/pcie/_vocab_argmax_cute.py b/b12x/comm/pcie/_vocab_argmax_cute.py
+new file mode 100644
+index 0000000000000000000000000000000000000000..bb4ea979ea66c95f58d84b7b22a903f7554d9921
+--- /dev/null
++++ b/b12x/comm/pcie/_vocab_argmax_cute.py
+@@ -0,0 +1,645 @@
++"""CuTeDSL kernel for bounded-degree vocabulary-parallel greedy sampling."""
++
++from __future__ import annotations
++
++import functools
++from collections.abc import Callable, Sequence
++
++import cuda.bindings.driver as cuda
++import cutlass
++import cutlass.cute as cute
++from cutlass import Float32, Int32, Int64, Uint32, Uint64
++from cutlass._mlir.dialects import llvm
++from cutlass.cutlass_dsl import T, dsl_user_op
++
++from b12x._lib.compiler import KernelCompileSpec
++from b12x._lib.compiler import compile as b12x_compile
++from b12x._lib.runtime_control import raise_if_kernel_resolution_frozen
++from b12x._lib.utils import current_cuda_stream, make_ptr
++
++
++ISLAND_SIZE = 4
++MAX_ISLANDS = 4
++MAX_WORLD_SIZE = ISLAND_SIZE * MAX_ISLANDS
++MAX_BATCH_SIZE = 8
++THREADS = 512
++SLOTS = 2
++
++# Every protocol flag occupies an independent 128-byte system-scope cache line.
++_GENERATION_OFFSET = 0
++_LOCAL_READY_OFFSET = 256
++_LOCAL_READY_BYTES = SLOTS * MAX_BATCH_SIZE * ISLAND_SIZE * 128
++_ISLAND_READY_OFFSET = _LOCAL_READY_OFFSET + _LOCAL_READY_BYTES
++_ISLAND_READY_BYTES = SLOTS * MAX_BATCH_SIZE * MAX_ISLANDS * 128
++_LOCAL_KEY_OFFSET = _ISLAND_READY_OFFSET + _ISLAND_READY_BYTES
++_ISLAND_KEY_OFFSET = _LOCAL_KEY_OFFSET + SLOTS * MAX_BATCH_SIZE * 8
++SLAB_BYTES = _ISLAND_KEY_OFFSET + SLOTS * MAX_BATCH_SIZE * 8
++
++
++@dsl_user_op
++def _atomic_add_global_u32(
++    address: Int64, value: Uint32, *, loc=None, ip=None
++) -> Uint32:
++    return Uint32(
++        llvm.inline_asm(
++            T.i32(),
++            [
++                Int64(address).ir_value(loc=loc, ip=ip),
++                Uint32(value).ir_value(loc=loc, ip=ip),
++            ],
++            "atom.global.add.u32 $0, [$1], $2;",
++            "=r,l,r",
++            has_side_effects=True,
++            is_align_stack=False,
++            asm_dialect=llvm.AsmDialect.AD_ATT,
++            loc=loc,
++            ip=ip,
++        )
++    )
++
++
++@dsl_user_op
++def _load_acquire_sys_u32(address: Int64, *, loc=None, ip=None) -> Uint32:
++    return Uint32(
++        llvm.inline_asm(
++            T.i32(),
++            [Int64(address).ir_value(loc=loc, ip=ip)],
++            "ld.acquire.sys.global.u32 $0, [$1];",
++            "=r,l",
++            has_side_effects=True,
++            is_align_stack=False,
++            asm_dialect=llvm.AsmDialect.AD_ATT,
++            loc=loc,
++            ip=ip,
++        )
++    )
++
++
++@dsl_user_op
++def _store_release_sys_u32(
++    address: Int64, value: Uint32, *, loc=None, ip=None
++) -> None:
++    llvm.inline_asm(
++        None,
++        [
++            Int64(address).ir_value(loc=loc, ip=ip),
++            Uint32(value).ir_value(loc=loc, ip=ip),
++        ],
++        "st.release.sys.global.u32 [$0], $1;",
++        "l,r",
++        has_side_effects=True,
++        is_align_stack=False,
++        asm_dialect=llvm.AsmDialect.AD_ATT,
++        loc=loc,
++        ip=ip,
++    )
++
++
++@dsl_user_op
++def _fence_sc_sys(*, loc=None, ip=None) -> None:
++    llvm.inline_asm(
++        None,
++        [],
++        "fence.sc.sys;",
++        "",
++        has_side_effects=True,
++        is_align_stack=False,
++        asm_dialect=llvm.AsmDialect.AD_ATT,
++        loc=loc,
++        ip=ip,
++    )
++
++
++@dsl_user_op
++def _nanosleep(cycles: Uint32, *, loc=None, ip=None) -> None:
++    llvm.inline_asm(
++        None,
++        [Uint32(cycles).ir_value(loc=loc, ip=ip)],
++        "nanosleep.u32 $0;",
++        "r",
++        has_side_effects=True,
++        is_align_stack=False,
++        asm_dialect=llvm.AsmDialect.AD_ATT,
++        loc=loc,
++        ip=ip,
++    )
++
++
++@dsl_user_op
++def _score_order_key(value: Float32, *, loc=None, ip=None) -> Uint32:
++    """Map an FP32 score to the exact greedy-sampling comparison order.
++
++    NaNs dominate finite values, positive and negative zero compare equal, and
++    unsigned integer order matches numeric order for every remaining value.
++    """
++
++    return Uint32(
++        llvm.inline_asm(
++            T.i32(),
++            [Float32(value).ir_value(loc=loc, ip=ip)],
++            """
++            {
++                .reg .pred is_nan, is_zero;
++                .reg .u32 bits, mask;
++                mov.b32 bits, $1;
++                shr.u32 mask, bits, 31;
++                mul.lo.u32 mask, mask, 0x7fffffff;
++                or.b32 mask, mask, 0x80000000;
++                xor.b32 $0, bits, mask;
++                setp.eq.f32 is_zero, $1, 0f00000000;
++                @is_zero mov.u32 $0, 0x80000000;
++                setp.nan.f32 is_nan, $1, $1;
++                @is_nan mov.u32 $0, 0xffffffff;
++            }
++            """,
++            "=r,f",
++            has_side_effects=False,
++            is_align_stack=False,
++            asm_dialect=llvm.AsmDialect.AD_ATT,
++            loc=loc,
++            ip=ip,
++        )
++    )
++
++
++@dsl_user_op
++def _warp_max_u64(value: Uint64, *, loc=None, ip=None) -> Uint64:
++    """Return the warp-wide unsigned maximum of a packed 64-bit key."""
++
++    return Uint64(
++        llvm.inline_asm(
++            T.i64(),
++            [Uint64(value).ir_value(loc=loc, ip=ip)],
++            """
++            {
++                .reg .pred high_matches;
++                .reg .u32 low, high, max_high, candidate_low, max_low;
++                mov.b64 {low, high}, $1;
++                redux.sync.max.u32 max_high, high, 0xffffffff;
++                setp.eq.u32 high_matches, high, max_high;
++                selp.u32 candidate_low, low, 0, high_matches;
++                redux.sync.max.u32 max_low, candidate_low, 0xffffffff;
++                mov.b64 $0, {max_low, max_high};
++            }
++            """,
++            "=l,l",
++            has_side_effects=True,
++            is_align_stack=False,
++            asm_dialect=llvm.AsmDialect.AD_ATT,
++            loc=loc,
++            ip=ip,
++        )
++    )
++
++
++@cute.jit
++def _wait_for(address: Int64, generation: Uint32, cycles: int) -> None:
++    observed = _load_acquire_sys_u32(address)
++    while observed != generation:
++        if cutlass.const_expr(cycles > 0):
++            _nanosleep(Uint32(cycles))
++        observed = _load_acquire_sys_u32(address)
++
++
++@cute.jit
++def _flag_address(
++    base: Int64,
++    region: int,
++    slot: Int32,
++    row: Int32,
++    index: Int32,
++) -> Int64:
++    return (
++        base
++        + Int64(region)
++        + (
++            (
++                Int64(slot) * Int64(MAX_BATCH_SIZE)
++                + Int64(row)
++            )
++            * Int64(ISLAND_SIZE)
++            + Int64(index)
++        )
++        * Int64(128)
++    )
++
++
++@cute.jit
++def _key_address(base: Int64, region: int, slot: Int32, row: Int32) -> Int64:
++    return (
++        base
++        + Int64(region)
++        + (
++            Int64(slot) * Int64(MAX_BATCH_SIZE) + Int64(row)
++        )
++        * Int64(8)
++    )
++
++
++@cute.jit
++def _pack_key(score: Float32, global_index: Int32) -> Uint64:
++    return (
++        Uint64(_score_order_key(score)) << Uint64(32)
++    ) | (Uint64(0xFFFFFFFF) - Uint64(global_index))
++
++
++@cute.jit
++def _key_index(key: Uint64) -> Int64:
++    return Int64(Uint64(0xFFFFFFFF) - (key & Uint64(0xFFFFFFFF)))
++
++
++class _VocabArgmaxLaunch:
++    def __init__(
++        self,
++        world_size: int,
++        rank: int,
++        *,
++        wait_nanosleep_cycles: int,
++    ) -> None:
++        self._world_size = int(world_size)
++        self._num_islands = self._world_size // ISLAND_SIZE
++        self._rank = int(rank)
++        self._island = self._rank // ISLAND_SIZE
++        self._local_rank = self._rank % ISLAND_SIZE
++        self._wait_nanosleep_cycles = int(wait_nanosleep_cycles)
++        if self._world_size not in (8, 12, 16):
++            raise ValueError(f"unsupported world size {self._world_size}")
++        if not 0 <= self._rank < self._world_size:
++            raise ValueError(
++                f"invalid rank {self._rank} for world size {self._world_size}"
++            )
++        if not 0 <= self._wait_nanosleep_cycles <= 1024:
++            raise ValueError("wait_nanosleep_cycles must be in [0, 1024]")
++
++    @cute.jit
++    def __call__(
++        self,
++        slab0: cute.Pointer,
++        slab1: cute.Pointer,
++        slab2: cute.Pointer,
++        slab3: cute.Pointer,
++        slab4: cute.Pointer,
++        slab5: cute.Pointer,
++        slab6: cute.Pointer,
++        slab7: cute.Pointer,
++        slab8: cute.Pointer,
++        slab9: cute.Pointer,
++        slab10: cute.Pointer,
++        slab11: cute.Pointer,
++        slab12: cute.Pointer,
++        slab13: cute.Pointer,
++        slab14: cute.Pointer,
++        slab15: cute.Pointer,
++        base: cute.Pointer,
++        bias: cute.Pointer,
++        output: cute.Pointer,
++        local_elements: Int64,
++        base_row_stride: Int64,
++        bias_row_stride: Int64,
++        batch: Int32,
++        stream: cuda.CUstream,
++    ) -> None:
++        self.kernel(
++            slab0,
++            slab1,
++            slab2,
++            slab3,
++            slab4,
++            slab5,
++            slab6,
++            slab7,
++            slab8,
++            slab9,
++            slab10,
++            slab11,
++            slab12,
++            slab13,
++            slab14,
++            slab15,
++            base,
++            bias,
++            output,
++            local_elements,
++            base_row_stride,
++            bias_row_stride,
++        ).launch(
++            grid=(batch, 1, 1),
++            block=(THREADS, 1, 1),
++            cluster=(1, 1, 1),
++            stream=stream,
++        )
++
++    @cute.kernel
++    def kernel(
++        self,
++        slab0: cute.Pointer,
++        slab1: cute.Pointer,
++        slab2: cute.Pointer,
++        slab3: cute.Pointer,
++        slab4: cute.Pointer,
++        slab5: cute.Pointer,
++        slab6: cute.Pointer,
++        slab7: cute.Pointer,
++        slab8: cute.Pointer,
++        slab9: cute.Pointer,
++        slab10: cute.Pointer,
++        slab11: cute.Pointer,
++        slab12: cute.Pointer,
++        slab13: cute.Pointer,
++        slab14: cute.Pointer,
++        slab15: cute.Pointer,
++        base: cute.Pointer,
++        bias: cute.Pointer,
++        output: cute.Pointer,
++        local_elements: Int64,
++        base_row_stride: Int64,
++        bias_row_stride: Int64,
++    ) -> None:
++        slabs = (
++            slab0,
++            slab1,
++            slab2,
++            slab3,
++            slab4,
++            slab5,
++            slab6,
++            slab7,
++            slab8,
++            slab9,
++            slab10,
++            slab11,
++            slab12,
++            slab13,
++            slab14,
++            slab15,
++        )
++        tidx, _, _ = cute.arch.thread_idx()
++        row, _, _ = cute.arch.block_idx()
++        lane = Int32(tidx) % Int32(32)
++        warp = Int32(tidx) // Int32(32)
++
++        initial = Uint64(_score_order_key(Float32(float("-inf")))) << Uint64(32)
++        best = initial
++        index = Int64(tidx)
++        base_offset = Int64(row) * base_row_stride
++        bias_offset = Int64(row) * bias_row_stride
++        while index < local_elements:
++            value = Float32(
++                cutlass.BFloat16(
++                    Float32(base[base_offset + index])
++                    + Float32(bias[bias_offset + index])
++                )
++            )
++            global_index = (
++                Int64(self._rank) * local_elements + index
++            )
++            candidate = _pack_key(value, Int32(global_index))
++            best = cutlass.max(best, candidate)
++            index += Int64(THREADS)
++        best = _warp_max_u64(best)
++
++        allocator = cutlass.utils.SmemAllocator()
++        warp_keys = allocator.allocate_tensor(
++            element_type=Uint64,
++            layout=cute.make_layout((THREADS // 32,)),
++            byte_alignment=16,
++        )
++        shared_generation = allocator.allocate_tensor(
++            element_type=Uint32,
++            layout=cute.make_layout((1,)),
++            byte_alignment=4,
++        )
++        if lane == Int32(0):
++            warp_keys[warp] = best
++        cute.arch.barrier()
++
++        block_key = initial
++        if warp == Int32(0):
++            if lane < Int32(THREADS // 32):
++                block_key = warp_keys[lane]
++            block_key = _warp_max_u64(block_key)
++        self_base = Int64(slabs[self._rank].toint())
++        if tidx == Int32(0):
++            generation = _atomic_add_global_u32(
++                self_base + Int64(row) * Int64(4), Uint32(1)
++            ) + Uint32(1)
++            shared_generation[0] = generation
++        cute.arch.barrier()
++
++        if tidx == Int32(0):
++            generation = Uint32(shared_generation[0])
++            slot = Int32(generation & Uint32(1))
++            local_key_ptr = cute.make_ptr(
++                Uint64,
++                _key_address(self_base, _LOCAL_KEY_OFFSET, slot, Int32(row)),
++                cute.AddressSpace.gmem,
++                assumed_align=8,
++            )
++            local_key_ptr[0] = block_key
++            _fence_sc_sys()
++
++            island_base_rank = self._island * ISLAND_SIZE
++            for peer_local in cutlass.range_constexpr(ISLAND_SIZE):
++                if cutlass.const_expr(peer_local != self._local_rank):
++                    peer_rank = island_base_rank + peer_local
++                    _store_release_sys_u32(
++                        _flag_address(
++                            Int64(slabs[peer_rank].toint()),
++                            _LOCAL_READY_OFFSET,
++                            slot,
++                            Int32(row),
++                            Int32(self._local_rank),
++                        ),
++                        generation,
++                    )
++            for peer_local in cutlass.range_constexpr(ISLAND_SIZE):
++                if cutlass.const_expr(peer_local != self._local_rank):
++                    _wait_for(
++                        _flag_address(
++                            self_base,
++                            _LOCAL_READY_OFFSET,
++                            slot,
++                            Int32(row),
++                            Int32(peer_local),
++                        ),
++                        generation,
++                        self._wait_nanosleep_cycles,
++                    )
++
++            island_key = initial
++            for peer_local in cutlass.range_constexpr(ISLAND_SIZE):
++                peer_rank = island_base_rank + peer_local
++                peer_key_ptr = cute.make_ptr(
++                    Uint64,
++                    _key_address(
++                        Int64(slabs[peer_rank].toint()),
++                        _LOCAL_KEY_OFFSET,
++                        slot,
++                        Int32(row),
++                    ),
++                    cute.AddressSpace.gmem,
++                    assumed_align=8,
++                )
++                island_key = cutlass.max(island_key, peer_key_ptr[0])
++            island_key_ptr = cute.make_ptr(
++                Uint64,
++                _key_address(self_base, _ISLAND_KEY_OFFSET, slot, Int32(row)),
++                cute.AddressSpace.gmem,
++                assumed_align=8,
++            )
++            island_key_ptr[0] = island_key
++            _fence_sc_sys()
++
++            for peer_island in cutlass.range_constexpr(MAX_ISLANDS):
++                if cutlass.const_expr(peer_island < self._num_islands):
++                    if cutlass.const_expr(peer_island != self._island):
++                        peer_rank = peer_island * ISLAND_SIZE + self._local_rank
++                        _store_release_sys_u32(
++                            _flag_address(
++                                Int64(slabs[peer_rank].toint()),
++                                _ISLAND_READY_OFFSET,
++                                slot,
++                                Int32(row),
++                                Int32(self._island),
++                            ),
++                            generation,
++                        )
++            for peer_island in cutlass.range_constexpr(MAX_ISLANDS):
++                if cutlass.const_expr(peer_island < self._num_islands):
++                    if cutlass.const_expr(peer_island != self._island):
++                        _wait_for(
++                            _flag_address(
++                                self_base,
++                                _ISLAND_READY_OFFSET,
++                                slot,
++                                Int32(row),
++                                Int32(peer_island),
++                            ),
++                            generation,
++                            self._wait_nanosleep_cycles,
++                        )
++
++            global_key = initial
++            for peer_island in cutlass.range_constexpr(MAX_ISLANDS):
++                if cutlass.const_expr(peer_island < self._num_islands):
++                    peer_rank = peer_island * ISLAND_SIZE + self._local_rank
++                    peer_key_ptr = cute.make_ptr(
++                        Uint64,
++                        _key_address(
++                            Int64(slabs[peer_rank].toint()),
++                            _ISLAND_KEY_OFFSET,
++                            slot,
++                            Int32(row),
++                        ),
++                        cute.AddressSpace.gmem,
++                        assumed_align=8,
++                    )
++                    global_key = cutlass.max(global_key, peer_key_ptr[0])
++            output[Int64(row)] = _key_index(global_key)
++
++
++@functools.cache
++def get_vocab_argmax_launcher(
++    world_size: int,
++    rank: int,
++    device_index: int,
++    *,
++    wait_nanosleep_cycles: int,
++) -> Callable[..., None]:
++    """Return a rank-specialized launcher for TP8, TP12, or TP16."""
++
++    del device_index  # retained in the process-local cache key
++    launch = _VocabArgmaxLaunch(
++        world_size,
++        rank,
++        wait_nanosleep_cycles=wait_nanosleep_cycles,
++    )
++    cache_key = (
++        int(world_size),
++        int(rank),
++        int(wait_nanosleep_cycles),
++    )
++    raise_if_kernel_resolution_frozen(
++        "cute.compile", target=launch, cache_key=cache_key
++    )
++    slab_placeholder = make_ptr(
++        cutlass.Uint8,
++        256,
++        cute.AddressSpace.gmem,
++        assumed_align=256,
++    )
++    raw = b12x_compile(
++        launch,
++        *(slab_placeholder for _ in range(MAX_WORLD_SIZE)),
++        make_ptr(cutlass.BFloat16, 16, cute.AddressSpace.gmem, assumed_align=2),
++        make_ptr(cutlass.BFloat16, 16, cute.AddressSpace.gmem, assumed_align=2),
++        make_ptr(cutlass.Int64, 16, cute.AddressSpace.gmem, assumed_align=8),
++        1,
++        1,
++        1,
++        1,
++        current_cuda_stream(),
++        compile_spec=KernelCompileSpec.from_key(
++            "comm.pcie.vocab_argmax.bf16",
++            1,
++            cache_key,
++            labels=("world_size", "rank", "wait_nanosleep_cycles"),
++        ),
++    )
++
++    def run(
++        slab_addresses: Sequence[int],
++        base_address: int,
++        bias_address: int,
++        output_address: int,
++        local_elements: int,
++        base_row_stride: int,
++        bias_row_stride: int,
++        batch: int,
++    ) -> None:
++        if len(slab_addresses) != world_size:
++            raise ValueError(
++                f"expected {world_size} slab addresses, got {len(slab_addresses)}"
++            )
++        padded_slabs = tuple(int(address) for address in slab_addresses) + (
++            0,
++        ) * (MAX_WORLD_SIZE - world_size)
++        raw(
++            *(
++                make_ptr(
++                    cutlass.Uint8,
++                    address,
++                    cute.AddressSpace.gmem,
++                    assumed_align=256,
++                )
++                for address in padded_slabs
++            ),
++            make_ptr(
++                cutlass.BFloat16,
++                base_address,
++                cute.AddressSpace.gmem,
++                assumed_align=2,
++            ),
++            make_ptr(
++                cutlass.BFloat16,
++                bias_address,
++                cute.AddressSpace.gmem,
++                assumed_align=2,
++            ),
++            make_ptr(
++                cutlass.Int64,
++                output_address,
++                cute.AddressSpace.gmem,
++                assumed_align=8,
++            ),
++            local_elements,
++            base_row_stride,
++            bias_row_stride,
++            batch,
++            current_cuda_stream(),
++        )
++
++    return run
++
++
++__all__ = ["SLAB_BYTES", "get_vocab_argmax_launcher"]
+diff --git a/b12x/comm/pcie/api.py b/b12x/comm/pcie/api.py
+index 098d100320990f7b8bb4bf4ecd228688ccbc2f79..2873e175902b394d8944a72c081699a9082d35ce 100644
+--- a/b12x/comm/pcie/api.py
++++ b/b12x/comm/pcie/api.py
+@@ -13,7 +13,9 @@ from .pcie_dcp_a2a import (
+     PCIeDCPA2APool as DcpAllToAllPool,
+ )
+ from .pcie_dcp_a2a import (
++    kimi_topk16,
+     lse_reduce_scatter_reference,
++    prepare_kimi_topk16,
+ )
+ from .pcie_dcp_topk import (
+     PCIeDCPTopKOwnerExchange as DcpTopKOwnerExchange,
+@@ -37,6 +39,9 @@ from .pcie_oneshot import (
+ from .pcie_twoshot import (
+     PCIeTwoShotSP as TwoShotReduceScatter,
+ )
++from .pcie_vocab_argmax import (
++    PCIeVocabParallelArgmax as VocabParallelArgmax,
++)
+ 
+ 
+ def is_supported(device=None) -> bool:
+@@ -59,6 +64,9 @@ __all__ = [
+     "DcpAllToAll",
+     "DcpAllToAllPool",
+     "DcpTopKOwnerExchange",
++    "VocabParallelArgmax",
++    "kimi_topk16",
++    "prepare_kimi_topk16",
+     "autotune_dma_crossovers",
+     "parse_oneshot_max_size",
+     "lse_reduce_scatter_reference",
+diff --git a/b12x/comm/pcie/pcie_allreduce.py b/b12x/comm/pcie/pcie_allreduce.py
+index f97b314af912aae858ee69251bd692ecfeca4127..973d47077ae5f6196ddaed7cd6f68b1b04a812f9 100644
+--- a/b12x/comm/pcie/pcie_allreduce.py
++++ b/b12x/comm/pcie/pcie_allreduce.py
+@@ -2,7 +2,10 @@
+ 
+ from __future__ import annotations
+ 
+-from contextlib import contextmanager
++import logging
++import os
++
++from contextlib import ExitStack, contextmanager
+ from typing import Any, Optional, Sequence
+ 
+ import torch
+@@ -15,6 +18,18 @@ from .pcie_hierarchical import (
+ from .pcie_hierarchical import (
+     PCIeHierarchicalAllReduce,
+ )
++from .pcie_island_rs import (
++    CROSSOVER_ELEMENTS as ISLAND_RS_CROSSOVER_ELEMENTS,
++)
++from .pcie_island_rs import (
++    PREFERRED_ALIGNMENT_ELEMENTS as ISLAND_RS_PREFERRED_ALIGNMENT_ELEMENTS,
++)
++from .pcie_island_rs import (
++    SUPPORTED_WORLD_SIZES as ISLAND_RS_WORLD_SIZES,
++)
++from .pcie_island_rs import (
++    PCIeIslandRSAllReduce,
++)
+ from .pcie_oneshot import (
+     DEFAULT_MAX_SIZE,
+     DEFAULT_RANK_DATA_BYTES,
+@@ -23,6 +38,41 @@ from .pcie_oneshot import (
+ )
+ 
+ 
++logger = logging.getLogger(__name__)
++
++
++# Maximum message capacity qualified for the TP16 island runtime. Callers use
++# this shared policy instead of duplicating an implementation-specific limit.
++ISLAND_RS_MAX_BYTES = 160 * 1024
++
++
++def _algorithm_override() -> str:
++    """Select the established runtime or enable size-routed island dispatch."""
++
++    choice = os.getenv("B12X_PCIE_ALLREDUCE_ALGORITHM", "auto").strip().lower()
++    if choice not in ("auto", "hierarchical", "island_rs"):
++        raise ValueError(
++            "B12X_PCIE_ALLREDUCE_ALGORITHM must be auto, hierarchical or "
++            f"island_rs, got {choice!r}"
++        )
++    return choice
++
++
++def recommended_max_bytes(world_size: int, *, default: int = DEFAULT_MAX_SIZE) -> int:
++    """Largest all-reduce this runtime expects to win at, for this world size.
++
++    Callers that force the equal-quarter implementation advertise its complete
++    qualified capacity. Automatic consumers retain their existing limit
++    because a CUDA-graph caller without explicit output storage cannot use the
++    equal-quarter implementation for large messages and may otherwise replace
++    a faster fallback collective with hierarchical all-reduce.
++    """
++
++    if world_size in ISLAND_RS_WORLD_SIZES and _algorithm_override() == "island_rs":
++        return max(default, ISLAND_RS_MAX_BYTES)
++    return default
++
++
+ MAX_DIRECT_WORLD_SIZE = 8
+ DIRECT_WORLD_SIZES = tuple(
+     world_size
+@@ -52,8 +102,29 @@ class PCIeAllReduce:
+     connection limit.
+     """
+ 
+-    def __init__(self, runtime: Any, algorithm: str) -> None:
++    def __init__(
++        self,
++        runtime: Any,
++        algorithm: str,
++        island_rs: Any = None,
++        *,
++        algorithm_override: Optional[str] = None,
++    ) -> None:
+         self._runtime = runtime
++        # Optional second implementation for the same world. When present the
++        # dispatcher routes by message size instead of exposing a knob.
++        self._island_rs = island_rs
++        resolved_override = (
++            _algorithm_override()
++            if algorithm_override is None
++            else str(algorithm_override)
++        )
++        if resolved_override not in ("auto", "hierarchical", "island_rs"):
++            raise ValueError(
++                "algorithm_override must be auto, hierarchical or island_rs, "
++                f"got {resolved_override!r}"
++            )
++        self._algorithm_override = resolved_override
+         self.algorithm = algorithm
+         self.rank = runtime.rank
+         self.world_size = runtime.world_size
+@@ -70,9 +141,11 @@ class PCIeAllReduce:
+         rank_data_bytes: int = DEFAULT_RANK_DATA_BYTES,
+         ext_module=None,
+         single_channel: bool = False,
++        max_concurrent_channels: int = 1,
+     ) -> "PCIeAllReduce":
+         world_size = dist.get_world_size(group=exchange_group)
+         algorithm = _algorithm_for_world_size(world_size)
++        algorithm_override = _algorithm_override()
+         if algorithm == "oneshot":
+             runtime = PCIeOneshotAllReducePool.from_exchange_group(
+                 exchange_group=exchange_group,
+@@ -82,8 +155,13 @@ class PCIeAllReduce:
+                 rank_data_bytes=rank_data_bytes,
+                 ext_module=ext_module,
+                 single_channel=single_channel,
++                max_concurrent_channels=max_concurrent_channels,
+             )
+         else:
++            if int(max_concurrent_channels) != 1:
++                raise ValueError(
++                    "hierarchical all-reduce supports exactly one concurrent channel"
++                )
+             if max_size < torch.bfloat16.itemsize:
+                 raise ValueError("max_size must hold at least one BF16 element")
+             runtime = PCIeHierarchicalAllReduce(
+@@ -92,7 +170,60 @@ class PCIeAllReduce:
+                 max_elements=max_size // torch.bfloat16.itemsize,
+                 ext_module=ext_module,
+             )
+-        return cls(runtime, algorithm)
++        island_rs = cls._maybe_island_rs(
++            exchange_group=exchange_group,
++            device=device,
++            max_size=max_size,
++            algorithm_override=algorithm_override,
++        )
++        return cls(
++            runtime,
++            algorithm,
++            island_rs,
++            algorithm_override=algorithm_override,
++        )
++
++    @staticmethod
++    def _maybe_island_rs(
++        *,
++        exchange_group: ProcessGroup,
++        device: torch.device | int | str,
++        max_size: int,
++        algorithm_override: str,
++    ) -> Any:
++        """Attach the equal-quarter runtime after an explicit policy opt-in.
++
++        Opt-in capacity includes :data:`ISLAND_RS_MAX_BYTES` independently of
++        the caller's ``max_size``. A coordinated construction failure leaves
++        every rank on the hierarchical runtime and records the reason in the
++        process log.
++        """
++
++        world_size = dist.get_world_size(group=exchange_group)
++        if world_size not in ISLAND_RS_WORLD_SIZES:
++            return None
++        # The equal-quarter runtime owns an additional CUDA IPC slab and has a
++        # stricter CUDA-graph output contract than the hierarchical runtime.
++        # Construct it only for an explicit opt-in so unrelated auxiliary IPC
++        # collectives retain the established peer-mapping and setup behavior.
++        if algorithm_override != "island_rs":
++            return None
++        capacity = max(int(max_size), ISLAND_RS_MAX_BYTES)
++        elements = capacity // torch.bfloat16.itemsize
++        try:
++            return PCIeIslandRSAllReduce(
++                exchange_group=exchange_group,
++                device=device,
++                max_elements=elements - (elements % 2),
++            )
++        except RuntimeError as exc:
++            if dist.get_rank(group=exchange_group) == 0:
++                logger.warning(
++                    "PCIe island reduce-scatter is unavailable; using the "
++                    "hierarchical all-reduce runtime: %s",
++                    exc,
++                )
++            return None
+ 
+     @classmethod
+     def from_process_group(
+@@ -106,6 +237,7 @@ class PCIeAllReduce:
+         rank_data_bytes: int = DEFAULT_RANK_DATA_BYTES,
+         ext_module=None,
+         single_channel: bool = False,
++        max_concurrent_channels: int = 1,
+     ) -> "PCIeAllReduce":
+         return cls.from_exchange_group(
+             exchange_group=process_group,
+@@ -117,6 +249,7 @@ class PCIeAllReduce:
+             rank_data_bytes=rank_data_bytes,
+             ext_module=ext_module,
+             single_channel=single_channel,
++            max_concurrent_channels=max_concurrent_channels,
+         )
+ 
+     @property
+@@ -125,8 +258,55 @@ class PCIeAllReduce:
+ 
+         return self.algorithm == "oneshot"
+ 
+-    def for_stream(self, stream: object = None):
+-        return self._runtime.for_stream(stream)
++    def prepare_channels(self, channel_ids: Sequence[str]) -> None:
++        """Prepare the runtime's semantic channel owners."""
++        self._runtime.prepare_channels(channel_ids)
++        if self._island_rs is not None:
++            self._island_rs.prepare_channels(channel_ids)
++
++    def for_stream(
++        self,
++        stream: object = None,
++        *,
++        channel_id: Optional[str] = None,
++    ):
++        if self._island_rs is not None:
++            self._island_rs.for_stream(stream, channel_id=channel_id)
++        return self._runtime.for_stream(stream, channel_id=channel_id)
++
++    def _use_island_rs(
++        self,
++        inp: torch.Tensor,
++    ) -> bool:
++        """Route aligned large messages to the equal-quarter runtime.
++
++        Small ones stay on the hierarchy, whose critical path is shorter for the
++        ranks that are not the island leader. Unaligned quarters also stay on
++        the hierarchy because the equal-quarter kernel's partial transfer group
++        costs more than the leader path. Large aligned vectors would otherwise
++        funnel the whole vector through the island leader's PCIe link.
++        """
++
++        if self._island_rs is None:
++            return False
++        override = self._algorithm_override
++        if override == "hierarchical":
++            return False
++        island_accepts = self._island_rs.should_allreduce(inp)
++        if not island_accepts:
++            return False
++        hierarchy_accepts = self._runtime.should_allreduce(inp)
++        if not hierarchy_accepts:
++            return True
++        return (
++            inp.numel() > ISLAND_RS_CROSSOVER_ELEMENTS
++            and inp.numel() % ISLAND_RS_PREFERRED_ALIGNMENT_ELEMENTS == 0
++        )
++
++    def should_allreduce(self, inp: torch.Tensor) -> bool:
++        if self._runtime.should_allreduce(inp):
++            return True
++        return self._use_island_rs(inp)
+ 
+     def all_reduce(
+         self,
+@@ -136,17 +316,27 @@ class PCIeAllReduce:
+         peer_input_ptrs: Optional[Sequence[int]] = None,
+         blocks: Optional[int] = None,
+         stream: object = None,
++        channel_id: Optional[str] = None,
+     ) -> torch.Tensor:
+         if self.algorithm == "hierarchical":
+             if peer_input_ptrs is not None:
+                 raise ValueError(
+                     "peer_input_ptrs are unavailable for hierarchical all-reduce"
+                 )
++            if self._use_island_rs(inp):
++                return self._island_rs.all_reduce(
++                    inp,
++                    out=out,
++                    blocks=blocks,
++                    stream=stream,
++                    channel_id=channel_id,
++                )
+             return self._runtime.all_reduce(
+                 inp,
+                 out=out,
+                 blocks=blocks,
+                 stream=stream,
++                channel_id=channel_id,
+             )
+         if blocks is not None:
+             raise ValueError("blocks is only available for hierarchical all-reduce")
+@@ -155,14 +345,32 @@ class PCIeAllReduce:
+             out=out,
+             peer_input_ptrs=peer_input_ptrs,
+             stream=stream,
++            channel_id=channel_id,
+         )
+ 
+     @contextmanager
+-    def capture(self, stream: object = None):
+-        with self._runtime.capture(stream=stream) as runtime:
+-            yield runtime
++    def capture(
++        self,
++        stream: object = None,
++        *,
++        channel_id: Optional[str] = None,
++    ):
++        with ExitStack() as stack:
++            stack.enter_context(
++                self._runtime.capture(stream=stream, channel_id=channel_id)
++            )
++            if self._island_rs is not None:
++                stack.enter_context(
++                    self._island_rs.capture(stream=stream, channel_id=channel_id)
++                )
++            # Callers must retain message-size dispatch while recording a
++            # graph; yielding the hierarchy would bypass the island runtime.
++            yield self
+ 
+     def close(self) -> None:
++        if self._island_rs is not None:
++            self._island_rs.close()
++            self._island_rs = None
+         self._runtime.close()
+ 
+     def __getattr__(self, name: str):
+diff --git a/b12x/comm/pcie/pcie_dcp_a2a.py b/b12x/comm/pcie/pcie_dcp_a2a.py
+index 7806c18cbd310ed32a52093e928e6d778b709a9b..7d77b9e94834fb14cd252acaf978d90b17969608 100644
+--- a/b12x/comm/pcie/pcie_dcp_a2a.py
++++ b/b12x/comm/pcie/pcie_dcp_a2a.py
+@@ -75,6 +75,107 @@ def _is_supported_bhd_layout(tensor: torch.Tensor) -> bool:
+     return packed_token_major or capacity_strided_head_major
+ 
+ 
++def prepare_kimi_topk16(
++    *,
++    device: torch.device | int | str,
++    threads: int = 256,
++) -> None:
++    """Compile the stateless Kimi-K3 top-16 launcher before graph capture."""
++
++    device_obj = _normalize_device(device)
++    if device_obj.type != "cuda":
++        raise ValueError("Kimi top-16 requires a CUDA device")
++    if _is_current_stream_capturing(device_obj):
++        raise RuntimeError("prepare_kimi_topk16() must run before capture")
++    from ._dcp_a2a_cute import _get_compiled_kimi_topk16
++
++    with torch.cuda.device(device_obj):
++        _get_compiled_kimi_topk16(threads)
++
++
++def kimi_topk16(
++    router_logits: torch.Tensor,
++    correction_bias: torch.Tensor,
++    output_weights: Optional[torch.Tensor] = None,
++    output_ids: Optional[torch.Tensor] = None,
++    *,
++    threads: int = 256,
++) -> tuple[torch.Tensor, torch.Tensor]:
++    """Select Kimi-K3's 16 routed experts without communication state.
++
++    The operation accepts one to eight assembled FP32 router rows. It launches
++    on the current CUDA stream and is CUDA-graph safe after an eager launch or
++    :func:`prepare_kimi_topk16`. Graph capture requires caller-owned outputs.
++    """
++
++    if router_logits.ndim != 2:
++        raise ValueError("router_logits must be a contiguous rank-2 tensor")
++    rows = int(router_logits.shape[0])
++    if rows < 1 or rows > 8:
++        raise ValueError(f"Kimi top-16 rows {rows} must be between 1 and 8")
++    device = router_logits.device
++    if device.type != "cuda":
++        raise ValueError("Kimi top-16 requires CUDA tensors")
++    expected = (
++        (router_logits, (rows, 896), torch.float32, "router_logits"),
++        (correction_bias, (896,), torch.float32, "correction_bias"),
++    )
++    for value, shape, dtype, name in expected:
++        if (
++            value.device != device
++            or value.shape != shape
++            or value.dtype != dtype
++            or not value.is_contiguous()
++        ):
++            raise ValueError(f"{name} must be contiguous {shape} {dtype} on {device}")
++
++    capturing = _is_current_stream_capturing(device)
++    if capturing and (output_weights is None or output_ids is None):
++        raise RuntimeError(
++            "Kimi top-16 CUDA graph capture requires caller-owned "
++            "output_weights and output_ids"
++        )
++    if output_weights is None:
++        output_weights = torch.empty((rows, 16), device=device, dtype=torch.float32)
++    if output_ids is None:
++        output_ids = torch.empty((rows, 16), device=device, dtype=torch.int32)
++    outputs = (
++        (output_weights, torch.float32, "output_weights"),
++        (output_ids, torch.int32, "output_ids"),
++    )
++    for value, dtype, name in outputs:
++        if (
++            value.device != device
++            or value.shape != (rows, 16)
++            or value.dtype != dtype
++            or not value.is_contiguous()
++        ):
++            raise ValueError(
++                f"{name} must be contiguous {(rows, 16)} {dtype} on {device}"
++            )
++    if capturing:
++        from ._dcp_a2a_cute import is_kimi_topk16_prepared
++
++        if not is_kimi_topk16_prepared(threads):
++            raise RuntimeError(
++                "cold Kimi top-16 CUDA graph capture is not allowed; call "
++                "prepare_kimi_topk16() before capture"
++            )
++
++    from ._dcp_a2a_cute import kimi_topk16 as launch_kimi_topk16
++
++    with torch.cuda.device(device):
++        launch_kimi_topk16(
++            router_logits_ptr=router_logits.data_ptr(),
++            correction_bias_ptr=correction_bias.data_ptr(),
++            output_weights_ptr=output_weights.data_ptr(),
++            output_ids_ptr=output_ids.data_ptr(),
++            rows=rows,
++            threads=threads,
++        )
++    return output_weights, output_ids
++
++
+ @dataclass(frozen=True)
+ class _StagingLayout:
+     signal_bytes: int
+@@ -753,10 +854,13 @@ class PCIeDCPA2A:
+             )
+ 
+     def prepare_graph_all_gather_pair_kimi_topk(self) -> None:
+-        """Compile/load the TP16 Kimi fused launcher before graph capture."""
++        """Compile/load the Kimi fused launcher before graph capture."""
+ 
+-        if self.world_size != 16:
+-            raise ValueError("Kimi paired gather+top-k requires TP16")
++        if self.world_size not in SUPPORTED_WORLD_SIZES:
++            raise ValueError(
++                "Kimi paired gather+top-k requires a supported PCIe DCP "
++                f"world size, got {self.world_size}"
++            )
+         if _is_current_stream_capturing(self.device):
+             raise RuntimeError(
+                 "prepare_graph_all_gather_pair_kimi_topk() must run before capture"
+@@ -764,7 +868,25 @@ class PCIeDCPA2A:
+         from ._dcp_a2a_cute import _get_compiled_all_gather_pair
+ 
+         with torch.cuda.device(self.device):
+-            _get_compiled_all_gather_pair(16, self.rank, 512, True, True)
++            _get_compiled_all_gather_pair(
++                self.world_size,
++                self.rank,
++                512,
++                True,
++                True,
++            )
++
++    def prepare_graph_kimi_topk16(self, *, threads: int = 256) -> None:
++        """Compile/load batched Kimi expert selection before graph capture."""
++
++        if _is_current_stream_capturing(self.device):
++            raise RuntimeError(
++                "prepare_graph_kimi_topk16() must run before capture"
++            )
++        from ._dcp_a2a_cute import _get_compiled_kimi_topk16
++
++        with torch.cuda.device(self.device):
++            _get_compiled_kimi_topk16(threads)
+ 
+     def _validate(
+         self,
+@@ -1270,15 +1392,30 @@ class PCIeDCPA2A:
+         topk_weights: Optional[torch.Tensor] = None,
+         topk_ids: Optional[torch.Tensor] = None,
+     ) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor]:
+-        """Gather Kimi-K3's TP16 latent row and select its 16 experts."""
++        """Gather Kimi-K3's sharded latent row and select its 16 experts."""
+         self._check_stream()
+         if self._closed:
+             raise RuntimeError("PCIeDCPA2A is closed")
+-        if self.world_size != 16:
+-            raise ValueError("Kimi paired gather+top-k requires TP16")
++        if self.world_size not in SUPPORTED_WORLD_SIZES:
++            raise ValueError(
++                "Kimi paired gather+top-k requires a supported PCIe DCP "
++                f"world size, got TP{self.world_size}"
++            )
++        local_down_width = 3584 // self.world_size
++        local_router_width = 896 // self.world_size
+         expected = (
+-            (local_down, (1, 224), torch.bfloat16, "local_down"),
+-            (local_router, (1, 56), torch.float32, "local_router"),
++            (
++                local_down,
++                (1, local_down_width),
++                torch.bfloat16,
++                "local_down",
++            ),
++            (
++                local_router,
++                (1, local_router_width),
++                torch.float32,
++                "local_router",
++            ),
+             (correction_bias, (896,), torch.float32, "correction_bias"),
+         )
+         for value, shape, dtype, name in expected:
+@@ -1317,7 +1454,7 @@ class PCIeDCPA2A:
+             from ._dcp_a2a_cute import is_all_gather_pair_prepared
+ 
+             if not is_all_gather_pair_prepared(
+-                16,
++                self.world_size,
+                 self.rank,
+                 512,
+                 True,
+@@ -1363,6 +1500,7 @@ class PCIeDCPA2A:
+ 
+         with torch.cuda.device(self.device):
+             all_gather_pair_kimi_topk(
++                world_size=self.world_size,
+                 rank=self.rank,
+                 local_down_ptr=local_down.data_ptr(),
+                 local_router_ptr=local_router.data_ptr(),
+@@ -1378,6 +1516,125 @@ class PCIeDCPA2A:
+                 ),
+             )
+ 
++    def kimi_topk16(
++        self,
++        router_logits: torch.Tensor,
++        correction_bias: torch.Tensor,
++        output_weights: Optional[torch.Tensor] = None,
++        output_ids: Optional[torch.Tensor] = None,
++        *,
++        threads: int = 256,
++    ) -> tuple[torch.Tensor, torch.Tensor]:
++        """Select Kimi-K3's 16 routed experts for one to eight tokens."""
++
++        with _device_guard(self.device):
++            self._check_stream()
++            if self._closed:
++                raise RuntimeError("PCIeDCPA2A is closed")
++            if router_logits.ndim != 2:
++                raise ValueError(
++                    "router_logits must be a contiguous rank-2 tensor"
++                )
++            rows = int(router_logits.shape[0])
++            capacity = min(self.max_batch_size, 8)
++            if rows <= 0 or rows > capacity:
++                raise ValueError(
++                    f"Kimi top-16 rows {rows} must be between 1 and the "
++                    f"supported capacity {capacity}"
++                )
++            expected = (
++                (
++                    router_logits,
++                    (rows, 896),
++                    torch.float32,
++                    "router_logits",
++                ),
++                (
++                    correction_bias,
++                    (896,),
++                    torch.float32,
++                    "correction_bias",
++                ),
++            )
++            for value, shape, dtype, name in expected:
++                if (
++                    value.device != self.device
++                    or value.shape != shape
++                    or value.dtype != dtype
++                    or not value.is_contiguous()
++                ):
++                    raise ValueError(
++                        f"{name} must be contiguous {shape} {dtype} on "
++                        f"{self.device}"
++                    )
++            capturing = _is_current_stream_capturing(self.device)
++            if capturing and (output_weights is None or output_ids is None):
++                raise RuntimeError(
++                    "Kimi top-16 CUDA graph capture requires caller-owned "
++                    "output_weights and output_ids"
++                )
++            if output_weights is None:
++                output_weights = torch.empty(
++                    (rows, 16), device=self.device, dtype=torch.float32
++                )
++            if output_ids is None:
++                output_ids = torch.empty(
++                    (rows, 16), device=self.device, dtype=torch.int32
++                )
++            outputs = (
++                (output_weights, torch.float32, "output_weights"),
++                (output_ids, torch.int32, "output_ids"),
++            )
++            for value, dtype, name in outputs:
++                if (
++                    value.device != self.device
++                    or value.shape != (rows, 16)
++                    or value.dtype != dtype
++                    or not value.is_contiguous()
++                ):
++                    raise ValueError(
++                        f"{name} must be contiguous {(rows, 16)} {dtype} on "
++                        f"{self.device}"
++                    )
++            if capturing:
++                from ._dcp_a2a_cute import is_kimi_topk16_prepared
++
++                if not is_kimi_topk16_prepared(threads):
++                    raise RuntimeError(
++                        "cold PCIe DCP Kimi top-16 CUDA graph capture is not "
++                        "allowed; call prepare_graph_kimi_topk16() before "
++                        "capture"
++                    )
++            self._launch_kimi_topk16(
++                router_logits,
++                correction_bias,
++                output_weights,
++                output_ids,
++                threads=threads,
++            )
++            return output_weights, output_ids
++
++    def _launch_kimi_topk16(
++        self,
++        router_logits: torch.Tensor,
++        correction_bias: torch.Tensor,
++        output_weights: torch.Tensor,
++        output_ids: torch.Tensor,
++        *,
++        threads: int,
++    ) -> None:
++        from ._dcp_a2a_cute import kimi_topk16
++
++        with torch.cuda.device(self.device):
++            kimi_topk16(
++                router_logits_ptr=router_logits.data_ptr(),
++                correction_bias_ptr=correction_bias.data_ptr(),
++                output_weights_ptr=output_weights.data_ptr(),
++                output_ids_ptr=output_ids.data_ptr(),
++                rows=int(router_logits.shape[0]),
++                threads=threads,
++            )
++
+     def _closed_import_indices(self) -> set[tuple[int, int]]:
+         closed = getattr(self, "_closed_ipc_import_indices", None)
+         if closed is None:
+@@ -1922,6 +2179,20 @@ class PCIeDCPA2APool:
+                 stream, channel_id=channel_id
+             ).prepare_graph_all_gather_pair_kimi_topk()
+ 
++    def prepare_graph_kimi_topk16(
++        self,
++        *,
++        threads: int = 256,
++        stream: object = None,
++        channel_id: Optional[str] = None,
++    ) -> None:
++        """Prepare batched Kimi expert selection before graph capture."""
++
++        with _device_guard(self.device):
++            self.for_stream(
++                stream, channel_id=channel_id
++            ).prepare_graph_kimi_topk16(threads=threads)
++
+     def lse_reduce_scatter(
+         self,
+         partial_output: torch.Tensor,
+@@ -2085,6 +2356,35 @@ class PCIeDCPA2APool:
+             topk_ids,
+         )
+ 
++    def kimi_topk16(
++        self,
++        router_logits: torch.Tensor,
++        correction_bias: torch.Tensor,
++        output_weights: Optional[torch.Tensor] = None,
++        output_ids: Optional[torch.Tensor] = None,
++        *,
++        threads: int = 256,
++        stream: object = None,
++        channel_id: Optional[str] = None,
++    ) -> tuple[torch.Tensor, torch.Tensor]:
++        channel = self.for_stream(stream, channel_id=channel_id)
++        if stream is not None and self.device.type == "cuda":
++            with torch.cuda.stream(stream):
++                return channel.kimi_topk16(
++                    router_logits,
++                    correction_bias,
++                    output_weights,
++                    output_ids,
++                    threads=threads,
++                )
++        return channel.kimi_topk16(
++            router_logits,
++            correction_bias,
++            output_weights,
++            output_ids,
++            threads=threads,
++        )
++
+     @contextmanager
+     def capture(self, stream: object = None, *, channel_id: Optional[str] = None):
+         """Bind capture to a globally named channel.
+@@ -2211,5 +2511,7 @@ __all__ = [
+     "PCIeDCPA2A",
+     "PCIeDCPA2APool",
+     "SUPPORTED_WORLD_SIZES",
++    "kimi_topk16",
+     "lse_reduce_scatter_reference",
++    "prepare_kimi_topk16",
+ ]
+diff --git a/b12x/comm/pcie/pcie_hierarchical.py b/b12x/comm/pcie/pcie_hierarchical.py
+index 01dfd729689e5a6f9fe433e55b77331137a484ec..6dd0d1a4d34dac851e746539fd5284151f425cd6 100644
+--- a/b12x/comm/pcie/pcie_hierarchical.py
++++ b/b12x/comm/pcie/pcie_hierarchical.py
+@@ -13,7 +13,7 @@ from __future__ import annotations
+ import os
+ from contextlib import contextmanager, suppress
+ from dataclasses import dataclass
+-from typing import Optional
++from typing import Optional, Sequence
+ 
+ import torch
+ import torch.distributed as dist
+@@ -282,8 +282,9 @@ class PCIeHierarchicalAllReduce:
+         out: Optional[torch.Tensor] = None,
+         blocks: Optional[int] = None,
+         stream: object = None,
++        channel_id: Optional[str] = None,
+     ) -> torch.Tensor:
+-        del stream
++        del stream, channel_id
+         if not self.should_allreduce(inp):
+             raise ValueError(
+                 "input does not satisfy hierarchical all-reduce requirements "
+@@ -337,7 +338,22 @@ class PCIeHierarchicalAllReduce:
+             )
+         return out
+ 
+-    def for_stream(self, stream: object = None) -> "PCIeHierarchicalAllReduce":
++    def prepare_channels(self, channel_ids: Sequence[str]) -> None:
++        """Accept semantic owner names without allocating additional channels.
++
++        The hierarchical runtime has one ordered channel. Owner names provide
++        API compatibility for callers that serialize TP12/TP16 collectives;
++        they do not permit overlapping collective streams.
++        """
++
++        del channel_ids
++
++    def for_stream(
++        self,
++        stream: object = None,
++        *,
++        channel_id: Optional[str] = None,
++    ) -> "PCIeHierarchicalAllReduce":
+         """Compatibility with the vLLM PCIe runtime interface.
+ 
+         Synchronization generations live in device memory, so captured graphs
+@@ -345,12 +361,17 @@ class PCIeHierarchicalAllReduce:
+         single ordered channel; callers must not overlap collective streams.
+         """
+ 
+-        del stream
++        del stream, channel_id
+         return self
+ 
+     @contextmanager
+-    def capture(self, stream: object = None):
+-        del stream
++    def capture(
++        self,
++        stream: object = None,
++        *,
++        channel_id: Optional[str] = None,
++    ):
++        del stream, channel_id
+         yield self
+ 
+     def register_graph_buffers(self) -> None:
+diff --git a/b12x/comm/pcie/pcie_island_rs.py b/b12x/comm/pcie/pcie_island_rs.py
+new file mode 100644
+index 0000000000000000000000000000000000000000..48aaf9d5376728023477534ec34fffd91f6848e9
+--- /dev/null
++++ b/b12x/comm/pcie/pcie_island_rs.py
+@@ -0,0 +1,304 @@
++"""Pull-based island reduce-scatter TP16 all-reduce runtime."""
++
++from __future__ import annotations
++
++import os
++from contextlib import contextmanager
++from typing import Optional, Sequence
++
++import torch
++import torch.distributed as dist
++from torch.distributed import ProcessGroup
++
++from ._island_rs_cute import (
++    HEADER_BYTES,
++    MAX_BLOCKS,
++    get_island_rs_launcher,
++    island_rs_peers,
++)
++from ._cuda_ipc import CudaRTLibrary
++from .pcie_oneshot import (
++    PCIeOneshotAllReduce,
++    _finish_collective_runtime_setup,
++    _normalize_device,
++)
++
++
++SUPPORTED_WORLD_SIZES = (16,)
++SUPPORTED_BLOCKS = (1, 2, 4, 8, 16, 32)
++_ISLAND_SIZE = 4
++_ALIGNMENT = 256
++
++
++def _align_up(value: int, alignment: int = _ALIGNMENT) -> int:
++    return (int(value) + alignment - 1) // alignment * alignment
++
++
++def _threads_from_env() -> int:
++    # Default CUDA thread count for the TP16 equal-quarter launch.
++    raw = os.getenv("B12X_PCIE_ISLAND_RS_THREADS", "512")
++    threads = int(raw)
++    if not 32 <= threads <= 1024 or threads % 32:
++        raise ValueError(
++            "B12X_PCIE_ISLAND_RS_THREADS must be a multiple of 32 in [32, 1024]"
++        )
++    return threads
++
++
++def _wait_nanosleep_cycles_from_env() -> int:
++    cycles = int(os.getenv("B12X_PCIE_ISLAND_RS_NANOSLEEP_CYCLES", "24"))
++    if not 0 <= cycles <= 1024:
++        raise ValueError("B12X_PCIE_ISLAND_RS_NANOSLEEP_CYCLES must be in [0, 1024]")
++    return cycles
++
++
++def _pick_blocks(elements: int) -> int:
++    """Return the default launch geometry for a BF16 element count."""
++
++    if elements <= 4096:
++        return 8
++    return 16
++
++
++# Auto dispatch keeps a single 7,168-element row on the shorter hierarchical
++# protocol and routes larger vectors through equal-quarter ownership when each
++# rank-owned quarter is aligned to a complete 32-word transfer group.
++CROSSOVER_ELEMENTS = 7_168
++PREFERRED_ALIGNMENT_ELEMENTS = 128
++
++
++class PCIeIslandRSAllReduce:
++    """Equal-quarter BF16 TP16 all-reduce with no leader hotspot.
++
++    Every rank owns one quarter of the vector and reaches six peers: the three
++    other lanes of its four-GPU island, and the same lane in the three other
++    islands. Peer degree is bounded at six, and no rank carries the whole
++    vector on behalf of the others.
++    """
++
++    def __init__(
++        self,
++        *,
++        exchange_group: ProcessGroup,
++        device: torch.device | int | str,
++        max_elements: int,
++        blocks: Optional[int] = None,
++    ) -> None:
++        self.group = exchange_group
++        self.rank = dist.get_rank(group=exchange_group)
++        self.world_size = dist.get_world_size(group=exchange_group)
++        self.device = _normalize_device(device)
++        if self.world_size not in SUPPORTED_WORLD_SIZES:
++            raise ValueError(
++                f"island reduce-scatter requires TP16, got TP{self.world_size}"
++            )
++        if self.device.type != "cuda":
++            raise ValueError("island reduce-scatter requires a CUDA device")
++        if blocks is not None and blocks not in SUPPORTED_BLOCKS:
++            raise ValueError(f"blocks must be one of {SUPPORTED_BLOCKS}")
++        if max_elements <= 0 or max_elements % 2:
++            raise ValueError("max_elements must be a positive even count")
++
++        self.max_elements = int(max_elements)
++        self.blocks = None if blocks is None else int(blocks)
++        self.threads = _threads_from_env()
++        self.wait_nanosleep_cycles = _wait_nanosleep_cycles_from_env()
++
++        max_pairs = self.max_elements // 2
++        # Quarter stride in BF16x2 words. Every transient region has two slots
++        # selected by the device generation so a rank cannot overwrite data a
++        # slower peer is still consuming from the preceding invocation.
++        self.quarter_capacity = _align_up(
++            (max_pairs + _ISLAND_SIZE - 1) // _ISLAND_SIZE, 8
++        )
++        quarter_bytes = self.quarter_capacity * 4
++        vector_bytes = quarter_bytes * _ISLAND_SIZE
++        self.stage_offset = _align_up(HEADER_BYTES)
++        self.part_offset = _align_up(self.stage_offset + 2 * vector_bytes)
++        self.final_offset = _align_up(self.part_offset + 2 * quarter_bytes)
++        self.slab_bytes = _align_up(self.final_offset + 2 * vector_bytes)
++
++        self._ipc = CudaRTLibrary()
++        self._ipc.cudaSetDevice(self.device.index or 0)
++        self._slab_ptrs: tuple[int, ...] = ()
++        self._local_ptr = 0
++        self._remote_ptrs: list[int] = []
++        self._closed = False
++        self._launcher = None
++        self._mapped_peers = island_rs_peers(self.rank, self.world_size)
++
++        shared = PCIeOneshotAllReduce._allocate_shared_buffer(
++            exchange_group,
++            self.slab_bytes,
++            zero_fill=True,
++            ipc=self._ipc,
++            peer_ranks=self._mapped_peers,
++        )
++        self._local_ptr = shared.local_ptr
++        self._remote_ptrs = list(shared.remote_ptrs)
++        self._slab_ptrs = shared.peer_ptrs
++
++        init_error: BaseException | None = None
++        try:
++            with torch.cuda.device(self.device):
++                self._launcher = get_island_rs_launcher(
++                    self.world_size,
++                    self.rank,
++                    self.device.index or 0,
++                    threads=self.threads,
++                    wait_nanosleep_cycles=self.wait_nanosleep_cycles,
++                )
++        except Exception as exc:
++            init_error = exc
++
++        def detach_shared_ownership() -> None:
++            self._slab_ptrs = ()
++            self._remote_ptrs.clear()
++            self._local_ptr = 0
++
++        _finish_collective_runtime_setup(
++            owner="PCIe island reduce-scatter",
++            exchange_group=exchange_group,
++            ipc=self._ipc,
++            shared=shared,
++            local_error=init_error,
++            detach_shared_ownership=detach_shared_ownership,
++        )
++
++    @property
++    def mapped_peer_count(self) -> int:
++        return len(self._remote_ptrs)
++
++    @property
++    def mapped_peers(self) -> tuple[int, ...]:
++        """Group ranks whose CUDA IPC allocations are mapped by this rank."""
++
++        return self._mapped_peers
++
++    def should_allreduce(self, inp: torch.Tensor) -> bool:
++        return (
++            not self._closed
++            and inp.device == self.device
++            and inp.dtype == torch.bfloat16
++            and inp.is_contiguous()
++            and 0 < inp.numel() <= self.max_elements
++            and inp.numel() % 2 == 0
++            and inp.data_ptr() % 4 == 0
++        )
++
++    def all_reduce(
++        self,
++        inp: torch.Tensor,
++        *,
++        out: Optional[torch.Tensor] = None,
++        blocks: Optional[int] = None,
++        stream: object = None,
++        channel_id: Optional[str] = None,
++    ) -> torch.Tensor:
++        del channel_id  # The runtime exposes one ordered collective channel.
++        if not self.should_allreduce(inp):
++            raise ValueError(
++                "input does not satisfy island reduce-scatter requirements "
++                f"(shape={tuple(inp.shape)}, dtype={inp.dtype})"
++            )
++        if out is None:
++            # During CUDA graph capture, PyTorch allocates this tensor from the
++            # graph-private pool. The captured graph retains a fixed address
++            # and replays without allocator activity.
++            out = torch.empty_like(inp)
++        if (
++            out.dtype != inp.dtype
++            or out.device != inp.device
++            or out.shape != inp.shape
++            or not out.is_contiguous()
++            or out.data_ptr() % 4 != 0
++        ):
++            raise ValueError("output must match input and be 4-byte aligned")
++        if blocks is not None:
++            selected = int(blocks)
++        elif self.blocks is not None:
++            selected = self.blocks
++        else:
++            selected = _pick_blocks(inp.numel())
++        if selected not in SUPPORTED_BLOCKS or selected > MAX_BLOCKS:
++            raise ValueError(f"blocks must be one of {SUPPORTED_BLOCKS}")
++        with torch.cuda.device(self.device):
++            self._launcher(
++                self._slab_ptrs,
++                inp.data_ptr(),
++                out.data_ptr(),
++                self.stage_offset,
++                self.part_offset,
++                self.final_offset,
++                self.quarter_capacity,
++                inp.numel(),
++                selected,
++                stream,
++            )
++        return out
++
++    def prepare_channels(self, channel_ids: Sequence[str]) -> None:
++        """Accept owner names for the single ordered collective channel."""
++
++        del channel_ids
++
++    def for_stream(
++        self,
++        stream: object = None,
++        *,
++        channel_id: Optional[str] = None,
++    ) -> "PCIeIslandRSAllReduce":
++        # Binding is validated at launch through the explicit stream argument.
++        # Owner names are accepted because this runtime has one serialized
++        # channel rather than per-owner storage.
++        del channel_id
++        if stream is not None and not hasattr(stream, "cuda_stream"):
++            int(stream)
++        return self
++
++    @contextmanager
++    def capture(
++        self,
++        stream: object = None,
++        *,
++        channel_id: Optional[str] = None,
++    ):
++        self.for_stream(stream, channel_id=channel_id)
++        if stream is None:
++            yield self
++        else:
++            torch_stream = (
++                stream
++                if hasattr(stream, "cuda_stream")
++                else torch.cuda.ExternalStream(int(stream), device=self.device)
++            )
++            with torch.cuda.stream(torch_stream):
++                yield self
++
++    def register_graph_buffers(self) -> None:
++        return None
++
++    def close(self) -> None:
++        if self._closed:
++            return
++        self._closed = True
++        if self.device.type == "cuda":
++            torch.cuda.synchronize(self.device)
++        dist.barrier(group=self.group)
++        self._slab_ptrs = ()
++        for ptr in self._remote_ptrs:
++            self._ipc.cudaIpcCloseMemHandle(ptr)
++        self._remote_ptrs.clear()
++        dist.barrier(group=self.group)
++        if self._local_ptr:
++            self._ipc.cudaFree(self._local_ptr)
++            self._local_ptr = 0
++        dist.barrier(group=self.group)
++
++
++__all__ = [
++    "CROSSOVER_ELEMENTS",
++    "PCIeIslandRSAllReduce",
++    "PREFERRED_ALIGNMENT_ELEMENTS",
++    "SUPPORTED_WORLD_SIZES",
++]
+diff --git a/b12x/comm/pcie/pcie_oneshot.py b/b12x/comm/pcie/pcie_oneshot.py
+index 6dcc3c8df2e8ba22617f6e8fd5f67ca990126172..4df34d6f7e82f9a7a945484873c96ad24b1f36e6 100644
+--- a/b12x/comm/pcie/pcie_oneshot.py
++++ b/b12x/comm/pcie/pcie_oneshot.py
+@@ -279,12 +279,15 @@ def _object_broadcast_device(group: ProcessGroup) -> torch.device | str:
+             backend = dist.get_backend(group)
+     except Exception as exc:
+         raise RuntimeError(
+-            "PCIe oneshot IPC exchange requires a CUDA/NCCL process group"
++            "PCIe object exchange requires a valid process group"
+         ) from exc
+     backend_name = str(backend).lower()
++    if "gloo" in backend_name:
++        return torch.device("cpu")
+     if "nccl" not in backend_name:
+         raise RuntimeError(
+-            f"PCIe oneshot IPC exchange requires an NCCL process group, got {backend}"
++            "PCIe object exchange requires an NCCL or Gloo process group, "
++            f"got {backend}"
+         )
+     if not torch.cuda.is_available():
+         raise RuntimeError("PCIe oneshot IPC exchange requires CUDA")
+@@ -2331,8 +2334,21 @@ class PCIeOneshotAllReduce:
+         *,
+         zero_fill: bool,
+         ipc: CudaRTLibrary,
++        peer_ranks: Optional[Sequence[int]] = None,
+     ) -> _OwnedSharedBuffer:
+         _require_no_retained_ipc_setup(exchange_group)
++        world_size = dist.get_world_size(group=exchange_group)
++        rank = dist.get_rank(group=exchange_group)
++        selected_peers = (
++            set(range(world_size)) - {rank}
++            if peer_ranks is None
++            else {int(peer) for peer in peer_ranks}
++        )
++        if rank in selected_peers or any(
++            not 0 <= peer < world_size for peer in selected_peers
++        ):
++            raise ValueError("peer_ranks must contain valid remote group ranks")
++
+         local_ptr: int | None = None
+         local_handle: bytes | None = None
+         prepare_error: BaseException | None = None
+@@ -2435,8 +2451,6 @@ class PCIeOneshotAllReduce:
+         peer_ptrs: list[int] = []
+         remote_ptrs: list[int] = []
+         try:
+-            world_size = dist.get_world_size(group=exchange_group)
+-            rank = dist.get_rank(group=exchange_group)
+             handles = _broadcast_gather_object(local_handle, exchange_group)
+         except Exception as exchange_error:
+             # No rank has opened an import before handle exchange completes.
+@@ -2460,6 +2474,9 @@ class PCIeOneshotAllReduce:
+             if idx == rank:
+                 peer_ptrs.append(local_ptr)
+                 continue
++            if idx not in selected_peers:
++                peer_ptrs.append(0)
++                continue
+             try:
+                 remote_ptr = ipc.cudaIpcOpenMemHandleBytes(handle)
+             except Exception as exc:
+diff --git a/b12x/comm/pcie/pcie_vocab_argmax.py b/b12x/comm/pcie/pcie_vocab_argmax.py
+new file mode 100644
+index 0000000000000000000000000000000000000000..f4b28db469c4e9d0830156794dd4799bae4cedcf
+--- /dev/null
++++ b/b12x/comm/pcie/pcie_vocab_argmax.py
+@@ -0,0 +1,388 @@
++"""Bounded-degree vocabulary-parallel argmax runtime."""
++
++from __future__ import annotations
++
++import os
++from contextlib import contextmanager, suppress
++from typing import Iterator, Optional
++from warnings import warn
++
++import torch
++import torch.distributed as dist
++from torch.distributed import ProcessGroup
++
++from ._cuda_ipc import CudaRTLibrary
++from ._vocab_argmax_cute import SLAB_BYTES, get_vocab_argmax_launcher
++from .pcie_oneshot import (
++    PCIeOneshotAllReduce,
++    _broadcast_gather_object,
++    _run_collective_preallocation_setup,
++)
++
++
++ISLAND_SIZE = 4
++MAX_BATCH_SIZE = 8
++SUPPORTED_WORLD_SIZES = (8, 12, 16)
++
++
++def _exchange_ipc_handles(
++    local_handle: object,
++    group: ProcessGroup,
++) -> list[object]:
++    """Exchange CUDA IPC handles over NCCL or a metadata-only Gloo group."""
++
++    backend = str(dist.get_backend(group=group)).lower()
++    if "nccl" in backend:
++        return _broadcast_gather_object(local_handle, group)
++    if "gloo" not in backend:
++        raise ValueError(
++            "vocabulary argmax IPC exchange requires an NCCL or Gloo group, "
++            f"got {backend}"
++        )
++
++    world_size = dist.get_world_size(group=group)
++    handles: list[object | None] = [None] * world_size
++    dist.all_gather_object(handles, local_handle, group=group)
++    if any(handle is None for handle in handles):
++        raise RuntimeError("vocabulary argmax IPC exchange returned an empty handle")
++    return list(handles)
++
++
++def _require_uniform_geometry(
++    local_vocab_size: int,
++    max_batch_size: int,
++    group: ProcessGroup,
++) -> None:
++    """Reject rank-local geometry before allocating collective resources."""
++    geometry = (int(local_vocab_size), int(max_batch_size))
++    # vLLM supplies its metadata-only Gloo TP group here so initialization does
++    # not allocate an NCCL object-collective workspace.  Geometry validation
++    # must preserve the same NCCL-or-Gloo contract as CUDA IPC handle exchange.
++    peer_geometry = _exchange_ipc_handles(geometry, group)
++    if any(candidate != geometry for candidate in peer_geometry):
++        raise RuntimeError(
++            f"vocabulary argmax geometry differs across ranks: {peer_geometry}"
++        )
++
++
++def _wait_nanosleep_cycles_from_env() -> int:
++    raw = os.getenv("B12X_PCIE_VOCAB_ARGMAX_NANOSLEEP_CYCLES", "24")
++    try:
++        cycles = int(raw)
++    except ValueError as exc:
++        raise ValueError(
++            "B12X_PCIE_VOCAB_ARGMAX_NANOSLEEP_CYCLES must be an integer"
++        ) from exc
++    if not 0 <= cycles <= 1024:
++        raise ValueError("B12X_PCIE_VOCAB_ARGMAX_NANOSLEEP_CYCLES must be in [0, 1024]")
++    return cycles
++
++
++def _selected_peers(rank: int, world_size: int = 16) -> tuple[int, ...]:
++    """Return three island peers plus the same lane in other islands."""
++
++    if world_size not in SUPPORTED_WORLD_SIZES:
++        raise ValueError(
++            "vocabulary argmax requires "
++            f"{SUPPORTED_WORLD_SIZES}, got TP{world_size}"
++        )
++    if not 0 <= rank < world_size:
++        raise ValueError(f"invalid rank {rank} for TP{world_size}")
++    island = rank // ISLAND_SIZE
++    lane = rank % ISLAND_SIZE
++    local = set(range(island * ISLAND_SIZE, (island + 1) * ISLAND_SIZE))
++    cross_island = set(range(lane, world_size, ISLAND_SIZE))
++    return tuple(sorted((local | cross_island) - {rank}))
++
++
++class PCIeVocabParallelArgmax:
++    """Fuse BF16 add and exact global greedy sampling across TP shards.
++
++    Every TP rank must invoke ``fused_add_argmax`` once per logical step with
++    the same batch size. Tensor-parallel schedulers satisfy this collective
++    ordering invariant; callers that cannot guarantee it must not use this
++    runtime. Construction verifies that local vocabulary and capacity geometry
++    match on all ranks.
++    """
++
++    def __init__(
++        self,
++        *,
++        exchange_group: ProcessGroup,
++        device: torch.device | int | str,
++        local_vocab_size: int,
++        max_batch_size: int = MAX_BATCH_SIZE,
++    ) -> None:
++        self.group = exchange_group
++        self.rank = dist.get_rank(group=exchange_group)
++        self.world_size = dist.get_world_size(group=exchange_group)
++
++        def normalize_and_validate():
++            device_obj = (
++                device
++                if isinstance(device, torch.device)
++                else torch.device(
++                    f"cuda:{device}" if isinstance(device, int) else device
++                )
++            )
++            if self.world_size not in SUPPORTED_WORLD_SIZES:
++                raise ValueError(
++                    "vocabulary argmax requires "
++                    f"{SUPPORTED_WORLD_SIZES}, got TP{self.world_size}"
++                )
++            if device_obj.type != "cuda":
++                raise ValueError("vocabulary argmax requires a CUDA device")
++            if device_obj.index is None:
++                device_obj = torch.device("cuda", torch.cuda.current_device())
++            normalized_local_vocab_size = int(local_vocab_size)
++            normalized_max_batch_size = int(max_batch_size)
++            if (
++                normalized_local_vocab_size <= 0
++                or normalized_local_vocab_size * self.world_size >= 1 << 31
++            ):
++                raise ValueError("global vocabulary must fit a positive int32 index")
++            if not 0 < normalized_max_batch_size <= MAX_BATCH_SIZE:
++                raise ValueError(
++                    f"max_batch_size must be in [1, {MAX_BATCH_SIZE}]"
++                )
++            return (
++                device_obj,
++                normalized_local_vocab_size,
++                normalized_max_batch_size,
++                _wait_nanosleep_cycles_from_env(),
++            )
++
++        (
++            self.device,
++            self.local_vocab_size,
++            self.max_batch_size,
++            wait_nanosleep_cycles,
++        ) = _run_collective_preallocation_setup(
++            owner="PCIe vocabulary argmax argument validation",
++            exchange_group=exchange_group,
++            setup=normalize_and_validate,
++        )
++        _require_uniform_geometry(
++            self.local_vocab_size,
++            self.max_batch_size,
++            exchange_group,
++        )
++        self._slab_ptrs: tuple[int, ...] = ()
++        self._launcher = None
++        self._local_ptr = 0
++        self._remote_ptrs: list[int] = []
++        self._closed = True
++
++        def prepare_runtime():
++            self._ipc = CudaRTLibrary()
++            with self._cuda_runtime_device():
++                launcher = get_vocab_argmax_launcher(
++                    self.world_size,
++                    self.rank,
++                    self.device.index or 0,
++                    wait_nanosleep_cycles=wait_nanosleep_cycles,
++                )
++            return self._ipc, launcher
++
++        self._ipc, self._launcher = _run_collective_preallocation_setup(
++            owner="PCIe vocabulary argmax runtime preparation",
++            exchange_group=exchange_group,
++            setup=prepare_runtime,
++        )
++        with self._cuda_runtime_device():
++            shared = PCIeOneshotAllReduce._allocate_shared_buffer(
++                exchange_group,
++                SLAB_BYTES,
++                zero_fill=True,
++                ipc=self._ipc,
++                peer_ranks=_selected_peers(self.rank, self.world_size),
++            )
++        self._local_ptr = shared.local_ptr
++        self._slab_ptrs = shared.peer_ptrs
++        self._remote_ptrs = list(shared.remote_ptrs)
++        self._closed = False
++
++    @classmethod
++    def from_exchange_group(
++        cls,
++        *,
++        exchange_group: ProcessGroup,
++        device: torch.device | int | str,
++        local_vocab_size: int,
++        max_batch_size: int = MAX_BATCH_SIZE,
++    ) -> "PCIeVocabParallelArgmax":
++        return cls(
++            exchange_group=exchange_group,
++            device=device,
++            local_vocab_size=local_vocab_size,
++            max_batch_size=max_batch_size,
++        )
++
++    @classmethod
++    def from_process_group(
++        cls,
++        *,
++        process_group: ProcessGroup,
++        device: torch.device | int | str,
++        local_vocab_size: int,
++        max_batch_size: int = MAX_BATCH_SIZE,
++    ) -> "PCIeVocabParallelArgmax":
++        return cls.from_exchange_group(
++            exchange_group=process_group,
++            device=device,
++            local_vocab_size=local_vocab_size,
++            max_batch_size=max_batch_size,
++        )
++
++    @property
++    def mapped_peer_count(self) -> int:
++        return len(self._remote_ptrs)
++
++    @contextmanager
++    def _cuda_runtime_device(self) -> Iterator[None]:
++        """Select this runtime's CUDA device and restore the caller's device."""
++        if self.device.type != "cuda" or self.device.index is None:
++            yield
++            return
++        previous_device: int | None
++        try:
++            previous_device = torch.cuda.current_device()
++        except Exception:
++            previous_device = None
++        self._ipc.cudaSetDevice(self.device.index)
++        try:
++            yield
++        finally:
++            if previous_device is not None and previous_device != self.device.index:
++                self._ipc.cudaSetDevice(previous_device)
++
++    def fused_add_argmax(
++        self,
++        base: torch.Tensor,
++        bias: torch.Tensor,
++        out: Optional[torch.Tensor] = None,
++    ) -> torch.Tensor:
++        """Return exact global argmax of the BF16-rounded local sum."""
++
++        if self._closed:
++            raise RuntimeError("vocabulary argmax runtime is closed")
++        if base.device != self.device or bias.device != self.device:
++            raise ValueError("inputs must be on the runtime device")
++        if base.dtype != torch.bfloat16 or bias.dtype != torch.bfloat16:
++            raise ValueError("inputs must be BF16")
++        if base.ndim != 2 or base.shape != bias.shape:
++            raise ValueError("inputs must have matching [batch, local_vocab] shapes")
++        batch, local_vocab = (int(value) for value in base.shape)
++        if not 0 < batch <= self.max_batch_size:
++            raise ValueError(
++                f"batch size {batch} exceeds capacity {self.max_batch_size}"
++            )
++        if local_vocab != self.local_vocab_size:
++            raise ValueError(
++                f"local vocabulary must be {self.local_vocab_size}, got {local_vocab}"
++            )
++        if base.stride(1) != 1 or bias.stride(1) != 1:
++            raise ValueError("input last dimensions must be contiguous")
++        if base.stride(0) <= 0 or bias.stride(0) <= 0:
++            raise ValueError("input row strides must be positive")
++        if out is None:
++            out = torch.empty(batch, dtype=torch.int64, device=self.device)
++        if (
++            out.device != self.device
++            or out.dtype != torch.int64
++            or out.shape != (batch,)
++            or not out.is_contiguous()
++        ):
++            raise ValueError("output must be contiguous int64 [batch] on the device")
++        if self._launcher is None:
++            raise RuntimeError("vocabulary argmax launcher is unavailable")
++        with self._cuda_runtime_device():
++            self._launcher(
++                self._slab_ptrs,
++                base.data_ptr(),
++                bias.data_ptr(),
++                out.data_ptr(),
++                self.local_vocab_size,
++                base.stride(0),
++                bias.stride(0),
++                batch,
++            )
++        return out
++
++    def for_stream(self, stream: object = None) -> "PCIeVocabParallelArgmax":
++        del stream
++        return self
++
++    @contextmanager
++    def capture(self, stream: object = None):
++        del stream
++        yield self
++
++    def register_graph_buffers(self) -> None:
++        return None
++
++    def close(self) -> None:
++        if self._closed:
++            return
++        self._closed = True
++        with self._cuda_runtime_device():
++            torch.cuda.synchronize(self.device)
++            dist.barrier(group=self.group)
++            try:
++                self._launcher = None
++                self._slab_ptrs = ()
++            finally:
++                try:
++                    for ptr in self._remote_ptrs:
++                        self._ipc.cudaIpcCloseMemHandle(ptr)
++                finally:
++                    self._remote_ptrs.clear()
++                    dist.barrier(group=self.group)
++                    try:
++                        if self._local_ptr:
++                            self._ipc.cudaFree(self._local_ptr)
++                    finally:
++                        self._local_ptr = 0
++                        dist.barrier(group=self.group)
++
++    def __enter__(self) -> "PCIeVocabParallelArgmax":
++        return self
++
++    def __exit__(self, *_args) -> None:
++        self.close()
++
++    def __del__(self) -> None:
++        if getattr(self, "_closed", True):
++            return
++
++        # Python garbage collection is not ordered across distributed ranks.
++        # Calling close() here could deadlock on its collective barriers, so
++        # finalization releases only resources owned by this rank. Callers
++        # must use close() or the context manager for coordinated teardown.
++        self._closed = True
++        with suppress(Exception):
++            warn(
++                "PCIeVocabParallelArgmax was garbage-collected without close(); "
++                "releasing rank-local CUDA resources without collective teardown",
++                ResourceWarning,
++                stacklevel=2,
++            )
++
++        with suppress(Exception), self._cuda_runtime_device():
++            self._launcher = None
++            self._slab_ptrs = ()
++
++            remote_ptrs = list(getattr(self, "_remote_ptrs", ()))
++            self._remote_ptrs = []
++            for ptr in remote_ptrs:
++                with suppress(Exception):
++                    self._ipc.cudaIpcCloseMemHandle(ptr)
++
++            local_ptr = getattr(self, "_local_ptr", 0)
++            self._local_ptr = 0
++            if local_ptr:
++                with suppress(Exception):
++                    self._ipc.cudaFree(local_ptr)
++
++
++__all__ = ["PCIeVocabParallelArgmax"]
+diff --git a/b12x/moe/_shared/kernels/w4a16/route_pack.py b/b12x/moe/_shared/kernels/w4a16/route_pack.py
+index 9b05f7f68a7801d624b67c0697949161e09e210f..faaad8817dfb484e1d3f770c8a9593f1bf7fcbc5 100644
+--- a/b12x/moe/_shared/kernels/w4a16/route_pack.py
++++ b/b12x/moe/_shared/kernels/w4a16/route_pack.py
+@@ -77,6 +77,22 @@ def _next_power_of_2(x: int) -> int:
+     return 1 << (int(x) - 1).bit_length()
+ 
+ 
++def _numel_capacity_for_route_workspace(
++    packed_routes: int,
++    route_blocks: int,
++    block_size: int,
++    num_experts: int,
++) -> int:
++    """Recover the largest live route count covered by a fixed workspace."""
++    block_size = int(block_size)
++    num_experts = int(num_experts)
++    padded_slots = min(int(packed_routes), int(route_blocks) * block_size)
++    fully_padded_experts = num_experts * block_size
++    if padded_slots <= fully_padded_experts:
++        return padded_slots // block_size
++    return padded_slots - num_experts * (block_size - 1)
++
++
+ def _workspace_slice(
+     tensor: torch.Tensor | None,
+     *,
+@@ -289,22 +305,54 @@ def pack_topk_routes_by_expert(
+         int(num_experts),
+         topk=topk,
+     )
+-    if packed_route_indices is not None and block_expert_ids is not None:
++    provided_routes = (
++        None if packed_route_indices is None else int(packed_route_indices.numel())
++    )
++    provided_blocks = (
++        None if block_expert_ids is None else int(block_expert_ids.numel())
++    )
++    if (
++        provided_routes is not None
++        and provided_blocks is not None
++        and (
++            provided_routes < capacity_packed_routes
++            or provided_blocks < capacity_route_blocks
++        )
++    ):
++        (
++            exact_numel_capacity,
++            exact_packed_routes,
++            exact_route_blocks,
++        ) = route_pack_capacity(
++            numel,
++            int(block_size),
++            int(num_experts),
++            topk=topk,
++            bucket_tokens=False,
++        )
+         if (
+-            int(packed_route_indices.numel()) < capacity_packed_routes
+-            or int(block_expert_ids.numel()) < capacity_route_blocks
++            provided_routes >= exact_packed_routes
++            and provided_blocks >= exact_route_blocks
+         ):
+-            (
+-                numel_capacity,
+-                capacity_packed_routes,
+-                capacity_route_blocks,
+-            ) = route_pack_capacity(
+-                numel,
++            # A serving caller can own one fixed arena sized for its configured
++            # maximum while a live prefill tail belongs to a larger power-of-two
++            # bucket. Reuse the full caller capacity instead of specializing each
++            # exact tail. The small-prefix and post-prefix kernels fill unused
++            # route slots with ``live_numel`` and unused blocks with ``-1``. The
++            # recovered live-route capacity also keeps the small-prefix loop bound
++            # stable without changing the caller's allocation or route semantics.
++            numel_capacity = _numel_capacity_for_route_workspace(
++                provided_routes,
++                provided_blocks,
+                 int(block_size),
+                 int(num_experts),
+-                topk=topk,
+-                bucket_tokens=False,
+             )
++            capacity_packed_routes = provided_routes
++            capacity_route_blocks = provided_blocks
++        else:
++            numel_capacity = exact_numel_capacity
++            capacity_packed_routes = exact_packed_routes
++            capacity_route_blocks = exact_route_blocks
+     max_packed_routes = capacity_packed_routes
+     max_route_blocks = capacity_route_blocks
+     max_packed_routes = max(max_packed_routes, 1)

--- a/patches/releases/kimi-k3-qsrt-tp8-safety/b12x/integration.lock.json
+++ b/patches/releases/kimi-k3-qsrt-tp8-safety/b12x/integration.lock.json
@@ -1,0 +1,38 @@
+{
+  "base": {
+    "commit": "6e2c6bfb3991b27509c0e2e70dda5d90bb039691",
+    "ref": "refs/heads/agent/pr197-base-glm52-sqg",
+    "repository": "https://github.com/local-inference-lab/b12x.git"
+  },
+  "composition": null,
+  "composition_strategy": "merge",
+  "manifest": {
+    "sha256": "3132fad58d73eca70ff819568eba9109f90f4ee9d931164ee2cc256013d1ca79"
+  },
+  "name": "kimi-k3-qsrt-tp8-safety-b12x",
+  "pull_requests": [
+    {
+      "commits": [
+        "7917d618a09cb01cde7df31ac6696dbe86dd72ab"
+      ],
+      "disposition": "merged",
+      "head": "7917d618a09cb01cde7df31ac6696dbe86dd72ab",
+      "number": 237,
+      "ref": "refs/pull/237/head",
+      "title": "Sanitize inactive QSRT W4A16 routes"
+    }
+  ],
+  "result": {
+    "patch": "integration.patch",
+    "patch_sha256": "27f2b710d930ab42ec5bb1944be4217d5a7892ba08f83ed6cf2adcb46e511ea1",
+    "tree": "64dc2cb0c6582f45a3414f5ba40c370aca7600f1"
+  },
+  "schema_version": 1,
+  "source_patches": [
+    {
+      "path": "patches/kimi-k3-qsrt-tp8-qualified-compat.patch",
+      "sha256": "3937584294c689de1a2507ff420d0554a3e93bc4dfe39a208790fbe07c84bd55",
+      "title": "Restore the qualified Kimi-K3 QSRT atoms-v2 and PCIe runtime contracts"
+    }
+  ]
+}

--- a/patches/releases/kimi-k3-qsrt-tp8-safety/b12x/integration.patch
+++ b/patches/releases/kimi-k3-qsrt-tp8-safety/b12x/integration.patch
@@ -1,0 +1,7222 @@
+diff --git a/b12x/attention/__init__.py b/b12x/attention/__init__.py
+index 40e6066fa41b3da36880f0451bdaf279d9eb84d7..c5d4a69ce0b3c9e99e0792370bcd6c9bf90da93a 100644
+--- a/b12x/attention/__init__.py
++++ b/b12x/attention/__init__.py
+@@ -2,9 +2,8 @@
+ 
+ - ``paged``: paged-KV self-attention (decode + extend, FP8 KV, MSA
+   block-sparse variant) with on-device graph-replay metadata staging.
+-- ``dense_mla``: dense compressed-cache MLA with strided physical records and
+-  optional causal sliding-window masking.
+-- ``sparse_mla``: top-k-selected MLA, including strided physical records.
++- ``dense_mla``: dense compressed-cache MLA for Kimi K3 geometry.
++- ``sparse_mla``: top-k-selected MLA decode/extend (DeepSeek-V3.2 / GLM NSA).
+ - ``compressed_mla``: MLA decode directly from compressed KV pages (DSV4).
+ - ``nsa_indexer``: the NSA index stage — quantize -> score -> select.
+ - ``varlen``: contiguous batched/varlen attention (reduced-assurance tier).
+diff --git a/b12x/attention/_shared/contiguous/api.py b/b12x/attention/_shared/contiguous/api.py
+index b293c49ae30657484d4664d61467c8ba34bcb62a..3b2bf678d01e5b206b39baaba70bae76e231a89e 100644
+--- a/b12x/attention/_shared/contiguous/api.py
++++ b/b12x/attention/_shared/contiguous/api.py
+@@ -75,12 +75,6 @@ def _lse_shape(q_shape: tuple[int, ...]) -> tuple[int, ...]:
+     return (batch, q_heads, seqlen_q)
+ 
+ 
+-def _output_shape(
+-    q_shape: tuple[int, ...], v_shape: tuple[int, ...]
+-) -> tuple[int, ...]:
+-    return (*q_shape[:-1], int(v_shape[-1]))
+-
+-
+ def _seq_dims(shape: tuple[int, ...]) -> tuple[tuple[int, ...], int, int, int]:
+     if len(shape) == 3:
+         seqlen, num_heads, head_dim = shape
+@@ -230,10 +224,10 @@ def _validate_forward_inputs(
+     batch_v, _, v_heads, v_head_dim = _seq_dims(v_shape)
+     if batch_q != batch_k or batch_q != batch_v:
+         raise ValueError("q, k, and v must have matching batch dimensions")
+-    if q_head_dim != k_head_dim:
+-        raise ValueError("q and k must have matching head dimensions")
+-    if v_head_dim <= 0:
+-        raise ValueError("v head dimension must be positive")
++    if q_head_dim != k_head_dim or q_head_dim != v_head_dim:
++        raise ValueError(
++            "q, k, and v must have matching head dimensions in the initial path"
++        )
+     if kv_heads != v_heads:
+         raise ValueError("k and v must have the same number of KV heads")
+     if q_heads % kv_heads != 0:
+@@ -736,13 +730,13 @@ class _AttentionForwardLaunch:
+         self._q_shape = q_shape
+         self._k_shape = k_shape
+         self._v_shape = v_shape
+-        self._o_shape = _output_shape(q_shape, v_shape)
++        self._o_shape = q_shape
+         self._lse_shape = _lse_shape(q_shape)
+         self._attention_sink_bias_shape = (q_shape[-2],)
+         self._q_stride = _contiguous_stride(q_shape)
+         self._k_stride = _contiguous_stride(k_shape)
+         self._v_stride = _contiguous_stride(v_shape)
+-        self._o_stride = _contiguous_stride(self._o_shape)
++        self._o_stride = _contiguous_stride(q_shape)
+         self._lse_stride = _contiguous_stride(self._lse_shape)
+         self._attention_sink_bias_stride = _contiguous_stride(
+             self._attention_sink_bias_shape
+@@ -876,7 +870,7 @@ class _VarlenAttentionForwardLaunch:
+         self._v_shape = v_shape
+         self._cu_seqlens_q_shape = cu_seqlens_q_shape
+         self._cu_seqlens_k_shape = cu_seqlens_k_shape
+-        self._o_shape = _output_shape(q_shape, v_shape)
++        self._o_shape = q_shape
+         self._lse_shape = _lse_shape(q_shape)
+         self._attention_sink_bias_shape = (q_shape[-2],)
+         self._q_stride = _contiguous_stride(q_shape)
+@@ -884,7 +878,7 @@ class _VarlenAttentionForwardLaunch:
+         self._v_stride = _contiguous_stride(v_shape)
+         self._cu_seqlens_q_stride = _contiguous_stride(cu_seqlens_q_shape)
+         self._cu_seqlens_k_stride = _contiguous_stride(cu_seqlens_k_shape)
+-        self._o_stride = _contiguous_stride(self._o_shape)
++        self._o_stride = _contiguous_stride(q_shape)
+         self._lse_stride = _contiguous_stride(self._lse_shape)
+         self._attention_sink_bias_stride = _contiguous_stride(
+             self._attention_sink_bias_shape
+@@ -942,7 +936,9 @@ class _VarlenAttentionForwardLaunch:
+             # existing unpacked-head kernel as the static fallback for those
+             # shapes; this choice depends only on plan geometry and is graph
+             # capture safe.
+-            pack_gqa=(qhead_per_kvhead != 1 and tile_m % qhead_per_kvhead == 0),
++            pack_gqa=(
++                qhead_per_kvhead != 1 and tile_m % qhead_per_kvhead == 0
++            ),
+             tile_m=tile_m,
+             tile_n=tile_n,
+         )
+@@ -1396,11 +1392,9 @@ def _validate_attention_output_lse(
+     lse: torch.Tensor,
+     plan: AttentionPlan | VarlenAttentionPlan,
+ ) -> None:
+-    expected_output_shape = _output_shape(plan.q_shape, plan.v_shape)
+-    if output.shape != expected_output_shape:
++    if output.shape != plan.q_shape:
+         raise ValueError(
+-            "attention output must have shape "
+-            f"{expected_output_shape}, got {tuple(output.shape)}"
++            f"attention output must have shape {plan.q_shape}, got {tuple(output.shape)}"
+         )
+     if output.device != plan.device:
+         raise ValueError(
+@@ -1428,13 +1422,12 @@ def _validate_attention_output_lse(
+ def _attention_scratch_layout(
+     *,
+     q_shape: tuple[int, ...],
+-    v_shape: tuple[int, ...],
+     dtype: torch.dtype,
+ ) -> _AttentionScratchLayout:
+     cursor = 0
+     cursor = _align_up(cursor, _ARENA_ALIGN_BYTES)
+     output_offset_bytes = cursor
+-    cursor += _shape_numel(_output_shape(q_shape, v_shape)) * _dtype_nbytes(dtype)
++    cursor += _shape_numel(q_shape) * _dtype_nbytes(dtype)
+     cursor = _align_up(cursor, _ARENA_ALIGN_BYTES)
+     lse_offset_bytes = cursor
+     cursor += _shape_numel(_lse_shape(q_shape)) * _dtype_nbytes(torch.float32)
+@@ -1493,7 +1486,7 @@ def _attention_scratch_views_from_arena(
+     output = _arena_view(
+         arena,
+         offset_bytes=layout.output_offset_bytes,
+-        shape=_output_shape(plan.q_shape, plan.v_shape),
++        shape=plan.q_shape,
+         dtype=plan.dtype,
+     )
+     lse = _arena_view(
+@@ -1547,7 +1540,7 @@ def _varlen_attention_scratch_views_from_arena(
+     output = _arena_view(
+         arena,
+         offset_bytes=layout.output_offset_bytes,
+-        shape=_output_shape(plan.q_shape, plan.v_shape),
++        shape=plan.q_shape,
+         dtype=plan.dtype,
+     )
+     lse = _arena_view(
+@@ -1962,9 +1955,7 @@ def _build_varlen_attention_binding_from_views(
+ 
+ 
+ def plan_attention_scratch(plan: AttentionPlan) -> AttentionScratchPlan:
+-    layout = _attention_scratch_layout(
+-        q_shape=plan.q_shape, v_shape=plan.v_shape, dtype=plan.dtype
+-    )
++    layout = _attention_scratch_layout(q_shape=plan.q_shape, dtype=plan.dtype)
+     return AttentionScratchPlan(
+         plan=plan,
+         _layout=layout,
+@@ -1981,9 +1972,7 @@ def plan_attention_scratch(plan: AttentionPlan) -> AttentionScratchPlan:
+ def plan_varlen_attention_scratch(
+     plan: VarlenAttentionPlan,
+ ) -> VarlenAttentionScratchPlan:
+-    layout = _attention_scratch_layout(
+-        q_shape=plan.q_shape, v_shape=plan.v_shape, dtype=plan.dtype
+-    )
++    layout = _attention_scratch_layout(q_shape=plan.q_shape, dtype=plan.dtype)
+     return VarlenAttentionScratchPlan(
+         plan=plan,
+         _layout=layout,
+@@ -1999,11 +1988,7 @@ def plan_varlen_attention_scratch(
+ 
+ def allocate_attention_workspace_for_plan(plan: AttentionPlan) -> AttentionWorkspace:
+     """Allocate reusable scratch for one exact contiguous attention plan."""
+-    output = torch.empty(
+-        _output_shape(plan.q_shape, plan.v_shape),
+-        dtype=plan.dtype,
+-        device=plan.device,
+-    )
++    output = torch.empty(plan.q_shape, dtype=plan.dtype, device=plan.device)
+     lse = torch.empty(_lse_shape(plan.q_shape), dtype=torch.float32, device=plan.device)
+     return AttentionWorkspace(
+         q_shape=plan.q_shape,
+@@ -2027,11 +2012,7 @@ def allocate_varlen_attention_workspace_for_plan(
+     plan: VarlenAttentionPlan,
+ ) -> VarlenAttentionWorkspace:
+     """Allocate reusable scratch for one exact packed varlen attention plan."""
+-    output = torch.empty(
+-        _output_shape(plan.q_shape, plan.v_shape),
+-        dtype=plan.dtype,
+-        device=plan.device,
+-    )
++    output = torch.empty(plan.q_shape, dtype=plan.dtype, device=plan.device)
+     lse = torch.empty(_lse_shape(plan.q_shape), dtype=torch.float32, device=plan.device)
+     return VarlenAttentionWorkspace(
+         q_shape=plan.q_shape,
+diff --git a/b12x/attention/_shared/static_fp8_quant.py b/b12x/attention/_shared/static_fp8_quant.py
+deleted file mode 100644
+index d1714437d414595dff3d82ae7d76e0a8ae649ea6..0000000000000000000000000000000000000000
+--- a/b12x/attention/_shared/static_fp8_quant.py
++++ /dev/null
+@@ -1,188 +0,0 @@
+-"""Graph-safe BF16 to per-tensor E4M3 query quantization."""
+-
+-from __future__ import annotations
+-
+-from dataclasses import dataclass
+-from threading import RLock
+-
+-import cuda.bindings.driver as cuda
+-import cutlass
+-import cutlass.cute as cute
+-import torch
+-from cutlass import Float32, Int32, Int64
+-from cutlass.cute.runtime import from_dlpack
+-
+-from b12x._lib.compiler import KernelCompileSpec, compile as compile_cute
+-from b12x._lib.compiler import key_field, run_compiled
+-from b12x._lib.intrinsics import (
+-    bfloat2_to_float2_scaled,
+-    cvt_f32x4_to_e4m3x4,
+-    get_ptr_as_int64,
+-    ld_global_v2_u32,
+-    st_global_u32,
+-)
+-
+-FP8 = torch.float8_e4m3fn
+-_THREADS = 128
+-_VALUES_PER_THREAD = 4
+-_LOCK = RLock()
+-_CACHE: dict[tuple[int, int], object] = {}
+-
+-
+-def _byte_base_pointer(tensor: torch.Tensor) -> torch.Tensor:
+-    byte_view = tensor.view(torch.uint8)
+-    return torch.as_strided(byte_view, size=(1,), stride=(1,))
+-
+-
+-def _to_cute(tensor: torch.Tensor, dtype, *, align: int):
+-    converted = from_dlpack(tensor, assumed_align=align)
+-    converted.element_type = dtype
+-    return converted.mark_layout_dynamic(leading_dim=0)
+-
+-
+-class _StaticFp8QuantKernel:
+-    def __init__(self, max_numel: int):
+-        self.max_numel = int(max_numel)
+-
+-    @cute.jit
+-    def __call__(
+-        self,
+-        source_bytes: cute.Tensor,
+-        output_bytes: cute.Tensor,
+-        scale: cute.Tensor,
+-        active_numel: Int32,
+-        stream: cuda.CUstream,
+-    ):
+-        grid = (self.max_numel + _THREADS * _VALUES_PER_THREAD - 1) // (
+-            _THREADS * _VALUES_PER_THREAD
+-        )
+-        self.kernel(source_bytes, output_bytes, scale, active_numel).launch(
+-            grid=(grid, 1, 1),
+-            block=(_THREADS, 1, 1),
+-            stream=stream,
+-        )
+-
+-    @cute.kernel
+-    def kernel(
+-        self,
+-        source_bytes: cute.Tensor,
+-        output_bytes: cute.Tensor,
+-        scale: cute.Tensor,
+-        active_numel: Int32,
+-    ):
+-        thread, _, _ = cute.arch.thread_idx()
+-        block, _, _ = cute.arch.block_idx()
+-        word = Int32(block) * Int32(_THREADS) + Int32(thread)
+-        element = word * Int32(_VALUES_PER_THREAD)
+-        if element < active_numel:
+-            inverse_scale = Float32(1.0) / Float32(scale[0])
+-            lo, hi = ld_global_v2_u32(
+-                get_ptr_as_int64(source_bytes, element.to(Int64) * Int64(2))
+-            )
+-            value0, value1 = bfloat2_to_float2_scaled(lo, inverse_scale)
+-            value2, value3 = bfloat2_to_float2_scaled(hi, inverse_scale)
+-            packed = cvt_f32x4_to_e4m3x4(value0, value1, value2, value3)
+-            st_global_u32(
+-                get_ptr_as_int64(output_bytes, element.to(Int64)),
+-                packed,
+-            )
+-
+-
+-@dataclass(frozen=True)
+-class Binding:
+-    source: torch.Tensor
+-    output: torch.Tensor
+-    scale: torch.Tensor
+-    max_numel: int
+-
+-
+-def bind(
+-    *,
+-    source: torch.Tensor,
+-    output: torch.Tensor,
+-    scale: torch.Tensor,
+-    max_numel: int,
+-) -> Binding:
+-    if source.dtype != torch.bfloat16 or not source.is_contiguous():
+-        raise TypeError("query source must be contiguous BF16")
+-    if output.dtype != FP8 or tuple(output.shape) != tuple(source.shape):
+-        raise TypeError("query quant output must be E4M3 with the source shape")
+-    if not output.is_contiguous() or output.device != source.device:
+-        raise ValueError("query quant output must be contiguous on the source device")
+-    if scale.dtype != torch.float32 or scale.numel() != 1:
+-        raise TypeError("query quant scale must be a scalar float32 tensor")
+-    if scale.device != source.device:
+-        raise ValueError("query quant scale must be on the source device")
+-    if source.numel() % _VALUES_PER_THREAD:
+-        raise ValueError("query element count must be divisible by four")
+-    if not 0 < source.numel() <= int(max_numel):
+-        raise ValueError("query element count exceeds the planned quant capacity")
+-    return Binding(
+-        source=source.detach(),
+-        output=output.detach(),
+-        scale=scale.detach(),
+-        max_numel=int(max_numel),
+-    )
+-
+-
+-def _launch(binding: Binding):
+-    source_bytes = _byte_base_pointer(binding.source)
+-    output_bytes = _byte_base_pointer(binding.output)
+-    stream = cuda.CUstream(torch.cuda.current_stream().cuda_stream)
+-    entry = _StaticFp8QuantKernel(binding.max_numel)
+-    args = (
+-        _to_cute(source_bytes, cutlass.Uint8, align=16),
+-        _to_cute(output_bytes, cutlass.Uint8, align=16),
+-        _to_cute(binding.scale.reshape(1), cutlass.Float32, align=4),
+-        Int32(binding.source.numel()),
+-        stream,
+-    )
+-    spec = KernelCompileSpec.from_fields(
+-        "attention.static_fp8_query_quant",
+-        1,
+-        key_field("max_numel", binding.max_numel),
+-    )
+-    return entry, args, spec
+-
+-
+-def _signature(binding: Binding) -> tuple[int, int]:
+-    index = binding.source.device.index
+-    if index is None:
+-        index = torch.cuda.current_device()
+-    return int(index), int(binding.max_numel)
+-
+-
+-def compile(*, binding: Binding) -> None:
+-    signature = _signature(binding)
+-    with _LOCK:
+-        compiled = _CACHE.get(signature)
+-    if compiled is None:
+-        entry, args, spec = _launch(binding)
+-        compiled = compile_cute(entry, *args, compile_spec=spec)
+-        with _LOCK:
+-            _CACHE[signature] = compiled
+-
+-
+-def run(*, binding: Binding) -> torch.Tensor:
+-    signature = _signature(binding)
+-    with _LOCK:
+-        compiled = _CACHE.get(signature)
+-    if compiled is None:
+-        if torch.cuda.is_current_stream_capturing():
+-            raise RuntimeError(
+-                "query quant compile miss during CUDA graph capture; call compile first"
+-            )
+-        compile(binding=binding)
+-        with _LOCK:
+-            compiled = _CACHE[signature]
+-    _, args, _ = _launch(binding)
+-    run_compiled(compiled, args)
+-    return binding.output
+-
+-
+-def clear_caches() -> None:
+-    with _LOCK:
+-        _CACHE.clear()
+-
+-
+-__all__ = ["Binding", "bind", "clear_caches", "compile", "run"]
+diff --git a/b12x/attention/dense_mla/__init__.py b/b12x/attention/dense_mla/__init__.py
+index 46361faf5110eedb0c07ac8c2dfb003bb15cc777..50a8f9a6bcd438a48a00cfedf3651ccdea9365fd 100644
+--- a/b12x/attention/dense_mla/__init__.py
++++ b/b12x/attention/dense_mla/__init__.py
+@@ -1,25 +1,22 @@
+-"""Paged dense Multi-head Latent Attention on SM12x.
++"""Dense Multi-head Latent Attention for Kimi K3 on SM12x.
+ 
+-The operator consumes absorbed queries and combined compressed-cache records
+-directly. Logical Q/K width, logical value width, and physical-record width
+-are planned independently. Supported logical widths are ``(576, 512)`` and
+-``(1088, 1024)``.
++The operator consumes the absorbed K3 query and the combined compressed-cache
++record directly:
+ 
+-* query: ``[total_q, local_heads, logical_qk_width]``;
+-* cache: ``[pages, page_size, physical_record_width]`` (or a singleton-head
+-  rank-4 view), where the logical key prefix is read directly;
+-* value: the logical value prefix of each record.
++* query: ``[total_q, local_heads, 576]``;
++* cache: ``[pages, page_size, 576]`` (or a singleton-head rank-4 view);
++* key: all 576 record elements;
++* value: the first 512 record elements.
+ 
+-``window_size=None`` attends to the full causal context. A positive
+-``window_size`` restricts query position ``p`` to the inclusive interval
+-``[max(0, p - window_size + 1), p]``. The attention scale is caller-provided.
+-BF16 and E4M3 records are supported. For E4M3 cache with BF16 query input,
+-``q_dtype=torch.bfloat16`` plans fixed query-quantization storage in the same
+-caller-owned scratch buffer.
++The attention scale is based on K3's *raw* 192-wide QK head
++(``1 / sqrt(192)``), not the 576-wide absorbed record.  BF16 and standard
++E4M3 combined records are supported; E4M3 uses one caller-provided FP32 scalar
++scale for the whole record.
+ 
+ Planned lifecycle: ``plan(Caps(...))`` -> caller allocates ``scratch_specs`` ->
+-``bind`` (views and validation only) -> ``compile``/``run``. Decode and extend
+-share the same graph-safe dense core. No selected-index array is materialized.
++``bind`` (views and validation only) -> ``compile``/``run``.  Decode and
++single-request prefill share the same graph-safe dense core.  No selected-index
++array is materialized.
+ """
+ 
+ from __future__ import annotations
+@@ -48,7 +45,7 @@ META = OpMeta(
+         "clear_caches",
+     ),
+     dtypes=("bf16", "fp8_e4m3"),
+-    recipes=("strided_paged_dense_mla",),
++    recipes=("kimi_k3_dense_mla",),
+     requires=(),
+     provenance=Provenance(
+         repo="https://github.com/lukealonso/b12x",
+@@ -62,8 +59,9 @@ META = OpMeta(
+     test_path="tests/attention/test_dense_mla.py",
+     since="0.8.0",
+     notes=(
+-        "Physical page and record addressing is 64-bit. Optional BF16-to-E4M3 "
+-        "query conversion uses planned caller-owned storage."
++        "K3 TP12 uses eight local heads, a 576-element absorbed Q/K record, "
++        "a 512-element latent value, and 1/sqrt(192) scaling. Pool-scaled "
++        "addressing is 64-bit and the runtime owns no allocations."
+     ),
+ )
+ 
+diff --git a/b12x/attention/dense_mla/_forward.py b/b12x/attention/dense_mla/_forward.py
+index 64316b37125e29927e43e902c32e8e8ca8c32e88..f244b18b2ce8749af6a6b6691273fb35d56caaa5 100644
+--- a/b12x/attention/dense_mla/_forward.py
++++ b/b12x/attention/dense_mla/_forward.py
+@@ -60,9 +60,6 @@ class DenseMlaForwardKernel:
+         chunks_per_split: int,
+         query_tile: int,
+         fp8: bool,
+-        qk_dim: int,
+-        value_dim: int,
+-        window_size: int | None,
+     ):
+         self.layout = layout
+         self.page_size = int(page_size)
+@@ -72,9 +69,6 @@ class DenseMlaForwardKernel:
+         self.chunks_per_split = int(chunks_per_split)
+         self.query_tile = int(query_tile)
+         self.fp8 = bool(fp8)
+-        self.qk_dim = int(qk_dim)
+-        self.value_dim = int(value_dim)
+-        self.window_size = None if window_size is None else int(window_size)
+         self.kv_stages = int(layout.kv_stages)
+         self.math_warps = MATH_WARPS_PER_QUERY * self.query_tile
+         self.math_threads = self.math_warps * 32
+@@ -98,7 +92,6 @@ class DenseMlaForwardKernel:
+         q_stride_row_bytes: Int64,
+         q_stride_head_bytes: Int64,
+         page_stride_bytes: Int64,
+-        cache_record_stride_bytes: Int64,
+         page_table_stride: Int64,
+         total_q: Int32,
+         batch: Int32,
+@@ -122,7 +115,6 @@ class DenseMlaForwardKernel:
+             q_stride_row_bytes,
+             q_stride_head_bytes,
+             page_stride_bytes,
+-            cache_record_stride_bytes,
+             page_table_stride,
+             total_q,
+             batch,
+@@ -146,7 +138,6 @@ class DenseMlaForwardKernel:
+         mbar_base,
+         active_chunks: Int32,
+         split_first_chunk: Int32,
+-        visible_begin: Int32,
+         visible_end: Int32,
+         query_row: Int32,
+         head_base: Int32,
+@@ -165,10 +156,10 @@ class DenseMlaForwardKernel:
+         *,
+         barrier_id: cutlass.Constexpr,
+     ):
+-        accumulator_fragment = cute.make_rmem_tensor(self.value_dim // 16, Float32)
++        accumulator_fragment = cute.make_rmem_tensor(32, Float32)
+         global_max_fragment = cute.make_rmem_tensor(2, Float32)
+         global_sum_fragment = cute.make_rmem_tensor(2, Float32)
+-        for idx in cutlass.range_constexpr(self.value_dim // 16):
++        for idx in cutlass.range_constexpr(32):
+             accumulator_fragment[idx] = Float32(0.0)
+         global_max_fragment[0] = Float32(-1.0e30)
+         global_max_fragment[1] = Float32(-1.0e30)
+@@ -201,7 +192,7 @@ class DenseMlaForwardKernel:
+                         accumulator_fragment[tile * 2],
+                         accumulator_fragment[tile * 2 + 1],
+                     ]
+-                    for tile in range(self.value_dim // 32)
++                    for tile in range(16)
+                 ]
+                 global_max = [
+                     global_max_fragment[0],
+@@ -225,7 +216,6 @@ class DenseMlaForwardKernel:
+                         local_warp,
+                         lane,
+                         record_stride_bytes=self.layout.record_stride_bytes,
+-                        qk_dim=self.qk_dim,
+                     )
+                 else:
+                     qk = qk_bf16(
+@@ -235,12 +225,10 @@ class DenseMlaForwardKernel:
+                         local_warp,
+                         lane,
+                         record_stride_bytes=self.layout.record_stride_bytes,
+-                        qk_dim=self.qk_dim,
+                     )
+                 qk = mask_and_scale(
+                     qk,
+                     chunk_begin,
+-                    visible_begin,
+                     visible_end,
+                     score_scale_log2,
+                     local_warp,
+@@ -264,7 +252,6 @@ class DenseMlaForwardKernel:
+                     lane,
+                     local_tid,
+                     barrier_id=barrier_id,
+-                    value_dim=self.value_dim,
+                 )
+                 weights = [
+                     probability[0] * warp_scale0,
+@@ -284,7 +271,6 @@ class DenseMlaForwardKernel:
+                         local_tid,
+                         record_stride_bytes=self.layout.record_stride_bytes,
+                         barrier_id=barrier_id,
+-                        value_dim=self.value_dim,
+                     )
+                 else:
+                     accumulator = pv_bf16(
+@@ -296,9 +282,8 @@ class DenseMlaForwardKernel:
+                         lane,
+                         record_stride_bytes=self.layout.record_stride_bytes,
+                         barrier_id=barrier_id,
+-                        value_dim=self.value_dim,
+                     )
+-                for tile in cutlass.range_constexpr(self.value_dim // 32):
++                for tile in cutlass.range_constexpr(16):
+                     accumulator_fragment[tile * 2] = accumulator[tile][0]
+                     accumulator_fragment[tile * 2 + 1] = accumulator[tile][1]
+                 global_max_fragment[0] = global_max[0]
+@@ -324,7 +309,7 @@ class DenseMlaForwardKernel:
+                 accumulator_fragment[tile * 2],
+                 accumulator_fragment[tile * 2 + 1],
+             ]
+-            for tile in range(self.value_dim // 32)
++            for tile in range(16)
+         ]
+         global_max = [
+             global_max_fragment[0],
+@@ -353,7 +338,6 @@ class DenseMlaForwardKernel:
+                     has_splits=True,
+                     fp8=self.fp8,
+                     ln2=0.6931471805599453,
+-                    value_dim=self.value_dim,
+                 )
+             else:
+                 write_partial_or_final(
+@@ -373,7 +357,6 @@ class DenseMlaForwardKernel:
+                     has_splits=False,
+                     fp8=self.fp8,
+                     ln2=0.6931471805599453,
+-                    value_dim=self.value_dim,
+                 )
+         else:
+             write_partial_or_final(
+@@ -393,7 +376,6 @@ class DenseMlaForwardKernel:
+                 has_splits=False,
+                 fp8=self.fp8,
+                 ln2=0.6931471805599453,
+-                value_dim=self.value_dim,
+             )
+ 
+     @cute.kernel
+@@ -414,7 +396,6 @@ class DenseMlaForwardKernel:
+         q_stride_row_bytes: Int64,
+         q_stride_head_bytes: Int64,
+         page_stride_bytes: Int64,
+-        cache_record_stride_bytes: Int64,
+         page_table_stride: Int64,
+         total_q: Int32,
+         batch: Int32,
+@@ -446,25 +427,10 @@ class DenseMlaForwardKernel:
+         query_length = query_end - query_begin
+         cache_length = Int32(cache_seqlens[request])
+ 
+-        first_valid_chunk = Int32(0)
+-        visible_chunks_end = cache_length
+-        if cutlass.const_expr(self.window_size is not None):
+-            tile_local_query = query_start - query_begin
+-            visible_chunks_end = (
+-                cache_length - query_length + tile_local_query + Int32(1)
+-            )
+-            if visible_chunks_end < Int32(0):
+-                visible_chunks_end = Int32(0)
+-            if visible_chunks_end > cache_length:
+-                visible_chunks_end = cache_length
+-            visible_chunks_begin = visible_chunks_end - Int32(self.window_size)
+-            if visible_chunks_begin < Int32(0):
+-                visible_chunks_begin = Int32(0)
+-            first_valid_chunk = visible_chunks_begin // Int32(CANDIDATES_PER_CHUNK)
+-        valid_chunks = (visible_chunks_end + Int32(CANDIDATES_PER_CHUNK - 1)) // Int32(
++        valid_chunks = (cache_length + Int32(CANDIDATES_PER_CHUNK - 1)) // Int32(
+             CANDIDATES_PER_CHUNK
+         )
+-        split_first_chunk = first_valid_chunk + split * Int32(self.chunks_per_split)
++        split_first_chunk = split * Int32(self.chunks_per_split)
+         split_last_chunk = split_first_chunk + Int32(self.chunks_per_split)
+         if split_last_chunk > valid_chunks:
+             split_last_chunk = valid_chunks
+@@ -478,8 +444,9 @@ class DenseMlaForwardKernel:
+                 query_slot = entry // Int32(HEADS_PER_TILE)
+                 local_head = entry - query_slot * Int32(HEADS_PER_TILE)
+                 query_row = query_start + query_slot
+-                if query_row < total_q and head_base + local_head < Int32(
+-                    self.num_heads
++                if (
++                    query_row < total_q
++                    and head_base + local_head < Int32(self.num_heads)
+                 ):
+                     if cutlass.const_expr(self.num_splits > 1):
+                         if active_splits > Int32(1):
+@@ -546,7 +513,6 @@ class DenseMlaForwardKernel:
+                     cache_length,
+                     io_lane,
+                     page_stride_bytes,
+-                    cache_record_stride_bytes,
+                     page_table_stride,
+                     page_size=self.page_size,
+                     record_bytes=self.layout.record_bytes,
+@@ -589,11 +555,6 @@ class DenseMlaForwardKernel:
+                 visible_end = Int32(0)
+             if visible_end > cache_length:
+                 visible_end = cache_length
+-            visible_begin = Int32(0)
+-            if cutlass.const_expr(self.window_size is not None):
+-                visible_begin = visible_end - Int32(self.window_size)
+-                if visible_begin < Int32(0):
+-                    visible_begin = Int32(0)
+ 
+             score_scale = sm_scale_log2
+             value_scale = Float32(1.0)
+@@ -628,7 +589,6 @@ class DenseMlaForwardKernel:
+                     mbar_base,
+                     active_chunks,
+                     split_first_chunk,
+-                    visible_begin,
+                     visible_end,
+                     query_row,
+                     head_base,
+@@ -657,7 +617,6 @@ class DenseMlaForwardKernel:
+                     mbar_base,
+                     active_chunks,
+                     split_first_chunk,
+-                    visible_begin,
+                     visible_end,
+                     query_row,
+                     head_base,
+@@ -686,7 +645,6 @@ class DenseMlaForwardKernel:
+                     mbar_base,
+                     active_chunks,
+                     split_first_chunk,
+-                    visible_begin,
+                     visible_end,
+                     query_row,
+                     head_base,
+@@ -715,7 +673,6 @@ class DenseMlaForwardKernel:
+                     mbar_base,
+                     active_chunks,
+                     split_first_chunk,
+-                    visible_begin,
+                     visible_end,
+                     query_row,
+                     head_base,
+diff --git a/b12x/attention/dense_mla/_io.py b/b12x/attention/dense_mla/_io.py
+index f6e082bac27a68c5a0cc01752e65e1086f3e7222..5f91aaf6d7888b0c49bca31561b54ce4757fae4a 100644
+--- a/b12x/attention/dense_mla/_io.py
++++ b/b12x/attention/dense_mla/_io.py
+@@ -26,7 +26,6 @@ def issue_dense_page_gather(
+     token_end: Int32,
+     io_lane: Int32,
+     page_stride_bytes: Int64,
+-    record_stride_bytes_global: Int64,
+     page_table_stride: Int64,
+     *,
+     page_size: cutlass.Constexpr,
+@@ -61,10 +60,9 @@ def issue_dense_page_gather(
+ 
+         # Load-bearing Int64 conversions. Neither multiplication is allowed to
+         # occur in Int32, even when benchmark page ids happen to be small.
+-        source_offset = (
+-            physical_page.to(Int64) * page_stride_bytes
+-            + in_page.to(Int64) * record_stride_bytes_global
+-        )
++        source_offset = physical_page.to(Int64) * page_stride_bytes + in_page.to(
++            Int64
++        ) * Int64(record_bytes)
+         cp_async_bulk_g2s_mbar(
+             kv_dst_addr + entry * Int32(record_stride_bytes),
+             get_ptr_as_int64(cache_bytes, source_offset),
+diff --git a/b12x/attention/dense_mla/_kernel.py b/b12x/attention/dense_mla/_kernel.py
+index 6f14d2470052da209dcf7567883d20b1c249e61d..12bae04d9c33d022434a637f9ac1fe5c3fe5f726 100644
+--- a/b12x/attention/dense_mla/_kernel.py
++++ b/b12x/attention/dense_mla/_kernel.py
+@@ -21,7 +21,6 @@ from b12x._lib.compiler import (
+     tensor_key,
+ )
+ 
+-from .._shared import static_fp8_quant
+ from ._forward import DenseMlaForwardKernel
+ from ._layout import make_smem_layout
+ from ._merge import DenseMlaMergeKernel
+@@ -83,10 +82,6 @@ def _signature(binding: Binding) -> tuple[object, ...]:
+         scratch.query_tile,
+         scratch.num_splits,
+         scratch.chunks_per_split,
+-        scratch.physical_record_width,
+-        scratch.head_dim,
+-        scratch.v_head_dim,
+-        scratch.window_size,
+         tuple(int(value) for value in binding.q.stride()),
+         tuple(int(value) for value in binding.kv_cache.stride()),
+         tuple(int(value) for value in binding.output.stride()),
+@@ -118,7 +113,6 @@ def _forward_launch(binding: Binding) -> _ForwardLaunch:
+     layout = make_smem_layout(
+         query_tile=scratch.query_tile,
+         fp8=fp8,
+-        qk_dim=scratch.head_dim,
+     )
+     entry = DenseMlaForwardKernel(
+         layout=layout,
+@@ -128,9 +122,6 @@ def _forward_launch(binding: Binding) -> _ForwardLaunch:
+         chunks_per_split=scratch.chunks_per_split,
+         query_tile=scratch.query_tile,
+         fp8=fp8,
+-        qk_dim=scratch.head_dim,
+-        value_dim=scratch.v_head_dim,
+-        window_size=scratch.window_size,
+     )
+ 
+     q_bytes = _byte_base_pointer(binding.q)
+@@ -194,7 +185,6 @@ def _forward_launch(binding: Binding) -> _ForwardLaunch:
+         Int64(int(binding.q.stride(0)) * binding.q.element_size()),
+         Int64(int(binding.q.stride(1)) * binding.q.element_size()),
+         Int64(int(binding.kv_cache.stride(0)) * binding.kv_cache.element_size()),
+-        Int64(int(binding.kv_cache.stride(1)) * binding.kv_cache.element_size()),
+         Int64(int(binding.page_table.stride(0))),
+         Int32(int(binding.q.shape[0])),
+         Int32(int(binding.cache_seqlens.shape[0])),
+@@ -203,7 +193,7 @@ def _forward_launch(binding: Binding) -> _ForwardLaunch:
+     )
+     spec = KernelCompileSpec.from_fields(
+         "attention.dense_mla.forward",
+-        4,
++        3,
+         key_field("dtype", "fp8" if fp8 else "bf16"),
+         key_field("heads", scratch.num_q_heads),
+         key_field("page_size", scratch.page_size),
+@@ -212,10 +202,6 @@ def _forward_launch(binding: Binding) -> _ForwardLaunch:
+         key_field("query_tile", scratch.query_tile),
+         key_field("num_splits", scratch.num_splits),
+         key_field("chunks_per_split", scratch.chunks_per_split),
+-        key_field("physical_record_width", scratch.physical_record_width),
+-        key_field("head_dim", scratch.head_dim),
+-        key_field("v_head_dim", scratch.v_head_dim),
+-        key_field("window_size", scratch.window_size),
+         key_field("record_stride_bytes", layout.record_stride_bytes),
+         tensor_key(
+             "q",
+@@ -223,7 +209,7 @@ def _forward_launch(binding: Binding) -> _ForwardLaunch:
+             dims=(
+                 DimKey.dynamic(),
+                 DimKey.exact(scratch.num_q_heads),
+-                DimKey.exact(scratch.head_dim),
++                DimKey.exact(576),
+             ),
+         ),
+         tensor_key(
+@@ -232,7 +218,7 @@ def _forward_launch(binding: Binding) -> _ForwardLaunch:
+             dims=(
+                 DimKey.dynamic(),
+                 DimKey.exact(scratch.page_size),
+-                DimKey.exact(scratch.physical_record_width),
++                DimKey.exact(576),
+             ),
+         ),
+         tensor_key(
+@@ -241,7 +227,7 @@ def _forward_launch(binding: Binding) -> _ForwardLaunch:
+             dims=(
+                 DimKey.dynamic(),
+                 DimKey.exact(scratch.num_q_heads),
+-                DimKey.exact(scratch.v_head_dim),
++                DimKey.exact(512),
+             ),
+         ),
+     )
+@@ -254,7 +240,7 @@ def _merge_launch(binding: Binding) -> _MergeLaunch | None:
+         return None
+     assert scratch.partial_output is not None
+     assert scratch.partial_lse is not None
+-    entry = DenseMlaMergeKernel(scratch.num_splits, scratch.v_head_dim)
++    entry = DenseMlaMergeKernel(scratch.num_splits)
+     stream = cuda.CUstream(torch.cuda.current_stream().cuda_stream)
+     args = (
+         _to_cute(
+@@ -278,7 +264,6 @@ def _merge_launch(binding: Binding) -> _MergeLaunch | None:
+         4,
+         key_field("num_splits", scratch.num_splits),
+         key_field("heads", scratch.num_q_heads),
+-        key_field("v_head_dim", scratch.v_head_dim),
+         tensor_key(
+             "partial_output",
+             scratch.partial_output,
+@@ -286,7 +271,7 @@ def _merge_launch(binding: Binding) -> _MergeLaunch | None:
+                 DimKey.capacity(scratch.max_total_q),
+                 DimKey.exact(scratch.num_q_heads),
+                 DimKey.exact(scratch.num_splits),
+-                DimKey.exact(scratch.v_head_dim),
++                DimKey.exact(512),
+             ),
+         ),
+         tensor_key(
+@@ -295,7 +280,7 @@ def _merge_launch(binding: Binding) -> _MergeLaunch | None:
+             dims=(
+                 DimKey.dynamic(),
+                 DimKey.exact(scratch.num_q_heads),
+-                DimKey.exact(scratch.v_head_dim),
++                DimKey.exact(512),
+             ),
+         ),
+     )
+@@ -333,8 +318,6 @@ def compile_dense_mla(*, binding: Binding) -> None:
+     """Compile the exact native forward/merge entries without launching."""
+     if not binding.q.is_cuda:
+         raise ValueError("dense MLA native compilation requires CUDA tensors")
+-    if binding.query_quant is not None:
+-        static_fp8_quant.compile(binding=binding.query_quant)
+     _compile_entries(binding)
+ 
+ 
+@@ -345,8 +328,6 @@ def run_dense_mla(
+     """Launch only previously planned storage; no device allocation occurs."""
+     if not binding.q.is_cuda:
+         raise ValueError("dense MLA native execution requires CUDA tensors")
+-    if binding.query_quant is not None:
+-        static_fp8_quant.run(binding=binding.query_quant)
+     signature = _signature(binding)
+     with _LOCK:
+         compiled_forward = _FORWARD_CACHE.get(signature)
+@@ -374,7 +355,6 @@ def run_dense_mla(
+ 
+ 
+ def clear_dense_mla_kernel_caches() -> None:
+-    static_fp8_quant.clear_caches()
+     with _LOCK:
+         _FORWARD_CACHE.clear()
+         _MERGE_CACHE.clear()
+diff --git a/b12x/attention/dense_mla/_layout.py b/b12x/attention/dense_mla/_layout.py
+index ab6f417d78e32f3f3bf78a2d2125d9750ea134cb..4b5856771f84ad36317bef9aa8ebc0bf81fe1933 100644
+--- a/b12x/attention/dense_mla/_layout.py
++++ b/b12x/attention/dense_mla/_layout.py
+@@ -33,9 +33,7 @@ class SmemLayout:
+     total_bytes: int
+ 
+ 
+-def make_smem_layout(
+-    *, query_tile: int, fp8: bool, qk_dim: int = K3_QK_DIM
+-) -> SmemLayout:
++def make_smem_layout(*, query_tile: int, fp8: bool) -> SmemLayout:
+     query_tile = int(query_tile)
+     if query_tile not in (1, 2, 4):
+         raise ValueError("dense MLA query_tile must be 1, 2, or 4")
+@@ -47,11 +45,8 @@ def make_smem_layout(
+     # opt-in SMEM limit exposed by RTX PRO 6000 Blackwell.  BF16 retains the
+     # same producer/consumer transaction protocol with one stage; the primary
+     # E4M3 serving path keeps the latency-hiding double buffer.
+-    qk_dim = int(qk_dim)
+-    if qk_dim <= 0 or qk_dim % 32:
+-        raise ValueError("dense MLA qk_dim must be a positive multiple of 32")
+-    kv_stages = KV_STAGES if fp8 and qk_dim <= K3_QK_DIM else 1
+-    record_bytes = qk_dim * element_bytes
++    kv_stages = KV_STAGES if fp8 else 1
++    record_bytes = K3_QK_DIM * element_bytes
+     # The extra 16 bytes rotate successive rows across banks while making
+     # every row a legal cp.async.bulk destination.
+     record_stride_bytes = record_bytes + 16
+diff --git a/b12x/attention/dense_mla/_math.py b/b12x/attention/dense_mla/_math.py
+index ae8d92925cdd6ca43bb7d95a24f40cdd4109c6d2..e40b02b4c58703146cf0cec30b8b8d9ba068b472 100644
+--- a/b12x/attention/dense_mla/_math.py
++++ b/b12x/attention/dense_mla/_math.py
+@@ -39,6 +39,8 @@ from b12x._lib.intrinsics import (
+ from ._layout import (
+     CANDIDATES_PER_CHUNK,
+     HEADS_PER_TILE,
++    K3_QK_DIM,
++    K3_VALUE_DIM,
+     MATH_WARPS_PER_QUERY,
+ )
+ 
+@@ -155,7 +157,6 @@ def qk_fp8(
+     lane: Int32,
+     *,
+     record_stride_bytes: cutlass.Constexpr,
+-    qk_dim: cutlass.Constexpr,
+ ):
+     """Raw E4M3 K-by-Q MMA for one 16-candidate warp tile."""
+     a_row = (lane & Int32(7)) + ((lane >> Int32(3)) & Int32(1)) * Int32(8)
+@@ -164,7 +165,7 @@ def qk_fp8(
+     b_col = ((lane >> Int32(3)) & Int32(1)) * Int32(16)
+     first_candidate = local_warp * Int32(16)
+ 
+-    for ks in cutlass.range_constexpr(qk_dim // 32):
++    for ks in cutlass.range_constexpr(K3_QK_DIM // 32):
+         ko = Int32(ks * 32)
+         a_addr = (
+             kv_smem_addr
+@@ -199,7 +200,6 @@ def qk_bf16(
+     lane: Int32,
+     *,
+     record_stride_bytes: cutlass.Constexpr,
+-    qk_dim: cutlass.Constexpr,
+ ):
+     """Raw BF16 K-by-Q MMA for one 16-candidate warp tile."""
+     gid = lane >> Int32(2)
+@@ -208,7 +208,7 @@ def qk_bf16(
+     a_col = (lane >> Int32(4)) * Int32(8)
+     first_candidate = local_warp * Int32(16)
+ 
+-    for ks in cutlass.range_constexpr(qk_dim // 16):
++    for ks in cutlass.range_constexpr(K3_QK_DIM // 16):
+         ko = Int32(ks * 16)
+         a_addr = (
+             kv_smem_addr
+@@ -238,7 +238,6 @@ def qk_bf16(
+ def mask_and_scale(
+     qk,
+     chunk_begin: Int32,
+-    visible_begin: Int32,
+     visible_end: Int32,
+     scale_log2: Float32,
+     local_warp: Int32,
+@@ -248,10 +247,10 @@ def mask_and_scale(
+     gid = lane >> Int32(2)
+     candidate0 = chunk_begin + local_warp * Int32(16) + gid
+     candidate1 = candidate0 + Int32(8)
+-    if candidate0 < visible_begin or candidate0 >= visible_end:
++    if candidate0 >= visible_end:
+         qk[0] = Float32(_MASK)
+         qk[1] = Float32(_MASK)
+-    if candidate1 < visible_begin or candidate1 >= visible_end:
++    if candidate1 >= visible_end:
+         qk[2] = Float32(_MASK)
+         qk[3] = Float32(_MASK)
+     for idx in cutlass.range_constexpr(4):
+@@ -273,7 +272,6 @@ def online_softmax(
+     local_tid: Int32,
+     *,
+     barrier_id: cutlass.Constexpr,
+-    value_dim: cutlass.Constexpr,
+ ):
+     """Update a base-2 online softmax and rescale persistent PV registers."""
+     gid = lane >> Int32(2)
+@@ -368,7 +366,7 @@ def online_softmax(
+     row_alpha = row_alpha0
+     if (gid & Int32(1)) != Int32(0):
+         row_alpha = row_alpha1
+-    for tile in cutlass.range_constexpr(value_dim // 32):
++    for tile in cutlass.range_constexpr(16):
+         acc[tile][0] = acc[tile][0] * row_alpha
+         acc[tile][1] = acc[tile][1] * row_alpha
+ 
+@@ -474,7 +472,6 @@ def pv_fp8(
+     *,
+     record_stride_bytes: cutlass.Constexpr,
+     barrier_id: cutlass.Constexpr,
+-    value_dim: cutlass.Constexpr,
+ ):
+     """HIGH/LOW E4M3 probability MMA against the raw K3 value prefix."""
+     gid = lane >> Int32(2)
+@@ -566,7 +563,7 @@ def pv_fp8(
+     a_row = (lane & Int32(7)) + ((lane >> Int32(3)) & Int32(1)) * Int32(8)
+     a_col = (lane >> Int32(4)) * Int32(16)
+     row_scale = ld_shared_f32(weight_scale_addr + gid * Int32(4))
+-    for value_chunk in cutlass.range_constexpr(value_dim // 64):
++    for value_chunk in cutlass.range_constexpr(K3_VALUE_DIM // 64):
+         for n_tile in cutlass.range_constexpr(2):
+             dimension = Int32(value_chunk * 64) + (
+                 Int32(n_tile * MATH_WARPS_PER_QUERY) + local_warp
+@@ -615,7 +612,6 @@ def pv_bf16(
+     *,
+     record_stride_bytes: cutlass.Constexpr,
+     barrier_id: cutlass.Constexpr,
+-    value_dim: cutlass.Constexpr,
+ ):
+     """BF16 probability/value MMA for the K3 value prefix."""
+     gid = lane >> Int32(2)
+@@ -648,7 +644,7 @@ def pv_bf16(
+ 
+     a_row = (lane & Int32(7)) + ((lane >> Int32(3)) & Int32(1)) * Int32(8)
+     a_col = (lane >> Int32(4)) * Int32(8)
+-    for value_chunk in cutlass.range_constexpr(value_dim // 64):
++    for value_chunk in cutlass.range_constexpr(K3_VALUE_DIM // 64):
+         for n_tile in cutlass.range_constexpr(2):
+             column = (
+                 Int32(value_chunk * 64)
+@@ -725,7 +721,6 @@ def write_partial_or_final(
+     has_splits: cutlass.Constexpr,
+     fp8: cutlass.Constexpr,
+     ln2: cutlass.Constexpr,
+-    value_dim: cutlass.Constexpr,
+ ):
+     """Write a normalized split partial, or the final one-split result."""
+     gid = lane >> Int32(2)
+@@ -749,7 +744,7 @@ def write_partial_or_final(
+         scale = scale * value_scale
+ 
+     if query_valid != Int32(0) and head_base + gid < Int32(num_heads):
+-        for value_chunk in cutlass.range_constexpr(value_dim // 64):
++        for value_chunk in cutlass.range_constexpr(K3_VALUE_DIM // 64):
+             for n_tile in cutlass.range_constexpr(2):
+                 tile = value_chunk * 2 + n_tile
+                 dimension = (
+diff --git a/b12x/attention/dense_mla/_merge.py b/b12x/attention/dense_mla/_merge.py
+index 5f26c5aa2d46751b0134662b3341e0bb2430f5a8..afe93603ed25bab6d65013533b5b30fe8e7f28cd 100644
+--- a/b12x/attention/dense_mla/_merge.py
++++ b/b12x/attention/dense_mla/_merge.py
+@@ -21,9 +21,8 @@ from ._math import exp2_approx, log2_approx
+ class DenseMlaMergeKernel:
+     """Merge normalized BF16 split partials and emit natural-log LSE."""
+ 
+-    def __init__(self, num_splits: int, value_dim: int):
++    def __init__(self, num_splits: int):
+         self.num_splits = int(num_splits)
+-        self.value_dim = int(value_dim)
+ 
+     def _get_shared_storage_cls(self):
+         """Return the per-CTA split-weight storage.
+@@ -149,57 +148,55 @@ class DenseMlaMergeKernel:
+ 
+         cute.arch.barrier()
+ 
+-        while dimension < Int32(self.value_dim):
+-            accumulator = cute.make_rmem_tensor(4, Float32)
+-            for idx in cutlass.range_constexpr(4):
+-                accumulator[idx] = Float32(0.0)
+-
+-            split = Int32(0)
+-            while split < active_splits:
+-                weight = Float32(split_weight[split])
+-                # Capture-static tail splits deliberately leave their partial
+-                # vectors undefined and publish -inf LSE.  Do not load those
+-                # vectors: NaN * 0 would otherwise poison the merged output.
+-                if weight > Float32(0.0):
+-                    partial_offset = (
+-                        (Int64(query) * Int64(partial_output.shape[1]) + Int64(head))
+-                        * Int64(self.num_splits)
+-                        + Int64(split)
+-                    ) * Int64(self.value_dim) + Int64(dimension)
+-                    packed0, packed1 = ld_global_v2_u32(
+-                        get_ptr_as_int64(partial_output, partial_offset)
+-                    )
+-                    value0, value1 = bfloat2_to_float2_scaled(
+-                        packed0,
+-                        weight,
+-                    )
+-                    value2, value3 = bfloat2_to_float2_scaled(
+-                        packed1,
+-                        weight,
+-                    )
+-                    accumulator[0] += value0
+-                    accumulator[1] += value1
+-                    accumulator[2] += value2
+-                    accumulator[3] += value3
+-                split += Int32(1)
+-
+-            inverse = Float32(inverse_storage[0])
+-            output_offset = cute.crd2idx(
+-                (query, head, dimension),
+-                output.layout,
+-            )
+-            st_global_v2_u32(
+-                get_ptr_as_int64(output, output_offset),
+-                pack_f32x2_to_bfloat2(
+-                    accumulator[0] * inverse,
+-                    accumulator[1] * inverse,
+-                ),
+-                pack_f32x2_to_bfloat2(
+-                    accumulator[2] * inverse,
+-                    accumulator[3] * inverse,
+-                ),
+-            )
+-            dimension += Int32(128 * 4)
++        accumulator = cute.make_rmem_tensor(4, Float32)
++        for idx in cutlass.range_constexpr(4):
++            accumulator[idx] = Float32(0.0)
++
++        split = Int32(0)
++        while split < active_splits:
++            weight = Float32(split_weight[split])
++            # Capture-static tail splits deliberately leave their partial
++            # vectors undefined and publish -inf LSE.  Do not load those
++            # vectors: NaN * 0 would otherwise poison the merged output.
++            if weight > Float32(0.0):
++                partial_offset = (
++                    (Int64(query) * Int64(partial_output.shape[1]) + Int64(head))
++                    * Int64(self.num_splits)
++                    + Int64(split)
++                ) * Int64(512) + Int64(dimension)
++                packed0, packed1 = ld_global_v2_u32(
++                    get_ptr_as_int64(partial_output, partial_offset)
++                )
++                value0, value1 = bfloat2_to_float2_scaled(
++                    packed0,
++                    weight,
++                )
++                value2, value3 = bfloat2_to_float2_scaled(
++                    packed1,
++                    weight,
++                )
++                accumulator[0] += value0
++                accumulator[1] += value1
++                accumulator[2] += value2
++                accumulator[3] += value3
++            split += Int32(1)
++
++        inverse = Float32(inverse_storage[0])
++        output_offset = cute.crd2idx(
++            (query, head, dimension),
++            output.layout,
++        )
++        st_global_v2_u32(
++            get_ptr_as_int64(output, output_offset),
++            pack_f32x2_to_bfloat2(
++                accumulator[0] * inverse,
++                accumulator[1] * inverse,
++            ),
++            pack_f32x2_to_bfloat2(
++                accumulator[2] * inverse,
++                accumulator[3] * inverse,
++            ),
++        )
+ 
+ 
+ __all__ = ["DenseMlaMergeKernel"]
+diff --git a/b12x/attention/dense_mla/_reference.py b/b12x/attention/dense_mla/_reference.py
+index 21a10e6c7729c4ec660a493828a0cf903e3b65ef..1d6b329cc45b91e04893db3e528b405c4a053b2d 100644
+--- a/b12x/attention/dense_mla/_reference.py
++++ b/b12x/attention/dense_mla/_reference.py
+@@ -1,4 +1,4 @@
+-"""High-precision paged dense-MLA oracle."""
++"""High-precision paged dense-MLA oracle for the Kimi-K3 contract."""
+ 
+ from __future__ import annotations
+ 
+@@ -12,20 +12,17 @@ K3_RAW_QK_DIM = 192
+ K3_SM_SCALE = 1.0 / math.sqrt(K3_RAW_QK_DIM)
+ 
+ 
+-def _cache_rank3(cache: torch.Tensor, *, head_dim: int) -> torch.Tensor:
++def _cache_rank3(cache: torch.Tensor) -> torch.Tensor:
+     if cache.ndim == 4:
+         if int(cache.shape[2]) != 1:
+             raise ValueError("rank-4 dense MLA cache must have one KV head")
+         cache = cache[:, :, 0, :]
+     if cache.ndim != 3:
+         raise ValueError(
+-            "cache must be [pages,page_size,physical_record_width] or its "
+-            "singleton-head rank-4 form"
+-        )
+-    if int(cache.shape[-1]) < head_dim:
+-        raise ValueError(
+-            f"dense MLA cache record must contain at least {head_dim} elements"
++            "cache must be [pages,page_size,576] or [pages,page_size,1,576]"
+         )
++    if int(cache.shape[-1]) != K3_ABSORBED_DIM:
++        raise ValueError(f"dense MLA cache record must be {K3_ABSORBED_DIM} wide")
+     return cache
+ 
+ 
+@@ -49,29 +46,16 @@ def dense_mla_reference(
+     kv_scale: torch.Tensor | float | None = None,
+     q_scale: torch.Tensor | float | None = None,
+     sm_scale: float = K3_SM_SCALE,
+-    v_head_dim: int | None = None,
+-    window_size: int | None = None,
+ ) -> tuple[torch.Tensor, torch.Tensor]:
+-    """Compute right-aligned causal dense MLA with an optional local window.
++    """Compute the exact right-aligned causal K3 dense MLA definition.
+ 
+     The cache already contains the current query chunk.  Query row ``i`` in a
+     request of length ``Q`` therefore sees keys through
+     ``cache_len - Q + i`` (inclusive).
+     """
+-    if q.ndim != 3:
+-        raise ValueError("q must have shape [total_q, heads, head_dim]")
+-    head_dim = int(q.shape[-1])
+-    default_value_dims = {K3_ABSORBED_DIM: K3_VALUE_DIM, 1088: 1024}
+-    if head_dim not in default_value_dims:
+-        raise ValueError(f"unsupported dense MLA query width {head_dim}")
+-    if v_head_dim is None:
+-        v_head_dim = default_value_dims[head_dim]
+-    v_head_dim = int(v_head_dim)
+-    if not 0 < v_head_dim <= head_dim:
+-        raise ValueError("v_head_dim must be in [1, head_dim]")
+-    if window_size is not None and int(window_size) <= 0:
+-        raise ValueError("window_size must be positive or None")
+-    cache = _cache_rank3(kv_cache, head_dim=head_dim)
++    cache = _cache_rank3(kv_cache)
++    if q.ndim != 3 or tuple(q.shape[1:])[-1:] != (K3_ABSORBED_DIM,):
++        raise ValueError("q must have shape [total_q, heads, 576]")
+     if q.dtype not in (torch.bfloat16, torch.float8_e4m3fn):
+         raise TypeError("q must be BF16 or E4M3")
+     if cache.dtype not in (torch.bfloat16, torch.float8_e4m3fn):
+@@ -98,22 +82,6 @@ def dense_mla_reference(
+         raise ValueError("E4M3 kv_cache requires kv_scale")
+     if q.dtype == torch.float8_e4m3fn and q_scale is None:
+         raise ValueError("E4M3 q requires q_scale")
+-    if cache.dtype == torch.bfloat16 and (kv_scale is not None or q_scale is not None):
+-        raise ValueError("BF16 dense MLA does not accept quantization scales")
+-    if q.dtype != cache.dtype and not (
+-        q.dtype == torch.bfloat16 and cache.dtype == torch.float8_e4m3fn
+-    ):
+-        raise TypeError(
+-            "dense MLA reference supports matching query/cache dtypes or a "
+-            "BF16 query with an E4M3 cache"
+-        )
+-    if q.dtype == torch.bfloat16 and cache.dtype == torch.float8_e4m3fn:
+-        if q_scale is None:
+-            raise ValueError("BF16 query quantization for E4M3 cache requires q_scale")
+-        quantized_q = (q.float() / q_mul).to(torch.float8_e4m3fn)
+-        q_f32 = quantized_q.float() * q_mul
+-    else:
+-        q_f32 = q.float() * q_mul
+ 
+     cu_host = [int(v) for v in cu_seqlens_q.detach().cpu().tolist()]
+     lens_host = [int(v) for v in cache_seqlens.detach().cpu().tolist()]
+@@ -121,7 +89,7 @@ def dense_mla_reference(
+         raise ValueError("cu_seqlens_q must span exactly q.shape[0] rows")
+     page_size = int(cache.shape[1])
+     output = torch.empty(
+-        (int(q.shape[0]), int(q.shape[1]), v_head_dim),
++        (int(q.shape[0]), int(q.shape[1]), K3_VALUE_DIM),
+         dtype=torch.float32,
+         device=q.device,
+     )
+@@ -143,24 +111,18 @@ def dense_mla_reference(
+         if pages_needed > int(page_table.shape[1]):
+             raise ValueError("page_table is too narrow for cache_seqlens")
+         physical_pages = page_table[request, :pages_needed].to(torch.long)
+-        records = cache.index_select(0, physical_pages).reshape(
+-            -1, int(cache.shape[-1])
+-        )
+-        records = records[:, :head_dim]
++        records = cache.index_select(0, physical_pages).reshape(-1, K3_ABSORBED_DIM)
+         records = records[:kv_len].float() * kv_mul
+ 
+-        q_rows = q_f32[q_begin:q_end]
++        q_rows = q[q_begin:q_end].float() * q_mul
+         for local_q in range(q_len):
+             visible = kv_len - q_len + local_q + 1
+-            visible_begin = (
+-                0 if window_size is None else max(0, visible - int(window_size))
+-            )
+-            key = records[visible_begin:visible]
++            key = records[:visible]
+             logits = torch.einsum("hd,kd->hk", q_rows[local_q], key)
+             logits = logits * float(sm_scale)
+             probs = torch.softmax(logits, dim=-1)
+             output[q_begin + local_q] = torch.einsum(
+-                "hk,kd->hd", probs, key[:, :v_head_dim]
++                "hk,kd->hd", probs, key[:, :K3_VALUE_DIM]
+             )
+             lse[q_begin + local_q] = torch.logsumexp(logits, dim=-1)
+ 
+diff --git a/b12x/attention/dense_mla/_scratch.py b/b12x/attention/dense_mla/_scratch.py
+index 37235c1d46caa37d4ecab8bcb44cf85b872c2d14..ba4362bf6b6035e6046285036a4ac21d31ce317e 100644
+--- a/b12x/attention/dense_mla/_scratch.py
++++ b/b12x/attention/dense_mla/_scratch.py
+@@ -20,7 +20,6 @@ from b12x._lib.scratch_layout import (
+     materialize_scratch_view,
+ )
+ 
+-from .._shared import static_fp8_quant
+ from .planner import Budget, choose_num_splits
+ from ._layout import make_smem_layout
+ from ._reference import (
+@@ -30,7 +29,7 @@ from ._reference import (
+ )
+ 
+ _FP8 = torch.float8_e4m3fn
+-_MAX_Q_ROWS = 65_536
++_MAX_Q_ROWS = 1_024
+ _MAX_CACHE_TOKENS = 1_048_576
+ 
+ 
+@@ -42,20 +41,13 @@ def _canonical_device(device: torch.device | str) -> torch.device:
+ 
+ 
+ def _query_tile(caps: Caps) -> int:
+-    if caps.mode == "decode" or caps.max_batch != 1 or caps.window_size is not None:
++    if caps.mode == "decode" or caps.max_batch != 1:
+         return 1
+     if caps.kv_dtype == _FP8 and caps.max_total_q >= 3:
+         return 4
+     return 2
+ 
+ 
+-def _max_attended_tokens(caps: Caps) -> int:
+-    if caps.window_size is None:
+-        return caps.max_cache_tokens
+-    # A local interval can begin and end in partial physical pages.
+-    return min(caps.max_cache_tokens, caps.window_size + caps.page_size - 1)
+-
+-
+ @dataclass(frozen=True, kw_only=True)
+ class Caps:
+     device: torch.device | str
+@@ -69,11 +61,8 @@ class Caps:
+     max_page_table_width: int
+     num_cache_pages: int
+     dtype: torch.dtype = torch.bfloat16
+-    q_dtype: torch.dtype | None = None
+     head_dim: int = K3_ABSORBED_DIM
+     v_head_dim: int = K3_VALUE_DIM
+-    physical_record_width: int = K3_ABSORBED_DIM
+-    window_size: int | None = None
+     use_cuda_graph: bool = False
+     budget: Budget | None = None
+ 
+@@ -82,35 +71,19 @@ class Caps:
+         if self.mode not in ("decode", "extend", "verify"):
+             raise ValueError(f"unsupported dense MLA mode {self.mode!r}")
+         if self.dtype != torch.bfloat16:
+-            raise TypeError("dense MLA output must be torch.bfloat16")
++            raise TypeError("K3 dense MLA activations/output must be torch.bfloat16")
+         if self.kv_dtype not in (torch.bfloat16, _FP8):
+-            raise TypeError("dense MLA KV must be BF16 or E4M3")
+-        q_dtype = self.kv_dtype if self.q_dtype is None else self.q_dtype
+-        if q_dtype not in (torch.bfloat16, _FP8):
+-            raise TypeError("dense MLA query must be BF16 or E4M3")
+-        if q_dtype != self.kv_dtype and not (
+-            q_dtype == torch.bfloat16 and self.kv_dtype == _FP8
+-        ):
+-            raise TypeError(
+-                "dense MLA supports matching query/cache dtypes or a BF16 "
+-                "query with an E4M3 cache"
+-            )
+-        object.__setattr__(self, "q_dtype", q_dtype)
+-        geometry = (int(self.head_dim), int(self.v_head_dim))
+-        if geometry not in ((K3_ABSORBED_DIM, K3_VALUE_DIM), (1088, 1024)):
+-            raise ValueError(
+-                "dense MLA supports logical (QK, V) widths (576, 512) and (1088, 1024)"
+-            )
+-        if int(self.physical_record_width) < int(self.head_dim):
+-            raise ValueError("physical_record_width must cover the logical key record")
+-        if self.window_size is not None and int(self.window_size) <= 0:
+-            raise ValueError("window_size must be positive or None")
++            raise TypeError("K3 dense MLA KV must be BF16 or E4M3")
++        if int(self.head_dim) != K3_ABSORBED_DIM:
++            raise ValueError(f"K3 dense MLA head_dim must be {K3_ABSORBED_DIM}")
++        if int(self.v_head_dim) != K3_VALUE_DIM:
++            raise ValueError(f"K3 dense MLA v_head_dim must be {K3_VALUE_DIM}")
+         heads = int(self.num_q_heads)
+         if heads <= 0:
+             raise ValueError("num_q_heads must be positive")
+         page_size = int(self.page_size)
+-        if page_size <= 0 or (page_size != 1 and page_size % 16):
+-            raise ValueError("page_size must be 1 or a positive multiple of 16")
++        if page_size <= 0 or page_size % 16:
++            raise ValueError("page_size must be a positive multiple of 16")
+         max_total_q = int(self.max_total_q)
+         if not 1 <= max_total_q <= _MAX_Q_ROWS:
+             raise ValueError(f"max_total_q must be in [1, {_MAX_Q_ROWS}]")
+@@ -140,12 +113,9 @@ class Caps:
+             "num_cache_pages",
+             "head_dim",
+             "v_head_dim",
+-            "physical_record_width",
+         ):
+             object.__setattr__(self, name, int(getattr(self, name)))
+         object.__setattr__(self, "use_cuda_graph", bool(self.use_cuda_graph))
+-        if self.window_size is not None:
+-            object.__setattr__(self, "window_size", int(self.window_size))
+ 
+ 
+ @dataclass(frozen=True)
+@@ -156,21 +126,18 @@ class _ScratchLayout:
+     partial_output_offset_bytes: int | None
+     partial_lse_offset_bytes: int | None
+     final_lse_offset_bytes: int
+-    quantized_q_offset_bytes: int | None
+ 
+ 
+ def _dense_mla_scratch_layout(
+     caps: Caps,
+ ) -> _ScratchLayout:
+     query_tile = _query_tile(caps)
+-    max_attended_tokens = _max_attended_tokens(caps)
+     if caps.device.type == "cuda":
+         properties = torch.cuda.get_device_properties(caps.device)
+         sm_count = int(properties.multi_processor_count)
+         shared_layout = make_smem_layout(
+             query_tile=query_tile,
+             fp8=caps.kv_dtype == _FP8,
+-            qk_dim=caps.head_dim,
+         )
+         shared_limit = int(properties.shared_memory_per_block_optin)
+         if shared_layout.total_bytes > shared_limit:
+@@ -182,14 +149,14 @@ def _dense_mla_scratch_layout(
+     else:
+         sm_count = 1
+     num_splits = choose_num_splits(
+-        max_cache_tokens=max_attended_tokens,
++        max_cache_tokens=caps.max_cache_tokens,
+         max_total_q=caps.max_total_q,
+         num_q_heads=caps.num_q_heads,
+         query_tile=query_tile,
+         sm_count=sm_count,
+         budget=caps.budget,
+     )
+-    num_chunks = (max_attended_tokens + 63) // 64
++    num_chunks = (caps.max_cache_tokens + 63) // 64
+     chunks_per_split = (num_chunks + num_splits - 1) // num_splits
+     partial_rows = caps.max_total_q * num_splits
+     if (
+@@ -213,7 +180,7 @@ def _dense_mla_scratch_layout(
+             caps.max_total_q
+             * caps.num_q_heads
+             * num_splits
+-            * caps.v_head_dim
++            * K3_VALUE_DIM
+             * dtype_nbytes(torch.bfloat16)
+         )
+         cursor = align_up(cursor, SCRATCH_ALIGN_BYTES)
+@@ -228,13 +195,6 @@ def _dense_mla_scratch_layout(
+     cursor = align_up(cursor, SCRATCH_ALIGN_BYTES)
+     final_lse_offset_bytes = cursor
+     cursor += caps.max_total_q * caps.num_q_heads * dtype_nbytes(torch.float32)
+-    quantized_q_offset_bytes = None
+-    if caps.q_dtype != caps.kv_dtype:
+-        cursor = align_up(cursor, SCRATCH_ALIGN_BYTES)
+-        quantized_q_offset_bytes = cursor
+-        cursor += (
+-            caps.max_total_q * caps.num_q_heads * caps.head_dim * dtype_nbytes(_FP8)
+-        )
+     cursor = align_up(cursor, SCRATCH_ALIGN_BYTES)
+     return _ScratchLayout(
+         nbytes=max(cursor, SCRATCH_ALIGN_BYTES),
+@@ -243,7 +203,6 @@ def _dense_mla_scratch_layout(
+         partial_output_offset_bytes=partial_output_offset_bytes,
+         partial_lse_offset_bytes=partial_lse_offset_bytes,
+         final_lse_offset_bytes=final_lse_offset_bytes,
+-        quantized_q_offset_bytes=quantized_q_offset_bytes,
+     )
+ 
+ 
+@@ -252,7 +211,6 @@ class Scratch:
+     shared_scratch: torch.Tensor
+     device: torch.device
+     mode: str
+-    q_dtype: torch.dtype
+     kv_dtype: torch.dtype
+     num_q_heads: int
+     page_size: int
+@@ -261,10 +219,6 @@ class Scratch:
+     max_cache_tokens: int
+     max_page_table_width: int
+     num_cache_pages: int
+-    physical_record_width: int
+-    head_dim: int
+-    v_head_dim: int
+-    window_size: int | None
+     num_splits: int
+     chunks_per_split: int
+     query_tile: int
+@@ -272,7 +226,6 @@ class Scratch:
+     partial_output: torch.Tensor | None
+     partial_lse: torch.Tensor | None
+     final_lse: torch.Tensor
+-    quantized_q: torch.Tensor | None
+ 
+ 
+ @dataclass(frozen=True, kw_only=True)
+@@ -288,7 +241,6 @@ class Binding:
+     q_scale: torch.Tensor | None
+     sm_scale: float
+     active_splits: int
+-    query_quant: static_fp8_quant.Binding | None
+ 
+ 
+ def _storage_bounds(tensor: torch.Tensor, *, name: str) -> None:
+@@ -350,8 +302,7 @@ def _rank3_cache(
+         cache = cache[:, :, 0, :]
+     if cache.ndim != 3:
+         raise ValueError(
+-            "kv_cache must be [pages,page_size,physical_record_width] or "
+-            "[pages,page_size,1,physical_record_width]"
++            "kv_cache must be [pages,page_size,576] or [pages,page_size,1,576]"
+         )
+     if cache.dtype != scratch.kv_dtype:
+         raise TypeError(
+@@ -359,26 +310,18 @@ def _rank3_cache(
+         )
+     if cache.device != scratch.device:
+         raise ValueError("kv_cache device does not match dense MLA plan")
+-    if tuple(cache.shape[1:]) != (
+-        scratch.page_size,
+-        scratch.physical_record_width,
+-    ):
++    if tuple(cache.shape[1:]) != (scratch.page_size, K3_ABSORBED_DIM):
+         raise ValueError(
+             "kv_cache inner shape must be "
+-            f"({scratch.page_size}, {scratch.physical_record_width}), got "
+-            f"{tuple(cache.shape[1:])}"
++            f"({scratch.page_size}, {K3_ABSORBED_DIM}), got {tuple(cache.shape[1:])}"
+         )
+     if int(cache.shape[0]) > scratch.num_cache_pages:
+         raise ValueError("kv_cache page count exceeds planned capacity")
+-    if (
+-        int(cache.stride(2)) != 1
+-        or int(cache.stride(1)) < scratch.physical_record_width
+-    ):
++    if int(cache.stride(2)) != 1 or int(cache.stride(1)) != K3_ABSORBED_DIM:
+         raise ValueError(
+-            "kv_cache requires contiguous elements and a token stride covering "
+-            "physical_record_width"
++            "kv_cache requires contiguous records/tokens (stride[-1]=1, stride[-2]=576)"
+         )
+-    if int(cache.stride(0)) < scratch.page_size * int(cache.stride(1)):
++    if int(cache.stride(0)) < scratch.page_size * K3_ABSORBED_DIM:
+         raise ValueError("kv_cache page stride is smaller than one page payload")
+     _require_16_byte_records(
+         cache,
+@@ -405,23 +348,21 @@ def _validate_binding(
+ ) -> Binding:
+     if q.ndim != 3 or tuple(q.shape[1:]) != (
+         scratch.num_q_heads,
+-        scratch.head_dim,
++        K3_ABSORBED_DIM,
+     ):
+         raise ValueError(
+             "q must have shape "
+-            f"[total_q,{scratch.num_q_heads},{scratch.head_dim}], got {tuple(q.shape)}"
+-        )
+-    if q.dtype != scratch.q_dtype:
+-        raise TypeError(
+-            f"q dtype {q.dtype} does not match planned query dtype {scratch.q_dtype}"
++            f"[total_q,{scratch.num_q_heads},{K3_ABSORBED_DIM}], got {tuple(q.shape)}"
+         )
++    if q.dtype not in (torch.bfloat16, _FP8):
++        raise TypeError("q must be BF16 or E4M3")
+     if q.device != scratch.device:
+         raise ValueError("q device does not match dense MLA plan")
+     if not 1 <= int(q.shape[0]) <= scratch.max_total_q:
+         raise ValueError("q rows exceed planned capacity")
+-    if int(q.stride(2)) != 1 or int(q.stride(1)) != scratch.head_dim:
++    if int(q.stride(2)) != 1 or int(q.stride(1)) != K3_ABSORBED_DIM:
+         raise ValueError("q requires contiguous absorbed head records")
+-    if int(q.stride(0)) < scratch.num_q_heads * scratch.head_dim:
++    if int(q.stride(0)) < scratch.num_q_heads * K3_ABSORBED_DIM:
+         raise ValueError("q row stride overlaps absorbed head records")
+     _require_16_byte_records(
+         q,
+@@ -431,21 +372,26 @@ def _validate_binding(
+     _storage_bounds(q, name="q")
+ 
+     cache = _rank3_cache(kv_cache, scratch=scratch)
++    if q.dtype != cache.dtype:
++        raise TypeError(
++            "q and kv_cache must use the same native dense MLA format "
++            "(BF16/BF16 or E4M3/E4M3)"
++        )
+     if output.ndim != 3 or tuple(output.shape) != (
+         int(q.shape[0]),
+         scratch.num_q_heads,
+-        scratch.v_head_dim,
++        K3_VALUE_DIM,
+     ):
+         raise ValueError(
+             "output must have shape "
+-            f"{(int(q.shape[0]), scratch.num_q_heads, scratch.v_head_dim)}, "
++            f"{(int(q.shape[0]), scratch.num_q_heads, K3_VALUE_DIM)}, "
+             f"got {tuple(output.shape)}"
+         )
+     if output.dtype != torch.bfloat16 or output.device != scratch.device:
+         raise TypeError("output must be BF16 on the plan device")
+-    if int(output.stride(2)) != 1 or int(output.stride(1)) != scratch.v_head_dim:
++    if int(output.stride(2)) != 1 or int(output.stride(1)) != K3_VALUE_DIM:
+         raise ValueError("output requires contiguous latent head records")
+-    if int(output.stride(0)) < scratch.num_q_heads * scratch.v_head_dim:
++    if int(output.stride(0)) < scratch.num_q_heads * K3_VALUE_DIM:
+         raise ValueError("output row stride overlaps latent head records")
+     _require_16_byte_records(
+         output,
+@@ -488,24 +434,10 @@ def _validate_binding(
+         q_scale,
+         name="q_scale",
+         device=scratch.device,
+-        required=cache.dtype == _FP8,
++        required=q.dtype == _FP8,
+     )
+-    if cache.dtype != _FP8 and (kv_scale is not None or q_scale is not None):
++    if q.dtype != _FP8 and (kv_scale is not None or q_scale is not None):
+         raise ValueError("BF16 dense MLA does not accept quantization scales")
+-    query_quant = None
+-    native_q = q
+-    if q.dtype != cache.dtype:
+-        if scratch.quantized_q is None:
+-            raise RuntimeError("dense MLA query quantization scratch is missing")
+-        if q_scale is None:
+-            raise RuntimeError("dense MLA query quantization scale is missing")
+-        native_q = scratch.quantized_q[: int(q.shape[0])]
+-        query_quant = static_fp8_quant.bind(
+-            source=q,
+-            output=native_q,
+-            scale=q_scale,
+-            max_numel=(scratch.max_total_q * scratch.num_q_heads * scratch.head_dim),
+-        )
+     sm_scale = float(sm_scale)
+     if not (sm_scale > 0.0):
+         raise ValueError("sm_scale must be positive")
+@@ -517,7 +449,7 @@ def _validate_binding(
+         )
+     return Binding(
+         scratch=scratch,
+-        q=native_q.detach(),
++        q=q.detach(),
+         kv_cache=cache,
+         output=output,
+         page_table=page_table.detach(),
+@@ -527,7 +459,6 @@ def _validate_binding(
+         q_scale=q_scale,
+         sm_scale=sm_scale,
+         active_splits=active_splits,
+-        query_quant=query_quant,
+     )
+ 
+ 
+@@ -548,7 +479,7 @@ def _materialize(
+                 caps.max_total_q,
+                 caps.num_q_heads,
+                 layout.num_splits,
+-                caps.v_head_dim,
++                K3_VALUE_DIM,
+             ),
+             dtype=torch.bfloat16,
+         )
+@@ -564,20 +495,11 @@ def _materialize(
+         shape=(caps.max_total_q, caps.num_q_heads),
+         dtype=torch.float32,
+     )
+-    quantized_q = None
+-    if layout.quantized_q_offset_bytes is not None:
+-        quantized_q, _ = materialize_scratch_view(
+-            scratch_storage,
+-            offset_bytes=layout.quantized_q_offset_bytes,
+-            shape=(caps.max_total_q, caps.num_q_heads, caps.head_dim),
+-            dtype=_FP8,
+-        )
+     query_tile = _query_tile(caps)
+     return Scratch(
+         shared_scratch=scratch_storage,
+         device=caps.device,
+         mode=caps.mode,
+-        q_dtype=caps.q_dtype,
+         kv_dtype=caps.kv_dtype,
+         num_q_heads=caps.num_q_heads,
+         page_size=caps.page_size,
+@@ -586,10 +508,6 @@ def _materialize(
+         max_cache_tokens=caps.max_cache_tokens,
+         max_page_table_width=caps.max_page_table_width,
+         num_cache_pages=caps.num_cache_pages,
+-        physical_record_width=caps.physical_record_width,
+-        head_dim=caps.head_dim,
+-        v_head_dim=caps.v_head_dim,
+-        window_size=caps.window_size,
+         num_splits=layout.num_splits,
+         chunks_per_split=layout.chunks_per_split,
+         query_tile=query_tile,
+@@ -597,7 +515,6 @@ def _materialize(
+         partial_output=partial_output,
+         partial_lse=partial_lse,
+         final_lse=final_lse,
+-        quantized_q=quantized_q,
+     )
+ 
+ 
+diff --git a/b12x/attention/dense_mla/api.py b/b12x/attention/dense_mla/api.py
+index 198d69dcd216e3d8e8ef2b0cef84684a084195a7..90c438972932c023e5e4c3a9da2c5fd73f1894be 100644
+--- a/b12x/attention/dense_mla/api.py
++++ b/b12x/attention/dense_mla/api.py
+@@ -1,4 +1,4 @@
+-"""Public planned API for paged dense MLA."""
++"""Public planned API for dense Kimi-K3 MLA."""
+ 
+ from __future__ import annotations
+ 
+@@ -43,7 +43,7 @@ def run(*, binding: Binding) -> tuple[torch.Tensor, torch.Tensor]:
+ 
+ 
+ def reference(*args, **kwargs):
+-    """Run the FP32 paged dense-MLA oracle."""
++    """Run the FP32 paged K3 dense-MLA oracle."""
+     return dense_mla_reference(*args, **kwargs)
+ 
+ 
+@@ -55,10 +55,9 @@ def is_supported(device=None) -> bool:
+     """True only for the fail-closed SM120/SM121 production envelope."""
+     if not default_is_supported(device, requires=META.requires):
+         return False
+-    if device is None:
+-        device = torch.device("cuda", torch.cuda.current_device())
+-    else:
+-        device = torch.device(device)
++    device = torch.device(
++        device if device is not None else ("cuda", torch.cuda.current_device())
++    )
+     return tuple(torch.cuda.get_device_capability(device)) in ((12, 0), (12, 1))
+ 
+ 
+diff --git a/b12x/attention/sparse_mla/_paged_index_remap.py b/b12x/attention/sparse_mla/_paged_index_remap.py
+deleted file mode 100644
+index e6d4674252e6b523e69e60687699a561f2f2bba3..0000000000000000000000000000000000000000
+--- a/b12x/attention/sparse_mla/_paged_index_remap.py
++++ /dev/null
+@@ -1,376 +0,0 @@
+-"""Native request-relative to physical-slot remapping for paged sparse MLA."""
+-
+-from __future__ import annotations
+-
+-from dataclasses import dataclass
+-from threading import RLock
+-
+-import cuda.bindings.driver as cuda
+-import cutlass
+-import cutlass.cute as cute
+-import torch
+-from cutlass import Int32, Int64
+-from cutlass.cute.runtime import from_dlpack
+-
+-from b12x._lib.compiler import KernelCompileSpec, compile as compile_cute
+-from b12x._lib.compiler import key_field, run_compiled
+-from b12x._lib.utils import current_cuda_stream
+-
+-_LOCK = RLock()
+-_CACHE: dict[tuple[int, int, bool], object] = {}
+-BLOCK_SIZE = 64
+-TOPK = 2048
+-THREADS = 32
+-INDICES_PER_THREAD = TOPK // THREADS
+-
+-
+-def _flat_i32(tensor: torch.Tensor):
+-    converted = from_dlpack(tensor.reshape(-1), assumed_align=4)
+-    converted.element_type = cutlass.Int32
+-    return converted.mark_layout_dynamic(leading_dim=0)
+-
+-
+-class _RemapKernel:
+-    def __init__(self, max_q_rows: int, request_relative: bool):
+-        self.max_q_rows = int(max_q_rows)
+-        self.request_relative = bool(request_relative)
+-
+-    @cute.jit
+-    def __call__(
+-        self,
+-        request_ids: cute.Tensor,
+-        block_table: cute.Tensor,
+-        logical_indices: cute.Tensor,
+-        physical_indices: cute.Tensor,
+-        input_counts: cute.Tensor,
+-        selected_counts: cute.Tensor,
+-        active_rows: Int32,
+-        request_count: Int32,
+-        table_width: Int32,
+-        num_cache_blocks: Int32,
+-        block_stride_records: Int64,
+-        token_stride_records: Int64,
+-        stream: cuda.CUstream,
+-    ):
+-        self.kernel(
+-            request_ids,
+-            block_table,
+-            logical_indices,
+-            physical_indices,
+-            input_counts,
+-            selected_counts,
+-            active_rows,
+-            request_count,
+-            table_width,
+-            num_cache_blocks,
+-            block_stride_records,
+-            token_stride_records,
+-        ).launch(
+-            grid=(self.max_q_rows, 1, 1),
+-            block=(THREADS, 1, 1),
+-            stream=stream,
+-        )
+-
+-    @cute.kernel
+-    def kernel(
+-        self,
+-        request_ids: cute.Tensor,
+-        block_table: cute.Tensor,
+-        logical_indices: cute.Tensor,
+-        physical_indices: cute.Tensor,
+-        input_counts: cute.Tensor,
+-        selected_counts: cute.Tensor,
+-        active_rows: Int32,
+-        request_count: Int32,
+-        table_width: Int32,
+-        num_cache_blocks: Int32,
+-        block_stride_records: Int64,
+-        token_stride_records: Int64,
+-    ):
+-        row_idx, _, _ = cute.arch.block_idx()
+-        row = Int32(row_idx)
+-        if row < active_rows:
+-            thread = Int32(cute.arch.thread_idx()[0])
+-            request = Int32(0)
+-            if cutlass.const_expr(self.request_relative):
+-                request = request_ids[row].to(Int32)
+-            column_begin = thread * Int32(INDICES_PER_THREAD)
+-            count = Int32(0)
+-            for offset in cutlass.range(Int32(INDICES_PER_THREAD), unroll=1):
+-                column = column_begin + offset
+-                logical_offset = Int64(row) * Int64(TOPK) + Int64(column)
+-                logical_slot = logical_indices[logical_offset].to(Int32)
+-                logical_block = logical_slot // Int32(BLOCK_SIZE)
+-                valid = (logical_slot >= Int32(0)) & (logical_block >= Int32(0))
+-                if cutlass.const_expr(self.request_relative):
+-                    valid = (
+-                        valid
+-                        & (request >= Int32(0))
+-                        & (request < request_count)
+-                        & (logical_block < table_width)
+-                    )
+-                else:
+-                    valid = valid & (column < input_counts[row].to(Int32))
+-                if valid:
+-                    physical_block = logical_block
+-                    if cutlass.const_expr(self.request_relative):
+-                        table_offset = request.to(Int64) * table_width.to(
+-                            Int64
+-                        ) + logical_block.to(Int64)
+-                        physical_block = block_table[table_offset].to(Int32)
+-                    if (physical_block >= Int32(0)) & (
+-                        physical_block < num_cache_blocks
+-                    ):
+-                        count += Int32(1)
+-
+-            # The first warp of the output row is temporary storage for the
+-            # per-thread counts. Every thread loads its stable prefix before
+-            # any thread overwrites the temporary values.
+-            row_offset = Int64(row) * Int64(TOPK)
+-            physical_indices[row_offset + thread.to(Int64)] = count
+-            cute.arch.sync_threads()
+-            output_base = Int32(0)
+-            total = Int32(0)
+-            for peer in cutlass.range_constexpr(THREADS):
+-                peer_count = physical_indices[row_offset + Int64(peer)].to(Int32)
+-                if Int32(peer) < thread:
+-                    output_base += peer_count
+-                total += peer_count
+-            cute.arch.sync_threads()
+-            if thread == Int32(0):
+-                selected_counts[row] = total
+-
+-            local_output = Int32(0)
+-            for offset in cutlass.range(Int32(INDICES_PER_THREAD), unroll=1):
+-                column = column_begin + offset
+-                logical_offset = row_offset + column.to(Int64)
+-                logical_slot = logical_indices[logical_offset].to(Int32)
+-                logical_block = logical_slot // Int32(BLOCK_SIZE)
+-                valid = (logical_slot >= Int32(0)) & (logical_block >= Int32(0))
+-                if cutlass.const_expr(self.request_relative):
+-                    valid = (
+-                        valid
+-                        & (request >= Int32(0))
+-                        & (request < request_count)
+-                        & (logical_block < table_width)
+-                    )
+-                else:
+-                    valid = valid & (column < input_counts[row].to(Int32))
+-                if valid:
+-                    physical_block = logical_block
+-                    if cutlass.const_expr(self.request_relative):
+-                        table_offset = request.to(Int64) * table_width.to(
+-                            Int64
+-                        ) + logical_block.to(Int64)
+-                        physical_block = block_table[table_offset].to(Int32)
+-                    if (physical_block >= Int32(0)) & (
+-                        physical_block < num_cache_blocks
+-                    ):
+-                        physical_record = (
+-                            physical_block.to(Int64) * block_stride_records
+-                            + (logical_slot % Int32(BLOCK_SIZE)).to(Int64)
+-                            * token_stride_records
+-                        )
+-                        output_offset = (
+-                            row_offset + output_base.to(Int64) + local_output.to(Int64)
+-                        )
+-                        physical_indices[output_offset] = physical_record.to(Int32)
+-                        local_output += Int32(1)
+-
+-
+-@dataclass(frozen=True)
+-class Binding:
+-    request_ids: torch.Tensor
+-    block_table: torch.Tensor
+-    logical_indices: torch.Tensor
+-    physical_indices: torch.Tensor
+-    input_counts: torch.Tensor
+-    selected_counts: torch.Tensor
+-    max_q_rows: int
+-    num_cache_blocks: int
+-    block_stride_records: int
+-    token_stride_records: int
+-    request_relative: bool
+-
+-
+-def bind(
+-    *,
+-    request_ids: torch.Tensor,
+-    block_table: torch.Tensor,
+-    logical_indices: torch.Tensor,
+-    physical_indices: torch.Tensor,
+-    selected_counts: torch.Tensor,
+-    max_q_rows: int,
+-    num_cache_blocks: int,
+-    block_stride_records: int,
+-    token_stride_records: int,
+-) -> Binding:
+-    rows = int(logical_indices.shape[0])
+-    tensors = (
+-        request_ids,
+-        block_table,
+-        logical_indices,
+-        physical_indices,
+-        selected_counts,
+-    )
+-    if any(tensor.dtype != torch.int32 for tensor in tensors):
+-        raise TypeError("sparse index metadata must use int32 tensors")
+-    if any(not tensor.is_contiguous() for tensor in tensors):
+-        raise ValueError("sparse index metadata must be contiguous")
+-    if any(tensor.device != logical_indices.device for tensor in tensors):
+-        raise ValueError("sparse index metadata must share one device")
+-    if tuple(logical_indices.shape) != (rows, TOPK):
+-        raise ValueError(f"logical_indices must have shape ({rows}, {TOPK})")
+-    if tuple(physical_indices.shape) != (rows, TOPK):
+-        raise ValueError(f"physical_indices must have shape ({rows}, {TOPK})")
+-    if tuple(request_ids.shape) != (rows,):
+-        raise ValueError(f"request_ids must have shape ({rows},)")
+-    if tuple(selected_counts.shape) != (rows,):
+-        raise ValueError(f"selected_counts must have shape ({rows},)")
+-    if block_table.ndim != 2 or block_table.shape[0] <= 0 or block_table.shape[1] <= 0:
+-        raise ValueError("block_table must be a non-empty two-dimensional tensor")
+-    if not 0 < rows <= int(max_q_rows):
+-        raise ValueError("logical index rows exceed the planned capacity")
+-    if not 0 < int(num_cache_blocks) <= torch.iinfo(torch.int32).max // BLOCK_SIZE:
+-        raise ValueError("num_cache_blocks exceeds the physical-slot int32 range")
+-    if int(block_stride_records) <= 0 or int(token_stride_records) <= 0:
+-        raise ValueError("physical record strides must be positive")
+-    return Binding(
+-        request_ids=request_ids.detach(),
+-        block_table=block_table.detach(),
+-        logical_indices=logical_indices.detach(),
+-        physical_indices=physical_indices.detach(),
+-        input_counts=selected_counts.detach(),
+-        selected_counts=selected_counts.detach(),
+-        max_q_rows=int(max_q_rows),
+-        num_cache_blocks=int(num_cache_blocks),
+-        block_stride_records=int(block_stride_records),
+-        token_stride_records=int(token_stride_records),
+-        request_relative=True,
+-    )
+-
+-
+-def bind_physical_slots(
+-    *,
+-    physical_slots: torch.Tensor,
+-    input_counts: torch.Tensor,
+-    physical_indices: torch.Tensor,
+-    selected_counts: torch.Tensor,
+-    max_q_rows: int,
+-    num_cache_blocks: int,
+-    block_stride_records: int,
+-    token_stride_records: int,
+-) -> Binding:
+-    rows = int(physical_slots.shape[0])
+-    tensors = (physical_slots, input_counts, physical_indices, selected_counts)
+-    if any(tensor.dtype != torch.int32 for tensor in tensors):
+-        raise TypeError("sparse index metadata must use int32 tensors")
+-    if any(not tensor.is_contiguous() for tensor in tensors):
+-        raise ValueError("sparse index metadata must be contiguous")
+-    if any(tensor.device != physical_slots.device for tensor in tensors):
+-        raise ValueError("sparse index metadata must share one device")
+-    if tuple(physical_slots.shape) != (rows, TOPK):
+-        raise ValueError(f"physical_slots must have shape ({rows}, {TOPK})")
+-    if tuple(physical_indices.shape) != (rows, TOPK):
+-        raise ValueError(f"physical_indices must have shape ({rows}, {TOPK})")
+-    if tuple(input_counts.shape) != (rows,) or tuple(selected_counts.shape) != (rows,):
+-        raise ValueError(f"sparse counts must have shape ({rows},)")
+-    if not 0 < rows <= int(max_q_rows):
+-        raise ValueError("physical slot rows exceed the planned capacity")
+-    if not 0 < int(num_cache_blocks) <= torch.iinfo(torch.int32).max // BLOCK_SIZE:
+-        raise ValueError("num_cache_blocks exceeds the physical-slot int32 range")
+-    if int(block_stride_records) <= 0 or int(token_stride_records) <= 0:
+-        raise ValueError("physical record strides must be positive")
+-    placeholder = input_counts
+-    return Binding(
+-        request_ids=placeholder.detach(),
+-        block_table=placeholder.detach(),
+-        logical_indices=physical_slots.detach(),
+-        physical_indices=physical_indices.detach(),
+-        input_counts=input_counts.detach(),
+-        selected_counts=selected_counts.detach(),
+-        max_q_rows=int(max_q_rows),
+-        num_cache_blocks=int(num_cache_blocks),
+-        block_stride_records=int(block_stride_records),
+-        token_stride_records=int(token_stride_records),
+-        request_relative=False,
+-    )
+-
+-
+-def _signature(binding: Binding) -> tuple[int, int, bool]:
+-    index = binding.logical_indices.device.index
+-    if index is None:
+-        index = torch.cuda.current_device()
+-    return int(index), int(binding.max_q_rows), bool(binding.request_relative)
+-
+-
+-def _launch(binding: Binding):
+-    entry = _RemapKernel(binding.max_q_rows, binding.request_relative)
+-    request_count = int(binding.block_table.shape[0]) if binding.request_relative else 1
+-    table_width = int(binding.block_table.shape[1]) if binding.request_relative else 1
+-    args = (
+-        _flat_i32(binding.request_ids),
+-        _flat_i32(binding.block_table),
+-        _flat_i32(binding.logical_indices),
+-        _flat_i32(binding.physical_indices),
+-        _flat_i32(binding.input_counts),
+-        _flat_i32(binding.selected_counts),
+-        Int32(binding.logical_indices.shape[0]),
+-        Int32(request_count),
+-        Int32(table_width),
+-        Int32(binding.num_cache_blocks),
+-        Int64(binding.block_stride_records),
+-        Int64(binding.token_stride_records),
+-        current_cuda_stream(),
+-    )
+-    spec = KernelCompileSpec.from_fields(
+-        "attention.paged_sparse_index_remap",
+-        2,
+-        key_field("max_q_rows", binding.max_q_rows),
+-        key_field("request_relative", binding.request_relative),
+-    )
+-    return entry, args, spec
+-
+-
+-def compile(*, binding: Binding) -> None:
+-    signature = _signature(binding)
+-    with _LOCK:
+-        compiled = _CACHE.get(signature)
+-    if compiled is None:
+-        entry, args, spec = _launch(binding)
+-        compiled = compile_cute(entry, *args, compile_spec=spec)
+-        with _LOCK:
+-            _CACHE[signature] = compiled
+-
+-
+-def run(*, binding: Binding) -> tuple[torch.Tensor, torch.Tensor]:
+-    signature = _signature(binding)
+-    with _LOCK:
+-        compiled = _CACHE.get(signature)
+-    if compiled is None:
+-        if torch.cuda.is_current_stream_capturing():
+-            raise RuntimeError(
+-                "sparse index remap compile miss during CUDA graph capture; "
+-                "call compile first"
+-            )
+-        compile(binding=binding)
+-        with _LOCK:
+-            compiled = _CACHE[signature]
+-    _, args, _ = _launch(binding)
+-    run_compiled(compiled, args)
+-    return binding.physical_indices, binding.selected_counts
+-
+-
+-def clear_caches() -> None:
+-    with _LOCK:
+-        _CACHE.clear()
+-
+-
+-__all__ = [
+-    "Binding",
+-    "bind",
+-    "bind_physical_slots",
+-    "clear_caches",
+-    "compile",
+-    "run",
+-]
+diff --git a/b12x/attention/sparse_mla/strided.py b/b12x/attention/sparse_mla/strided.py
+deleted file mode 100644
+index a961dfa2d68f6e35bdf45d4ed6b22bd6ba6abdf1..0000000000000000000000000000000000000000
+--- a/b12x/attention/sparse_mla/strided.py
++++ /dev/null
+@@ -1,503 +0,0 @@
+-"""Planned strided-record sparse-MLA API."""
+-
+-from __future__ import annotations
+-
+-import math
+-from dataclasses import dataclass
+-
+-import torch
+-
+-from ..._lib.gating import default_is_supported
+-from ..._lib.scratch import ScratchBufferSpec, scratch_buffer_spec, scratch_tensor
+-from ..._lib.scratch_layout import (
+-    SCRATCH_ALIGN_BYTES,
+-    align_up,
+-    materialize_scratch_view,
+-)
+-from .._shared import static_fp8_quant
+-from ..dense_mla._kernel import (
+-    clear_dense_mla_kernel_caches,
+-    compile_dense_mla,
+-    run_dense_mla,
+-)
+-from ..dense_mla._scratch import Binding as _NativeBinding
+-from ..dense_mla._scratch import Caps as _NativeCaps
+-from ..dense_mla._scratch import Plan as _NativePlan
+-from ..dense_mla._scratch import Scratch
+-from ..dense_mla._scratch import plan_dense_mla_scratch
+-from ..dense_mla.planner import Budget
+-from . import _paged_index_remap
+-
+-FP8 = torch.float8_e4m3fn
+-BLOCK_SIZE = 64
+-TOTAL_HEADS = 128
+-QK_DIM = 576
+-VALUE_DIM = 512
+-PHYSICAL_RECORD_WIDTH = 1088
+-TOPK = 2048
+-SM_SCALE = 1.0 / math.sqrt(192)
+-
+-
+-@dataclass(frozen=True, kw_only=True)
+-class Caps:
+-    device: torch.device | str
+-    num_q_heads: int
+-    tp_size: int
+-    max_q_rows: int
+-    num_cache_blocks: int
+-    max_physical_records: int | None = None
+-    block_size: int = BLOCK_SIZE
+-    topk: int = TOPK
+-    kv_dtype: torch.dtype = FP8
+-    use_cuda_graph: bool = False
+-    budget: Budget | None = None
+-
+-    def __post_init__(self) -> None:
+-        if int(self.tp_size) != 8:
+-            raise ValueError("strided sparse MLA is qualified only for TP8")
+-        if int(self.num_q_heads) != TOTAL_HEADS // int(self.tp_size):
+-            raise ValueError("num_q_heads must equal total_heads / tp_size")
+-        if int(self.block_size) != BLOCK_SIZE:
+-            raise ValueError(f"strided sparse MLA block_size must be {BLOCK_SIZE}")
+-        if int(self.topk) != TOPK:
+-            raise ValueError(f"strided sparse MLA topk must be {TOPK}")
+-        if self.kv_dtype != FP8:
+-            raise TypeError("strided sparse MLA requires E4M3 KV cache")
+-        if int(self.max_q_rows) <= 0:
+-            raise ValueError("max_q_rows must be positive")
+-        if int(self.num_cache_blocks) <= 0:
+-            raise ValueError("num_cache_blocks must be positive")
+-        if int(self.num_cache_blocks) > torch.iinfo(torch.int32).max // BLOCK_SIZE:
+-            raise ValueError("num_cache_blocks exceeds the physical-slot int32 range")
+-        max_physical_records = (
+-            int(self.num_cache_blocks) * BLOCK_SIZE
+-            if self.max_physical_records is None
+-            else int(self.max_physical_records)
+-        )
+-        if not int(self.num_cache_blocks) * BLOCK_SIZE <= max_physical_records:
+-            raise ValueError(
+-                "max_physical_records must cover all contiguous physical slots"
+-            )
+-        if max_physical_records > torch.iinfo(torch.int32).max:
+-            raise ValueError("max_physical_records exceeds the index int32 range")
+-        object.__setattr__(self, "max_physical_records", max_physical_records)
+-
+-
+-@dataclass(frozen=True)
+-class Binding:
+-    native: _NativeBinding
+-    query_quant: static_fp8_quant.Binding
+-    index_remap: _paged_index_remap.Binding | None
+-    kv_cache: torch.Tensor
+-    selected_indices: torch.Tensor
+-    selected_counts: torch.Tensor
+-
+-
+-@dataclass(frozen=True)
+-class Plan:
+-    caps: Caps
+-    native: _NativePlan
+-    query_offset_bytes: int
+-    physical_indices_offset_bytes: int
+-    selected_counts_offset_bytes: int
+-    _scratch_specs: tuple[ScratchBufferSpec, ...]
+-
+-    def scratch_specs(self):
+-        return self._scratch_specs
+-
+-    def shapes_and_dtypes(self):
+-        return tuple((spec.shape, spec.dtype) for spec in self._scratch_specs)
+-
+-    @property
+-    def num_splits(self) -> int:
+-        return self.native.num_splits
+-
+-
+-def plan(caps: Caps) -> Plan:
+-    native_caps = _NativeCaps(
+-        device=caps.device,
+-        mode="decode",
+-        kv_dtype=FP8,
+-        num_q_heads=int(caps.num_q_heads),
+-        page_size=1,
+-        max_total_q=int(caps.max_q_rows),
+-        max_batch=int(caps.max_q_rows),
+-        max_cache_tokens=TOPK,
+-        max_page_table_width=TOPK,
+-        num_cache_pages=int(caps.max_physical_records),
+-        head_dim=QK_DIM,
+-        v_head_dim=VALUE_DIM,
+-        physical_record_width=PHYSICAL_RECORD_WIDTH,
+-        use_cuda_graph=bool(caps.use_cuda_graph),
+-        budget=caps.budget,
+-    )
+-    native = plan_dense_mla_scratch(native_caps)
+-    native_spec = native.scratch_specs()[0]
+-    query_offset_bytes = align_up(native_spec.nbytes, SCRATCH_ALIGN_BYTES)
+-    query_nbytes = int(caps.max_q_rows) * int(caps.num_q_heads) * QK_DIM
+-    physical_indices_offset_bytes = align_up(
+-        query_offset_bytes + query_nbytes,
+-        SCRATCH_ALIGN_BYTES,
+-    )
+-    physical_indices_nbytes = int(caps.max_q_rows) * TOPK * torch.int32.itemsize
+-    selected_counts_offset_bytes = align_up(
+-        physical_indices_offset_bytes + physical_indices_nbytes,
+-        SCRATCH_ALIGN_BYTES,
+-    )
+-    selected_counts_nbytes = int(caps.max_q_rows) * torch.int32.itemsize
+-    total_nbytes = align_up(
+-        selected_counts_offset_bytes + selected_counts_nbytes,
+-        SCRATCH_ALIGN_BYTES,
+-    )
+-    return Plan(
+-        caps=caps,
+-        native=native,
+-        query_offset_bytes=query_offset_bytes,
+-        physical_indices_offset_bytes=physical_indices_offset_bytes,
+-        selected_counts_offset_bytes=selected_counts_offset_bytes,
+-        _scratch_specs=(
+-            scratch_buffer_spec(
+-                "sparse_mla.strided.scratch",
+-                nbytes=total_nbytes,
+-                device=native_spec.device,
+-            ),
+-        ),
+-    )
+-
+-
+-def _physical_record_view(
+-    plan: Plan,
+-    kv_cache: torch.Tensor,
+-) -> tuple[torch.Tensor, int, int]:
+-    expected_record_shape = (BLOCK_SIZE, PHYSICAL_RECORD_WIDTH)
+-    if (
+-        kv_cache.dtype != FP8
+-        or kv_cache.ndim != 3
+-        or tuple(kv_cache.shape[1:]) != expected_record_shape
+-        or not 0 < int(kv_cache.shape[0]) <= int(plan.caps.num_cache_blocks)
+-    ):
+-        raise ValueError(
+-            "kv_cache must be E4M3 with shape "
+-            f"[1..{plan.caps.num_cache_blocks}, {BLOCK_SIZE}, "
+-            f"{PHYSICAL_RECORD_WIDTH}], got "
+-            f"dtype={kv_cache.dtype}, shape={tuple(kv_cache.shape)}"
+-        )
+-    block_stride, token_stride, element_stride = map(int, kv_cache.stride())
+-    if (
+-        element_stride != 1
+-        or token_stride < PHYSICAL_RECORD_WIDTH
+-        or block_stride < BLOCK_SIZE * token_stride
+-        or token_stride % PHYSICAL_RECORD_WIDTH
+-        or block_stride % PHYSICAL_RECORD_WIDTH
+-    ):
+-        raise ValueError(
+-            "kv_cache must use non-overlapping, whole 1088-element physical "
+-            f"record strides, got stride={tuple(kv_cache.stride())}"
+-        )
+-    block_stride_records = block_stride // PHYSICAL_RECORD_WIDTH
+-    token_stride_records = token_stride // PHYSICAL_RECORD_WIDTH
+-    physical_records = (
+-        (int(kv_cache.shape[0]) - 1) * block_stride_records
+-        + (BLOCK_SIZE - 1) * token_stride_records
+-        + 1
+-    )
+-    if physical_records > int(plan.caps.max_physical_records):
+-        raise ValueError(
+-            "kv_cache physical record span exceeds planned capacity: "
+-            f"need {physical_records}, planned {plan.caps.max_physical_records}"
+-        )
+-    flat_cache = torch.as_strided(
+-        kv_cache,
+-        size=(physical_records, 1, PHYSICAL_RECORD_WIDTH),
+-        stride=(PHYSICAL_RECORD_WIDTH, PHYSICAL_RECORD_WIDTH, 1),
+-    )
+-    return flat_cache, block_stride_records, token_stride_records
+-
+-
+-def _bind_native(
+-    plan: Plan,
+-    *,
+-    scratch_storage: torch.Tensor,
+-    q: torch.Tensor,
+-    flat_cache: torch.Tensor,
+-    original_cache: torch.Tensor,
+-    output: torch.Tensor,
+-    record_indices: torch.Tensor,
+-    selected_counts: torch.Tensor,
+-    cu_seqlens_q: torch.Tensor,
+-    kv_scale: torch.Tensor,
+-    q_scale: torch.Tensor,
+-    active_splits: int | None = None,
+-) -> Binding:
+-    if q.dtype != torch.bfloat16:
+-        raise TypeError("strided sparse MLA absorbed query must be BF16")
+-    rows = int(q.shape[0])
+-    if record_indices.dtype != torch.int32 or tuple(record_indices.shape) != (
+-        rows,
+-        TOPK,
+-    ):
+-        raise ValueError(f"record_indices must be int32 with shape ({rows}, {TOPK})")
+-    if selected_counts.dtype != torch.int32 or tuple(selected_counts.shape) != (rows,):
+-        raise ValueError(f"selected_counts must be int32 with shape ({rows},)")
+-    if tuple(cu_seqlens_q.shape) != (rows + 1,):
+-        raise ValueError(f"cu_seqlens_q must have shape ({rows + 1},)")
+-    q_fp8, _ = materialize_scratch_view(
+-        scratch_storage,
+-        offset_bytes=plan.query_offset_bytes,
+-        shape=tuple(q.shape),
+-        dtype=FP8,
+-    )
+-    query_quant = static_fp8_quant.bind(
+-        source=q,
+-        output=q_fp8,
+-        scale=q_scale,
+-        max_numel=int(plan.caps.max_q_rows) * int(plan.caps.num_q_heads) * QK_DIM,
+-    )
+-    native = plan.native.bind(
+-        scratch=scratch_storage,
+-        q=q_fp8,
+-        kv_cache=flat_cache,
+-        output=output,
+-        page_table=record_indices,
+-        cache_seqlens=selected_counts,
+-        cu_seqlens_q=cu_seqlens_q,
+-        kv_scale=kv_scale,
+-        q_scale=q_scale,
+-        sm_scale=SM_SCALE,
+-        active_splits=active_splits,
+-    )
+-    return Binding(
+-        native=native,
+-        query_quant=query_quant,
+-        index_remap=None,
+-        kv_cache=original_cache,
+-        selected_indices=record_indices,
+-        selected_counts=selected_counts,
+-    )
+-
+-
+-def _index_scratch(
+-    plan: Plan,
+-    scratch_storage: torch.Tensor,
+-    rows: int,
+-) -> tuple[torch.Tensor, torch.Tensor]:
+-    physical_indices, _ = materialize_scratch_view(
+-        scratch_storage,
+-        offset_bytes=plan.physical_indices_offset_bytes,
+-        shape=(rows, TOPK),
+-        dtype=torch.int32,
+-    )
+-    selected_counts, _ = materialize_scratch_view(
+-        scratch_storage,
+-        offset_bytes=plan.selected_counts_offset_bytes,
+-        shape=(rows,),
+-        dtype=torch.int32,
+-    )
+-    return physical_indices, selected_counts
+-
+-
+-def bind(
+-    plan: Plan,
+-    *,
+-    scratch,
+-    q: torch.Tensor,
+-    kv_cache: torch.Tensor,
+-    output: torch.Tensor,
+-    selected_indices: torch.Tensor,
+-    selected_counts: torch.Tensor,
+-    cu_seqlens_q: torch.Tensor,
+-    kv_scale: torch.Tensor,
+-    q_scale: torch.Tensor,
+-    active_splits: int | None = None,
+-) -> Binding:
+-    scratch_storage = scratch_tensor(
+-        scratch,
+-        plan.scratch_specs(),
+-        owner="strided sparse MLA",
+-    )
+-    rows = int(q.shape[0])
+-    record_indices, remapped_counts = _index_scratch(plan, scratch_storage, rows)
+-    flat_cache, block_stride_records, token_stride_records = _physical_record_view(
+-        plan, kv_cache
+-    )
+-    binding = _bind_native(
+-        plan,
+-        scratch_storage=scratch_storage,
+-        q=q,
+-        flat_cache=flat_cache,
+-        original_cache=kv_cache,
+-        output=output,
+-        record_indices=record_indices,
+-        selected_counts=remapped_counts,
+-        cu_seqlens_q=cu_seqlens_q,
+-        kv_scale=kv_scale,
+-        q_scale=q_scale,
+-        active_splits=active_splits,
+-    )
+-    remap = _paged_index_remap.bind_physical_slots(
+-        physical_slots=selected_indices,
+-        input_counts=selected_counts,
+-        physical_indices=record_indices,
+-        selected_counts=remapped_counts,
+-        max_q_rows=int(plan.caps.max_q_rows),
+-        num_cache_blocks=int(kv_cache.shape[0]),
+-        block_stride_records=block_stride_records,
+-        token_stride_records=token_stride_records,
+-    )
+-    return Binding(
+-        native=binding.native,
+-        query_quant=binding.query_quant,
+-        index_remap=remap,
+-        kv_cache=binding.kv_cache,
+-        selected_indices=binding.selected_indices,
+-        selected_counts=binding.selected_counts,
+-    )
+-
+-
+-def bind_indexed(
+-    plan: Plan,
+-    *,
+-    scratch,
+-    q: torch.Tensor,
+-    kv_cache: torch.Tensor,
+-    output: torch.Tensor,
+-    logical_indices: torch.Tensor,
+-    request_ids: torch.Tensor,
+-    block_table: torch.Tensor,
+-    cu_seqlens_q: torch.Tensor,
+-    kv_scale: torch.Tensor,
+-    q_scale: torch.Tensor,
+-    active_splits: int | None = None,
+-) -> Binding:
+-    scratch_storage = scratch_tensor(
+-        scratch,
+-        plan.scratch_specs(),
+-        owner="strided sparse MLA",
+-    )
+-    rows = int(q.shape[0])
+-    physical_indices, selected_counts = _index_scratch(plan, scratch_storage, rows)
+-    flat_cache, block_stride_records, token_stride_records = _physical_record_view(
+-        plan, kv_cache
+-    )
+-    binding = _bind_native(
+-        plan,
+-        scratch_storage=scratch_storage,
+-        q=q,
+-        flat_cache=flat_cache,
+-        original_cache=kv_cache,
+-        output=output,
+-        record_indices=physical_indices,
+-        selected_counts=selected_counts,
+-        cu_seqlens_q=cu_seqlens_q,
+-        kv_scale=kv_scale,
+-        q_scale=q_scale,
+-        active_splits=active_splits,
+-    )
+-    remap = _paged_index_remap.bind(
+-        request_ids=request_ids,
+-        block_table=block_table,
+-        logical_indices=logical_indices,
+-        physical_indices=physical_indices,
+-        selected_counts=selected_counts,
+-        max_q_rows=int(plan.caps.max_q_rows),
+-        num_cache_blocks=int(kv_cache.shape[0]),
+-        block_stride_records=block_stride_records,
+-        token_stride_records=token_stride_records,
+-    )
+-    return Binding(
+-        native=binding.native,
+-        query_quant=binding.query_quant,
+-        index_remap=remap,
+-        kv_cache=binding.kv_cache,
+-        selected_indices=binding.selected_indices,
+-        selected_counts=binding.selected_counts,
+-    )
+-
+-
+-def compile(*, binding: Binding) -> None:
+-    if binding.index_remap is not None:
+-        _paged_index_remap.compile(binding=binding.index_remap)
+-    static_fp8_quant.compile(binding=binding.query_quant)
+-    compile_dense_mla(binding=binding.native)
+-
+-
+-def run_decode(*, binding: Binding) -> tuple[torch.Tensor, torch.Tensor]:
+-    if binding.index_remap is not None:
+-        _paged_index_remap.run(binding=binding.index_remap)
+-    static_fp8_quant.run(binding=binding.query_quant)
+-    return run_dense_mla(binding=binding.native)
+-
+-
+-def run_extend(*, binding: Binding) -> tuple[torch.Tensor, torch.Tensor]:
+-    if binding.index_remap is not None:
+-        _paged_index_remap.run(binding=binding.index_remap)
+-    static_fp8_quant.run(binding=binding.query_quant)
+-    return run_dense_mla(binding=binding.native)
+-
+-
+-def reference(
+-    q: torch.Tensor,
+-    kv_cache: torch.Tensor,
+-    selected_indices: torch.Tensor,
+-    selected_counts: torch.Tensor,
+-    *,
+-    kv_scale: torch.Tensor | float,
+-    q_scale: torch.Tensor | float,
+-) -> tuple[torch.Tensor, torch.Tensor]:
+-    def scalar(value: torch.Tensor | float) -> float:
+-        if isinstance(value, torch.Tensor):
+-            return float(value.detach().cpu().item())
+-        return float(value)
+-
+-    count_host = [int(value) for value in selected_counts.detach().cpu().tolist()]
+-    q_mul = scalar(q_scale)
+-    q_f32 = (q.float() / q_mul).to(FP8).float() * q_mul
+-    kv_mul = scalar(kv_scale)
+-    output = torch.empty(
+-        q.shape[0], q.shape[1], VALUE_DIM, dtype=torch.float32, device=q.device
+-    )
+-    lse = torch.empty(q.shape[:2], dtype=torch.float32, device=q.device)
+-    for row, count in enumerate(count_host):
+-        ids = selected_indices[row, :count].to(torch.long)
+-        blocks = torch.div(ids, BLOCK_SIZE, rounding_mode="floor")
+-        tokens = ids.remainder(BLOCK_SIZE)
+-        records = kv_cache[blocks, tokens, :QK_DIM].float() * kv_mul
+-        logits = torch.einsum("hd,kd->hk", q_f32[row], records) * SM_SCALE
+-        probability = torch.softmax(logits, dim=-1)
+-        output[row] = torch.einsum("hk,kd->hd", probability, records[:, :VALUE_DIM])
+-        lse[row] = torch.logsumexp(logits, dim=-1)
+-    return output.to(torch.bfloat16), lse
+-
+-
+-def is_supported(device=None) -> bool:
+-    if not default_is_supported(device, requires=()):
+-        return False
+-    if device is None:
+-        device = torch.device("cuda", torch.cuda.current_device())
+-    else:
+-        device = torch.device(device)
+-    return tuple(torch.cuda.get_device_capability(device)) in ((12, 0), (12, 1))
+-
+-
+-def clear_caches() -> None:
+-    _paged_index_remap.clear_caches()
+-    static_fp8_quant.clear_caches()
+-    clear_dense_mla_kernel_caches()
+-
+-
+-__all__ = [
+-    "Binding",
+-    "Budget",
+-    "Caps",
+-    "Plan",
+-    "Scratch",
+-    "bind",
+-    "bind_indexed",
+-    "clear_caches",
+-    "compile",
+-    "is_supported",
+-    "plan",
+-    "reference",
+-    "run_decode",
+-    "run_extend",
+-]
+diff --git a/b12x/attention/varlen/__init__.py b/b12x/attention/varlen/__init__.py
+index d5c078f90d91a8388e50e6b7da5a838f90dd357b..ea66aa0308ec9d4afc28c19c28642eec89cfd522 100644
+--- a/b12x/attention/varlen/__init__.py
++++ b/b12x/attention/varlen/__init__.py
+@@ -1,8 +1,7 @@
+ """Contiguous (non-paged) attention for SM12x: batched and varlen forward.
+ 
+-BF16/FP16 Q/K/V, including different Q/K and V head dimensions, causal +
+-sliding-window + attention-sink; tile shapes auto-selected by Q/K head
+-dimension and causality. ``run`` is the varlen (cu_seqlens)
++BF16/FP16 Q/K/V, causal + sliding-window + attention-sink; tile shapes
++auto-selected by head_dim/causality. ``run`` is the varlen (cu_seqlens)
+ entry, ``run_batched`` the fixed-shape batched entry; each has its own
+ plan/scratch/binding family (``create_plan*`` for the per-shape kernel plan,
+ ``plan*`` for scratch sizing).
+diff --git a/b12x/comm/pcie/__init__.py b/b12x/comm/pcie/__init__.py
+index 216310e44c775a422d3dec494fac60673b309760..bbcb1d834c1871d33a948db26e40cd47c446e170 100644
+--- a/b12x/comm/pcie/__init__.py
++++ b/b12x/comm/pcie/__init__.py
+@@ -15,8 +15,10 @@ pools via ``<Class>Pool``.
+   per-token FP8-e4m3 transport.
+ - ``DcpAllToAll``: DCP attention exchange with fused LSE reduce-scatter.
+ - ``DcpTopKOwnerExchange``: exact DCP candidate owner staging.
++- ``VocabParallelArgmax``: TP8/TP12/TP16 fused BF16 add and exact global
++  greedy argmax.
+ 
+-Every device kernel is authored in Python with CuTe DSL.  Host-side CUDA
++Every device kernel is authored in Python with CuTe DSL. Host-side CUDA
+ Runtime/Driver calls are also made from Python; this package contains no
+ repo-authored C++ or CUDA source and never invokes a native extension build.
+ """
+@@ -40,13 +42,16 @@ META = OpMeta(
+         "DcpAllToAll",
+         "DcpAllToAllPool",
+         "DcpTopKOwnerExchange",
++        "VocabParallelArgmax",
++        "kimi_topk16",
++        "prepare_kimi_topk16",
+         "autotune_dma_crossovers",
+         "parse_oneshot_max_size",
+         "lse_reduce_scatter_reference",
+         "owner_stage_reference",
+         "is_supported",
+     ),
+-    dtypes=("bf16", "fp32", "fp8_e4m3", "int32"),
++    dtypes=("bf16", "fp32", "fp8_e4m3", "int32", "int64"),
+     requires=("multi_gpu",),
+     provenance=Provenance(
+         repo="https://github.com/lukealonso/b12x",
+@@ -68,11 +73,14 @@ if TYPE_CHECKING:  # static analysis only; runtime resolution is lazy
+         OneshotAllReduce,
+         OneshotAllReducePool,
+         TwoShotReduceScatter,
++        VocabParallelArgmax,
+         autotune_dma_crossovers,
+         is_supported,
++        kimi_topk16,
+         lse_reduce_scatter_reference,
+         owner_stage_reference,
+         parse_oneshot_max_size,
++        prepare_kimi_topk16,
+     )
+ 
+ install_lazy_api(globals(), META)
+diff --git a/b12x/comm/pcie/_cute_intrinsics.py b/b12x/comm/pcie/_cute_intrinsics.py
+index 6f2daab78ea857079cdbc74cec904b54aa0688a2..f65c60211700800186d467edc249f43037df3b78 100644
+--- a/b12x/comm/pcie/_cute_intrinsics.py
++++ b/b12x/comm/pcie/_cute_intrinsics.py
+@@ -501,3 +501,57 @@ def rsqrt_approx_f32(value: Float32, *, loc=None, ip=None) -> Float32:
+             ip=ip,
+         )
+     )
++
++
++@dsl_user_op
++def float_order_key(value: Float32, *, loc=None, ip=None) -> Uint32:
++    """Map a float onto a u32 whose unsigned order matches float order.
++
++    Lets a (score, expert) pair be packed into one integer key, so "better
++    candidate" becomes a plain integer max and the tie-break stops costing a
++    second comparison.
++    """
++    return Uint32(
++        llvm.inline_asm(
++            T.i32(),
++            [Float32(value).ir_value(loc=loc, ip=ip)],
++            """
++            {
++                .reg .u32 bits, mask;
++                mov.b32 bits, $1;
++                shr.u32 mask, bits, 31;
++                mul.lo.u32 mask, mask, 0x7fffffff;
++                or.b32 mask, mask, 0x80000000;
++                xor.b32 $0, bits, mask;
++            }
++            """,
++            "=r,f",
++            has_side_effects=False,
++            is_align_stack=False,
++            asm_dialect=llvm.AsmDialect.AD_ATT,
++            loc=loc,
++            ip=ip,
++        )
++    )
++
++
++@dsl_user_op
++def redux_max_u32(value: Uint32, *, loc=None, ip=None) -> Uint32:
++    """Warp-wide unsigned max in one instruction.
++
++    ``cute.arch.warp_redux_sync`` exposes the float variant, which libNVVM
++    rejects for sm_120a; the integer one is what the kernel actually needs.
++    """
++    return Uint32(
++        llvm.inline_asm(
++            T.i32(),
++            [Uint32(value).ir_value(loc=loc, ip=ip)],
++            "redux.sync.max.u32 $0, $1, 0xffffffff;",
++            "=r,r",
++            has_side_effects=True,
++            is_align_stack=False,
++            asm_dialect=llvm.AsmDialect.AD_ATT,
++            loc=loc,
++            ip=ip,
++        )
++    )
+diff --git a/b12x/comm/pcie/_dcp_a2a_cute.py b/b12x/comm/pcie/_dcp_a2a_cute.py
+index 0dea2609cbb9a6e337ea54b2be37002c989c405c..e64169abe1fb97cda3b6c75e850622d44e9ac4be 100644
+--- a/b12x/comm/pcie/_dcp_a2a_cute.py
++++ b/b12x/comm/pcie/_dcp_a2a_cute.py
+@@ -17,12 +17,15 @@ from b12x._lib.intrinsics import (
+     fmax_f32,
+     ld_global_v4_u32,
+     st_global_v4_u32,
++    u32_as_f32,
+ )
+ from b12x._lib.runtime_control import raise_if_kernel_resolution_frozen
+ from b12x._lib.utils import current_cuda_stream, make_ptr
+ 
+ from ._dcp_cute_common import block_pair_barrier
+ from ._cute_intrinsics import (
++    float_order_key,
++    redux_max_u32,
+     ld_generic_f32,
+     ld_relaxed_gpu_u32,
+     pack_f32x2_to_bf16x2,
+@@ -45,6 +48,7 @@ _GRAPH_ARRIVED_INDEX = _SELF_COUNTER_WORDS + 2
+ _PREPARED_LSE_LAUNCHERS: set[tuple[object, ...]] = set()
+ _PREPARED_GATHER_LAUNCHERS: set[tuple[object, ...]] = set()
+ _PREPARED_PAIR_LAUNCHERS: set[tuple[object, ...]] = set()
++_PREPARED_KIMI_TOPK_LAUNCHERS: set[int] = set()
+ 
+ 
+ @dsl_user_op
+@@ -106,6 +110,89 @@ def _copy_16b(source: cute.Pointer, destination: cute.Pointer) -> None:
+     st_global_v4_u32(destination.toint(), *values)
+ 
+ 
++@dsl_user_op
++def _select_if_eq_u32(
++    lhs: Uint32,
++    rhs: Uint32,
++    on_equal: Uint32,
++    otherwise: Uint32,
++    *,
++    loc=None,
++    ip=None,
++) -> Uint32:
++    """``lhs == rhs ? on_equal : otherwise`` as one predicated select."""
++
++    return Uint32(
++        llvm.inline_asm(
++            T.i32(),
++            [
++                Uint32(lhs).ir_value(loc=loc, ip=ip),
++                Uint32(rhs).ir_value(loc=loc, ip=ip),
++                Uint32(on_equal).ir_value(loc=loc, ip=ip),
++                Uint32(otherwise).ir_value(loc=loc, ip=ip),
++            ],
++            "{ .reg .pred p; setp.eq.u32 p, $1, $2; selp.b32 $0, $3, $4, p; }",
++            "=r,r,r,r,r",
++            has_side_effects=False,
++            is_align_stack=False,
++            asm_dialect=llvm.AsmDialect.AD_ATT,
++            loc=loc,
++            ip=ip,
++        )
++    )
++
++
++@dsl_user_op
++def _select_if_eq_u64(
++    lhs: cutlass.Uint64,
++    rhs: cutlass.Uint64,
++    on_equal: cutlass.Uint64,
++    otherwise: cutlass.Uint64,
++    *,
++    loc=None,
++    ip=None,
++) -> cutlass.Uint64:
++    """``lhs == rhs ? on_equal : otherwise`` as one predicated select.
++
++    A Python ``if`` on a runtime condition becomes a branch region. The top-16
++    rounds update a register-held key array, so a divergent branch can spill the
++    array to local memory. A ternary chain emits straight-line predicated code
++    and lets ptxas fold repeated ``setp`` operations.
++    """
++
++    return cutlass.Uint64(
++        llvm.inline_asm(
++            T.i64(),
++            [
++                cutlass.Uint64(lhs).ir_value(loc=loc, ip=ip),
++                cutlass.Uint64(rhs).ir_value(loc=loc, ip=ip),
++                cutlass.Uint64(on_equal).ir_value(loc=loc, ip=ip),
++                cutlass.Uint64(otherwise).ir_value(loc=loc, ip=ip),
++            ],
++            "{ .reg .pred p; setp.eq.u64 p, $1, $2; selp.b64 $0, $3, $4, p; }",
++            "=l,l,l,l,l",
++            has_side_effects=False,
++            is_align_stack=False,
++            asm_dialect=llvm.AsmDialect.AD_ATT,
++            loc=loc,
++            ip=ip,
++        )
++    )
++
++
++@cute.jit
++def _copy_16b_addr(source: Int64, destination: Int64) -> None:
++    """Copy 16B between two byte addresses already resolved by the caller.
++
++    The gather loops pick their source rank at runtime.  Selecting the address
++    first and issuing one copy keeps a single load in flight per thread; cloning
++    the copy once per peer inside a constexpr chain makes a warp that straddles
++    two source ranks issue its loads in two serialised batches.
++    """
++    values = ld_global_v4_u32(source)
++    st_global_v4_u32(destination, *values)
++
++
+ @dsl_user_op
+ def _fma_rn_f32(
+     a: Float32,
+@@ -168,7 +255,7 @@ def _add_u64_opaque(
+     loc=None,
+     ip=None,
+ ) -> Int64:
+-    """Add a payload offset without CSE into the earlier LSE address phase."""
++    """Add a payload offset without CSE into the LSE-address calculation."""
+ 
+     return Int64(
+         llvm.inline_asm(
+@@ -188,6 +275,70 @@ def _add_u64_opaque(
+     )
+ 
+ 
++
++_KIMI_NEG_INF = float("-inf")
++
++
++@cute.jit
++def _kimi_pack_key(score: Float32, expert: Int32) -> cutlass.Uint64:
++    """Pack (score, expert) so that a plain integer max picks the winner.
++
++    The expert index goes in complemented, so a tie on score resolves to the
++    lower index -- the same order the native reference produces, without a
++    second comparison at every step.
++    """
++    return (cutlass.Uint64(float_order_key(score)) << cutlass.Uint64(32)) | (
++        cutlass.Uint64(0xFFFF) - cutlass.Uint64(expert)
++    )
++
++
++@cute.jit
++def _kimi_key_expert(key: cutlass.Uint64) -> Int32:
++    return Int32(cutlass.Uint64(0xFFFF) - (key & cutlass.Uint64(0xFFFF)))
++
++
++@cute.jit
++def _kimi_warp_max_key(key: cutlass.Uint64) -> cutlass.Uint64:
++    """Warp-wide max of a 64-bit key in two instructions.
++
++    Reduces the high words, then only the low words of the lanes that tied on
++    the high word, which is cheaper than carrying a 64-bit value through a
++    shuffle chain.
++    """
++    hi = cutlass.Uint32(key >> cutlass.Uint64(32))
++    lo = cutlass.Uint32(key & cutlass.Uint64(0xFFFFFFFF))
++    max_hi = redux_max_u32(hi)
++    contribution = _select_if_eq_u32(hi, max_hi, lo, Uint32(0))
++    max_lo = redux_max_u32(contribution)
++    return (cutlass.Uint64(max_hi) << cutlass.Uint64(32)) | cutlass.Uint64(max_lo)
++
++
++def _kimi_sort_desc(keys, count: int) -> None:
++    """Descending bitonic sort over a compile-time number of packed keys.
++
++    Every index is a Python constant, so the whole network unrolls and the
++    per-round selection can just read ``keys[0]``.
++    """
++    width = 2
++    while width <= count:
++        stride = width // 2
++        while stride > 0:
++            for index in range(count):
++                peer = index ^ stride
++                if peer <= index:
++                    continue
++                descending = (index & width) == 0
++                lower = keys[index]
++                upper = keys[peer]
++                if descending:
++                    keys[index] = cutlass.max(lower, upper)
++                    keys[peer] = cutlass.min(lower, upper)
++                else:
++                    keys[index] = cutlass.min(lower, upper)
++                    keys[peer] = cutlass.max(lower, upper)
++            stride //= 2
++        width *= 2
++
+ class _DCPA2ABase:
+     def __init__(
+         self,
+@@ -902,23 +1053,31 @@ class _AllGatherHeadsLaunch(_DCPA2ABase):
+                 * Int64(packs_per_head)
+             )
+             output_base = Int64(row) * Int64(packs_per_head)
++            # Resolve the peer's base address first and copy once. Cloning the
++            # whole pack loop into all sixteen arms of the constexpr chain
++            # bloats the kernel and pays the chain on every row.
++            source_address = Int64(
++                (local_input + source_base * Int64(4)).toint()
++            )
+             for source in cutlass.range_constexpr(self._world_size):
+                 if source_rank == Int32(source):
+                     if cutlass.const_expr(source == self._rank):
+                         source_words = local_input
+                     else:
+                         source_words = self._staging_words(staging[source])
+-                    pack = lane
+-                    while pack < packs_per_head:
+-                        _copy_16b(
+-                            source_words
+-                            + source_base * Int64(4)
+-                            + Int64(pack) * Int64(4),
+-                            output
+-                            + output_base * Int64(4)
+-                            + Int64(pack) * Int64(4),
+-                        )
+-                        pack += Int32(32)
++                    source_address = Int64(
++                        (source_words + source_base * Int64(4)).toint()
++                    )
++            output_address = Int64(
++                (output + output_base * Int64(4)).toint()
++            )
++            pack = lane
++            while pack < packs_per_head:
++                _copy_16b_addr(
++                    source_address + Int64(pack) * Int64(16),
++                    output_address + Int64(pack) * Int64(16),
++                )
++                pack += Int32(32)
+             row += warp_stride
+ 
+         if cutlass.const_expr(self._device_slot_selection):
+@@ -1188,6 +1347,19 @@ class _AllGatherPairLaunch(_DCPA2ABase):
+             )
+             source_rank = row_pack // first_packs
+             pack = row_pack - source_rank * first_packs
++            # Default to this rank's own slice so the address is always
++            # mappable; the chain below always overwrites it, because
++            # source_rank is derived from row_pack and is in range.
++            source_address = Int64(
++                (
++                    local_first
++                    + (
++                        Int64(batch_index) * Int64(first_packs)
++                        + Int64(pack)
++                    )
++                    * Int64(4)
++                ).toint()
++            )
+             for source in cutlass.range_constexpr(self._world_size):
+                 if source_rank == Int32(source):
+                     if cutlass.const_expr(source == self._rank):
+@@ -1200,11 +1372,16 @@ class _AllGatherPairLaunch(_DCPA2ABase):
+                         source_base = (
+                             Int64(batch_index) * Int64(combined_packs)
+                         )
+-                    _copy_16b(
+-                        source_words
+-                        + (source_base + Int64(pack)) * Int64(4),
+-                        output_first + Int64(linear) * Int64(4),
++                    source_address = Int64(
++                        (
++                            source_words
++                            + (source_base + Int64(pack)) * Int64(4)
++                        ).toint()
+                     )
++            _copy_16b_addr(
++                source_address,
++                Int64((output_first + Int64(linear) * Int64(4)).toint()),
++            )
+             linear += Int32(self._threads)
+ 
+         if cutlass.const_expr(not self._kimi_topk):
+@@ -1221,6 +1398,16 @@ class _AllGatherPairLaunch(_DCPA2ABase):
+                 )
+                 source_rank = row_pack // second_packs
+                 pack = row_pack - source_rank * second_packs
++                source_address = Int64(
++                    (
++                        local_second
++                        + (
++                            Int64(batch_index) * Int64(second_packs)
++                            + Int64(pack)
++                        )
++                        * Int64(4)
++                    ).toint()
++                )
+                 for source in cutlass.range_constexpr(self._world_size):
+                     if source_rank == Int32(source):
+                         if cutlass.const_expr(source == self._rank):
+@@ -1236,11 +1423,18 @@ class _AllGatherPairLaunch(_DCPA2ABase):
+                                 Int64(batch_index) * Int64(combined_packs)
+                                 + Int64(first_packs)
+                             )
+-                        _copy_16b(
+-                            source_words
+-                            + (source_base + Int64(pack)) * Int64(4),
+-                            output_second + Int64(linear) * Int64(4),
++                        source_address = Int64(
++                            (
++                                source_words
++                                + (source_base + Int64(pack)) * Int64(4)
++                            ).toint()
+                         )
++                _copy_16b_addr(
++                    source_address,
++                    Int64(
++                        (output_second + Int64(linear) * Int64(4)).toint()
++                    ),
++                )
+                 linear += Int32(self._threads)
+         else:
+             smem_alloc = cutlass.utils.SmemAllocator()
+@@ -1253,6 +1447,10 @@ class _AllGatherPairLaunch(_DCPA2ABase):
+                 unbiased_scores: cute.struct.Align[
+                     cute.struct.MemRange[Float32, 896], 16
+                 ]
++                # The 64 survivors of the warp-local rounds, as packed keys.
++                reduce_keys: cute.struct.Align[
++                    cute.struct.MemRange[cutlass.Uint64, 64], 16
++                ]
+ 
+             storage = smem_alloc.allocate(SharedStorage)
+             selection_scores = storage.selection_scores.get_tensor(
+@@ -1261,30 +1459,52 @@ class _AllGatherPairLaunch(_DCPA2ABase):
+             unbiased_scores = storage.unbiased_scores.get_tensor(
+                 cute.make_layout((896,), stride=(1,))
+             )
++            reduce_keys = storage.reduce_keys.get_tensor(
++                cute.make_layout((64,), stride=(1,))
++            )
+ 
+-            expert = Int32(tidx)
+-            while expert < Int32(896):
+-                source_rank = expert // Int32(56)
+-                local_expert = expert - source_rank * Int32(56)
+-                router_value = Float32(0.0)
++            # Pull the 3,584-byte router row in 16-byte packs. This uses 224
++            # peer transactions instead of 896 scalar transactions; PCIe
++            # transaction count dominates router-row transfer time.
++            router_pack = Int32(tidx)
++            router_packs_total = Int32(self._world_size) * second_packs
++            while router_pack < router_packs_total:
++                source_rank = router_pack // second_packs
++                pack = router_pack - source_rank * second_packs
++                source_address = Int64(
++                    (local_second + Int64(pack) * Int64(4)).toint()
++                )
+                 for source in cutlass.range_constexpr(self._world_size):
+                     if source_rank == Int32(source):
+                         if cutlass.const_expr(source == self._rank):
+-                            source_router = cute.recast_ptr(
+-                                local_second.align(4), dtype=Float32
+-                            )
++                            source_words = local_second
++                            source_base = Int64(0)
+                         else:
+-                            source_router = cute.recast_ptr(
+-                                (
+-                                    staging[source]
+-                                    + slot_offset
+-                                    + Int64(first_packs) * Int64(16)
+-                                ).align(4),
+-                                dtype=Float32,
++                            source_words = self._staging_words(
++                                staging[source] + slot_offset
+                             )
+-                        router_value = cute.arch.load(
+-                            source_router + Int64(local_expert), Float32
++                            source_base = Int64(first_packs)
++                        source_address = Int64(
++                            (
++                                source_words
++                                + (source_base + Int64(pack)) * Int64(4)
++                            ).toint()
+                         )
++                word0, word1, word2, word3 = ld_global_v4_u32(source_address)
++                # router_pack counts packs in rank-major order, so multiplying
++                # it by four yields the first global expert index in the pack
++                # for every supported world size.
++                base_expert = router_pack * Int32(4)
++                selection_scores[base_expert] = u32_as_f32(word0)
++                selection_scores[base_expert + Int32(1)] = u32_as_f32(word1)
++                selection_scores[base_expert + Int32(2)] = u32_as_f32(word2)
++                selection_scores[base_expert + Int32(3)] = u32_as_f32(word3)
++                router_pack += Int32(self._threads)
++            cute.arch.sync_threads()
++
++            expert = Int32(tidx)
++            while expert < Int32(896):
++                router_value = selection_scores[expert]
+                 bias = cute.arch.load(
+                     correction_bias + Int64(expert), Float32
+                 )
+@@ -1306,43 +1526,89 @@ class _AllGatherPairLaunch(_DCPA2ABase):
+                 expert += Int32(self._threads)
+             cute.arch.sync_threads()
+ 
+-            if Int32(tidx) == Int32(0):
+-                selected_ids = cute.make_rmem_tensor((16,), Int32)
+-                selected_weights = cute.make_rmem_tensor((16,), Float32)
++            # Two-level top-16 over packed (score, expert) keys. Four warps each
++            # reduce 256 experts held in registers (8 per lane); warp 0 then
++            # merges the 64 survivors.
++            # A round costs one warp reduction -- two instructions -- because the
++            # tie-break lives in the key rather than in a second comparison.
++            lane = Int32(tidx) % Int32(32)
++            warp = Int32(tidx) // Int32(32)
++            lane_key = cutlass.Uint64(0)
++            keys = cute.make_rmem_tensor((8,), cutlass.Uint64)
++            if warp < Int32(4):
++                for item in cutlass.range_constexpr(8):
++                    expert_id = warp * Int32(256) + Int32(item * 32) + lane
++                    value = Float32(_KIMI_NEG_INF)
++                    if expert_id < Int32(896):
++                        value = selection_scores[expert_id]
++                    keys[item] = _kimi_pack_key(value, expert_id)
++                _kimi_sort_desc(keys, 8)
++                previous = cutlass.Uint64(0)
+                 for selected in cutlass.range_constexpr(16):
+-                    selected_ids[selected] = Int32(-1)
+-                    selected_weights[selected] = Float32(0.0)
+-                weight_sum = Float32(0.0)
++                    if cutlass.const_expr(selected > 0):
++                        # Hold the head before the shift overwrites it, so
++                        # every element selects on the same condition.
++                        head = keys[0]
++                        tail_key = _kimi_pack_key(
++                            Float32(_KIMI_NEG_INF), _kimi_key_expert(keys[7])
++                        )
++                        for item in cutlass.range_constexpr(7):
++                            keys[item] = _select_if_eq_u64(
++                                previous, head, keys[item + 1], keys[item]
++                            )
++                        keys[7] = _select_if_eq_u64(
++                            previous, head, tail_key, keys[7]
++                        )
++                    previous = _kimi_warp_max_key(keys[0])
++                    lane_key = _select_if_eq_u64(
++                        cutlass.Uint64(lane),
++                        cutlass.Uint64(selected),
++                        previous,
++                        lane_key,
++                    )
++                if lane < Int32(16):
++                    reduce_keys[warp * Int32(16) + lane] = lane_key
++            cute.arch.sync_threads()
++            selected_ids = cute.make_rmem_tensor((16,), Int32)
++            selected_weights = cute.make_rmem_tensor((16,), Float32)
++            weight_sum = Float32(0.0)
++            if warp == Int32(0):
++                merge_keys = cute.make_rmem_tensor((2,), cutlass.Uint64)
++                for item in cutlass.range_constexpr(2):
++                    merge_keys[item] = reduce_keys[Int32(item * 32) + lane]
++                _kimi_sort_desc(merge_keys, 2)
++                previous = cutlass.Uint64(0)
+                 for selected in cutlass.range_constexpr(16):
+-                    best_score = Float32(float("-inf"))
+-                    best_expert = Int32(-1)
+-                    candidate = Int32(0)
+-                    while candidate < Int32(896):
+-                        already_selected = False
+-                        for prior in cutlass.range_constexpr(selected):
+-                            if selected_ids[prior] == candidate:
+-                                already_selected = True
+-                        score = selection_scores[candidate]
+-                        if not already_selected:
+-                            if (
+-                                score > best_score
+-                                or (
+-                                    score == best_score
+-                                    and (
+-                                        best_expert < Int32(0)
+-                                        or candidate < best_expert
+-                                    )
+-                                )
+-                            ):
+-                                best_score = score
+-                                best_expert = candidate
+-                        candidate += Int32(1)
+-                    selected_ids[selected] = best_expert
+-                    weight = Float32(0.0)
+-                    if best_expert >= Int32(0):
+-                        weight = unbiased_scores[best_expert]
++                    if cutlass.const_expr(selected > 0):
++                        head = merge_keys[0]
++                        tail_key = _kimi_pack_key(
++                            Float32(_KIMI_NEG_INF),
++                            _kimi_key_expert(merge_keys[1]),
++                        )
++                        merge_keys[0] = _select_if_eq_u64(
++                            previous, head, merge_keys[1], merge_keys[0]
++                        )
++                        merge_keys[1] = _select_if_eq_u64(
++                            previous, head, tail_key, merge_keys[1]
++                        )
++                    previous = _kimi_warp_max_key(merge_keys[0])
++                    # The reduction broadcasts, so every lane agrees here.
++                    final_expert = _kimi_key_expert(previous)
++                    selected_ids[selected] = final_expert
++                    weight = unbiased_scores[final_expert]
+                     selected_weights[selected] = weight
+-                    weight_sum += weight
++                # The native kernel renormalises with cg::reduce over the warp,
++                # which folds by halves (lane l adds lane l+stride, stride
++                # halving from 16). Summing left to right instead lands a ULP
++                # away, so fold in the same order. Same fifteen adds.
++                eight = [
++                    selected_weights[item] + selected_weights[item + 8]
++                    for item in range(8)
++                ]
++                four = [eight[item] + eight[item + 4] for item in range(4)]
++                two = [four[item] + four[item + 2] for item in range(2)]
++                weight_sum = two[0] + two[1]
++            if Int32(tidx) == Int32(0):
+                 scale = Float32(1.0) / (weight_sum + Float32(1.0e-20))
+                 for selected in cutlass.range_constexpr(16):
+                     cute.arch.store(
+@@ -1363,6 +1629,165 @@ class _AllGatherPairLaunch(_DCPA2ABase):
+                 )
+ 
+ 
++class _KimiTopK16Launch:
++    """Select Kimi-K3's 16 routed experts in one CTA per token."""
++
++    def __init__(self, threads: int) -> None:
++        self._threads = int(threads)
++
++    @cute.jit
++    def __call__(
++        self,
++        router_logits: cute.Pointer,
++        correction_bias: cute.Pointer,
++        output_weights: cute.Pointer,
++        output_ids: cute.Pointer,
++        rows: Int32,
++        stream: cuda.CUstream,
++    ) -> None:
++        self.kernel(
++            router_logits,
++            correction_bias,
++            output_weights,
++            output_ids,
++        ).launch(
++            grid=(rows, 1, 1),
++            block=(self._threads, 1, 1),
++            max_number_threads=(512, 1, 1),
++            min_blocks_per_mp=1,
++            cluster=(1, 1, 1),
++            stream=stream,
++        )
++
++    @cute.kernel
++    def kernel(
++        self,
++        router_logits: cute.Pointer,
++        correction_bias: cute.Pointer,
++        output_weights: cute.Pointer,
++        output_ids: cute.Pointer,
++    ) -> None:
++        tidx, _, _ = cute.arch.thread_idx()
++        bidx, _, _ = cute.arch.block_idx()
++        smem_alloc = cutlass.utils.SmemAllocator()
++
++        @cute.struct
++        class SharedStorage:
++            selection_scores: cute.struct.Align[
++                cute.struct.MemRange[Float32, 896], 16
++            ]
++            unbiased_scores: cute.struct.Align[
++                cute.struct.MemRange[Float32, 896], 16
++            ]
++            active_experts: cute.struct.Align[
++                cute.struct.MemRange[Int32, 896], 16
++            ]
++            warp_keys: cute.struct.Align[
++                cute.struct.MemRange[cutlass.Uint64, 16], 16
++            ]
++
++        storage = smem_alloc.allocate(SharedStorage)
++        selection_scores = storage.selection_scores.get_tensor(
++            cute.make_layout((896,), stride=(1,))
++        )
++        unbiased_scores = storage.unbiased_scores.get_tensor(
++            cute.make_layout((896,), stride=(1,))
++        )
++        active_experts = storage.active_experts.get_tensor(
++            cute.make_layout((896,), stride=(1,))
++        )
++        warp_keys = storage.warp_keys.get_tensor(
++            cute.make_layout((16,), stride=(1,))
++        )
++
++        row_offset = Int64(bidx) * Int64(896)
++        expert = Int32(tidx)
++        while expert < Int32(896):
++            router_value = cute.arch.load(
++                router_logits + row_offset + Int64(expert), Float32
++            )
++            bias = cute.arch.load(
++                correction_bias + Int64(expert), Float32
++            )
++            unbiased = Float32(1.0) / (
++                Float32(1.0) + cute.math.exp(-router_value, fastmath=True)
++            )
++            if not cute.math.isfinite(unbiased):
++                unbiased = Float32(0.0)
++            selection = unbiased + bias
++            if not cute.math.isfinite(selection):
++                if selection > Float32(0.0):
++                    selection = Float32(float("inf"))
++                else:
++                    selection = Float32(float("-inf"))
++            # Canonicalize signed zero because packed keys distinguish -0.0
++            # from +0.0 and expert ties require one deterministic ordering.
++            if selection == Float32(0.0):
++                selection = Float32(0.0)
++            selection_scores[expert] = selection
++            unbiased_scores[expert] = unbiased
++            active_experts[expert] = Int32(1)
++            expert += Int32(self._threads)
++        cute.arch.sync_threads()
++
++        # Each round reduces one candidate per thread, then merges the warp
++        # winners. The selected key is invalidated in shared memory before the
++        # following round. Packed keys preserve lower-ID tie-breaking.
++        lane = Int32(tidx) % Int32(32)
++        warp = Int32(tidx) // Int32(32)
++        selected_ids = cute.make_rmem_tensor((16,), Int32)
++        selected_weights = cute.make_rmem_tensor((16,), Float32)
++        for selected in cutlass.range_constexpr(16):
++            thread_key = cutlass.Uint64(0)
++            candidate = Int32(tidx)
++            while candidate < Int32(896):
++                candidate_key = cutlass.Uint64(0)
++                if active_experts[candidate] != Int32(0):
++                    candidate_key = _kimi_pack_key(
++                        selection_scores[candidate], candidate
++                    )
++                thread_key = cutlass.max(thread_key, candidate_key)
++                candidate += Int32(self._threads)
++            warp_key = _kimi_warp_max_key(thread_key)
++            if lane == Int32(0):
++                warp_keys[warp] = warp_key
++            cute.arch.sync_threads()
++            if Int32(tidx) == Int32(0):
++                selected_key = warp_keys[0]
++                for source_warp in cutlass.range_constexpr(
++                    1, self._threads // 32
++                ):
++                    selected_key = cutlass.max(
++                        selected_key, warp_keys[source_warp]
++                    )
++                final_expert = _kimi_key_expert(selected_key)
++                selected_ids[selected] = final_expert
++                selected_weights[selected] = unbiased_scores[final_expert]
++                active_experts[final_expert] = Int32(0)
++            cute.arch.sync_threads()
++
++        weight_sum = Float32(0.0)
++        if Int32(tidx) == Int32(0):
++            for selected in cutlass.range_constexpr(16):
++                weight_sum += selected_weights[selected]
++
++        if Int32(tidx) == Int32(0):
++            output_offset = Int64(bidx) * Int64(16)
++            denominator = Float32(1.0)
++            if weight_sum > Float32(0.0):
++                denominator = weight_sum
++            scale = Float32(1.0) / denominator
++            for selected in cutlass.range_constexpr(16):
++                cute.arch.store(
++                    output_weights + output_offset + Int64(selected),
++                    selected_weights[selected] * scale,
++                )
++                cute.arch.store(
++                    output_ids + output_offset + Int64(selected),
++                    selected_ids[selected],
++                )
++
++
+ def _pad_ptrs(values: Sequence[int], world_size: int) -> tuple[int, ...]:
+     if len(values) != world_size:
+         raise ValueError("pointer bundle does not match DCP world size")
+@@ -1776,6 +2201,59 @@ def _get_compiled_all_gather_pair(
+     return run
+ 
+ 
++def is_kimi_topk16_prepared(threads: int = 256) -> bool:
++    return int(threads) in _PREPARED_KIMI_TOPK_LAUNCHERS
++
++
++@functools.cache
++def _get_compiled_kimi_topk16(threads: int = 256) -> Callable:
++    normalized_threads = int(threads)
++    if normalized_threads not in (128, 256, 512):
++        raise ValueError("Kimi top-16 threads must be 128, 256, or 512")
++    launch = _KimiTopK16Launch(normalized_threads)
++    raise_if_kernel_resolution_frozen(
++        "cute.compile",
++        target=launch,
++        cache_key=(normalized_threads,),
++    )
++    p_f32 = _f32_ptr(16)
++    p_i32 = _i32_ptr(16)
++    raw = b12x_compile(
++        launch,
++        p_f32,
++        p_f32,
++        p_f32,
++        p_i32,
++        1,
++        current_cuda_stream(),
++        compile_spec=KernelCompileSpec.from_key(
++            "comm.pcie.dcp_a2a.kimi_topk16",
++            1,
++            (normalized_threads,),
++            labels=("threads",),
++        ),
++    )
++
++    def run(
++        router_logits_ptr: int,
++        correction_bias_ptr: int,
++        output_weights_ptr: int,
++        output_ids_ptr: int,
++        rows: int,
++    ) -> None:
++        raw(
++            _f32_ptr(router_logits_ptr),
++            _f32_ptr(correction_bias_ptr),
++            _f32_ptr(output_weights_ptr),
++            _i32_ptr(output_ids_ptr),
++            int(rows),
++            current_cuda_stream(),
++        )
++
++    _PREPARED_KIMI_TOPK_LAUNCHERS.add(normalized_threads)
++    return run
++
++
+ def lse_reduce_scatter(
+     *,
+     world_size: int,
+@@ -1928,6 +2406,7 @@ def all_gather_pair(
+ 
+ def all_gather_pair_kimi_topk(
+     *,
++    world_size: int,
+     rank: int,
+     local_down_ptr: int,
+     local_router_ptr: int,
+@@ -1942,14 +2421,16 @@ def all_gather_pair_kimi_topk(
+ ) -> None:
+     slot_delta_256b = _slot_delta_256b(slot_delta_bytes)
+     launcher = _get_compiled_all_gather_pair(
+-        16,
++        world_size,
+         rank,
+         512,
+         device_slot_selection,
+         True,
+     )
+     if not device_slot_selection:
+-        _get_compiled_all_gather_pair(16, rank, 512, True, True)
++        _get_compiled_all_gather_pair(
++            world_size, rank, 512, True, True
++        )
+     launcher(
+         local_down_ptr,
+         local_router_ptr,
+@@ -1960,15 +2441,34 @@ def all_gather_pair_kimi_topk(
+         staging_ptrs,
+         signal_ptrs,
+         1,
+-        28,
+-        14,
++        448 // world_size,
++        224 // world_size,
+         slot_delta_256b,
+     )
+ 
+ 
++def kimi_topk16(
++    *,
++    router_logits_ptr: int,
++    correction_bias_ptr: int,
++    output_weights_ptr: int,
++    output_ids_ptr: int,
++    rows: int,
++    threads: int = 256,
++) -> None:
++    _get_compiled_kimi_topk16(threads)(
++        router_logits_ptr,
++        correction_bias_ptr,
++        output_weights_ptr,
++        output_ids_ptr,
++        rows,
++    )
++
++
+ __all__ = [
+     "all_gather_heads",
+     "all_gather_pair",
+     "all_gather_pair_kimi_topk",
++    "kimi_topk16",
+     "lse_reduce_scatter",
+ ]
+diff --git a/b12x/comm/pcie/_island_rs_cute.py b/b12x/comm/pcie/_island_rs_cute.py
+new file mode 100644
+index 0000000000000000000000000000000000000000..460755463d59762238f6b8af3df7cf671b58f761
+--- /dev/null
++++ b/b12x/comm/pcie/_island_rs_cute.py
+@@ -0,0 +1,683 @@
++"""CuTeDSL pull-based island reduce-scatter TP16 collective.
++
++Rank ``island * 4 + lane`` owns one equal quarter of the vector. Each rank
++pulls from six peers: the three other lanes of its four-rank island and the
++same lane in the three other islands. This bounds peer degree at six while
++distributing inter-island traffic across every rank. The three protocol rounds
++move 2.25 times the BF16 payload per rank.
++"""
++
++from __future__ import annotations
++
++import functools
++from collections.abc import Callable, Sequence
++from typing import Tuple
++
++import cuda.bindings.driver as cuda
++import cutlass
++import cutlass.cute as cute
++import cutlass.utils
++from cutlass import Float32, Int32, Int64, Uint32
++from cutlass._mlir.dialects import llvm
++from cutlass.cutlass_dsl import T, dsl_user_op
++
++from b12x._lib.compiler import KernelCompileSpec
++from b12x._lib.compiler import compile as b12x_compile
++from b12x._lib.runtime_control import raise_if_kernel_resolution_frozen
++from b12x._lib.utils import (
++    cuda_stream_from_int_or_current,
++    cuda_stream_to_int,
++    current_cuda_stream,
++    make_ptr,
++)
++
++
++@dsl_user_op
++def _atomic_add_global_u32(
++    address: Int64, value: Uint32, *, loc=None, ip=None
++) -> Uint32:
++    return Uint32(
++        llvm.inline_asm(
++            T.i32(),
++            [
++                Int64(address).ir_value(loc=loc, ip=ip),
++                Uint32(value).ir_value(loc=loc, ip=ip),
++            ],
++            "atom.global.add.u32 $0, [$1], $2;",
++            "=r,l,r",
++            has_side_effects=True,
++            is_align_stack=False,
++            asm_dialect=llvm.AsmDialect.AD_ATT,
++            loc=loc,
++            ip=ip,
++        )
++    )
++
++
++@dsl_user_op
++def _load_acquire_sys_u32(address: Int64, *, loc=None, ip=None) -> Uint32:
++    return Uint32(
++        llvm.inline_asm(
++            T.i32(),
++            [Int64(address).ir_value(loc=loc, ip=ip)],
++            "ld.acquire.sys.global.u32 $0, [$1];",
++            "=r,l",
++            has_side_effects=True,
++            is_align_stack=False,
++            asm_dialect=llvm.AsmDialect.AD_ATT,
++            loc=loc,
++            ip=ip,
++        )
++    )
++
++
++@dsl_user_op
++def _store_release_sys_u32(address: Int64, value: Uint32, *, loc=None, ip=None) -> None:
++    llvm.inline_asm(
++        None,
++        [
++            Int64(address).ir_value(loc=loc, ip=ip),
++            Uint32(value).ir_value(loc=loc, ip=ip),
++        ],
++        "st.release.sys.global.u32 [$0], $1;",
++        "l,r",
++        has_side_effects=True,
++        is_align_stack=False,
++        asm_dialect=llvm.AsmDialect.AD_ATT,
++        loc=loc,
++        ip=ip,
++    )
++
++
++@dsl_user_op
++def _fence_sc_sys(*, loc=None, ip=None) -> None:
++    llvm.inline_asm(
++        None,
++        [],
++        "fence.sc.sys;",
++        "",
++        has_side_effects=True,
++        is_align_stack=False,
++        asm_dialect=llvm.AsmDialect.AD_ATT,
++        loc=loc,
++        ip=ip,
++    )
++
++
++@dsl_user_op
++def _nanosleep(cycles: Uint32, *, loc=None, ip=None) -> None:
++    llvm.inline_asm(
++        None,
++        [Uint32(cycles).ir_value(loc=loc, ip=ip)],
++        "nanosleep.u32 $0;",
++        "r",
++        has_side_effects=True,
++        is_align_stack=False,
++        asm_dialect=llvm.AsmDialect.AD_ATT,
++        loc=loc,
++        ip=ip,
++    )
++
++
++@cute.jit
++def _wait_for(address: Int64, generation: Uint32, cycles: int) -> None:
++    observed = _load_acquire_sys_u32(address)
++    while observed < generation:
++        if cutlass.const_expr(cycles > 0):
++            _nanosleep(Uint32(cycles))
++        observed = _load_acquire_sys_u32(address)
++
++
++@cute.jit
++def _flag_address(base: Int64, region: int, block: Int32, index: Int32) -> Int64:
++    return (
++        base
++        + Int64(region)
++        + (Int64(block) * Int64(_ISLAND_SIZE) + Int64(index)) * Int64(128)
++    )
++
++
++@dsl_user_op
++def unpack_bf16x2(value: Uint32, *, loc=None, ip=None) -> Tuple[Float32, Float32]:
++    result = llvm.inline_asm(
++        llvm.StructType.get_literal([T.f32(), T.f32()]),
++        [Uint32(value).ir_value(loc=loc, ip=ip)],
++        """
++        {
++            .reg .b16 lo, hi;
++            mov.b32 {lo, hi}, $2;
++            cvt.f32.bf16 $0, lo;
++            cvt.f32.bf16 $1, hi;
++        }
++        """,
++        "=f,=f,r",
++        has_side_effects=False,
++        is_align_stack=False,
++        asm_dialect=llvm.AsmDialect.AD_ATT,
++        loc=loc,
++        ip=ip,
++    )
++    return (
++        Float32(llvm.extractvalue(T.f32(), result, [0], loc=loc, ip=ip)),
++        Float32(llvm.extractvalue(T.f32(), result, [1], loc=loc, ip=ip)),
++    )
++
++
++@dsl_user_op
++def pack_f32x2_to_bf16x2(lo: Float32, hi: Float32, *, loc=None, ip=None) -> Uint32:
++    """Match two scalar ``__float2bfloat16`` conversions without saturation."""
++    return Uint32(
++        llvm.inline_asm(
++            T.i32(),
++            [
++                Float32(lo).ir_value(loc=loc, ip=ip),
++                Float32(hi).ir_value(loc=loc, ip=ip),
++            ],
++            """
++            {
++                .reg .b16 blo, bhi;
++                cvt.rn.bf16.f32 blo, $1;
++                cvt.rn.bf16.f32 bhi, $2;
++                mov.b32 $0, {blo, bhi};
++            }
++            """,
++            "=r,f,f",
++            has_side_effects=False,
++            is_align_stack=False,
++            asm_dialect=llvm.AsmDialect.AD_ATT,
++            loc=loc,
++            ip=ip,
++        )
++    )
++
++
++_ISLAND_SIZE = 4
++_MAX_ISLANDS = 4
++_MAX_WORLD_SIZE = _ISLAND_SIZE * _MAX_ISLANDS
++
++# One 128-byte line per (block, slot); 32 blocks x 4 slots per region.
++_RS_ARRIVED = 256
++_XS_ARRIVED = 16_640
++_AG_ARRIVED = 33_024
++HEADER_BYTES = 49_408
++MAX_BLOCKS = 32
++
++
++def island_rs_peers(rank: int, world_size: int) -> tuple[int, ...]:
++    """Slabs this rank maps: three island lanes, three same-lane partners."""
++
++    if world_size != _MAX_WORLD_SIZE:
++        raise ValueError(f"island reduce-scatter requires TP16, got TP{world_size}")
++    if not 0 <= rank < world_size:
++        raise ValueError(f"invalid rank {rank} for TP{world_size}")
++    island, lane = divmod(rank, _ISLAND_SIZE)
++    lanes = {island * _ISLAND_SIZE + p for p in range(_ISLAND_SIZE)}
++    partners = {j * _ISLAND_SIZE + lane for j in range(_MAX_ISLANDS)}
++    return tuple(sorted((lanes | partners) - {rank}))
++
++
++class _IslandRSLaunch:
++    """Rank-specialized launcher; every peer index folds away at compile time."""
++
++    def __init__(
++        self,
++        world_size: int,
++        rank: int,
++        *,
++        threads: int = 128,
++        wait_nanosleep_cycles: int = 24,
++    ) -> None:
++        if world_size != _MAX_WORLD_SIZE:
++            raise ValueError(f"unsupported world size {world_size}")
++        if not 0 <= rank < world_size:
++            raise ValueError(f"invalid rank {rank} for world size {world_size}")
++        if not 32 <= threads <= 1024 or threads % 32:
++            raise ValueError("threads must be a multiple of 32 in [32, 1024]")
++        self._world_size = int(world_size)
++        self._rank = int(rank)
++        self._threads = int(threads)
++        self._wait_nanosleep_cycles = int(wait_nanosleep_cycles)
++        self._island = self._rank // _ISLAND_SIZE
++        self._lane = self._rank % _ISLAND_SIZE
++
++    @cute.jit
++    def __call__(
++        self,
++        slab0: cute.Pointer,
++        slab1: cute.Pointer,
++        slab2: cute.Pointer,
++        slab3: cute.Pointer,
++        slab4: cute.Pointer,
++        slab5: cute.Pointer,
++        slab6: cute.Pointer,
++        slab7: cute.Pointer,
++        slab8: cute.Pointer,
++        slab9: cute.Pointer,
++        slab10: cute.Pointer,
++        slab11: cute.Pointer,
++        slab12: cute.Pointer,
++        slab13: cute.Pointer,
++        slab14: cute.Pointer,
++        slab15: cute.Pointer,
++        input_ptr: cute.Pointer,
++        output_ptr: cute.Pointer,
++        stage_offset: Int64,
++        part_offset: Int64,
++        final_offset: Int64,
++        quarter_capacity: Int64,
++        elements: Int64,
++        blocks: Int32,
++        stream: cuda.CUstream,
++    ) -> None:
++        self.kernel(
++            slab0,
++            slab1,
++            slab2,
++            slab3,
++            slab4,
++            slab5,
++            slab6,
++            slab7,
++            slab8,
++            slab9,
++            slab10,
++            slab11,
++            slab12,
++            slab13,
++            slab14,
++            slab15,
++            input_ptr,
++            output_ptr,
++            stage_offset,
++            part_offset,
++            final_offset,
++            quarter_capacity,
++            elements,
++        ).launch(
++            grid=(blocks, 1, 1),
++            block=[self._threads, 1, 1],
++            cluster=(1, 1, 1),
++            stream=stream,
++        )
++
++    @cute.kernel
++    def kernel(
++        self,
++        slab0: cute.Pointer,
++        slab1: cute.Pointer,
++        slab2: cute.Pointer,
++        slab3: cute.Pointer,
++        slab4: cute.Pointer,
++        slab5: cute.Pointer,
++        slab6: cute.Pointer,
++        slab7: cute.Pointer,
++        slab8: cute.Pointer,
++        slab9: cute.Pointer,
++        slab10: cute.Pointer,
++        slab11: cute.Pointer,
++        slab12: cute.Pointer,
++        slab13: cute.Pointer,
++        slab14: cute.Pointer,
++        slab15: cute.Pointer,
++        input_ptr: cute.Pointer,
++        output_ptr: cute.Pointer,
++        stage_offset: Int64,
++        part_offset: Int64,
++        final_offset: Int64,
++        quarter_capacity: Int64,
++        elements: Int64,
++    ) -> None:
++        slabs = (
++            slab0,
++            slab1,
++            slab2,
++            slab3,
++            slab4,
++            slab5,
++            slab6,
++            slab7,
++            slab8,
++            slab9,
++            slab10,
++            slab11,
++            slab12,
++            slab13,
++            slab14,
++            slab15,
++        )
++        tidx, _, _ = cute.arch.thread_idx()
++        bidx, _, _ = cute.arch.block_idx()
++        gdim, _, _ = cute.arch.grid_dim()
++        self_base = Int64(slabs[self._rank].toint())
++
++        allocator = cutlass.utils.SmemAllocator()
++        shared_generation = allocator.allocate_tensor(
++            element_type=cutlass.Uint32,
++            layout=cute.make_layout((1,)),
++            byte_alignment=4,
++        )
++        if tidx == Int32(0):
++            shared_generation[0] = _atomic_add_global_u32(
++                self_base + Int64(bidx) * Int64(4), Uint32(1)
++            ) + Uint32(1)
++        cute.arch.barrier()
++        generation = Uint32(shared_generation[0])
++        if generation % Uint32(2) != Uint32(0):
++            stage_offset += quarter_capacity * Int64(_ISLAND_SIZE * 4)
++            part_offset += quarter_capacity * Int64(4)
++            final_offset += quarter_capacity * Int64(_ISLAND_SIZE * 4)
++
++        # Everything below counts in bf16x2 words; callers guarantee an even
++        # element count so there is no scalar tail to chase.
++        pairs = elements // Int64(2)
++        quarter = (pairs + Int64(_ISLAND_SIZE - 1)) // Int64(_ISLAND_SIZE)
++        stride = Int64(gdim) * Int64(self._threads)
++        start = Int64(bidx) * Int64(self._threads) + Int64(tidx)
++
++        input_words = cute.recast_ptr(input_ptr.align(4), dtype=Uint32)
++        output_words = cute.recast_ptr(output_ptr.align(4), dtype=Uint32)
++
++        # Every remote transfer is a read. The equal-quarter ownership keeps
++        # any rank from moving the complete vector on behalf of its island.
++
++        # Phase 1 -- publish my whole input locally, then reduce my quarter by
++        # pulling it out of the four island stages.
++        self_stage = cute.recast_ptr(
++            cute.make_ptr(
++                cutlass.BFloat16,
++                self_base + stage_offset,
++                cute.AddressSpace.gmem,
++                assumed_align=16,
++            ).align(4),
++            dtype=Uint32,
++        )
++        # A block publishes the same shifted residue class that the matching
++        # block on each destination lane consumes after its per-block arrival
++        # flag. This keeps data ownership aligned with synchronization even
++        # when a quarter boundary is not divisible by the launch stride.
++        for lane in cutlass.range_constexpr(_ISLAND_SIZE):
++            begin = Int64(lane) * quarter
++            stop = begin + quarter
++            if stop > pairs:
++                stop = pairs
++            index = start
++            while index < stop - begin:
++                self_stage[begin + index] = input_words[begin + index]
++                index += stride
++        cute.arch.barrier()
++        if tidx == Int32(0):
++            _fence_sc_sys()
++            for p in cutlass.range_constexpr(_ISLAND_SIZE):
++                if cutlass.const_expr(p != self._lane):
++                    peer = self._island * _ISLAND_SIZE + p
++                    _store_release_sys_u32(
++                        _flag_address(
++                            Int64(slabs[peer].toint()),
++                            _RS_ARRIVED,
++                            bidx,
++                            Int32(self._lane),
++                        ),
++                        generation,
++                    )
++            for p in cutlass.range_constexpr(_ISLAND_SIZE):
++                if cutlass.const_expr(p != self._lane):
++                    _wait_for(
++                        _flag_address(self_base, _RS_ARRIVED, bidx, Int32(p)),
++                        generation,
++                        self._wait_nanosleep_cycles,
++                    )
++        cute.arch.barrier()
++
++        mine_begin = Int64(self._lane) * quarter
++        mine_stop = mine_begin + quarter
++        if mine_stop > pairs:
++            mine_stop = pairs
++        mine_length = mine_stop - mine_begin
++
++        self_part = cute.recast_ptr(
++            cute.make_ptr(
++                cutlass.BFloat16,
++                self_base + part_offset,
++                cute.AddressSpace.gmem,
++                assumed_align=16,
++            ).align(4),
++            dtype=Uint32,
++        )
++        index = start
++        while index < mine_length:
++            total_lo = Float32(0.0)
++            total_hi = Float32(0.0)
++            for p in cutlass.range_constexpr(_ISLAND_SIZE):
++                peer = self._island * _ISLAND_SIZE + p
++                peer_stage = cute.recast_ptr(
++                    cute.make_ptr(
++                        cutlass.BFloat16,
++                        Int64(slabs[peer].toint()) + stage_offset,
++                        cute.AddressSpace.gmem,
++                        assumed_align=16,
++                    ).align(4),
++                    dtype=Uint32,
++                )
++                lo, hi = unpack_bf16x2(peer_stage[mine_begin + index])
++                total_lo += lo
++                total_hi += hi
++            self_part[index] = pack_f32x2_to_bf16x2(total_lo, total_hi)
++            index += stride
++        cute.arch.barrier()
++
++        # Phase 2 -- combine the four island partials for my quarter, again by
++        # pulling, from the same lane in every island.
++        if tidx == Int32(0):
++            _fence_sc_sys()
++            for j in cutlass.range_constexpr(_MAX_ISLANDS):
++                if cutlass.const_expr(j != self._island):
++                    partner = j * _ISLAND_SIZE + self._lane
++                    _store_release_sys_u32(
++                        _flag_address(
++                            Int64(slabs[partner].toint()),
++                            _XS_ARRIVED,
++                            bidx,
++                            Int32(self._island),
++                        ),
++                        generation,
++                    )
++            for j in cutlass.range_constexpr(_MAX_ISLANDS):
++                if cutlass.const_expr(j != self._island):
++                    _wait_for(
++                        _flag_address(self_base, _XS_ARRIVED, bidx, Int32(j)),
++                        generation,
++                        self._wait_nanosleep_cycles,
++                    )
++        cute.arch.barrier()
++
++        self_final = cute.recast_ptr(
++            cute.make_ptr(
++                cutlass.BFloat16,
++                self_base + final_offset,
++                cute.AddressSpace.gmem,
++                assumed_align=16,
++            ).align(4),
++            dtype=Uint32,
++        )
++        index = start
++        while index < mine_length:
++            total_lo = Float32(0.0)
++            total_hi = Float32(0.0)
++            for j in cutlass.range_constexpr(_MAX_ISLANDS):
++                partner = j * _ISLAND_SIZE + self._lane
++                partner_part = cute.recast_ptr(
++                    cute.make_ptr(
++                        cutlass.BFloat16,
++                        Int64(slabs[partner].toint()) + part_offset,
++                        cute.AddressSpace.gmem,
++                        assumed_align=16,
++                    ).align(4),
++                    dtype=Uint32,
++                )
++                lo, hi = unpack_bf16x2(partner_part[index])
++                total_lo += lo
++                total_hi += hi
++            value = pack_f32x2_to_bf16x2(total_lo, total_hi)
++            self_final[mine_begin + index] = value
++            output_words[mine_begin + index] = value
++            index += stride
++        cute.arch.barrier()
++
++        # Phase 3 -- island all-gather, pulling the three quarters I do not own
++        # straight into my output.
++        if tidx == Int32(0):
++            _fence_sc_sys()
++            for p in cutlass.range_constexpr(_ISLAND_SIZE):
++                if cutlass.const_expr(p != self._lane):
++                    peer = self._island * _ISLAND_SIZE + p
++                    _store_release_sys_u32(
++                        _flag_address(
++                            Int64(slabs[peer].toint()),
++                            _AG_ARRIVED,
++                            bidx,
++                            Int32(self._lane),
++                        ),
++                        generation,
++                    )
++            for p in cutlass.range_constexpr(_ISLAND_SIZE):
++                if cutlass.const_expr(p != self._lane):
++                    _wait_for(
++                        _flag_address(self_base, _AG_ARRIVED, bidx, Int32(p)),
++                        generation,
++                        self._wait_nanosleep_cycles,
++                    )
++        cute.arch.barrier()
++
++        for p in cutlass.range_constexpr(_ISLAND_SIZE):
++            if cutlass.const_expr(p != self._lane):
++                peer = self._island * _ISLAND_SIZE + p
++                peer_final = cute.recast_ptr(
++                    cute.make_ptr(
++                        cutlass.BFloat16,
++                        Int64(slabs[peer].toint()) + final_offset,
++                        cute.AddressSpace.gmem,
++                        assumed_align=16,
++                    ).align(4),
++                    dtype=Uint32,
++                )
++                begin = Int64(p) * quarter
++                stop = begin + quarter
++                if stop > pairs:
++                    stop = pairs
++                index = start
++                while index < stop - begin:
++                    output_words[begin + index] = peer_final[begin + index]
++                    index += stride
++
++
++@functools.lru_cache(maxsize=None)
++def get_island_rs_launcher(
++    world_size: int,
++    rank: int,
++    device_index: int,
++    *,
++    threads: int = 128,
++    wait_nanosleep_cycles: int = 24,
++) -> Callable[..., None]:
++    """Return the rank-specialized TP16 island reduce-scatter launcher."""
++
++    del device_index  # retained in the process-local cache key
++    launch = _IslandRSLaunch(
++        world_size,
++        rank,
++        threads=threads,
++        wait_nanosleep_cycles=wait_nanosleep_cycles,
++    )
++    cache_key = (
++        int(world_size),
++        int(rank),
++        int(threads),
++        int(wait_nanosleep_cycles),
++    )
++    raise_if_kernel_resolution_frozen(
++        "cute.compile", target=launch, cache_key=cache_key
++    )
++    slab_placeholder = make_ptr(
++        cutlass.Uint8,
++        256,
++        cute.AddressSpace.gmem,
++        assumed_align=256,
++    )
++    raw = b12x_compile(
++        launch,
++        *(slab_placeholder for _ in range(_MAX_WORLD_SIZE)),
++        make_ptr(cutlass.BFloat16, 16, cute.AddressSpace.gmem, assumed_align=2),
++        make_ptr(cutlass.BFloat16, 16, cute.AddressSpace.gmem, assumed_align=2),
++        1,
++        1,
++        1,
++        1,
++        1,
++        1,
++        current_cuda_stream(),
++        compile_spec=KernelCompileSpec.from_key(
++            "comm.pcie.island_rs.bf16",
++            1,
++            cache_key,
++            labels=(
++                "world_size",
++                "rank",
++                "threads",
++                "wait_nanosleep_cycles",
++            ),
++        ),
++    )
++
++    def run(
++        slab_addresses: Sequence[int],
++        input_address: int,
++        output_address: int,
++        stage_offset: int,
++        part_offset: int,
++        final_offset: int,
++        quarter_capacity: int,
++        elements: int,
++        blocks: int,
++        stream: object = None,
++    ) -> None:
++        if len(slab_addresses) != world_size:
++            raise ValueError(
++                f"expected {world_size} slab addresses, got {len(slab_addresses)}"
++            )
++        if not 1 <= int(blocks) <= MAX_BLOCKS:
++            raise ValueError(f"blocks must be in [1, {MAX_BLOCKS}], got {blocks}")
++        raw(
++            *(
++                make_ptr(
++                    cutlass.Uint8,
++                    int(address),
++                    cute.AddressSpace.gmem,
++                    assumed_align=256,
++                )
++                for address in slab_addresses
++            ),
++            make_ptr(
++                cutlass.BFloat16,
++                input_address,
++                cute.AddressSpace.gmem,
++                assumed_align=2,
++            ),
++            make_ptr(
++                cutlass.BFloat16,
++                output_address,
++                cute.AddressSpace.gmem,
++                assumed_align=2,
++            ),
++            stage_offset,
++            part_offset,
++            final_offset,
++            quarter_capacity,
++            elements,
++            blocks,
++            cuda_stream_from_int_or_current(cuda_stream_to_int(stream)),
++        )
++
++    return run
++
++
++__all__ = ["HEADER_BYTES", "MAX_BLOCKS", "get_island_rs_launcher", "island_rs_peers"]
+diff --git a/b12x/comm/pcie/_vocab_argmax_cute.py b/b12x/comm/pcie/_vocab_argmax_cute.py
+new file mode 100644
+index 0000000000000000000000000000000000000000..bb4ea979ea66c95f58d84b7b22a903f7554d9921
+--- /dev/null
++++ b/b12x/comm/pcie/_vocab_argmax_cute.py
+@@ -0,0 +1,645 @@
++"""CuTeDSL kernel for bounded-degree vocabulary-parallel greedy sampling."""
++
++from __future__ import annotations
++
++import functools
++from collections.abc import Callable, Sequence
++
++import cuda.bindings.driver as cuda
++import cutlass
++import cutlass.cute as cute
++from cutlass import Float32, Int32, Int64, Uint32, Uint64
++from cutlass._mlir.dialects import llvm
++from cutlass.cutlass_dsl import T, dsl_user_op
++
++from b12x._lib.compiler import KernelCompileSpec
++from b12x._lib.compiler import compile as b12x_compile
++from b12x._lib.runtime_control import raise_if_kernel_resolution_frozen
++from b12x._lib.utils import current_cuda_stream, make_ptr
++
++
++ISLAND_SIZE = 4
++MAX_ISLANDS = 4
++MAX_WORLD_SIZE = ISLAND_SIZE * MAX_ISLANDS
++MAX_BATCH_SIZE = 8
++THREADS = 512
++SLOTS = 2
++
++# Every protocol flag occupies an independent 128-byte system-scope cache line.
++_GENERATION_OFFSET = 0
++_LOCAL_READY_OFFSET = 256
++_LOCAL_READY_BYTES = SLOTS * MAX_BATCH_SIZE * ISLAND_SIZE * 128
++_ISLAND_READY_OFFSET = _LOCAL_READY_OFFSET + _LOCAL_READY_BYTES
++_ISLAND_READY_BYTES = SLOTS * MAX_BATCH_SIZE * MAX_ISLANDS * 128
++_LOCAL_KEY_OFFSET = _ISLAND_READY_OFFSET + _ISLAND_READY_BYTES
++_ISLAND_KEY_OFFSET = _LOCAL_KEY_OFFSET + SLOTS * MAX_BATCH_SIZE * 8
++SLAB_BYTES = _ISLAND_KEY_OFFSET + SLOTS * MAX_BATCH_SIZE * 8
++
++
++@dsl_user_op
++def _atomic_add_global_u32(
++    address: Int64, value: Uint32, *, loc=None, ip=None
++) -> Uint32:
++    return Uint32(
++        llvm.inline_asm(
++            T.i32(),
++            [
++                Int64(address).ir_value(loc=loc, ip=ip),
++                Uint32(value).ir_value(loc=loc, ip=ip),
++            ],
++            "atom.global.add.u32 $0, [$1], $2;",
++            "=r,l,r",
++            has_side_effects=True,
++            is_align_stack=False,
++            asm_dialect=llvm.AsmDialect.AD_ATT,
++            loc=loc,
++            ip=ip,
++        )
++    )
++
++
++@dsl_user_op
++def _load_acquire_sys_u32(address: Int64, *, loc=None, ip=None) -> Uint32:
++    return Uint32(
++        llvm.inline_asm(
++            T.i32(),
++            [Int64(address).ir_value(loc=loc, ip=ip)],
++            "ld.acquire.sys.global.u32 $0, [$1];",
++            "=r,l",
++            has_side_effects=True,
++            is_align_stack=False,
++            asm_dialect=llvm.AsmDialect.AD_ATT,
++            loc=loc,
++            ip=ip,
++        )
++    )
++
++
++@dsl_user_op
++def _store_release_sys_u32(
++    address: Int64, value: Uint32, *, loc=None, ip=None
++) -> None:
++    llvm.inline_asm(
++        None,
++        [
++            Int64(address).ir_value(loc=loc, ip=ip),
++            Uint32(value).ir_value(loc=loc, ip=ip),
++        ],
++        "st.release.sys.global.u32 [$0], $1;",
++        "l,r",
++        has_side_effects=True,
++        is_align_stack=False,
++        asm_dialect=llvm.AsmDialect.AD_ATT,
++        loc=loc,
++        ip=ip,
++    )
++
++
++@dsl_user_op
++def _fence_sc_sys(*, loc=None, ip=None) -> None:
++    llvm.inline_asm(
++        None,
++        [],
++        "fence.sc.sys;",
++        "",
++        has_side_effects=True,
++        is_align_stack=False,
++        asm_dialect=llvm.AsmDialect.AD_ATT,
++        loc=loc,
++        ip=ip,
++    )
++
++
++@dsl_user_op
++def _nanosleep(cycles: Uint32, *, loc=None, ip=None) -> None:
++    llvm.inline_asm(
++        None,
++        [Uint32(cycles).ir_value(loc=loc, ip=ip)],
++        "nanosleep.u32 $0;",
++        "r",
++        has_side_effects=True,
++        is_align_stack=False,
++        asm_dialect=llvm.AsmDialect.AD_ATT,
++        loc=loc,
++        ip=ip,
++    )
++
++
++@dsl_user_op
++def _score_order_key(value: Float32, *, loc=None, ip=None) -> Uint32:
++    """Map an FP32 score to the exact greedy-sampling comparison order.
++
++    NaNs dominate finite values, positive and negative zero compare equal, and
++    unsigned integer order matches numeric order for every remaining value.
++    """
++
++    return Uint32(
++        llvm.inline_asm(
++            T.i32(),
++            [Float32(value).ir_value(loc=loc, ip=ip)],
++            """
++            {
++                .reg .pred is_nan, is_zero;
++                .reg .u32 bits, mask;
++                mov.b32 bits, $1;
++                shr.u32 mask, bits, 31;
++                mul.lo.u32 mask, mask, 0x7fffffff;
++                or.b32 mask, mask, 0x80000000;
++                xor.b32 $0, bits, mask;
++                setp.eq.f32 is_zero, $1, 0f00000000;
++                @is_zero mov.u32 $0, 0x80000000;
++                setp.nan.f32 is_nan, $1, $1;
++                @is_nan mov.u32 $0, 0xffffffff;
++            }
++            """,
++            "=r,f",
++            has_side_effects=False,
++            is_align_stack=False,
++            asm_dialect=llvm.AsmDialect.AD_ATT,
++            loc=loc,
++            ip=ip,
++        )
++    )
++
++
++@dsl_user_op
++def _warp_max_u64(value: Uint64, *, loc=None, ip=None) -> Uint64:
++    """Return the warp-wide unsigned maximum of a packed 64-bit key."""
++
++    return Uint64(
++        llvm.inline_asm(
++            T.i64(),
++            [Uint64(value).ir_value(loc=loc, ip=ip)],
++            """
++            {
++                .reg .pred high_matches;
++                .reg .u32 low, high, max_high, candidate_low, max_low;
++                mov.b64 {low, high}, $1;
++                redux.sync.max.u32 max_high, high, 0xffffffff;
++                setp.eq.u32 high_matches, high, max_high;
++                selp.u32 candidate_low, low, 0, high_matches;
++                redux.sync.max.u32 max_low, candidate_low, 0xffffffff;
++                mov.b64 $0, {max_low, max_high};
++            }
++            """,
++            "=l,l",
++            has_side_effects=True,
++            is_align_stack=False,
++            asm_dialect=llvm.AsmDialect.AD_ATT,
++            loc=loc,
++            ip=ip,
++        )
++    )
++
++
++@cute.jit
++def _wait_for(address: Int64, generation: Uint32, cycles: int) -> None:
++    observed = _load_acquire_sys_u32(address)
++    while observed != generation:
++        if cutlass.const_expr(cycles > 0):
++            _nanosleep(Uint32(cycles))
++        observed = _load_acquire_sys_u32(address)
++
++
++@cute.jit
++def _flag_address(
++    base: Int64,
++    region: int,
++    slot: Int32,
++    row: Int32,
++    index: Int32,
++) -> Int64:
++    return (
++        base
++        + Int64(region)
++        + (
++            (
++                Int64(slot) * Int64(MAX_BATCH_SIZE)
++                + Int64(row)
++            )
++            * Int64(ISLAND_SIZE)
++            + Int64(index)
++        )
++        * Int64(128)
++    )
++
++
++@cute.jit
++def _key_address(base: Int64, region: int, slot: Int32, row: Int32) -> Int64:
++    return (
++        base
++        + Int64(region)
++        + (
++            Int64(slot) * Int64(MAX_BATCH_SIZE) + Int64(row)
++        )
++        * Int64(8)
++    )
++
++
++@cute.jit
++def _pack_key(score: Float32, global_index: Int32) -> Uint64:
++    return (
++        Uint64(_score_order_key(score)) << Uint64(32)
++    ) | (Uint64(0xFFFFFFFF) - Uint64(global_index))
++
++
++@cute.jit
++def _key_index(key: Uint64) -> Int64:
++    return Int64(Uint64(0xFFFFFFFF) - (key & Uint64(0xFFFFFFFF)))
++
++
++class _VocabArgmaxLaunch:
++    def __init__(
++        self,
++        world_size: int,
++        rank: int,
++        *,
++        wait_nanosleep_cycles: int,
++    ) -> None:
++        self._world_size = int(world_size)
++        self._num_islands = self._world_size // ISLAND_SIZE
++        self._rank = int(rank)
++        self._island = self._rank // ISLAND_SIZE
++        self._local_rank = self._rank % ISLAND_SIZE
++        self._wait_nanosleep_cycles = int(wait_nanosleep_cycles)
++        if self._world_size not in (8, 12, 16):
++            raise ValueError(f"unsupported world size {self._world_size}")
++        if not 0 <= self._rank < self._world_size:
++            raise ValueError(
++                f"invalid rank {self._rank} for world size {self._world_size}"
++            )
++        if not 0 <= self._wait_nanosleep_cycles <= 1024:
++            raise ValueError("wait_nanosleep_cycles must be in [0, 1024]")
++
++    @cute.jit
++    def __call__(
++        self,
++        slab0: cute.Pointer,
++        slab1: cute.Pointer,
++        slab2: cute.Pointer,
++        slab3: cute.Pointer,
++        slab4: cute.Pointer,
++        slab5: cute.Pointer,
++        slab6: cute.Pointer,
++        slab7: cute.Pointer,
++        slab8: cute.Pointer,
++        slab9: cute.Pointer,
++        slab10: cute.Pointer,
++        slab11: cute.Pointer,
++        slab12: cute.Pointer,
++        slab13: cute.Pointer,
++        slab14: cute.Pointer,
++        slab15: cute.Pointer,
++        base: cute.Pointer,
++        bias: cute.Pointer,
++        output: cute.Pointer,
++        local_elements: Int64,
++        base_row_stride: Int64,
++        bias_row_stride: Int64,
++        batch: Int32,
++        stream: cuda.CUstream,
++    ) -> None:
++        self.kernel(
++            slab0,
++            slab1,
++            slab2,
++            slab3,
++            slab4,
++            slab5,
++            slab6,
++            slab7,
++            slab8,
++            slab9,
++            slab10,
++            slab11,
++            slab12,
++            slab13,
++            slab14,
++            slab15,
++            base,
++            bias,
++            output,
++            local_elements,
++            base_row_stride,
++            bias_row_stride,
++        ).launch(
++            grid=(batch, 1, 1),
++            block=(THREADS, 1, 1),
++            cluster=(1, 1, 1),
++            stream=stream,
++        )
++
++    @cute.kernel
++    def kernel(
++        self,
++        slab0: cute.Pointer,
++        slab1: cute.Pointer,
++        slab2: cute.Pointer,
++        slab3: cute.Pointer,
++        slab4: cute.Pointer,
++        slab5: cute.Pointer,
++        slab6: cute.Pointer,
++        slab7: cute.Pointer,
++        slab8: cute.Pointer,
++        slab9: cute.Pointer,
++        slab10: cute.Pointer,
++        slab11: cute.Pointer,
++        slab12: cute.Pointer,
++        slab13: cute.Pointer,
++        slab14: cute.Pointer,
++        slab15: cute.Pointer,
++        base: cute.Pointer,
++        bias: cute.Pointer,
++        output: cute.Pointer,
++        local_elements: Int64,
++        base_row_stride: Int64,
++        bias_row_stride: Int64,
++    ) -> None:
++        slabs = (
++            slab0,
++            slab1,
++            slab2,
++            slab3,
++            slab4,
++            slab5,
++            slab6,
++            slab7,
++            slab8,
++            slab9,
++            slab10,
++            slab11,
++            slab12,
++            slab13,
++            slab14,
++            slab15,
++        )
++        tidx, _, _ = cute.arch.thread_idx()
++        row, _, _ = cute.arch.block_idx()
++        lane = Int32(tidx) % Int32(32)
++        warp = Int32(tidx) // Int32(32)
++
++        initial = Uint64(_score_order_key(Float32(float("-inf")))) << Uint64(32)
++        best = initial
++        index = Int64(tidx)
++        base_offset = Int64(row) * base_row_stride
++        bias_offset = Int64(row) * bias_row_stride
++        while index < local_elements:
++            value = Float32(
++                cutlass.BFloat16(
++                    Float32(base[base_offset + index])
++                    + Float32(bias[bias_offset + index])
++                )
++            )
++            global_index = (
++                Int64(self._rank) * local_elements + index
++            )
++            candidate = _pack_key(value, Int32(global_index))
++            best = cutlass.max(best, candidate)
++            index += Int64(THREADS)
++        best = _warp_max_u64(best)
++
++        allocator = cutlass.utils.SmemAllocator()
++        warp_keys = allocator.allocate_tensor(
++            element_type=Uint64,
++            layout=cute.make_layout((THREADS // 32,)),
++            byte_alignment=16,
++        )
++        shared_generation = allocator.allocate_tensor(
++            element_type=Uint32,
++            layout=cute.make_layout((1,)),
++            byte_alignment=4,
++        )
++        if lane == Int32(0):
++            warp_keys[warp] = best
++        cute.arch.barrier()
++
++        block_key = initial
++        if warp == Int32(0):
++            if lane < Int32(THREADS // 32):
++                block_key = warp_keys[lane]
++            block_key = _warp_max_u64(block_key)
++        self_base = Int64(slabs[self._rank].toint())
++        if tidx == Int32(0):
++            generation = _atomic_add_global_u32(
++                self_base + Int64(row) * Int64(4), Uint32(1)
++            ) + Uint32(1)
++            shared_generation[0] = generation
++        cute.arch.barrier()
++
++        if tidx == Int32(0):
++            generation = Uint32(shared_generation[0])
++            slot = Int32(generation & Uint32(1))
++            local_key_ptr = cute.make_ptr(
++                Uint64,
++                _key_address(self_base, _LOCAL_KEY_OFFSET, slot, Int32(row)),
++                cute.AddressSpace.gmem,
++                assumed_align=8,
++            )
++            local_key_ptr[0] = block_key
++            _fence_sc_sys()
++
++            island_base_rank = self._island * ISLAND_SIZE
++            for peer_local in cutlass.range_constexpr(ISLAND_SIZE):
++                if cutlass.const_expr(peer_local != self._local_rank):
++                    peer_rank = island_base_rank + peer_local
++                    _store_release_sys_u32(
++                        _flag_address(
++                            Int64(slabs[peer_rank].toint()),
++                            _LOCAL_READY_OFFSET,
++                            slot,
++                            Int32(row),
++                            Int32(self._local_rank),
++                        ),
++                        generation,
++                    )
++            for peer_local in cutlass.range_constexpr(ISLAND_SIZE):
++                if cutlass.const_expr(peer_local != self._local_rank):
++                    _wait_for(
++                        _flag_address(
++                            self_base,
++                            _LOCAL_READY_OFFSET,
++                            slot,
++                            Int32(row),
++                            Int32(peer_local),
++                        ),
++                        generation,
++                        self._wait_nanosleep_cycles,
++                    )
++
++            island_key = initial
++            for peer_local in cutlass.range_constexpr(ISLAND_SIZE):
++                peer_rank = island_base_rank + peer_local
++                peer_key_ptr = cute.make_ptr(
++                    Uint64,
++                    _key_address(
++                        Int64(slabs[peer_rank].toint()),
++                        _LOCAL_KEY_OFFSET,
++                        slot,
++                        Int32(row),
++                    ),
++                    cute.AddressSpace.gmem,
++                    assumed_align=8,
++                )
++                island_key = cutlass.max(island_key, peer_key_ptr[0])
++            island_key_ptr = cute.make_ptr(
++                Uint64,
++                _key_address(self_base, _ISLAND_KEY_OFFSET, slot, Int32(row)),
++                cute.AddressSpace.gmem,
++                assumed_align=8,
++            )
++            island_key_ptr[0] = island_key
++            _fence_sc_sys()
++
++            for peer_island in cutlass.range_constexpr(MAX_ISLANDS):
++                if cutlass.const_expr(peer_island < self._num_islands):
++                    if cutlass.const_expr(peer_island != self._island):
++                        peer_rank = peer_island * ISLAND_SIZE + self._local_rank
++                        _store_release_sys_u32(
++                            _flag_address(
++                                Int64(slabs[peer_rank].toint()),
++                                _ISLAND_READY_OFFSET,
++                                slot,
++                                Int32(row),
++                                Int32(self._island),
++                            ),
++                            generation,
++                        )
++            for peer_island in cutlass.range_constexpr(MAX_ISLANDS):
++                if cutlass.const_expr(peer_island < self._num_islands):
++                    if cutlass.const_expr(peer_island != self._island):
++                        _wait_for(
++                            _flag_address(
++                                self_base,
++                                _ISLAND_READY_OFFSET,
++                                slot,
++                                Int32(row),
++                                Int32(peer_island),
++                            ),
++                            generation,
++                            self._wait_nanosleep_cycles,
++                        )
++
++            global_key = initial
++            for peer_island in cutlass.range_constexpr(MAX_ISLANDS):
++                if cutlass.const_expr(peer_island < self._num_islands):
++                    peer_rank = peer_island * ISLAND_SIZE + self._local_rank
++                    peer_key_ptr = cute.make_ptr(
++                        Uint64,
++                        _key_address(
++                            Int64(slabs[peer_rank].toint()),
++                            _ISLAND_KEY_OFFSET,
++                            slot,
++                            Int32(row),
++                        ),
++                        cute.AddressSpace.gmem,
++                        assumed_align=8,
++                    )
++                    global_key = cutlass.max(global_key, peer_key_ptr[0])
++            output[Int64(row)] = _key_index(global_key)
++
++
++@functools.cache
++def get_vocab_argmax_launcher(
++    world_size: int,
++    rank: int,
++    device_index: int,
++    *,
++    wait_nanosleep_cycles: int,
++) -> Callable[..., None]:
++    """Return a rank-specialized launcher for TP8, TP12, or TP16."""
++
++    del device_index  # retained in the process-local cache key
++    launch = _VocabArgmaxLaunch(
++        world_size,
++        rank,
++        wait_nanosleep_cycles=wait_nanosleep_cycles,
++    )
++    cache_key = (
++        int(world_size),
++        int(rank),
++        int(wait_nanosleep_cycles),
++    )
++    raise_if_kernel_resolution_frozen(
++        "cute.compile", target=launch, cache_key=cache_key
++    )
++    slab_placeholder = make_ptr(
++        cutlass.Uint8,
++        256,
++        cute.AddressSpace.gmem,
++        assumed_align=256,
++    )
++    raw = b12x_compile(
++        launch,
++        *(slab_placeholder for _ in range(MAX_WORLD_SIZE)),
++        make_ptr(cutlass.BFloat16, 16, cute.AddressSpace.gmem, assumed_align=2),
++        make_ptr(cutlass.BFloat16, 16, cute.AddressSpace.gmem, assumed_align=2),
++        make_ptr(cutlass.Int64, 16, cute.AddressSpace.gmem, assumed_align=8),
++        1,
++        1,
++        1,
++        1,
++        current_cuda_stream(),
++        compile_spec=KernelCompileSpec.from_key(
++            "comm.pcie.vocab_argmax.bf16",
++            1,
++            cache_key,
++            labels=("world_size", "rank", "wait_nanosleep_cycles"),
++        ),
++    )
++
++    def run(
++        slab_addresses: Sequence[int],
++        base_address: int,
++        bias_address: int,
++        output_address: int,
++        local_elements: int,
++        base_row_stride: int,
++        bias_row_stride: int,
++        batch: int,
++    ) -> None:
++        if len(slab_addresses) != world_size:
++            raise ValueError(
++                f"expected {world_size} slab addresses, got {len(slab_addresses)}"
++            )
++        padded_slabs = tuple(int(address) for address in slab_addresses) + (
++            0,
++        ) * (MAX_WORLD_SIZE - world_size)
++        raw(
++            *(
++                make_ptr(
++                    cutlass.Uint8,
++                    address,
++                    cute.AddressSpace.gmem,
++                    assumed_align=256,
++                )
++                for address in padded_slabs
++            ),
++            make_ptr(
++                cutlass.BFloat16,
++                base_address,
++                cute.AddressSpace.gmem,
++                assumed_align=2,
++            ),
++            make_ptr(
++                cutlass.BFloat16,
++                bias_address,
++                cute.AddressSpace.gmem,
++                assumed_align=2,
++            ),
++            make_ptr(
++                cutlass.Int64,
++                output_address,
++                cute.AddressSpace.gmem,
++                assumed_align=8,
++            ),
++            local_elements,
++            base_row_stride,
++            bias_row_stride,
++            batch,
++            current_cuda_stream(),
++        )
++
++    return run
++
++
++__all__ = ["SLAB_BYTES", "get_vocab_argmax_launcher"]
+diff --git a/b12x/comm/pcie/api.py b/b12x/comm/pcie/api.py
+index 098d100320990f7b8bb4bf4ecd228688ccbc2f79..2873e175902b394d8944a72c081699a9082d35ce 100644
+--- a/b12x/comm/pcie/api.py
++++ b/b12x/comm/pcie/api.py
+@@ -13,7 +13,9 @@ from .pcie_dcp_a2a import (
+     PCIeDCPA2APool as DcpAllToAllPool,
+ )
+ from .pcie_dcp_a2a import (
++    kimi_topk16,
+     lse_reduce_scatter_reference,
++    prepare_kimi_topk16,
+ )
+ from .pcie_dcp_topk import (
+     PCIeDCPTopKOwnerExchange as DcpTopKOwnerExchange,
+@@ -37,6 +39,9 @@ from .pcie_oneshot import (
+ from .pcie_twoshot import (
+     PCIeTwoShotSP as TwoShotReduceScatter,
+ )
++from .pcie_vocab_argmax import (
++    PCIeVocabParallelArgmax as VocabParallelArgmax,
++)
+ 
+ 
+ def is_supported(device=None) -> bool:
+@@ -59,6 +64,9 @@ __all__ = [
+     "DcpAllToAll",
+     "DcpAllToAllPool",
+     "DcpTopKOwnerExchange",
++    "VocabParallelArgmax",
++    "kimi_topk16",
++    "prepare_kimi_topk16",
+     "autotune_dma_crossovers",
+     "parse_oneshot_max_size",
+     "lse_reduce_scatter_reference",
+diff --git a/b12x/comm/pcie/pcie_allreduce.py b/b12x/comm/pcie/pcie_allreduce.py
+index f97b314af912aae858ee69251bd692ecfeca4127..973d47077ae5f6196ddaed7cd6f68b1b04a812f9 100644
+--- a/b12x/comm/pcie/pcie_allreduce.py
++++ b/b12x/comm/pcie/pcie_allreduce.py
+@@ -2,7 +2,10 @@
+ 
+ from __future__ import annotations
+ 
+-from contextlib import contextmanager
++import logging
++import os
++
++from contextlib import ExitStack, contextmanager
+ from typing import Any, Optional, Sequence
+ 
+ import torch
+@@ -15,6 +18,18 @@ from .pcie_hierarchical import (
+ from .pcie_hierarchical import (
+     PCIeHierarchicalAllReduce,
+ )
++from .pcie_island_rs import (
++    CROSSOVER_ELEMENTS as ISLAND_RS_CROSSOVER_ELEMENTS,
++)
++from .pcie_island_rs import (
++    PREFERRED_ALIGNMENT_ELEMENTS as ISLAND_RS_PREFERRED_ALIGNMENT_ELEMENTS,
++)
++from .pcie_island_rs import (
++    SUPPORTED_WORLD_SIZES as ISLAND_RS_WORLD_SIZES,
++)
++from .pcie_island_rs import (
++    PCIeIslandRSAllReduce,
++)
+ from .pcie_oneshot import (
+     DEFAULT_MAX_SIZE,
+     DEFAULT_RANK_DATA_BYTES,
+@@ -23,6 +38,41 @@ from .pcie_oneshot import (
+ )
+ 
+ 
++logger = logging.getLogger(__name__)
++
++
++# Maximum message capacity qualified for the TP16 island runtime. Callers use
++# this shared policy instead of duplicating an implementation-specific limit.
++ISLAND_RS_MAX_BYTES = 160 * 1024
++
++
++def _algorithm_override() -> str:
++    """Select the established runtime or enable size-routed island dispatch."""
++
++    choice = os.getenv("B12X_PCIE_ALLREDUCE_ALGORITHM", "auto").strip().lower()
++    if choice not in ("auto", "hierarchical", "island_rs"):
++        raise ValueError(
++            "B12X_PCIE_ALLREDUCE_ALGORITHM must be auto, hierarchical or "
++            f"island_rs, got {choice!r}"
++        )
++    return choice
++
++
++def recommended_max_bytes(world_size: int, *, default: int = DEFAULT_MAX_SIZE) -> int:
++    """Largest all-reduce this runtime expects to win at, for this world size.
++
++    Callers that force the equal-quarter implementation advertise its complete
++    qualified capacity. Automatic consumers retain their existing limit
++    because a CUDA-graph caller without explicit output storage cannot use the
++    equal-quarter implementation for large messages and may otherwise replace
++    a faster fallback collective with hierarchical all-reduce.
++    """
++
++    if world_size in ISLAND_RS_WORLD_SIZES and _algorithm_override() == "island_rs":
++        return max(default, ISLAND_RS_MAX_BYTES)
++    return default
++
++
+ MAX_DIRECT_WORLD_SIZE = 8
+ DIRECT_WORLD_SIZES = tuple(
+     world_size
+@@ -52,8 +102,29 @@ class PCIeAllReduce:
+     connection limit.
+     """
+ 
+-    def __init__(self, runtime: Any, algorithm: str) -> None:
++    def __init__(
++        self,
++        runtime: Any,
++        algorithm: str,
++        island_rs: Any = None,
++        *,
++        algorithm_override: Optional[str] = None,
++    ) -> None:
+         self._runtime = runtime
++        # Optional second implementation for the same world. When present the
++        # dispatcher routes by message size instead of exposing a knob.
++        self._island_rs = island_rs
++        resolved_override = (
++            _algorithm_override()
++            if algorithm_override is None
++            else str(algorithm_override)
++        )
++        if resolved_override not in ("auto", "hierarchical", "island_rs"):
++            raise ValueError(
++                "algorithm_override must be auto, hierarchical or island_rs, "
++                f"got {resolved_override!r}"
++            )
++        self._algorithm_override = resolved_override
+         self.algorithm = algorithm
+         self.rank = runtime.rank
+         self.world_size = runtime.world_size
+@@ -70,9 +141,11 @@ class PCIeAllReduce:
+         rank_data_bytes: int = DEFAULT_RANK_DATA_BYTES,
+         ext_module=None,
+         single_channel: bool = False,
++        max_concurrent_channels: int = 1,
+     ) -> "PCIeAllReduce":
+         world_size = dist.get_world_size(group=exchange_group)
+         algorithm = _algorithm_for_world_size(world_size)
++        algorithm_override = _algorithm_override()
+         if algorithm == "oneshot":
+             runtime = PCIeOneshotAllReducePool.from_exchange_group(
+                 exchange_group=exchange_group,
+@@ -82,8 +155,13 @@ class PCIeAllReduce:
+                 rank_data_bytes=rank_data_bytes,
+                 ext_module=ext_module,
+                 single_channel=single_channel,
++                max_concurrent_channels=max_concurrent_channels,
+             )
+         else:
++            if int(max_concurrent_channels) != 1:
++                raise ValueError(
++                    "hierarchical all-reduce supports exactly one concurrent channel"
++                )
+             if max_size < torch.bfloat16.itemsize:
+                 raise ValueError("max_size must hold at least one BF16 element")
+             runtime = PCIeHierarchicalAllReduce(
+@@ -92,7 +170,60 @@ class PCIeAllReduce:
+                 max_elements=max_size // torch.bfloat16.itemsize,
+                 ext_module=ext_module,
+             )
+-        return cls(runtime, algorithm)
++        island_rs = cls._maybe_island_rs(
++            exchange_group=exchange_group,
++            device=device,
++            max_size=max_size,
++            algorithm_override=algorithm_override,
++        )
++        return cls(
++            runtime,
++            algorithm,
++            island_rs,
++            algorithm_override=algorithm_override,
++        )
++
++    @staticmethod
++    def _maybe_island_rs(
++        *,
++        exchange_group: ProcessGroup,
++        device: torch.device | int | str,
++        max_size: int,
++        algorithm_override: str,
++    ) -> Any:
++        """Attach the equal-quarter runtime after an explicit policy opt-in.
++
++        Opt-in capacity includes :data:`ISLAND_RS_MAX_BYTES` independently of
++        the caller's ``max_size``. A coordinated construction failure leaves
++        every rank on the hierarchical runtime and records the reason in the
++        process log.
++        """
++
++        world_size = dist.get_world_size(group=exchange_group)
++        if world_size not in ISLAND_RS_WORLD_SIZES:
++            return None
++        # The equal-quarter runtime owns an additional CUDA IPC slab and has a
++        # stricter CUDA-graph output contract than the hierarchical runtime.
++        # Construct it only for an explicit opt-in so unrelated auxiliary IPC
++        # collectives retain the established peer-mapping and setup behavior.
++        if algorithm_override != "island_rs":
++            return None
++        capacity = max(int(max_size), ISLAND_RS_MAX_BYTES)
++        elements = capacity // torch.bfloat16.itemsize
++        try:
++            return PCIeIslandRSAllReduce(
++                exchange_group=exchange_group,
++                device=device,
++                max_elements=elements - (elements % 2),
++            )
++        except RuntimeError as exc:
++            if dist.get_rank(group=exchange_group) == 0:
++                logger.warning(
++                    "PCIe island reduce-scatter is unavailable; using the "
++                    "hierarchical all-reduce runtime: %s",
++                    exc,
++                )
++            return None
+ 
+     @classmethod
+     def from_process_group(
+@@ -106,6 +237,7 @@ class PCIeAllReduce:
+         rank_data_bytes: int = DEFAULT_RANK_DATA_BYTES,
+         ext_module=None,
+         single_channel: bool = False,
++        max_concurrent_channels: int = 1,
+     ) -> "PCIeAllReduce":
+         return cls.from_exchange_group(
+             exchange_group=process_group,
+@@ -117,6 +249,7 @@ class PCIeAllReduce:
+             rank_data_bytes=rank_data_bytes,
+             ext_module=ext_module,
+             single_channel=single_channel,
++            max_concurrent_channels=max_concurrent_channels,
+         )
+ 
+     @property
+@@ -125,8 +258,55 @@ class PCIeAllReduce:
+ 
+         return self.algorithm == "oneshot"
+ 
+-    def for_stream(self, stream: object = None):
+-        return self._runtime.for_stream(stream)
++    def prepare_channels(self, channel_ids: Sequence[str]) -> None:
++        """Prepare the runtime's semantic channel owners."""
++        self._runtime.prepare_channels(channel_ids)
++        if self._island_rs is not None:
++            self._island_rs.prepare_channels(channel_ids)
++
++    def for_stream(
++        self,
++        stream: object = None,
++        *,
++        channel_id: Optional[str] = None,
++    ):
++        if self._island_rs is not None:
++            self._island_rs.for_stream(stream, channel_id=channel_id)
++        return self._runtime.for_stream(stream, channel_id=channel_id)
++
++    def _use_island_rs(
++        self,
++        inp: torch.Tensor,
++    ) -> bool:
++        """Route aligned large messages to the equal-quarter runtime.
++
++        Small ones stay on the hierarchy, whose critical path is shorter for the
++        ranks that are not the island leader. Unaligned quarters also stay on
++        the hierarchy because the equal-quarter kernel's partial transfer group
++        costs more than the leader path. Large aligned vectors would otherwise
++        funnel the whole vector through the island leader's PCIe link.
++        """
++
++        if self._island_rs is None:
++            return False
++        override = self._algorithm_override
++        if override == "hierarchical":
++            return False
++        island_accepts = self._island_rs.should_allreduce(inp)
++        if not island_accepts:
++            return False
++        hierarchy_accepts = self._runtime.should_allreduce(inp)
++        if not hierarchy_accepts:
++            return True
++        return (
++            inp.numel() > ISLAND_RS_CROSSOVER_ELEMENTS
++            and inp.numel() % ISLAND_RS_PREFERRED_ALIGNMENT_ELEMENTS == 0
++        )
++
++    def should_allreduce(self, inp: torch.Tensor) -> bool:
++        if self._runtime.should_allreduce(inp):
++            return True
++        return self._use_island_rs(inp)
+ 
+     def all_reduce(
+         self,
+@@ -136,17 +316,27 @@ class PCIeAllReduce:
+         peer_input_ptrs: Optional[Sequence[int]] = None,
+         blocks: Optional[int] = None,
+         stream: object = None,
++        channel_id: Optional[str] = None,
+     ) -> torch.Tensor:
+         if self.algorithm == "hierarchical":
+             if peer_input_ptrs is not None:
+                 raise ValueError(
+                     "peer_input_ptrs are unavailable for hierarchical all-reduce"
+                 )
++            if self._use_island_rs(inp):
++                return self._island_rs.all_reduce(
++                    inp,
++                    out=out,
++                    blocks=blocks,
++                    stream=stream,
++                    channel_id=channel_id,
++                )
+             return self._runtime.all_reduce(
+                 inp,
+                 out=out,
+                 blocks=blocks,
+                 stream=stream,
++                channel_id=channel_id,
+             )
+         if blocks is not None:
+             raise ValueError("blocks is only available for hierarchical all-reduce")
+@@ -155,14 +345,32 @@ class PCIeAllReduce:
+             out=out,
+             peer_input_ptrs=peer_input_ptrs,
+             stream=stream,
++            channel_id=channel_id,
+         )
+ 
+     @contextmanager
+-    def capture(self, stream: object = None):
+-        with self._runtime.capture(stream=stream) as runtime:
+-            yield runtime
++    def capture(
++        self,
++        stream: object = None,
++        *,
++        channel_id: Optional[str] = None,
++    ):
++        with ExitStack() as stack:
++            stack.enter_context(
++                self._runtime.capture(stream=stream, channel_id=channel_id)
++            )
++            if self._island_rs is not None:
++                stack.enter_context(
++                    self._island_rs.capture(stream=stream, channel_id=channel_id)
++                )
++            # Callers must retain message-size dispatch while recording a
++            # graph; yielding the hierarchy would bypass the island runtime.
++            yield self
+ 
+     def close(self) -> None:
++        if self._island_rs is not None:
++            self._island_rs.close()
++            self._island_rs = None
+         self._runtime.close()
+ 
+     def __getattr__(self, name: str):
+diff --git a/b12x/comm/pcie/pcie_dcp_a2a.py b/b12x/comm/pcie/pcie_dcp_a2a.py
+index 7806c18cbd310ed32a52093e928e6d778b709a9b..7d77b9e94834fb14cd252acaf978d90b17969608 100644
+--- a/b12x/comm/pcie/pcie_dcp_a2a.py
++++ b/b12x/comm/pcie/pcie_dcp_a2a.py
+@@ -75,6 +75,107 @@ def _is_supported_bhd_layout(tensor: torch.Tensor) -> bool:
+     return packed_token_major or capacity_strided_head_major
+ 
+ 
++def prepare_kimi_topk16(
++    *,
++    device: torch.device | int | str,
++    threads: int = 256,
++) -> None:
++    """Compile the stateless Kimi-K3 top-16 launcher before graph capture."""
++
++    device_obj = _normalize_device(device)
++    if device_obj.type != "cuda":
++        raise ValueError("Kimi top-16 requires a CUDA device")
++    if _is_current_stream_capturing(device_obj):
++        raise RuntimeError("prepare_kimi_topk16() must run before capture")
++    from ._dcp_a2a_cute import _get_compiled_kimi_topk16
++
++    with torch.cuda.device(device_obj):
++        _get_compiled_kimi_topk16(threads)
++
++
++def kimi_topk16(
++    router_logits: torch.Tensor,
++    correction_bias: torch.Tensor,
++    output_weights: Optional[torch.Tensor] = None,
++    output_ids: Optional[torch.Tensor] = None,
++    *,
++    threads: int = 256,
++) -> tuple[torch.Tensor, torch.Tensor]:
++    """Select Kimi-K3's 16 routed experts without communication state.
++
++    The operation accepts one to eight assembled FP32 router rows. It launches
++    on the current CUDA stream and is CUDA-graph safe after an eager launch or
++    :func:`prepare_kimi_topk16`. Graph capture requires caller-owned outputs.
++    """
++
++    if router_logits.ndim != 2:
++        raise ValueError("router_logits must be a contiguous rank-2 tensor")
++    rows = int(router_logits.shape[0])
++    if rows < 1 or rows > 8:
++        raise ValueError(f"Kimi top-16 rows {rows} must be between 1 and 8")
++    device = router_logits.device
++    if device.type != "cuda":
++        raise ValueError("Kimi top-16 requires CUDA tensors")
++    expected = (
++        (router_logits, (rows, 896), torch.float32, "router_logits"),
++        (correction_bias, (896,), torch.float32, "correction_bias"),
++    )
++    for value, shape, dtype, name in expected:
++        if (
++            value.device != device
++            or value.shape != shape
++            or value.dtype != dtype
++            or not value.is_contiguous()
++        ):
++            raise ValueError(f"{name} must be contiguous {shape} {dtype} on {device}")
++
++    capturing = _is_current_stream_capturing(device)
++    if capturing and (output_weights is None or output_ids is None):
++        raise RuntimeError(
++            "Kimi top-16 CUDA graph capture requires caller-owned "
++            "output_weights and output_ids"
++        )
++    if output_weights is None:
++        output_weights = torch.empty((rows, 16), device=device, dtype=torch.float32)
++    if output_ids is None:
++        output_ids = torch.empty((rows, 16), device=device, dtype=torch.int32)
++    outputs = (
++        (output_weights, torch.float32, "output_weights"),
++        (output_ids, torch.int32, "output_ids"),
++    )
++    for value, dtype, name in outputs:
++        if (
++            value.device != device
++            or value.shape != (rows, 16)
++            or value.dtype != dtype
++            or not value.is_contiguous()
++        ):
++            raise ValueError(
++                f"{name} must be contiguous {(rows, 16)} {dtype} on {device}"
++            )
++    if capturing:
++        from ._dcp_a2a_cute import is_kimi_topk16_prepared
++
++        if not is_kimi_topk16_prepared(threads):
++            raise RuntimeError(
++                "cold Kimi top-16 CUDA graph capture is not allowed; call "
++                "prepare_kimi_topk16() before capture"
++            )
++
++    from ._dcp_a2a_cute import kimi_topk16 as launch_kimi_topk16
++
++    with torch.cuda.device(device):
++        launch_kimi_topk16(
++            router_logits_ptr=router_logits.data_ptr(),
++            correction_bias_ptr=correction_bias.data_ptr(),
++            output_weights_ptr=output_weights.data_ptr(),
++            output_ids_ptr=output_ids.data_ptr(),
++            rows=rows,
++            threads=threads,
++        )
++    return output_weights, output_ids
++
++
+ @dataclass(frozen=True)
+ class _StagingLayout:
+     signal_bytes: int
+@@ -753,10 +854,13 @@ class PCIeDCPA2A:
+             )
+ 
+     def prepare_graph_all_gather_pair_kimi_topk(self) -> None:
+-        """Compile/load the TP16 Kimi fused launcher before graph capture."""
++        """Compile/load the Kimi fused launcher before graph capture."""
+ 
+-        if self.world_size != 16:
+-            raise ValueError("Kimi paired gather+top-k requires TP16")
++        if self.world_size not in SUPPORTED_WORLD_SIZES:
++            raise ValueError(
++                "Kimi paired gather+top-k requires a supported PCIe DCP "
++                f"world size, got {self.world_size}"
++            )
+         if _is_current_stream_capturing(self.device):
+             raise RuntimeError(
+                 "prepare_graph_all_gather_pair_kimi_topk() must run before capture"
+@@ -764,7 +868,25 @@ class PCIeDCPA2A:
+         from ._dcp_a2a_cute import _get_compiled_all_gather_pair
+ 
+         with torch.cuda.device(self.device):
+-            _get_compiled_all_gather_pair(16, self.rank, 512, True, True)
++            _get_compiled_all_gather_pair(
++                self.world_size,
++                self.rank,
++                512,
++                True,
++                True,
++            )
++
++    def prepare_graph_kimi_topk16(self, *, threads: int = 256) -> None:
++        """Compile/load batched Kimi expert selection before graph capture."""
++
++        if _is_current_stream_capturing(self.device):
++            raise RuntimeError(
++                "prepare_graph_kimi_topk16() must run before capture"
++            )
++        from ._dcp_a2a_cute import _get_compiled_kimi_topk16
++
++        with torch.cuda.device(self.device):
++            _get_compiled_kimi_topk16(threads)
+ 
+     def _validate(
+         self,
+@@ -1270,15 +1392,30 @@ class PCIeDCPA2A:
+         topk_weights: Optional[torch.Tensor] = None,
+         topk_ids: Optional[torch.Tensor] = None,
+     ) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor]:
+-        """Gather Kimi-K3's TP16 latent row and select its 16 experts."""
++        """Gather Kimi-K3's sharded latent row and select its 16 experts."""
+         self._check_stream()
+         if self._closed:
+             raise RuntimeError("PCIeDCPA2A is closed")
+-        if self.world_size != 16:
+-            raise ValueError("Kimi paired gather+top-k requires TP16")
++        if self.world_size not in SUPPORTED_WORLD_SIZES:
++            raise ValueError(
++                "Kimi paired gather+top-k requires a supported PCIe DCP "
++                f"world size, got TP{self.world_size}"
++            )
++        local_down_width = 3584 // self.world_size
++        local_router_width = 896 // self.world_size
+         expected = (
+-            (local_down, (1, 224), torch.bfloat16, "local_down"),
+-            (local_router, (1, 56), torch.float32, "local_router"),
++            (
++                local_down,
++                (1, local_down_width),
++                torch.bfloat16,
++                "local_down",
++            ),
++            (
++                local_router,
++                (1, local_router_width),
++                torch.float32,
++                "local_router",
++            ),
+             (correction_bias, (896,), torch.float32, "correction_bias"),
+         )
+         for value, shape, dtype, name in expected:
+@@ -1317,7 +1454,7 @@ class PCIeDCPA2A:
+             from ._dcp_a2a_cute import is_all_gather_pair_prepared
+ 
+             if not is_all_gather_pair_prepared(
+-                16,
++                self.world_size,
+                 self.rank,
+                 512,
+                 True,
+@@ -1363,6 +1500,7 @@ class PCIeDCPA2A:
+ 
+         with torch.cuda.device(self.device):
+             all_gather_pair_kimi_topk(
++                world_size=self.world_size,
+                 rank=self.rank,
+                 local_down_ptr=local_down.data_ptr(),
+                 local_router_ptr=local_router.data_ptr(),
+@@ -1378,6 +1516,125 @@ class PCIeDCPA2A:
+                 ),
+             )
+ 
++    def kimi_topk16(
++        self,
++        router_logits: torch.Tensor,
++        correction_bias: torch.Tensor,
++        output_weights: Optional[torch.Tensor] = None,
++        output_ids: Optional[torch.Tensor] = None,
++        *,
++        threads: int = 256,
++    ) -> tuple[torch.Tensor, torch.Tensor]:
++        """Select Kimi-K3's 16 routed experts for one to eight tokens."""
++
++        with _device_guard(self.device):
++            self._check_stream()
++            if self._closed:
++                raise RuntimeError("PCIeDCPA2A is closed")
++            if router_logits.ndim != 2:
++                raise ValueError(
++                    "router_logits must be a contiguous rank-2 tensor"
++                )
++            rows = int(router_logits.shape[0])
++            capacity = min(self.max_batch_size, 8)
++            if rows <= 0 or rows > capacity:
++                raise ValueError(
++                    f"Kimi top-16 rows {rows} must be between 1 and the "
++                    f"supported capacity {capacity}"
++                )
++            expected = (
++                (
++                    router_logits,
++                    (rows, 896),
++                    torch.float32,
++                    "router_logits",
++                ),
++                (
++                    correction_bias,
++                    (896,),
++                    torch.float32,
++                    "correction_bias",
++                ),
++            )
++            for value, shape, dtype, name in expected:
++                if (
++                    value.device != self.device
++                    or value.shape != shape
++                    or value.dtype != dtype
++                    or not value.is_contiguous()
++                ):
++                    raise ValueError(
++                        f"{name} must be contiguous {shape} {dtype} on "
++                        f"{self.device}"
++                    )
++            capturing = _is_current_stream_capturing(self.device)
++            if capturing and (output_weights is None or output_ids is None):
++                raise RuntimeError(
++                    "Kimi top-16 CUDA graph capture requires caller-owned "
++                    "output_weights and output_ids"
++                )
++            if output_weights is None:
++                output_weights = torch.empty(
++                    (rows, 16), device=self.device, dtype=torch.float32
++                )
++            if output_ids is None:
++                output_ids = torch.empty(
++                    (rows, 16), device=self.device, dtype=torch.int32
++                )
++            outputs = (
++                (output_weights, torch.float32, "output_weights"),
++                (output_ids, torch.int32, "output_ids"),
++            )
++            for value, dtype, name in outputs:
++                if (
++                    value.device != self.device
++                    or value.shape != (rows, 16)
++                    or value.dtype != dtype
++                    or not value.is_contiguous()
++                ):
++                    raise ValueError(
++                        f"{name} must be contiguous {(rows, 16)} {dtype} on "
++                        f"{self.device}"
++                    )
++            if capturing:
++                from ._dcp_a2a_cute import is_kimi_topk16_prepared
++
++                if not is_kimi_topk16_prepared(threads):
++                    raise RuntimeError(
++                        "cold PCIe DCP Kimi top-16 CUDA graph capture is not "
++                        "allowed; call prepare_graph_kimi_topk16() before "
++                        "capture"
++                    )
++            self._launch_kimi_topk16(
++                router_logits,
++                correction_bias,
++                output_weights,
++                output_ids,
++                threads=threads,
++            )
++            return output_weights, output_ids
++
++    def _launch_kimi_topk16(
++        self,
++        router_logits: torch.Tensor,
++        correction_bias: torch.Tensor,
++        output_weights: torch.Tensor,
++        output_ids: torch.Tensor,
++        *,
++        threads: int,
++    ) -> None:
++        from ._dcp_a2a_cute import kimi_topk16
++
++        with torch.cuda.device(self.device):
++            kimi_topk16(
++                router_logits_ptr=router_logits.data_ptr(),
++                correction_bias_ptr=correction_bias.data_ptr(),
++                output_weights_ptr=output_weights.data_ptr(),
++                output_ids_ptr=output_ids.data_ptr(),
++                rows=int(router_logits.shape[0]),
++                threads=threads,
++            )
++
+     def _closed_import_indices(self) -> set[tuple[int, int]]:
+         closed = getattr(self, "_closed_ipc_import_indices", None)
+         if closed is None:
+@@ -1922,6 +2179,20 @@ class PCIeDCPA2APool:
+                 stream, channel_id=channel_id
+             ).prepare_graph_all_gather_pair_kimi_topk()
+ 
++    def prepare_graph_kimi_topk16(
++        self,
++        *,
++        threads: int = 256,
++        stream: object = None,
++        channel_id: Optional[str] = None,
++    ) -> None:
++        """Prepare batched Kimi expert selection before graph capture."""
++
++        with _device_guard(self.device):
++            self.for_stream(
++                stream, channel_id=channel_id
++            ).prepare_graph_kimi_topk16(threads=threads)
++
+     def lse_reduce_scatter(
+         self,
+         partial_output: torch.Tensor,
+@@ -2085,6 +2356,35 @@ class PCIeDCPA2APool:
+             topk_ids,
+         )
+ 
++    def kimi_topk16(
++        self,
++        router_logits: torch.Tensor,
++        correction_bias: torch.Tensor,
++        output_weights: Optional[torch.Tensor] = None,
++        output_ids: Optional[torch.Tensor] = None,
++        *,
++        threads: int = 256,
++        stream: object = None,
++        channel_id: Optional[str] = None,
++    ) -> tuple[torch.Tensor, torch.Tensor]:
++        channel = self.for_stream(stream, channel_id=channel_id)
++        if stream is not None and self.device.type == "cuda":
++            with torch.cuda.stream(stream):
++                return channel.kimi_topk16(
++                    router_logits,
++                    correction_bias,
++                    output_weights,
++                    output_ids,
++                    threads=threads,
++                )
++        return channel.kimi_topk16(
++            router_logits,
++            correction_bias,
++            output_weights,
++            output_ids,
++            threads=threads,
++        )
++
+     @contextmanager
+     def capture(self, stream: object = None, *, channel_id: Optional[str] = None):
+         """Bind capture to a globally named channel.
+@@ -2211,5 +2511,7 @@ __all__ = [
+     "PCIeDCPA2A",
+     "PCIeDCPA2APool",
+     "SUPPORTED_WORLD_SIZES",
++    "kimi_topk16",
+     "lse_reduce_scatter_reference",
++    "prepare_kimi_topk16",
+ ]
+diff --git a/b12x/comm/pcie/pcie_hierarchical.py b/b12x/comm/pcie/pcie_hierarchical.py
+index 01dfd729689e5a6f9fe433e55b77331137a484ec..6dd0d1a4d34dac851e746539fd5284151f425cd6 100644
+--- a/b12x/comm/pcie/pcie_hierarchical.py
++++ b/b12x/comm/pcie/pcie_hierarchical.py
+@@ -13,7 +13,7 @@ from __future__ import annotations
+ import os
+ from contextlib import contextmanager, suppress
+ from dataclasses import dataclass
+-from typing import Optional
++from typing import Optional, Sequence
+ 
+ import torch
+ import torch.distributed as dist
+@@ -282,8 +282,9 @@ class PCIeHierarchicalAllReduce:
+         out: Optional[torch.Tensor] = None,
+         blocks: Optional[int] = None,
+         stream: object = None,
++        channel_id: Optional[str] = None,
+     ) -> torch.Tensor:
+-        del stream
++        del stream, channel_id
+         if not self.should_allreduce(inp):
+             raise ValueError(
+                 "input does not satisfy hierarchical all-reduce requirements "
+@@ -337,7 +338,22 @@ class PCIeHierarchicalAllReduce:
+             )
+         return out
+ 
+-    def for_stream(self, stream: object = None) -> "PCIeHierarchicalAllReduce":
++    def prepare_channels(self, channel_ids: Sequence[str]) -> None:
++        """Accept semantic owner names without allocating additional channels.
++
++        The hierarchical runtime has one ordered channel. Owner names provide
++        API compatibility for callers that serialize TP12/TP16 collectives;
++        they do not permit overlapping collective streams.
++        """
++
++        del channel_ids
++
++    def for_stream(
++        self,
++        stream: object = None,
++        *,
++        channel_id: Optional[str] = None,
++    ) -> "PCIeHierarchicalAllReduce":
+         """Compatibility with the vLLM PCIe runtime interface.
+ 
+         Synchronization generations live in device memory, so captured graphs
+@@ -345,12 +361,17 @@ class PCIeHierarchicalAllReduce:
+         single ordered channel; callers must not overlap collective streams.
+         """
+ 
+-        del stream
++        del stream, channel_id
+         return self
+ 
+     @contextmanager
+-    def capture(self, stream: object = None):
+-        del stream
++    def capture(
++        self,
++        stream: object = None,
++        *,
++        channel_id: Optional[str] = None,
++    ):
++        del stream, channel_id
+         yield self
+ 
+     def register_graph_buffers(self) -> None:
+diff --git a/b12x/comm/pcie/pcie_island_rs.py b/b12x/comm/pcie/pcie_island_rs.py
+new file mode 100644
+index 0000000000000000000000000000000000000000..48aaf9d5376728023477534ec34fffd91f6848e9
+--- /dev/null
++++ b/b12x/comm/pcie/pcie_island_rs.py
+@@ -0,0 +1,304 @@
++"""Pull-based island reduce-scatter TP16 all-reduce runtime."""
++
++from __future__ import annotations
++
++import os
++from contextlib import contextmanager
++from typing import Optional, Sequence
++
++import torch
++import torch.distributed as dist
++from torch.distributed import ProcessGroup
++
++from ._island_rs_cute import (
++    HEADER_BYTES,
++    MAX_BLOCKS,
++    get_island_rs_launcher,
++    island_rs_peers,
++)
++from ._cuda_ipc import CudaRTLibrary
++from .pcie_oneshot import (
++    PCIeOneshotAllReduce,
++    _finish_collective_runtime_setup,
++    _normalize_device,
++)
++
++
++SUPPORTED_WORLD_SIZES = (16,)
++SUPPORTED_BLOCKS = (1, 2, 4, 8, 16, 32)
++_ISLAND_SIZE = 4
++_ALIGNMENT = 256
++
++
++def _align_up(value: int, alignment: int = _ALIGNMENT) -> int:
++    return (int(value) + alignment - 1) // alignment * alignment
++
++
++def _threads_from_env() -> int:
++    # Default CUDA thread count for the TP16 equal-quarter launch.
++    raw = os.getenv("B12X_PCIE_ISLAND_RS_THREADS", "512")
++    threads = int(raw)
++    if not 32 <= threads <= 1024 or threads % 32:
++        raise ValueError(
++            "B12X_PCIE_ISLAND_RS_THREADS must be a multiple of 32 in [32, 1024]"
++        )
++    return threads
++
++
++def _wait_nanosleep_cycles_from_env() -> int:
++    cycles = int(os.getenv("B12X_PCIE_ISLAND_RS_NANOSLEEP_CYCLES", "24"))
++    if not 0 <= cycles <= 1024:
++        raise ValueError("B12X_PCIE_ISLAND_RS_NANOSLEEP_CYCLES must be in [0, 1024]")
++    return cycles
++
++
++def _pick_blocks(elements: int) -> int:
++    """Return the default launch geometry for a BF16 element count."""
++
++    if elements <= 4096:
++        return 8
++    return 16
++
++
++# Auto dispatch keeps a single 7,168-element row on the shorter hierarchical
++# protocol and routes larger vectors through equal-quarter ownership when each
++# rank-owned quarter is aligned to a complete 32-word transfer group.
++CROSSOVER_ELEMENTS = 7_168
++PREFERRED_ALIGNMENT_ELEMENTS = 128
++
++
++class PCIeIslandRSAllReduce:
++    """Equal-quarter BF16 TP16 all-reduce with no leader hotspot.
++
++    Every rank owns one quarter of the vector and reaches six peers: the three
++    other lanes of its four-GPU island, and the same lane in the three other
++    islands. Peer degree is bounded at six, and no rank carries the whole
++    vector on behalf of the others.
++    """
++
++    def __init__(
++        self,
++        *,
++        exchange_group: ProcessGroup,
++        device: torch.device | int | str,
++        max_elements: int,
++        blocks: Optional[int] = None,
++    ) -> None:
++        self.group = exchange_group
++        self.rank = dist.get_rank(group=exchange_group)
++        self.world_size = dist.get_world_size(group=exchange_group)
++        self.device = _normalize_device(device)
++        if self.world_size not in SUPPORTED_WORLD_SIZES:
++            raise ValueError(
++                f"island reduce-scatter requires TP16, got TP{self.world_size}"
++            )
++        if self.device.type != "cuda":
++            raise ValueError("island reduce-scatter requires a CUDA device")
++        if blocks is not None and blocks not in SUPPORTED_BLOCKS:
++            raise ValueError(f"blocks must be one of {SUPPORTED_BLOCKS}")
++        if max_elements <= 0 or max_elements % 2:
++            raise ValueError("max_elements must be a positive even count")
++
++        self.max_elements = int(max_elements)
++        self.blocks = None if blocks is None else int(blocks)
++        self.threads = _threads_from_env()
++        self.wait_nanosleep_cycles = _wait_nanosleep_cycles_from_env()
++
++        max_pairs = self.max_elements // 2
++        # Quarter stride in BF16x2 words. Every transient region has two slots
++        # selected by the device generation so a rank cannot overwrite data a
++        # slower peer is still consuming from the preceding invocation.
++        self.quarter_capacity = _align_up(
++            (max_pairs + _ISLAND_SIZE - 1) // _ISLAND_SIZE, 8
++        )
++        quarter_bytes = self.quarter_capacity * 4
++        vector_bytes = quarter_bytes * _ISLAND_SIZE
++        self.stage_offset = _align_up(HEADER_BYTES)
++        self.part_offset = _align_up(self.stage_offset + 2 * vector_bytes)
++        self.final_offset = _align_up(self.part_offset + 2 * quarter_bytes)
++        self.slab_bytes = _align_up(self.final_offset + 2 * vector_bytes)
++
++        self._ipc = CudaRTLibrary()
++        self._ipc.cudaSetDevice(self.device.index or 0)
++        self._slab_ptrs: tuple[int, ...] = ()
++        self._local_ptr = 0
++        self._remote_ptrs: list[int] = []
++        self._closed = False
++        self._launcher = None
++        self._mapped_peers = island_rs_peers(self.rank, self.world_size)
++
++        shared = PCIeOneshotAllReduce._allocate_shared_buffer(
++            exchange_group,
++            self.slab_bytes,
++            zero_fill=True,
++            ipc=self._ipc,
++            peer_ranks=self._mapped_peers,
++        )
++        self._local_ptr = shared.local_ptr
++        self._remote_ptrs = list(shared.remote_ptrs)
++        self._slab_ptrs = shared.peer_ptrs
++
++        init_error: BaseException | None = None
++        try:
++            with torch.cuda.device(self.device):
++                self._launcher = get_island_rs_launcher(
++                    self.world_size,
++                    self.rank,
++                    self.device.index or 0,
++                    threads=self.threads,
++                    wait_nanosleep_cycles=self.wait_nanosleep_cycles,
++                )
++        except Exception as exc:
++            init_error = exc
++
++        def detach_shared_ownership() -> None:
++            self._slab_ptrs = ()
++            self._remote_ptrs.clear()
++            self._local_ptr = 0
++
++        _finish_collective_runtime_setup(
++            owner="PCIe island reduce-scatter",
++            exchange_group=exchange_group,
++            ipc=self._ipc,
++            shared=shared,
++            local_error=init_error,
++            detach_shared_ownership=detach_shared_ownership,
++        )
++
++    @property
++    def mapped_peer_count(self) -> int:
++        return len(self._remote_ptrs)
++
++    @property
++    def mapped_peers(self) -> tuple[int, ...]:
++        """Group ranks whose CUDA IPC allocations are mapped by this rank."""
++
++        return self._mapped_peers
++
++    def should_allreduce(self, inp: torch.Tensor) -> bool:
++        return (
++            not self._closed
++            and inp.device == self.device
++            and inp.dtype == torch.bfloat16
++            and inp.is_contiguous()
++            and 0 < inp.numel() <= self.max_elements
++            and inp.numel() % 2 == 0
++            and inp.data_ptr() % 4 == 0
++        )
++
++    def all_reduce(
++        self,
++        inp: torch.Tensor,
++        *,
++        out: Optional[torch.Tensor] = None,
++        blocks: Optional[int] = None,
++        stream: object = None,
++        channel_id: Optional[str] = None,
++    ) -> torch.Tensor:
++        del channel_id  # The runtime exposes one ordered collective channel.
++        if not self.should_allreduce(inp):
++            raise ValueError(
++                "input does not satisfy island reduce-scatter requirements "
++                f"(shape={tuple(inp.shape)}, dtype={inp.dtype})"
++            )
++        if out is None:
++            # During CUDA graph capture, PyTorch allocates this tensor from the
++            # graph-private pool. The captured graph retains a fixed address
++            # and replays without allocator activity.
++            out = torch.empty_like(inp)
++        if (
++            out.dtype != inp.dtype
++            or out.device != inp.device
++            or out.shape != inp.shape
++            or not out.is_contiguous()
++            or out.data_ptr() % 4 != 0
++        ):
++            raise ValueError("output must match input and be 4-byte aligned")
++        if blocks is not None:
++            selected = int(blocks)
++        elif self.blocks is not None:
++            selected = self.blocks
++        else:
++            selected = _pick_blocks(inp.numel())
++        if selected not in SUPPORTED_BLOCKS or selected > MAX_BLOCKS:
++            raise ValueError(f"blocks must be one of {SUPPORTED_BLOCKS}")
++        with torch.cuda.device(self.device):
++            self._launcher(
++                self._slab_ptrs,
++                inp.data_ptr(),
++                out.data_ptr(),
++                self.stage_offset,
++                self.part_offset,
++                self.final_offset,
++                self.quarter_capacity,
++                inp.numel(),
++                selected,
++                stream,
++            )
++        return out
++
++    def prepare_channels(self, channel_ids: Sequence[str]) -> None:
++        """Accept owner names for the single ordered collective channel."""
++
++        del channel_ids
++
++    def for_stream(
++        self,
++        stream: object = None,
++        *,
++        channel_id: Optional[str] = None,
++    ) -> "PCIeIslandRSAllReduce":
++        # Binding is validated at launch through the explicit stream argument.
++        # Owner names are accepted because this runtime has one serialized
++        # channel rather than per-owner storage.
++        del channel_id
++        if stream is not None and not hasattr(stream, "cuda_stream"):
++            int(stream)
++        return self
++
++    @contextmanager
++    def capture(
++        self,
++        stream: object = None,
++        *,
++        channel_id: Optional[str] = None,
++    ):
++        self.for_stream(stream, channel_id=channel_id)
++        if stream is None:
++            yield self
++        else:
++            torch_stream = (
++                stream
++                if hasattr(stream, "cuda_stream")
++                else torch.cuda.ExternalStream(int(stream), device=self.device)
++            )
++            with torch.cuda.stream(torch_stream):
++                yield self
++
++    def register_graph_buffers(self) -> None:
++        return None
++
++    def close(self) -> None:
++        if self._closed:
++            return
++        self._closed = True
++        if self.device.type == "cuda":
++            torch.cuda.synchronize(self.device)
++        dist.barrier(group=self.group)
++        self._slab_ptrs = ()
++        for ptr in self._remote_ptrs:
++            self._ipc.cudaIpcCloseMemHandle(ptr)
++        self._remote_ptrs.clear()
++        dist.barrier(group=self.group)
++        if self._local_ptr:
++            self._ipc.cudaFree(self._local_ptr)
++            self._local_ptr = 0
++        dist.barrier(group=self.group)
++
++
++__all__ = [
++    "CROSSOVER_ELEMENTS",
++    "PCIeIslandRSAllReduce",
++    "PREFERRED_ALIGNMENT_ELEMENTS",
++    "SUPPORTED_WORLD_SIZES",
++]
+diff --git a/b12x/comm/pcie/pcie_oneshot.py b/b12x/comm/pcie/pcie_oneshot.py
+index 6dcc3c8df2e8ba22617f6e8fd5f67ca990126172..4df34d6f7e82f9a7a945484873c96ad24b1f36e6 100644
+--- a/b12x/comm/pcie/pcie_oneshot.py
++++ b/b12x/comm/pcie/pcie_oneshot.py
+@@ -279,12 +279,15 @@ def _object_broadcast_device(group: ProcessGroup) -> torch.device | str:
+             backend = dist.get_backend(group)
+     except Exception as exc:
+         raise RuntimeError(
+-            "PCIe oneshot IPC exchange requires a CUDA/NCCL process group"
++            "PCIe object exchange requires a valid process group"
+         ) from exc
+     backend_name = str(backend).lower()
++    if "gloo" in backend_name:
++        return torch.device("cpu")
+     if "nccl" not in backend_name:
+         raise RuntimeError(
+-            f"PCIe oneshot IPC exchange requires an NCCL process group, got {backend}"
++            "PCIe object exchange requires an NCCL or Gloo process group, "
++            f"got {backend}"
+         )
+     if not torch.cuda.is_available():
+         raise RuntimeError("PCIe oneshot IPC exchange requires CUDA")
+@@ -2331,8 +2334,21 @@ class PCIeOneshotAllReduce:
+         *,
+         zero_fill: bool,
+         ipc: CudaRTLibrary,
++        peer_ranks: Optional[Sequence[int]] = None,
+     ) -> _OwnedSharedBuffer:
+         _require_no_retained_ipc_setup(exchange_group)
++        world_size = dist.get_world_size(group=exchange_group)
++        rank = dist.get_rank(group=exchange_group)
++        selected_peers = (
++            set(range(world_size)) - {rank}
++            if peer_ranks is None
++            else {int(peer) for peer in peer_ranks}
++        )
++        if rank in selected_peers or any(
++            not 0 <= peer < world_size for peer in selected_peers
++        ):
++            raise ValueError("peer_ranks must contain valid remote group ranks")
++
+         local_ptr: int | None = None
+         local_handle: bytes | None = None
+         prepare_error: BaseException | None = None
+@@ -2435,8 +2451,6 @@ class PCIeOneshotAllReduce:
+         peer_ptrs: list[int] = []
+         remote_ptrs: list[int] = []
+         try:
+-            world_size = dist.get_world_size(group=exchange_group)
+-            rank = dist.get_rank(group=exchange_group)
+             handles = _broadcast_gather_object(local_handle, exchange_group)
+         except Exception as exchange_error:
+             # No rank has opened an import before handle exchange completes.
+@@ -2460,6 +2474,9 @@ class PCIeOneshotAllReduce:
+             if idx == rank:
+                 peer_ptrs.append(local_ptr)
+                 continue
++            if idx not in selected_peers:
++                peer_ptrs.append(0)
++                continue
+             try:
+                 remote_ptr = ipc.cudaIpcOpenMemHandleBytes(handle)
+             except Exception as exc:
+diff --git a/b12x/comm/pcie/pcie_vocab_argmax.py b/b12x/comm/pcie/pcie_vocab_argmax.py
+new file mode 100644
+index 0000000000000000000000000000000000000000..f4b28db469c4e9d0830156794dd4799bae4cedcf
+--- /dev/null
++++ b/b12x/comm/pcie/pcie_vocab_argmax.py
+@@ -0,0 +1,388 @@
++"""Bounded-degree vocabulary-parallel argmax runtime."""
++
++from __future__ import annotations
++
++import os
++from contextlib import contextmanager, suppress
++from typing import Iterator, Optional
++from warnings import warn
++
++import torch
++import torch.distributed as dist
++from torch.distributed import ProcessGroup
++
++from ._cuda_ipc import CudaRTLibrary
++from ._vocab_argmax_cute import SLAB_BYTES, get_vocab_argmax_launcher
++from .pcie_oneshot import (
++    PCIeOneshotAllReduce,
++    _broadcast_gather_object,
++    _run_collective_preallocation_setup,
++)
++
++
++ISLAND_SIZE = 4
++MAX_BATCH_SIZE = 8
++SUPPORTED_WORLD_SIZES = (8, 12, 16)
++
++
++def _exchange_ipc_handles(
++    local_handle: object,
++    group: ProcessGroup,
++) -> list[object]:
++    """Exchange CUDA IPC handles over NCCL or a metadata-only Gloo group."""
++
++    backend = str(dist.get_backend(group=group)).lower()
++    if "nccl" in backend:
++        return _broadcast_gather_object(local_handle, group)
++    if "gloo" not in backend:
++        raise ValueError(
++            "vocabulary argmax IPC exchange requires an NCCL or Gloo group, "
++            f"got {backend}"
++        )
++
++    world_size = dist.get_world_size(group=group)
++    handles: list[object | None] = [None] * world_size
++    dist.all_gather_object(handles, local_handle, group=group)
++    if any(handle is None for handle in handles):
++        raise RuntimeError("vocabulary argmax IPC exchange returned an empty handle")
++    return list(handles)
++
++
++def _require_uniform_geometry(
++    local_vocab_size: int,
++    max_batch_size: int,
++    group: ProcessGroup,
++) -> None:
++    """Reject rank-local geometry before allocating collective resources."""
++    geometry = (int(local_vocab_size), int(max_batch_size))
++    # vLLM supplies its metadata-only Gloo TP group here so initialization does
++    # not allocate an NCCL object-collective workspace.  Geometry validation
++    # must preserve the same NCCL-or-Gloo contract as CUDA IPC handle exchange.
++    peer_geometry = _exchange_ipc_handles(geometry, group)
++    if any(candidate != geometry for candidate in peer_geometry):
++        raise RuntimeError(
++            f"vocabulary argmax geometry differs across ranks: {peer_geometry}"
++        )
++
++
++def _wait_nanosleep_cycles_from_env() -> int:
++    raw = os.getenv("B12X_PCIE_VOCAB_ARGMAX_NANOSLEEP_CYCLES", "24")
++    try:
++        cycles = int(raw)
++    except ValueError as exc:
++        raise ValueError(
++            "B12X_PCIE_VOCAB_ARGMAX_NANOSLEEP_CYCLES must be an integer"
++        ) from exc
++    if not 0 <= cycles <= 1024:
++        raise ValueError("B12X_PCIE_VOCAB_ARGMAX_NANOSLEEP_CYCLES must be in [0, 1024]")
++    return cycles
++
++
++def _selected_peers(rank: int, world_size: int = 16) -> tuple[int, ...]:
++    """Return three island peers plus the same lane in other islands."""
++
++    if world_size not in SUPPORTED_WORLD_SIZES:
++        raise ValueError(
++            "vocabulary argmax requires "
++            f"{SUPPORTED_WORLD_SIZES}, got TP{world_size}"
++        )
++    if not 0 <= rank < world_size:
++        raise ValueError(f"invalid rank {rank} for TP{world_size}")
++    island = rank // ISLAND_SIZE
++    lane = rank % ISLAND_SIZE
++    local = set(range(island * ISLAND_SIZE, (island + 1) * ISLAND_SIZE))
++    cross_island = set(range(lane, world_size, ISLAND_SIZE))
++    return tuple(sorted((local | cross_island) - {rank}))
++
++
++class PCIeVocabParallelArgmax:
++    """Fuse BF16 add and exact global greedy sampling across TP shards.
++
++    Every TP rank must invoke ``fused_add_argmax`` once per logical step with
++    the same batch size. Tensor-parallel schedulers satisfy this collective
++    ordering invariant; callers that cannot guarantee it must not use this
++    runtime. Construction verifies that local vocabulary and capacity geometry
++    match on all ranks.
++    """
++
++    def __init__(
++        self,
++        *,
++        exchange_group: ProcessGroup,
++        device: torch.device | int | str,
++        local_vocab_size: int,
++        max_batch_size: int = MAX_BATCH_SIZE,
++    ) -> None:
++        self.group = exchange_group
++        self.rank = dist.get_rank(group=exchange_group)
++        self.world_size = dist.get_world_size(group=exchange_group)
++
++        def normalize_and_validate():
++            device_obj = (
++                device
++                if isinstance(device, torch.device)
++                else torch.device(
++                    f"cuda:{device}" if isinstance(device, int) else device
++                )
++            )
++            if self.world_size not in SUPPORTED_WORLD_SIZES:
++                raise ValueError(
++                    "vocabulary argmax requires "
++                    f"{SUPPORTED_WORLD_SIZES}, got TP{self.world_size}"
++                )
++            if device_obj.type != "cuda":
++                raise ValueError("vocabulary argmax requires a CUDA device")
++            if device_obj.index is None:
++                device_obj = torch.device("cuda", torch.cuda.current_device())
++            normalized_local_vocab_size = int(local_vocab_size)
++            normalized_max_batch_size = int(max_batch_size)
++            if (
++                normalized_local_vocab_size <= 0
++                or normalized_local_vocab_size * self.world_size >= 1 << 31
++            ):
++                raise ValueError("global vocabulary must fit a positive int32 index")
++            if not 0 < normalized_max_batch_size <= MAX_BATCH_SIZE:
++                raise ValueError(
++                    f"max_batch_size must be in [1, {MAX_BATCH_SIZE}]"
++                )
++            return (
++                device_obj,
++                normalized_local_vocab_size,
++                normalized_max_batch_size,
++                _wait_nanosleep_cycles_from_env(),
++            )
++
++        (
++            self.device,
++            self.local_vocab_size,
++            self.max_batch_size,
++            wait_nanosleep_cycles,
++        ) = _run_collective_preallocation_setup(
++            owner="PCIe vocabulary argmax argument validation",
++            exchange_group=exchange_group,
++            setup=normalize_and_validate,
++        )
++        _require_uniform_geometry(
++            self.local_vocab_size,
++            self.max_batch_size,
++            exchange_group,
++        )
++        self._slab_ptrs: tuple[int, ...] = ()
++        self._launcher = None
++        self._local_ptr = 0
++        self._remote_ptrs: list[int] = []
++        self._closed = True
++
++        def prepare_runtime():
++            self._ipc = CudaRTLibrary()
++            with self._cuda_runtime_device():
++                launcher = get_vocab_argmax_launcher(
++                    self.world_size,
++                    self.rank,
++                    self.device.index or 0,
++                    wait_nanosleep_cycles=wait_nanosleep_cycles,
++                )
++            return self._ipc, launcher
++
++        self._ipc, self._launcher = _run_collective_preallocation_setup(
++            owner="PCIe vocabulary argmax runtime preparation",
++            exchange_group=exchange_group,
++            setup=prepare_runtime,
++        )
++        with self._cuda_runtime_device():
++            shared = PCIeOneshotAllReduce._allocate_shared_buffer(
++                exchange_group,
++                SLAB_BYTES,
++                zero_fill=True,
++                ipc=self._ipc,
++                peer_ranks=_selected_peers(self.rank, self.world_size),
++            )
++        self._local_ptr = shared.local_ptr
++        self._slab_ptrs = shared.peer_ptrs
++        self._remote_ptrs = list(shared.remote_ptrs)
++        self._closed = False
++
++    @classmethod
++    def from_exchange_group(
++        cls,
++        *,
++        exchange_group: ProcessGroup,
++        device: torch.device | int | str,
++        local_vocab_size: int,
++        max_batch_size: int = MAX_BATCH_SIZE,
++    ) -> "PCIeVocabParallelArgmax":
++        return cls(
++            exchange_group=exchange_group,
++            device=device,
++            local_vocab_size=local_vocab_size,
++            max_batch_size=max_batch_size,
++        )
++
++    @classmethod
++    def from_process_group(
++        cls,
++        *,
++        process_group: ProcessGroup,
++        device: torch.device | int | str,
++        local_vocab_size: int,
++        max_batch_size: int = MAX_BATCH_SIZE,
++    ) -> "PCIeVocabParallelArgmax":
++        return cls.from_exchange_group(
++            exchange_group=process_group,
++            device=device,
++            local_vocab_size=local_vocab_size,
++            max_batch_size=max_batch_size,
++        )
++
++    @property
++    def mapped_peer_count(self) -> int:
++        return len(self._remote_ptrs)
++
++    @contextmanager
++    def _cuda_runtime_device(self) -> Iterator[None]:
++        """Select this runtime's CUDA device and restore the caller's device."""
++        if self.device.type != "cuda" or self.device.index is None:
++            yield
++            return
++        previous_device: int | None
++        try:
++            previous_device = torch.cuda.current_device()
++        except Exception:
++            previous_device = None
++        self._ipc.cudaSetDevice(self.device.index)
++        try:
++            yield
++        finally:
++            if previous_device is not None and previous_device != self.device.index:
++                self._ipc.cudaSetDevice(previous_device)
++
++    def fused_add_argmax(
++        self,
++        base: torch.Tensor,
++        bias: torch.Tensor,
++        out: Optional[torch.Tensor] = None,
++    ) -> torch.Tensor:
++        """Return exact global argmax of the BF16-rounded local sum."""
++
++        if self._closed:
++            raise RuntimeError("vocabulary argmax runtime is closed")
++        if base.device != self.device or bias.device != self.device:
++            raise ValueError("inputs must be on the runtime device")
++        if base.dtype != torch.bfloat16 or bias.dtype != torch.bfloat16:
++            raise ValueError("inputs must be BF16")
++        if base.ndim != 2 or base.shape != bias.shape:
++            raise ValueError("inputs must have matching [batch, local_vocab] shapes")
++        batch, local_vocab = (int(value) for value in base.shape)
++        if not 0 < batch <= self.max_batch_size:
++            raise ValueError(
++                f"batch size {batch} exceeds capacity {self.max_batch_size}"
++            )
++        if local_vocab != self.local_vocab_size:
++            raise ValueError(
++                f"local vocabulary must be {self.local_vocab_size}, got {local_vocab}"
++            )
++        if base.stride(1) != 1 or bias.stride(1) != 1:
++            raise ValueError("input last dimensions must be contiguous")
++        if base.stride(0) <= 0 or bias.stride(0) <= 0:
++            raise ValueError("input row strides must be positive")
++        if out is None:
++            out = torch.empty(batch, dtype=torch.int64, device=self.device)
++        if (
++            out.device != self.device
++            or out.dtype != torch.int64
++            or out.shape != (batch,)
++            or not out.is_contiguous()
++        ):
++            raise ValueError("output must be contiguous int64 [batch] on the device")
++        if self._launcher is None:
++            raise RuntimeError("vocabulary argmax launcher is unavailable")
++        with self._cuda_runtime_device():
++            self._launcher(
++                self._slab_ptrs,
++                base.data_ptr(),
++                bias.data_ptr(),
++                out.data_ptr(),
++                self.local_vocab_size,
++                base.stride(0),
++                bias.stride(0),
++                batch,
++            )
++        return out
++
++    def for_stream(self, stream: object = None) -> "PCIeVocabParallelArgmax":
++        del stream
++        return self
++
++    @contextmanager
++    def capture(self, stream: object = None):
++        del stream
++        yield self
++
++    def register_graph_buffers(self) -> None:
++        return None
++
++    def close(self) -> None:
++        if self._closed:
++            return
++        self._closed = True
++        with self._cuda_runtime_device():
++            torch.cuda.synchronize(self.device)
++            dist.barrier(group=self.group)
++            try:
++                self._launcher = None
++                self._slab_ptrs = ()
++            finally:
++                try:
++                    for ptr in self._remote_ptrs:
++                        self._ipc.cudaIpcCloseMemHandle(ptr)
++                finally:
++                    self._remote_ptrs.clear()
++                    dist.barrier(group=self.group)
++                    try:
++                        if self._local_ptr:
++                            self._ipc.cudaFree(self._local_ptr)
++                    finally:
++                        self._local_ptr = 0
++                        dist.barrier(group=self.group)
++
++    def __enter__(self) -> "PCIeVocabParallelArgmax":
++        return self
++
++    def __exit__(self, *_args) -> None:
++        self.close()
++
++    def __del__(self) -> None:
++        if getattr(self, "_closed", True):
++            return
++
++        # Python garbage collection is not ordered across distributed ranks.
++        # Calling close() here could deadlock on its collective barriers, so
++        # finalization releases only resources owned by this rank. Callers
++        # must use close() or the context manager for coordinated teardown.
++        self._closed = True
++        with suppress(Exception):
++            warn(
++                "PCIeVocabParallelArgmax was garbage-collected without close(); "
++                "releasing rank-local CUDA resources without collective teardown",
++                ResourceWarning,
++                stacklevel=2,
++            )
++
++        with suppress(Exception), self._cuda_runtime_device():
++            self._launcher = None
++            self._slab_ptrs = ()
++
++            remote_ptrs = list(getattr(self, "_remote_ptrs", ()))
++            self._remote_ptrs = []
++            for ptr in remote_ptrs:
++                with suppress(Exception):
++                    self._ipc.cudaIpcCloseMemHandle(ptr)
++
++            local_ptr = getattr(self, "_local_ptr", 0)
++            self._local_ptr = 0
++            if local_ptr:
++                with suppress(Exception):
++                    self._ipc.cudaFree(local_ptr)
++
++
++__all__ = ["PCIeVocabParallelArgmax"]
+diff --git a/b12x/moe/_shared/kernels/micro.py b/b12x/moe/_shared/kernels/micro.py
+index c743212e838a382de9b8940d81632a25173f54e0..7e592bf62a349d73d24ea479ea9b4efde51d8c28 100644
+--- a/b12x/moe/_shared/kernels/micro.py
++++ b/b12x/moe/_shared/kernels/micro.py
+@@ -406,6 +406,7 @@ class MoEMicroKernelBackend:
+         weight_layout: str = "modelopt",
+         trellis_bits: int | None = None,
+         trellis_coupled: bool = False,
++        stage_inactive_routes: bool = False,
+     ):
+         activation = normalize_moe_activation(activation)
+         if int(compile_time_phase) not in {0, 1, 2}:
+@@ -473,8 +474,10 @@ class MoEMicroKernelBackend:
+         self.weight_layout_trellis256 = weight_layout == "trellis3_t256"
+         self.trellis_bits = 0 if trellis_bits is None else int(trellis_bits)
+         self.trellis_coupled = bool(trellis_coupled)
++        self.stage_inactive_routes = bool(stage_inactive_routes)
+         self.trellis_ksplit = 1
+         self.trellis_scratch_u32 = 0
++        self.route_slots = 0
+         self._cfg = None
+         self.m_const = 0
+         self.m1_fc2_onepass = False
+@@ -497,6 +500,7 @@ class MoEMicroKernelBackend:
+             self.weight_layout,
+             self.trellis_bits,
+             self.trellis_coupled,
++            self.stage_inactive_routes,
+             self.trellis_ksplit,
+             self.scale_format,
+             self.e8m0_scale_layout,
+@@ -511,6 +515,7 @@ class MoEMicroKernelBackend:
+             self.m1_fc2_onepass,
+             self.m1_fc2_rows_per_cta,
+             self.launch_block_dim,
++            self.route_slots,
+         )
+ 
+     @cute.jit
+@@ -548,6 +553,32 @@ class MoEMicroKernelBackend:
+             )
+         return fp4_dot4_sum_f32acc(u_packed, x0, x1, x2, x3)
+ 
++    @cute.jit
++    def _fc2_route(
++        self,
++        topk_ids: cute.Tensor,
++        topk_weights: cute.Tensor,
++        eid_addr: Int32,
++        route_expert_limit: Int32,
++    ) -> Tuple[Int32, Float32]:
++        """Return an addressable expert and its effective router weight.
++
++        Fixed-M fused launches receive a route table sanitized in shared
++        memory before FC1 and FC2 execute. The FC2-only endpoint instead uses
++        runtime M with a compile-time expert-capacity bucket, so it must check
++        each route against the resident expert count supplied by the caller.
++        Invalid routes address expert zero with an exact-zero effective weight.
++        """
++        if cutlass.const_expr(self.compile_time_phase == 2):
++            raw_expert = Int64(topk_ids[eid_addr])
++            expert = Int32(0)
++            weight = Float32(0.0)
++            if raw_expert >= Int64(0) and raw_expert < Int64(route_expert_limit):
++                expert = Int32(raw_expert)
++                weight = Float32(topk_weights[eid_addr])
++            return expert, weight
++        return Int32(topk_ids[eid_addr]), Float32(topk_weights[eid_addr])
++
+     @cute.jit
+     def _scale_byte_to_f32(self, byte: Uint32) -> Float32:
+         """Decode one block-scale byte to f32 (E8M0 in MXFP4 mode, else E4M3)."""
+@@ -894,6 +925,7 @@ class MoEMicroKernelBackend:
+         self.m1_fc2_rows_per_cta = m1_fc2_rows
+         self.launch_block_dim = _K_PER_CTA * 16 if m1_half_cta_fc2 else _BLOCK_DIM
+         self.grid_x = grid_x
++        self.route_slots = m * cfg.num_topk
+         # Required inter_fp32 element count: the per-token intermediate plus
+         # the trellis K-split scratch tail. Callers must zero-initialize; the
+         # kernel restores the tail to zero after each use.
+@@ -933,6 +965,7 @@ class MoEMicroKernelBackend:
+         w2_alphas: cute.Tensor,
+         topk_ids: cute.Tensor,
+         topk_weights: cute.Tensor,
++        route_expert_limit: Int32,
+         scatter_output: cute.Tensor,
+     ):
+         cfg = self._cfg
+@@ -965,8 +998,9 @@ class MoEMicroKernelBackend:
+ 
+         for kk in cutlass.range_constexpr(cfg.num_topk):
+             eid_addr = Int32(kk)
+-            eid = Int32(topk_ids[eid_addr])
+-            router_w = topk_weights[eid_addr]
++            eid, router_w = self._fc2_route(
++                topk_ids, topk_weights, eid_addr, route_expert_limit
++            )
+             if cutlass.const_expr(
+                 self.w4a16_mode
+                 and (not self.is_gated)
+@@ -1165,6 +1199,7 @@ class MoEMicroKernelBackend:
+         w2_alphas: cute.Tensor,
+         topk_ids: cute.Tensor,
+         topk_weights: cute.Tensor,
++        route_expert_limit: Int32,
+         scatter_output: cute.Tensor,
+     ):
+         cfg = self._cfg
+@@ -1190,8 +1225,9 @@ class MoEMicroKernelBackend:
+ 
+         for kk in cutlass.range_constexpr(cfg.num_topk):
+             eid_addr = Int32(kk)
+-            eid = Int32(topk_ids[eid_addr])
+-            router_w = topk_weights[eid_addr]
++            eid, router_w = self._fc2_route(
++                topk_ids, topk_weights, eid_addr, route_expert_limit
++            )
+             if cutlass.const_expr(
+                 self.w4a16_mode
+                 and (not self.is_gated)
+@@ -1405,6 +1441,7 @@ class MoEMicroKernelBackend:
+         w2_alphas: cute.Tensor,
+         topk_ids: cute.Tensor,
+         topk_weights: cute.Tensor,
++        route_expert_limit: Int32,
+         scatter_output: cute.Tensor,
+     ):
+         cfg = self._cfg
+@@ -1445,8 +1482,9 @@ class MoEMicroKernelBackend:
+ 
+         for kk in cutlass.range_constexpr(cfg.num_topk):
+             eid_addr = t * Int32(cfg.num_topk) + Int32(kk)
+-            eid = Int32(topk_ids[eid_addr])
+-            router_w = topk_weights[eid_addr]
++            eid, router_w = self._fc2_route(
++                topk_ids, topk_weights, eid_addr, route_expert_limit
++            )
+             if cutlass.const_expr(
+                 self.w4a16_mode
+                 and (not self.is_gated)
+@@ -1636,6 +1674,7 @@ class MoEMicroKernelBackend:
+         w2_alphas: cute.Tensor,
+         topk_ids: cute.Tensor,
+         topk_weights: cute.Tensor,
++        route_expert_limit: Int32,
+         scatter_output: cute.Tensor,
+     ):
+         cfg = self._cfg
+@@ -1673,8 +1712,9 @@ class MoEMicroKernelBackend:
+ 
+         for kk in cutlass.range_constexpr(cfg.num_topk):
+             eid_addr = t * Int32(cfg.num_topk) + Int32(kk)
+-            eid = Int32(topk_ids[eid_addr])
+-            router_w = topk_weights[eid_addr]
++            eid, router_w = self._fc2_route(
++                topk_ids, topk_weights, eid_addr, route_expert_limit
++            )
+             if cutlass.const_expr(
+                 self.w4a16_mode
+                 and (not self.is_gated)
+@@ -1870,6 +1910,7 @@ class MoEMicroKernelBackend:
+         w2_alphas: cute.Tensor,
+         topk_ids: cute.Tensor,
+         topk_weights: cute.Tensor,
++        route_expert_limit: Int32,
+         scatter_output: cute.Tensor,
+     ):
+         cfg = self._cfg
+@@ -1919,8 +1960,9 @@ class MoEMicroKernelBackend:
+ 
+         for kk in cutlass.range_constexpr(cfg.num_topk):
+             eid_addr = t * Int32(cfg.num_topk) + Int32(kk)
+-            eid = Int32(topk_ids[eid_addr])
+-            router_w = topk_weights[eid_addr]
++            eid, router_w = self._fc2_route(
++                topk_ids, topk_weights, eid_addr, route_expert_limit
++            )
+             if cutlass.const_expr(
+                 self.w4a16_mode
+                 and (not self.is_gated)
+@@ -2393,12 +2435,44 @@ class MoEMicroKernelBackend:
+         barrier_epoch: cute.Tensor,
+         trellis_lut: cute.Tensor,
+         trellis_rotations: cute.Tensor,
++        route_expert_limit: Int32,
+         m_val: Int32,
+     ):
+         cfg = self._cfg
+         bidx_x, _, _ = cute.arch.block_idx()
+         tidx, _, _ = cute.arch.thread_idx()
+         gdim_x, _, _ = cute.arch.grid_dim()
++        if cutlass.const_expr(self.stage_inactive_routes):
++            # The native direct path bypasses dynamic route packing, so stage
++            # its bounded route table once per CTA. Invalid IDs receive an
++            # addressable placeholder and an exact-zero effective weight.
++            # Inner FC1/FC2 loops then retain their unchecked hot path while
++            # caller-owned route tensors remain unchanged across graph replay.
++            staged_ids_ptr = cute.arch.alloc_smem(Int32, self.route_slots)
++            staged_weights_ptr = cute.arch.alloc_smem(Float32, self.route_slots)
++            staged_ids = cute.make_tensor(
++                staged_ids_ptr, cute.make_layout(self.route_slots)
++            )
++            staged_weights = cute.make_tensor(
++                staged_weights_ptr, cute.make_layout(self.route_slots)
++            )
++            route_slot = Int32(tidx)
++            while route_slot < Int32(self.route_slots):
++                raw_expert = Int64(topk_ids[route_slot])
++                expert = Int32(0)
++                weight = Float32(0.0)
++                if (
++                    raw_expert >= Int64(0)
++                    and raw_expert < Int64(route_expert_limit)
++                ):
++                    expert = Int32(raw_expert)
++                    weight = Float32(topk_weights[route_slot])
++                staged_ids[route_slot] = expert
++                staged_weights[route_slot] = weight
++                route_slot += Int32(self.launch_block_dim)
++            cute.arch.sync_threads()
++            topk_ids = staged_ids
++            topk_weights = staged_weights
+         if cutlass.const_expr(self.compile_time_phase == 2):
+             self._run_fc2(
+                 Int32(bidx_x),
+@@ -2412,6 +2486,7 @@ class MoEMicroKernelBackend:
+                 intermediate,
+                 topk_ids,
+                 topk_weights,
++                route_expert_limit,
+                 scatter_output,
+                 trellis_lut,
+             )
+@@ -5500,6 +5575,7 @@ class MoEMicroKernelBackend:
+             intermediate,
+             topk_ids,
+             topk_weights,
++            route_expert_limit,
+             scatter_output,
+             trellis_lut,
+         )
+@@ -5631,6 +5707,7 @@ class MoEMicroKernelBackend:
+         intermediate: cute.Tensor,
+         topk_ids: cute.Tensor,
+         topk_weights: cute.Tensor,
++        route_expert_limit: Int32,
+         scatter_output: cute.Tensor,
+         trellis_lut: cute.Tensor,
+     ):
+@@ -5674,6 +5751,7 @@ class MoEMicroKernelBackend:
+                             w2_alphas,
+                             topk_ids,
+                             topk_weights,
++                            route_expert_limit,
+                             scatter_output,
+                         )
+                     else:
+@@ -5687,6 +5765,7 @@ class MoEMicroKernelBackend:
+                             w2_alphas,
+                             topk_ids,
+                             topk_weights,
++                            route_expert_limit,
+                             scatter_output,
+                         )
+             else:
+@@ -5703,6 +5782,7 @@ class MoEMicroKernelBackend:
+                             w2_alphas,
+                             topk_ids,
+                             topk_weights,
++                            route_expert_limit,
+                             scatter_output,
+                         )
+                     else:
+@@ -5716,6 +5796,7 @@ class MoEMicroKernelBackend:
+                             w2_alphas,
+                             topk_ids,
+                             topk_weights,
++                            route_expert_limit,
+                             scatter_output,
+                         )
+                     fc2_task += Int32(gdim_x)
+@@ -5740,6 +5821,7 @@ class MoEMicroKernelBackend:
+                         w2_alphas,
+                         topk_ids,
+                         topk_weights,
++                        route_expert_limit,
+                         scatter_output,
+                     )
+                 elif cutlass.const_expr(cfg.fc2_n_chunks > 1):
+@@ -5753,6 +5835,7 @@ class MoEMicroKernelBackend:
+                         w2_alphas,
+                         topk_ids,
+                         topk_weights,
++                        route_expert_limit,
+                         scatter_output,
+                     )
+                 else:
+@@ -5766,6 +5849,7 @@ class MoEMicroKernelBackend:
+                         w2_alphas,
+                         topk_ids,
+                         topk_weights,
++                        route_expert_limit,
+                         scatter_output,
+                     )
+                 fc2_task += Int32(gdim_x)
+@@ -5788,6 +5872,7 @@ class MoEMicroKernelBackend:
+         out_ptr: cute.Pointer,
+         barrier_count: cute.Tensor,
+         barrier_epoch: cute.Tensor,
++        route_expert_limit: Int32,
+         m_val: Int32,
+         grid_x: Int32,
+         stream,
+@@ -5888,6 +5973,7 @@ class MoEMicroKernelBackend:
+                 if cutlass.const_expr(trellis_rot_ptr is not None)
+                 else barrier_count
+             ),
++            route_expert_limit,
+             m_val,
+         ).launch(
+             grid=(grid_x, Int32(1), Int32(1)),
+@@ -5950,6 +6036,7 @@ class MoEMicroKernelBackend:
+             ptr(cutlass.BFloat16, out),
+             barrier_count,
+             barrier_epoch,
++            Int32(w1_alphas.numel()),
+             Int32(m),
+             Int32(grid_x),
+             stream,
+diff --git a/b12x/moe/_shared/kernels/w4a16/kernel.py b/b12x/moe/_shared/kernels/w4a16/kernel.py
+index 46938eb1abed8dd21140ab1f34d464cfa9f7b1b7..3bbc5b2f92b31ef4a157d7031e9c8fcdaa9b983c 100644
+--- a/b12x/moe/_shared/kernels/w4a16/kernel.py
++++ b/b12x/moe/_shared/kernels/w4a16/kernel.py
+@@ -771,6 +771,9 @@ class MoEMicroKernelW4A16SmallMDirect(MoEMicroKernelBackend):
+             swiglu_beta=swiglu_beta,
+             w13_layout=w13_layout,
+             compile_time_phase=compile_time_phase,
++            # Fused direct launches have a compile-time route-table extent.
++            # FC2-only uses runtime M and sanitizes each route inside FC2.
++            stage_inactive_routes=int(compile_time_phase) != 2,
+         )
+ 
+ 
+@@ -9191,12 +9194,13 @@ def _compile_w4a16_small_m_direct(
+         dummy(cutlass.BFloat16),
+         barrier_fake,
+         barrier_fake,
++        Int32(num_experts),
+         Int32(m),
+         Int32(kernel.grid_x),
+         current_cuda_stream(),
+         compile_spec=KernelCompileSpec.from_facts(
+             "moe.w4a16.small_m_direct",
+-            1,
++            2,
+             ("device_index", None if device is None else int(device.index or 0)),
+             ("m", int(m)),
+             ("hidden_size", int(hidden_size)),
+@@ -9328,12 +9332,13 @@ def _compile_w4a16_fc2_direct(
+         dummy(cutlass.BFloat16),
+         barrier_fake,
+         barrier_fake,
++        Int32(expert_capacity),
+         Int32(2),
+         Int32(kernel.grid_x),
+         current_cuda_stream(),
+         compile_spec=KernelCompileSpec.from_facts(
+             "moe.w4a16.fc2_direct",
+-            3,
++            4,
+             ("device_index", int(device.index or 0)),
+             ("hidden_size", int(hidden_size)),
+             ("intermediate_size", int(intermediate_size)),
+@@ -10544,6 +10549,7 @@ def _w4a16_small_m_direct_launch_flat(
+         ptr(cutlass.BFloat16, output),
+         barrier_count,
+         barrier_epoch,
++        Int32(num_experts),
+         Int32(m),
+         Int32(direct_launch.grid_x),
+         cuda.CUstream(stream_int),
+@@ -10691,6 +10697,7 @@ def _w4a16_fc2_direct_launch_flat(
+         ptr(cutlass.BFloat16, output),
+         barrier_count,
+         barrier_epoch,
++        Int32(num_experts),
+         Int32(m),
+         Int32(launch.grid_x),
+         cuda.CUstream(stream_int),
+diff --git a/b12x/moe/_shared/kernels/w4a16/route_pack.py b/b12x/moe/_shared/kernels/w4a16/route_pack.py
+index 9b05f7f68a7801d624b67c0697949161e09e210f..faaad8817dfb484e1d3f770c8a9593f1bf7fcbc5 100644
+--- a/b12x/moe/_shared/kernels/w4a16/route_pack.py
++++ b/b12x/moe/_shared/kernels/w4a16/route_pack.py
+@@ -77,6 +77,22 @@ def _next_power_of_2(x: int) -> int:
+     return 1 << (int(x) - 1).bit_length()
+ 
+ 
++def _numel_capacity_for_route_workspace(
++    packed_routes: int,
++    route_blocks: int,
++    block_size: int,
++    num_experts: int,
++) -> int:
++    """Recover the largest live route count covered by a fixed workspace."""
++    block_size = int(block_size)
++    num_experts = int(num_experts)
++    padded_slots = min(int(packed_routes), int(route_blocks) * block_size)
++    fully_padded_experts = num_experts * block_size
++    if padded_slots <= fully_padded_experts:
++        return padded_slots // block_size
++    return padded_slots - num_experts * (block_size - 1)
++
++
+ def _workspace_slice(
+     tensor: torch.Tensor | None,
+     *,
+@@ -289,22 +305,54 @@ def pack_topk_routes_by_expert(
+         int(num_experts),
+         topk=topk,
+     )
+-    if packed_route_indices is not None and block_expert_ids is not None:
++    provided_routes = (
++        None if packed_route_indices is None else int(packed_route_indices.numel())
++    )
++    provided_blocks = (
++        None if block_expert_ids is None else int(block_expert_ids.numel())
++    )
++    if (
++        provided_routes is not None
++        and provided_blocks is not None
++        and (
++            provided_routes < capacity_packed_routes
++            or provided_blocks < capacity_route_blocks
++        )
++    ):
++        (
++            exact_numel_capacity,
++            exact_packed_routes,
++            exact_route_blocks,
++        ) = route_pack_capacity(
++            numel,
++            int(block_size),
++            int(num_experts),
++            topk=topk,
++            bucket_tokens=False,
++        )
+         if (
+-            int(packed_route_indices.numel()) < capacity_packed_routes
+-            or int(block_expert_ids.numel()) < capacity_route_blocks
++            provided_routes >= exact_packed_routes
++            and provided_blocks >= exact_route_blocks
+         ):
+-            (
+-                numel_capacity,
+-                capacity_packed_routes,
+-                capacity_route_blocks,
+-            ) = route_pack_capacity(
+-                numel,
++            # A serving caller can own one fixed arena sized for its configured
++            # maximum while a live prefill tail belongs to a larger power-of-two
++            # bucket. Reuse the full caller capacity instead of specializing each
++            # exact tail. The small-prefix and post-prefix kernels fill unused
++            # route slots with ``live_numel`` and unused blocks with ``-1``. The
++            # recovered live-route capacity also keeps the small-prefix loop bound
++            # stable without changing the caller's allocation or route semantics.
++            numel_capacity = _numel_capacity_for_route_workspace(
++                provided_routes,
++                provided_blocks,
+                 int(block_size),
+                 int(num_experts),
+-                topk=topk,
+-                bucket_tokens=False,
+             )
++            capacity_packed_routes = provided_routes
++            capacity_route_blocks = provided_blocks
++        else:
++            numel_capacity = exact_numel_capacity
++            capacity_packed_routes = exact_packed_routes
++            capacity_route_blocks = exact_route_blocks
+     max_packed_routes = capacity_packed_routes
+     max_route_blocks = capacity_route_blocks
+     max_packed_routes = max(max_packed_routes, 1)
+diff --git a/b12x/moe/fused_moe/_impl.py b/b12x/moe/fused_moe/_impl.py
+index 72b29a82a1184ab0b87c08b828f2405379fe8835..0f1f2e42721da3aa45ad1feb9280a253f8c138a5 100644
+--- a/b12x/moe/fused_moe/_impl.py
++++ b/b12x/moe/fused_moe/_impl.py
+@@ -8361,6 +8361,7 @@ def _get_micro_kernel(
+         dummy(cutlass.BFloat16),  # out_ptr
+         barrier_fake,  # barrier_count
+         barrier_fake,  # barrier_epoch
++        Int32(weight_E),  # route_expert_limit
+         Int32(compile_m),  # m_val
+         Int32(1),  # grid_x
+         current_cuda_stream(),  # stream
+diff --git a/tests/moe/test_w4a16_e2e.py b/tests/moe/test_w4a16_e2e.py
+index af83fe89c26c7680e5149ef8f9d1c66700bca328..4583de5cc1a4ff666f4743cffea2b8d51136711a 100644
+--- a/tests/moe/test_w4a16_e2e.py
++++ b/tests/moe/test_w4a16_e2e.py
+@@ -62,6 +62,19 @@ def test_w4a16_small_m_host_barrier_reset_kill_switch(
+     assert not _small_m_direct_host_barrier_reset_enabled()
+ 
+ 
++def test_w4a16_fc2_runtime_m_does_not_use_fixed_route_staging() -> None:
++    kernel = MoEMicroKernelW4A16SmallMDirect(
++        activation="silu",
++        fast_math=False,
++        share_input_across_experts=False,
++        share_expert_scales=True,
++        single_token=False,
++        scale_format="e8m0_k32",
++        compile_time_phase=2,
++    )
++    assert not kernel.stage_inactive_routes
++
++
+ @pytest.mark.skipif(not torch.cuda.is_available(), reason="requires CUDA")
+ @pytest.mark.parametrize("host_barrier_reset", [False, True])
+ def test_w4a16_small_m_direct_barrier_modes_eager_and_graph(
+@@ -1084,6 +1097,163 @@ def test_w4a16_e8m0_native_micro_matches_raw_e8m0_oracle(
+         _assert_matches_oracle(buffers.output, expected, activation=activation)
+ 
+ 
++@pytest.mark.skipif(not torch.cuda.is_available(), reason="requires CUDA")
++@pytest.mark.parametrize(
++    ("m", "route_ids_dtype"),
++    [
++        (1, torch.int32),
++        (2, torch.int32),
++        (4, torch.int32),
++        (8, torch.int32),
++        (1, torch.int64),
++    ],
++)
++def test_w4a16_e8m0_native_micro_ignores_inactive_routes_during_graph_replay(
++    m: int,
++    route_ids_dtype: torch.dtype,
++    monkeypatch: pytest.MonkeyPatch,
++) -> None:
++    """Native small-M execution must not address weights for inactive routes."""
++    import b12x.moe._shared.kernels.w4a16.kernel as w4a16_kernel
++
++    monkeypatch.setenv("B12X_W4A16_SMALL_M_DIRECT", "1")
++    direct_launches = 0
++    real_direct_launch = w4a16_kernel._w4a16_small_m_direct_launch_flat
++
++    def spy_direct_launch(*args, **kwargs) -> None:
++        nonlocal direct_launches
++        direct_launches += 1
++        real_direct_launch(*args, **kwargs)
++
++    monkeypatch.setattr(
++        w4a16_kernel,
++        "_w4a16_small_m_direct_launch_flat",
++        spy_direct_launch,
++    )
++    experts, hidden_size, intermediate_size = 4, 128, 192
++    topk, activation = 2, "situ"
++    rows = 2 * intermediate_size
++    torch.manual_seed(20260817 + m)
++    w13 = torch.randint(
++        0,
++        256,
++        (experts, rows, hidden_size // 2),
++        dtype=torch.uint8,
++        device="cuda",
++    )
++    w2 = torch.randint(
++        0,
++        256,
++        (experts, hidden_size, intermediate_size // 2),
++        dtype=torch.uint8,
++        device="cuda",
++    )
++    w13_scale = _pattern_e8m0((experts, rows, hidden_size // 32))
++    w2_scale = _pattern_e8m0((experts, hidden_size, intermediate_size // 32), offset=1)
++    global_scale = torch.ones(experts, dtype=torch.float32, device="cuda")
++    prepared = prepare_w4a16_e8m0_native_weights(
++        w13,
++        w13_scale,
++        global_scale,
++        w2,
++        w2_scale,
++        global_scale,
++        activation=activation,
++        params_dtype=torch.bfloat16,
++        w13_layout="w31",
++    )
++    buffers = make_w4a16_buffers(
++        prepared,
++        m=m,
++        topk=topk,
++        dtype=torch.bfloat16,
++        device=torch.device("cuda"),
++    )
++    fc2_n_chunks = ((intermediate_size // 2) + 127) // 128
++    intermediate_cache2 = torch.zeros(
++        2 * m * fc2_n_chunks * 128 * topk,
++        dtype=torch.bfloat16,
++        device="cuda",
++    )
++    inputs = torch.randn(m, hidden_size, dtype=torch.bfloat16, device="cuda")
++    topk_ids = torch.randint(
++        0, experts, (m, topk), dtype=route_ids_dtype, device="cuda"
++    )
++    topk_weights = torch.rand(m, topk, dtype=torch.float32, device="cuda")
++
++    def launch() -> torch.Tensor:
++        return run_w4a16_moe(
++            inputs,
++            prepared,
++            topk_weights,
++            topk_ids,
++            activation=activation,
++            intermediate_cache13=buffers.intermediate_cache13,
++            intermediate_cache2=intermediate_cache2,
++            output=buffers.output,
++            fc1_c_tmp=buffers.fc1_c_tmp,
++            fc2_c_tmp=buffers.fc2_c_tmp,
++            packed_route_indices=buffers.packed_route_indices,
++            block_expert_ids=buffers.block_expert_ids,
++            packed_route_count=buffers.packed_route_count,
++            expert_offsets=buffers.expert_offsets,
++        )
++
++    valid_eager = launch().clone()
++    torch.cuda.synchronize()
++    assert direct_launches == 1
++    assert bool(torch.isfinite(valid_eager).all().item())
++    assert bool((valid_eager.abs().sum(dim=1) > 0).all().item())
++    graph = torch.cuda.CUDAGraph()
++    with torch.cuda.graph(graph):
++        captured = launch()
++    assert direct_launches == 2
++
++    inactive_ids = topk_ids.clone()
++    invalid_upper = 1 << 32 if route_ids_dtype == torch.int64 else experts
++    inactive_ids[-1] = torch.tensor(
++        [-1, invalid_upper], dtype=route_ids_dtype, device="cuda"
++    )
++    if m > 1:
++        inactive_ids[0, 0] = -1
++    topk_ids.copy_(inactive_ids)
++    original_weights = topk_weights.clone()
++    active = (inactive_ids >= 0) & (inactive_ids < experts)
++    reference_ids = torch.where(active, inactive_ids, torch.zeros_like(inactive_ids))
++    reference_weights = torch.where(
++        active, topk_weights, torch.zeros_like(topk_weights)
++    )
++    expected = moe_reference_w4a16_fp4_e8m0_k32(
++        inputs,
++        w13,
++        w13_scale,
++        global_scale,
++        w2,
++        w2_scale,
++        global_scale,
++        reference_ids,
++        reference_weights,
++        experts,
++        hidden_size,
++        intermediate_size,
++        activation=activation,
++        w13_layout="w31",
++    )
++
++    eager = launch().clone()
++    torch.cuda.synchronize()
++    _assert_matches_oracle(eager, expected, activation=activation)
++    torch.testing.assert_close(eager[-1], torch.zeros_like(eager[-1]), rtol=0, atol=0)
++
++    captured.fill_(float("nan"))
++    graph.replay()
++    torch.cuda.synchronize()
++    assert bool(torch.isfinite(captured).all().item())
++    torch.testing.assert_close(captured, eager, rtol=0, atol=0)
++    torch.testing.assert_close(topk_ids, inactive_ids, rtol=0, atol=0)
++    torch.testing.assert_close(topk_weights, original_weights, rtol=0, atol=0)
++
++
+ @pytest.mark.skipif(not torch.cuda.is_available(), reason="requires CUDA")
+ def test_w4a16_e8m0_native_aligned_generic_fc1_uses_k32_scale_stride() -> None:
+     """K/32 scales keep their native expert stride in aligned generic FC1."""
+@@ -3268,15 +3438,11 @@ def test_w4a16_fc2_only_is_cuda_graph_safe_with_preallocated_output() -> None:
+     intermediate = torch.ones(
+         (routes, intermediate_size), dtype=torch.bfloat16, device="cuda"
+     )
+-    route_ids = torch.tensor(
+-        [0, 1, 2, 3, 4, 0, 2], dtype=torch.int32, device="cuda"
+-    )
++    route_ids = torch.tensor([0, 1, 2, 3, 4, 0, 2], dtype=torch.int32, device="cuda")
+     route_weights = torch.linspace(
+         0.125, 0.875, routes, dtype=torch.float32, device="cuda"
+     )
+-    output = torch.empty(
+-        (routes, hidden_size), dtype=torch.bfloat16, device="cuda"
+-    )
++    output = torch.empty((routes, hidden_size), dtype=torch.bfloat16, device="cuda")
+ 
+     prepared = prepare_w4a16_fc2_e8m0(w2, scales)
+     prewarm_w4a16_fc2_e8m0(prepared, route_ids_dtype=torch.int32)

--- a/patches/releases/kimi-k3-qsrt-tp8-safety/lmcache/integration.lock.json
+++ b/patches/releases/kimi-k3-qsrt-tp8-safety/lmcache/integration.lock.json
@@ -1,0 +1,21 @@
+{
+  "base": {
+    "commit": "a128b2e286ebb3556cb43124149e600ff99fe481",
+    "ref": "refs/heads/release/v0.5.2-glm52-dcp-base",
+    "repository": "https://github.com/local-inference-lab/LMCache.git"
+  },
+  "composition": null,
+  "composition_strategy": "merge",
+  "manifest": {
+    "sha256": "23c11407f114554da63e7e2018f3f358cce15a7258f015d4ed5bb53235167b11"
+  },
+  "name": "kimi-k3-production-lmcache",
+  "pull_requests": [],
+  "result": {
+    "patch": "integration.patch",
+    "patch_sha256": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+    "tree": "e045d729bc5c4c63a40e13d032f42923de97812f"
+  },
+  "schema_version": 1,
+  "source_patches": []
+}

--- a/patches/releases/kimi-k3-qsrt-tp8-safety/vllm/integration.lock.json
+++ b/patches/releases/kimi-k3-qsrt-tp8-safety/vllm/integration.lock.json
@@ -1,0 +1,125 @@
+{
+  "base": {
+    "commit": "6dc2f516688fe6f84c6994dcd20fddf296853a6c",
+    "ref": "refs/heads/dev/infernal-invocation",
+    "repository": "https://github.com/local-inference-lab/vllm.git"
+  },
+  "composition": {
+    "commit": "86529c1ec06d5db98a14e1e6a9fde1f40a0d069b",
+    "ref": "refs/heads/agent/kimi-k3-production-sampler-overlay-20260819"
+  },
+  "composition_strategy": "pinned_branch",
+  "manifest": {
+    "sha256": "85f1c1918426f52142effb7035d2552124f6e229306e4400fba1a332c4de5a1c"
+  },
+  "name": "kimi-k3-production-vllm",
+  "pull_requests": [
+    {
+      "commits": [
+        "f85d3d87e196546eff162c2a61b49aab13f2e625"
+      ],
+      "disposition": "recorded_in_composition",
+      "head": "f85d3d87e196546eff162c2a61b49aab13f2e625",
+      "number": 310,
+      "ref": "refs/pull/310/head",
+      "title": "Preserve replicated DFlash-family draft semantics under DCP"
+    },
+    {
+      "commits": [
+        "3ebc8967dab28a9df103d8c66bff9688525263bc"
+      ],
+      "disposition": "recorded_in_composition",
+      "head": "3ebc8967dab28a9df103d8c66bff9688525263bc",
+      "number": 413,
+      "ref": "refs/pull/413/head",
+      "title": "Stream Kimi-K3 tool arguments incrementally"
+    },
+    {
+      "commits": [
+        "990a63debf7201ae5446436a712609fcc8ffaef7"
+      ],
+      "disposition": "recorded_in_composition",
+      "head": "990a63debf7201ae5446436a712609fcc8ffaef7",
+      "number": 414,
+      "ref": "refs/pull/414/head",
+      "title": "Preserve Mamba CoW after external prefix hits"
+    },
+    {
+      "commits": [
+        "c805ebd0896ccfbd2569bc0b2a7944d3282106ff"
+      ],
+      "disposition": "recorded_in_composition",
+      "head": "c805ebd0896ccfbd2569bc0b2a7944d3282106ff",
+      "number": 415,
+      "ref": "refs/pull/415/head",
+      "title": "Preserve the DSpark CUDA-graph capture contract"
+    },
+    {
+      "commits": [
+        "6b18a8a767f406f08a519757ca6d5ef118b18296"
+      ],
+      "disposition": "recorded_in_composition",
+      "head": "6b18a8a767f406f08a519757ca6d5ef118b18296",
+      "number": 418,
+      "ref": "refs/pull/418/head",
+      "title": "Keep recurrent cache position state unsharded under DCP"
+    },
+    {
+      "commits": [
+        "04a6acfe467f4a208c7231a18fc99faf656d016a"
+      ],
+      "disposition": "recorded_in_composition",
+      "head": "04a6acfe467f4a208c7231a18fc99faf656d016a",
+      "number": 419,
+      "ref": "refs/pull/419/head",
+      "title": "Keep Kimi K3 protocol markers out of streamed content"
+    },
+    {
+      "commits": [
+        "6bafa633153a44ba1aa54eb7c5bafac248fe68e6"
+      ],
+      "disposition": "recorded_in_composition",
+      "head": "3c296be28b31dba5c4a0ced714d2e21dabe246af",
+      "number": 422,
+      "ref": "refs/pull/422/head",
+      "title": "Handle KV load failures across hybrid cache groups"
+    },
+    {
+      "commits": [
+        "0ad95065da12e45c28d585d8c758a87d3a708b1f"
+      ],
+      "disposition": "recorded_in_composition",
+      "head": "0ad95065da12e45c28d585d8c758a87d3a708b1f",
+      "number": 427,
+      "ref": "refs/pull/427/head",
+      "title": "Materialize Kimi-K3 interleaved MLA decode queries"
+    },
+    {
+      "commits": [
+        "45962db4c38a0e430450a087843fc2762a38beb4"
+      ],
+      "disposition": "recorded_in_composition",
+      "head": "45962db4c38a0e430450a087843fc2762a38beb4",
+      "number": 428,
+      "ref": "refs/pull/428/head",
+      "title": "Warm Kimi vision interpolation before KV allocation"
+    },
+    {
+      "commits": [
+        "9151d114e270250fb0367333b2dc5a49c6383796"
+      ],
+      "disposition": "recorded_in_composition",
+      "head": "9151d114e270250fb0367333b2dc5a49c6383796",
+      "number": 433,
+      "ref": "refs/pull/433/head",
+      "title": "Enforce cached MRV2 logits-processing state"
+    }
+  ],
+  "result": {
+    "patch": "integration.patch",
+    "patch_sha256": "44afa8afe0f191c39bff9df1a3b223ad690a8e792033facefbcf01159c2b8bab",
+    "tree": "12776c0df15ca4087b636c43004b5bc1fde61434"
+  },
+  "schema_version": 1,
+  "source_patches": []
+}

--- a/patches/releases/kimi-k3-qsrt-tp8-safety/vllm/integration.patch
+++ b/patches/releases/kimi-k3-qsrt-tp8-safety/vllm/integration.patch
@@ -1,0 +1,2079 @@
+diff --git a/tests/models/kimi_k3/test_vision_warmup.py b/tests/models/kimi_k3/test_vision_warmup.py
+new file mode 100644
+index 0000000000000000000000000000000000000000..7fc562b31fd3b8f76c76fc2dac3a675c2a9bc0a4
+--- /dev/null
++++ b/tests/models/kimi_k3/test_vision_warmup.py
+@@ -0,0 +1,59 @@
++# SPDX-License-Identifier: Apache-2.0
++# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
++
++from types import SimpleNamespace
++from unittest.mock import Mock
++
++import torch
++
++from vllm.model_executor.models import kimi_k25_vit
++from vllm.model_executor.warmup import kimi_k3_triton_warmup
++from vllm.model_executor.warmup.kimi_k3_triton_warmup import (
++    _warm_vision_position_interpolation,
++)
++
++
++def test_warm_vision_position_interpolation(monkeypatch) -> None:
++    model = torch.nn.Sequential(
++        kimi_k25_vit.Learnable2DInterpPosEmbDivided_fixed(
++            height=14,
++            width=14,
++            num_frames=4,
++            dim=32,
++        )
++    )
++    get_rope_shape = Mock(return_value=torch.empty(64 * 64, 32))
++    monkeypatch.setattr(kimi_k25_vit, "get_rope_shape", get_rope_shape)
++
++    assert _warm_vision_position_interpolation(model) == 1
++    get_rope_shape.assert_called_once_with(
++        model[0].weight,
++        interpolation_mode="bicubic",
++        shape=(64, 64),
++    )
++
++
++def test_warm_vision_position_interpolation_ignores_other_modules() -> None:
++    assert _warm_vision_position_interpolation(torch.nn.Linear(2, 2)) == 0
++
++
++def test_kimi_warmup_runs_vision_before_kda_state_exists(monkeypatch) -> None:
++    model = torch.nn.Linear(2, 2)
++    calls = []
++    warm_vision = Mock(side_effect=lambda model: calls.append("vision") or 1)
++    get_kda_layer = Mock(side_effect=lambda worker: calls.append("kda"))
++    monkeypatch.setattr(kimi_k3_triton_warmup.current_platform, "is_cuda", lambda: True)
++    monkeypatch.setattr(
++        kimi_k3_triton_warmup,
++        "_warm_vision_position_interpolation",
++        warm_vision,
++    )
++    monkeypatch.setattr(kimi_k3_triton_warmup, "_get_kda_layer", get_kda_layer)
++
++    kimi_k3_triton_warmup.kimi_k3_triton_warmup(
++        SimpleNamespace(get_model=lambda: model)
++    )
++
++    warm_vision.assert_called_once_with(model)
++    get_kda_layer.assert_called_once()
++    assert calls == ["vision", "kda"]
+diff --git a/tests/reasoning/test_kimi_k3_reasoning_parser.py b/tests/reasoning/test_kimi_k3_reasoning_parser.py
+index 4f831e851e9b6ed6ef6b028e5ae0faca7dfac4fa..83ee0b5d0951e0f58074d0ee2d56e94b914fe649 100644
+--- a/tests/reasoning/test_kimi_k3_reasoning_parser.py
++++ b/tests/reasoning/test_kimi_k3_reasoning_parser.py
+@@ -52,6 +52,7 @@ def test_parser_selection_thinking_disabled():
+     )
+ 
+     assert parser._thinking_enabled is False
++    assert parser.thinking_enabled is False
+ 
+ 
+ def test_extract_reasoning_with_xtml_tags():
+@@ -119,6 +120,103 @@ def test_is_reasoning_end_ignores_stale_close_from_prior_turn():
+     assert not parser.is_reasoning_end([*new_open])
+ 
+ 
++def test_fresh_assistant_prompt_does_not_inherit_closed_reasoning():
++    parser = KimiK3ReasoningParser(
++        DummyTokenizer(),
++        chat_template_kwargs={
++            "thinking": True,
++            "add_generation_prompt": True,
++            "continue_final_message": False,
++        },
++    )
++
++    assert not parser.is_reasoning_end_for_prompt(CLOSE_IDS)
++
++
++def test_continued_assistant_prompt_uses_rendered_reasoning_state():
++    parser = KimiK3ReasoningParser(
++        DummyTokenizer(),
++        chat_template_kwargs={
++            "thinking": True,
++            "add_generation_prompt": False,
++            "continue_final_message": True,
++        },
++    )
++
++    assert parser.is_reasoning_end_for_prompt(CLOSE_IDS)
++    assert not parser.is_reasoning_end_for_prompt(OPEN_IDS)
++
++
++def test_fresh_assistant_stream_classifies_first_tokens_as_reasoning():
++    parser = ReasoningOnlyParser(
++        DummyTokenizer(),
++        chat_template_kwargs={
++            "thinking": True,
++            "add_generation_prompt": True,
++        },
++    )
++    request = ChatCompletionRequest(model="test-model", messages=[])
++
++    first = parser.parse_delta(
++        delta_text=".",
++        delta_token_ids=[9],
++        request=request,
++        prompt_token_ids=CLOSE_IDS,
++        finished=False,
++    )
++    partial_close = parser.parse_delta(
++        delta_text=f"{CLOSE}think",
++        delta_token_ids=CLOSE_IDS[:2],
++        request=request,
++        prompt_token_ids=CLOSE_IDS,
++        finished=False,
++    )
++    closed = parser.parse_delta(
++        delta_text=f"{SEP}{RESPONSE_OPEN}",
++        delta_token_ids=[CLOSE_IDS[2], 10],
++        request=request,
++        prompt_token_ids=CLOSE_IDS,
++        finished=False,
++    )
++
++    assert first is not None
++    assert first.reasoning == "."
++    assert first.content is None
++    assert partial_close is None
++    assert closed is None
++
++
++def test_content_filter_holds_and_removes_split_protocol_markers():
++    parser = ReasoningOnlyParser(
++        DummyTokenizer(),
++        chat_template_kwargs={
++            "thinking": True,
++            "add_generation_prompt": False,
++            "continue_final_message": True,
++        },
++    )
++    request = ChatCompletionRequest(model="test-model", messages=[])
++    chunks = [".", f"{CLOSE}think", SEP, RESPONSE_OPEN]
++    messages: list[DeltaMessage] = []
++
++    for index, chunk in enumerate(chunks):
++        delta = parser.parse_delta(
++            delta_text=chunk,
++            delta_token_ids=[9 + index],
++            request=request,
++            prompt_token_ids=CLOSE_IDS,
++            finished=index == len(chunks) - 1,
++        )
++        if delta is not None:
++            messages.append(delta)
++
++    content = "".join(message.content or "" for message in messages)
++    assert content == "."
++    assert OPEN not in content
++    assert CLOSE not in content
++    assert SEP not in content
++
++
+ def test_streaming_split_open_marker_is_held_back():
+     parser = KimiK3ReasoningParser(DummyTokenizer())
+ 
+diff --git a/tests/tool_use/test_kimi_k3_tool_parser.py b/tests/tool_use/test_kimi_k3_tool_parser.py
+index 118c51db574e5511d4659e93dd57ec4058c3f7d6..43f29edfc32a7a9a165e497a39899f8fb27d23d5 100644
+--- a/tests/tool_use/test_kimi_k3_tool_parser.py
++++ b/tests/tool_use/test_kimi_k3_tool_parser.py
+@@ -171,6 +171,48 @@ def test_delegating_parser_preserves_tool_calls_after_reasoning():
+     assert json.loads(tool_calls[0].arguments) == {"x": 1}
+ 
+ 
++def test_fresh_tool_stream_does_not_inherit_closed_reasoning():
++    parser = KimiK3DelegatingParser(
++        DummyTokenizer(),
++        chat_template_kwargs={
++            "thinking": True,
++            "add_generation_prompt": True,
++        },
++    )
++    request = _request()
++    messages: list[DeltaMessage] = []
++    chunks = [
++        (".", [9]),
++        (f"{CLOSE}think", [4, 2]),
++        (
++            f"{SEP}{_response('')}{_tools(_call('calc', 1))}",
++            [3, 10],
++        ),
++    ]
++
++    for index, (text, token_ids) in enumerate(chunks):
++        delta = parser.parse_delta(
++            delta_text=text,
++            delta_token_ids=token_ids,
++            request=request,
++            prompt_token_ids=[4, 2, 3],
++            finished=index == len(chunks) - 1,
++        )
++        if delta is not None:
++            messages.append(delta)
++
++    reasoning = "".join(message.reasoning or "" for message in messages)
++    content = "".join(message.content or "" for message in messages)
++    tool_calls = [call for message in messages for call in (message.tool_calls or [])]
++    assert reasoning == "."
++    assert content == ""
++    assert len(tool_calls) == 1
++    assert tool_calls[0].function.name == "calc"
++    assert OPEN not in reasoning + content
++    assert CLOSE not in reasoning + content
++    assert SEP not in reasoning + content
++
++
+ def test_delegating_parser_required_tool_choice_uses_xtml_parser():
+     parser = KimiK3DelegatingParser(DummyTokenizer())
+     request = _request().model_copy(update={"tool_choice": "required"})
+@@ -361,9 +403,141 @@ def test_streaming_split_markers_do_not_leak():
+     assert content == "Hi"
+     assert OPEN not in content
+     assert SEP not in content
+-    assert len(tool_deltas) == 1
+-    assert tool_deltas[0].function.name == "calc"
+-    assert json.loads(tool_deltas[0].function.arguments) == {"x": 1}
++    assert [tool_call.function.name for tool_call in tool_deltas if tool_call.id] == [
++        "calc"
++    ]
++    arguments = "".join(tool_call.function.arguments or "" for tool_call in tool_deltas)
++    assert json.loads(arguments) == {"x": 1}
++
++
++def test_streaming_emits_argument_text_as_it_arrives():
++    """A long string argument must stream, not land in one delta at the close."""
++    parser = KimiK3ToolParser(DummyTokenizer())
++    request = _request()
++    value = "word " * 200
++    body_chunks = [value[i : i + 5] for i in range(0, len(value), 5)]
++    chunks = [
++        f"{OPEN}tools{SEP}",
++        f'{OPEN}call tool="write_file" index="1"{SEP}',
++        f'{OPEN}argument key="content" type="string"{SEP}',
++        *body_chunks,
++        f"{CLOSE}argument{SEP}",
++        f"{CLOSE}call{SEP}",
++    ]
++    previous_text = ""
++    previous_ids: list[int] = []
++    messages: list[DeltaMessage] = []
++    arguments_before_close = ""
++
++    for i, chunk in enumerate(chunks, start=1):
++        if chunk == f"{CLOSE}argument{SEP}":
++            arguments_before_close = "".join(
++                tool_call.function.arguments or ""
++                for message in messages
++                for tool_call in (message.tool_calls or [])
++            )
++        current_text = previous_text + chunk
++        current_ids = previous_ids + [i]
++        delta = parser.extract_tool_calls_streaming(
++            previous_text=previous_text,
++            current_text=current_text,
++            delta_text=chunk,
++            previous_token_ids=previous_ids,
++            current_token_ids=current_ids,
++            delta_token_ids=[i],
++            request=request,
++        )
++        if delta is not None:
++            messages.append(delta)
++        previous_text = current_text
++        previous_ids = current_ids
++
++    tool_deltas = [
++        tool_call for message in messages for tool_call in (message.tool_calls or [])
++    ]
++
++    # the name is announced once, up front, and every body chunk moves the stream
++    assert [tool_call.function.name for tool_call in tool_deltas if tool_call.id] == [
++        "write_file"
++    ]
++    assert len(tool_deltas) >= len(body_chunks)
++    assert all(tool_call.index == 0 for tool_call in tool_deltas)
++    assert (
++        arguments_before_close
++        == json.dumps({"content": value}, ensure_ascii=False)[:-2]
++    )
++
++    arguments = "".join(tool_call.function.arguments or "" for tool_call in tool_deltas)
++    assert json.loads(arguments) == {"content": value}
++    non_streamed = parser.extract_tool_calls(previous_text, request)
++    assert arguments == non_streamed.tool_calls[0].function.arguments
++
++
++def test_streaming_holds_whitespace_tolerant_argument_close_fragments():
++    parser = KimiK3ToolParser(DummyTokenizer())
++    request = _request()
++    chunks = [
++        f"{OPEN}tools{SEP}",
++        f'{OPEN}call tool="write_file" index="1"{SEP}',
++        f'{OPEN}argument key="content" type="string"{SEP}',
++        "payload",
++        f"{CLOSE} arg",
++        "ument ",
++        "<|sep",
++        "|>",
++        f"{CLOSE}call{SEP}",
++    ]
++    previous_text = ""
++    previous_ids: list[int] = []
++    streamed_arguments = ""
++    partial_close_snapshots: list[str] = []
++
++    for i, chunk in enumerate(chunks, start=1):
++        current_text = previous_text + chunk
++        current_ids = previous_ids + [i]
++        delta = parser.extract_tool_calls_streaming(
++            previous_text=previous_text,
++            current_text=current_text,
++            delta_text=chunk,
++            previous_token_ids=previous_ids,
++            current_token_ids=current_ids,
++            delta_token_ids=[i],
++            request=request,
++        )
++        if delta is not None:
++            streamed_arguments += "".join(
++                tool_call.function.arguments or ""
++                for tool_call in (delta.tool_calls or [])
++            )
++        if 5 <= i <= 7:
++            partial_close_snapshots.append(streamed_arguments)
++        previous_text = current_text
++        previous_ids = current_ids
++
++    expected_prefix = json.dumps({"content": "payload"}, ensure_ascii=False)[:-2]
++    assert partial_close_snapshots == [expected_prefix] * 3
++    assert json.loads(streamed_arguments) == {"content": "payload"}
++    non_streamed = parser.extract_tool_calls(previous_text, request)
++    assert streamed_arguments == non_streamed.tool_calls[0].function.arguments
++
++
++def test_streaming_ignores_call_shaped_text_after_tools_close():
++    parser = KimiK3ToolParser(DummyTokenizer())
++    request = _request()
++    output = _tools() + _call("calc", 1, _arg("x", "number", "1"))
++
++    delta = parser.extract_tool_calls_streaming(
++        previous_text="",
++        current_text=output,
++        delta_text=output,
++        previous_token_ids=[],
++        current_token_ids=[1],
++        delta_token_ids=[1],
++        request=request,
++    )
++
++    assert delta is None
++    assert parser.extract_tool_calls(output, request).tools_called is False
+ 
+ 
+ def test_tool_call_ids_are_unique_across_messages():
+diff --git a/tests/v1/core/prefix_cache/test_partial_prefix_cache_hits.py b/tests/v1/core/prefix_cache/test_partial_prefix_cache_hits.py
+index 8f43039face2b3a1b5ebbb5a54603c45924ec49a..54e26459ceeb0a160b8926e3b31a56093abb1579 100644
+--- a/tests/v1/core/prefix_cache/test_partial_prefix_cache_hits.py
++++ b/tests/v1/core/prefix_cache/test_partial_prefix_cache_hits.py
+@@ -514,6 +514,79 @@ def test_hybrid_mamba_partial_tail_owner_uses_cow_on_continue():
+     assert moved[0].block_hash_num_tokens == 6
+ 
+ 
++def test_external_mamba_hit_same_block_uses_running_cow_on_continue():
++    """An external mid-block hit must become a running request even when its
++    first continuation does not need another Mamba block."""
++    hash_block_size = 2
++    mamba_block_size = 4 * hash_block_size
++    kv_cache_config = KVCacheConfig(
++        num_blocks=32,
++        kv_cache_tensors=[],
++        kv_cache_groups=[
++            KVCacheGroupSpec(
++                ["full"],
++                FullAttentionSpec(
++                    block_size=hash_block_size,
++                    num_kv_heads=1,
++                    head_size=1,
++                    dtype=torch.float32,
++                ),
++            ),
++            KVCacheGroupSpec(
++                ["mamba"],
++                MambaSpec(
++                    block_size=mamba_block_size,
++                    shapes=(1, 1),
++                    dtypes=(torch.float32,),
++                    mamba_cache_mode="align",
++                ),
++            ),
++        ],
++    )
++    manager = make_kv_cache_manager(
++        kv_cache_config=kv_cache_config,
++        max_model_len=8192,
++        enable_caching=True,
++        hash_block_size=hash_block_size,
++    )
++
++    request = make_request("0", [0] * 15, hash_block_size, sha256)
++    loaded_blocks = manager.allocate_slots(
++        request,
++        num_new_tokens=0,
++        num_external_computed_tokens=10,
++        delay_cache_blocks=True,
++    )
++    assert loaded_blocks is not None
++
++    request.num_computed_tokens = 10
++    first_step_blocks = manager.allocate_slots(request, num_new_tokens=4)
++    assert first_step_blocks is not None
++    assert first_step_blocks.get_block_ids()[1] == []
++
++    source_block_id = manager.get_blocks("0").get_block_ids()[1][1]
++    partial_hash = request.block_hashes[14 // hash_block_size - 1]
++    partial_block = manager.block_pool.get_cached_block(
++        partial_hash, kv_cache_group_ids=[1]
++    )
++    assert partial_block is not None
++    assert partial_block[0].block_id == source_block_id
++
++    request.num_computed_tokens = 14
++    continuation_blocks = manager.allocate_slots(request, num_new_tokens=1)
++    assert continuation_blocks is not None
++
++    assert continuation_blocks.get_block_ids()[1] == []
++    assert manager.get_blocks("0").get_block_ids()[1][1] == source_block_id
++    copies, _ = manager.take_kv_cache_block_copies()
++    cow_copy = next(c for c in copies if c.src_block_id == source_block_id)
++    assert cow_copy.dst_block_id != source_block_id
++
++    moved = manager.block_pool.get_cached_block(partial_hash, kv_cache_group_ids=[1])
++    assert moved is not None
++    assert moved[0].block_id == cow_copy.dst_block_id
++
++
+ def test_take_partial_tail_offloads_returns_cow_target():
+     """The connector offload hand-off exposes the mamba CoW *target* block Y
+     (the durable boundary state), not the overwritten source X, and only at
+diff --git a/tests/v1/core/test_kv_cache_utils.py b/tests/v1/core/test_kv_cache_utils.py
+index fbcb05908e5c5326efb6628b98df6956daec6e66..8ef1c234ef2b29e5d539dbac561585f86d7776f3 100644
+--- a/tests/v1/core/test_kv_cache_utils.py
++++ b/tests/v1/core/test_kv_cache_utils.py
+@@ -58,6 +58,7 @@ from vllm.v1.kv_cache_interface import (
+     SlidingWindowMLASpec,
+     SlidingWindowSpec,
+     UniformTypeKVCacheSpecs,
++    get_kv_cache_dcp_shard_count,
+     get_kv_cache_spec_kind,
+     get_kv_cache_spec_sliding_window,
+ )
+@@ -197,6 +198,16 @@ def new_mamba_spec(
+     )
+ 
+ 
++def test_mamba_cache_has_one_dcp_token_position_shard():
++    spec = new_mamba_spec(block_size=768, num_speculative_blocks=7)
++    vllm_config = SimpleNamespace(
++        cache_config=SimpleNamespace(mamba_cache_mode="align")
++    )
++
++    assert get_kv_cache_dcp_shard_count(spec, dcp_world_size=16) == 1
++    assert spec.max_num_blocks_per_req(vllm_config, max_len=1_000_000) == 1310
++
++
+ def test_unify_kv_cache_spec_page_size_uses_lcm_for_non_divisible_pages():
+     mimo_spec = FullAttentionSpec(
+         block_size=64,
+diff --git a/tests/v1/kv_connector/unit/test_invalid_blocks_correctness.py b/tests/v1/kv_connector/unit/test_invalid_blocks_correctness.py
+index 77d62972977651f0cdee838f5be6c71324025259..9c41bd40782818ded855422eddd6a6d74a2c32d8 100644
+--- a/tests/v1/kv_connector/unit/test_invalid_blocks_correctness.py
++++ b/tests/v1/kv_connector/unit/test_invalid_blocks_correctness.py
+@@ -15,8 +15,18 @@ from collections.abc import Callable
+ from unittest.mock import Mock
+ 
+ import pytest
++import torch
+ 
++from vllm.distributed.kv_transfer.kv_connector.v1.nixl.connector import (
++    NixlBaseConnector,
++)
+ from vllm.v1.core.sched.scheduler import Scheduler
++from vllm.v1.kv_cache_interface import (
++    FullAttentionSpec,
++    KVCacheConfig,
++    KVCacheGroupSpec,
++    SlidingWindowSpec,
++)
+ from vllm.v1.request import FinishReason, Request, RequestStatus
+ 
+ from .utils import (
+@@ -24,6 +34,7 @@ from .utils import (
+     create_request,
+     create_scheduler,
+     create_vllm_config,
++    make_kv_cache_config,
+ )
+ 
+ pytestmark = pytest.mark.cpu_test
+@@ -478,3 +489,299 @@ def test_async_recompute_blocks_not_cached_when_invalid(
+ 
+     # request should be in the running queue
+     assert request in recompute_scheduler.running
++
++
++def test_sync_recompute_handles_invalid_block_in_second_kv_cache_group():
++    """Invalid blocks in any hybrid KV group must trigger recomputation."""
++    block_size = 16
++    num_blocks = 128
++    num_prompt_blocks = 8
++    num_external_computed_blocks = 7
++    invalid_block_idx = 3
++
++    vllm_config = create_vllm_config(
++        block_size=block_size,
++        kv_load_failure_policy="recompute",
++    )
++    scheduler = create_scheduler(
++        vllm_config,
++        num_blocks=num_blocks,
++        kv_cache_config=make_kv_cache_config(
++            block_size=block_size,
++            swa_enabled=True,
++            sw_size=num_prompt_blocks * block_size,
++            num_blocks=num_blocks,
++        ),
++    )
++
++    request = create_request(
++        num_tokens=num_prompt_blocks * block_size,
++        block_size=block_size,
++    )
++    scheduler.add_request(request)
++
++    num_external_computed_tokens = num_external_computed_blocks * block_size
++    scheduler.connector = Mock()
++    scheduler.connector.get_num_new_matched_tokens.side_effect = (
++        _make_get_num_new_matched_tokens(
++            {
++                request.request_id: num_external_computed_tokens,
++            },
++            False,
++        )
++    )
++    scheduler.connector.request_finished.return_value = (False, None)
++    scheduler.connector.request_finished_all_groups.return_value = (
++        False,
++        None,
++    )
++    scheduler.connector.take_events.return_value = ()
++
++    scheduler_output = scheduler.schedule()
++
++    assert request.status == RequestStatus.RUNNING
++    assert len(scheduler_output.scheduled_new_reqs) == 1
++
++    block_ids_by_group = scheduler_output.scheduled_new_reqs[0].block_ids
++    assert len(block_ids_by_group) == 2
++    assert all(
++        len(group_block_ids) > invalid_block_idx
++        for group_block_ids in block_ids_by_group
++    )
++
++    # Report a load failure in the second KV cache group, not the first.
++    invalid_block_id = block_ids_by_group[1][invalid_block_idx]
++    model_runner_output = create_model_runner_output(
++        [request],
++        invalid_block_ids={invalid_block_id},
++        use_eos=False,
++    )
++
++    scheduler.update_from_output(
++        scheduler_output,
++        model_runner_output,
++    )
++
++    assert request.status == RequestStatus.RUNNING
++    assert request.num_computed_tokens == invalid_block_idx * block_size
++    assert request in scheduler.running
++    assert request.request_id in scheduler.requests
++
++
++def test_sync_fail_handles_invalid_block_in_seventeenth_kv_cache_group():
++    """A hybrid-cache load failure must fail one request, not the scheduler."""
++    block_size = 16
++    num_blocks = 512
++    num_prompt_blocks = 8
++    num_external_computed_blocks = 7
++    invalid_block_idx = 3
++    num_kv_cache_groups = 17
++
++    vllm_config = create_vllm_config(
++        block_size=block_size,
++        kv_load_failure_policy="fail",
++    )
++    kv_cache_config = KVCacheConfig(
++        num_blocks=num_blocks,
++        kv_cache_tensors=[],
++        kv_cache_groups=[
++            *[
++                KVCacheGroupSpec(
++                    [f"full_attention_layer_{group_idx}"],
++                    FullAttentionSpec(
++                        block_size=block_size,
++                        num_kv_heads=1,
++                        head_size=1,
++                        dtype=torch.float32,
++                    ),
++                )
++                for group_idx in range(num_kv_cache_groups - 1)
++            ],
++            KVCacheGroupSpec(
++                ["sliding_window_layer"],
++                SlidingWindowSpec(
++                    block_size=block_size,
++                    num_kv_heads=1,
++                    head_size=1,
++                    dtype=torch.float32,
++                    sliding_window=num_prompt_blocks * block_size,
++                ),
++            ),
++        ],
++    )
++    scheduler = create_scheduler(
++        vllm_config,
++        num_blocks=num_blocks,
++        kv_cache_config=kv_cache_config,
++    )
++
++    failed_request = create_request(
++        num_tokens=num_prompt_blocks * block_size,
++        block_size=block_size,
++    )
++    scheduler.add_request(failed_request)
++
++    num_external_computed_tokens = num_external_computed_blocks * block_size
++    scheduler.connector = Mock(spec=NixlBaseConnector)
++    scheduler.connector.get_num_new_matched_tokens.side_effect = (
++        _make_get_num_new_matched_tokens(
++            {
++                failed_request.request_id: num_external_computed_tokens,
++            },
++            False,
++        )
++    )
++    scheduler.connector.request_finished.return_value = (False, None)
++    scheduler.connector.request_finished_all_groups.return_value = (
++        False,
++        None,
++    )
++    scheduler.connector.take_events.return_value = ()
++
++    scheduler_output = scheduler.schedule()
++    block_ids_by_group = scheduler_output.scheduled_new_reqs[0].block_ids
++
++    assert len(block_ids_by_group) == num_kv_cache_groups
++    invalid_block_id = block_ids_by_group[-1][invalid_block_idx]
++    model_runner_output = create_model_runner_output(
++        [failed_request],
++        invalid_block_ids={invalid_block_id},
++        use_eos=False,
++    )
++
++    outputs = scheduler.update_from_output(scheduler_output, model_runner_output)
++
++    assert failed_request.status == RequestStatus.FINISHED_ERROR
++    assert failed_request.request_id not in scheduler.requests
++    assert failed_request not in scheduler.running
++    assert len(outputs) == 1
++    engine_output = next(iter(outputs.values())).outputs[0]
++    assert engine_output.request_id == failed_request.request_id
++    assert engine_output.finish_reason == FinishReason.ERROR
++
++    healthy_request = create_request(
++        num_tokens=2 * block_size,
++        block_size=block_size,
++    )
++    scheduler.add_request(healthy_request)
++    next_scheduler_output = scheduler.schedule()
++
++    assert healthy_request.request_id in next_scheduler_output.num_scheduled_tokens
++    assert healthy_request.status == RequestStatus.RUNNING
++
++
++def test_sync_recompute_handles_mixed_kv_group_block_sizes():
++    """Recompute from a common boundary for mixed KV block sizes."""
++    hash_block_size = 16
++    scheduler_block_size = 64
++    num_blocks = 512
++    num_prompt_tokens = 8 * scheduler_block_size
++    num_external_computed_tokens = 7 * scheduler_block_size
++
++    # The invalid block begins at token 3 * 32 = 96.
++    # Scheduling granularity is 64, so recomputation must restart at 64.
++    invalid_group_idx = 1
++    invalid_block_idx = 3
++
++    vllm_config = create_vllm_config(
++        block_size=scheduler_block_size,
++        kv_load_failure_policy="recompute",
++    )
++    kv_cache_config = KVCacheConfig(
++        num_blocks=num_blocks,
++        kv_cache_tensors=[],
++        kv_cache_groups=[
++            KVCacheGroupSpec(
++                ["full_16"],
++                FullAttentionSpec(
++                    block_size=16,
++                    num_kv_heads=4,
++                    head_size=16,
++                    dtype=torch.float16,
++                ),
++            ),
++            KVCacheGroupSpec(
++                ["window_32"],
++                SlidingWindowSpec(
++                    block_size=32,
++                    num_kv_heads=4,
++                    head_size=16,
++                    dtype=torch.float16,
++                    sliding_window=num_prompt_tokens,
++                ),
++            ),
++            KVCacheGroupSpec(
++                ["full_64"],
++                FullAttentionSpec(
++                    block_size=64,
++                    num_kv_heads=1,
++                    head_size=32,
++                    dtype=torch.float16,
++                ),
++            ),
++        ],
++    )
++    scheduler = create_scheduler(
++        vllm_config,
++        num_blocks=num_blocks,
++        kv_cache_config=kv_cache_config,
++        hash_block_size=hash_block_size,
++    )
++
++    request = create_request(
++        num_tokens=num_prompt_tokens,
++        block_size=hash_block_size,
++    )
++    scheduler.add_request(request)
++
++    scheduler.connector = Mock()
++    scheduler.connector.get_num_new_matched_tokens.side_effect = (
++        _make_get_num_new_matched_tokens(
++            {
++                request.request_id: num_external_computed_tokens,
++            },
++            False,
++        )
++    )
++    scheduler.connector.request_finished.return_value = (
++        False,
++        None,
++    )
++    scheduler.connector.request_finished_all_groups.return_value = (
++        False,
++        None,
++    )
++    scheduler.connector.take_events.return_value = ()
++
++    scheduler_output = scheduler.schedule()
++
++    assert request.status == RequestStatus.RUNNING
++    assert len(scheduler_output.scheduled_new_reqs) == 1
++
++    block_ids_by_group = scheduler_output.scheduled_new_reqs[0].block_ids
++    assert len(block_ids_by_group) == 3
++    assert len(block_ids_by_group[invalid_group_idx]) > invalid_block_idx
++
++    invalid_block_id = block_ids_by_group[invalid_group_idx][invalid_block_idx]
++    model_runner_output = create_model_runner_output(
++        [request],
++        invalid_block_ids={invalid_block_id},
++        use_eos=False,
++    )
++
++    scheduler.update_from_output(
++        scheduler_output,
++        model_runner_output,
++    )
++
++    invalid_block_start = invalid_block_idx * 32
++    expected_recompute_from = (
++        invalid_block_start // scheduler_block_size * scheduler_block_size
++    )
++
++    assert invalid_block_start == 96
++    assert expected_recompute_from == 64
++    assert request.num_computed_tokens == expected_recompute_from
++    assert request.status == RequestStatus.RUNNING
++    assert request in scheduler.running
++    assert request.request_id in scheduler.requests
+diff --git a/tests/v1/kv_connector/unit/utils.py b/tests/v1/kv_connector/unit/utils.py
+index b1fb43353374a470b7fd6454e8c197ffe92f008b..a2908b7ab2e4713e81be8001a551e13148fd4c63 100644
+--- a/tests/v1/kv_connector/unit/utils.py
++++ b/tests/v1/kv_connector/unit/utils.py
+@@ -153,6 +153,7 @@ def create_scheduler(
+     vllm_config: VllmConfig,
+     num_blocks: int = 10000,
+     kv_cache_config: KVCacheConfig | None = None,
++    hash_block_size: int | None = None,
+ ) -> Scheduler | AsyncScheduler:
+     """Initialize Scheduler For Testing."""
+     block_size = vllm_config.cache_config.block_size
+@@ -183,6 +184,7 @@ def create_scheduler(
+         log_stats=True,
+         structured_output_manager=StructuredOutputManager(vllm_config),
+         block_size=block_size,
++        hash_block_size=hash_block_size,
+     )
+ 
+ 
+diff --git a/tests/v1/spec_decode/test_dflash_causality.py b/tests/v1/spec_decode/test_dflash_causality.py
+index 02e2a0bdbec21f64e5cf2eabf52de5d9f53205cb..015281027894615b75f1e10e1e73aa83b4f5eb4e 100644
+--- a/tests/v1/spec_decode/test_dflash_causality.py
++++ b/tests/v1/spec_decode/test_dflash_causality.py
+@@ -10,11 +10,13 @@ per-layer causality, and the no-``layer_types`` fallback) is worth pinning.
+ from types import SimpleNamespace
+ 
+ import pytest
++import torch.nn as nn
+ 
+ from vllm.model_executor.models.qwen3_dflash import (
+     _dflash_layer_causal,
+     _get_dflash_fc_input_size,
+     dflash_has_any_non_causal,
++    dflash_target_rope_is_neox_style,
+ )
+ from vllm.v1.worker.gpu.spec_decode.eagle.eagle3_utils import (
+     get_eagle3_aux_layers_from_config,
+@@ -89,3 +91,105 @@ def test_eagle_aux_layers_preserves_legacy_layer_ids(config_name):
+     assert get_eagle3_aux_layers_from_config(vllm_config.speculative_config) == tuple(
+         layer_ids
+     )
++
++
++class _TargetRotaryModule(nn.Module):
++    def __init__(self, is_neox_style: bool):
++        super().__init__()
++        self.is_neox_style = is_neox_style
++
++
++class _TargetModel(nn.Module):
++    def __init__(self, is_neox_style: bool):
++        super().__init__()
++        self.rotary = _TargetRotaryModule(is_neox_style)
++
++
++@pytest.mark.parametrize("is_neox_style", [False, True])
++def test_dflash_target_rope_layout_is_discovered(is_neox_style):
++    target = _TargetModel(is_neox_style)
++
++    assert dflash_target_rope_is_neox_style(target) is is_neox_style
++
++
++def test_dflash_loader_propagates_target_rope_layout(monkeypatch):
++    """DFlash configures the target rotary layout before draft construction."""
++    from vllm.v1.worker.gpu.spec_decode.dflash import utils as loader_module
++
++    draft_hf_config = SimpleNamespace(
++        num_hidden_layers=1,
++        layer_types=["sliding_attention"],
++        dflash_config={"causal": True},
++    )
++    speculative_config = SimpleNamespace(
++        draft_model_config=SimpleNamespace(hf_config=draft_hf_config),
++        attention_backend=None,
++        kv_cache_dtype=None,
++        draft_load_config=None,
++    )
++    vllm_config = SimpleNamespace(
++        speculative_config=speculative_config,
++        attention_config=SimpleNamespace(),
++        cache_config=SimpleNamespace(),
++        quant_config=None,
++    )
++
++    def fake_replace(obj, **changes):
++        values = vars(obj).copy()
++        values.update(changes)
++        return SimpleNamespace(**values)
++
++    class DraftConstructionObserved(Exception):
++        pass
++
++    def fake_get_model(**_kwargs):
++        assert draft_hf_config.is_neox_style is False
++        raise DraftConstructionObserved
++
++    monkeypatch.setattr(loader_module, "replace", fake_replace)
++    monkeypatch.setattr(loader_module, "get_model", fake_get_model)
++    with pytest.raises(DraftConstructionObserved):
++        loader_module.load_dflash_model(_TargetModel(is_neox_style=False), vllm_config)
++
++
++def test_dspark_loader_preserves_checkpoint_rope_layout(monkeypatch):
++    """DSpark inference uses the rotary layout encoded by its training model."""
++    from vllm.model_executor.models import utils as model_utils
++    from vllm.v1.worker.gpu.spec_decode.dspark import utils as loader_module
++
++    draft_hf_config = SimpleNamespace(
++        num_hidden_layers=1,
++        layer_types=["sliding_attention"],
++        dflash_config={"causal": True},
++        is_neox_style=True,
++    )
++    speculative_config = SimpleNamespace(
++        draft_model_config=SimpleNamespace(hf_config=draft_hf_config),
++        attention_backend=None,
++        kv_cache_dtype=None,
++        draft_load_config=None,
++    )
++    vllm_config = SimpleNamespace(
++        speculative_config=speculative_config,
++        attention_config=SimpleNamespace(),
++        cache_config=SimpleNamespace(),
++        quant_config=None,
++    )
++
++    class DraftConstructionObserved(Exception):
++        pass
++
++    def fake_get_model(**_kwargs):
++        assert draft_hf_config.is_neox_style is True
++        raise DraftConstructionObserved
++
++    monkeypatch.setattr(loader_module, "get_model", fake_get_model)
++    monkeypatch.setattr(
++        loader_module,
++        "_create_draft_vllm_config",
++        lambda _config: vllm_config,
++    )
++    monkeypatch.setattr(model_utils, "get_draft_quant_config", lambda _config: None)
++
++    with pytest.raises(DraftConstructionObserved):
++        loader_module.load_dspark_model(_TargetModel(is_neox_style=False), vllm_config)
+diff --git a/tests/v1/spec_decode/test_dflash_swa.py b/tests/v1/spec_decode/test_dflash_swa.py
+index 2a0c9d6d6f7e6765f7ca3c490896472228f1b2b6..092e86492cb5883092450975c660e97797caee5a 100644
+--- a/tests/v1/spec_decode/test_dflash_swa.py
++++ b/tests/v1/spec_decode/test_dflash_swa.py
+@@ -10,6 +10,7 @@ from vllm.model_executor.layers.attention import Attention
+ from vllm.model_executor.models.qwen3_dflash import DFlashAttention
+ from vllm.transformers_utils.configs.speculators import SpeculatorsConfig
+ from vllm.v1.attention.backend import AttentionType, CommonAttentionMetadata
++from vllm.v1.attention.backends import flash_attn as flash_attn_backend
+ from vllm.v1.kv_cache_interface import (
+     FullAttentionSpec,
+     SlidingWindowSpec,
+@@ -161,6 +162,53 @@ def test_dflash_swa_layers_keep_sliding_window_kv_cache_spec(monkeypatch):
+     assert spec.dcp_replicated is True
+ 
+ 
++def test_flash_attention_metadata_treats_replicated_kv_as_dcp1(monkeypatch):
++    """Replicated draft cache metadata uses global sequence lengths locally."""
++    spec = SlidingWindowSpec(
++        block_size=16,
++        num_kv_heads=1,
++        head_size=128,
++        dtype=torch.bfloat16,
++        sliding_window=2048,
++        dcp_replicated=True,
++    )
++    model_config = SimpleNamespace(
++        get_num_attention_heads=lambda _parallel_config: 96,
++        get_num_kv_heads=lambda _parallel_config: 16,
++        get_head_size=lambda: 128,
++        rswa_window=None,
++        is_mm_prefix_lm=False,
++    )
++    vllm_config = SimpleNamespace(
++        model_config=model_config,
++        parallel_config=SimpleNamespace(cp_kv_cache_interleave_size=1),
++        cache_config=SimpleNamespace(cache_dtype="bfloat16"),
++        compilation_config=SimpleNamespace(
++            cudagraph_mode=SimpleNamespace(has_full_cudagraphs=lambda: False),
++            max_cudagraph_capture_size=None,
++        ),
++        attention_config=SimpleNamespace(
++            flash_attn_max_num_splits_for_cuda_graph=0,
++        ),
++        scheduler_config=SimpleNamespace(max_num_seqs=1),
++    )
++
++    monkeypatch.setattr(
++        flash_attn_backend,
++        "get_dcp_group",
++        lambda: SimpleNamespace(world_size=16, rank_in_group=7),
++    )
++    builder = flash_attn_backend.FlashAttentionMetadataBuilder(
++        spec,
++        ["draft.layer"],
++        vllm_config,
++        torch.device("cpu"),
++    )
++
++    assert builder.dcp_world_size == 1
++    assert builder.dcp_rank == 0
++
++
+ def test_dflash_swa_layers_use_causal_metadata():
+     proposer = object.__new__(DFlashProposer)
+     proposer.model = SimpleNamespace(sliding_attention_layer_names={"layer.sw"})
+diff --git a/tests/v1/spec_decode/test_dspark_cudagraph_contract.py b/tests/v1/spec_decode/test_dspark_cudagraph_contract.py
+new file mode 100644
+index 0000000000000000000000000000000000000000..c1c1c444e52f85dd9b0c84ae7283cc3b4bb50c1d
+--- /dev/null
++++ b/tests/v1/spec_decode/test_dspark_cudagraph_contract.py
+@@ -0,0 +1,43 @@
++# SPDX-License-Identifier: Apache-2.0
++# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
++
++from types import SimpleNamespace
++from unittest.mock import Mock
++
++import torch
++
++from vllm.config.compilation import CUDAGraphMode
++from vllm.v1.worker.gpu.spec_decode.dspark.speculator import DSparkSpeculator
++
++
++def test_dspark_generate_draft_accepts_dflash_capture_contract():
++    head_hidden = torch.randn(10, 8)
++    speculator = SimpleNamespace(
++        num_query_per_req=5,
++        capacity_activation_batch_size=1,
++        _speculative_steps_for_query_len=Mock(return_value=5),
++        _run_model=Mock(return_value=head_hidden),
++        _sample_sequential=Mock(),
++    )
++
++    DSparkSpeculator._generate_draft(
++        speculator,
++        num_reqs=2,
++        num_tokens_padded=10,
++        attn_metadata=None,
++        slot_mappings=None,
++        num_tokens_across_dp=None,
++        cudagraph_runtime_mode=CUDAGraphMode.FULL,
++        is_profile=True,
++        num_query_per_req=5,
++        capture_only=True,
++    )
++
++    speculator._sample_sequential.assert_called_once_with(
++        2,
++        head_hidden,
++        5,
++        5,
++        is_profile=True,
++        use_capacity=True,
++    )
+diff --git a/tests/v1/worker/test_cp_utils.py b/tests/v1/worker/test_cp_utils.py
+index 186d49a038c2bbb8e481c037d9e4757fc038efed..ddcf0c171dcab4a7d00d0ed1cf2fcba130c68c1b 100644
+--- a/tests/v1/worker/test_cp_utils.py
++++ b/tests/v1/worker/test_cp_utils.py
+@@ -94,3 +94,34 @@ def test_check_attention_cp_compatibility_rejects_no_lse_return(monkeypatch):
+ 
+     with pytest.raises(AssertionError, match="requires attention implementations"):
+         cp_utils.check_attention_cp_compatibility(_make_config(dcp_size=2))
++
++
++def test_replicated_kv_group_executes_attention_as_dcp1(monkeypatch):
++    """A complete per-rank KV copy must not enter DCP attention collectives."""
++    impl = SimpleNamespace(
++        can_return_lse_for_decode=True,
++        dcp_world_size=16,
++        dcp_rank=7,
++        total_cp_world_size=16,
++        total_cp_rank=7,
++        need_to_return_lse_for_decode=True,
++        supports_pcp=False,
++    )
++    layer = SimpleNamespace(
++        impl=impl,
++        get_kv_cache_spec=lambda _config: SimpleNamespace(dcp_replicated=True),
++    )
++
++    monkeypatch.setattr(
++        cp_utils,
++        "get_layers_from_vllm_config",
++        lambda vllm_config, layer_type: {"draft.layer": layer},
++    )
++
++    cp_utils.check_attention_cp_compatibility(_make_config(dcp_size=16))
++
++    assert impl.dcp_world_size == 1
++    assert impl.dcp_rank == 0
++    assert impl.total_cp_world_size == 1
++    assert impl.total_cp_rank == 0
++    assert impl.need_to_return_lse_for_decode is False
+diff --git a/tests/v1/worker/test_gpu_sampler_flags.py b/tests/v1/worker/test_gpu_sampler_flags.py
+new file mode 100644
+index 0000000000000000000000000000000000000000..3fd1cb3b3c681fddb66c9bb03b85201a38face3f
+--- /dev/null
++++ b/tests/v1/worker/test_gpu_sampler_flags.py
+@@ -0,0 +1,90 @@
++# SPDX-License-Identifier: Apache-2.0
++# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
++
++import numpy as np
++import pytest
++import torch
++
++pytest.importorskip("triton")
++if not torch.cuda.is_available():
++    pytest.skip("CUDA required for sampler flag tests", allow_module_level=True)
++
++from vllm.sampling_params import SamplingParams
++from vllm.v1.worker.gpu.sample.sampler import Sampler
++from vllm.v1.worker.gpu.states import RequestState
++
++DEVICE = torch.device("cuda")
++VOCAB_SIZE = 128
++
++
++class MockReasoningConfig:
++    reasoning_start_token_ids = [90]
++    reasoning_end_token_ids = [91]
++    natural_reasoning_end_token_ids = [91]
++
++
++def _make_sampler() -> Sampler:
++    req_states = RequestState(
++        max_num_reqs=4,
++        max_model_len=64,
++        max_num_batched_tokens=16,
++        num_speculative_steps=1,
++        vocab_size=VOCAB_SIZE,
++        device=DEVICE,
++    )
++    return Sampler(
++        max_num_reqs=4,
++        vocab_size=VOCAB_SIZE,
++        device=DEVICE,
++        req_states=req_states,
++        reasoning_config=MockReasoningConfig(),
++    )
++
++
++@pytest.mark.parametrize(
++    ("sampling_params", "expected"),
++    [
++        pytest.param(SamplingParams(), False, id="defaults"),
++        pytest.param(SamplingParams(temperature=0.0), False, id="greedy"),
++        pytest.param(
++            SamplingParams(thinking_token_budget=3), True, id="thinking-budget"
++        ),
++        pytest.param(SamplingParams(logit_bias={1: 1.0}), True, id="logit-bias"),
++        pytest.param(SamplingParams(frequency_penalty=0.1), True, id="penalty"),
++        pytest.param(SamplingParams(_bad_words_token_ids=[[1]]), True, id="bad-words"),
++        pytest.param(SamplingParams(temperature=0.7), True, id="temperature"),
++        pytest.param(SamplingParams(min_p=0.1), True, id="min-p"),
++        pytest.param(SamplingParams(top_k=10), True, id="top-k"),
++        pytest.param(SamplingParams(top_p=0.9), True, id="top-p"),
++        pytest.param(
++            SamplingParams.for_sampler_warmup(), True, id="all-logits-processors"
++        ),
++    ],
++)
++def test_logits_processing_cache_matches_request_features(
++    sampling_params: SamplingParams, expected: bool
++):
++    sampler = _make_sampler()
++    sampler.add_request(3, prompt_len=1, sampling_params=sampling_params)
++
++    assert sampler.needs_logits_processing[3] == expected
++
++
++def test_logits_processing_cache_is_overwritten_when_slot_is_reused():
++    sampler = _make_sampler()
++    sampler.add_request(3, 1, SamplingParams.for_sampler_warmup())
++    sampler.add_request(3, 1, SamplingParams())
++
++    assert not sampler.needs_logits_processing[3]
++
++
++def test_logits_processing_cache_only_checks_active_requests():
++    sampler = _make_sampler()
++    sampler.add_request(0, 1, SamplingParams(temperature=0.0))
++    sampler.add_request(2, 1, SamplingParams.for_sampler_warmup())
++
++    sampling_only = np.array([0], dtype=np.int32)
++    with_processing = np.array([0, 2], dtype=np.int32)
++
++    assert not np.any(sampler.needs_logits_processing[sampling_only])
++    assert np.any(sampler.needs_logits_processing[with_processing])
+diff --git a/tests/v1/worker/test_gpu_thinking_budget.py b/tests/v1/worker/test_gpu_thinking_budget.py
+index 0b0f19f7dbf0129a0273b5fcf143a0a04e684b40..2bc697b0843834dbe09109e0ec5fb37cf96a5de9 100644
+--- a/tests/v1/worker/test_gpu_thinking_budget.py
++++ b/tests/v1/worker/test_gpu_thinking_budget.py
+@@ -12,6 +12,7 @@ if not torch.cuda.is_available():
+     )
+ 
+ from vllm.sampling_params import SamplingParams
++from vllm.v1.worker.gpu.sample.sampler import Sampler
+ from vllm.v1.worker.gpu.sample.thinking_budget import ThinkingBudgetState
+ from vllm.v1.worker.gpu.states import RequestState
+ 
+@@ -185,6 +186,44 @@ def test_v2_thinking_budget_ignores_plain_request():
+     assert torch.all(out == 0)
+ 
+ 
++def test_v2_greedy_sampling_applies_thinking_budget():
++    """Greedy-only requests must not bypass thinking-budget processing."""
++    req_states = _make_req_states([1, START, 10, 11, 12], prompt_len=1)
++    sampler = Sampler(
++        max_num_reqs=4,
++        vocab_size=VOCAB_SIZE,
++        device=DEVICE,
++        req_states=req_states,
++        reasoning_config=MockReasoningConfig(),
++    )
++    sampler.add_request(
++        req_idx=3,
++        prompt_len=1,
++        sampling_params=SamplingParams(
++            temperature=0.0,
++            thinking_token_budget=3,
++        ),
++    )
++    sampler.apply_staged_writes()
++
++    idx_mapping = torch.tensor([3], dtype=torch.int32, device=DEVICE)
++    idx_mapping_np = idx_mapping.cpu().numpy()
++    expanded_idx_mapping = idx_mapping.clone()
++    input_ids = torch.tensor([12], dtype=torch.int32, device=DEVICE)
++    logits = torch.zeros((1, VOCAB_SIZE), device=DEVICE)
++    out = sampler.apply_sampling_params(
++        logits,
++        expanded_idx_mapping,
++        idx_mapping,
++        idx_mapping_np,
++        torch.tensor([4], dtype=torch.int32, device=DEVICE),
++        input_ids,
++        torch.tensor([0], dtype=torch.int32, device=DEVICE),
++    )
++
++    assert out[0, END].item() == pytest.approx(1.0e9)
++
++
+ def test_v2_thinking_budget_latest_prefill_end_disables_forcing():
+     req_states = _make_req_states(
+         [1, START, 10, 11, 12, END, 13],
+diff --git a/vllm/model_executor/models/qwen3_dflash.py b/vllm/model_executor/models/qwen3_dflash.py
+index 58c59fcbb5cbf653760dd8a543ea3d3226db41b6..929beae39207a8e6c31f95eef65eb85fbfe79459 100644
+--- a/vllm/model_executor/models/qwen3_dflash.py
++++ b/vllm/model_executor/models/qwen3_dflash.py
+@@ -86,6 +86,33 @@ def dflash_has_any_non_causal(config: Qwen3Config) -> bool:
+     )
+ 
+ 
++def dflash_target_rope_is_neox_style(target_model: nn.Module) -> bool | None:
++    """Return the target model's rotary-embedding layout when it is exposed.
++
++    A DFlash-family draft must rotate query and key tensors with the same
++    dimension layout as the target model used during hidden-state extraction.
++    Draft checkpoints do not encode this property. A mismatch changes every
++    drafted attention result without raising an error and collapses token
++    acceptance.
++
++    Args:
++        target_model: Target model that can expose rotary layout modules.
++
++    Returns:
++        The exposed NeoX rotary-layout setting, or ``None`` when unavailable.
++    """
++    language_model = (
++        target_model.get_language_model()
++        if hasattr(target_model, "get_language_model")
++        else target_model
++    )
++    for module in language_model.modules():
++        style = getattr(module, "is_neox_style", None)
++        if isinstance(style, bool):
++            return style
++    return None
++
++
+ def _get_dflash_fc_input_size(vllm_config: VllmConfig) -> int:
+     spec_config = vllm_config.speculative_config
+     config = spec_config.draft_model_config.hf_config
+@@ -216,6 +243,7 @@ class DFlashQwen3Attention(nn.Module):
+         add_swa_attention_sink_bias: bool = False,
+         sliding_window: int | None = None,
+         causal: bool = False,
++        is_neox_style: bool = True,
+         cache_config: CacheConfig | None = None,
+         quant_config: QuantizationConfig | None = None,
+         prefix: str = "",
+@@ -259,6 +287,7 @@ class DFlashQwen3Attention(nn.Module):
+         self.rotary_emb = get_rope(
+             self.head_dim,
+             max_position=max_position,
++            is_neox_style=is_neox_style,
+             rope_parameters=rope_parameters,
+         )
+ 
+@@ -342,6 +371,12 @@ class DFlashQwen3DecoderLayer(nn.Module):
+         # non-causal) from the draft config.
+         sliding_window, causal = _resolve_layer_attention(config, layer_idx)
+ 
++        # The loader copies this value from the built target model. Kimi-K3
++        # uses interleaved rotary dimensions while Qwen3 defaults to NeoX
++        # rotary dimensions, so relying on the Qwen3 default is not valid for
++        # a Kimi-trained DFlash-family checkpoint.
++        is_neox_style = getattr(config, "is_neox_style", True)
++
+         self.self_attn = DFlashQwen3Attention(
+             hidden_size=self.hidden_size,
+             num_heads=config.num_attention_heads,
+@@ -352,6 +387,7 @@ class DFlashQwen3DecoderLayer(nn.Module):
+             add_swa_attention_sink_bias=add_swa_attention_sink_bias,
+             sliding_window=sliding_window,
+             causal=causal,
++            is_neox_style=is_neox_style,
+             head_dim=getattr(config, "head_dim", None),
+             cache_config=cache_config,
+             quant_config=quant_config,
+diff --git a/vllm/model_executor/warmup/kimi_k3_triton_warmup.py b/vllm/model_executor/warmup/kimi_k3_triton_warmup.py
+index 257c8a8bceadca0b59c300408c1b51d91c239f30..83162b5d3591fce9bf78d5aa6a26a022dd8df913 100644
+--- a/vllm/model_executor/warmup/kimi_k3_triton_warmup.py
++++ b/vllm/model_executor/warmup/kimi_k3_triton_warmup.py
+@@ -18,6 +18,34 @@ if TYPE_CHECKING:
+ logger = init_logger(__name__)
+ 
+ 
++def _warm_vision_position_interpolation(model: torch.nn.Module) -> int:
++    """Compile Kimi vision interpolation before KV-cache allocation.
++
++    Args:
++        model: Loaded model whose module tree may contain Kimi vision position
++            embeddings.
++
++    Returns:
++        Number of Kimi vision interpolation modules invoked.
++    """
++    from vllm.model_executor.models.kimi_k25_vit import (
++        Learnable2DInterpPosEmbDivided_fixed,
++        get_rope_shape,
++    )
++
++    warmed = 0
++    for module in model.modules():
++        if not isinstance(module, Learnable2DInterpPosEmbDivided_fixed):
++            continue
++        get_rope_shape(
++            module.weight,
++            interpolation_mode=module.interpolation_mode,
++            shape=(64, 64),
++        )
++        warmed += 1
++    return warmed
++
++
+ def _get_kda_layer(worker: Worker) -> KimiK3DeltaAttention | None:
+     from vllm.models.kimi_k3.nvidia.kda import KimiK3DeltaAttention
+ 
+@@ -187,6 +215,15 @@ def kimi_k3_triton_warmup(worker: Worker) -> None:
+     if not current_platform.is_cuda():
+         return
+ 
++    warmed_vision_interpolators = _warm_vision_position_interpolation(
++        worker.get_model()
++    )
++    if warmed_vision_interpolators:
++        logger.info(
++            "Warmed up %d Kimi vision position interpolator(s).",
++            warmed_vision_interpolators,
++        )
++
+     layer = _get_kda_layer(worker)
+     if layer is None:
+         return
+diff --git a/vllm/parser/kimi_k3.py b/vllm/parser/kimi_k3.py
+index 380e2cce5f91182fda7f95469d40d9af07a2746d..e3f58d25f4d7b76598f448d358b10709336d998a 100644
+--- a/vllm/parser/kimi_k3.py
++++ b/vllm/parser/kimi_k3.py
+@@ -12,6 +12,7 @@ from vllm.entrypoints.openai.engine.protocol import (
+ )
+ from vllm.parser.abstract_parser import DelegatingParser
+ from vllm.reasoning.kimi_k3_reasoning_parser import KimiK3ReasoningParser
++from vllm.tool_parsers.utils import partial_tag_overlap
+ 
+ if TYPE_CHECKING:
+     from vllm.entrypoints.openai.chat_completion.protocol import (
+@@ -23,6 +24,45 @@ if TYPE_CHECKING:
+ class KimiK3Parser(DelegatingParser):
+     """Compose the Kimi K3 reasoning and tool parsers for XTML output."""
+ 
++    _CONTENT_PROTOCOL_MARKERS = (
++        "<|open|>think<|sep|>",
++        "<|close|>think<|sep|>",
++        "<|open|>response<|sep|>",
++        "<|close|>response<|sep|>",
++        "<|close|>message<|sep|>",
++    )
++
++    def __init__(self, *args, **kwargs):
++        super().__init__(*args, **kwargs)
++        self._pending_content_protocol = ""
++
++    def _strip_content_protocol(
++        self, content: str | None, *, finished: bool
++    ) -> str | None:
++        """Remove Kimi XTML control markers from streamed API content.
++
++        Reasoning and tool parsers normally consume these markers before this
++        method runs. The final filter preserves the API invariant when a
++        malformed model transition or an inconsistent initial parser phase
++        routes a marker through the content field. Marker prefixes are held
++        across stream chunks so partial control tokens are never exposed.
++        """
++        pending = self._pending_content_protocol + (content or "")
++        for marker in self._CONTENT_PROTOCOL_MARKERS:
++            pending = pending.replace(marker, "")
++
++        overlap = max(
++            partial_tag_overlap(pending, marker)
++            for marker in self._CONTENT_PROTOCOL_MARKERS
++        )
++        if overlap:
++            emitted = pending[:-overlap]
++            self._pending_content_protocol = "" if finished else pending[-overlap:]
++        else:
++            emitted = pending
++            self._pending_content_protocol = ""
++        return emitted or None
++
+     # TODO: Switch Kimi K3 to the parser engine once its XTML reasoning/tool
+     # path is covered there.
+     def _extract_tool_calls(
+@@ -113,18 +153,25 @@ class KimiK3Parser(DelegatingParser):
+         )
+ 
+         if (
+-            self._tool_parser is not None
+-            or not isinstance(self._reasoning_parser, KimiK3ReasoningParser)
+-            or not state.reasoning_ended
+-            or delta_message is None
++            delta_message is not None
++            and self._tool_parser is None
++            and isinstance(self._reasoning_parser, KimiK3ReasoningParser)
++            and state.reasoning_ended
+         ):
+-            return delta_message
++            stripped = self._reasoning_parser.strip_content_streaming(
++                previous_text=previous_content,
++                current_text=state.previous_text,
++            )
++            delta_message.content = stripped.content if stripped is not None else None
++
++        if delta_message is None:
++            if finished:
++                self._pending_content_protocol = ""
++            return None
+ 
+-        stripped = self._reasoning_parser.strip_content_streaming(
+-            previous_text=previous_content,
+-            current_text=state.previous_text,
++        delta_message.content = self._strip_content_protocol(
++            delta_message.content, finished=finished
+         )
+-        delta_message.content = stripped.content if stripped is not None else None
+         if (
+             delta_message.role is None
+             and delta_message.content is None
+diff --git a/vllm/reasoning/kimi_k3_reasoning_parser.py b/vllm/reasoning/kimi_k3_reasoning_parser.py
+index f05d5c044805c4111cd49e9aeebc07aa5a15c518..d170652a20e8f1253099c8e78e0aec9bc41e501c 100644
+--- a/vllm/reasoning/kimi_k3_reasoning_parser.py
++++ b/vllm/reasoning/kimi_k3_reasoning_parser.py
+@@ -95,6 +95,9 @@ class KimiK3ReasoningParser(ReasoningParser):
+         if thinking is None:
+             thinking = chat_kwargs.get("enable_thinking", True)
+         self._thinking_enabled = bool(thinking)
++        self._starts_new_assistant_message = bool(
++            chat_kwargs.get("add_generation_prompt", True)
++        ) and not bool(chat_kwargs.get("continue_final_message", False))
+ 
+         # XTML markers as literal strings (skip_special_tokens=False at serve time)
+         self._think_open = "<|open|>think<|sep|>"
+@@ -145,6 +148,11 @@ class KimiK3ReasoningParser(ReasoningParser):
+     def reasoning_end_str(self) -> str | None:
+         return self._think_close
+ 
++    @property
++    def thinking_enabled(self) -> bool:
++        """Whether the request opens a Kimi K3 reasoning channel."""
++        return self._thinking_enabled
++
+     def adjust_request(
+         self,
+         request: "ChatCompletionRequest | ResponsesRequest",
+@@ -170,6 +178,24 @@ class KimiK3ReasoningParser(ReasoningParser):
+             _newest_marker(input_ids, self._think_close_ids, self._think_open_ids) == 0
+         )
+ 
++    def is_reasoning_end_for_prompt(self, input_ids: Sequence[int]) -> bool:
++        """Return the reasoning phase at the generation boundary.
++
++        A fresh Kimi K3 assistant message starts in the think channel whenever
++        thinking is enabled. That request contract is authoritative even when
++        the token list exposed to the output parser does not contain the
++        generation-prefix marker; closed think channels from historical turns
++        cannot determine the phase of a fresh assistant message.
++
++        ``continue_final_message`` does not open a fresh channel, so its prompt
++        markers remain authoritative.
++        """
++        if not self._thinking_enabled:
++            return True
++        if self._starts_new_assistant_message:
++            return False
++        return self.is_reasoning_end(input_ids)
++
+     def is_reasoning_end_streaming(
+         self, input_ids: Sequence[int], delta_ids: Iterable[int]
+     ) -> bool:
+diff --git a/vllm/tool_parsers/kimi_k3_tool_parser.py b/vllm/tool_parsers/kimi_k3_tool_parser.py
+index 9f688f2270e4733fe143781b12edfc4437ca8bdc..e1fc5a156996453515a9467c62189db773aaa4f7 100644
+--- a/vllm/tool_parsers/kimi_k3_tool_parser.py
++++ b/vllm/tool_parsers/kimi_k3_tool_parser.py
+@@ -37,6 +37,7 @@ from collections.abc import Sequence
+ import regex as re
+ from openai.types.responses import ToolChoiceFunction
+ 
++from vllm.entrypoints.chat_utils import make_tool_call_id
+ from vllm.entrypoints.openai.chat_completion.protocol import (
+     ChatCompletionNamedToolChoiceParam,
+     ChatCompletionRequest,
+@@ -69,6 +70,25 @@ def _partial_tag_overlap(text: str, tag: str) -> int:
+     return 0
+ 
+ 
++def _partial_pattern_overlap(text: str, pattern: re.Pattern) -> int:
++    """Return a trailing prefix accepted by a partial regular expression.
++
++    Args:
++        text: Generated text that may end inside a structural marker.
++        pattern: Complete structural-marker expression.
++
++    Returns:
++        The number of trailing characters that form an incomplete match.
++    """
++    candidate = text.rfind("<")
++    while candidate >= 0:
++        match = pattern.fullmatch(text[candidate:], partial=True)
++        if match is not None and match.partial:
++            return len(text) - candidate
++        candidate = text.rfind("<", 0, candidate)
++    return 0
++
++
+ class KimiK3ToolParser(ToolParser):
+     supports_required_and_named = False
+     # Enables the vLLM-side XTML structural tag builder
+@@ -86,6 +106,7 @@ class KimiK3ToolParser(ToolParser):
+         self.tools_close = "<|close|>tools<|sep|>"
+         self.response_open = "<|open|>response<|sep|>"
+         self.response_close = "<|close|>response<|sep|>"
++        self.argument_close = "<|close|>argument<|sep|>"
+ 
+         # Regexes operate on detokenized text. The XTML markers reach us as the
+         # literal strings <|open|>/<|close|>/<|sep|>. adjust_request keeps them
+@@ -127,6 +148,16 @@ class KimiK3ToolParser(ToolParser):
+             + _S,
+             re.DOTALL,
+         )
++        # Half-open variants: streaming needs to see a call/argument as soon as
++        # its opening marker lands, before the matching close marker exists.
++        self._call_open_re = re.compile(
++            _O + r"\s*call\s+(?P<attrs>" + _TEXT_UNTIL_SEP + r")" + _S
++        )
++        self._call_close_re = re.compile(_C + r"\s*call\s*" + _S)
++        self._arg_open_re = re.compile(
++            _O + r"\s*argument\s+(?P<attrs>" + _TEXT_UNTIL_SEP + r")" + _S
++        )
++        self._arg_close_re = re.compile(_C + r"\s*argument\s*" + _S)
+         # attr segment: key="value" (value already escaped on the encode side)
+         self._attr_re = re.compile(r'(?P<k>\w+)="(?P<v>[^"]*)"')
+         self._response_re = re.compile(
+@@ -136,7 +167,8 @@ class KimiK3ToolParser(ToolParser):
+ 
+         # streaming state
+         self._sent_content_idx = 0
+-        self._sent_tool_call_count = 0
++        # arguments already streamed, per tool-call index
++        self._streamed_args: list[str] = []
+ 
+         if not self.model_tokenizer:
+             raise ValueError(
+@@ -218,6 +250,17 @@ class KimiK3ToolParser(ToolParser):
+         """
+         call_attrs = self._attrs(attrs)
+         tool_name = call_attrs.get("tool", "")
++        if not tool_name:
++            return None
++        return ToolCall(
++            type="function",
++            function=FunctionCall(
++                name=tool_name,
++                arguments=json.dumps(self._decode_arguments(body), ensure_ascii=False),
++            ),
++        )
++
++    def _decode_arguments(self, body: str) -> dict:
+         arguments: dict = {}
+         for arg_match in self._arg_re.finditer(body):
+             arg_attrs = self._attrs(arg_match["attrs"])
+@@ -231,15 +274,37 @@ class KimiK3ToolParser(ToolParser):
+                     arguments[key] = json.loads(raw_value)
+                 except json.JSONDecodeError:
+                     arguments[key] = raw_value
+-        if not tool_name:
+-            return None
+-        return ToolCall(
+-            type="function",
+-            function=FunctionCall(
+-                name=tool_name,
+-                arguments=json.dumps(arguments, ensure_ascii=False),
+-            ),
+-        )
++        return arguments
++
++    def _partial_arguments(self, body: str) -> str:
++        """Serialize the arguments of a ``call`` block that has not closed yet.
++
++        Args:
++            body: The incomplete XTML call body.
++
++        Returns:
++            A prefix of the completed call's JSON arguments. String values can
++            stream as generated. Other argument types remain buffered until
++            their complete JSON literal is available.
++        """
++        closed_end = 0
++        for arg_match in self._arg_re.finditer(body):
++            closed_end = arg_match.end()
++        arguments = self._decode_arguments(body[:closed_end])
++
++        m_open = self._arg_open_re.search(body, closed_end)
++        if m_open is None:
++            # drop the closing "}" of the object
++            return json.dumps(arguments, ensure_ascii=False)[:-1]
++
++        arg_attrs = self._attrs(m_open["attrs"])
++        if arg_attrs.get("type", "string") != "string":
++            return json.dumps(arguments, ensure_ascii=False)[:-1]
++        raw_value = body[m_open.end() :]
++        held = _partial_pattern_overlap(raw_value, self._arg_close_re)
++        arguments[arg_attrs.get("key", "")] = raw_value[: len(raw_value) - held]
++        # drop the closing quote of the open value and the "}" of the object
++        return json.dumps(arguments, ensure_ascii=False)[:-2]
+ 
+     def _strip_response_content(self, text: str) -> str | None:
+         """Strip XTML response/message markers from generated response text.
+@@ -361,35 +426,66 @@ class KimiK3ToolParser(ToolParser):
+         delta_token_ids: Sequence[int],
+         request: ChatCompletionRequest,
+     ) -> DeltaMessage | None:
+-        # Conservative streaming: stream unwrapped response-channel text, then
+-        # buffer tool calls and emit each call once its block closes.
++        # Stream unwrapped response-channel text, then stream each tool call as
++        # it is generated: the open marker carries the name, and argument text
++        # is forwarded as it arrives rather than buffered until the call closes.
+         content = self._extract_response_content(current_text)
+ 
+-        # tools channel is open: parse fully-closed calls we have not emitted yet
+         m_tools = self._tools_open_re.search(current_text)
+         if m_tools is None:
+             return DeltaMessage(content=content) if content else None
+ 
+-        section = current_text[m_tools.end() :]
+-        calls = [
+-            tc
+-            for m in self._call_re.finditer(section)
+-            if (tc := self._decode_call(m["attrs"], m["body"])) is not None
+-        ]
+-        if len(calls) <= self._sent_tool_call_count:
+-            return DeltaMessage(content=content) if content else None
+-        new = calls[self._sent_tool_call_count :]
+-
+-        deltas = [
+-            DeltaToolCall(
+-                index=self._sent_tool_call_count + i,
+-                id=tc.id,
+-                type="function",
+-                function=DeltaFunctionCall(
+-                    name=tc.function.name, arguments=tc.function.arguments
+-                ).model_dump(exclude_none=True),
++        section_start = m_tools.end()
++        m_tools_close = self._tools_close_re.search(current_text, section_start)
++        section = current_text[
++            section_start : (
++                len(current_text) if m_tools_close is None else m_tools_close.start()
+             )
+-            for i, tc in enumerate(new)
+         ]
+-        self._sent_tool_call_count = len(calls)
++        opens = list(self._call_open_re.finditer(section))
++        deltas: list[DeltaToolCall] = []
++        index = 0
++        for i, m_open in enumerate(opens):
++            end = opens[i + 1].start() if i + 1 < len(opens) else len(section)
++            body = section[m_open.end() : end]
++            name = self._attrs(m_open["attrs"]).get("tool", "")
++            if not name:
++                # an empty/garbage block is dropped, as in _decode_call
++                continue
++            m_close = self._call_close_re.search(body)
++            if m_close is None:
++                arguments = self._partial_arguments(body)
++            else:
++                arguments = json.dumps(
++                    self._decode_arguments(body[: m_close.start()]), ensure_ascii=False
++                )
++
++            if index == len(self._streamed_args):
++                self._streamed_args.append(arguments)
++                deltas.append(
++                    DeltaToolCall(
++                        index=index,
++                        id=make_tool_call_id(),
++                        type="function",
++                        function=DeltaFunctionCall(
++                            name=name, arguments=arguments
++                        ).model_dump(exclude_none=True),
++                    )
++                )
++            else:
++                sent = self._streamed_args[index]
++                if arguments != sent and arguments.startswith(sent):
++                    self._streamed_args[index] = arguments
++                    deltas.append(
++                        DeltaToolCall(
++                            index=index,
++                            function=DeltaFunctionCall(
++                                arguments=arguments[len(sent) :]
++                            ).model_dump(exclude_none=True),
++                        )
++                    )
++            index += 1
++
++        if not deltas:
++            return DeltaMessage(content=content) if content else None
+         return DeltaMessage(content=content, tool_calls=deltas)
+diff --git a/vllm/v1/attention/backends/flash_attn.py b/vllm/v1/attention/backends/flash_attn.py
+index 97f30736fda34bd38df5e06fcb44dd6235253a98..a8444f7bbb7bd3895a8273cbd64ec02ca979f948 100755
+--- a/vllm/v1/attention/backends/flash_attn.py
++++ b/vllm/v1/attention/backends/flash_attn.py
+@@ -395,15 +395,20 @@ class FlashAttentionMetadataBuilder(AttentionMetadataBuilder[FlashAttentionMetad
+         self.max_num_splits = 0  # No upper bound on the number of splits.
+         self.aot_schedule = get_flash_attn_version() == 3
+ 
+-        try:
+-            from vllm.distributed.parallel_state import get_dcp_group
+-
+-            self.dcp_world_size = get_dcp_group().world_size
+-            self.dcp_rank = get_dcp_group().rank_in_group
+-        except AssertionError:
+-            # DCP might not be initialized in testing
++        # A DCP-replicated KV group stores the complete sequence on every
++        # rank. Build ordinary local-attention metadata for that group instead
++        # of partitioning its sequence lengths for a second time.
++        if getattr(kv_cache_spec, "dcp_replicated", False):
+             self.dcp_world_size = 1
+             self.dcp_rank = 0
++        else:
++            try:
++                self.dcp_world_size = get_dcp_group().world_size
++                self.dcp_rank = get_dcp_group().rank_in_group
++            except AssertionError:
++                # DCP might not be initialized in testing
++                self.dcp_world_size = 1
++                self.dcp_rank = 0
+ 
+         self.cp_kv_cache_interleave_size = (
+             self.parallel_config.cp_kv_cache_interleave_size
+diff --git a/vllm/v1/core/sched/scheduler.py b/vllm/v1/core/sched/scheduler.py
+index ae08df9c35b2f6694109452b53d79c0d237bb244..dcb2cd1a5fe1459bd8b5eb276f4ab0c5ac61aec0 100644
+--- a/vllm/v1/core/sched/scheduler.py
++++ b/vllm/v1/core/sched/scheduler.py
+@@ -2914,50 +2914,73 @@ class Scheduler(SchedulerInterface):
+             is_affected = False
+             marked_invalid_block = False
+             req_id = request.request_id
+-            # TODO (davidb): add support for hybrid memory allocator
+-            (req_block_ids,) = self.kv_cache_manager.get_block_ids(req_id)
+-            # We iterate only over blocks that may contain externally computed
+-            # tokens
++            req_block_ids_by_group = self.kv_cache_manager.get_block_ids(req_id)
++            # We iterate only over blocks that may contain externally
++            # computed tokens.
+             req_num_computed_tokens = (
+                 request.num_computed_tokens - num_scheduled_tokens.get(req_id, 0)
+             )
++            computed_block_ids_by_group = (
++                self.kv_cache_manager.get_block_ids_for_computed_tokens(
++                    req_id,
++                    req_num_computed_tokens,
++                )
++            )
+ 
+-            req_num_computed_blocks = (
+-                req_num_computed_tokens + self.block_size - 1
+-            ) // self.block_size
+-            for idx, block_id in zip(range(req_num_computed_blocks), req_block_ids):
+-                if block_id not in invalid_block_ids:
+-                    continue
+-
+-                is_affected = True
+-
+-                if block_id in marked_invalid_block_ids:
+-                    # This invalid block is shared with a previous request
+-                    # and was already marked for recomputation.
+-                    # This means this request can still consider this block
+-                    # as computed when rescheduled.
+-                    # Currently this only applies to sync loading; Async
+-                    # loading does not yet support block sharing
+-                    continue
+-
+-                marked_invalid_block_ids.add(block_id)
++            # Map each invalid block to the earliest scheduler-aligned token
++            # boundary from which this request must be recomputed.
++            invalid_block_boundaries: dict[int, int] = {}
++            for group, group_block_ids in zip(
++                self.kv_cache_config.kv_cache_groups,
++                computed_block_ids_by_group,
++                strict=True,
++            ):
++                group_block_size = group.kv_cache_spec.block_size
++                for block_idx, block_id in enumerate(group_block_ids):
++                    if block_id not in invalid_block_ids:
++                        continue
+ 
+-                if marked_invalid_block:
+-                    # This request has already marked an invalid block for
+-                    # recomputation and updated its num_computed_tokens.
+-                    continue
++                    block_start = block_idx * group_block_size
++                    recompute_from = block_start // self.block_size * self.block_size
++                    previous_boundary = invalid_block_boundaries.get(block_id)
++                    invalid_block_boundaries[block_id] = (
++                        recompute_from
++                        if previous_boundary is None
++                        else min(previous_boundary, recompute_from)
++                    )
+ 
+-                marked_invalid_block = True
+-                # Truncate the computed tokens at the first failed block
+-                request.num_computed_tokens = idx * self.block_size
+-                num_affected_tokens = (
+-                    req_num_computed_tokens - request.num_computed_tokens
++            if invalid_block_boundaries:
++                is_affected = True
++                new_invalid_block_ids = (
++                    invalid_block_boundaries.keys() - marked_invalid_block_ids
+                 )
+-                total_affected_tokens += num_affected_tokens
++                marked_invalid_block_ids.update(new_invalid_block_ids)
+ 
+-                # collect invalid block and all downstream dependent blocks
+-                if evict_blocks:
+-                    blocks_to_evict.update(req_block_ids[idx:])
++                if new_invalid_block_ids:
++                    marked_invalid_block = True
++                    request.num_computed_tokens = min(
++                        invalid_block_boundaries[block_id]
++                        for block_id in new_invalid_block_ids
++                    )
++                    num_affected_tokens = (
++                        req_num_computed_tokens - request.num_computed_tokens
++                    )
++                    total_affected_tokens += num_affected_tokens
++
++                    # Every KV group after the common recomputation boundary
++                    # depends on the failed prefix, so collect downstream
++                    # blocks from all groups.
++                    if evict_blocks:
++                        for group, group_block_ids in zip(
++                            self.kv_cache_config.kv_cache_groups,
++                            req_block_ids_by_group,
++                            strict=True,
++                        ):
++                            group_block_size = group.kv_cache_spec.block_size
++                            first_block_idx = (
++                                request.num_computed_tokens // group_block_size
++                            )
++                            blocks_to_evict.update(group_block_ids[first_block_idx:])
+ 
+             if is_affected:
+                 if not marked_invalid_block:
+diff --git a/vllm/v1/core/single_type_kv_cache_manager.py b/vllm/v1/core/single_type_kv_cache_manager.py
+index a334a8dde9da0a52cd18bf4b156506477d1656ed..686cae8257e609619943c4328d0e8690c8e4bd30 100644
+--- a/vllm/v1/core/single_type_kv_cache_manager.py
++++ b/vllm/v1/core/single_type_kv_cache_manager.py
+@@ -1597,6 +1597,7 @@ class MambaManager(SingleTypeKVCacheManager):
+             # `num_required_blocks` might be less than `len(req_blocks)` if blocks are
+             # over-allocated at last round.
+             if num_required_blocks <= len(req_blocks) and not has_partial_hit:
++                self._allocated_block_reqs.add(request_id)
+                 return []
+             else:
+                 prev_block_len = len(req_blocks)
+diff --git a/vllm/v1/kv_cache_interface.py b/vllm/v1/kv_cache_interface.py
+index 14f238b4c735810f7e3d69dfc1e5c9fe7984dfc1..a69a5183f73ddb14100f627075f42c11b796e509 100644
+--- a/vllm/v1/kv_cache_interface.py
++++ b/vllm/v1/kv_cache_interface.py
+@@ -404,6 +404,13 @@ def get_kv_cache_dcp_shard_count(
+             f"Configured decode-context-parallel size must be positive: "
+             f"{configured_dcp}"
+         )
++    # Recurrent state has one token-position shard across the DCP group. Its
++    # feature dimensions may still be partitioned by TP. MambaManager therefore
++    # uses the unscaled Mamba block size; reporting multiple position shards
++    # here would make worker block tables too narrow for their absolute sparse
++    # indices and route state writes through out-of-bounds block IDs.
++    if isinstance(spec, MambaSpec):
++        return 1
+     replicated = bool(getattr(spec, "dcp_replicated", False))
+     override = getattr(spec, "dcp_kv_shard_count", None)
+     if replicated:
+diff --git a/vllm/v1/worker/cp_utils.py b/vllm/v1/worker/cp_utils.py
+index 243d8f19052c1a432218cfd97ecf472df643932c..f6725cba470cfc00de60ee1f7b19d6e8fbd60333 100644
+--- a/vllm/v1/worker/cp_utils.py
++++ b/vllm/v1/worker/cp_utils.py
+@@ -47,6 +47,15 @@ def check_attention_cp_compatibility(vllm_config: VllmConfig) -> None:
+                 except Exception:
+                     spec = None
+                 if getattr(spec, "dcp_replicated", False):
++                    # A replicated KV group contains the complete sequence on
++                    # every rank. Its attention kernel must therefore execute
++                    # as a local DCP1 operation; applying DCP collectives would
++                    # partition and reduce the same cache a second time.
++                    layer_impl.dcp_world_size = 1
++                    layer_impl.dcp_rank = 0
++                    layer_impl.total_cp_world_size = 1
++                    layer_impl.total_cp_rank = 0
++                    layer_impl.need_to_return_lse_for_decode = False
+                     continue
+             if vllm_config.speculative_config is not None and interleave_size > 1:
+                 assert layer_impl.supports_mtp_with_cp_non_trivial_interleave_size, (
+diff --git a/vllm/v1/worker/gpu/sample/sampler.py b/vllm/v1/worker/gpu/sample/sampler.py
+index bfea7ca635cbe49b5ff7b26925d1cb84d98d5d5c..557cc8bbae8925bbe8143fad5c496f1ef45675f8 100644
+--- a/vllm/v1/worker/gpu/sample/sampler.py
++++ b/vllm/v1/worker/gpu/sample/sampler.py
+@@ -53,6 +53,7 @@ class Sampler:
+         self.bad_words_state = BadWordsState(req_states)
+         self.logprob_token_ids_state = LogprobTokenIdsState(max_num_reqs, device)
+         self.thinking_budget_state = ThinkingBudgetState(req_states, reasoning_config)
++        self.needs_logits_processing = np.zeros(max_num_reqs, dtype=bool)
+         self.num_speculative_tokens = num_speculative_tokens
+         self.use_flashinfer = flashinfer_sampler_supported()
+ 
+@@ -66,6 +67,22 @@ class Sampler:
+         self.logprob_token_ids_state.add_request(req_idx, sampling_params)
+         self.thinking_budget_state.add_request(req_idx, sampling_params)
+ 
++        states = self.sampling_states
++        temperature = states.temperature.np[req_idx]
++        self.needs_logits_processing[req_idx] = (
++            self.logit_bias_state.use_logit_bias[req_idx]
++            or self.penalties_state.use_penalty[req_idx]
++            or self.bad_words_state.num_bad_words.np[req_idx] > 0
++            or (
++                self.thinking_budget_state.enabled
++                and self.thinking_budget_state.use_thinking_budget[req_idx]
++            )
++            or (temperature != 0.0 and temperature != 1.0)
++            or states.min_p.np[req_idx] != 0.0
++            or states.top_k.np[req_idx] != states.vocab_size
++            or states.top_p.np[req_idx] != 1.0
++        )
++
+     def apply_staged_writes(self) -> None:
+         self.sampling_states.apply_staged_writes()
+         self.penalties_state.apply_staged_writes()
+@@ -162,7 +179,7 @@ class Sampler:
+         expanded_local_pos: torch.Tensor,
+         skip_top_k_top_p: bool = False,
+     ) -> torch.Tensor:
+-        if not self._requires_logits_processing(idx_mapping_np):
++        if not np.any(self.needs_logits_processing[idx_mapping_np]):
+             return logits
+ 
+         # Copy logits to a new FP32 tensor.
+@@ -218,24 +235,6 @@ class Sampler:
+             logits, expanded_idx_mapping, idx_mapping_np
+         )
+ 
+-    def _requires_logits_processing(self, idx_mapping_np: np.ndarray) -> bool:
+-        if np.any(self.logit_bias_state.use_logit_bias[idx_mapping_np]):
+-            return True
+-        if np.any(self.penalties_state.use_penalty[idx_mapping_np]):
+-            return True
+-        if np.any(self.bad_words_state.num_bad_words.np[idx_mapping_np] > 0):
+-            return True
+-
+-        states = self.sampling_states
+-        temperatures = states.temperature.np[idx_mapping_np]
+-        if np.any((temperatures != 0.0) & (temperatures != 1.0)):
+-            return True
+-        if np.any(states.min_p.np[idx_mapping_np] != 0.0):
+-            return True
+-        if np.any(states.top_k.np[idx_mapping_np] != states.vocab_size):
+-            return True
+-        return bool(np.any(states.top_p.np[idx_mapping_np] != 1.0))
+-
+     def sample(
+         self,
+         logits: torch.Tensor,
+diff --git a/vllm/v1/worker/gpu/spec_decode/dflash/utils.py b/vllm/v1/worker/gpu/spec_decode/dflash/utils.py
+index 256f23c42ace86724eccf966eb727e213805855b..a5e643ed10c7bacbeb35086fc1a0db75dadddc06 100644
+--- a/vllm/v1/worker/gpu/spec_decode/dflash/utils.py
++++ b/vllm/v1/worker/gpu/spec_decode/dflash/utils.py
+@@ -81,11 +81,17 @@ def maybe_load_mask_embedding(
+ 
+ def load_dflash_model(target_model: nn.Module, vllm_config: VllmConfig) -> nn.Module:
+     from vllm.compilation.backends import set_model_tag
+-    from vllm.model_executor.models.qwen3_dflash import dflash_has_any_non_causal
++    from vllm.model_executor.models.qwen3_dflash import (
++        dflash_has_any_non_causal,
++        dflash_target_rope_is_neox_style,
++    )
+ 
+     speculative_config = vllm_config.speculative_config
+     assert speculative_config is not None
+     draft_model_config = speculative_config.draft_model_config
++    is_neox_style = dflash_target_rope_is_neox_style(target_model)
++    if is_neox_style is not None:
++        draft_model_config.hf_config.is_neox_style = is_neox_style
+     # Select an attention backend that supports the drafter's attention: mixing
+     # a non-causal layer onto a causal-only backend would fail.
+     draft_vllm_config = replace(
+diff --git a/vllm/v1/worker/gpu/spec_decode/dspark/utils.py b/vllm/v1/worker/gpu/spec_decode/dspark/utils.py
+index cd23ae1bb559fbaf58b773869acaa59d4333d035..f366a0386b90159f1d9f37331e1428389cbae557 100644
+--- a/vllm/v1/worker/gpu/spec_decode/dspark/utils.py
++++ b/vllm/v1/worker/gpu/spec_decode/dspark/utils.py
+@@ -59,7 +59,9 @@ def load_dspark_model(target_model: nn.Module, vllm_config: VllmConfig) -> nn.Mo
+ 
+     with rope_ownership, set_model_tag("dspark_head"):
+         draft_model = get_model(
+-            vllm_config=draft_vllm_config, model_config=draft_model_config
++            vllm_config=draft_vllm_config,
++            model_config=draft_model_config,
++            load_config=speculative_config.draft_load_config,
+         )
+ 
+     if get_pp_group().world_size != 1:

--- a/scripts/validate_kimi_k3_qsrt_runtime.py
+++ b/scripts/validate_kimi_k3_qsrt_runtime.py
@@ -1,0 +1,100 @@
+#!/usr/bin/env python3
+"""Validate the Kimi-K3 QSRT and inactive-route runtime contracts."""
+
+from __future__ import annotations
+
+import inspect
+from collections.abc import Callable
+from typing import Any
+
+
+class RuntimeContractError(RuntimeError):
+    """The active B12X tree cannot safely serve Kimi-K3 QSRT."""
+
+
+def _require_parameters(
+    function: Callable[..., Any],
+    names: tuple[str, ...],
+) -> None:
+    parameters = inspect.signature(function).parameters
+    missing = [name for name in names if name not in parameters]
+    if missing:
+        raise RuntimeContractError(
+            f"{function.__module__}.{function.__name__} is missing {', '.join(missing)}"
+        )
+
+
+def validate_contract(
+    plan_weights: Callable[..., Any],
+    prepare_weights: Callable[..., Any],
+    kernel_type: type,
+) -> dict[str, bool]:
+    """Validate QSRT atoms-v2 and W4A16 inactive-route behavior.
+
+    Args:
+        plan_weights: Active B12X weight-planning function.
+        prepare_weights: Active B12X weight-preparation function.
+        kernel_type: Active fixed-M W4A16 direct-kernel type.
+
+    Returns:
+        A machine-readable contract summary.
+
+    Raises:
+        RuntimeContractError: The active package is missing a required contract.
+    """
+    _require_parameters(plan_weights, ("qsrt_storage_format", "qsrt_profile"))
+    _require_parameters(
+        prepare_weights,
+        ("qsrt_atom_payload", "qsrt_first_atom_slot", "qsrt_layer_index"),
+    )
+
+    kernel_kwargs = {
+        "activation": "silu",
+        "fast_math": False,
+        "share_input_across_experts": False,
+        "share_expert_scales": True,
+        "single_token": False,
+        "scale_format": "e8m0_k32",
+    }
+    fixed_m = kernel_type(compile_time_phase=0, **kernel_kwargs)
+    fc2_only = kernel_type(compile_time_phase=2, **kernel_kwargs)
+    if not hasattr(fixed_m, "stage_inactive_routes"):
+        raise RuntimeContractError(
+            "the fixed-M W4A16 kernel is missing stage_inactive_routes"
+        )
+    if fixed_m.stage_inactive_routes is not True:
+        raise RuntimeContractError(
+            "the fixed-M W4A16 kernel does not stage inactive routes"
+        )
+    if fc2_only.stage_inactive_routes is not False:
+        raise RuntimeContractError(
+            "the FC2-only runtime-M path must validate routes inline"
+        )
+
+    return {
+        "fixed_m_route_staging": True,
+        "fc2_runtime_route_validation": True,
+        "qsrt_atoms_v2": True,
+    }
+
+
+def main() -> int:
+    from b12x.moe import fused_moe
+    from b12x.moe._shared.kernels.w4a16.kernel import (
+        MoEMicroKernelW4A16SmallMDirect,
+    )
+
+    result = validate_contract(
+        fused_moe.plan_weights,
+        fused_moe.prepare_weights,
+        MoEMicroKernelW4A16SmallMDirect,
+    )
+    print(
+        "Kimi-K3 QSRT runtime contract: "
+        + " ".join(f"{name}={int(value)}" for name, value in sorted(result.items()))
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/test_kimi_k3_qsrt_dspark_launcher.py
+++ b/tests/test_kimi_k3_qsrt_dspark_launcher.py
@@ -1,0 +1,76 @@
+from __future__ import annotations
+
+import os
+import subprocess
+from pathlib import Path
+
+REPOSITORY_ROOT = Path(__file__).resolve().parents[1]
+LAUNCHER = REPOSITORY_ROOT / "launchers" / "serve-kimi-k3-qsrt-dspark"
+TP8_LAUNCHER = REPOSITORY_ROOT / "launchers" / "serve-kimi-k3-qsrt-dspark-tp8"
+
+
+def _run_launcher(
+    path: Path = LAUNCHER, **overrides: str
+) -> subprocess.CompletedProcess[str]:
+    env = {
+        **os.environ,
+        "DRY_RUN": "1",
+        "MODEL": "/nonexistent/target",
+        "DRAFT_MODEL": "/nonexistent/draft",
+        **overrides,
+    }
+    return subprocess.run(
+        [str(path)],
+        env=env,
+        check=False,
+        text=True,
+        capture_output=True,
+    )
+
+
+def test_qsrt_dspark_dry_run_preserves_default_depth() -> None:
+    result = _run_launcher()
+
+    assert result.returncode == 0, result.stderr
+    assert '"num_speculative_tokens":7' in result.stdout
+    assert "--max-num-scheduled-tokens" not in result.stdout
+
+
+def test_qsrt_dspark_accepts_aligned_explicit_scheduler_budget() -> None:
+    result = _run_launcher(
+        DSPARK_SPECULATIVE_TOKENS="3",
+        MAX_NUM_BATCHED_TOKENS="1540",
+        MAX_NUM_SCHEDULED_TOKENS="1536",
+        MAX_NUM_SEQS="2",
+    )
+
+    assert result.returncode == 0, result.stderr
+    assert '"num_speculative_tokens":3' in result.stdout
+    assert "--max-num-batched-tokens 1540" in result.stdout
+    assert "--max-num-scheduled-tokens 1536" in result.stdout
+    assert "--max-num-seqs 2" in result.stdout
+    assert "DSpark reserve: 4" in result.stderr
+
+
+def test_qsrt_dspark_rejects_budget_without_draft_reserve() -> None:
+    result = _run_launcher(
+        DSPARK_SPECULATIVE_TOKENS="3",
+        MAX_NUM_BATCHED_TOKENS="1536",
+        MAX_NUM_SCHEDULED_TOKENS="1536",
+        MAX_NUM_SEQS="2",
+    )
+
+    assert result.returncode == 2
+    assert "requires at least 1540 total batch slots" in result.stderr
+
+
+def test_tp8_profile_preserves_recurrent_boundary() -> None:
+    result = _run_launcher(TP8_LAUNCHER)
+
+    assert result.returncode == 0, result.stderr
+    assert "TP_SIZE=8" in result.stdout
+    assert "DCP_SIZE=8" in result.stdout
+    assert '"num_speculative_tokens":3' in result.stdout
+    assert "--max-num-batched-tokens 1540" in result.stdout
+    assert "--max-num-scheduled-tokens 1536" in result.stdout
+    assert "--max-num-seqs 2" in result.stdout

--- a/tests/test_kimi_k3_qsrt_tp8_release.py
+++ b/tests/test_kimi_k3_qsrt_tp8_release.py
@@ -1,0 +1,53 @@
+from __future__ import annotations
+
+import hashlib
+import json
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+RELEASE = ROOT / "patches" / "releases" / "kimi-k3-qsrt-tp8-safety"
+MANIFEST = ROOT / "manifests" / "b12x" / "kimi-k3-qsrt-tp8-safety.json"
+SOURCE_PATCH = (
+    ROOT / "manifests" / "b12x" / "patches" / "kimi-k3-qsrt-tp8-qualified-compat.patch"
+)
+
+
+def _sha256(path: Path) -> str:
+    return hashlib.sha256(path.read_bytes()).hexdigest()
+
+
+def test_b12x_release_locks_qsrt_and_inactive_route_sources() -> None:
+    manifest = json.loads(MANIFEST.read_text())
+    lock = json.loads((RELEASE / "b12x" / "integration.lock.json").read_text())
+
+    assert manifest["base_ref"] == "refs/heads/agent/pr197-base-glm52-sqg"
+    assert manifest["pull_requests"] == [
+        {
+            "number": 237,
+            "head": "7917d618a09cb01cde7df31ac6696dbe86dd72ab",
+            "title": "Sanitize inactive QSRT W4A16 routes",
+        }
+    ]
+    assert manifest["source_patches"][0]["sha256"] == _sha256(SOURCE_PATCH)
+    assert lock["base"]["commit"] == "6e2c6bfb3991b27509c0e2e70dda5d90bb039691"
+    assert lock["pull_requests"][0]["number"] == 237
+    assert lock["pull_requests"][0]["head"] == manifest["pull_requests"][0]["head"]
+    assert lock["result"]["tree"] == "64dc2cb0c6582f45a3414f5ba40c370aca7600f1"
+    assert lock["result"]["patch_sha256"] == _sha256(
+        RELEASE / "b12x" / "integration.patch"
+    )
+
+
+def test_vllm_and_lmcache_sources_remain_qualified() -> None:
+    vllm = json.loads((RELEASE / "vllm" / "integration.lock.json").read_text())
+    lmcache = json.loads((RELEASE / "lmcache" / "integration.lock.json").read_text())
+
+    assert vllm["result"]["tree"] == "12776c0df15ca4087b636c43004b5bc1fde61434"
+    assert lmcache["result"]["tree"] == "e045d729bc5c4c63a40e13d032f42923de97812f"
+
+
+def test_build_script_uses_tp8_safety_release() -> None:
+    script = (ROOT / "build-kimi-k3-qsrt-tp16-runtime.sh").read_text()
+
+    assert "release_root=patches/releases/kimi-k3-qsrt-tp8-safety" in script
+    assert 'revision="${REVISION:-qsrt-tp8-safety}"' in script

--- a/tests/test_validate_kimi_k3_qsrt_runtime.py
+++ b/tests/test_validate_kimi_k3_qsrt_runtime.py
@@ -1,0 +1,75 @@
+from __future__ import annotations
+
+import importlib.util
+from pathlib import Path
+
+import pytest
+
+SCRIPT = (
+    Path(__file__).resolve().parents[1] / "scripts" / "validate_kimi_k3_qsrt_runtime.py"
+)
+SPEC = importlib.util.spec_from_file_location("validate_kimi_k3_qsrt_runtime", SCRIPT)
+assert SPEC is not None and SPEC.loader is not None
+MODULE = importlib.util.module_from_spec(SPEC)
+SPEC.loader.exec_module(MODULE)
+
+RuntimeContractError = MODULE.RuntimeContractError
+validate_contract = MODULE.validate_contract
+
+
+def _plan_weights(
+    *,
+    qsrt_storage_format=None,
+    qsrt_profile=None,
+):
+    del qsrt_storage_format, qsrt_profile
+
+
+def _prepare_weights(
+    *,
+    qsrt_atom_payload=None,
+    qsrt_first_atom_slot=None,
+    qsrt_layer_index=None,
+):
+    del qsrt_atom_payload, qsrt_first_atom_slot, qsrt_layer_index
+
+
+class _SafeKernel:
+    def __init__(self, *, compile_time_phase: int, **_kwargs) -> None:
+        self.stage_inactive_routes = compile_time_phase != 2
+
+
+def test_validator_accepts_qsrt_atoms_v2_and_inactive_route_safety() -> None:
+    result = validate_contract(_plan_weights, _prepare_weights, _SafeKernel)
+
+    assert result == {
+        "fixed_m_route_staging": True,
+        "fc2_runtime_route_validation": True,
+        "qsrt_atoms_v2": True,
+    }
+
+
+def test_validator_rejects_binary_package_without_qsrt_kwargs() -> None:
+    def old_plan_weights():
+        return None
+
+    with pytest.raises(RuntimeContractError, match="qsrt_storage_format"):
+        validate_contract(old_plan_weights, _prepare_weights, _SafeKernel)
+
+
+def test_validator_rejects_compatibility_tree_without_pr227() -> None:
+    class UnsafeKernel:
+        def __init__(self, **_kwargs) -> None:
+            pass
+
+    with pytest.raises(RuntimeContractError, match="stage_inactive_routes"):
+        validate_contract(_plan_weights, _prepare_weights, UnsafeKernel)
+
+
+def test_validator_rejects_fc2_fixed_route_staging() -> None:
+    class UnsafeFc2Kernel:
+        def __init__(self, **_kwargs) -> None:
+            self.stage_inactive_routes = True
+
+    with pytest.raises(RuntimeContractError, match="FC2-only"):
+        validate_contract(_plan_weights, _prepare_weights, UnsafeFc2Kernel)

--- a/validation/kimi-k3-qsrt-tp8-scheduler-inactive-routes-20260819.json
+++ b/validation/kimi-k3-qsrt-tp8-scheduler-inactive-routes-20260819.json
@@ -7,8 +7,10 @@
     "base_image_digest": "sha256:a54da4e2432138d42334cac54555f3a51188489cb66029da0d96e4b39162d726",
     "qualified_image_digest": "sha256:eed268e6993935bd3aeed53c973d324645eae0cf16440438128c987e7893e105",
     "vllm_tree": "12776c0df15ca4087b636c43004b5bc1fde61434",
+    "b12x_tree": "64dc2cb0c6582f45a3414f5ba40c370aca7600f1",
     "b12x_qsrt_compat_tree_sha256": "acbe42b83673b9de75b99a7d50caaa16b8e0491a6169e9be0660d927802f2b06",
     "b12x_inactive_route_pr": "227@0eba6ae99e0d1fad6ec268d8c291f498ec1dd4d9",
+    "b12x_compatibility_port_pr": "237@7917d618a09cb01cde7df31ac6696dbe86dd72ab",
     "lmcache_tree": "e045d729bc5c4c63a40e13d032f42923de97812f",
     "code_bind_mounts": 0
   },

--- a/validation/kimi-k3-qsrt-tp8-scheduler-inactive-routes-20260819.json
+++ b/validation/kimi-k3-qsrt-tp8-scheduler-inactive-routes-20260819.json
@@ -1,0 +1,73 @@
+{
+  "schema_version": 1,
+  "status": "qualified",
+  "qualified_at_utc": "2026-08-19",
+  "scope": "Kimi-K3 QSRT-K2 TP8/DCP8 with Inferact DSpark depth 3",
+  "runtime": {
+    "base_image_digest": "sha256:a54da4e2432138d42334cac54555f3a51188489cb66029da0d96e4b39162d726",
+    "qualified_image_digest": "sha256:eed268e6993935bd3aeed53c973d324645eae0cf16440438128c987e7893e105",
+    "vllm_tree": "12776c0df15ca4087b636c43004b5bc1fde61434",
+    "b12x_qsrt_compat_tree_sha256": "acbe42b83673b9de75b99a7d50caaa16b8e0491a6169e9be0660d927802f2b06",
+    "b12x_inactive_route_pr": "227@0eba6ae99e0d1fad6ec268d8c291f498ec1dd4d9",
+    "lmcache_tree": "e045d729bc5c4c63a40e13d032f42923de97812f",
+    "code_bind_mounts": 0
+  },
+  "scheduler": {
+    "recurrent_block_tokens": 1536,
+    "max_num_batched_tokens": 1540,
+    "max_num_scheduled_tokens": 1536,
+    "max_num_seqs": 2,
+    "num_speculative_tokens": 3,
+    "parallel_draft_reserved_slots": 4,
+    "invariant": "1540 = 1536 + (3 - 1) * 2"
+  },
+  "pre_fix_reproduction": {
+    "max_num_batched_tokens": 1536,
+    "derived_max_num_scheduled_tokens": 1532,
+    "first_unstable_prompt_tokens": 1536,
+    "failure": "four of four unique-salt greedy requests returned NaN logprobs and HTTP 400",
+    "api_error": "Out of range float values are not JSON compliant: nan"
+  },
+  "post_fix_boundary": {
+    "prompt_tokens": 1540,
+    "partial_prefill_tail_tokens": 4,
+    "unique_salt_greedy_runs": 10,
+    "http_successes": 10,
+    "chosen_first_token": "The",
+    "nan_or_control_marker_failures": 0
+  },
+  "captured_incident_payload": {
+    "sha256": "234e71dab93cb0c1563c345c98e006995b2cdae3f73aa40a89a710523abef43c",
+    "direct_vllm_unique_salt_runs": 5,
+    "direct_vllm_coherent_runs": 5,
+    "llmconduit_runs": 5,
+    "llmconduit_coherent_runs": 5,
+    "local_prefix_hit_tokens": 1536,
+    "local_replay_equal_to_cold": true
+  },
+  "lmcache": {
+    "fixture_prompt_tokens": 14505,
+    "chunk_tokens": 12288,
+    "cold_output": "K3_CACHE_OK",
+    "l1_external_hit_tokens": 12288,
+    "l1_output_equal_to_cold": true,
+    "restarted_l2_external_hit_tokens": 12288,
+    "restarted_l2_output_equal_to_cold": true,
+    "l2_objects": 136,
+    "l2_bytes_approx": 941359104
+  },
+  "user_paths": {
+    "direct_vllm_health": 200,
+    "lmcache_health": 200,
+    "llmconduit_output": "현재 정상 작동 중입니다.",
+    "chatapp_output": "현재 정상 작동 중입니다."
+  },
+  "runtime_failures": {
+    "container_restarts": 0,
+    "oom_killed": false,
+    "nan_or_nonfinite_markers": 0,
+    "cublas_or_illegal_memory_markers": 0,
+    "worker_or_engine_death_markers": 0,
+    "thermal_slowdown_gpus": 0
+  }
+}


### PR DESCRIPTION
## Bug description

The Kimi-K3 QSRT TP8/DCP8 profile could emit Kimi control markers, multilingual token salad, or a low-entropy `1.! 1.!` loop while continuing to decode at normal throughput.

A loopback capture proved that direct vLLM SSE was already corrupt and llmconduit only preserved the same deltas. Unique-cache-salt controls with zero local and external cache hits still failed, ruling out gateway parsing and stale LMCache objects as the origin.

## Root cause

Two independent contracts were missing from the deployment boundary:

1. `max_num_batched_tokens=1536`, DSpark depth 3, and two active sequences caused vLLM to reserve four draft slots and reduce the target scheduler budget to 1,532 tokens. The 1,536-token Kimi recurrent block was split as `1532 + 4`.
2. A QSRT atoms-v2 compatibility package could shadow the B12X inactive-route behavior from #227. The four-token partial-prefill tail then exposed graph-padding expert routes to fixed-M W4A16 execution instead of giving those routes zero effective weight.

Before the fix, unique-salt greedy prompts were stable through 1,534 tokens and failed at exactly 1,536 tokens: four of four requests produced NaN logprobs and HTTP 400 with `Out of range float values are not JSON compliant: nan`.

## Fix

- Make QSRT DSpark depth configurable while preserving the historical depth-7 default.
- Accept an explicit `MAX_NUM_SCHEDULED_TOKENS` target budget.
- Validate `max_num_batched_tokens >= max_num_scheduled_tokens + (depth - 1) * max_num_seqs` before starting vLLM.
- Add `/usr/local/bin/serve-kimi-k3-qsrt-dspark-tp8` with the qualified geometry:
  - total batch slots: 1,540
  - target scheduler tokens: 1,536
  - DSpark depth: 3
  - active sequences: 2
- Add a fail-closed runtime validator for the active imported B12X package:
  - QSRT atoms-v2 planner/preparation ABI
  - fixed-M inactive-route staging
  - FC2-only runtime-M inline route validation
- Install and execute the validator during image build and before QSRT launch.
- Add launcher/validator regressions, an operator document, and a machine-readable qualification receipt.

The kernel behavior remains owned by B12X #227. The compatibility-base port is companion PR local-inference-lab/b12x#237; this PR does not duplicate those product changes.

## Immutable source composition

The build now reads `patches/releases/kimi-k3-qsrt-tp8-safety`:

- vLLM tree: `12776c0df15ca4087b636c43004b5bc1fde61434`
- LMCache tree: `e045d729bc5c4c63a40e13d032f42923de97812f`
- B12X tree: `64dc2cb0c6582f45a3414f5ba40c370aca7600f1`

The B12X tree starts from the pinned QSRT compatibility branch, merges PR #237, and applies a SHA-256-locked patch for the remaining qualified Kimi PCIe and atoms-v2 runtime files. The release composer reproduces the committed lock and patch byte-for-byte, and the resulting 243 `b12x/` files are byte-identical to the deployed qualified candidate. The manifest patch deliberately excludes the three product files owned by PR #237.

## How to verify

```bash
python3 -m pytest -q
bash -n \
  launchers/serve-kimi-k3-qsrt-dspark \
  launchers/serve-kimi-k3-qsrt-dspark-tp8
DRY_RUN=1 MODEL=/unused DRAFT_MODEL=/unused \
  launchers/serve-kimi-k3-qsrt-dspark-tp8
```

The dry run must report:

```text
DSpark reserve: 4; target scheduler budget: 1536; total batch slots: 1540
--max-num-batched-tokens 1540
--max-num-scheduled-tokens 1536
--max-num-seqs 2
num_speculative_tokens":3
```

The base source-overlay image fails the validator because its active B12X package lacks the QSRT atoms-v2 arguments. The qualified child image containing the compatibility package plus inactive-route safety passes all validator contracts.

## Test plan

- [x] New launcher/validator tests: 8 passed
- [x] Complete repository suite: 39 passed
- [x] Ruff check and format check on new Python files
- [x] Shell syntax checks on both QSRT launchers and the build script
- [x] `docker build --check`: no warnings
- [x] Exact four-token partial-prefill boundary: 10/10 coherent runs
- [x] Captured incident payload: direct vLLM 5/5, llmconduit 5/5
- [x] Same-process local APC replay: 1,536 hit tokens, output equal to cold
- [x] LMCache L1 replay: 12,288 external-hit tokens, byte-equivalent
- [x] Same-image restarted L2 replay: 12,288 external-hit tokens, byte-equivalent
- [x] ChatApp and llmconduit user paths returned `현재 정상 작동 중입니다.`
- [x] Zero restarts, OOM, NaN/nonfinite, CUBLAS/illegal-memory, worker-death, or thermal-slowdown markers after qualification

Machine-readable evidence:

```text
validation/kimi-k3-qsrt-tp8-scheduler-inactive-routes-20260819.json
```

## Compatibility

- The generic QSRT DSpark defaults remain unchanged when no explicit scheduler budget is selected.
- The provided TP8 profile is specific to a 1,536-token recurrent block, depth 3, and two active sequences.
- Changing depth or concurrency requires recomputing the reserve and repeating exact-boundary qualification.
- This is the language-only QSRT-K2 profile, not the official MXFP4 native-vision TP16 contract.

## Risk assessment

**Medium.** The generic launcher command construction changes from a direct `exec` to an array so it can conditionally append the scheduler flag. Tests cover default behavior, aligned explicit geometry, insufficient-budget rejection, and the TP8 profile. Runtime safety is fail-closed when the active B12X package does not satisfy the required ABI.

## AI assistance

AI assistance was used for root-cause analysis, implementation, test design, runtime qualification, independent review, and PR drafting. The submitting human must review every changed line and be able to defend the scheduler and B12X contracts before merge.

Signed-off-by: myshytf <9619163+myshytf@users.noreply.github.com>
