### PR TITLE
Build GLM-5.3 DFlash2 MXFP8 TP4 runtime

### DIFF
--- a/Dockerfile.glm53-flash-nvfp4-jovian-cu133-torch213
+++ b/Dockerfile.glm53-flash-nvfp4-jovian-cu133-torch213
@@ -1,0 +1,298 @@
+# syntax=docker/dockerfile:1.7
+
+ARG BASE_IMAGE=voipmonitor/vllm@sha256:03b67e53dda73c3fa317d4cb529ad38a220c51c7365ee8d54c16e5063fcc54e2
+FROM ${BASE_IMAGE}
+
+ARG BASE_IMAGE
+ARG BASE_IMAGE_ID
+ARG VLLM_REPO
+ARG VLLM_REF
+ARG VLLM_COMMIT
+ARG VLLM_PATCH_FILE
+ARG VLLM_PATCH_SHA256
+ARG VLLM_INTEGRATION_TREE
+ARG VLLM_INTEGRATION_LOCK_SHA256
+ARG VLLM_PRS
+ARG VLLM_MERGE_HEADS
+ARG B12X_REPO
+ARG B12X_REF
+ARG B12X_COMMIT
+ARG B12X_PATCH_FILE
+ARG B12X_PATCH_SHA256
+ARG B12X_INTEGRATION_TREE
+ARG B12X_INTEGRATION_LOCK_SHA256
+ARG B12X_PRS
+ARG B12X_MERGE_HEADS
+ARG SOURCE_LOCK_SHA256
+ARG VLLM_PACKAGE_VERSION
+ARG FLASH_ATTN_REPO=https://github.com/JaredforReal/flash-attention.git
+ARG FLASH_ATTN_COMMIT=2b84100f50e1d2a8726a86c86d14c2f9c9e5a67c
+ARG CACHE_FINGERPRINT
+
+SHELL ["/bin/bash", "-o", "pipefail", "-c"]
+
+ENV VIRTUAL_ENV=/opt/venv \
+    PATH=/opt/venv/bin:${PATH} \
+    PYTHONPATH=/opt/glm53-flash/vllm:/opt/glm53-flash/b12x \
+    SPARKINFER_DIR=/opt/glm53-flash/b12x \
+    CUTLASS_DSL_VERSION=4.6.2 \
+    TORCH_CUDA_ARCH_LIST=12.0a \
+    CMAKE_CUDA_ARCHITECTURES=120a \
+    FLASHINFER_CUDA_ARCH_LIST=12.0f \
+    FLASHINFER_LOCAL_VERSION=cu133 \
+    FLASHINFER_DISABLE_VERSION_CHECK=1 \
+    NVCC_THREADS=4 \
+    PYTORCH_CUDA_ALLOC_CONF=expandable_segments:True \
+    CUDA_DEVICE_ORDER=PCI_BUS_ID \
+    NCCL_IB_DISABLE=1 \
+    NCCL_P2P_LEVEL=SYS \
+    NCCL_P2P_DISABLE=0 \
+    NCCL_CUMEM_ENABLE=0 \
+    NCCL_PROTO=LL,LL128,Simple \
+    VLLM_ENABLE_PCIE_ALLREDUCE=1 \
+    VLLM_PCIE_ALLREDUCE_BACKEND=b12x \
+    VLLM_CPP_AR_1STAGE_NCCL_CUTOFF=56KB \
+    VLLM_CPP_AR_IGNORE_CUTOFF_MAX_ROWS=0
+
+ENV LOCAL_INFERENCE_CACHE_FINGERPRINT=${CACHE_FINGERPRINT} \
+    XDG_CACHE_HOME=/cache/jit/${CACHE_FINGERPRINT} \
+    VLLM_CACHE_ROOT=/cache/jit/${CACHE_FINGERPRINT}/vllm \
+    VLLM_CACHE_DIR=/cache/jit/${CACHE_FINGERPRINT}/vllm \
+    TRITON_CACHE_DIR=/cache/jit/${CACHE_FINGERPRINT}/triton \
+    TORCH_EXTENSIONS_DIR=/cache/jit/${CACHE_FINGERPRINT}/torch-extensions \
+    TORCHINDUCTOR_CACHE_DIR=/cache/jit/${CACHE_FINGERPRINT}/torchinductor \
+    VLLM_FLASHINFER_AUTOTUNE_CACHE_DIR=/cache/jit/${CACHE_FINGERPRINT}/flashinfer-autotune \
+    FLASHINFER_WORKSPACE_BASE=/cache/jit/${CACHE_FINGERPRINT}/flashinfer \
+    TVM_FFI_CACHE_DIR=/cache/jit/${CACHE_FINGERPRINT}/tvm-ffi \
+    TVM_CACHE_DIR=/cache/jit/${CACHE_FINGERPRINT}/tvm \
+    TILELANG_CACHE_DIR=/cache/jit/${CACHE_FINGERPRINT}/tilelang \
+    CUTE_DSL_CACHE_DIR=/cache/jit/${CACHE_FINGERPRINT}/cute-dsl \
+    B12X_CUTE_COMPILE_CACHE_DIR=/cache/jit/${CACHE_FINGERPRINT}/b12x/cute \
+    B12X_COMPILE_CACHE_DIR=/cache/jit/${CACHE_FINGERPRINT}/b12x/compile \
+    SPARKINFER_COMPILE_CACHE_DIR=/cache/jit/${CACHE_FINGERPRINT}/b12x/compile \
+    DG_JIT_CACHE_DIR=/cache/jit/${CACHE_FINGERPRINT}/deep-gemm \
+    CUDA_CACHE_PATH=/cache/jit/${CACHE_FINGERPRINT}/cuda \
+    CUPY_CACHE_DIR=/cache/jit/${CACHE_FINGERPRINT}/cupy \
+    HF_HOME=/root/.cache/huggingface
+
+COPY patches/releases/glm53-flash-nvfp4-jovian /tmp/release-patches/glm53-flash-nvfp4-jovian
+
+# Reconstruct both source directories from content-addressed base commits and
+# integration patches. Exact result-tree checks make any source change fail the
+# build.
+RUN set -eux; \
+    mkdir -p /opt/glm53-flash; \
+    compose_source() { \
+      component="$1"; destination="$2"; repository="$3"; reference="$4"; \
+      commit="$5"; patch_file="$6"; patch_sha256="$7"; expected_tree="$8"; \
+      git clone --filter=blob:none --no-checkout "${repository}" "${destination}"; \
+      git -C "${destination}" fetch --filter=blob:none origin "${reference}"; \
+      git -C "${destination}" checkout --detach "${commit}"; \
+      test "$(git -C "${destination}" rev-parse HEAD)" = "${commit}"; \
+      patch_path="/tmp/release-patches/${patch_file}"; \
+      echo "${patch_sha256}  ${patch_path}" | sha256sum -c -; \
+      if test -s "${patch_path}"; then git -C "${destination}" apply --index "${patch_path}"; fi; \
+      actual_tree="$(git -C "${destination}" write-tree)"; \
+      test "${actual_tree}" = "${expected_tree}" || { \
+        echo "${component} tree ${actual_tree} does not match ${expected_tree}" >&2; \
+        exit 1; \
+      }; \
+      if ! git -C "${destination}" diff --cached --quiet; then \
+        GIT_AUTHOR_NAME='Release Composer' \
+        GIT_AUTHOR_EMAIL='release-composer@local' \
+        GIT_COMMITTER_NAME='Release Composer' \
+        GIT_COMMITTER_EMAIL='release-composer@local' \
+        GIT_AUTHOR_DATE='2000-01-01T00:00:00+00:00' \
+        GIT_COMMITTER_DATE='2000-01-01T00:00:00+00:00' \
+          git -C "${destination}" commit --quiet --no-gpg-sign \
+            -m "Compose ${component} source"; \
+      fi; \
+      test "$(git -C "${destination}" rev-parse 'HEAD^{tree}')" = "${expected_tree}"; \
+      test -z "$(git -C "${destination}" status --porcelain)"; \
+    }; \
+    compose_source vllm /opt/glm53-flash/vllm \
+      "${VLLM_REPO}" "${VLLM_REF}" "${VLLM_COMMIT}" \
+      "${VLLM_PATCH_FILE}" "${VLLM_PATCH_SHA256}" "${VLLM_INTEGRATION_TREE}"; \
+    compose_source b12x /opt/glm53-flash/b12x \
+      "${B12X_REPO}" "${B12X_REF}" "${B12X_COMMIT}" \
+      "${B12X_PATCH_FILE}" "${B12X_PATCH_SHA256}" "${B12X_INTEGRATION_TREE}"; \
+    test "$(git -C /opt/glm53-flash/vllm config --get remote.origin.url)" = "${VLLM_REPO}"; \
+    test "$(git -C /opt/glm53-flash/b12x config --get remote.origin.url)" = "${B12X_REPO}"; \
+    rm -rf /tmp/release-patches
+
+# The source-neutral foundation supplies the qualified CUDA 13.3, PyTorch
+# 2.13, FlashInfer, InstantTensor, Rust, and CuTe DSL toolchains.
+RUN set -eux; \
+    test "$(python -c 'import sys; print(sys.prefix)')" = /opt/venv; \
+    python -c 'import torch; assert torch.__version__.startswith("2.13.0")'; \
+    test "$(python -c 'import importlib.metadata as m; print(m.version("flashinfer-python"))')" = 0.6.18+cu133; \
+    test "$(python -c 'import importlib.metadata as m; print(m.version("instanttensor"))')" = 0.1.9; \
+    test "$(python -c 'import importlib.metadata as m; print(m.version("nvidia-cutlass-dsl"))')" = 4.6.2; \
+    python -m pip install --no-build-isolation --no-deps --force-reinstall \
+      /opt/glm53-flash/b12x
+
+WORKDIR /opt/glm53-flash/vllm
+
+# Rebuild vLLM native extensions against the source-locked tree and the
+# foundation's packaged PyTorch ABI.
+RUN --mount=type=cache,id=glm53-dflash2-mxfp8-cu133-vllm-extensions,target=/tmp/vllm-extensions,sharing=locked \
+    set -eux; \
+    cmake -S . -B /tmp/vllm-extensions -G Ninja \
+      -U MARLIN_GEN_SCRIPT_HASH_AND_ARCH \
+      -U MOE_MARLIN_GEN_SCRIPT_HASH_AND_ARCH \
+      -DCMAKE_BUILD_TYPE=Release \
+      -DCMAKE_CUDA_ARCHITECTURES=75 \
+      -DVLLM_TARGET_DEVICE=cuda \
+      -DVLLM_PYTHON_EXECUTABLE=/opt/venv/bin/python \
+      -DNVCC_THREADS=4; \
+    cmake --build /tmp/vllm-extensions --parallel 48; \
+    cmake --install /tmp/vllm-extensions \
+      --prefix /tmp/vllm-flash-attn-python \
+      --component _vllm_fa4_cutedsl_C; \
+    test -f /tmp/vllm-flash-attn-python/vllm/vllm_flash_attn/cute/utils.py; \
+    flash_attn_source=/tmp/vllm-extensions/_deps/vllm-flash-attn-src/vllm_flash_attn; \
+    test -f "${flash_attn_source}/layers/rotary.py"; \
+    test -f "${flash_attn_source}/ops/triton/rotary.py"; \
+    cp -a /tmp/vllm-flash-attn-python/vllm/vllm_flash_attn/cute \
+      /opt/glm53-flash/vllm/vllm/vllm_flash_attn/; \
+    cp -a "${flash_attn_source}/layers" "${flash_attn_source}/ops" \
+      /opt/glm53-flash/vllm/vllm/vllm_flash_attn/; \
+    find /tmp/vllm-extensions -name '*.abi3.so' > /tmp/vllm-extension-list; \
+    while IFS= read -r extension; do \
+      case "${extension}" in \
+        */vllm-flash-attn/*) destination=/opt/glm53-flash/vllm/vllm/vllm_flash_attn ;; \
+        */_deps/*) continue ;; \
+        *) destination=/opt/glm53-flash/vllm/vllm ;; \
+      esac; \
+      cp "${extension}" "${destination}/$(basename "${extension}")"; \
+    done < /tmp/vllm-extension-list; \
+    test -f /opt/glm53-flash/vllm/vllm/_C_stable_libtorch.abi3.so; \
+    test -f /opt/glm53-flash/vllm/vllm/cumem_allocator.abi3.so; \
+    test -f /opt/glm53-flash/vllm/vllm/vllm_flash_attn/cute/utils.py; \
+    test -f /opt/glm53-flash/vllm/vllm/vllm_flash_attn/layers/rotary.py; \
+    test -f /opt/glm53-flash/vllm/vllm/vllm_flash_attn/ops/triton/rotary.py
+
+ARG TRITON_KERNELS_REPO=https://github.com/triton-lang/triton.git
+ARG TRITON_KERNELS_COMMIT=0add68262ab0a2e33b84524346cb27cbb2787356
+
+RUN set -eux; \
+    git clone --filter=blob:none --no-checkout "${TRITON_KERNELS_REPO}" /tmp/triton-kernels-src; \
+    git -C /tmp/triton-kernels-src fetch --depth=1 origin "${TRITON_KERNELS_COMMIT}"; \
+    git -C /tmp/triton-kernels-src checkout --detach "${TRITON_KERNELS_COMMIT}"; \
+    source_dir=/tmp/triton-kernels-src/python/triton_kernels/triton_kernels; \
+    destination=/opt/glm53-flash/vllm/vllm/third_party/triton_kernels; \
+    test -f "${source_dir}/matmul_ogs.py"; \
+    mkdir -p "${destination}"; \
+    cp -a "${source_dir}/." "${destination}/"; \
+    site_packages="$(python -c 'import site; print(site.getsitepackages()[0])')"; \
+    rm -f "${site_packages}/triton_kernels"; \
+    ln -s "${destination}" "${site_packages}/triton_kernels"; \
+    rm -rf /tmp/triton-kernels-src
+
+# Install package metadata, CLI entry points, and the Rust parser without
+# replacing the native extensions compiled above.
+RUN set -eux; \
+    source /root/.cargo/env; \
+    rust_toolchain="$(sed -n 's/^channel = "\([^"]*\)"/\1/p' rust-toolchain.toml)"; \
+    if ! rustup toolchain list | grep -Fq "${rust_toolchain}"; then \
+      rustup toolchain install "${rust_toolchain}"; \
+    fi; \
+    rustup default "${rust_toolchain}"; \
+    python tools/build_rust.py --release; \
+    VLLM_TARGET_DEVICE=empty VLLM_VERSION_OVERRIDE="${VLLM_PACKAGE_VERSION}" \
+      VLLM_REQUIRE_RUST_FRONTEND=1 \
+      python -m pip install --no-build-isolation --no-deps --force-reinstall .; \
+    test "$(python -c 'import importlib.metadata as m; print(m.version("vllm"))')" = \
+      "${VLLM_PACKAGE_VERSION}"; \
+    site_packages="$(python -c 'import site; print(site.getsitepackages()[0])')"; \
+    installed_package="${site_packages}/vllm"; \
+    find /opt/glm53-flash/vllm/vllm -maxdepth 1 -type f \
+      -name '*.abi3.so' -exec cp -a -t "${installed_package}" {} +; \
+    rm -rf "${installed_package}/vllm_flash_attn"; \
+    cp -a /opt/glm53-flash/vllm/vllm/vllm_flash_attn \
+      "${installed_package}/vllm_flash_attn"; \
+    test -f "${installed_package}/_C_stable_libtorch.abi3.so"; \
+    test -f "${installed_package}/vllm_flash_attn/_vllm_fa2_C.abi3.so"; \
+    test -f "${installed_package}/vllm_flash_attn/layers/rotary.py"; \
+    test -f "${installed_package}/vllm_flash_attn/ops/triton/rotary.py"; \
+    (cd / && env -u PYTHONPATH python -c \
+      'import pathlib, vllm; expected=pathlib.Path("/opt/venv/lib/python3.12/site-packages/vllm"); assert pathlib.Path(vllm.__file__).resolve().is_relative_to(expected)'); \
+    rm -rf /root/.cargo /root/.rustup target rust/target
+
+COPY launchers/serve-glm53-flash-nvfp4.sh /usr/local/bin/serve-glm53-flash-nvfp4.sh
+COPY tests/verify_glm53_flash_nvfp4_runtime.py /opt/local-inference/verify_glm53_flash_nvfp4_runtime.py
+
+RUN set -eux; \
+    chmod 0755 /usr/local/bin/serve-glm53-flash-nvfp4.sh; \
+    bash -n /usr/local/bin/serve-glm53-flash-nvfp4.sh; \
+    mkdir -p "/cache/jit/${CACHE_FINGERPRINT}"; \
+    python /opt/local-inference/verify_glm53_flash_nvfp4_runtime.py \
+      --vllm-version "${VLLM_PACKAGE_VERSION}" \
+      --vllm-tree "${VLLM_INTEGRATION_TREE}" \
+      --b12x-tree "${B12X_INTEGRATION_TREE}"
+
+ARG RELEASE_DATE
+ARG DOCKER_COMMIT
+ARG RELEASE_STATUS=qualified
+
+LABEL org.opencontainers.image.title="GLM-5.3-Flash NVFP4 and DFlash2 MXFP8 CUDA 13.3 runtime" \
+      org.opencontainers.image.description="Source-locked GLM-5.3-Flash TP4 runtime with B12X target kernels, B12X PCIe all-reduce, and serialized ModelOpt MXFP8 DFlash2 speculation" \
+      org.opencontainers.image.source="https://github.com/local-inference-lab/blackwell-llm-docker" \
+      org.opencontainers.image.version="${RELEASE_DATE}" \
+      org.opencontainers.image.revision="${DOCKER_COMMIT}" \
+      local-inference.release.name="glm53-flash-nvfp4-dflash2-mxfp8" \
+      local-inference.status="${RELEASE_STATUS}" \
+      local-inference.docker.commit="${DOCKER_COMMIT}" \
+      local-inference.runtime.base-image="${BASE_IMAGE}" \
+      local-inference.runtime.base-id="${BASE_IMAGE_ID}" \
+      local-inference.runtime.source-lock.sha256="${SOURCE_LOCK_SHA256}" \
+      local-inference.runtime.host-kv-default="disabled" \
+      local-inference.cache.fingerprint="${CACHE_FINGERPRINT}" \
+      local-inference.vllm.repo="${VLLM_REPO}" \
+      local-inference.vllm.branch="${VLLM_REF}" \
+      local-inference.vllm.commit="${VLLM_COMMIT}" \
+      local-inference.vllm.upstream-base="${VLLM_COMMIT}" \
+      local-inference.vllm.integration.tree="${VLLM_INTEGRATION_TREE}" \
+      local-inference.vllm.integration.prs="${VLLM_PRS}" \
+      local-inference.vllm.merge-heads="${VLLM_MERGE_HEADS}" \
+      local-inference.vllm.patch_sha256="${VLLM_PATCH_SHA256}" \
+      local-inference.vllm.integration.lock_sha256="${VLLM_INTEGRATION_LOCK_SHA256}" \
+      local-inference.vllm.package-version="${VLLM_PACKAGE_VERSION}" \
+      local-inference.b12x.repo="${B12X_REPO}" \
+      local-inference.b12x.branch="${B12X_REF}" \
+      local-inference.b12x.commit="${B12X_COMMIT}" \
+      local-inference.b12x.upstream-base="${B12X_COMMIT}" \
+      local-inference.b12x.integration.tree="${B12X_INTEGRATION_TREE}" \
+      local-inference.b12x.integration.prs="${B12X_PRS}" \
+      local-inference.b12x.merge-heads="${B12X_MERGE_HEADS}" \
+      local-inference.b12x.patch_sha256="${B12X_PATCH_SHA256}" \
+      local-inference.b12x.integration.lock_sha256="${B12X_INTEGRATION_LOCK_SHA256}" \
+      local-inference.flash-attention.repo="${FLASH_ATTN_REPO}" \
+      local-inference.flash-attention.commit="${FLASH_ATTN_COMMIT}" \
+      local-inference.flashinfer.version="0.6.18+cu133" \
+      local-inference.instanttensor.version="0.1.9" \
+      local-inference.cutlass-dsl.version="4.6.2" \
+      local-inference.cuda.version="13.3" \
+      local-inference.torch.version="2.13.0" \
+      local-inference.nccl.version="2.31.2"
+
+LABEL local-inference.model.repository="local-inference-lab/GLM-5.3-Flash-NVFP4" \
+      local-inference.model.revision="520de24eabf507659eaef7c70f14fd584527facc" \
+      local-inference.draft-model.repository="local-inference-lab/GLM-5.3-Flash-DFlash2-MXFP8" \
+      local-inference.draft-model.revision="b6d33aa93fc1ac5b23a88251a1c0ce0bfe2ad17c" \
+      local-inference.draft-model.quantization="ModelOpt MXFP8 1x32" \
+      local-inference.backend.attention.default="B12X" \
+      local-inference.backend.indexer.decode="B12X_C4" \
+      local-inference.backend.indexer.prefill="DeepGEMM_C4" \
+      local-inference.backend.moe.default="b12x" \
+      local-inference.backend.linear.default="b12x" \
+      local-inference.backend.allreduce.default="B12X_PCIE" \
+      local-inference.backend.kda.non-speculative="Triton" \
+      local-inference.backend.kda.speculative="B12X"
+
+ENV NCCL_VERSION=2.31.2 \
+    NCCL_NET_PLUGIN=none \
+    NCCL_TUNER_PLUGIN=none
+
+WORKDIR /
+ENTRYPOINT ["/usr/local/bin/serve-glm53-flash-nvfp4.sh"]

--- a/README.md
+++ b/README.md
@@ -11,6 +11,7 @@ Docker images for LLM inference on NVIDIA Blackwell GPUs (SM120).
 | `voipmonitor/vllm:cu130` | `Dockerfile.vllm-cu130` | CUDA 13.0, torch 2.11 stable cu130, FlashInfer source (PR #2913), vLLM + cherry-picks |
 | `voipmonitor/vllm:vllm-b12x-cu132` | `Dockerfile.vllm-b12x-cu132` | Clean CUDA 13.2.1, PyTorch 2.12 cu132 wheels, patched NCCL 2.30.4, FlashInfer, DeepGEMM, B12X, vLLM |
 | `voipmonitor/vllm:lucifer` | `Dockerfile.vllm-b12x-cu132` | Lucifer DS4 Flash/CUTLASS vLLM branch on the same CUDA 13.2.1 base, FlashInfer, DeepGEMM, and Triton kernels source hook |
+| `voipmonitor/vllm:glm53-flash-dflash2-mxfp8-*` | `Dockerfile.glm53-flash-nvfp4-jovian-cu133-torch213` | GLM-5.3-Flash NVFP4 TP4 target with B12X kernels and serialized ModelOpt MXFP8 DFlash2 |
 
 Base image for cu132 (torch + FlashInfer compiled from source):
 
@@ -107,6 +108,10 @@ IMAGE=voipmonitor/vllm:vllm-b12x-cu132 ./build-vllm-b12x-cu132.sh
 # Invocation, B12X, and LMCache integration trees on CUDA 13.3/PyTorch 2.13.
 ./build-deepseek-infernal-invocation-cu133-torch213.sh
 
+# Build the GLM-5.3-Flash NVFP4 TP4 runtime from dev/jovian-judgement plus
+# vLLM PR #491 and B12X master plus B12X PR #250.
+./build-glm53-flash-nvfp4-jovian-cu133-torch213.sh
+
 # Build the unified GLM-5.2 and DS4/DSpark v16 image from immutable vLLM,
 # B12X, FlashInfer, DeepGEMM, CUTLASS, InstantTensor, and NCCL commits.
 ./build-fathomless-firmament-v16-cu132.sh
@@ -120,6 +125,101 @@ IMAGE=voipmonitor/vllm:vllm-b12x-cu132 ./build-vllm-b12x-cu132.sh
 # manifests from scratch.
 ./build-gilded-gnosis-v20-final-cu132.sh
 ```
+
+### GLM-5.3-Flash NVFP4 with ModelOpt MXFP8 DFlash2
+
+Status: **qualified** for TP4 on NVIDIA RTX PRO 6000 Blackwell GPUs. The build
+script composes these immutable source inputs:
+
+- `local-inference-lab/vllm:dev/jovian-judgement` at
+  `015dcd423d6aabf843c8ad69074ff67d35c2a395` plus vLLM PR #491 at
+  `608010a003ccb900a5268b2235d09f81d37bf66e`;
+- `local-inference-lab/b12x:master` at
+  `2fcf23a0ce269be27b2e03fece73d46e90e6aeea` plus test-only B12X PR #250 at
+  `dd8cf60505e0363ab9d6ef6b2116c3a37216a2f1`.
+
+The integration locks under `patches/releases/glm53-flash-nvfp4-jovian/`
+record both branch commits, both pull-request heads, the generated patch
+digests, and the resulting Git trees. The Docker build independently verifies
+those trees before compiling vLLM and installing B12X.
+
+The serving interface uses these Hugging Face model identifiers:
+
+- target: `local-inference-lab/GLM-5.3-Flash-NVFP4`;
+- DFlash2 draft: `local-inference-lab/GLM-5.3-Flash-DFlash2-MXFP8`.
+
+The launcher pins the target checkpoint to
+`520de24eabf507659eaef7c70f14fd584527facc` and the DFlash2 checkpoint to
+`b6d33aa93fc1ac5b23a88251a1c0ce0bfe2ad17c`. `MODEL_REVISION` and
+`DFLASH_MODEL_REVISION` override those revisions; an empty value disables the
+corresponding revision argument for a repository model identifier.
+
+Build the image:
+
+```bash
+export GLM53_IMAGE="$(
+  PRINT_RELEASE_CONFIG=1 \
+    ./build-glm53-flash-nvfp4-jovian-cu133-torch213.sh |
+    sed -n 's/^image=//p'
+)"
+./build-glm53-flash-nvfp4-jovian-cu133-torch213.sh
+```
+
+The qualified build tag records the first 12 hexadecimal characters of the
+Docker recipe commit after the `-git` suffix. This prevents two clean recipe
+commits from publishing different artifacts under one qualified tag. Setting
+`BASE_IMAGE`, `VLLM_PACKAGE_VERSION`, or `ALLOW_DIRTY_BUILD=1` requires an
+explicit `IMAGE` tag containing a `dev`, `test`, or `scratch` marker. Such an
+image is labeled `research-only`; `PUSH_IMAGE=1` is rejected whenever
+`ALLOW_DIRTY_BUILD=1` is set.
+
+The launcher defaults to physical GPUs selected by Docker, TP4, target FP8 KV
+cache, NVFP4 W4A4 routed experts, B12X attention/MoE/linear kernels, B12X PCIe
+all-reduce, and `CUDAGRAPH_MODE=FULL`. The target GDN backend captures decode;
+unsupported prefill segments execute eagerly. DFlash2 uses its checkpoint
+default BF16 KV cache and seven draft tokens.
+
+Start target-only serving on physical GPUs 4, 5, 6, and 7:
+
+```bash
+docker run --rm --name glm53-target-tp4 \
+  --gpus '"device=4,5,6,7"' --network host --ipc host --shm-size 32g \
+  -v glm53-hf:/root/.cache/huggingface \
+  -v glm53-target-jit:/cache/jit \
+  "${GLM53_IMAGE}"
+```
+
+Start MTP with three draft tokens:
+
+```bash
+docker run --rm --name glm53-mtp3-tp4 \
+  --gpus '"device=4,5,6,7"' --network host --ipc host --shm-size 32g \
+  -v glm53-hf:/root/.cache/huggingface \
+  -v glm53-mtp3-jit:/cache/jit \
+  -e SPECULATOR=mtp -e MTP=3 \
+  "${GLM53_IMAGE}"
+```
+
+Start DFlash2 with seven draft tokens:
+
+```bash
+docker run --rm --name glm53-dflash2-tp4 \
+  --gpus '"device=4,5,6,7"' --network host --ipc host --shm-size 32g \
+  -v glm53-hf:/root/.cache/huggingface \
+  -v glm53-dflash2-jit:/cache/jit \
+  -e SPECULATOR=dflash \
+  "${GLM53_IMAGE}"
+```
+
+The launcher listens on `0.0.0.0:8000` by default and does not add an
+authentication layer. Set `HOST=127.0.0.1` for host-local access or place the
+server behind an authenticated proxy and network policy before exposing it to
+untrusted clients.
+
+The MTP expert is serialized as MXFP8 and uses Humming because B12X does not
+implement that MTP projection format. The DFlash2 ModelOpt MXFP8 projections
+use the selected B12X linear backend. The DFlash2 causal attention layers use
+their compatible attention backend while the GLM-5.3 target remains on B12X.
 
 ### Kimi-K3 source-locked production runtime
 

--- a/README.md
+++ b/README.md
@@ -133,7 +133,7 @@ script composes these immutable source inputs:
 
 - `local-inference-lab/vllm:dev/jovian-judgement` at
   `015dcd423d6aabf843c8ad69074ff67d35c2a395` plus vLLM PR #491 at
-  `608010a003ccb900a5268b2235d09f81d37bf66e`;
+  `b77333ca8824897ff6ddf96a62208ea406c555a9`;
 - `local-inference-lab/b12x:master` at
   `2fcf23a0ce269be27b2e03fece73d46e90e6aeea` plus test-only B12X PR #250 at
   `dd8cf60505e0363ab9d6ef6b2116c3a37216a2f1`.

--- a/build-glm53-flash-nvfp4-jovian-cu133-torch213.sh
+++ b/build-glm53-flash-nvfp4-jovian-cu133-torch213.sh
@@ -71,7 +71,7 @@ source_lock_sha256="$({
 
 test "${VLLM_REF}" = dev/jovian-judgement
 test "${B12X_REF}" = master
-test "${VLLM_PRS}" = "491@608010a003ccb900a5268b2235d09f81d37bf66e"
+test "${VLLM_PRS}" = "491@b77333ca8824897ff6ddf96a62208ea406c555a9"
 test "${B12X_PRS}" = "250@dd8cf60505e0363ab9d6ef6b2116c3a37216a2f1"
 test "$(jq -er '.source_patches | length' "${composition_root}/vllm/integration.lock.json")" = 0
 test "$(jq -er '.source_patches | length' "${composition_root}/b12x/integration.lock.json")" = 0

--- a/build-glm53-flash-nvfp4-jovian-cu133-torch213.sh
+++ b/build-glm53-flash-nvfp4-jovian-cu133-torch213.sh
@@ -1,0 +1,249 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Build a reproducible GLM-5.3-Flash NVFP4 runtime with ModelOpt MXFP8
+# DFlash2 support from pinned branch bases and pull-request heads.
+
+repo_root="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+cd "${repo_root}"
+
+base_image_overridden=0
+vllm_package_version_overridden=0
+image_overridden=0
+[[ -v BASE_IMAGE ]] && base_image_overridden=1
+[[ -v VLLM_PACKAGE_VERSION ]] && vllm_package_version_overridden=1
+[[ -v IMAGE ]] && image_overridden=1
+
+release_date=${RELEASE_DATE:-20260828}
+revision=${REVISION:-r1}
+composition_root=patches/releases/glm53-flash-nvfp4-jovian
+base_image=${BASE_IMAGE:-voipmonitor/vllm@sha256:03b67e53dda73c3fa317d4cb529ad38a220c51c7365ee8d54c16e5063fcc54e2}
+allow_dirty_build=${ALLOW_DIRTY_BUILD:-0}
+push_image=${PUSH_IMAGE:-0}
+
+case "${revision}" in
+  r[1-9]|r[1-9][0-9]*) ;;
+  *) printf 'REVISION must use the rN form; got %s\n' "${revision}" >&2; exit 2 ;;
+esac
+[[ "${release_date}" =~ ^[0-9]{8}$ ]] || {
+  printf 'RELEASE_DATE must use YYYYMMDD; got %s\n' "${release_date}" >&2
+  exit 2
+}
+case "${allow_dirty_build}" in
+  0 | 1) ;;
+  *) printf 'ALLOW_DIRTY_BUILD must be 0 or 1; got %s\n' "${allow_dirty_build}" >&2; exit 2 ;;
+esac
+case "${push_image}" in
+  0 | 1) ;;
+  *) printf 'PUSH_IMAGE must be 0 or 1; got %s\n' "${push_image}" >&2; exit 2 ;;
+esac
+if ((allow_dirty_build == 1 && push_image == 1)); then
+  printf 'PUSH_IMAGE=1 is forbidden when ALLOW_DIRTY_BUILD=1.\n' >&2
+  exit 2
+fi
+
+read_lock() {
+  local component=$1 prefix=$2
+  local lock="${composition_root}/${component}/integration.lock.json"
+  local patch="${composition_root}/${component}/integration.patch"
+
+  test -f "${lock}" || { printf 'Missing composition lock: %s\n' "${lock}" >&2; exit 1; }
+  test -f "${patch}" || { printf 'Missing integration patch: %s\n' "${patch}" >&2; exit 1; }
+  echo "$(jq -er '.result.patch_sha256' "${lock}")  ${patch}" | sha256sum -c - >/dev/null
+
+  export "${prefix}_REPO=$(jq -er '.base.repository' "${lock}")"
+  export "${prefix}_REF=$(jq -er '.base.ref | sub("^refs/heads/"; "")' "${lock}")"
+  export "${prefix}_COMMIT=$(jq -er '.base.commit' "${lock}")"
+  export "${prefix}_PATCH_FILE=${composition_root#patches/releases/}/${component}/integration.patch"
+  export "${prefix}_PATCH_SHA256=$(jq -er '.result.patch_sha256' "${lock}")"
+  export "${prefix}_INTEGRATION_TREE=$(jq -er '.result.tree' "${lock}")"
+  export "${prefix}_INTEGRATION_LOCK_SHA256=$(sha256sum "${lock}" | cut -d' ' -f1)"
+  export "${prefix}_PRS=$(jq -er '[.pull_requests[] | "\(.number)@\(.head)"] | join(",")' "${lock}")"
+  export "${prefix}_MERGE_HEADS=$(jq -er '[.pull_requests[].head] | join(",")' "${lock}")"
+}
+
+read_lock vllm VLLM
+read_lock b12x B12X
+source_lock_sha256="$({
+  printf '%s\n' "${VLLM_INTEGRATION_LOCK_SHA256}"
+  printf '%s\n' "${B12X_INTEGRATION_LOCK_SHA256}"
+} | sha256sum | cut -d' ' -f1)"
+
+test "${VLLM_REF}" = dev/jovian-judgement
+test "${B12X_REF}" = master
+test "${VLLM_PRS}" = "491@608010a003ccb900a5268b2235d09f81d37bf66e"
+test "${B12X_PRS}" = "250@dd8cf60505e0363ab9d6ef6b2116c3a37216a2f1"
+test "$(jq -er '.source_patches | length' "${composition_root}/vllm/integration.lock.json")" = 0
+test "$(jq -er '.source_patches | length' "${composition_root}/b12x/integration.lock.json")" = 0
+
+docker_commit="$(git rev-parse HEAD)"
+worktree_dirty=0
+if [[ -n "$(git status --porcelain --untracked-files=all)" ]]; then
+  worktree_dirty=1
+fi
+if ((worktree_dirty == 1 && allow_dirty_build == 0)); then
+  printf 'Commit the runtime recipe or set ALLOW_DIRTY_BUILD=1.\n' >&2
+  git status --short >&2
+  exit 1
+fi
+
+vllm_package_version=${VLLM_PACKAGE_VERSION:-0.26.1rc0+glm53.flash.dflash2.mxfp8.${revision}.vllm${VLLM_INTEGRATION_TREE:0:7}.b12x${B12X_INTEGRATION_TREE:0:7}}
+cache_fingerprint="cu133-torch213-glm53-dflash2-mxfp8-vllm${VLLM_INTEGRATION_TREE:0:10}-b12x${B12X_INTEGRATION_TREE:0:10}"
+qualified_image="voipmonitor/vllm:glm53-flash-dflash2-mxfp8-vllm${VLLM_INTEGRATION_TREE:0:7}-b12x${B12X_INTEGRATION_TREE:0:7}-fi1ac6942-cu133-torch213-${release_date}-${revision}-git${docker_commit:0:12}"
+image=${IMAGE:-${qualified_image}}
+release_status=qualified
+
+override_reasons=()
+((base_image_overridden == 1)) && override_reasons+=(BASE_IMAGE)
+((vllm_package_version_overridden == 1)) && override_reasons+=(VLLM_PACKAGE_VERSION)
+((allow_dirty_build == 1)) && override_reasons+=(ALLOW_DIRTY_BUILD)
+if ((${#override_reasons[@]} > 0)); then
+  if ((image_overridden == 0)); then
+    printf 'Build overrides (%s) require an explicit non-release IMAGE tag.\n' \
+      "$(IFS=,; printf '%s' "${override_reasons[*]}")" >&2
+    exit 2
+  fi
+  image_tag=${image##*:}
+  case "${image_tag}" in
+    dev-* | test-* | scratch-* | *-dev-* | *-test-* | *-scratch-*) ;;
+    *)
+      printf 'Override IMAGE tags must contain a dev, test, or scratch marker; got %s.\n' \
+        "${image}" >&2
+      exit 2
+      ;;
+  esac
+  release_status=research-only
+fi
+
+if [[ "${PRINT_RELEASE_CONFIG:-0}" == 1 ]]; then
+  printf 'base=%s\nimage=%s\nstatus=%s\ndocker_commit=%s\n' \
+    "${base_image}" "${image}" "${release_status}" "${docker_commit}"
+  printf 'vllm_ref=%s\nvllm_commit=%s\nvllm_prs=%s\nvllm_tree=%s\n' \
+    "${VLLM_REF}" "${VLLM_COMMIT}" "${VLLM_PRS}" "${VLLM_INTEGRATION_TREE}"
+  printf 'b12x_ref=%s\nb12x_commit=%s\nb12x_prs=%s\nb12x_tree=%s\n' \
+    "${B12X_REF}" "${B12X_COMMIT}" "${B12X_PRS}" "${B12X_INTEGRATION_TREE}"
+  printf 'vllm_package_version=%s\n' "${vllm_package_version}"
+  printf 'torch=2.13.0\ncuda=13.3\nnccl=2.31.2\nflashinfer=0.6.18+cu133\n'
+  exit 0
+fi
+
+if ! docker image inspect "${base_image}" >/dev/null 2>&1; then
+  docker pull "${base_image}"
+fi
+base_image_id="$(docker image inspect "${base_image}" --format '{{.Id}}')"
+base_labels="$(docker image inspect "${base_image}" --format '{{json .Config.Labels}}')"
+jq -e '
+  ."local-inference.runtime.foundation.source-packages" == "absent" and
+  ."local-inference.cuda.version" == "13.3" and
+  ."local-inference.torch.version" == "2.13.0" and
+  ."local-inference.flashinfer.version" == "0.6.18+cu133" and
+  ."local-inference.cutlass-dsl.version" == "4.6.2" and
+  ."local-inference.instanttensor.version" == "0.1.9"
+' <<<"${base_labels}" >/dev/null
+
+printf 'base=%s (%s)\nimage=%s\n' "${base_image}" "${base_image_id}" "${image}"
+printf 'vllm=%s + %s -> %s\nb12x=%s + %s -> %s\n' \
+  "${VLLM_COMMIT}" "${VLLM_PRS}" "${VLLM_INTEGRATION_TREE}" \
+  "${B12X_COMMIT}" "${B12X_PRS}" "${B12X_INTEGRATION_TREE}"
+
+DOCKER_BUILDKIT=1 docker build \
+  --pull=false \
+  --build-arg "BASE_IMAGE=${base_image}" \
+  --build-arg "BASE_IMAGE_ID=${base_image_id}" \
+  --build-arg "VLLM_REPO=${VLLM_REPO}" \
+  --build-arg "VLLM_REF=${VLLM_REF}" \
+  --build-arg "VLLM_COMMIT=${VLLM_COMMIT}" \
+  --build-arg "VLLM_PATCH_FILE=${VLLM_PATCH_FILE}" \
+  --build-arg "VLLM_PATCH_SHA256=${VLLM_PATCH_SHA256}" \
+  --build-arg "VLLM_INTEGRATION_TREE=${VLLM_INTEGRATION_TREE}" \
+  --build-arg "VLLM_INTEGRATION_LOCK_SHA256=${VLLM_INTEGRATION_LOCK_SHA256}" \
+  --build-arg "VLLM_PRS=${VLLM_PRS}" \
+  --build-arg "VLLM_MERGE_HEADS=${VLLM_MERGE_HEADS}" \
+  --build-arg "B12X_REPO=${B12X_REPO}" \
+  --build-arg "B12X_REF=${B12X_REF}" \
+  --build-arg "B12X_COMMIT=${B12X_COMMIT}" \
+  --build-arg "B12X_PATCH_FILE=${B12X_PATCH_FILE}" \
+  --build-arg "B12X_PATCH_SHA256=${B12X_PATCH_SHA256}" \
+  --build-arg "B12X_INTEGRATION_TREE=${B12X_INTEGRATION_TREE}" \
+  --build-arg "B12X_INTEGRATION_LOCK_SHA256=${B12X_INTEGRATION_LOCK_SHA256}" \
+  --build-arg "B12X_PRS=${B12X_PRS}" \
+  --build-arg "B12X_MERGE_HEADS=${B12X_MERGE_HEADS}" \
+  --build-arg "SOURCE_LOCK_SHA256=${source_lock_sha256}" \
+  --build-arg "VLLM_PACKAGE_VERSION=${vllm_package_version}" \
+  --build-arg "CACHE_FINGERPRINT=${cache_fingerprint}" \
+  --build-arg "RELEASE_DATE=${release_date}" \
+  --build-arg "DOCKER_COMMIT=${docker_commit}" \
+  --build-arg "RELEASE_STATUS=${release_status}" \
+  --file Dockerfile.glm53-flash-nvfp4-jovian-cu133-torch213 \
+  --tag "${image}" \
+  .
+
+labels="$(docker image inspect "${image}" --format '{{json .Config.Labels}}')"
+assert_label() {
+  local key=$1 expected=$2
+  jq -e --arg key "${key}" --arg expected "${expected}" \
+    '.[$key] == $expected' <<<"${labels}" >/dev/null || {
+      printf 'Image label %s does not match %s\n' "${key}" "${expected}" >&2
+      exit 1
+    }
+}
+
+assert_label local-inference.runtime.base-id "${base_image_id}"
+assert_label local-inference.vllm.commit "${VLLM_COMMIT}"
+assert_label local-inference.vllm.integration.tree "${VLLM_INTEGRATION_TREE}"
+assert_label local-inference.b12x.commit "${B12X_COMMIT}"
+assert_label local-inference.b12x.integration.tree "${B12X_INTEGRATION_TREE}"
+assert_label local-inference.runtime.source-lock.sha256 "${source_lock_sha256}"
+assert_label local-inference.vllm.integration.prs "${VLLM_PRS}"
+assert_label local-inference.vllm.merge-heads "${VLLM_MERGE_HEADS}"
+assert_label local-inference.b12x.integration.prs "${B12X_PRS}"
+assert_label local-inference.b12x.merge-heads "${B12X_MERGE_HEADS}"
+assert_label local-inference.status "${release_status}"
+assert_label local-inference.backend.indexer.decode "B12X_C4"
+assert_label local-inference.backend.indexer.prefill "DeepGEMM_C4"
+
+docker run --rm --entrypoint /opt/venv/bin/python "${image}" \
+  /opt/local-inference/verify_glm53_flash_nvfp4_runtime.py \
+  --vllm-version "${vllm_package_version}" \
+  --vllm-tree "${VLLM_INTEGRATION_TREE}" \
+  --b12x-tree "${B12X_INTEGRATION_TREE}"
+
+launcher_output="$(docker run --rm -e DRY_RUN=1 "${image}")"
+grep -Fq -- '--revision 520de24eabf507659eaef7c70f14fd584527facc' <<<"${launcher_output}"
+grep -Fq -- '--tensor-parallel-size 4' <<<"${launcher_output}"
+grep -Fq -- '--load-format instanttensor' <<<"${launcher_output}"
+grep -Fq -- '--max-num-seqs 16' <<<"${launcher_output}"
+grep -Fq -- '--max-model-len 262144' <<<"${launcher_output}"
+grep -Fq -- '--max-num-batched-tokens 4096' <<<"${launcher_output}"
+grep -Fq -- '--attention-backend B12X' <<<"${launcher_output}"
+grep -Fq -- '--moe-backend b12x' <<<"${launcher_output}"
+grep -Fq -- '--linear-backend b12x' <<<"${launcher_output}"
+grep -Fq -- '--mamba-cache-mode align' <<<"${launcher_output}"
+grep -Fq -- '--quantization modelopt_mixed' <<<"${launcher_output}"
+grep -Fq -- '--block-size 256' <<<"${launcher_output}"
+grep -Fq -- '--enable-prefix-caching' <<<"${launcher_output}"
+grep -Fq -- '--compilation-config' <<<"${launcher_output}"
+grep -Fq -- 'cudagraph_mode\":\"FULL' <<<"${launcher_output}"
+if grep -Fq -- '--disable-custom-all-reduce' <<<"${launcher_output}"; then
+  printf 'The default launcher must retain B12X PCIe all-reduce.\n' >&2
+  exit 1
+fi
+
+mtp_launcher_output="$(docker run --rm -e DRY_RUN=1 -e SPECULATOR=mtp -e MTP=3 "${image}")"
+grep -Fq -- 'num_speculative_tokens\":3' <<<"${mtp_launcher_output}"
+grep -Fq -- 'moe_backend\":\"humming' <<<"${mtp_launcher_output}"
+grep -Fq -- 'attention_backend\":\"B12X' <<<"${mtp_launcher_output}"
+
+dflash_launcher_output="$(docker run --rm -e DRY_RUN=1 -e SPECULATOR=dflash "${image}")"
+grep -Fq -- 'method\":\"dflash' <<<"${dflash_launcher_output}"
+grep -Fq -- 'model\":\"local-inference-lab/GLM-5.3-Flash-DFlash2-MXFP8' <<<"${dflash_launcher_output}"
+grep -Fq -- 'revision\":\"b6d33aa93fc1ac5b23a88251a1c0ce0bfe2ad17c' <<<"${dflash_launcher_output}"
+grep -Fq -- 'num_speculative_tokens\":7' <<<"${dflash_launcher_output}"
+grep -Fq -- 'kv_cache_dtype\":\"auto' <<<"${dflash_launcher_output}"
+printf '%s\n' "${launcher_output}"
+
+if ((push_image == 1)); then docker push "${image}"; fi
+
+docker image inspect "${image}" --format \
+  'image={{.Id}} size={{.Size}} entrypoint={{json .Config.Entrypoint}}'
+printf '%s\n' "${image}"

--- a/launchers/serve-glm53-flash-nvfp4.sh
+++ b/launchers/serve-glm53-flash-nvfp4.sh
@@ -1,0 +1,167 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# NCCL interprets an empty graph-file value as a path and fails communicator
+# initialization. The runtime does not require an external NCCL topology file.
+unset NCCL_GRAPH_FILE
+
+model=${MODEL:-local-inference-lab/GLM-5.3-Flash-NVFP4}
+if (($# > 0)) && [[ "$1" != -* ]]; then
+  model=$1
+  shift
+fi
+model_revision=${MODEL_REVISION-520de24eabf507659eaef7c70f14fd584527facc}
+
+served_model_name=${SERVED_MODEL_NAME:-GLM-5.3-Flash-NVFP4}
+host=${HOST:-0.0.0.0}
+port=${PORT:-8000}
+tp=${TP:-4}
+max_num_seqs=${MAX_NUM_SEQS:-16}
+max_model_len=${MAX_MODEL_LEN:-262144}
+max_num_batched_tokens=${MAX_NUM_BATCHED_TOKENS:-4096}
+gpu_memory_utilization=${GPU_MEMORY_UTILIZATION:-0.90}
+load_format=${LOAD_FORMAT:-instanttensor}
+speculator=${SPECULATOR:-mtp}
+dflash_model=${DFLASH_MODEL:-local-inference-lab/GLM-5.3-Flash-DFlash2-MXFP8}
+dflash_model_revision=${DFLASH_MODEL_REVISION-b6d33aa93fc1ac5b23a88251a1c0ce0bfe2ad17c}
+attention_backend=${ATTENTION_BACKEND:-B12X}
+moe_backend=${MOE_BACKEND:-b12x}
+linear_backend=${LINEAR_BACKEND:-b12x}
+mtp_attention_backend=${MTP_ATTENTION_BACKEND:-B12X}
+mtp_moe_backend=${MTP_MOE_BACKEND:-humming}
+b12x_pcie_allreduce=${B12X_PCIE_ALLREDUCE:-1}
+kda_decode_backend=${GLM53_KDA_DECODE_BACKEND:-auto}
+cudagraph_mode=${CUDAGRAPH_MODE:-FULL}
+
+case "${speculator}" in
+  mtp)
+    num_speculative_tokens=${NUM_SPECULATIVE_TOKENS:-${MTP:-0}}
+    ;;
+  dflash | dflash2)
+    # DFlash2 verifies one target token and drafts the remaining seven tokens
+    # in its serialized eight-token block.
+    num_speculative_tokens=${NUM_SPECULATIVE_TOKENS:-7}
+    ;;
+  *)
+    printf 'SPECULATOR must be mtp, dflash, or dflash2; got %s\n' \
+      "${speculator}" >&2
+    exit 2
+    ;;
+esac
+
+if [[ ! "${num_speculative_tokens}" =~ ^[0-9]+$ ]]; then
+  printf 'NUM_SPECULATIVE_TOKENS/MTP must be a non-negative integer; got %s\n' \
+    "${num_speculative_tokens}" >&2
+  exit 2
+fi
+
+case "${b12x_pcie_allreduce}" in
+  0 | 1) ;;
+  *)
+    printf 'B12X_PCIE_ALLREDUCE must be 0 or 1; got %s\n' \
+      "${b12x_pcie_allreduce}" >&2
+    exit 2
+    ;;
+esac
+
+case "${kda_decode_backend}" in
+  auto | b12x | triton) ;;
+  *)
+    printf 'GLM53_KDA_DECODE_BACKEND must be auto, b12x, or triton; got %s\n' \
+      "${kda_decode_backend}" >&2
+    exit 2
+    ;;
+esac
+
+# Zero retains the target checkpoint's NVFP4 W4A4 routed-expert path.
+export VLLM_B12X_MOE_FP4_FORCE_A16="${VLLM_B12X_MOE_FP4_FORCE_A16:-0}"
+export VLLM_ENABLE_PCIE_ALLREDUCE="${b12x_pcie_allreduce}"
+export VLLM_PCIE_ALLREDUCE_BACKEND=b12x
+export VLLM_PLUGINS=
+
+revision_args=()
+if [[ -n "${model_revision}" && "${model}" != /* ]]; then
+  revision_args=(--revision "${model_revision}")
+fi
+
+cmd=(
+  /opt/venv/bin/vllm serve "${model}"
+  "${revision_args[@]}"
+  --served-model-name "${served_model_name}"
+  --host "${host}"
+  --port "${port}"
+  --tensor-parallel-size "${tp}"
+  --pipeline-parallel-size 1
+  --decode-context-parallel-size 1
+  --max-num-seqs "${max_num_seqs}"
+  --max-model-len "${max_model_len}"
+  --max-num-batched-tokens "${max_num_batched_tokens}"
+  --gpu-memory-utilization "${gpu_memory_utilization}"
+  --mamba-cache-mode align
+  --enable-chunked-prefill
+  --dtype bfloat16
+  --kv-cache-dtype fp8
+  --quantization modelopt_mixed
+  --block-size 256
+  --load-format "${load_format}"
+  --attention-backend "${attention_backend}"
+  --moe-backend "${moe_backend}"
+  --linear-backend "${linear_backend}"
+  --no-enable-flashinfer-autotune
+  --enable-auto-tool-choice
+  --tool-call-parser glm47
+  --reasoning-parser glm45
+  --additional-config
+  "{\"glm53_kda_decode_backend\":\"${kda_decode_backend}\"}"
+  --compilation-config
+  "{\"cudagraph_mode\":\"${cudagraph_mode}\"}"
+)
+
+if ((b12x_pcie_allreduce == 0)); then
+  cmd+=(--disable-custom-all-reduce)
+fi
+
+case "${ENABLE_PREFIX_CACHING:-1}" in
+  0) ;;
+  1) cmd+=(--enable-prefix-caching) ;;
+  *)
+    printf 'ENABLE_PREFIX_CACHING must be 0 or 1; got %s\n' \
+      "${ENABLE_PREFIX_CACHING}" >&2
+    exit 2
+    ;;
+esac
+
+if ((num_speculative_tokens > 0)); then
+  case "${speculator}" in
+    mtp)
+      cmd+=(
+        --speculative-config
+        "{\"method\":\"mtp\",\"num_speculative_tokens\":${num_speculative_tokens},\"moe_backend\":\"${mtp_moe_backend}\",\"attention_backend\":\"${mtp_attention_backend}\"}"
+      )
+      ;;
+    dflash | dflash2)
+      if [[ -n "${dflash_model_revision}" && "${dflash_model}" != /* ]]; then
+        cmd+=(
+          --speculative-config
+          "{\"method\":\"dflash\",\"model\":\"${dflash_model}\",\"revision\":\"${dflash_model_revision}\",\"num_speculative_tokens\":${num_speculative_tokens},\"kv_cache_dtype\":\"auto\"}"
+        )
+      else
+        cmd+=(
+          --speculative-config
+          "{\"method\":\"dflash\",\"model\":\"${dflash_model}\",\"num_speculative_tokens\":${num_speculative_tokens},\"kv_cache_dtype\":\"auto\"}"
+        )
+      fi
+      ;;
+  esac
+fi
+
+cmd+=("$@")
+
+if [[ "${DRY_RUN:-0}" == 1 ]]; then
+  printf 'GLM-5.3-Flash NVFP4 launch:'
+  printf ' %q' "${cmd[@]}"
+  printf '\n'
+  exit 0
+fi
+
+exec "${cmd[@]}"

--- a/manifests/b12x/glm53-flash-nvfp4-master.json
+++ b/manifests/b12x/glm53-flash-nvfp4-master.json
@@ -1,0 +1,44 @@
+{
+  "schema_version": 1,
+  "name": "glm53-flash-nvfp4-dflash2-mxfp8-b12x",
+  "repository": "https://github.com/local-inference-lab/b12x.git",
+  "base_ref": "refs/heads/master",
+  "pull_requests": [
+    {
+      "number": 250,
+      "head": "dd8cf60505e0363ab9d6ef6b2116c3a37216a2f1",
+      "title": "test(moe): qualify GLM-5.3 TP4 graph replay"
+    }
+  ],
+  "source_patches": [],
+  "source_evidence": [
+    {
+      "role": "FP8 C4 decode scoring and top-k selection for GLM-5.3-Flash",
+      "repository": "https://github.com/local-inference-lab/b12x.git",
+      "branch": "master",
+      "commit": "2fcf23a0ce269be27b2e03fece73d46e90e6aeea",
+      "resolution": "The B12X DSA indexer accepts 32 query heads, selects 512 four-token pools, uses caller-provided scratch, and supports CUDA graph replay and high physical page IDs for decode."
+    },
+    {
+      "role": "Lower-bounded KDA decode used by GLM-5.3-Flash",
+      "repository": "https://github.com/local-inference-lab/b12x.git",
+      "branch": "master",
+      "commit": "2fcf23a0ce269be27b2e03fece73d46e90e6aeea",
+      "resolution": "The GDN dispatcher exposes lower-bounded KDA through a plan, binding, and replay contract used by GLM decode."
+    },
+    {
+      "role": "Hyperconnection normalization and MTP feedback used by GLM-5.3-Flash",
+      "repository": "https://github.com/local-inference-lab/b12x.git",
+      "branch": "master",
+      "commit": "2fcf23a0ce269be27b2e03fece73d46e90e6aeea",
+      "resolution": "The B12X public APIs provide CuTe DSL kernels for hyperconnection normalization and MTP feedback with caller-owned runtime bindings."
+    },
+    {
+      "role": "CUDA graph qualification for the GLM-5.3 TP4 NVFP4 routed-expert geometry",
+      "repository": "https://github.com/local-inference-lab/b12x.git",
+      "branch": "pull/250/head",
+      "commit": "dd8cf60505e0363ab9d6ef6b2116c3a37216a2f1",
+      "resolution": "The qualification captures the 42-layer routed-expert geometry and token widths from 8 through 128 over caller-owned shared scratch. It compares graph replay with eager execution, requires inactive rows to remain zero, rejects replay-time CUDA allocations, and asserts stable buffer addresses. The pull request changes tests only; the runtime kernel remains the implementation from the pinned master commit."
+    }
+  ]
+}

--- a/manifests/vllm/glm53-flash-nvfp4-jovian.json
+++ b/manifests/vllm/glm53-flash-nvfp4-jovian.json
@@ -1,0 +1,23 @@
+{
+  "schema_version": 1,
+  "name": "glm53-flash-nvfp4-dflash2-mxfp8-vllm",
+  "repository": "https://github.com/local-inference-lab/vllm.git",
+  "base_ref": "refs/heads/dev/jovian-judgement",
+  "pull_requests": [
+    {
+      "number": 491,
+      "head": "608010a003ccb900a5268b2235d09f81d37bf66e",
+      "title": "Optimize GLM-5.3 B12X and DFlash2 MXFP8 serving"
+    }
+  ],
+  "source_patches": [],
+  "source_evidence": [
+    {
+      "role": "GLM-5.3-Flash target model and DFlash2 MXFP8 serving integration",
+      "repository": "https://github.com/local-inference-lab/vllm.git",
+      "branch": "dev/jovian-judgement",
+      "commit": "015dcd423d6aabf843c8ad69074ff67d35c2a395",
+      "resolution": "The composed vLLM tree executes GLM-5.3 packed C4 prefill through DeepGEMM, routes decode-sized multipath hyperconnection and KDA operations through B12X, retains CUDA-graph-owned B12X resources, loads serialized ModelOpt MXFP8 DFlash2 projections without an online conversion, preserves the draft model's attention-specific KV cache format, and loads multimodal processor artifacts from the target checkpoint revision."
+    }
+  ]
+}

--- a/manifests/vllm/glm53-flash-nvfp4-jovian.json
+++ b/manifests/vllm/glm53-flash-nvfp4-jovian.json
@@ -6,7 +6,7 @@
   "pull_requests": [
     {
       "number": 491,
-      "head": "608010a003ccb900a5268b2235d09f81d37bf66e",
+      "head": "b77333ca8824897ff6ddf96a62208ea406c555a9",
       "title": "Optimize GLM-5.3 B12X and DFlash2 MXFP8 serving"
     }
   ],

--- a/patches/releases/glm53-flash-nvfp4-jovian/b12x/integration.lock.json
+++ b/patches/releases/glm53-flash-nvfp4-jovian/b12x/integration.lock.json
@@ -1,0 +1,32 @@
+{
+  "base": {
+    "commit": "2fcf23a0ce269be27b2e03fece73d46e90e6aeea",
+    "ref": "refs/heads/master",
+    "repository": "https://github.com/local-inference-lab/b12x.git"
+  },
+  "composition": null,
+  "composition_strategy": "merge",
+  "manifest": {
+    "sha256": "d0033f0f350aed46326862b13f67e027b27cc614bcab7c96f36ee01926dd9e01"
+  },
+  "name": "glm53-flash-nvfp4-dflash2-mxfp8-b12x",
+  "pull_requests": [
+    {
+      "commits": [
+        "dd8cf60505e0363ab9d6ef6b2116c3a37216a2f1"
+      ],
+      "disposition": "merged",
+      "head": "dd8cf60505e0363ab9d6ef6b2116c3a37216a2f1",
+      "number": 250,
+      "ref": "refs/pull/250/head",
+      "title": "test(moe): qualify GLM-5.3 TP4 graph replay"
+    }
+  ],
+  "result": {
+    "patch": "integration.patch",
+    "patch_sha256": "c53df70226775cf3c0b076dab23d8d37788e1d779aab16422151db7d26c48193",
+    "tree": "fdbb504ccf5842ae7bb7089caa01fc076a7043c0"
+  },
+  "schema_version": 1,
+  "source_patches": []
+}

--- a/patches/releases/glm53-flash-nvfp4-jovian/b12x/integration.patch
+++ b/patches/releases/glm53-flash-nvfp4-jovian/b12x/integration.patch
@@ -1,0 +1,463 @@
+diff --git a/tests/moe/test_cute_migration_moe_standard_corpus.py b/tests/moe/test_cute_migration_moe_standard_corpus.py
+index 9b4cd2ef6f516c158b8d16f6dcd440bde7468fbc..59d83b79a6bb596a62d9cb56bcd90695473456cf 100644
+--- a/tests/moe/test_cute_migration_moe_standard_corpus.py
++++ b/tests/moe/test_cute_migration_moe_standard_corpus.py
+@@ -289,7 +289,12 @@ def _prepare_and_bind(
+     quant_mode: str,
+     source_format: str,
+     num_topk: int = _TOPK,
++    w13_layout: str = "w13",
++    fast_math: bool | None = False,
++    swiglu_limit: float | None = None,
+ ) -> _BoundCase:
++    """Prepare checkpoint weights and bind caller-owned launch storage."""
++
+     from b12x.moe.fused_moe._impl import TPMoEScratchCaps, plan_tp_moe_scratch
+ 
+     experts = prepare_tp_moe_fp4_experts(
+@@ -305,7 +310,7 @@ def _prepare_and_bind(
+         activation="silu",
+         quant_mode=quant_mode,
+         source_format=source_format,
+-        w13_layout="w13",
++        w13_layout=w13_layout,
+     )
+     scratch_plan = plan_tp_moe_scratch(
+         TPMoEScratchCaps(
+@@ -316,6 +321,7 @@ def _prepare_and_bind(
+             quant_mode=quant_mode,
+             core_token_counts=(int(inputs.a.shape[0]),),
+             route_num_experts=0,
++            swiglu_limit=swiglu_limit,
+             frozen=True,
+         )
+     )
+@@ -332,7 +338,7 @@ def _prepare_and_bind(
+         topk_ids=inputs.topk_ids,
+         output=output,
+         input_scales_static=True,
+-        fast_math=False,
++        fast_math=fast_math,
+     )
+     assert binding.output is output
+     return _BoundCase(
+@@ -384,6 +390,8 @@ def _run_live_graph_check(
+     require_bit_exact_replay: bool = True,
+     assert_no_replay_allocations: bool = False,
+ ) -> None:
++    """Validate eager execution and in-place graph replay against GPU oracles."""
++
+     from b12x.moe.fused_moe._impl import b12x_moe_fp4
+ 
+     binding = case.binding
+@@ -423,7 +431,13 @@ def _run_live_graph_check(
+     initial.a.copy_(changed.a)
+     initial.topk_ids.copy_(changed.topk_ids)
+     initial.topk_weights.copy_(changed.topk_weights)
+-    live_tensors = (*case.scratch, initial.a, initial.topk_ids, initial.topk_weights, output)
++    live_tensors = (
++        *case.scratch,
++        initial.a,
++        initial.topk_ids,
++        initial.topk_weights,
++        output,
++    )
+     live_addresses = tuple(tensor.data_ptr() for tensor in live_tensors)
+     replay_output = None
+     for replay_idx in range(replay_count):
+@@ -445,7 +459,9 @@ def _run_live_graph_check(
+                 replay_idx,
+                 "live CUDA bytes changed during graph replay",
+             )
+-            assert tuple(tensor.data_ptr() for tensor in live_tensors) == live_addresses, (
++            assert (
++                tuple(tensor.data_ptr() for tensor in live_tensors) == live_addresses
++            ), (
+                 context,
+                 replay_idx,
+                 "serving tensor address changed during graph replay",
+@@ -668,6 +684,384 @@ def test_standard_moe_dynamic_prefill_live_graph_oracle(
+     )
+ 
+ 
++def test_standard_moe_glm53_tp4_nvfp4_live_graph_replay(
++    monkeypatch: pytest.MonkeyPatch,
++) -> None:
++    """Replay the GLM-5.3 TP4 NVFP4 expert geometry in a CUDA graph."""
++
++    from b12x.moe.fused_moe._impl import b12x_moe_fp4
++
++    num_experts = 288
++    hidden_size = 4096
++    intermediate_size = 512
++    topk = 8
++    tokens = 128
++    device = require_b12x()
++    _reset_dispatch_environment(monkeypatch)
++    weights = _make_nvfp4_weights(
++        device,
++        seed=211,
++        num_experts=num_experts,
++        hidden_size=hidden_size,
++        intermediate_size=intermediate_size,
++    )
++    weights = _Weights(
++        w1_fp4=weights.w1_fp4,
++        w1_scale=weights.w1_scale,
++        w1_alpha=weights.w1_alpha,
++        a1_scale=torch.linspace(
++            0.7, 1.3, num_experts, dtype=torch.float32, device=device
++        ),
++        w2_fp4=weights.w2_fp4,
++        w2_scale=weights.w2_scale,
++        w2_alpha=weights.w2_alpha,
++        a2_scale=torch.linspace(
++            0.8, 1.2, num_experts, dtype=torch.float32, device=device
++        ),
++    )
++    initial = _make_inputs(
++        device,
++        m=tokens,
++        seed=212,
++        route_shift=0,
++        num_experts=num_experts,
++        hidden_size=hidden_size,
++        topk=topk,
++    )
++    case = _prepare_and_bind(
++        weights,
++        initial,
++        quant_mode="nvfp4",
++        source_format="modelopt_nvfp4",
++        num_topk=topk,
++        w13_layout="w31",
++        fast_math=None,
++        swiglu_limit=10.0,
++    )
++    assert case.scratch_plan.launch_plan.implementation == "dynamic"
++    assert case.binding.implementation == "dynamic"
++
++    layer_inputs = [initial]
++    bindings = [case.binding]
++    for layer_idx in range(1, 42):
++        layer_input = _make_inputs(
++            device,
++            m=tokens,
++            seed=212 + layer_idx,
++            route_shift=layer_idx * 7,
++            num_experts=num_experts,
++            hidden_size=hidden_size,
++            topk=topk,
++        )
++        layer_output = torch.empty_like(layer_input.a)
++        layer_binding = case.scratch_plan.bind(
++            scratch=case.scratch,
++            a=layer_input.a,
++            experts=case.experts,
++            topk_weights=layer_input.topk_weights,
++            topk_ids=layer_input.topk_ids,
++            output=layer_output,
++            input_scales_static=True,
++            fast_math=None,
++        )
++        assert layer_binding.implementation == "dynamic"
++        layer_inputs.append(layer_input)
++        bindings.append(layer_binding)
++
++    for binding in bindings:
++        b12x_moe_fp4(binding=binding)
++    torch.cuda.synchronize()
++    assert all(
++        bool(binding.output.float().isfinite().all().item()) for binding in bindings
++    )
++
++    graph = torch.cuda.CUDAGraph()
++    capture_stream = torch.cuda.Stream()
++    capture_stream.wait_stream(torch.cuda.current_stream())
++    with torch.cuda.stream(capture_stream), torch.cuda.graph(graph):
++        for binding in bindings:
++            b12x_moe_fp4(binding=binding)
++    torch.cuda.current_stream().wait_stream(capture_stream)
++    torch.cuda.synchronize()
++
++    for layer_idx, layer_input in enumerate(layer_inputs):
++        layer_changed = _make_inputs(
++            device,
++            m=tokens,
++            seed=413 + layer_idx,
++            route_shift=97 + layer_idx * 11,
++            num_experts=num_experts,
++            hidden_size=hidden_size,
++            topk=topk,
++        )
++        layer_input.a.copy_(layer_changed.a)
++        layer_input.topk_ids.copy_(layer_changed.topk_ids)
++        layer_input.topk_weights.copy_(layer_changed.topk_weights)
++    for binding in bindings:
++        b12x_moe_fp4(binding=binding)
++    torch.cuda.synchronize()
++    expected = tuple(binding.output.clone() for binding in bindings)
++    assert all(bool(output.float().isfinite().all().item()) for output in expected)
++
++    live_tensors = list(case.scratch)
++    for layer_input, binding in zip(layer_inputs, bindings, strict=True):
++        live_tensors.extend(
++            (
++                layer_input.a,
++                layer_input.topk_ids,
++                layer_input.topk_weights,
++                binding.output,
++            )
++        )
++    live_addresses = tuple(tensor.data_ptr() for tensor in live_tensors)
++
++    for replay_idx in range(3):
++        for binding in bindings:
++            binding.output.fill_(37.0)
++        allocation_count_before = torch.cuda.memory_stats(device)[
++            "allocation.all.allocated"
++        ]
++        allocated_bytes_before = torch.cuda.memory_allocated(device)
++        graph.replay()
++        torch.cuda.synchronize()
++        assert (
++            torch.cuda.memory_stats(device)["allocation.all.allocated"]
++            == allocation_count_before
++        ), (replay_idx, "CUDA allocation during 42-layer graph replay")
++        assert torch.cuda.memory_allocated(device) == allocated_bytes_before, (
++            replay_idx,
++            "live CUDA bytes changed during 42-layer graph replay",
++        )
++        assert tuple(tensor.data_ptr() for tensor in live_tensors) == live_addresses, (
++            replay_idx,
++            "serving tensor address changed during 42-layer graph replay",
++        )
++        for layer_idx, (binding, layer_expected) in enumerate(
++            zip(bindings, expected, strict=True)
++        ):
++            assert bool(binding.output.float().isfinite().all().item()), (
++                replay_idx,
++                layer_idx,
++            )
++            error = (
++                (binding.output.float() - layer_expected.float()).square().mean().sqrt()
++            )
++            reference_rms = layer_expected.float().square().mean().sqrt()
++            assert float(error / reference_rms) < 0.01, (replay_idx, layer_idx)
++
++
++def test_standard_moe_glm53_tp4_nvfp4_multishape_graph_replay(
++    monkeypatch: pytest.MonkeyPatch,
++) -> None:
++    """Replay token widths 8 through 128 against one shared CUDA workspace.
++
++    Each eight-token increment has an independent captured graph. One uint8
++    allocation sized for the widest shape backs every graph's scratch plan at
++    a 256-byte-aligned offset after the caller-owned output reservation.
++    """
++
++    from b12x.moe.fused_moe._impl import (
++        TPMoEScratchCaps,
++        b12x_moe_fp4,
++        plan_tp_moe_scratch,
++    )
++
++    num_experts = 288
++    hidden_size = 4096
++    intermediate_size = 512
++    topk = 8
++    device = require_b12x()
++    _reset_dispatch_environment(monkeypatch)
++    weights = _make_nvfp4_weights(
++        device,
++        seed=251,
++        num_experts=num_experts,
++        hidden_size=hidden_size,
++        intermediate_size=intermediate_size,
++    )
++    weights = _Weights(
++        w1_fp4=weights.w1_fp4,
++        w1_scale=weights.w1_scale,
++        w1_alpha=weights.w1_alpha,
++        a1_scale=torch.linspace(
++            0.7, 1.3, num_experts, dtype=torch.float32, device=device
++        ),
++        w2_fp4=weights.w2_fp4,
++        w2_scale=weights.w2_scale,
++        w2_alpha=weights.w2_alpha,
++        a2_scale=torch.linspace(
++            0.8, 1.2, num_experts, dtype=torch.float32, device=device
++        ),
++    )
++    owner_input = _make_inputs(
++        device,
++        m=128,
++        seed=252,
++        route_shift=0,
++        num_experts=num_experts,
++        hidden_size=hidden_size,
++        topk=topk,
++    )
++    owner = _prepare_and_bind(
++        weights,
++        owner_input,
++        quant_mode="nvfp4",
++        source_format="modelopt_nvfp4",
++        num_topk=topk,
++        w13_layout="w31",
++        fast_math=None,
++        swiglu_limit=10.0,
++    )
++
++    plans = []
++    workspace_sizes = []
++    for tokens in range(8, 129, 8):
++        plan = plan_tp_moe_scratch(
++            TPMoEScratchCaps(
++                max_tokens=tokens,
++                num_topk=topk,
++                device=owner.experts.w1_fp4.device,
++                weight_plan=owner.experts.plan,
++                quant_mode="nvfp4",
++                core_token_counts=(tokens,),
++                route_num_experts=0,
++                swiglu_limit=10.0,
++                frozen=True,
++            )
++        )
++        output_nbytes = tokens * hidden_size * torch.bfloat16.itemsize
++        output_workspace_nbytes = (output_nbytes + 255) // 256 * 256
++        scratch_nbytes = plan.scratch_specs()[0].nbytes
++        assert plan.launch_plan.implementation == "dynamic", tokens
++        plans.append((tokens, plan, output_workspace_nbytes))
++        workspace_sizes.append(output_workspace_nbytes + scratch_nbytes)
++
++    workspace = torch.empty(max(workspace_sizes), dtype=torch.uint8, device=device)
++    graphs = []
++    graph_owners = []
++    for graph_idx, (tokens, plan, scratch_offset) in enumerate(plans):
++        inputs = _make_inputs(
++            device,
++            m=tokens,
++            seed=253 + graph_idx,
++            route_shift=graph_idx * 13,
++            num_experts=num_experts,
++            hidden_size=hidden_size,
++            topk=topk,
++        )
++        output = torch.empty_like(inputs.a)
++        scratch = workspace.narrow(
++            0,
++            scratch_offset,
++            workspace.numel() - scratch_offset,
++        )
++        binding = plan.bind(
++            scratch=scratch,
++            a=inputs.a,
++            experts=owner.experts,
++            topk_weights=inputs.topk_weights,
++            topk_ids=inputs.topk_ids,
++            output=output,
++            input_scales_static=True,
++            fast_math=None,
++        )
++        assert binding.implementation == "dynamic", tokens
++        b12x_moe_fp4(binding=binding)
++        torch.cuda.synchronize()
++        graph = torch.cuda.CUDAGraph()
++        capture_stream = torch.cuda.Stream()
++        capture_stream.wait_stream(torch.cuda.current_stream())
++        with torch.cuda.stream(capture_stream), torch.cuda.graph(graph):
++            workspace.fill_(0xA5)
++            captured_binding = plan.bind(
++                scratch=scratch,
++                a=inputs.a,
++                experts=owner.experts,
++                topk_weights=inputs.topk_weights,
++                topk_ids=inputs.topk_ids,
++                output=output,
++                input_scales_static=True,
++                fast_math=None,
++            )
++            assert captured_binding.implementation == "dynamic", tokens
++            b12x_moe_fp4(binding=captured_binding)
++        torch.cuda.current_stream().wait_stream(capture_stream)
++        torch.cuda.synchronize()
++        graphs.append(graph)
++        graph_owners.append(
++            (inputs, output, scratch, binding, captured_binding, capture_stream)
++        )
++
++    live_tensors = [workspace]
++    for inputs, output, scratch, _binding, _captured_binding, _stream in graph_owners:
++        live_tensors.extend(
++            (inputs.a, inputs.topk_ids, inputs.topk_weights, output, scratch)
++        )
++    live_addresses = tuple(tensor.data_ptr() for tensor in live_tensors)
++
++    for replay_idx in range(3):
++        graph_order = (
++            range(len(graphs)) if replay_idx % 2 == 0 else reversed(range(len(graphs)))
++        )
++        for graph_idx in graph_order:
++            inputs, output, _scratch, binding, _captured_binding, _capture_stream = (
++                graph_owners[graph_idx]
++            )
++            inputs.topk_ids.copy_(
++                torch.arange(topk, dtype=torch.int32, device=device)
++                .unsqueeze(0)
++                .expand_as(inputs.topk_ids)
++            )
++            inputs.topk_weights.fill_(1.0 / topk)
++            live_tokens = inputs.topk_ids.shape[0]
++            if replay_idx == 2:
++                live_tokens = max(1, inputs.topk_ids.shape[0] // 2)
++                inputs.topk_ids[live_tokens:].fill_(-1)
++                inputs.topk_weights[live_tokens:].zero_()
++
++            workspace.fill_(0xA5)
++            b12x_moe_fp4(binding=binding)
++            torch.cuda.synchronize()
++            expected = output.clone()
++
++            output.fill_(37.0)
++            allocation_count_before = torch.cuda.memory_stats(device)[
++                "allocation.all.allocated"
++            ]
++            allocated_bytes_before = torch.cuda.memory_allocated(device)
++            graphs[graph_idx].replay()
++            torch.cuda.synchronize()
++            assert (
++                torch.cuda.memory_stats(device)["allocation.all.allocated"]
++                == allocation_count_before
++            ), (replay_idx, graph_idx, "CUDA allocation during graph replay")
++            assert torch.cuda.memory_allocated(device) == allocated_bytes_before, (
++                replay_idx,
++                graph_idx,
++                "live CUDA bytes changed during graph replay",
++            )
++            assert (
++                tuple(tensor.data_ptr() for tensor in live_tensors) == live_addresses
++            ), (
++                replay_idx,
++                graph_idx,
++                "serving tensor address changed during graph replay",
++            )
++            _assert_oracle(
++                output,
++                expected,
++                context=f"glm53-tp4-nvfp4-multishape-m{output.shape[0]}-replay-{replay_idx}",
++                min_cos=0.999,
++                max_normalized_rmse=0.01,
++            )
++            assert torch.count_nonzero(output[:live_tokens]).item() > 0
++            if live_tokens < inputs.topk_ids.shape[0]:
++                assert (
++                    torch.count_nonzero(inputs.topk_ids[live_tokens:] + 1).item() == 0
++                )
++                assert torch.count_nonzero(output[live_tokens:]).item() == 0
++
++
+ @pytest.mark.parametrize("m", [80, 96])
+ def test_standard_moe_nvfp4_tp4_padded_prefill_live_graph_oracle(
+     monkeypatch: pytest.MonkeyPatch,

--- a/patches/releases/glm53-flash-nvfp4-jovian/vllm/integration.lock.json
+++ b/patches/releases/glm53-flash-nvfp4-jovian/vllm/integration.lock.json
@@ -1,0 +1,32 @@
+{
+  "base": {
+    "commit": "015dcd423d6aabf843c8ad69074ff67d35c2a395",
+    "ref": "refs/heads/dev/jovian-judgement",
+    "repository": "https://github.com/local-inference-lab/vllm.git"
+  },
+  "composition": null,
+  "composition_strategy": "merge",
+  "manifest": {
+    "sha256": "ee95ddef2bbc43a0a62f8ff9b8475ceb79ee051f31f2bbe6da73b2969579b3fa"
+  },
+  "name": "glm53-flash-nvfp4-dflash2-mxfp8-vllm",
+  "pull_requests": [
+    {
+      "commits": [
+        "608010a003ccb900a5268b2235d09f81d37bf66e"
+      ],
+      "disposition": "merged",
+      "head": "608010a003ccb900a5268b2235d09f81d37bf66e",
+      "number": 491,
+      "ref": "refs/pull/491/head",
+      "title": "Optimize GLM-5.3 B12X and DFlash2 MXFP8 serving"
+    }
+  ],
+  "result": {
+    "patch": "integration.patch",
+    "patch_sha256": "58d04607eb790ccdd58d8194bf642e5255748377210a1cfbbe7c41b97e9cdbd0",
+    "tree": "79fcbdc440d5b0242a2d3f93fad83934e67f8f3e"
+  },
+  "schema_version": 1,
+  "source_patches": []
+}

--- a/patches/releases/glm53-flash-nvfp4-jovian/vllm/integration.lock.json
+++ b/patches/releases/glm53-flash-nvfp4-jovian/vllm/integration.lock.json
@@ -7,16 +7,16 @@
   "composition": null,
   "composition_strategy": "merge",
   "manifest": {
-    "sha256": "ee95ddef2bbc43a0a62f8ff9b8475ceb79ee051f31f2bbe6da73b2969579b3fa"
+    "sha256": "56a488f716dd878c78857bc2645928ae33c27d5d87e49677b447952dda3475e0"
   },
   "name": "glm53-flash-nvfp4-dflash2-mxfp8-vllm",
   "pull_requests": [
     {
       "commits": [
-        "608010a003ccb900a5268b2235d09f81d37bf66e"
+        "b77333ca8824897ff6ddf96a62208ea406c555a9"
       ],
       "disposition": "merged",
-      "head": "608010a003ccb900a5268b2235d09f81d37bf66e",
+      "head": "b77333ca8824897ff6ddf96a62208ea406c555a9",
       "number": 491,
       "ref": "refs/pull/491/head",
       "title": "Optimize GLM-5.3 B12X and DFlash2 MXFP8 serving"
@@ -24,8 +24,8 @@
   ],
   "result": {
     "patch": "integration.patch",
-    "patch_sha256": "58d04607eb790ccdd58d8194bf642e5255748377210a1cfbbe7c41b97e9cdbd0",
-    "tree": "79fcbdc440d5b0242a2d3f93fad83934e67f8f3e"
+    "patch_sha256": "4c87a33d1b90d0ce5273b248d4a501b7d2376f8ef074f274360ee9f6967c21d9",
+    "tree": "82bbab85cebf48b735b5898062ceca89826b3913"
   },
   "schema_version": 1,
   "source_patches": []

--- a/patches/releases/glm53-flash-nvfp4-jovian/vllm/integration.patch
+++ b/patches/releases/glm53-flash-nvfp4-jovian/vllm/integration.patch
@@ -1,0 +1,2048 @@
+diff --git a/tests/models/test_glm5next_model.py b/tests/models/test_glm5next_model.py
+index 6c9e67b0a2cc2374264515e5877cd8542a916ed3..435e791392aeac8ce99eba9394d3bf8e6ebd6fc8 100644
+--- a/tests/models/test_glm5next_model.py
++++ b/tests/models/test_glm5next_model.py
+@@ -252,7 +252,7 @@ def test_glm5next_kda_splits_mixed_decode_prefill_batch(monkeypatch) -> None:
+     layer.gate_lower_bound = -5.0
+     layer.A_log = torch.ones(1)
+     layer.dt_bias = torch.ones(1)
+-    layer._b12x_kda_binding = None
++    layer._b12x_kda_plan = None
+     layer.conv1d = SimpleNamespace(
+         weight=torch.ones(3, 1, 3),
+         bias=torch.zeros(3),
+@@ -339,6 +339,61 @@ def test_glm5next_alone_opts_into_b12x_kda_decode() -> None:
+     assert Glm5NextLinearAttention.b12x_kda_null_state_index == 0
+ 
+ 
++@pytest.mark.parametrize(
++    ("backend", "speculative", "uses_b12x"),
++    [
++        ("auto", False, False),
++        ("auto", True, True),
++        ("b12x", False, True),
++        ("b12x", True, True),
++        ("triton", False, False),
++        ("triton", True, False),
++    ],
++)
++def test_glm5next_selects_configured_kda_decode_backend(
++    monkeypatch,
++    backend: str,
++    speculative: bool,
++    uses_b12x: bool,
++) -> None:
++    monkeypatch.setattr(
++        KimiGatedDeltaNetAttention,
++        "__init__",
++        lambda self, config, vllm_config, prefix: None,
++    )
++    vllm_config = SimpleNamespace(
++        additional_config={"glm53_kda_decode_backend": backend},
++        speculative_config=object() if speculative else None,
++    )
++
++    layer = Glm5NextLinearAttention(object(), vllm_config)
++
++    assert layer.enable_b12x_kda_decode is uses_b12x
++
++
++def test_glm5next_defaults_to_hybrid_kda_decode(monkeypatch) -> None:
++    monkeypatch.setattr(
++        KimiGatedDeltaNetAttention,
++        "__init__",
++        lambda self, config, vllm_config, prefix: None,
++    )
++    vllm_config = SimpleNamespace(additional_config={}, speculative_config=None)
++
++    layer = Glm5NextLinearAttention(object(), vllm_config)
++
++    assert layer._glm53_kda_decode_backend == "auto"
++    assert not layer.enable_b12x_kda_decode
++
++
++def test_glm5next_rejects_unknown_kda_decode_backend() -> None:
++    vllm_config = SimpleNamespace(
++        additional_config={"glm53_kda_decode_backend": "unknown"}
++    )
++
++    with pytest.raises(ValueError, match="KDA decode backend"):
++        Glm5NextLinearAttention(object(), vllm_config)
++
++
+ def test_glm5next_b12x_mhc_builds_first_layer_broadcast_fn() -> None:
+     hidden_size = 4
+     hc_mult = 4
+@@ -442,6 +497,34 @@ def test_glm5next_dflash_maps_target_layers_to_completed_outputs() -> None:
+     assert supports_eagle3(Glm5NextForConditionalGeneration)
+ 
+ 
++@pytest.mark.parametrize(
++    ("num_tokens", "expected"),
++    [
++        (1, True),
++        (8, True),
++        (9, False),
++    ],
++)
++def test_glm5next_b12x_mhc_dispatches_decode_sized_batches(
++    num_tokens: int, expected: bool
++) -> None:
++    layer = Glm5NextDecoderLayer.__new__(Glm5NextDecoderLayer)
++    torch.nn.Module.__init__(layer)
++    layer._b12x_mhc = object()
++    layer._b12x_mhc_max_tokens = 8
++
++    assert layer._use_b12x_mhc(torch.empty(num_tokens, 4)) is expected
++
++
++def test_glm5next_b12x_mhc_dispatch_requires_available_backend() -> None:
++    layer = Glm5NextDecoderLayer.__new__(Glm5NextDecoderLayer)
++    torch.nn.Module.__init__(layer)
++    layer._b12x_mhc = None
++    layer._b12x_mhc_max_tokens = 8
++
++    assert not layer._use_b12x_mhc(torch.empty(1, 4))
++
++
+ def test_glm5next_conditional_post_load_finalizes_language_model() -> None:
+     class FakeLanguageModel(torch.nn.Module):
+         def __init__(self) -> None:
+@@ -500,6 +583,82 @@ def test_glm5next_b12x_kda_plan_reserves_null_state_zero(monkeypatch) -> None:
+     assert captured_caps["null_state_index"] == 0
+ 
+ 
++def test_glm5next_b12x_kda_binds_caller_scratch_per_run(monkeypatch) -> None:
++    scratch = torch.empty(32, dtype=torch.uint8)
++    bindings: list[dict[str, object]] = []
++    runs: list[object] = []
++
++    class FakePlan:
++        @staticmethod
++        def shapes_and_dtypes():
++            return (((32,), torch.uint8),)
++
++    class FakeApi:
++        @staticmethod
++        def bind_kda(plan, **kwargs):
++            binding = {"plan": plan, **kwargs}
++            bindings.append(binding)
++            return binding
++
++        @staticmethod
++        def run_kda(binding, **kwargs):
++            runs.append(binding)
++
++    workspace = SimpleNamespace(get_simultaneous=lambda *specs: (scratch,))
++    monkeypatch.setattr(
++        kimi_gdn_linear_attn,
++        "current_workspace_manager",
++        lambda: workspace,
++    )
++
++    layer = Glm5NextLinearAttention.__new__(Glm5NextLinearAttention)
++    torch.nn.Module.__init__(layer)
++    layer._b12x_kda_api = FakeApi()
++    layer._b12x_kda_plan = FakePlan()
++    layer._b12x_kda_max_tokens = 4
++    layer._b12x_kda_max_seqs = 2
++    layer._b12x_kda_state_index_columns = 2
++    layer.local_num_heads = 1
++    layer.head_dim = 2
++    layer.gate_lower_bound = -5.0
++    layer.A_log = torch.ones(1)
++    layer.dt_bias = torch.ones(2)
++    layer.o_norm = SimpleNamespace(weight=torch.ones(2), eps=1e-6)
++    layer.kv_cache = (torch.empty(0), torch.zeros(3, 1, 2, 2))
++    layer._b12x_kda_mixed_qkv = torch.empty(4, 6)
++    layer._b12x_kda_raw_g = torch.empty(4, 1, 2)
++    layer._b12x_kda_raw_beta = torch.empty(4, 1)
++    layer._b12x_kda_z = torch.empty(4, 1, 2)
++    layer._b12x_kda_output = torch.zeros(4, 1, 2)
++    layer._b12x_kda_query_start_loc = torch.zeros(3, dtype=torch.int32)
++    layer._b12x_kda_num_accepted_tokens = torch.ones(2, dtype=torch.int32)
++    layer._b12x_kda_state_indices = torch.zeros(2, 2, dtype=torch.int32)
++    layer._b12x_kda_num_seqs = torch.zeros(1, dtype=torch.int32)
++    layer._b12x_kda_num_tokens = torch.zeros(1, dtype=torch.int32)
++
++    kwargs = dict(
++        mixed_qkv=torch.ones(1, 6),
++        raw_g=torch.ones(1, 1, 2),
++        raw_beta=torch.ones(1, 1),
++        z=torch.ones(1, 1, 2),
++        output=torch.empty(1, 1, 2),
++        state_indices=torch.tensor([[1]], dtype=torch.int32),
++        query_start_loc=torch.tensor([0, 1], dtype=torch.int32),
++        num_accepted_tokens=None,
++        num_requests=1,
++    )
++    layer._run_b12x_kda_decode_post_conv(**kwargs)
++    layer._run_b12x_kda_decode_post_conv(**kwargs)
++
++    assert len(bindings) == 2
++    assert bindings[0] is not bindings[1]
++    assert bindings[0]["scratch"] is scratch
++    assert bindings[1]["scratch"] is scratch
++    assert len(runs) == 2
++    assert runs[0] is bindings[0]
++    assert runs[1] is bindings[1]
++
++
+ def test_glm5next_sparse_mla_selects_b12x_backend(monkeypatch) -> None:
+     captured: dict[str, object] = {}
+ 
+@@ -628,6 +787,40 @@ def test_glm5next_processor_resolves_repository_video_config(
+     )
+ 
+ 
++def test_glm5next_processing_info_pins_processor_revision(monkeypatch) -> None:
++    from vllm.models.glm5next.nvidia.multimodal import Glm5NextProcessingInfo
++
++    calls = []
++    processor = object()
++
++    def fake_from_pretrained(model, **kwargs):
++        calls.append((model, kwargs))
++        return processor
++
++    monkeypatch.setattr(
++        glm5next_processor.Glm5NextProcessor,
++        "from_pretrained",
++        staticmethod(fake_from_pretrained),
++    )
++    info = SimpleNamespace(
++        ctx=SimpleNamespace(
++            model_config=SimpleNamespace(
++                model="local-inference-lab/GLM-5.3-Flash-NVFP4",
++                revision="checkpoint-commit",
++            )
++        )
++    )
++
++    assert Glm5NextProcessingInfo.get_hf_processor(info) is processor
++    assert Glm5NextProcessingInfo.get_hf_processor(info) is processor
++    assert calls == [
++        (
++            "local-inference-lab/GLM-5.3-Flash-NVFP4",
++            {"revision": "checkpoint-commit"},
++        )
++    ]
++
++
+ def test_glm5next_processor_counts_video_only_tokens() -> None:
+     class FakeVideoProcessor:
+         merge_size = 2
+diff --git a/tests/models/test_glm5next_pooled_indexer.py b/tests/models/test_glm5next_pooled_indexer.py
+index 9af76ccb9e05cba21f12e4b4168b05b7d1d17c60..7eb9d02077449d688fd6f108a186e1ab99a1cba7 100644
+--- a/tests/models/test_glm5next_pooled_indexer.py
++++ b/tests/models/test_glm5next_pooled_indexer.py
+@@ -8,6 +8,7 @@ import pytest
+ import torch
+ from torch import nn
+ 
++from vllm.models.deepseek_v4.nvidia import b12x_indexer
+ from vllm.models.deepseek_v4.nvidia.b12x_indexer import _flatten_index_cache
+ from vllm.models.glm5next.nvidia.ops.glm_kpool import (
+     expand_c4_block_table,
+@@ -123,10 +124,12 @@ def test_glm53_selector_prefill_lengths_do_not_require_attention_backend() -> No
+         num_decode_tokens=1,
+         prefill=None,
+         prefill_query_lens_cpu=torch.tensor([3], dtype=torch.int32),
++        prefill_seq_lens_cpu=torch.tensor([8], dtype=torch.int32),
+     )
+ 
+     assert metadata.prefill is None
+     assert metadata.prefill_query_lens_cpu.tolist() == [3]
++    assert metadata.prefill_seq_lens_cpu.tolist() == [8]
+ 
+ 
+ def test_glm53_packed_c4_metadata_uses_parent_stride() -> None:
+@@ -376,6 +379,117 @@ def test_glm53_packed_tail_scores_through_existing_c4_indexer() -> None:
+     assert set(output[0, :2].tolist()) == {0, 1}
+ 
+ 
++def test_glm53_deepgemm_prefill_matches_b12x_on_packed_tail(
++    monkeypatch: pytest.MonkeyPatch,
++) -> None:
++    device = _require_glm_gpu()
++    _, main = _packed_main_cache(
++        device=device, blocks=2, layers=3, block_size=512, layer=1
++    )
++    index_cache, _, parent_stride_pages = Glm5NextPooledIndexer._index_cache_view(main)
++    virtual_page = parent_stride_pages
++    page = index_cache[virtual_page]
++    quant = page.as_strided(
++        (64, 128), (128, 1), storage_offset=page.storage_offset()
++    ).view(torch.float8_e4m3fn)
++    scales = page.as_strided(
++        (64 * 4,),
++        (1,),
++        storage_offset=page.storage_offset() + 64 * 128,
++    ).view(torch.float32)
++    generator = torch.Generator(device=device).manual_seed(5303)
++    quant.copy_(
++        torch.randn((64, 128), generator=generator, device=device).to(
++            torch.float8_e4m3fn
++        )
++    )
++    scales.copy_(
++        torch.exp2(
++            torch.randint(-3, 3, (64,), generator=generator, device=device).float()
++        )
++    )
++    q = torch.randn(
++        (3, 32, 128), generator=generator, device=device, dtype=torch.float32
++    ).to(torch.float8_e4m3fn)
++    weights = torch.randn(
++        (3, 32), generator=generator, device=device, dtype=torch.float32
++    )
++    seq_lens = torch.tensor([16, 37, 64], dtype=torch.int32, device=device)
++    block_table = torch.tensor([[virtual_page]], dtype=torch.int32, device=device)
++    topk = 512
++
++    from vllm.utils.b12x import get_b12x_dsa_indexer
++
++    module = get_b12x_dsa_indexer()
++    assert module is not None
++    plan = module.plan(
++        module.Caps(
++            device=device,
++            source_layout=module.SOURCE_LAYOUT_PAGED,
++            num_q_heads=32,
++            max_q_rows=3,
++            max_page_table_width=1,
++            topk=topk,
++            mode="prefill",
++            shared_page_table=True,
++        )
++    )
++    scratch = tuple(
++        torch.empty(shape, dtype=dtype, device=device)
++        for shape, dtype in plan.shapes_and_dtypes()
++    )
++    binding = plan.bind(
++        scratch=scratch,
++        real_page_table=block_table.expand(3, 1),
++        cache_seqlens_int32=seq_lens,
++        expected_num_q_heads=32,
++        shared_page_table=True,
++        output_physical_slots=False,
++    )
++    expected = torch.empty((3, topk), dtype=torch.int32, device=device)
++    module.index_topk_fp8(
++        q_fp8=q,
++        weights=weights,
++        index_k_cache=_flatten_index_cache(index_cache),
++        binding=binding,
++        page_size=64,
++        expected_num_q_heads=32,
++        out_indices=expected,
++    )
++
++    class Workspace:
++        def get_simultaneous(self, *specs):
++            return tuple(
++                torch.empty(shape, dtype=dtype, device=device) for shape, dtype in specs
++            )
++
++    monkeypatch.setattr(
++        b12x_indexer,
++        "current_workspace_manager",
++        lambda: Workspace(),
++    )
++    actual = torch.empty_like(expected)
++    b12x_indexer._run_deepgemm_prefill_topk(
++        q=q,
++        weights=weights,
++        kv_cache=index_cache,
++        seq_lens=seq_lens,
++        block_table=block_table,
++        gather_cu_seq_lens=torch.tensor([0, 64], dtype=torch.int32, device=device),
++        row_starts=torch.zeros(3, dtype=torch.int32, device=device),
++        output=actual,
++        topk=topk,
++        total_k_rows=64,
++        workspace_k_rows=64,
++    )
++    torch.accelerator.synchronize()
++
++    assert torch.equal(
++        torch.sort(actual, dim=-1).values,
++        torch.sort(expected, dim=-1).values,
++    )
++
++
+ def test_glm53_pool_write_matches_fp8_reference() -> None:
+     device = _require_glm_gpu()
+     generator = torch.Generator(device=device).manual_seed(53)
+@@ -458,7 +572,7 @@ def test_glm53_decode_tail_completes_the_same_pool_as_prefill() -> None:
+     torch.testing.assert_close(actual_scale, expected_scale.reshape(1), rtol=0, atol=0)
+ 
+ 
+-def test_glm53_decode_writer_matches_batched_prefill_writer() -> None:
++def test_glm53_decode_writer_matches_parallel_prefill_writer() -> None:
+     device = _require_glm_gpu()
+     generator = torch.Generator(device=device).manual_seed(56)
+     key = torch.randn(
+@@ -486,9 +600,13 @@ def test_glm53_decode_writer_matches_batched_prefill_writer() -> None:
+         key,
+         gate,
+         ape,
+-        torch.tensor([-1, -1, -1, 0, -1, -1, -1, 1], device=device),
++        torch.tensor([-1, -1, -1, 3, -1, -1, -1, 7], device=device),
+         torch.arange(8, dtype=torch.int64, device=device),
+         1,
++        num_decode_requests=0,
++        max_query_len=8,
++        model_block_size=256,
++        parent_stride_pages=1,
+     )
+     for position in range(8):
+         update_decode_pools(
+@@ -500,18 +618,127 @@ def test_glm53_decode_writer_matches_batched_prefill_writer() -> None:
+             gate[position : position + 1],
+             ape,
+             torch.tensor(
+-                [position // 4 if position % 4 == 3 else -1],
++                [position if position % 4 == 3 else -1],
+                 dtype=torch.int64,
+                 device=device,
+             ),
+             torch.tensor([position], dtype=torch.int64, device=device),
+             1,
++            model_block_size=256,
++            parent_stride_pages=1,
+         )
+ 
+     assert torch.equal(decode_cache, prefill_cache)
+     assert torch.equal(decode_tail, prefill_tail)
+ 
+ 
++def test_glm53_parallel_prefill_preserves_boundary_tail_and_state_slots() -> None:
++    device = _require_glm_gpu()
++    generator = torch.Generator(device=device).manual_seed(5304)
++    key = torch.randn(
++        (10, 128), generator=generator, device=device, dtype=torch.bfloat16
++    )
++    gate = torch.randn(
++        (10, 128), generator=generator, device=device, dtype=torch.bfloat16
++    )
++    ape = torch.randn(
++        (4, 128), generator=generator, device=device, dtype=torch.bfloat16
++    )
++    initial_tail = torch.randn(
++        (2, 2, 4, 128), generator=generator, device=device, dtype=torch.bfloat16
++    )
++    sequential_tail = initial_tail.clone()
++    parallel_tail = initial_tail.clone()
++    sequential_cache = torch.zeros((2, 64, 132), dtype=torch.uint8, device=device)
++    parallel_cache = torch.zeros_like(sequential_cache)
++    state_slots = torch.tensor([1, 0], dtype=torch.int32, device=device)
++    query_start_loc = torch.tensor([0, 5, 10], dtype=torch.int32, device=device)
++    positions = torch.tensor(
++        [4099, 4100, 4101, 4102, 4103, 4099, 4100, 4101, 4102, 4103],
++        dtype=torch.int64,
++        device=device,
++    )
++    slot_mapping = torch.tensor(
++        [3, -1, -1, -1, 7, 259, -1, -1, -1, 263],
++        dtype=torch.int64,
++        device=device,
++    )
++    common = dict(model_block_size=256, parent_stride_pages=1)
++
++    update_decode_pools(
++        sequential_cache,
++        sequential_tail,
++        state_slots,
++        query_start_loc,
++        key,
++        gate,
++        ape,
++        slot_mapping,
++        positions,
++        2,
++        **common,
++    )
++    update_decode_pools(
++        parallel_cache,
++        parallel_tail,
++        state_slots,
++        query_start_loc,
++        key,
++        gate,
++        ape,
++        slot_mapping,
++        positions,
++        2,
++        num_decode_requests=0,
++        max_query_len=5,
++        **common,
++    )
++
++    assert torch.equal(parallel_cache, sequential_cache)
++    assert torch.equal(parallel_tail, sequential_tail)
++
++
++def test_glm53_parallel_prefill_ignores_invalid_dummy_slots() -> None:
++    device = _require_glm_gpu()
++    generator = torch.Generator(device=device).manual_seed(5305)
++    key = torch.randn(
++        (8, 128), generator=generator, device=device, dtype=torch.bfloat16
++    )
++    gate = torch.randn(
++        (8, 128), generator=generator, device=device, dtype=torch.bfloat16
++    )
++    ape = torch.randn(
++        (4, 128), generator=generator, device=device, dtype=torch.bfloat16
++    )
++    cache = torch.zeros((1, 64, 132), dtype=torch.uint8, device=device)
++    initial_tail = torch.randn(
++        (1, 2, 4, 128), generator=generator, device=device, dtype=torch.bfloat16
++    )
++    tail = initial_tail.clone()
++
++    update_decode_pools(
++        cache,
++        tail,
++        torch.zeros(1, dtype=torch.int32, device=device),
++        torch.tensor([0, 8], dtype=torch.int32, device=device),
++        key,
++        gate,
++        ape,
++        torch.full((8,), -1, dtype=torch.int64, device=device),
++        torch.zeros(8, dtype=torch.int64, device=device),
++        1,
++        num_decode_requests=0,
++        max_query_len=8,
++        model_block_size=256,
++        parent_stride_pages=1,
++    )
++
++    assert torch.count_nonzero(cache).item() == 0
++    torch.testing.assert_close(tail[0, 0, 0], key[-1])
++    torch.testing.assert_close(tail[0, 1, 0], gate[-1])
++    assert torch.equal(tail[:, :, 1:], initial_tail[:, :, 1:])
++
++
+ def test_glm53_tail_state_isolated_between_requests() -> None:
+     device = _require_glm_gpu()
+     generator = torch.Generator(device=device).manual_seed(57)
+diff --git a/tests/v1/attention/test_b12x_sparse_mla_api.py b/tests/v1/attention/test_b12x_sparse_mla_api.py
+index 1227669e39ab4cd8ef22d6403a11040d634f040c..76943ff60661c31d7c96ff36df267906862643cf 100644
+--- a/tests/v1/attention/test_b12x_sparse_mla_api.py
++++ b/tests/v1/attention/test_b12x_sparse_mla_api.py
+@@ -170,10 +170,14 @@ def test_b12x_glm5_next_cache_spec_and_layout(monkeypatch) -> None:
+     assert invalid_reasons == []
+     assert unidentified == probe
+     assert packed_by_glm_backend.state_content_bytes == 528
+-    assert packed_by_glm_backend.page_size_padded == 64 * 528 + 16 * 128 * 2
++    assert packed_by_glm_backend.page_size_padded is None
++    assert packed_by_glm_backend.page_tail_bytes_per_token == 33
++    assert packed_by_glm_backend.page_size_bytes == 64 * (528 + 33)
+     assert packed_by_glm_backend.model_version == "glm5_next"
+     assert packed.state_content_bytes == 528
+-    assert packed.page_size_padded == 64 * 528 + 16 * 128 * 2
++    assert packed.page_size_padded is None
++    assert packed.page_tail_bytes_per_token == 33
++    assert packed.page_size_bytes == 64 * (528 + 33)
+     assert packed.model_version == "glm5_next"
+     assert packed_without_config_context == packed
+     assert layouts == (KVCacheLayout.BLHNC,)
+@@ -515,7 +519,7 @@ def test_glm_selector_metadata_builder_stages_padded_rows_and_capture(
+     monkeypatch.setattr(
+         SparseMLACommonMetadataBuilder,
+         "build",
+-        lambda *args, **kwargs: SimpleNamespace(),
++        lambda *args, **kwargs: SimpleNamespace(num_prefills=0),
+     )
+     builder = _bare_glm_selector_metadata_builder()
+     common = SimpleNamespace(
+@@ -591,7 +595,7 @@ def test_glm_selector_metadata_builder_requires_complete_runtime_state(
+     monkeypatch.setattr(
+         SparseMLACommonMetadataBuilder,
+         "build",
+-        lambda *args, **kwargs: SimpleNamespace(),
++        lambda *args, **kwargs: SimpleNamespace(num_prefills=0),
+     )
+     builder = _bare_glm_selector_metadata_builder()
+     common = SimpleNamespace(
+@@ -839,6 +843,7 @@ def test_b12x_wo_projection_packs_and_runs_public_api(monkeypatch) -> None:
+ 
+ def test_b12x_mhc_uses_public_plan_bind_run(monkeypatch) -> None:
+     calls: dict[str, Any] = {}
++    retained_bindings: list[Any] = []
+ 
+     def make_caps(**kwargs):
+         calls["caps"] = kwargs
+@@ -878,6 +883,11 @@ def test_b12x_mhc_uses_public_plan_bind_run(monkeypatch) -> None:
+     )
+     monkeypatch.setattr(b12x_mla, "_require_b12x_mhc", lambda: module)
+     monkeypatch.setattr(b12x_mla, "current_workspace_manager", lambda: _Workspace())
++    monkeypatch.setattr(
++        b12x_mla,
++        "retain_cuda_graph_capture_resource",
++        retained_bindings.append,
++    )
+ 
+     mhc = b12x_mla.B12xMHCResidual(
+         hidden_size=256,
+@@ -918,6 +928,10 @@ def test_b12x_mhc_uses_public_plan_bind_run(monkeypatch) -> None:
+     assert calls["bind"][1]["scratch"].dtype == torch.uint8
+     assert calls["pre"][1]["binding"].expected_m == 3
+     assert calls["post_pre"][1]["expected_m"] == 3
++    assert retained_bindings == [
++        calls["pre"][1]["binding"],
++        calls["post_pre"][1]["binding"],
++    ]
+     assert residual_out.shape == (3, 4, 256)
+     assert layer_input.shape == (3, 256)
+     assert final is next_outputs[0]
+diff --git a/tests/v1/attention/test_group_head_counts.py b/tests/v1/attention/test_group_head_counts.py
+index 969192681900a059855308560c5212cc0b46f62b..1b4bb0f0d5d291e41e589d38f9f0a70b6ac5499b 100644
+--- a/tests/v1/attention/test_group_head_counts.py
++++ b/tests/v1/attention/test_group_head_counts.py
+@@ -14,6 +14,7 @@ from vllm.v1.attention.backends.cpu_attn import (
+     CPUAttentionMetadataBuilder,
+ )
+ from vllm.v1.attention.backends.flash_attn import FlashAttentionMetadataBuilder
++from vllm.v1.attention.backends.utils import get_kv_cache_dtype_from_layers
+ 
+ requires_cpu = pytest.mark.skipif(
+     not current_platform.is_cpu(), reason="CPU attention backend"
+@@ -127,3 +128,18 @@ def test_flash_attention_geometry_comes_from_the_group():
+     assert builder.num_heads_q == 16
+     assert builder.num_heads_kv == 2
+     assert builder.headdim == 64
++
++
++def test_kv_cache_dtype_comes_from_the_attention_group():
++    """A draft attention group can use a different cache format than its target."""
++    layers = {
++        "draft.layer.0": SimpleNamespace(kv_cache_dtype="fp8"),
++        "draft.layer.1": SimpleNamespace(kv_cache_dtype="fp8"),
++    }
++    with patch(
++        "vllm.v1.attention.backends.utils.get_layers_from_vllm_config",
++        return_value=layers,
++    ):
++        cache_dtype = get_kv_cache_dtype_from_layers(MagicMock(), list(layers))
++
++    assert cache_dtype == "fp8"
+diff --git a/tests/v1/spec_decode/test_dflash2.py b/tests/v1/spec_decode/test_dflash2.py
+index 86cf3327a92252b095405d19d6812a4ee295c26e..78b7bd8cc8e116937edc63f537387b6e3e316224 100644
+--- a/tests/v1/spec_decode/test_dflash2.py
++++ b/tests/v1/spec_decode/test_dflash2.py
+@@ -60,6 +60,47 @@ def test_grouped_conv_matches_reference(block_size: int):
+     torch.testing.assert_close(actual, expected.flatten(0, 1).flatten(-2))
+ 
+ 
++def test_dflash2_auxiliary_linears_use_draft_quantization(
++    monkeypatch, default_vllm_config
++):
++    """Every checkpoint-serialized DFlash2 linear receives its quant config."""
++    from torch import nn
++
++    import vllm.model_executor.models.qwen3_dflash2 as dflash2
++
++    class StubLinear(nn.Module):
++        def __init__(self, *args, quant_config=None, **kwargs):
++            super().__init__()
++            self.quant_config = quant_config
++
++    monkeypatch.setattr(dflash2, "ReplicatedLinear", StubLinear)
++    quant_config = object()
++    from vllm.config import set_current_vllm_config
++
++    with set_current_vllm_config(default_vllm_config):
++        grouped_conv = dflash2.DFlashGroupedConv(
++            hidden_size=16,
++            taps=2,
++            group_size=4,
++            block_size=8,
++            params_dtype=torch.float32,
++            quant_config=quant_config,
++            prefix="attention_conv",
++        )
++        selector = dflash2.CandidateSelector(
++            hidden_size=16,
++            vocab_size=32,
++            rank=4,
++            top_k=3,
++            params_dtype=torch.float32,
++            quant_config=quant_config,
++            prefix="candidate_selector",
++        )
++
++    assert grouped_conv.kernel_projection.quant_config is quant_config
++    assert selector.hidden_projection.quant_config is quant_config
++
++
+ def test_selector_edges_match_sequential_reference():
+     torch.manual_seed(1)
+     batch, steps, top_k, rank = 2, 4, 3, 5
+diff --git a/tests/v1/worker/test_attn_utils.py b/tests/v1/worker/test_attn_utils.py
+index 06f3635c138097cf87ea1a44e6bc44c2ae349f5c..a0c4d67e2eceb09cf34f2f0de2fce2e49db070d3 100644
+--- a/tests/v1/worker/test_attn_utils.py
++++ b/tests/v1/worker/test_attn_utils.py
+@@ -28,6 +28,7 @@ from vllm.v1.worker.gpu.attn_utils import (
+     build_attn_metadata,
+     get_attn_cg_support,
+     get_query_lens_mismatch_unsupported_backend,
++    synchronize_attention_impl_kv_cache_layout,
+ )
+ from vllm.v1.worker.utils import (
+     AttentionGroup,
+@@ -79,6 +80,26 @@ class _CachingMetadataBuilder:
+         )
+ 
+ 
++def test_attention_impl_cache_layout_preserves_model_specific_dtype():
++    target_cache_config = SimpleNamespace(
++        cache_dtype="fp8_ds_mla", kv_cache_layout=None
++    )
++    draft_cache_config = SimpleNamespace(cache_dtype="fp8", kv_cache_layout=None)
++    layers = {
++        "target": SimpleNamespace(
++            impl=SimpleNamespace(cache_config=target_cache_config)
++        ),
++        "draft": SimpleNamespace(impl=SimpleNamespace(cache_config=draft_cache_config)),
++    }
++
++    synchronize_attention_impl_kv_cache_layout(layers, "BLHNC")
++
++    assert target_cache_config.kv_cache_layout == "BLHNC"
++    assert draft_cache_config.kv_cache_layout == "BLHNC"
++    assert target_cache_config.cache_dtype == "fp8_ds_mla"
++    assert draft_cache_config.cache_dtype == "fp8"
++
++
+ def test_attention_checks_preserve_global_and_target_scoped_support():
+     spec = FullAttentionSpec(
+         block_size=16,
+diff --git a/tests/v1/worker/test_workspace.py b/tests/v1/worker/test_workspace.py
+index a909ea9af89dd68bbee73174459afb7b9a30eaaa..8bbe8e9cc0d178ef886ec46f791568680aa9965c 100644
+--- a/tests/v1/worker/test_workspace.py
++++ b/tests/v1/worker/test_workspace.py
+@@ -100,3 +100,21 @@ def test_workspace_lane_validation(monkeypatch) -> None:
+ 
+     with pytest.raises(ValueError, match="at least one"):
+         workspace.WorkspaceManager(torch.device("cpu"), num_lanes=0)
++
++
++def test_cuda_graph_capture_resources_are_scoped_to_collector() -> None:
++    outside = object()
++    first = object()
++    nested = object()
++    second = object()
++
++    assert not workspace.retain_cuda_graph_capture_resource(outside)
++    with workspace.collect_cuda_graph_capture_resources() as resources:
++        assert workspace.retain_cuda_graph_capture_resource(first)
++        with workspace.collect_cuda_graph_capture_resources() as nested_resources:
++            assert workspace.retain_cuda_graph_capture_resource(nested)
++        assert workspace.retain_cuda_graph_capture_resource(second)
++
++    assert resources == [first, second]
++    assert nested_resources == [nested]
++    assert not workspace.retain_cuda_graph_capture_resource(outside)
+diff --git a/vllm/model_executor/layers/mamba/gdn/kimi_gdn_linear_attn.py b/vllm/model_executor/layers/mamba/gdn/kimi_gdn_linear_attn.py
+index a6760cb856e7e6808159490e794e022dd4a62db5..469e9a712bc99eccc9d10a44983fbaa705bf83e3 100644
+--- a/vllm/model_executor/layers/mamba/gdn/kimi_gdn_linear_attn.py
++++ b/vllm/model_executor/layers/mamba/gdn/kimi_gdn_linear_attn.py
+@@ -26,6 +26,7 @@ from vllm.third_party.flash_linear_attention.ops.kda import FusedRMSNormGated
+ from vllm.transformers_utils.configs.kimi_linear import KimiLinearConfig
+ from vllm.utils.b12x import get_b12x_gdn_decode
+ from vllm.v1.attention.backends.gdn_attn import GDNAttentionMetadata
++from vllm.v1.worker.workspace import current_workspace_manager
+ 
+ from ...linear import (
+     ColumnParallelLinear,
+@@ -308,7 +309,6 @@ class KimiGatedDeltaNetAttention(GatedDeltaNetAttention):
+         self.o_norm = FusedRMSNormGated(self.head_dim, activation="sigmoid")
+         self._b12x_kda_api: Any | None = None
+         self._b12x_kda_plan = None
+-        self._b12x_kda_binding = None
+         self._initialize_b12x_kda_decode(vllm_config)
+         self.o_proj = RowParallelLinear(
+             self.projection_size,
+@@ -412,12 +412,6 @@ class KimiGatedDeltaNetAttention(GatedDeltaNetAttention):
+             torch.zeros(1, dtype=torch.int32, device=device),
+             persistent=False,
+         )
+-        scratch_spec = provisional.scratch_specs()[0]
+-        self.register_buffer(
+-            "_b12x_kda_scratch",
+-            torch.empty(scratch_spec.shape, dtype=scratch_spec.dtype, device=device),
+-            persistent=False,
+-        )
+ 
+     def _make_b12x_kda_plan(self, max_state_slots: int):
+         api = self._b12x_kda_api
+@@ -450,27 +444,8 @@ class KimiGatedDeltaNetAttention(GatedDeltaNetAttention):
+         recurrent_state = self.kv_cache[1]
+         plan = self._make_b12x_kda_plan(max_state_slots=recurrent_state.shape[0])
+         self._b12x_kda_plan = plan
+-        self._b12x_kda_binding = api.bind_kda(
+-            plan,
+-            scratch=self._b12x_kda_scratch,
+-            mixed_qkv=self._b12x_kda_mixed_qkv,
+-            raw_g=self._b12x_kda_raw_g,
+-            raw_beta=self._b12x_kda_raw_beta,
+-            z=self._b12x_kda_z,
+-            A_log=self.A_log,
+-            dt_bias=self.dt_bias.view(self.local_num_heads, self.head_dim),
+-            norm_weight=self.o_norm.weight,
+-            recurrent_state=recurrent_state,
+-            query_start_loc=self._b12x_kda_query_start_loc,
+-            num_accepted_tokens=self._b12x_kda_num_accepted_tokens,
+-            state_indices=self._b12x_kda_state_indices,
+-            num_seqs=self._b12x_kda_num_seqs,
+-            num_tokens=self._b12x_kda_num_tokens,
+-            output=self._b12x_kda_output,
+-        )
+ 
+     def unbind_kv_cache(self) -> None:
+-        self._b12x_kda_binding = None
+         self._b12x_kda_plan = None
+         super().unbind_kv_cache()
+ 
+@@ -486,7 +461,7 @@ class KimiGatedDeltaNetAttention(GatedDeltaNetAttention):
+ 
+     def _can_use_b12x_kda_decode(self, m: GDNAttentionMetadata) -> bool:
+         if (
+-            self._b12x_kda_binding is None
++            self._b12x_kda_plan is None
+             or m.num_prefills != 0
+             or (m.num_decodes == 0 and m.num_spec_decodes == 0)
+         ):
+@@ -518,9 +493,9 @@ class KimiGatedDeltaNetAttention(GatedDeltaNetAttention):
+         num_accepted_tokens: torch.Tensor | None,
+         num_requests: int,
+     ) -> None:
+-        binding = self._b12x_kda_binding
++        plan = self._b12x_kda_plan
+         api = self._b12x_kda_api
+-        if binding is None or api is None:
++        if plan is None or api is None:
+             raise RuntimeError("b12x KDA KV cache was not bound before inference")
+         num_tokens = int(mixed_qkv.shape[0])
+         state_columns = int(state_indices.shape[1])
+@@ -559,6 +534,33 @@ class KimiGatedDeltaNetAttention(GatedDeltaNetAttention):
+             query_start_loc[num_requests : num_requests + 1]
+         )
+ 
++        scratch_buffers = current_workspace_manager().get_simultaneous(
++            *plan.shapes_and_dtypes()
++        )
++        if not scratch_buffers:
++            raise RuntimeError("b12x KDA plan did not expose caller scratch")
++        scratch: torch.Tensor | tuple[torch.Tensor, ...]
++        scratch = (
++            scratch_buffers[0] if len(scratch_buffers) == 1 else tuple(scratch_buffers)
++        )
++        binding = api.bind_kda(
++            plan,
++            scratch=scratch,
++            mixed_qkv=self._b12x_kda_mixed_qkv,
++            raw_g=self._b12x_kda_raw_g,
++            raw_beta=self._b12x_kda_raw_beta,
++            z=self._b12x_kda_z,
++            A_log=self.A_log,
++            dt_bias=self.dt_bias.view(self.local_num_heads, self.head_dim),
++            norm_weight=self.o_norm.weight,
++            recurrent_state=self.kv_cache[1],
++            query_start_loc=self._b12x_kda_query_start_loc,
++            num_accepted_tokens=self._b12x_kda_num_accepted_tokens,
++            state_indices=self._b12x_kda_state_indices,
++            num_seqs=self._b12x_kda_num_seqs,
++            num_tokens=self._b12x_kda_num_tokens,
++            output=self._b12x_kda_output,
++        )
+         api.run_kda(
+             binding,
+             lower_bound=self.gate_lower_bound,
+diff --git a/vllm/model_executor/models/qwen3_dflash.py b/vllm/model_executor/models/qwen3_dflash.py
+index f5a7bff8fc6e1521b9d39f23612a0ff8004e476a..b58b5b16b8f9ee093f7984b250ea6e494805774e 100644
+--- a/vllm/model_executor/models/qwen3_dflash.py
++++ b/vllm/model_executor/models/qwen3_dflash.py
+@@ -472,6 +472,14 @@ class DFlashQwen3Model(nn.Module):
+             self.config.hidden_size,
+             eps=self.config.rms_norm_eps,
+         )
++        # The context projection concatenates K/V weights from every draft
++        # layer. It is not a LinearBase module because its output layout is a
++        # DFlash-specific fusion. Serialized MXFP8 checkpoints retain an
++        # independently packed copy in this parameter container.
++        self._fused_kv_linear = nn.Module()
++        self._fused_kv_quant_method = None
++        self._fused_kv_weight: torch.Tensor | None = None
++        self._fused_kv_weight_scale: torch.Tensor | None = None
+ 
+     def embed_input_ids(self, input_ids: torch.Tensor) -> torch.Tensor:
+         embeds = self.embed_tokens(input_ids)
+@@ -491,6 +499,25 @@ class DFlashQwen3Model(nn.Module):
+         # KV projection weights: [num_layers * 2 * kv_size, hidden_size]
+         kv_weights = [a.qkv_proj.weight[a.q_size :] for a in layers_attn]
+         self._fused_kv_weight = torch.cat(kv_weights, dim=0)
++
++        from vllm.model_executor.layers.quantization.modelopt import (
++            ModelOptMxFp8LinearMethod,
++        )
++
++        quant_method = layers_attn[0].qkv_proj.quant_method
++        if isinstance(quant_method, ModelOptMxFp8LinearMethod):
++            if not all(
++                isinstance(a.qkv_proj.quant_method, ModelOptMxFp8LinearMethod)
++                for a in layers_attn
++            ):
++                raise ValueError(
++                    "Every DFlash attention layer must use the same MXFP8 "
++                    "linear format for the fused context K/V projection."
++                )
++            kv_scales = [a.qkv_proj.weight_scale[a.q_size :] for a in layers_attn]
++            self._fused_kv_weight_scale = torch.cat(kv_scales, dim=0)
++        else:
++            self._fused_kv_weight_scale = None
+         if has_bias:
+             kv_biases = [a.qkv_proj.bias[a.q_size :] for a in layers_attn]
+             self._fused_kv_bias: torch.Tensor | None = torch.cat(kv_biases, dim=0)
+@@ -546,6 +573,41 @@ class DFlashQwen3Model(nn.Module):
+         # References to inner Attention layers for direct cache writes
+         self._attn_layers = [layer.self_attn.attn for layer in self.layers]
+ 
++    def process_weights_after_loading(self) -> None:
++        """Pack the serialized MXFP8 context projection for its GEMM backend."""
++        from vllm.model_executor.layers.quantization.modelopt import (
++            ModelOptMxFp8LinearMethod,
++        )
++
++        quant_method = self.layers[0].self_attn.qkv_proj.quant_method
++        if not isinstance(quant_method, ModelOptMxFp8LinearMethod):
++            return
++        if self._fused_kv_weight is None or self._fused_kv_weight_scale is None:
++            raise RuntimeError(
++                "The DFlash MXFP8 context projection requires serialized K/V "
++                "weights and block scales to be fused during checkpoint loading."
++            )
++
++        output_size, input_size = self._fused_kv_weight.shape
++        self._fused_kv_linear.input_size_per_partition = input_size
++        self._fused_kv_linear.output_size_per_partition = output_size
++        self._fused_kv_linear.logical_widths = [output_size]
++        self._fused_kv_linear.register_parameter(
++            "weight", nn.Parameter(self._fused_kv_weight, requires_grad=False)
++        )
++        self._fused_kv_linear.register_parameter(
++            "weight_scale",
++            nn.Parameter(self._fused_kv_weight_scale, requires_grad=False),
++        )
++        quant_method.process_weights_after_loading(self._fused_kv_linear)
++        self._fused_kv_quant_method = quant_method
++        self._fused_kv_weight = None
++        self._fused_kv_weight_scale = None
++        logger.info_once(
++            "Using %s for the fused DFlash context K/V projection.",
++            type(quant_method.kernel).__name__,
++        )
++
+     def _project_context_kv(
+         self,
+         context_states: torch.Tensor,
+@@ -562,9 +624,18 @@ class DFlashQwen3Model(nn.Module):
+             self._hidden_norm_weight,
+             self._rms_norm_eps,
+         )
+-        all_kv_flat = F.linear(
+-            normed_context_states, self._fused_kv_weight, self._fused_kv_bias
+-        )
++        if self._fused_kv_quant_method is None:
++            if self._fused_kv_weight is None:
++                raise RuntimeError("DFlash context K/V projection is not initialized.")
++            all_kv_flat = F.linear(
++                normed_context_states, self._fused_kv_weight, self._fused_kv_bias
++            )
++        else:
++            all_kv_flat = self._fused_kv_quant_method.apply(
++                self._fused_kv_linear,
++                normed_context_states,
++                self._fused_kv_bias,
++            )
+         # Single contiguous copy that separates K/V and transposes to
+         # layer-major layout.  Result: [2, L, num_ctx, nkv, hd] contiguous.
+         # Indexing dim-0 gives contiguous [L, num_ctx, nkv, hd] for K and V.
+@@ -793,6 +864,10 @@ class DFlashQwen3ForCausalLM(Qwen3ForCausalLM):
+             context_states, context_positions, context_slot_mapping
+         )
+ 
++    def process_weights_after_loading(self) -> None:
++        """Finalize the DFlash fused context projection after linear packing."""
++        self.model.process_weights_after_loading()
++
+     def combine_hidden_states(
+         self,
+         hidden_states: torch.Tensor,
+diff --git a/vllm/model_executor/models/qwen3_dflash2.py b/vllm/model_executor/models/qwen3_dflash2.py
+index cb027293f98185b2baa467b00c153d75c7840a49..caaedb5578aca4dc56c70d9553a90225eae9a521 100644
+--- a/vllm/model_executor/models/qwen3_dflash2.py
++++ b/vllm/model_executor/models/qwen3_dflash2.py
+@@ -51,6 +51,7 @@ class DFlashGroupedConv(nn.Module):
+         group_size: int,
+         block_size: int,
+         params_dtype: torch.dtype,
++        quant_config: QuantizationConfig | None,
+         prefix: str,
+     ) -> None:
+         super().__init__()
+@@ -71,7 +72,7 @@ class DFlashGroupedConv(nn.Module):
+             2 * taps * self.num_groups,
+             bias=False,
+             params_dtype=params_dtype,
+-            quant_config=None,
++            quant_config=quant_config,
+             prefix=maybe_prefix(prefix, "kernel_projection"),
+             return_bias=False,
+         )
+@@ -130,6 +131,7 @@ class DFlash2Qwen3DecoderLayer(DFlashQwen3DecoderLayer):
+             # Query tokens per request: the bonus token plus the mask tokens.
+             block_size=1 + speculative_config.num_speculative_tokens,
+             params_dtype=vllm_config.model_config.dtype,
++            quant_config=quant_config,
+         )
+         self.attention_conv = DFlashGroupedConv(
+             **conv_args, prefix=maybe_prefix(prefix, "attention_conv")
+@@ -193,6 +195,7 @@ class CandidateSelector(nn.Module):
+         rank: int,
+         top_k: int,
+         params_dtype: torch.dtype,
++        quant_config: QuantizationConfig | None,
+         prefix: str,
+     ) -> None:
+         super().__init__()
+@@ -208,7 +211,7 @@ class CandidateSelector(nn.Module):
+             rank,
+             bias=False,
+             params_dtype=params_dtype,
+-            quant_config=None,
++            quant_config=quant_config,
+             prefix=maybe_prefix(prefix, "hidden_projection"),
+             return_bias=False,
+         )
+@@ -259,6 +262,7 @@ class DFlash2Qwen3Model(DFlashQwen3Model):
+                 rank=int(draft_config["selector_rank"]),
+                 top_k=int(draft_config["selector_top_k"]),
+                 params_dtype=vllm_config.model_config.dtype,
++                quant_config=self.quant_config,
+                 prefix=maybe_prefix(prefix, "candidate_selector"),
+             )
+ 
+diff --git a/vllm/models/deepseek_v4/nvidia/b12x.py b/vllm/models/deepseek_v4/nvidia/b12x.py
+index 6e4c4003072864a11342921314d9bf3392fb3cc8..649b502890917c71b69ed0bbdabfbc2a5de720fa 100644
+--- a/vllm/models/deepseek_v4/nvidia/b12x.py
++++ b/vllm/models/deepseek_v4/nvidia/b12x.py
+@@ -38,7 +38,10 @@ from vllm.v1.attention.backend import AttentionCGSupport
+ from vllm.v1.attention.backends.mla.compressor_utils import (
+     get_dspark_swa_index_width,
+ )
+-from vllm.v1.worker.workspace import current_workspace_manager
++from vllm.v1.worker.workspace import (
++    current_workspace_manager,
++    retain_cuda_graph_capture_resource,
++)
+ 
+ if TYPE_CHECKING:
+     from vllm.v1.attention.backends.mla.sparse_swa import (
+@@ -170,7 +173,7 @@ class B12xMHCResidual:
+             raise ValueError("B12x mHC scratch plan did not provide any buffers.")
+         scratch: torch.Tensor | tuple[torch.Tensor, ...]
+         scratch = buffers[0] if len(buffers) == 1 else tuple(buffers)
+-        return self._bind(
++        binding = self._bind(
+             plan,
+             scratch=scratch,
+             tokens=tokens,
+@@ -180,6 +183,8 @@ class B12xMHCResidual:
+             out=out,
+             expected_m=expected_m,
+         )
++        retain_cuda_graph_capture_resource(binding)
++        return binding
+ 
+     def run_pre(
+         self,
+diff --git a/vllm/models/deepseek_v4/nvidia/b12x_indexer.py b/vllm/models/deepseek_v4/nvidia/b12x_indexer.py
+index 212730d2f44aac08a8807532efa9c69991cf22ff..ccc915dfb5b56f91a245bba2e0c3cb5c858fcee0 100644
+--- a/vllm/models/deepseek_v4/nvidia/b12x_indexer.py
++++ b/vllm/models/deepseek_v4/nvidia/b12x_indexer.py
+@@ -8,10 +8,12 @@ from typing import Any, cast
+ import torch
+ from torch import nn
+ 
++from vllm import _custom_ops as ops
+ from vllm.config import CUDAGraphMode, VllmConfig
+ from vllm.forward_context import get_forward_context
+ from vllm.platforms import current_platform
+ from vllm.utils.b12x import get_b12x_dsa_indexer
++from vllm.utils.deep_gemm import fp8_fp4_mqa_logits
+ from vllm.v1.attention.backend import AttentionCGSupport
+ from vllm.v1.attention.backends.mla.indexer import (
+     DeepseekV4IndexerBackend,
+@@ -239,6 +241,95 @@ def _run_paged_topk(
+     )
+ 
+ 
++def _run_deepgemm_prefill_topk(
++    *,
++    q: torch.Tensor,
++    weights: torch.Tensor,
++    kv_cache: torch.Tensor,
++    seq_lens: torch.Tensor,
++    block_table: torch.Tensor,
++    gather_cu_seq_lens: torch.Tensor,
++    row_starts: torch.Tensor,
++    output: torch.Tensor,
++    topk: int,
++    total_k_rows: int,
++    workspace_k_rows: int,
++) -> None:
++    """Gather a shared paged cache and score prefill rows with DeepGEMM."""
++    q_rows = int(q.shape[0])
++    expected_cache_tail = (_INDEX_PAGE_SIZE, _INDEX_HEAD_DIM + _INDEX_SCALE_BYTES)
++    if q.ndim != 3 or int(q.shape[2]) != _INDEX_HEAD_DIM:
++        raise ValueError(
++            "DeepGEMM C4 prefill queries must have shape [rows, heads, 128]"
++        )
++    if weights.shape != (q_rows, int(q.shape[1])) or weights.dtype != torch.float32:
++        raise ValueError("DeepGEMM C4 prefill weights must be FP32 [rows, heads]")
++    if (
++        kv_cache.ndim != 3
++        or kv_cache.dtype != torch.uint8
++        or tuple(kv_cache.shape[1:]) != expected_cache_tail
++    ):
++        raise ValueError("DeepGEMM C4 prefill cache must be uint8 [pages, 64, 132]")
++    if seq_lens.shape != (q_rows,) or seq_lens.dtype != torch.int32:
++        raise ValueError("DeepGEMM C4 prefill lengths must be int32 [rows]")
++    if block_table.ndim != 2 or int(block_table.shape[0]) != 1:
++        raise ValueError("DeepGEMM C4 prefill requires one shared page-table row")
++    if gather_cu_seq_lens.shape != (2,) or gather_cu_seq_lens.dtype != torch.int32:
++        raise ValueError("DeepGEMM C4 gather boundaries must be int32 [2]")
++    if row_starts.shape != (q_rows,) or row_starts.dtype != torch.int32:
++        raise ValueError("DeepGEMM C4 row starts must be int32 [rows]")
++    if output.shape != (q_rows, int(topk)) or output.dtype != torch.int32:
++        raise ValueError("DeepGEMM C4 prefill output must be int32 [rows, topk]")
++    if not 0 <= int(total_k_rows) <= int(workspace_k_rows):
++        raise ValueError(
++            "DeepGEMM C4 gathered length exceeds workspace capacity: "
++            f"length={total_k_rows}, capacity={workspace_k_rows}"
++        )
++
++    output.fill_(-1)
++    if q_rows == 0 or total_k_rows == 0:
++        return
++
++    active_pages = (int(total_k_rows) + _INDEX_PAGE_SIZE - 1) // _INDEX_PAGE_SIZE
++    if active_pages > int(block_table.shape[1]):
++        raise ValueError(
++            "DeepGEMM C4 page table does not cover the gathered prefix: "
++            f"required={active_pages}, available={block_table.shape[1]}"
++        )
++
++    k_quant_full, k_scale_full = current_workspace_manager().get_simultaneous(
++        ((max(int(workspace_k_rows), 1), _INDEX_HEAD_DIM), q.dtype),
++        ((max(int(workspace_k_rows), 1), _INDEX_SCALE_BYTES), torch.uint8),
++    )
++    k_quant = k_quant_full[:total_k_rows]
++    k_scale_bytes = k_scale_full[:total_k_rows]
++    ops.cp_gather_indexer_k_quant_cache(
++        kv_cache,
++        k_quant,
++        k_scale_bytes,
++        block_table[:, :active_pages],
++        gather_cu_seq_lens,
++    )
++    logits = fp8_fp4_mqa_logits(
++        (q, None),
++        (k_quant, k_scale_bytes.view(torch.float32).squeeze(-1)),
++        weights,
++        row_starts,
++        seq_lens,
++        clean_logits=False,
++    )
++    ops.top_k_per_row_prefill(
++        logits,
++        row_starts,
++        seq_lens,
++        output,
++        q_rows,
++        int(logits.stride(0)),
++        int(logits.stride(1)),
++        int(topk),
++    )
++
++
+ class B12xC4SparseIndexer(nn.Module):
+     """Shared C4 FP8 paged indexer used by DeepSeek V4 and GLM-5.3-Flash."""
+ 
+@@ -301,6 +392,18 @@ class B12xC4SparseIndexer(nn.Module):
+             if shared_page_table:
+                 _assert_prefill_route(plan)
+             current_workspace_manager().get_simultaneous(*plan.shapes_and_dtypes())
++        current_workspace_manager().get_simultaneous(
++            ((max(self.max_model_len, 1), _INDEX_HEAD_DIM), q.dtype),
++            (
++                (max(self.max_model_len, 1), _INDEX_SCALE_BYTES),
++                torch.uint8,
++            ),
++        )
++        torch.empty(
++            (max(q_rows, 1), max(self.max_model_len, 1)),
++            dtype=torch.float32,
++            device=q.device,
++        )
+ 
+     def reserve_profile_workspace(self, q: torch.Tensor) -> None:
+         self._reserve_profile_workspace(q)
+@@ -347,6 +450,35 @@ class B12xC4SparseIndexer(nn.Module):
+         )
+         return output
+ 
++    def run_deepgemm_prefill_topk(
++        self,
++        *,
++        q: torch.Tensor,
++        weights: torch.Tensor,
++        kv_cache: torch.Tensor,
++        seq_lens: torch.Tensor,
++        block_table: torch.Tensor,
++        gather_cu_seq_lens: torch.Tensor,
++        row_starts: torch.Tensor,
++        output: torch.Tensor,
++        total_k_rows: int,
++    ) -> torch.Tensor:
++        """Use DeepGEMM for shared-page-table C4 prefill selection."""
++        _run_deepgemm_prefill_topk(
++            q=q,
++            weights=weights,
++            kv_cache=kv_cache,
++            seq_lens=seq_lens,
++            block_table=block_table,
++            gather_cu_seq_lens=gather_cu_seq_lens,
++            row_starts=row_starts,
++            output=output,
++            topk=self.topk_tokens,
++            total_k_rows=int(total_k_rows),
++            workspace_k_rows=self.max_model_len,
++        )
++        return output
++
+     def forward(
+         self,
+         hidden_states: torch.Tensor,
+diff --git a/vllm/models/glm5next/nvidia/kda.py b/vllm/models/glm5next/nvidia/kda.py
+index 47f2823fc6c207e5e4c3383c1549e4bb342f92b6..deb4c43527d2338ea884702381d8931f337d673a 100644
+--- a/vllm/models/glm5next/nvidia/kda.py
++++ b/vllm/models/glm5next/nvidia/kda.py
+@@ -2,8 +2,11 @@
+ # SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+ """GLM-5.3 KDA modeling adapter."""
+ 
++from typing import Any
++
+ import torch
+ 
++from vllm.config import VllmConfig
+ from vllm.model_executor.layers.mamba.gdn.kimi_gdn_linear_attn import (
+     KimiGatedDeltaNetAttention,
+ )
+@@ -15,6 +18,33 @@ class Glm5NextLinearAttention(KimiGatedDeltaNetAttention):
+     enable_b12x_kda_decode = True
+     b12x_kda_null_state_index = 0
+ 
++    def __init__(
++        self,
++        config: Any,
++        vllm_config: VllmConfig,
++        prefix: str = "",
++    ) -> None:
++        additional_config = vllm_config.additional_config
++        backend = (
++            additional_config.get("glm53_kda_decode_backend", "auto")
++            if isinstance(additional_config, dict)
++            else "auto"
++        )
++        if backend not in ("auto", "b12x", "triton"):
++            raise ValueError(
++                "GLM-5.3 KDA decode backend must be 'auto', 'b12x', or "
++                "'triton', "
++                f"got {backend!r}."
++            )
++        self._glm53_kda_decode_backend = backend
++        # A recurrent cache uses one KDA implementation for its full lifetime.
++        # Keeping its BF16 rounding consistent prevents speculative acceptance
++        # from depending on whether a step entered through plain or spec decode.
++        self.enable_b12x_kda_decode = backend == "b12x" or (
++            backend == "auto" and vllm_config.speculative_config is not None
++        )
++        super().__init__(config, vllm_config, prefix)
++
+     def forward(  # type: ignore[override]
+         self,
+         hidden_states: torch.Tensor,
+diff --git a/vllm/models/glm5next/nvidia/model.py b/vllm/models/glm5next/nvidia/model.py
+index 6b499ce780661faa81bc83f9e41ed97fad73e9e7..8b26bed16102052a7576029fbb240052eb4822dc 100644
+--- a/vllm/models/glm5next/nvidia/model.py
++++ b/vllm/models/glm5next/nvidia/model.py
+@@ -437,6 +437,17 @@ class Glm5NextDecoderLayer(nn.Module):
+             self.mhc_post_op = MHCPostOp()
+             self.mhc_fused_post_pre_op = MHCFusedPostPreOp()
+             self._b12x_mhc = None
++            max_decode_tokens = int(vllm_config.scheduler_config.max_num_seqs) * (
++                1 + int(vllm_config.num_speculative_tokens)
++            )
++            max_cudagraph_tokens = int(
++                vllm_config.compilation_config.max_cudagraph_capture_size or 0
++            )
++            max_b12x_mhc_tokens = max(max_decode_tokens, max_cudagraph_tokens)
++            if self.is_sequence_parallel:
++                tp_size = int(parallel_config.tensor_parallel_size)
++                max_b12x_mhc_tokens = (max_b12x_mhc_tokens + tp_size - 1) // tp_size
++            self._b12x_mhc_max_tokens = max_b12x_mhc_tokens
+             if (
+                 current_platform.is_cuda()
+                 and current_platform.is_device_capability_family(120)
+@@ -493,9 +504,11 @@ class Glm5NextDecoderLayer(nn.Module):
+         # hc_post with this layer's attn hc_pre into one kernel (inter-layer
+         # fusion). Layer 0 has no incoming state -> standalone hc_pre.
+         x = hidden_states
++        use_b12x_mhc = self._use_b12x_mhc(x)
+         if post is None:
+-            if self._b12x_mhc is not None:
++            if use_b12x_mhc:
+                 assert self.hc_attn_fn_broadcast is not None
++                assert self._b12x_mhc is not None
+                 residual, post, comb, x = self._b12x_mhc.run_pre(
+                     x,
+                     self.hc_attn_fn_broadcast,
+@@ -527,6 +540,7 @@ class Glm5NextDecoderLayer(nn.Module):
+                 self.hc_attn_base,
+                 norm_weight=self.input_layernorm.weight,
+                 norm_eps=self.input_layernorm.variance_epsilon,
++                use_b12x_mhc=use_b12x_mhc,
+             )
+ 
+         # Attention needs the full token sequence; mHC above ran on the SP
+@@ -553,6 +567,7 @@ class Glm5NextDecoderLayer(nn.Module):
+             self.hc_ffn_base,
+             norm_weight=self.post_attention_layernorm.weight,
+             norm_eps=self.post_attention_layernorm.variance_epsilon,
++            use_b12x_mhc=use_b12x_mhc,
+         )
+ 
+         # Fully Connected
+@@ -565,7 +580,7 @@ class Glm5NextDecoderLayer(nn.Module):
+         # to fuse with) then contracts; every other layer defers its hc_post to
+         # the next layer's fused pre, returning the state.
+         if self.layer_idx == self.num_hidden_layers - 1:
+-            x = self.hc_post(x, residual, post, comb)
++            x = self.hc_post(x, residual, post, comb, use_b12x_mhc=use_b12x_mhc)
+             x = hc_contract(x, self.n)
+             return x, None, None, None
+ 
+@@ -595,14 +610,31 @@ class Glm5NextDecoderLayer(nn.Module):
+         )
+         return post_mix, res_mix, layer_input
+ 
++    def _use_b12x_mhc(self, x: torch.Tensor) -> bool:
++        """Select B12X for decode-sized batches, including graph padding.
++
++        TileLang handles larger prefill batches. The threshold is expressed in
++        rank-local tokens so sequence-parallel layers make the same selection
++        before and after attention.
++        """
++        return self._b12x_mhc is not None and x.shape[0] <= self._b12x_mhc_max_tokens
++
+     def hc_post(
+         self,
+         x: torch.Tensor,
+         residual: torch.Tensor,
+         post: torch.Tensor,
+         comb: torch.Tensor,
++        *,
++        use_b12x_mhc: bool | None = None,
+     ):
+-        if self._b12x_mhc is not None:
++        # Auxiliary-state capture completes deferred mHC state outside the
++        # decoder-layer forward, so it must derive the backend from the same
++        # rank-local token count used by the layer dispatch.
++        if use_b12x_mhc is None:
++            use_b12x_mhc = self._use_b12x_mhc(x)
++        if use_b12x_mhc:
++            assert self._b12x_mhc is not None
+             return self._b12x_mhc.run_post(x, residual, post, comb)
+         return self.mhc_post_op(x, residual, post, comb)
+ 
+@@ -617,8 +649,11 @@ class Glm5NextDecoderLayer(nn.Module):
+         hc_base: torch.Tensor,
+         norm_weight: torch.Tensor | None = None,
+         norm_eps: float = 0.0,
++        *,
++        use_b12x_mhc: bool,
+     ):
+-        if self._b12x_mhc is not None:
++        if use_b12x_mhc:
++            assert self._b12x_mhc is not None
+             return self._b12x_mhc.run_post_pre(
+                 x,
+                 residual,
+diff --git a/vllm/models/glm5next/nvidia/multimodal.py b/vllm/models/glm5next/nvidia/multimodal.py
+index 15e25ade33b7f5182385345847f4e4b0594606cd..951fef21d876924224aa6a0f27b08999794be6a5 100644
+--- a/vllm/models/glm5next/nvidia/multimodal.py
++++ b/vllm/models/glm5next/nvidia/multimodal.py
+@@ -630,7 +630,10 @@ class Glm5NextProcessingInfo(Glm4vProcessingInfo):
+         if proc is None:
+             from vllm.transformers_utils.processors.glm5next import Glm5NextProcessor
+ 
+-            proc = Glm5NextProcessor.from_pretrained(self.ctx.model_config.model)
++            proc = Glm5NextProcessor.from_pretrained(
++                self.ctx.model_config.model,
++                revision=self.ctx.model_config.revision,
++            )
+             self._glm5_hf_processor = proc
+         return proc
+ 
+diff --git a/vllm/models/glm5next/nvidia/ops/glm_kpool.py b/vllm/models/glm5next/nvidia/ops/glm_kpool.py
+index 6f65e93008b5feb958e4df792d023c1050f098ea..918f4e8ee6216278d585048fdcd0db6ed854df02 100644
+--- a/vllm/models/glm5next/nvidia/ops/glm_kpool.py
++++ b/vllm/models/glm5next/nvidia/ops/glm_kpool.py
+@@ -251,6 +251,195 @@ def _decode_update_kernel(
+         tl.store(tail + base + tail_stride_1 + dim, current_gate, mask=dim_mask)
+ 
+ 
++@triton.jit
++def _prefill_pool_kernel(
++    cache_fp8,
++    cache_fp32,
++    tail,
++    state_slots,
++    query_start_loc,
++    key,
++    gate,
++    ape,
++    slot_mapping,
++    positions,
++    request_offset,
++    page_stride_bytes,
++    model_block_size,
++    parent_stride_pages,
++    tail_stride_0,
++    tail_stride_1,
++    tail_stride_2,
++    key_stride_0,
++    gate_stride_0,
++    ape_stride_0,
++    PAGE_SIZE: tl.constexpr,
++    HEAD_DIM: tl.constexpr,
++    POOL_SIZE: tl.constexpr,
++    FP8_MAX: tl.constexpr,
++    BLOCK_D: tl.constexpr,
++):
++    request = request_offset + tl.program_id(0)
++    pool_ordinal = tl.program_id(1)
++    state_slot = tl.load(state_slots + request).to(tl.int64)
++    start = tl.load(query_start_loc + request).to(tl.int64)
++    end = tl.load(query_start_loc + request + 1).to(tl.int64)
++    has_rows = end > start
++    first_position = tl.load(positions + start, mask=has_rows, other=0).to(tl.int64)
++    first_physical_slot = first_position % POOL_SIZE
++    first_completion = start + (POOL_SIZE - 1 - first_physical_slot)
++    completion_row = first_completion + pool_ordinal * POOL_SIZE
++    write_pool = has_rows & (completion_row < end) & (state_slot >= 0)
++    completion_position = tl.load(
++        positions + completion_row, mask=write_pool, other=-1
++    ).to(tl.int64)
++    write_pool &= completion_position % POOL_SIZE == POOL_SIZE - 1
++    main_cache_location = tl.load(
++        slot_mapping + completion_row, mask=write_pool, other=-1
++    ).to(tl.int64)
++    write_pool &= main_cache_location >= 0
++    parent_page = main_cache_location // model_block_size
++    model_page_offset = main_cache_location - parent_page * model_block_size
++    pool_offset = model_page_offset // POOL_SIZE
++    child_page = pool_offset // PAGE_SIZE
++    child_offset = pool_offset - child_page * PAGE_SIZE
++    cache_location = (
++        parent_page * parent_stride_pages + child_page
++    ) * PAGE_SIZE + child_offset
++
++    dim = tl.arange(0, BLOCK_D)
++    dim_mask = dim < HEAD_DIM
++    maximum = tl.full((BLOCK_D,), -float("inf"), tl.float32)
++    for slot in tl.static_range(0, POOL_SIZE):
++        source_row = completion_row - (POOL_SIZE - 1 - slot)
++        from_current_chunk = source_row >= start
++        tail_offset = (
++            state_slot * tail_stride_0 + tail_stride_1 + slot * tail_stride_2 + dim
++        )
++        current_score = tl.load(
++            gate + source_row * gate_stride_0 + dim,
++            mask=dim_mask & write_pool & from_current_chunk,
++            other=0.0,
++        ).to(tl.float32)
++        previous_score = tl.load(
++            tail + tail_offset,
++            mask=dim_mask & write_pool & ~from_current_chunk,
++            other=0.0,
++        ).to(tl.float32)
++        score = tl.where(from_current_chunk, current_score, previous_score)
++        score += tl.load(
++            ape + slot * ape_stride_0 + dim,
++            mask=dim_mask & write_pool,
++            other=0.0,
++        ).to(tl.float32)
++        maximum = tl.maximum(maximum, score)
++
++    numerator = tl.zeros((BLOCK_D,), tl.float32)
++    denominator = tl.zeros((BLOCK_D,), tl.float32)
++    for slot in tl.static_range(0, POOL_SIZE):
++        source_row = completion_row - (POOL_SIZE - 1 - slot)
++        from_current_chunk = source_row >= start
++        tail_offset = state_slot * tail_stride_0 + slot * tail_stride_2 + dim
++        current_value = tl.load(
++            key + source_row * key_stride_0 + dim,
++            mask=dim_mask & write_pool & from_current_chunk,
++            other=0.0,
++        ).to(tl.float32)
++        previous_value = tl.load(
++            tail + tail_offset,
++            mask=dim_mask & write_pool & ~from_current_chunk,
++            other=0.0,
++        ).to(tl.float32)
++        value = tl.where(from_current_chunk, current_value, previous_value)
++        current_score = tl.load(
++            gate + source_row * gate_stride_0 + dim,
++            mask=dim_mask & write_pool & from_current_chunk,
++            other=0.0,
++        ).to(tl.float32)
++        previous_score = tl.load(
++            tail + tail_offset + tail_stride_1,
++            mask=dim_mask & write_pool & ~from_current_chunk,
++            other=0.0,
++        ).to(tl.float32)
++        score = tl.where(from_current_chunk, current_score, previous_score)
++        score += tl.load(
++            ape + slot * ape_stride_0 + dim,
++            mask=dim_mask & write_pool,
++            other=0.0,
++        ).to(tl.float32)
++        weight = tl.exp(score - maximum)
++        numerator += value * weight
++        denominator += weight
++
++    pooled = numerator / tl.maximum(denominator, 1e-20)
++    _write_pool(
++        cache_fp8,
++        cache_fp32,
++        cache_location,
++        pooled,
++        dim,
++        dim_mask,
++        write_pool,
++        page_stride_bytes,
++        PAGE_SIZE,
++        HEAD_DIM,
++        FP8_MAX,
++    )
++
++
++@triton.jit
++def _prefill_tail_kernel(
++    tail,
++    state_slots,
++    query_start_loc,
++    key,
++    gate,
++    positions,
++    request_offset,
++    tail_stride_0,
++    tail_stride_1,
++    tail_stride_2,
++    key_stride_0,
++    gate_stride_0,
++    HEAD_DIM: tl.constexpr,
++    POOL_SIZE: tl.constexpr,
++    BLOCK_D: tl.constexpr,
++):
++    request = request_offset + tl.program_id(0)
++    state_slot = tl.load(state_slots + request).to(tl.int64)
++    start = tl.load(query_start_loc + request).to(tl.int64)
++    end = tl.load(query_start_loc + request + 1).to(tl.int64)
++    last_row = end - 1
++    has_rows = end > start
++    last_position = tl.load(positions + last_row, mask=has_rows, other=0).to(tl.int64)
++    last_physical_slot = last_position % POOL_SIZE
++    dim = tl.arange(0, BLOCK_D)
++    dim_mask = (dim < HEAD_DIM) & has_rows & (state_slot >= 0)
++    for slot in tl.static_range(0, POOL_SIZE):
++        distance = (last_physical_slot - slot + POOL_SIZE) % POOL_SIZE
++        source_row = last_row - distance
++        source_in_chunk = source_row >= start
++        source_position = tl.load(
++            positions + source_row,
++            mask=has_rows & source_in_chunk,
++            other=-1,
++        ).to(tl.int64)
++        write_slot = dim_mask & source_in_chunk & (source_position % POOL_SIZE == slot)
++        value = tl.load(
++            key + source_row * key_stride_0 + dim,
++            mask=write_slot,
++            other=0.0,
++        )
++        score = tl.load(
++            gate + source_row * gate_stride_0 + dim,
++            mask=write_slot,
++            other=0.0,
++        )
++        tail_offset = state_slot * tail_stride_0 + slot * tail_stride_2 + dim
++        tl.store(tail + tail_offset, value, mask=write_slot)
++        tl.store(tail + tail_offset + tail_stride_1, score, mask=write_slot)
++
++
+ def update_decode_pools(
+     kv_cache: torch.Tensor,
+     tail: torch.Tensor,
+@@ -263,10 +452,18 @@ def update_decode_pools(
+     positions: torch.Tensor,
+     num_requests: int,
+     *,
++    num_decode_requests: int | None = None,
++    max_query_len: int | None = None,
+     model_block_size: int | None = None,
+     parent_stride_pages: int | None = None,
+ ) -> None:
+-    """Update raw tails and write every newly completed FP8 pool."""
++    """Update request tails and write every newly completed FP8 C4 pool.
++
++    Decode and speculative-decode requests retain ordered row processing. Prefill
++    requests use one program per completed pool and a separate final-tail update;
++    their positions must be consecutive within each request, as required by the
++    packed GLM MLA cache contract.
++    """
+     if num_requests <= 0:
+         return
+     page_size = int(kv_cache.shape[1])
+@@ -287,7 +484,17 @@ def update_decode_pools(
+     assert parent_stride_pages is not None
+     if parent_stride_pages <= 0:
+         raise ValueError("GLM parent_stride_pages must be positive")
+-    _decode_update_kernel[(num_requests,)](
++    if num_decode_requests is None:
++        num_decode_requests = num_requests
++    if not 0 <= num_decode_requests <= num_requests:
++        raise ValueError("GLM decode request count exceeds the request batch")
++    num_prefill_requests = num_requests - num_decode_requests
++    if num_prefill_requests and not packed_main_slots:
++        raise ValueError("parallel GLM prefill requires packed main-cache slots")
++    if num_prefill_requests and (max_query_len is None or max_query_len <= 0):
++        raise ValueError("parallel GLM prefill requires a positive max_query_len")
++
++    common_args = (
+         kv_cache.view(torch.float8_e4m3fn),
+         kv_cache.view(torch.float32),
+         tail,
+@@ -307,14 +514,49 @@ def update_decode_pools(
+         int(key.stride(0)),
+         int(gate.stride(0)),
+         int(ape.stride(0)),
++    )
++    common_meta = dict(
+         PAGE_SIZE=page_size,
+         HEAD_DIM=_HEAD_DIM,
+         POOL_SIZE=_POOL_SIZE,
+         FP8_MAX=_FP8_MAX,
+         BLOCK_D=128,
+-        PACKED_MAIN_SLOTS=packed_main_slots,
+         num_warps=4,
+     )
++    if num_decode_requests:
++        _decode_update_kernel[(num_decode_requests,)](
++            *common_args,
++            PACKED_MAIN_SLOTS=packed_main_slots,
++            **common_meta,
++        )
++    if num_prefill_requests:
++        assert max_query_len is not None
++        _prefill_pool_kernel[
++            (num_prefill_requests, triton.cdiv(max_query_len, _POOL_SIZE))
++        ](
++            *common_args[:10],
++            num_decode_requests,
++            *common_args[10:],
++            **common_meta,
++        )
++        _prefill_tail_kernel[(num_prefill_requests,)](
++            tail,
++            state_slots,
++            query_start_loc,
++            key,
++            gate,
++            positions,
++            num_decode_requests,
++            int(tail.stride(0)),
++            int(tail.stride(1)),
++            int(tail.stride(2)),
++            int(key.stride(0)),
++            int(gate.stride(0)),
++            HEAD_DIM=_HEAD_DIM,
++            POOL_SIZE=_POOL_SIZE,
++            BLOCK_D=128,
++            num_warps=4,
++        )
+ 
+ 
+ @triton.jit
+diff --git a/vllm/models/glm5next/nvidia/pooled_indexer.py b/vllm/models/glm5next/nvidia/pooled_indexer.py
+index 71c1330f6dccee76eeea8191c92ca444aa474b6a..a4f10b829389bd83b559dcb5d04623f1ce5564fa 100644
+--- a/vllm/models/glm5next/nvidia/pooled_indexer.py
++++ b/vllm/models/glm5next/nvidia/pooled_indexer.py
+@@ -1,6 +1,6 @@
+ # SPDX-License-Identifier: Apache-2.0
+ # SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+-"""GLM-5.3 C4 pooling around the shared b12x FP8 paged indexer."""
++"""GLM-5.3 C4 pooling with B12X decode and DeepGEMM prefill selection."""
+ 
+ from __future__ import annotations
+ 
+@@ -50,7 +50,7 @@ _MLA_RECORD_BYTES = 528
+ 
+ 
+ class Glm5NextPooledIndexer(nn.Module):
+-    """Produce GLM C4 pools, select them with b12x, and expand token IDs."""
++    """Produce C4 pools, select them by execution phase, and expand token IDs."""
+ 
+     def __init__(
+         self,
+@@ -225,6 +225,16 @@ class Glm5NextPooledIndexer(nn.Module):
+             ),
+             persistent=False,
+         )
++        self.register_buffer(
++            "_pool_seq_starts",
++            torch.zeros(self.max_tokens, dtype=torch.int32, device=device),
++            persistent=False,
++        )
++        self.register_buffer(
++            "_gather_cu_seq_lens",
++            torch.zeros((self.max_seqs, 2), dtype=torch.int32, device=device),
++            persistent=False,
++        )
+         self.register_buffer(
+             "_pool_block_table",
+             torch.empty((self.max_seqs, 1), dtype=torch.int32, device=device),
+@@ -429,6 +439,8 @@ class Glm5NextPooledIndexer(nn.Module):
+             main_metadata.slot_mapping[:rows],
+             positions,
+             num_reqs,
++            num_decode_requests=num_decodes,
++            max_query_len=int(main_metadata.max_query_len),
+             model_block_size=self.block_size,
+             parent_stride_pages=self._parent_stride_pages,
+         )
+@@ -479,29 +491,49 @@ class Glm5NextPooledIndexer(nn.Module):
+ 
+         if decode_rows < live_rows:
+             query_lens_cpu = main_metadata.prefill_query_lens_cpu
+-            if query_lens_cpu is None:
++            request_seq_lens_cpu = main_metadata.prefill_seq_lens_cpu
++            if query_lens_cpu is None or request_seq_lens_cpu is None:
+                 raise RuntimeError("GLM selector prefill metadata is incomplete")
++            if len(query_lens_cpu) != len(request_seq_lens_cpu):
++                raise RuntimeError(
++                    "GLM selector prefill request metadata has inconsistent lengths"
++                )
+             row_start = decode_rows
+             for local_request, query_len in enumerate(query_lens_cpu.tolist()):
+                 row_end = row_start + int(query_len)
+                 request = num_decodes + local_request
+-                shared_table = self._pool_block_table[request : request + 1].expand(
+-                    int(query_len), -1
+-                )
+-                self.indexer_op.run_paged_topk(
+-                    q=q_fp8[row_start:row_end],
+-                    weights=weights[row_start:row_end],
+-                    kv_cache=index_cache,
+-                    seq_lens=seq_lens[row_start:row_end],
+-                    block_table=shared_table,
+-                    output=pool_ids[row_start:row_end],
+-                    scores=(
+-                        pool_scores[row_start:row_end]
+-                        if pool_scores is not None
+-                        else None
+-                    ),
+-                    shared_page_table=True,
+-                )
++                if self.dcp_world_size > 1:
++                    assert pool_scores is not None
++                    shared_table = self._pool_block_table[request : request + 1].expand(
++                        int(query_len), -1
++                    )
++                    self.indexer_op.run_paged_topk(
++                        q=q_fp8[row_start:row_end],
++                        weights=weights[row_start:row_end],
++                        kv_cache=index_cache,
++                        seq_lens=seq_lens[row_start:row_end],
++                        block_table=shared_table,
++                        output=pool_ids[row_start:row_end],
++                        scores=pool_scores[row_start:row_end],
++                        shared_page_table=True,
++                    )
++                else:
++                    total_pool_len = (
++                        int(request_seq_lens_cpu[local_request]) // _POOL_SIZE
++                    )
++                    gather_cu_seq_lens = self._gather_cu_seq_lens[local_request]
++                    gather_cu_seq_lens[1].fill_(total_pool_len)
++                    self.indexer_op.run_deepgemm_prefill_topk(
++                        q=q_fp8[row_start:row_end],
++                        weights=weights[row_start:row_end],
++                        kv_cache=index_cache,
++                        seq_lens=seq_lens[row_start:row_end],
++                        block_table=self._pool_block_table[request : request + 1],
++                        gather_cu_seq_lens=gather_cu_seq_lens,
++                        row_starts=self._pool_seq_starts[row_start:row_end],
++                        output=pool_ids[row_start:row_end],
++                        total_k_rows=total_pool_len,
++                    )
+                 if pool_scores is not None:
+                     _merge_dcp_topk(
+                         pool_ids[row_start:row_end],
+diff --git a/vllm/v1/attention/backends/flashinfer.py b/vllm/v1/attention/backends/flashinfer.py
+index a479b2ca48cc2e432efb6109e36375501b6c28b0..8e81e8fe09d22ffeb90a162efb637fc46cdc16d6 100755
+--- a/vllm/v1/attention/backends/flashinfer.py
++++ b/vllm/v1/attention/backends/flashinfer.py
+@@ -69,6 +69,7 @@ from vllm.v1.attention.backend import (
+ from vllm.v1.attention.backends.utils import (
+     get_dcp_local_seq_lens,
+     get_flashinfer_layout_string,
++    get_kv_cache_dtype_from_layers,
+     get_num_attention_heads_from_layers,
+     get_per_layer_parameters,
+     infer_global_hyperparameters,
+@@ -759,7 +760,10 @@ class FlashInferMetadataBuilder(AttentionMetadataBuilder[FlashInferMetadata]):
+         self.page_size = self.kv_cache_spec.block_size
+ 
+         if self.kv_cache_spec.kv_quant_mode != KVQuantMode.NONE:
+-            self.cache_dtype = self.cache_config.cache_dtype
++            self.cache_dtype = (
++                get_kv_cache_dtype_from_layers(vllm_config, layer_names)
++                or self.cache_config.cache_dtype
++            )
+             # Cannot use self.kv_cache_spec.dtype here because kv_cache_spec
+             # storage dtype may not be the same as the op dtype (uint8 vs fp8_e4m3)
+             self.is_kvcache_nvfp4 = self.cache_dtype.startswith("nvfp4")
+diff --git a/vllm/v1/attention/backends/mla/b12x_mla_sparse.py b/vllm/v1/attention/backends/mla/b12x_mla_sparse.py
+index b9aaf1ea25cedd7e338c69aefa30ea59957515ba..7c63728d7137fa6bd52701cbd41ada803606bd6c 100644
+--- a/vllm/v1/attention/backends/mla/b12x_mla_sparse.py
++++ b/vllm/v1/attention/backends/mla/b12x_mla_sparse.py
+@@ -265,6 +265,7 @@ class B12xMLASparseMetadata(AttentionMetadata):
+     prefill_max_seq_len: int = 0
+     prefill: MLACommonPrefillMetadata | None = None
+     prefill_query_lens_cpu: torch.Tensor | None = None
++    prefill_seq_lens_cpu: torch.Tensor | None = None
+     block_size: int = 64
+     topk_tokens: int = 2048
+     cp_kv_cache_interleave_size: int = 1
+@@ -490,6 +491,14 @@ class B12xMLASparseMetadataBuilder(
+             metadata.prefill_query_lens_cpu = torch.diff(
+                 common.query_start_loc_cpu[prefill_start:prefill_end]
+             )
++            seq_lens_cpu_source = (
++                common.seq_lens_cpu_upper_bound
++                if common.seq_lens_cpu_upper_bound is not None
++                else common.seq_lens_cpu
++            )
++            metadata.prefill_seq_lens_cpu = seq_lens_cpu_source[
++                prefill_start : prefill_start + metadata.num_prefills
++            ].clone()
+         (
+             metadata.selector_state_slot_ids,
+             metadata.selector_state_is_fresh,
+diff --git a/vllm/v1/attention/backends/utils.py b/vllm/v1/attention/backends/utils.py
+index 29f1ccdfd0623f45a5c62f3a14544426c552202b..ebf93dab3b52f098c66efb008f3974588ef4e766 100644
+--- a/vllm/v1/attention/backends/utils.py
++++ b/vllm/v1/attention/backends/utils.py
+@@ -387,6 +387,25 @@ def get_num_attention_heads_from_layers(
+     return heads.pop()
+ 
+ 
++def get_kv_cache_dtype_from_layers(
++    vllm_config: VllmConfig, layer_names: list[str]
++) -> str | None:
++    """Return the KV-cache format shared by one attention group."""
++    attn_layers = get_layers_from_vllm_config(
++        vllm_config,
++        AttentionLayerBase,  # type: ignore[type-abstract]
++        layer_names,
++    )
++    if not attn_layers:
++        return None
++    cache_dtypes = {cast(Any, layer).kv_cache_dtype for layer in attn_layers.values()}
++    assert len(cache_dtypes) == 1, (
++        "All layers in one attention group must share kv_cache_dtype; "
++        f"got {cache_dtypes} for {layer_names}."
++    )
++    return cache_dtypes.pop()
++
++
+ def infer_global_hyperparameters(
+     per_layer_params: dict[str, PerLayerParameters],
+ ) -> PerLayerParameters:
+diff --git a/vllm/v1/worker/gpu/attn_utils.py b/vllm/v1/worker/gpu/attn_utils.py
+index 5397b1b73dff4cc0ad472e87e66993fccd9bab80..e225c78ffe1989bffaf33a4b3a4da3feab19bf75 100644
+--- a/vllm/v1/worker/gpu/attn_utils.py
++++ b/vllm/v1/worker/gpu/attn_utils.py
+@@ -73,6 +73,24 @@ def get_shared_kv_cache_layers(vllm_config: VllmConfig):
+     }
+ 
+ 
++def synchronize_attention_impl_kv_cache_layout(
++    attn_layers: Mapping[str, AttentionLayerBase],
++    resolved_layout: str | None,
++) -> None:
++    """Give every attention implementation the allocated cache layout.
++
++    A speculative model can own a CacheConfig copy so its cache dtype differs
++    from the target model. The engine resolves one physical layout for all
++    cache groups, while dtype remains specific to each model-owned copy.
++    """
++    if resolved_layout is None:
++        return
++    for layer in attn_layers.values():
++        impl_cache_config = getattr(getattr(layer, "impl", None), "cache_config", None)
++        if impl_cache_config is not None:
++            impl_cache_config.kv_cache_layout = resolved_layout
++
++
+ def init_attn_backend(
+     kv_cache_config: KVCacheConfig,
+     vllm_config: VllmConfig,
+@@ -99,6 +117,10 @@ def init_attn_backend(
+         layer_type = cast(type[Any], AttentionLayerBase)
+         attn_layers = get_layers_from_vllm_config(vllm_config, layer_type, layer_names)
+ 
++        synchronize_attention_impl_kv_cache_layout(
++            attn_layers, vllm_config.cache_config.kv_cache_layout
++        )
++
+         group_map: dict[tuple[tuple[str, str], KVCacheSpec, int], AttentionGroup] = {}
+         group_order: list[tuple[tuple[str, str], KVCacheSpec, int]] = []
+ 
+diff --git a/vllm/v1/worker/gpu/cudagraph_utils.py b/vllm/v1/worker/gpu/cudagraph_utils.py
+index 6203b443104eaa9566cf9f98a1e4e4c8e9074a38..e17d1e787b7a752176e385f7078898ffb44787c8 100644
+--- a/vllm/v1/worker/gpu/cudagraph_utils.py
++++ b/vllm/v1/worker/gpu/cudagraph_utils.py
+@@ -38,6 +38,7 @@ from vllm.v1.worker.gpu.cp_utils import prepare_dcp_local_seq_lens
+ from vllm.v1.worker.gpu.input_batch import InputBatch, InputBuffers
+ from vllm.v1.worker.gpu.model_states.interface import ModelState
+ from vllm.v1.worker.utils import AttentionGroup, unbind_kv_cache
++from vllm.v1.worker.workspace import collect_cuda_graph_capture_resources
+ 
+ if TYPE_CHECKING:
+     from vllm.v1.worker.gpu.model_runner import GPUModelRunner
+@@ -133,6 +134,7 @@ class CudaGraphManager:
+         self._lora_dispatch_map, self._max_lora_case = self._build_lora_dispatch_map()
+ 
+         self.graphs: dict[BatchExecutionDescriptor, torch.cuda.CUDAGraph] = {}
++        self.graph_capture_resources: dict[BatchExecutionDescriptor, list[Any]] = {}
+         self.pool = current_platform.get_global_graph_pool() if cudagraph_mode else None
+ 
+         self._graphs_captured = False
+@@ -377,18 +379,20 @@ class CudaGraphManager:
+                         if self._capture_mem_samples is not None:
+                             torch.accelerator.synchronize()
+                             free_before = torch.accelerator.get_memory_info()[0]
+-                        with torch.cuda.graph(graph, self.pool):
++                        with (
++                            collect_cuda_graph_capture_resources() as resources,
++                            torch.cuda.graph(graph, self.pool),
++                        ):
+                             forward_fn(CUDAGraphMode.NONE)
+-                            # Join offloader's copy stream after forward to avoid
+-                            # unjoined stream error. The last layer's start_prefetch
+-                            # forks copy_stream, but wait_prefetch only happens in
+-                            # the next forward pass.
++                            # Join the offloader copy stream because the last layer
++                            # can leave a prefetch pending at capture end.
+                             get_offloader().join_after_forward()
+                         if self._capture_mem_samples is not None:
+                             torch.accelerator.synchronize()
+                             free_after = torch.accelerator.get_memory_info()[0]
+                             self._capture_mem_samples.append(free_before - free_after)
+                         self.graphs[desc] = graph
++                        self.graph_capture_resources[desc] = resources
+                         compilation_counter.num_cudagraph_captured += 1
+         self._graphs_captured = True
+ 
+@@ -817,6 +821,7 @@ def profile_cudagraph_memory(runner: "GPUModelRunner") -> int:
+         BreakableCUDAGraphWrapper.clear_all_graphs()
+         for graph_manager in graph_managers:
+             graph_manager.graphs.clear()
++            graph_manager.graph_capture_resources.clear()
+             graph_manager._graphs_captured = False
+             graph_manager.pool = original_manager_pools[id(graph_manager)]
+         live_wrappers = list(CUDAGraphWrapper._all_instances) + list(
+diff --git a/vllm/v1/worker/workspace.py b/vllm/v1/worker/workspace.py
+index 39b3b10349c3b829ba189d12e398cfc6ac679378..459b2974cee120b07a5e8eaf0aa4708eec1f4f35 100644
+--- a/vllm/v1/worker/workspace.py
++++ b/vllm/v1/worker/workspace.py
+@@ -8,6 +8,7 @@ from contextlib import contextmanager
+ from contextvars import ContextVar
+ from itertools import accumulate
+ from math import prod
++from typing import Any
+ 
+ import torch
+ 
+@@ -30,6 +31,9 @@ _GiB = 1024**3
+ # Global workspace manager instance
+ _manager: "WorkspaceManager | None" = None
+ _workspace_lane: ContextVar[int] = ContextVar("vllm_workspace_lane", default=0)
++_cuda_graph_capture_resources: ContextVar[list[Any] | None] = ContextVar(
++    "vllm_cuda_graph_capture_resources", default=None
++)
+ 
+ 
+ @contextmanager
+@@ -44,6 +48,33 @@ def use_workspace_lane(lane: int) -> Iterator[None]:
+         _workspace_lane.reset(token)
+ 
+ 
++@contextmanager
++def collect_cuda_graph_capture_resources() -> Iterator[list[Any]]:
++    """Collect objects whose storage is referenced by one CUDA graph.
++
++    A CUDA graph records device pointers, but it does not retain the Python
++    objects that own those allocations. Callers that allocate custom-op output
++    or scratch tensors during capture can register their owner with
++    :func:`retain_cuda_graph_capture_resource`. The graph manager keeps the
++    returned list alive for exactly as long as the captured graph.
++    """
++    resources: list[Any] = []
++    token = _cuda_graph_capture_resources.set(resources)
++    try:
++        yield resources
++    finally:
++        _cuda_graph_capture_resources.reset(token)
++
++
++def retain_cuda_graph_capture_resource(resource: Any) -> bool:
++    """Retain ``resource`` when called inside full CUDA graph capture."""
++    resources = _cuda_graph_capture_resources.get()
++    if resources is None:
++        return False
++    resources.append(resource)
++    return True
++
++
+ class WorkspaceManager:
+     """Manager for workspace allocation.
+ 

--- a/patches/releases/glm53-flash-nvfp4-jovian/vllm/integration.patch
+++ b/patches/releases/glm53-flash-nvfp4-jovian/vllm/integration.patch
@@ -233,7 +233,7 @@ index 6c9e67b0a2cc2374264515e5877cd8542a916ed3..435e791392aeac8ce99eba9394d3bf8e
      class FakeVideoProcessor:
          merge_size = 2
 diff --git a/tests/models/test_glm5next_pooled_indexer.py b/tests/models/test_glm5next_pooled_indexer.py
-index 9af76ccb9e05cba21f12e4b4168b05b7d1d17c60..7eb9d02077449d688fd6f108a186e1ab99a1cba7 100644
+index 9af76ccb9e05cba21f12e4b4168b05b7d1d17c60..fc98c1530e8b4f2af0df0089db7a5364377602c7 100644
 --- a/tests/models/test_glm5next_pooled_indexer.py
 +++ b/tests/models/test_glm5next_pooled_indexer.py
 @@ -8,6 +8,7 @@ import pytest
@@ -257,7 +257,7 @@ index 9af76ccb9e05cba21f12e4b4168b05b7d1d17c60..7eb9d02077449d688fd6f108a186e1ab
  
  
  def test_glm53_packed_c4_metadata_uses_parent_stride() -> None:
-@@ -376,6 +379,117 @@ def test_glm53_packed_tail_scores_through_existing_c4_indexer() -> None:
+@@ -376,6 +379,118 @@ def test_glm53_packed_tail_scores_through_existing_c4_indexer() -> None:
      assert set(output[0, :2].tolist()) == {0, 1}
  
  
@@ -266,38 +266,39 @@ index 9af76ccb9e05cba21f12e4b4168b05b7d1d17c60..7eb9d02077449d688fd6f108a186e1ab
 +) -> None:
 +    device = _require_glm_gpu()
 +    _, main = _packed_main_cache(
-+        device=device, blocks=2, layers=3, block_size=512, layer=1
++        device=device, blocks=2, layers=3, block_size=2304, layer=1
 +    )
 +    index_cache, _, parent_stride_pages = Glm5NextPooledIndexer._index_cache_view(main)
-+    virtual_page = parent_stride_pages
-+    page = index_cache[virtual_page]
-+    quant = page.as_strided(
-+        (64, 128), (128, 1), storage_offset=page.storage_offset()
-+    ).view(torch.float8_e4m3fn)
-+    scales = page.as_strided(
-+        (64 * 4,),
-+        (1,),
-+        storage_offset=page.storage_offset() + 64 * 128,
-+    ).view(torch.float32)
++    virtual_pages = list(range(parent_stride_pages, parent_stride_pages + 9))
 +    generator = torch.Generator(device=device).manual_seed(5303)
-+    quant.copy_(
-+        torch.randn((64, 128), generator=generator, device=device).to(
-+            torch.float8_e4m3fn
++    for virtual_page in virtual_pages:
++        page = index_cache[virtual_page]
++        quant = page.as_strided(
++            (64, 128), (128, 1), storage_offset=page.storage_offset()
++        ).view(torch.float8_e4m3fn)
++        scales = page.as_strided(
++            (64 * 4,),
++            (1,),
++            storage_offset=page.storage_offset() + 64 * 128,
++        ).view(torch.float32)
++        quant.copy_(
++            torch.randn((64, 128), generator=generator, device=device).to(
++                torch.float8_e4m3fn
++            )
 +        )
-+    )
-+    scales.copy_(
-+        torch.exp2(
-+            torch.randint(-3, 3, (64,), generator=generator, device=device).float()
++        scales.copy_(
++            torch.exp2(
++                torch.randint(-3, 3, (64,), generator=generator, device=device).float()
++            )
 +        )
-+    )
 +    q = torch.randn(
 +        (3, 32, 128), generator=generator, device=device, dtype=torch.float32
 +    ).to(torch.float8_e4m3fn)
 +    weights = torch.randn(
 +        (3, 32), generator=generator, device=device, dtype=torch.float32
 +    )
-+    seq_lens = torch.tensor([16, 37, 64], dtype=torch.int32, device=device)
-+    block_table = torch.tensor([[virtual_page]], dtype=torch.int32, device=device)
++    seq_lens = torch.tensor([513, 545, 576], dtype=torch.int32, device=device)
++    block_table = torch.tensor([virtual_pages], dtype=torch.int32, device=device)
 +    topk = 512
 +
 +    from vllm.utils.b12x import get_b12x_dsa_indexer
@@ -310,7 +311,7 @@ index 9af76ccb9e05cba21f12e4b4168b05b7d1d17c60..7eb9d02077449d688fd6f108a186e1ab
 +            source_layout=module.SOURCE_LAYOUT_PAGED,
 +            num_q_heads=32,
 +            max_q_rows=3,
-+            max_page_table_width=1,
++            max_page_table_width=len(virtual_pages),
 +            topk=topk,
 +            mode="prefill",
 +            shared_page_table=True,
@@ -322,7 +323,7 @@ index 9af76ccb9e05cba21f12e4b4168b05b7d1d17c60..7eb9d02077449d688fd6f108a186e1ab
 +    )
 +    binding = plan.bind(
 +        scratch=scratch,
-+        real_page_table=block_table.expand(3, 1),
++        real_page_table=block_table.expand(3, -1),
 +        cache_seqlens_int32=seq_lens,
 +        expected_num_q_heads=32,
 +        shared_page_table=True,
@@ -357,12 +358,12 @@ index 9af76ccb9e05cba21f12e4b4168b05b7d1d17c60..7eb9d02077449d688fd6f108a186e1ab
 +        kv_cache=index_cache,
 +        seq_lens=seq_lens,
 +        block_table=block_table,
-+        gather_cu_seq_lens=torch.tensor([0, 64], dtype=torch.int32, device=device),
++        gather_cu_seq_lens=torch.tensor([0, 576], dtype=torch.int32, device=device),
 +        row_starts=torch.zeros(3, dtype=torch.int32, device=device),
 +        output=actual,
 +        topk=topk,
-+        total_k_rows=64,
-+        workspace_k_rows=64,
++        total_k_rows=576,
++        workspace_k_rows=576,
 +    )
 +    torch.accelerator.synchronize()
 +
@@ -375,7 +376,7 @@ index 9af76ccb9e05cba21f12e4b4168b05b7d1d17c60..7eb9d02077449d688fd6f108a186e1ab
  def test_glm53_pool_write_matches_fp8_reference() -> None:
      device = _require_glm_gpu()
      generator = torch.Generator(device=device).manual_seed(53)
-@@ -458,7 +572,7 @@ def test_glm53_decode_tail_completes_the_same_pool_as_prefill() -> None:
+@@ -458,7 +573,7 @@ def test_glm53_decode_tail_completes_the_same_pool_as_prefill() -> None:
      torch.testing.assert_close(actual_scale, expected_scale.reshape(1), rtol=0, atol=0)
  
  
@@ -384,7 +385,7 @@ index 9af76ccb9e05cba21f12e4b4168b05b7d1d17c60..7eb9d02077449d688fd6f108a186e1ab
      device = _require_glm_gpu()
      generator = torch.Generator(device=device).manual_seed(56)
      key = torch.randn(
-@@ -486,9 +600,13 @@ def test_glm53_decode_writer_matches_batched_prefill_writer() -> None:
+@@ -486,9 +601,13 @@ def test_glm53_decode_writer_matches_batched_prefill_writer() -> None:
          key,
          gate,
          ape,
@@ -399,7 +400,7 @@ index 9af76ccb9e05cba21f12e4b4168b05b7d1d17c60..7eb9d02077449d688fd6f108a186e1ab
      )
      for position in range(8):
          update_decode_pools(
-@@ -500,18 +618,127 @@ def test_glm53_decode_writer_matches_batched_prefill_writer() -> None:
+@@ -500,18 +619,127 @@ def test_glm53_decode_writer_matches_batched_prefill_writer() -> None:
              gate[position : position + 1],
              ape,
              torch.tensor(
@@ -629,11 +630,67 @@ index 969192681900a059855308560c5212cc0b46f62b..1b4bb0f0d5d291e41e589d38f9f0a70b
 +        cache_dtype = get_kv_cache_dtype_from_layers(MagicMock(), list(layers))
 +
 +    assert cache_dtype == "fp8"
+diff --git a/tests/v1/cudagraph/test_breakable_cudagraph.py b/tests/v1/cudagraph/test_breakable_cudagraph.py
+index dc9c1ffb3067863a24c3e4716b9e597408c9343c..a0667e3895c71c10b126aeef3b10c185f05a7c3d 100644
+--- a/tests/v1/cudagraph/test_breakable_cudagraph.py
++++ b/tests/v1/cudagraph/test_breakable_cudagraph.py
+@@ -78,6 +78,51 @@ def test_piecewise_capture_builds_fresh_metadata_for_both_passes():
+     assert create_calls[0][1] is not create_calls[1][1]
+ 
+ 
++def test_breakable_wrapper_retains_capture_resources(monkeypatch):
++    import vllm.compilation.breakable_cudagraph as breakable
++    from vllm.v1.worker.workspace import retain_cuda_graph_capture_resource
++
++    class FakeCapture:
++        def __init__(self, pool):
++            self.pool = pool
++
++        def __enter__(self):
++            return self
++
++        def __exit__(self, exc_type, exc, tb):
++            return None
++
++    class FakeOffloader:
++        def sync_prev_onload(self):
++            pass
++
++        def join_after_forward(self):
++            pass
++
++    resource = object()
++
++    def runnable():
++        assert retain_cuda_graph_capture_resource(resource)
++        return object()
++
++    monkeypatch.setattr(breakable, "validate_cudagraph_capturing_enabled", lambda: None)
++    monkeypatch.setattr(breakable, "set_graph_pool_id", lambda _pool: None)
++    monkeypatch.setattr(breakable.gc, "collect", lambda: None)
++    monkeypatch.setattr(torch.accelerator, "empty_cache", lambda: None)
++    monkeypatch.setattr(breakable, "get_offloader", lambda: FakeOffloader())
++    monkeypatch.setattr(breakable, "BreakableCUDAGraphCapture", FakeCapture)
++    monkeypatch.setattr(breakable, "weak_ref_tensors", lambda value: value)
++
++    wrapper = object.__new__(breakable.BreakableCUDAGraphWrapper)
++    wrapper.runnable = runnable
++    wrapper.graph_pool = object()
++    entry = breakable._BreakableEntry(batch_descriptor=object())
++
++    wrapper._capture(entry, (), {})
++
++    assert entry.resources == [resource]
++
++
+ @pytest.fixture(autouse=True)
+ def _reset_breakable_tls():
+     """Defensively clear thread-local capture state between tests so a
 diff --git a/tests/v1/spec_decode/test_dflash2.py b/tests/v1/spec_decode/test_dflash2.py
-index 86cf3327a92252b095405d19d6812a4ee295c26e..78b7bd8cc8e116937edc63f537387b6e3e316224 100644
+index 86cf3327a92252b095405d19d6812a4ee295c26e..8d54a6b2a37121151e4eea2a24ea45af4143b91d 100644
 --- a/tests/v1/spec_decode/test_dflash2.py
 +++ b/tests/v1/spec_decode/test_dflash2.py
-@@ -60,6 +60,47 @@ def test_grouped_conv_matches_reference(block_size: int):
+@@ -60,6 +60,80 @@ def test_grouped_conv_matches_reference(block_size: int):
      torch.testing.assert_close(actual, expected.flatten(0, 1).flatten(-2))
  
  
@@ -676,6 +733,39 @@ index 86cf3327a92252b095405d19d6812a4ee295c26e..78b7bd8cc8e116937edc63f537387b6e
 +
 +    assert grouped_conv.kernel_projection.quant_config is quant_config
 +    assert selector.hidden_projection.quant_config is quant_config
++
++
++@pytest.mark.parametrize("mxfp8_layer", [0, 1])
++def test_dflash_context_projection_rejects_mixed_quantization(mxfp8_layer: int):
++    from torch import nn
++
++    from vllm.model_executor.layers.quantization.modelopt import (
++        ModelOptMxFp8LinearMethod,
++    )
++    from vllm.model_executor.models.qwen3_dflash import DFlashQwen3Model
++
++    class UnreadableWeight:
++        def __getitem__(self, _key):
++            raise AssertionError("weights must not be read before validation")
++
++    mxfp8_method = object.__new__(ModelOptMxFp8LinearMethod)
++    methods = [None, None]
++    methods[mxfp8_layer] = mxfp8_method
++    layers_attn = [
++        SimpleNamespace(
++            qkv_proj=SimpleNamespace(
++                quant_method=method,
++                q_size=1,
++                weight=UnreadableWeight(),
++            )
++        )
++        for method in methods
++    ]
++    model = object.__new__(DFlashQwen3Model)
++    nn.Module.__init__(model)
++
++    with pytest.raises(ValueError, match="Every DFlash attention layer"):
++        model._build_context_kv_buffers(layers_attn, has_bias=False)
 +
 +
  def test_selector_edges_match_sequential_reference():
@@ -746,6 +836,43 @@ index a909ea9af89dd68bbee73174459afb7b9a30eaaa..8bbe8e9cc0d178ef886ec46f79156868
 +    assert resources == [first, second]
 +    assert nested_resources == [nested]
 +    assert not workspace.retain_cuda_graph_capture_resource(outside)
+diff --git a/vllm/compilation/breakable_cudagraph.py b/vllm/compilation/breakable_cudagraph.py
+index 6da3ec71786128368adab1027c012bcae0885798..f4fe203714fb2aa24155b9065245084fe2d62b9f 100644
+--- a/vllm/compilation/breakable_cudagraph.py
++++ b/vllm/compilation/breakable_cudagraph.py
+@@ -45,6 +45,7 @@ from vllm.logger import init_logger
+ from vllm.model_executor.offloader.base import get_offloader
+ from vllm.platforms import current_platform
+ from vllm.utils.torch_utils import weak_ref_tensor, weak_ref_tensors
++from vllm.v1.worker.workspace import collect_cuda_graph_capture_resources
+ 
+ logger = init_logger(__name__)
+ 
+@@ -241,6 +242,7 @@ class _BreakableEntry:
+     capture: BreakableCUDAGraphCapture | None = None
+     output: Any = None
+     input_addresses: list[int] | None = None
++    resources: list[Any] | None = None
+ 
+ 
+ class BreakableCUDAGraphWrapper:
+@@ -379,7 +381,7 @@ class BreakableCUDAGraphWrapper:
+         get_offloader().sync_prev_onload()
+ 
+         capture = BreakableCUDAGraphCapture(pool=self.graph_pool)
+-        with capture:
++        with collect_cuda_graph_capture_resources() as resources, capture:
+             output = self.runnable(*args, **kwargs)
+             # Join the offloader's copy stream while we still hold the last
+             # segment open, so the join is captured into the graph (otherwise
+@@ -392,6 +394,7 @@ class BreakableCUDAGraphWrapper:
+             output = weak_ref_tensors(output)
+ 
+         entry.capture = capture
++        entry.resources = resources
+         entry.output = weak_ref_tensors(output)
+ 
+         logger.debug(
 diff --git a/vllm/model_executor/layers/mamba/gdn/kimi_gdn_linear_attn.py b/vllm/model_executor/layers/mamba/gdn/kimi_gdn_linear_attn.py
 index a6760cb856e7e6808159490e794e022dd4a62db5..469e9a712bc99eccc9d10a44983fbaa705bf83e3 100644
 --- a/vllm/model_executor/layers/mamba/gdn/kimi_gdn_linear_attn.py
@@ -863,7 +990,7 @@ index a6760cb856e7e6808159490e794e022dd4a62db5..469e9a712bc99eccc9d10a44983fbaa7
              binding,
              lower_bound=self.gate_lower_bound,
 diff --git a/vllm/model_executor/models/qwen3_dflash.py b/vllm/model_executor/models/qwen3_dflash.py
-index f5a7bff8fc6e1521b9d39f23612a0ff8004e476a..b58b5b16b8f9ee093f7984b250ea6e494805774e 100644
+index f5a7bff8fc6e1521b9d39f23612a0ff8004e476a..e3db761961bc8d7ffec06b4d16c00628caed8f05 100644
 --- a/vllm/model_executor/models/qwen3_dflash.py
 +++ b/vllm/model_executor/models/qwen3_dflash.py
 @@ -472,6 +472,14 @@ class DFlashQwen3Model(nn.Module):
@@ -881,25 +1008,31 @@ index f5a7bff8fc6e1521b9d39f23612a0ff8004e476a..b58b5b16b8f9ee093f7984b250ea6e49
  
      def embed_input_ids(self, input_ids: torch.Tensor) -> torch.Tensor:
          embeds = self.embed_tokens(input_ids)
-@@ -491,6 +499,25 @@ class DFlashQwen3Model(nn.Module):
-         # KV projection weights: [num_layers * 2 * kv_size, hidden_size]
-         kv_weights = [a.qkv_proj.weight[a.q_size :] for a in layers_attn]
-         self._fused_kv_weight = torch.cat(kv_weights, dim=0)
-+
+@@ -486,11 +494,31 @@ class DFlashQwen3Model(nn.Module):
+         layers_attn: list[nn.Module],
+         has_bias: bool,
+     ) -> None:
 +        from vllm.model_executor.layers.quantization.modelopt import (
 +            ModelOptMxFp8LinearMethod,
 +        )
 +
-+        quant_method = layers_attn[0].qkv_proj.quant_method
-+        if isinstance(quant_method, ModelOptMxFp8LinearMethod):
-+            if not all(
-+                isinstance(a.qkv_proj.quant_method, ModelOptMxFp8LinearMethod)
-+                for a in layers_attn
-+            ):
-+                raise ValueError(
-+                    "Every DFlash attention layer must use the same MXFP8 "
-+                    "linear format for the fused context K/V projection."
-+                )
++        quant_methods = [a.qkv_proj.quant_method for a in layers_attn]
++        uses_mxfp8 = [
++            isinstance(method, ModelOptMxFp8LinearMethod) for method in quant_methods
++        ]
++        if any(uses_mxfp8) and not all(uses_mxfp8):
++            raise ValueError(
++                "Every DFlash attention layer must use the same MXFP8 "
++                "linear format for the fused context K/V projection."
++            )
++
+         self._hidden_norm_weight = self.hidden_norm.weight.data
+ 
+         # KV projection weights: [num_layers * 2 * kv_size, hidden_size]
+         kv_weights = [a.qkv_proj.weight[a.q_size :] for a in layers_attn]
+         self._fused_kv_weight = torch.cat(kv_weights, dim=0)
++
++        if all(uses_mxfp8):
 +            kv_scales = [a.qkv_proj.weight_scale[a.q_size :] for a in layers_attn]
 +            self._fused_kv_weight_scale = torch.cat(kv_scales, dim=0)
 +        else:
@@ -907,7 +1040,7 @@ index f5a7bff8fc6e1521b9d39f23612a0ff8004e476a..b58b5b16b8f9ee093f7984b250ea6e49
          if has_bias:
              kv_biases = [a.qkv_proj.bias[a.q_size :] for a in layers_attn]
              self._fused_kv_bias: torch.Tensor | None = torch.cat(kv_biases, dim=0)
-@@ -546,6 +573,41 @@ class DFlashQwen3Model(nn.Module):
+@@ -546,6 +574,41 @@ class DFlashQwen3Model(nn.Module):
          # References to inner Attention layers for direct cache writes
          self._attn_layers = [layer.self_attn.attn for layer in self.layers]
  
@@ -949,7 +1082,7 @@ index f5a7bff8fc6e1521b9d39f23612a0ff8004e476a..b58b5b16b8f9ee093f7984b250ea6e49
      def _project_context_kv(
          self,
          context_states: torch.Tensor,
-@@ -562,9 +624,18 @@ class DFlashQwen3Model(nn.Module):
+@@ -562,9 +625,18 @@ class DFlashQwen3Model(nn.Module):
              self._hidden_norm_weight,
              self._rms_norm_eps,
          )
@@ -971,7 +1104,7 @@ index f5a7bff8fc6e1521b9d39f23612a0ff8004e476a..b58b5b16b8f9ee093f7984b250ea6e49
          # Single contiguous copy that separates K/V and transposes to
          # layer-major layout.  Result: [2, L, num_ctx, nkv, hd] contiguous.
          # Indexing dim-0 gives contiguous [L, num_ctx, nkv, hd] for K and V.
-@@ -793,6 +864,10 @@ class DFlashQwen3ForCausalLM(Qwen3ForCausalLM):
+@@ -793,6 +865,10 @@ class DFlashQwen3ForCausalLM(Qwen3ForCausalLM):
              context_states, context_positions, context_slot_mapping
          )
  
@@ -1411,7 +1544,7 @@ index 15e25ade33b7f5182385345847f4e4b0594606cd..951fef21d876924224aa6a0f27b08999
          return proc
  
 diff --git a/vllm/models/glm5next/nvidia/ops/glm_kpool.py b/vllm/models/glm5next/nvidia/ops/glm_kpool.py
-index 6f65e93008b5feb958e4df792d023c1050f098ea..918f4e8ee6216278d585048fdcd0db6ed854df02 100644
+index 6f65e93008b5feb958e4df792d023c1050f098ea..e9c2e1d29a38fb0812bce02d1eb3059d6ea30aa5 100644
 --- a/vllm/models/glm5next/nvidia/ops/glm_kpool.py
 +++ b/vllm/models/glm5next/nvidia/ops/glm_kpool.py
 @@ -251,6 +251,195 @@ def _decode_update_kernel(
@@ -1430,7 +1563,6 @@ index 6f65e93008b5feb958e4df792d023c1050f098ea..918f4e8ee6216278d585048fdcd0db6e
 +    ape,
 +    slot_mapping,
 +    positions,
-+    request_offset,
 +    page_stride_bytes,
 +    model_block_size,
 +    parent_stride_pages,
@@ -1440,6 +1572,7 @@ index 6f65e93008b5feb958e4df792d023c1050f098ea..918f4e8ee6216278d585048fdcd0db6e
 +    key_stride_0,
 +    gate_stride_0,
 +    ape_stride_0,
++    request_offset,
 +    PAGE_SIZE: tl.constexpr,
 +    HEAD_DIM: tl.constexpr,
 +    POOL_SIZE: tl.constexpr,
@@ -1649,7 +1782,7 @@ index 6f65e93008b5feb958e4df792d023c1050f098ea..918f4e8ee6216278d585048fdcd0db6e
          kv_cache.view(torch.float8_e4m3fn),
          kv_cache.view(torch.float32),
          tail,
-@@ -307,14 +514,49 @@ def update_decode_pools(
+@@ -307,14 +514,48 @@ def update_decode_pools(
          int(key.stride(0)),
          int(gate.stride(0)),
          int(ape.stride(0)),
@@ -1674,9 +1807,8 @@ index 6f65e93008b5feb958e4df792d023c1050f098ea..918f4e8ee6216278d585048fdcd0db6e
 +        _prefill_pool_kernel[
 +            (num_prefill_requests, triton.cdiv(max_query_len, _POOL_SIZE))
 +        ](
-+            *common_args[:10],
++            *common_args,
 +            num_decode_requests,
-+            *common_args[10:],
 +            **common_meta,
 +        )
 +        _prefill_tail_kernel[(num_prefill_requests,)](
@@ -1867,17 +1999,26 @@ index b9aaf1ea25cedd7e338c69aefa30ea59957515ba..7c63728d7137fa6bd52701cbd41ada80
              metadata.selector_state_slot_ids,
              metadata.selector_state_is_fresh,
 diff --git a/vllm/v1/attention/backends/utils.py b/vllm/v1/attention/backends/utils.py
-index 29f1ccdfd0623f45a5c62f3a14544426c552202b..ebf93dab3b52f098c66efb008f3974588ef4e766 100644
+index 29f1ccdfd0623f45a5c62f3a14544426c552202b..d2b1532edd823d84b13fd129df43730826f77e22 100644
 --- a/vllm/v1/attention/backends/utils.py
 +++ b/vllm/v1/attention/backends/utils.py
-@@ -387,6 +387,25 @@ def get_num_attention_heads_from_layers(
+@@ -387,6 +387,34 @@ def get_num_attention_heads_from_layers(
      return heads.pop()
  
  
 +def get_kv_cache_dtype_from_layers(
 +    vllm_config: VllmConfig, layer_names: list[str]
 +) -> str | None:
-+    """Return the KV-cache format shared by one attention group."""
++    """Return the KV-cache format shared by one attention group.
++
++    Args:
++        vllm_config: Engine configuration containing the attention layers.
++        layer_names: Names of the layers in the attention group.
++
++    Returns:
++        The shared cache format, or ``None`` when the group has no attention
++        layers.
++    """
 +    attn_layers = get_layers_from_vllm_config(
 +        vllm_config,
 +        AttentionLayerBase,  # type: ignore[type-abstract]
@@ -1991,7 +2132,7 @@ index 6203b443104eaa9566cf9f98a1e4e4c8e9074a38..e17d1e787b7a752176e385f7078898ff
              graph_manager.pool = original_manager_pools[id(graph_manager)]
          live_wrappers = list(CUDAGraphWrapper._all_instances) + list(
 diff --git a/vllm/v1/worker/workspace.py b/vllm/v1/worker/workspace.py
-index 39b3b10349c3b829ba189d12e398cfc6ac679378..459b2974cee120b07a5e8eaf0aa4708eec1f4f35 100644
+index 39b3b10349c3b829ba189d12e398cfc6ac679378..e98a05c99e4e03ec334074bdd7b18782916f3421 100644
 --- a/vllm/v1/worker/workspace.py
 +++ b/vllm/v1/worker/workspace.py
 @@ -8,6 +8,7 @@ from contextlib import contextmanager
@@ -2012,7 +2153,7 @@ index 39b3b10349c3b829ba189d12e398cfc6ac679378..459b2974cee120b07a5e8eaf0aa4708e
  
  
  @contextmanager
-@@ -44,6 +48,33 @@ def use_workspace_lane(lane: int) -> Iterator[None]:
+@@ -44,6 +48,40 @@ def use_workspace_lane(lane: int) -> Iterator[None]:
          _workspace_lane.reset(token)
  
  
@@ -2035,7 +2176,14 @@ index 39b3b10349c3b829ba189d12e398cfc6ac679378..459b2974cee120b07a5e8eaf0aa4708e
 +
 +
 +def retain_cuda_graph_capture_resource(resource: Any) -> bool:
-+    """Retain ``resource`` when called inside full CUDA graph capture."""
++    """Retain an object whose storage is referenced by a CUDA graph.
++
++    Args:
++        resource: Python owner that must remain alive while the graph exists.
++
++    Returns:
++        ``True`` when a capture resource collector retained the object.
++    """
 +    resources = _cuda_graph_capture_resources.get()
 +    if resources is None:
 +        return False

--- a/tests/test-glm53-flash-nvfp4-build-policy.sh
+++ b/tests/test-glm53-flash-nvfp4-build-policy.sh
@@ -1,0 +1,57 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Validate that qualified tags are immutable with respect to recipe commits and
+# that build-input overrides cannot inherit qualified release provenance.
+
+repo_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+build_script="${repo_root}/build-glm53-flash-nvfp4-jovian-cu133-torch213.sh"
+
+expect_failure() {
+  local expected=$1
+  shift
+  local output
+  if output="$("$@" 2>&1)"; then
+    printf 'Command unexpectedly succeeded: %q' "$1" >&2
+    printf ' %q' "${@:2}" >&2
+    printf '\n' >&2
+    exit 1
+  fi
+  grep -Fq -- "${expected}" <<<"${output}" || {
+    printf 'Expected failure text %q, got:\n%s\n' "${expected}" "${output}" >&2
+    exit 1
+  }
+}
+
+cd "${repo_root}"
+head_commit="$(git rev-parse HEAD)"
+qualified_config="$(
+  env -u BASE_IMAGE -u VLLM_PACKAGE_VERSION -u IMAGE \
+    -u ALLOW_DIRTY_BUILD -u PUSH_IMAGE \
+    PRINT_RELEASE_CONFIG=1 "${build_script}"
+)"
+grep -Fxq "status=qualified" <<<"${qualified_config}"
+grep -Fxq "docker_commit=${head_commit}" <<<"${qualified_config}"
+grep -Eq "^image=.*-git${head_commit:0:12}$" <<<"${qualified_config}"
+
+expect_failure 'require an explicit non-release IMAGE tag' \
+  env PRINT_RELEASE_CONFIG=1 BASE_IMAGE=example.invalid/runtime@sha256:deadbeef \
+  "${build_script}"
+expect_failure 'require an explicit non-release IMAGE tag' \
+  env PRINT_RELEASE_CONFIG=1 VLLM_PACKAGE_VERSION=0.0.0 "${build_script}"
+expect_failure 'require an explicit non-release IMAGE tag' \
+  env PRINT_RELEASE_CONFIG=1 ALLOW_DIRTY_BUILD=1 "${build_script}"
+expect_failure 'must contain a dev, test, or scratch marker' \
+  env PRINT_RELEASE_CONFIG=1 VLLM_PACKAGE_VERSION=0.0.0 \
+  IMAGE=voipmonitor/vllm:qualified-override "${build_script}"
+expect_failure 'PUSH_IMAGE=1 is forbidden when ALLOW_DIRTY_BUILD=1' \
+  env PRINT_RELEASE_CONFIG=1 ALLOW_DIRTY_BUILD=1 PUSH_IMAGE=1 \
+  IMAGE=voipmonitor/vllm:glm53-dev-dirty "${build_script}"
+
+override_config="$(
+  env PRINT_RELEASE_CONFIG=1 VLLM_PACKAGE_VERSION=0.0.0 \
+    IMAGE=voipmonitor/vllm:glm53-dev-package-override "${build_script}"
+)"
+grep -Fxq 'status=research-only' <<<"${override_config}"
+grep -Fxq 'image=voipmonitor/vllm:glm53-dev-package-override' <<<"${override_config}"
+grep -Fxq 'vllm_package_version=0.0.0' <<<"${override_config}"

--- a/tests/verify_glm53_flash_nvfp4_runtime.py
+++ b/tests/verify_glm53_flash_nvfp4_runtime.py
@@ -1,0 +1,83 @@
+#!/usr/bin/env python3
+"""Verify the installed GLM-5.3-Flash NVFP4 runtime contract."""
+
+from __future__ import annotations
+
+import argparse
+import importlib
+import importlib.metadata
+import pathlib
+import subprocess
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--vllm-version", required=True)
+    parser.add_argument("--vllm-tree", required=True)
+    parser.add_argument("--b12x-tree", required=True)
+    return parser.parse_args()
+
+
+def main() -> None:
+    args = parse_args()
+
+    assert importlib.metadata.version("vllm") == args.vllm_version
+    assert importlib.metadata.version("b12x") == "1.3.0"
+    assert importlib.metadata.version("flashinfer-python") == "0.6.18+cu133"
+    assert importlib.metadata.version("instanttensor") == "0.1.9"
+    assert importlib.metadata.version("nvidia-cutlass-dsl") == "4.6.2"
+
+    import b12x
+    import torch
+    import vllm
+    from vllm.model_executor.models.registry import ModelRegistry
+
+    assert torch.__version__.startswith("2.13.0")
+    supported_archs = ModelRegistry.get_supported_archs()
+    assert "Glm5NextForCausalLM" in supported_archs
+    assert "Glm5NextForConditionalGeneration" in supported_archs
+    assert "DFlash2DraftModel" in supported_archs
+
+    vllm_path = pathlib.Path(vllm.__file__).resolve()
+    b12x_path = pathlib.Path(b12x.__file__).resolve()
+    assert vllm_path.is_relative_to("/opt/glm53-flash/vllm")
+    assert b12x_path.is_relative_to("/opt/glm53-flash/b12x")
+    assert pathlib.Path("/opt/glm53-flash/vllm/vllm/models/glm5next").is_dir()
+
+    stable_ops_spec = importlib.util.find_spec("vllm._C_stable_libtorch")
+    assert stable_ops_spec is not None and stable_ops_spec.origin is not None
+    assert pathlib.Path(stable_ops_spec.origin).resolve(strict=True).is_file()
+    if torch.cuda.is_available():
+        importlib.import_module("vllm._C_stable_libtorch")
+    importlib.import_module("vllm.vllm_flash_attn.layers.rotary")
+    importlib.import_module("vllm.models.glm5next.nvidia.model")
+    importlib.import_module("vllm.model_executor.models.qwen3_dflash2")
+    importlib.import_module("instanttensor")
+
+    from vllm.models.deepseek_v4.nvidia import b12x_indexer
+    from vllm.models.deepseek_v4.nvidia.b12x_indexer import B12xC4SparseIndexer
+    from vllm.models.glm5next.nvidia.pooled_indexer import Glm5NextPooledIndexer
+
+    assert callable(B12xC4SparseIndexer.run_paged_topk)
+    assert callable(b12x_indexer._run_deepgemm_prefill_topk)
+    assert callable(B12xC4SparseIndexer.run_deepgemm_prefill_topk)
+    assert not hasattr(Glm5NextPooledIndexer, "run_deepgemm_prefill_topk")
+
+    assert len(args.vllm_tree) == 40
+    assert len(args.b12x_tree) == 40
+    for source_dir, expected_tree in (
+        ("/opt/glm53-flash/vllm", args.vllm_tree),
+        ("/opt/glm53-flash/b12x", args.b12x_tree),
+    ):
+        actual_tree = subprocess.check_output(
+            ["git", "-C", source_dir, "rev-parse", "HEAD^{tree}"], text=True
+        ).strip()
+        assert actual_tree == expected_tree
+        subprocess.run(
+            ["git", "-C", source_dir, "diff", "--quiet", "HEAD", "--"],
+            check=True,
+        )
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Resulting behavior

Status: **qualified** for GLM-5.3-Flash NVFP4 serving at tensor parallel size 4 on four NVIDIA RTX PRO 6000 Blackwell GPUs.

The source-locked CUDA 13.3 and PyTorch 2.13 image serves these pinned Hugging Face checkpoints:

- target: local-inference-lab/GLM-5.3-Flash-NVFP4 at 520de24eabf507659eaef7c70f14fd584527facc;
- DFlash2 draft: local-inference-lab/GLM-5.3-Flash-DFlash2-MXFP8 at b6d33aa93fc1ac5b23a88251a1c0ce0bfe2ad17c.

The launcher provides target-only, three-token MTP, and seven-token DFlash2 modes. Defaults are TP4, target FP8 KV cache, NVFP4 W4A4 target weights, B12X attention/MoE/linear kernels, B12X PCIe all-reduce, and a full CUDA-graph request.

The target GDN backend captures decode and executes unsupported prefill segments eagerly. DFlash2 graph families capture in full mode. The target indexer uses DeepGEMM C4 for prefill and B12X C4 for decode. ModelOpt MXFP8 DFlash2 projections use B12X linear kernels. DFlash2 causal attention uses FlashAttention 2 because B12X does not implement that draft contract. MTP uses Humming for its serialized MXFP8 expert projection.

## Source composition

The build validates patch hashes, reconstructed Git trees, clean source worktrees, image labels, and the Docker repository revision embedded in the qualified tag.

- vLLM base: local-inference-lab/vllm dev/jovian-judgement at 015dcd423d6aabf843c8ad69074ff67d35c2a395.
- vLLM immutable integration snapshot: [vLLM PR #491](https://github.com/local-inference-lab/vllm/pull/491) at b77333ca8824897ff6ddf96a62208ea406c555a9. This snapshot remains pinned because it identifies the source tree in the published image.
- vLLM thematic review PRs: [#493 CUDA graph resource ownership](https://github.com/local-inference-lab/vllm/pull/493), [#494 per-group KV formats](https://github.com/local-inference-lab/vllm/pull/494), [#495 GLM KDA execution](https://github.com/local-inference-lab/vllm/pull/495), [#496 GLM C4 prefill](https://github.com/local-inference-lab/vllm/pull/496), [#497 GLM processor revision](https://github.com/local-inference-lab/vllm/pull/497), [#498 GLM mHC dispatch](https://github.com/local-inference-lab/vllm/pull/498), and [#499 DFlash2 ModelOpt MXFP8](https://github.com/local-inference-lab/vllm/pull/499). Their merged content over dev/jovian-judgement commit c79f35ca00e8e93e0943a0d79b85b22b18aac939 produces tree 64c2eb4eb03a64660dc2965a3164004a5e9cec0f, exactly matching the merge tree of that base and the immutable #491 snapshot.
- vLLM result tree: 82bbab85cebf48b735b5898062ceca89826b3913.
- vLLM patch SHA-256: 4c87a33d1b90d0ce5273b248d4a501b7d2376f8ef074f274360ee9f6967c21d9.
- B12X base: local-inference-lab/b12x master at 2fcf23a0ce269be27b2e03fece73d46e90e6aeea.
- B12X qualification: [B12X PR #250](https://github.com/local-inference-lab/b12x/pull/250) at dd8cf60505e0363ab9d6ef6b2116c3a37216a2f1.
- B12X result tree: fdbb504ccf5842ae7bb7089caa01fc076a7043c0.
- B12X patch SHA-256: c53df70226775cf3c0b076dab23d8d37788e1d779aab16422151db7d26c48193.
- Additional vLLM or B12X source patches: none.
- Docker recipe commit: d3920aaa7c0546594d1052ec3dd530732e739719.

The integration patches reproduce the two result trees without fetching mutable pull-request refs during Docker builds. Build overrides are restricted to development, test, or scratch tags; dirty source cannot be published as qualified.

## Build and image

~~~bash
./build-glm53-flash-nvfp4-jovian-cu133-torch213.sh
~~~

- Image: voipmonitor/vllm:glm53-flash-dflash2-mxfp8-vllm82bbab8-b12xfdbb504-fi1ac6942-cu133-torch213-20260828-r1-gitd3920aaa7c05.
- Local image ID: sha256:f920a648cca3e4e17fb314554600a4e110cf3c002d9b7fafd953ce0aafc90718.
- Docker Hub manifest: sha256:1a210a6dcd4eeef4b9515aa03b8117dbd1bad70ed101cdf72ec4692015e2ac4b.

The README documents model-ID-only Docker commands for target-only, MTP with three proposed tokens, and DFlash2. The image entrypoint is launchers/serve-glm53-flash-nvfp4.sh.

## Validation

- Clean Docker build from commit d3920aaa7c0546594d1052ec3dd530732e739719: passed.
- Runtime source verifier and dry launcher tests: passed.
- Recipe composition, provenance-policy, and pull-request audit tests: 17 passed.
- B12X GLM TP4 NVFP4 graph qualification: 15 passed, including every DFlash target width and alternating replay order.
- vLLM focused and model suites: 80 passed and 14 skipped; review regression subsets and a physical SM120 ranking oracle passed.
- Exact-revision DFlash2 startup on physical GPUs 4, 5, 6, and 7 passed the health endpoint, model listing, and an OpenAI-compatible completion with HTTP 200.
- Runtime logs selected B12X PCIe all-reduce, B12X NVFP4 target MoE, B12X MXFP8 draft linear kernels, FlashAttention 2 draft causal attention, target decode CUDA graphs, and all 16 DFlash2 full-graph shapes.
- CC16 DFlash2 decode on the published image for 30 seconds: 987.69 output tokens/s, 363.76 verifier steps/s, effective accepted length 2.7153, and zero request errors.
- Standalone 32,768-token cold-prefill profile on the published image for 30 seconds: 12,692 input tokens/s over 10 samples.

## Compatibility and limitations

- Qualified hardware: four NVIDIA RTX PRO 6000 Blackwell GPUs.
- B12X does not implement the serialized MTP MXFP8 expert projection or DFlash2 causal-attention contract; the launcher selects compatible kernels for those operations.
- The target GDN path supports full decode graphs, not full target prefill graphs. The launcher requests full mode and vLLM reduces the target path to FULL_DECODE_ONLY while retaining full DFlash2 graphs.
- The published image remains source-locked to the immutable vLLM #491 integration snapshot. Mergeable vLLM review is partitioned across PRs #493 through #499. B12X runtime qualification remains in PR #250.
- Binding the API server to 0.0.0.0 exposes it on every host interface. The README calls out this access-control requirement.

## Duplicate-work check

No open or closed pull request in local-inference-lab/blackwell-llm-docker provides the same source-locked GLM-5.3 NVFP4 plus ModelOpt MXFP8 DFlash2 runtime recipe.

## Review disclosure

OpenAI Codex assisted with implementation, source audit, validation, profiling, benchmarking, build preparation, publication, and pull-request text. Human review is required for source composition, backend selection, checkpoint pins, and performance claims.
