### PR TITLE
fix(kimi): avoid FlashKDA SM120 bulk-copy syscall

### DIFF
--- a/Dockerfile.kimi-k3-infernal-invocation-cu133-torch213
+++ b/Dockerfile.kimi-k3-infernal-invocation-cu133-torch213
@@ -21,6 +21,14 @@ ARG B12X_PATCH_SHA256
 ARG B12X_INTEGRATION_TREE
 ARG B12X_INTEGRATION_LOCK_SHA256
 ARG B12X_PRS
+ARG FLASHKDA_REPO=https://github.com/vllm-project/FlashKDA.git
+ARG FLASHKDA_REF=dev
+ARG FLASHKDA_COMMIT=ee0be888cd0e972f9409bf53756f8c38c6652173
+ARG FLASHKDA_PATCH_FILE=releases/flashkda-sm120-tensormap-r1/flashkda/integration.patch
+ARG FLASHKDA_PATCH_SHA256=2119fdd721decd873cdbbbe5263f624e21b8b2e83cede36d9f19e75377895951
+ARG FLASHKDA_INTEGRATION_TREE=6851531e95decd57c28f166fa6ce8aa381a1aa04
+ARG FLASHKDA_INTEGRATION_LOCK_SHA256
+ARG FLASHKDA_CUTLASS_COMMIT=5c149f52a436782210263fb2f19b354443a61c6a
 ARG INSTANTTENSOR_REPO=https://github.com/voipmonitor/InstantTensor.git
 ARG INSTANTTENSOR_REF=49b4010afc1cae0441e71fe0b0bffc24fa05e932
 ARG INSTANTTENSOR_COMMIT=49b4010afc1cae0441e71fe0b0bffc24fa05e932
@@ -49,7 +57,7 @@ ENV VIRTUAL_ENV=/opt/venv \
     NCCL_CUMEM_ENABLE=0 \
     NCCL_PROTO=LL,LL128,Simple
 
-# Cache paths include both composed source trees. Target-only, DSpark, and
+# Cache paths include all composed source trees. Target-only, DSpark, and
 # DFlash profiles use separate host volumes so compiled modules cannot cross
 # profile boundaries.
 ENV LOCAL_INFERENCE_CACHE_FINGERPRINT=${CACHE_FINGERPRINT} \
@@ -107,6 +115,13 @@ RUN set -eux; \
     compose_source b12x /opt/kimi-k3/b12x \
       "${B12X_REPO}" "${B12X_REF}" "${B12X_COMMIT}" \
       "${B12X_PATCH_FILE}" "${B12X_PATCH_SHA256}" "${B12X_INTEGRATION_TREE}"; \
+    compose_source flashkda /opt/kimi-k3/flashkda \
+      "${FLASHKDA_REPO}" "${FLASHKDA_REF}" "${FLASHKDA_COMMIT}" \
+      "${FLASHKDA_PATCH_FILE}" "${FLASHKDA_PATCH_SHA256}" \
+      "${FLASHKDA_INTEGRATION_TREE}"; \
+    git -C /opt/kimi-k3/flashkda submodule update --init --recursive; \
+    test "$(git -C /opt/kimi-k3/flashkda/cutlass rev-parse HEAD)" = \
+      "${FLASHKDA_CUTLASS_COMMIT}"; \
     rm -rf /tmp/release-patches
 
 # The virtual environment inherits the CUDA 13.3 and stable PyTorch 2.13
@@ -174,6 +189,7 @@ RUN --mount=type=cache,id=kimi-k3-infernal-vllm-extensions,target=/tmp/vllm-exte
       -DCMAKE_CUDA_ARCHITECTURES=75 \
       -DVLLM_TARGET_DEVICE=cuda \
       -DVLLM_PYTHON_EXECUTABLE=/opt/venv/bin/python \
+      -DFETCHCONTENT_SOURCE_DIR_FLASHKDA=/opt/kimi-k3/flashkda \
       -DNVCC_THREADS=4; \
     cmake --build /tmp/vllm-extensions --parallel 48; \
     find /tmp/vllm-extensions -name '*.abi3.so' > /tmp/vllm-extension-list; \
@@ -309,7 +325,7 @@ ARG RELEASE_DATE
 ARG DOCKER_COMMIT
 
 LABEL org.opencontainers.image.title="Kimi-K3 dev/infernal-invocation CUDA 13.3 PyTorch 2.13 runtime" \
-      org.opencontainers.image.description="Pinned infernal-invocation and B12X Kimi-K3 serving runtime on stable PyTorch 2.13 and CUDA 13.3" \
+      org.opencontainers.image.description="Pinned infernal-invocation, B12X, and FlashKDA Kimi-K3 serving runtime on stable PyTorch 2.13 and CUDA 13.3" \
       org.opencontainers.image.source="https://github.com/local-inference-lab/blackwell-llm-docker" \
       org.opencontainers.image.version="${RELEASE_DATE}" \
       org.opencontainers.image.revision="${DOCKER_COMMIT}" \
@@ -335,6 +351,14 @@ LABEL org.opencontainers.image.title="Kimi-K3 dev/infernal-invocation CUDA 13.3 
       local-inference.b12x.patch_file="${B12X_PATCH_FILE}" \
       local-inference.b12x.patch_sha256="${B12X_PATCH_SHA256}" \
       local-inference.b12x.integration.lock_sha256="${B12X_INTEGRATION_LOCK_SHA256}" \
+      local-inference.flashkda.repo="${FLASHKDA_REPO}" \
+      local-inference.flashkda.branch="${FLASHKDA_REF}" \
+      local-inference.flashkda.commit="${FLASHKDA_COMMIT}" \
+      local-inference.flashkda.integration.tree="${FLASHKDA_INTEGRATION_TREE}" \
+      local-inference.flashkda.patch_file="${FLASHKDA_PATCH_FILE}" \
+      local-inference.flashkda.patch_sha256="${FLASHKDA_PATCH_SHA256}" \
+      local-inference.flashkda.integration.lock_sha256="${FLASHKDA_INTEGRATION_LOCK_SHA256}" \
+      local-inference.flashkda.cutlass.commit="${FLASHKDA_CUTLASS_COMMIT}" \
       local-inference.instanttensor.repo="${INSTANTTENSOR_REPO}" \
       local-inference.instanttensor.ref="${INSTANTTENSOR_REF}" \
       local-inference.instanttensor.commit="${INSTANTTENSOR_COMMIT}" \

--- a/README.md
+++ b/README.md
@@ -196,8 +196,14 @@ Status: **implemented**. The build script
 recorded by
 `patches/releases/kimi-k3-infernal-invocation-runtime-r1/vllm/integration.lock.json`
 with the B12X Git tree recorded by
-`patches/releases/kimi-k3-hh-runtime-r1/b12x/integration.lock.json`. The image
-uses CUDA 13.3, PyTorch 2.13.0, NCCL 2.31.2, and InstantTensor 0.1.9.
+`patches/releases/kimi-k3-hh-runtime-r1/b12x/integration.lock.json` and the
+FlashKDA Git tree recorded by
+`patches/releases/flashkda-sm120-tensormap-r1/flashkda/integration.lock.json`.
+The image uses CUDA 13.3, PyTorch 2.13.0, NCCL 2.31.2, and InstantTensor 0.1.9.
+The FlashKDA source lock replaces the SM120 bulk-copy syscall fallback with
+native TensorMap workspace loads while leaving SM90 and SM100 on their native
+bulk-copy path. Root-cause analysis and GPU qualification are in
+`docs/kimi-k3-flashkda-sm120-runtime.md`.
 
 The image contains these serving interfaces:
 

--- a/build-kimi-k3-infernal-invocation-cu133-torch213.sh
+++ b/build-kimi-k3-infernal-invocation-cu133-torch213.sh
@@ -8,6 +8,7 @@ release_date="${RELEASE_DATE:-$(date -u +%Y%m%d)}"
 revision="${REVISION:-r1}"
 vllm_composition_root="patches/releases/kimi-k3-infernal-invocation-runtime-r1"
 b12x_composition_root="patches/releases/kimi-k3-hh-runtime-r1"
+flashkda_composition_root="patches/releases/flashkda-sm120-tensormap-r1"
 instanttensor_repo="${INSTANTTENSOR_REPO:-https://github.com/voipmonitor/InstantTensor.git}"
 instanttensor_commit="${INSTANTTENSOR_COMMIT:-49b4010afc1cae0441e71fe0b0bffc24fa05e932}"
 instanttensor_libaio_repo="${INSTANTTENSOR_LIBAIO_REPO:-https://github.com/1g4-mirror/libaio.git}"
@@ -43,7 +44,25 @@ read_lock() {
 
 read_lock vllm VLLM "${vllm_composition_root}"
 read_lock b12x B12X "${b12x_composition_root}"
+read_lock flashkda FLASHKDA "${flashkda_composition_root}"
+FLASHKDA_CUTLASS_COMMIT="$(jq -er '.submodules.cutlass.commit' \
+  "${flashkda_composition_root}/flashkda/integration.lock.json")"
+export FLASHKDA_CUTLASS_COMMIT
+flashkda_manifest="manifests/flashkda/kimi-k3-sm120-tensormap.json"
+echo "$(jq -er '.manifest.sha256' \
+  "${flashkda_composition_root}/flashkda/integration.lock.json")  ${flashkda_manifest}" \
+  | sha256sum -c - >/dev/null
 vllm_package_version="${VLLM_PACKAGE_VERSION:-0.11.2.dev280+infernal.${VLLM_INTEGRATION_TREE:0:7}.cu133.torch213}"
+
+if [[ "${PRINT_RELEASE_CONFIG:-0}" == 1 ]]; then
+  printf 'flashkda_ref=%s\n' "${FLASHKDA_REF}"
+  printf 'flashkda_commit=%s\n' "${FLASHKDA_COMMIT}"
+  printf 'flashkda_tree=%s\n' "${FLASHKDA_INTEGRATION_TREE}"
+  printf 'flashkda_patch=%s\n' "${FLASHKDA_PATCH_FILE}"
+  printf 'flashkda_patch_sha256=%s\n' "${FLASHKDA_PATCH_SHA256}"
+  printf 'flashkda_cutlass_commit=%s\n' "${FLASHKDA_CUTLASS_COMMIT}"
+  exit 0
+fi
 
 base_image="${BASE_IMAGE:-voipmonitor/vllm:kimi-k3-cu133-torch213-nccl2312-20260811-r2}"
 if ! docker image inspect "${base_image}" >/dev/null 2>&1; then
@@ -59,14 +78,15 @@ if [[ -n "$(git status --porcelain --untracked-files=all)" ]] \
   exit 1
 fi
 
-cache_fingerprint="cu133-torch213-vllm${VLLM_INTEGRATION_TREE:0:10}-b12x${B12X_INTEGRATION_TREE:0:10}"
-image="${IMAGE:-voipmonitor/vllm:kimi-k3-infernal-vllm${VLLM_INTEGRATION_TREE:0:7}-b12x${B12X_INTEGRATION_TREE:0:7}-cu133-torch213-${release_date}-${revision}}"
+cache_fingerprint="cu133-torch213-vllm${VLLM_INTEGRATION_TREE:0:10}-b12x${B12X_INTEGRATION_TREE:0:10}-flashkda${FLASHKDA_INTEGRATION_TREE:0:10}"
+image="${IMAGE:-voipmonitor/vllm:kimi-k3-infernal-vllm${VLLM_INTEGRATION_TREE:0:7}-b12x${B12X_INTEGRATION_TREE:0:7}-fkda${FLASHKDA_INTEGRATION_TREE:0:7}-cu133-torch213-${release_date}-${revision}}"
 
 printf 'release=%s\n' "${release_name}"
 printf 'base=%s (%s)\n' "${base_image}" "${base_image_id}"
 printf 'vllm=%s + %s -> %s\n' "${VLLM_COMMIT}" "${VLLM_PRS}" "${VLLM_INTEGRATION_TREE}"
 printf 'vllm-package=%s\n' "${vllm_package_version}"
 printf 'b12x=%s + %s -> %s\n' "${B12X_COMMIT}" "${B12X_PRS}" "${B12X_INTEGRATION_TREE}"
+printf 'flashkda=%s -> %s\n' "${FLASHKDA_COMMIT}" "${FLASHKDA_INTEGRATION_TREE}"
 printf 'instanttensor=%s\n' "${instanttensor_commit}"
 printf 'flashinfer=%s\n' "${flashinfer_version}"
 printf 'triton-kernels=%s\n' "${triton_kernels_commit}"
@@ -93,6 +113,14 @@ DOCKER_BUILDKIT=1 docker build \
   --build-arg "B12X_INTEGRATION_TREE=${B12X_INTEGRATION_TREE}" \
   --build-arg "B12X_INTEGRATION_LOCK_SHA256=${B12X_INTEGRATION_LOCK_SHA256}" \
   --build-arg "B12X_PRS=${B12X_PRS}" \
+  --build-arg "FLASHKDA_REPO=${FLASHKDA_REPO}" \
+  --build-arg "FLASHKDA_REF=${FLASHKDA_REF}" \
+  --build-arg "FLASHKDA_COMMIT=${FLASHKDA_COMMIT}" \
+  --build-arg "FLASHKDA_PATCH_FILE=${FLASHKDA_PATCH_FILE}" \
+  --build-arg "FLASHKDA_PATCH_SHA256=${FLASHKDA_PATCH_SHA256}" \
+  --build-arg "FLASHKDA_INTEGRATION_TREE=${FLASHKDA_INTEGRATION_TREE}" \
+  --build-arg "FLASHKDA_INTEGRATION_LOCK_SHA256=${FLASHKDA_INTEGRATION_LOCK_SHA256}" \
+  --build-arg "FLASHKDA_CUTLASS_COMMIT=${FLASHKDA_CUTLASS_COMMIT}" \
   --build-arg "INSTANTTENSOR_REPO=${instanttensor_repo}" \
   --build-arg "INSTANTTENSOR_REF=${instanttensor_commit}" \
   --build-arg "INSTANTTENSOR_COMMIT=${instanttensor_commit}" \
@@ -130,6 +158,9 @@ assert_label local-inference.cache.fingerprint "${cache_fingerprint}"
 assert_label local-inference.vllm.integration.tree "${VLLM_INTEGRATION_TREE}"
 assert_label local-inference.vllm.package-version "${vllm_package_version}"
 assert_label local-inference.b12x.integration.tree "${B12X_INTEGRATION_TREE}"
+assert_label local-inference.flashkda.integration.tree "${FLASHKDA_INTEGRATION_TREE}"
+assert_label local-inference.flashkda.patch_sha256 "${FLASHKDA_PATCH_SHA256}"
+assert_label local-inference.flashkda.cutlass.commit "${FLASHKDA_CUTLASS_COMMIT}"
 assert_label local-inference.instanttensor.commit "${instanttensor_commit}"
 assert_label local-inference.instanttensor.libaio.repo "${instanttensor_libaio_repo}"
 assert_label local-inference.instanttensor.libaio.commit "${instanttensor_libaio_commit}"
@@ -138,6 +169,11 @@ assert_label local-inference.cutlass-dsl.version "${cutlass_dsl_version}"
 assert_label local-inference.flashinfer.version "${flashinfer_version}"
 assert_label local-inference.torchvision.version "${torchvision_version}"
 assert_label local-inference.triton-kernels.commit "${triton_kernels_commit}"
+
+docker run --rm --entrypoint /bin/bash "${image}" -lc \
+  '! /usr/local/cuda/bin/cuobjdump --dump-elf-symbols \
+      /opt/kimi-k3/vllm/vllm/_flashkda_C.abi3.so \
+      | grep -Fq __cuda_syscall_cp_async_bulk_unicast'
 
 docker run --rm --entrypoint /opt/venv/bin/python "${image}" \
   /opt/local-inference/verify_kimi_k3_cu133_runtime.py \

--- a/docs/kimi-k3-flashkda-sm120-runtime.md
+++ b/docs/kimi-k3-flashkda-sm120-runtime.md
@@ -1,0 +1,106 @@
+# Kimi-K3 FlashKDA SM120 runtime
+
+## Scope
+
+This release composes `vllm-project/FlashKDA` dev commit
+`ee0be888cd0e972f9409bf53756f8c38c6652173` with an SM120 workspace-transport
+fix. It does not narrow FlashKDA's generic state, dtype, fixed-length, varlen,
+or checkpoint ABI variants.
+
+The patch is applied as an independently locked source component when the
+CUDA 13.3 / PyTorch 2.13 Kimi-K3 image builds its vLLM native extensions.
+
+## Failure
+
+The first FlashKDA prefill on an RTX PRO 6000 Blackwell reserved about 3.8 GiB
+outside PyTorch's allocator. A checkpoint-aware build then failed with
+`cudaErrorMemoryAllocation`, even after reducing the served context from
+372,000 to 320,000 tokens and the explicit KV allocation from 2.0 to 1.75 GiB.
+
+The checkpoint ABI was not the source of the allocation:
+
+- the old and checkpoint-aware generic binaries reserved the same amount;
+- K1 alone reserved about 122 MiB;
+- K2 alone reproduced the complete allocation on both V-split and default
+  recurrence paths; and
+- only K2 referenced `__cuda_syscall_cp_async_bulk_unicast` in its SM120
+  cubin.
+
+CUDA 13.3 lowers K2's six `SM90_BULK_COPY_G2S` workspace restores to that
+driver-provided syscall on SM120. Loading the syscall runtime caused the
+multi-GiB context reservation.
+
+## Fix
+
+On SM120, the six separated K1 workspace arrays are described as raw `uint32`
+TensorMap tiles. K2 loads those tiles through the existing three-stage TMA
+transaction barrier. This preserves the private, swizzled K1-to-K2 byte-image
+ABI while removing the syscall dependency.
+
+SM90 and SM100 cubins retain the original native bulk-copy path. The selection
+is compile-time on `__CUDA_ARCH__`, so the SM120 cubin cannot contain the
+fallback call even when a fat binary also targets earlier architectures.
+
+The focused stage-reuse test uses five 16-token chunks. Four chunks exercise
+only the first circular-stage reuse and did not expose an intermediate
+cooperative-copy publication race; the fifth chunk did. The final TensorMap
+implementation passes Compute Sanitizer racecheck with zero hazards.
+
+## Reproduction
+
+The source lock is
+`patches/releases/flashkda-sm120-tensormap-r1/flashkda/integration.lock.json`.
+The build verifies the manifest, patch digest, resulting Git tree, image
+labels, and absence of the syscall symbol in the packaged extension.
+
+```bash
+pytest -q tests/test_flashkda_sm120_release.py
+bash -n build-kimi-k3-infernal-invocation-cu133-torch213.sh
+docker build --check \
+  -f Dockerfile.kimi-k3-infernal-invocation-cu133-torch213 .
+```
+
+The GPU qualification build used CUDA 13.3.73, PyTorch 2.13, and `sm_120a`.
+
+## Qualification
+
+- Generic ABI binary SHA-256:
+  `5d2466074b29005bc149e9da942e8e33f342af54f031e8055daa9d1daeecbde3`.
+- `cuobjdump`: no `__cuda_syscall`; no stack or local-memory spill.
+- Compute Sanitizer racecheck: 0 errors and 0 warnings.
+- FP32 reference comparisons passed for V-split and default K2 paths,
+  checkpoint off/on, and a 3,080-token production chunk with a 3,072-token
+  checkpoint. Relative RMSE was 0.0044 to 0.0056.
+- Reusable output, final-state, checkpoint-state, and workspace buffers were
+  bitwise stable across repeated calls.
+- Warm 3,080-token checkpoint call: 0.1283 ms for the generic patched build;
+  the old bulk-copy build measured 0.1354 ms.
+- First-call multi-GiB driver residency was eliminated.
+
+The production-specialized artifact has SHA-256
+`c0b440ab87e6cfec16b23138f95a67d8fe9142836c040a56c41a574dc7d27ed1`.
+The qualified image is
+`sha256:087276f1ec791909e71055d655eeadb3b35c246e46f2be21af9d210aa970a60b`.
+
+Live TP8/DCP8 validation covered exact normal output, JSON schema output,
+four concurrent requests, an 18K client disconnect followed by immediate
+retry, a 16,104-token cold prefill and checkpoint replay, and a 32,092-token
+cold prefill at approximately 884.6 prompt tokens/s. No request error,
+corruption, worker restart, container OOM, or CUDA error was observed.
+
+## Memory envelope
+
+The 372K / 2.0 GiB profile completed its first FlashKDA request, but a later
+264,241,152-byte allocation had only 263,585,792 bytes physically free on rank
+0. That profile was rejected despite the engine recovering.
+
+The active production envelope is therefore:
+
+- maximum context: 320,000 tokens;
+- explicit KV allocation: 1.75 GiB per rank;
+- KV capacity: 625,777 tokens; and
+- scheduler target/draft budgets: 3,080 / 3,080 tokens.
+
+The validated Triton launcher remains the primary rollback. Reducing
+`max_model_len` alone does not create working memory while the KV allocation is
+fixed explicitly; both values must be reviewed together.

--- a/manifests/flashkda/kimi-k3-sm120-tensormap.json
+++ b/manifests/flashkda/kimi-k3-sm120-tensormap.json
@@ -1,0 +1,19 @@
+{
+  "schema_version": 1,
+  "name": "flashkda-sm120-tensormap-r1",
+  "repository": "https://github.com/vllm-project/FlashKDA.git",
+  "base_ref": "refs/heads/dev",
+  "base_commit": "ee0be888cd0e972f9409bf53756f8c38c6652173",
+  "submodules": {
+    "cutlass": {
+      "path": "cutlass",
+      "commit": "5c149f52a436782210263fb2f19b354443a61c6a"
+    }
+  },
+  "source_patches": [
+    {
+      "path": "releases/flashkda-sm120-tensormap-r1/flashkda/integration.patch",
+      "sha256": "2119fdd721decd873cdbbbe5263f624e21b8b2e83cede36d9f19e75377895951"
+    }
+  ]
+}

--- a/patches/releases/flashkda-sm120-tensormap-r1/flashkda/integration.lock.json
+++ b/patches/releases/flashkda-sm120-tensormap-r1/flashkda/integration.lock.json
@@ -1,0 +1,24 @@
+{
+  "base": {
+    "commit": "ee0be888cd0e972f9409bf53756f8c38c6652173",
+    "ref": "refs/heads/dev",
+    "repository": "https://github.com/vllm-project/FlashKDA.git"
+  },
+  "manifest": {
+    "sha256": "90c7399584932d6996736b2993654ca205fbe5f865216b57e8070ec8a2af29e1"
+  },
+  "name": "flashkda-sm120-tensormap-r1",
+  "pull_requests": [],
+  "submodules": {
+    "cutlass": {
+      "commit": "5c149f52a436782210263fb2f19b354443a61c6a",
+      "path": "cutlass"
+    }
+  },
+  "result": {
+    "patch": "integration.patch",
+    "patch_sha256": "2119fdd721decd873cdbbbe5263f624e21b8b2e83cede36d9f19e75377895951",
+    "tree": "6851531e95decd57c28f166fa6ce8aa381a1aa04"
+  },
+  "schema_version": 1
+}

--- a/patches/releases/flashkda-sm120-tensormap-r1/flashkda/integration.patch
+++ b/patches/releases/flashkda-sm120-tensormap-r1/flashkda/integration.patch
@@ -1,0 +1,409 @@
+diff --git a/csrc/smxx/fwd_kernel2.cuh b/csrc/smxx/fwd_kernel2.cuh
+index add4054ff296d648f3d54ef333f37d2db78d0845..1bb3a66d73cc84c7d4c72b30cbc9c06df1b30aec 100644
+--- a/csrc/smxx/fwd_kernel2.cuh
++++ b/csrc/smxx/fwd_kernel2.cuh
+@@ -120,10 +120,33 @@ CUTLASS_DEVICE void movm_transpose_c_to_b_16x16(
+     }
+ }
+ 
++template <class TmaLoad, class GlobalTensor, class SmemLayout, class Barrier>
++CUTLASS_DEVICE void load_workspace_tile(
++    TmaLoad const& tma_load,
++    GlobalTensor const& global_tensor,
++    SmemLayout const& smem_layout,
++    uint32_t* smem_ptr,
++    int workspace_idx,
++    Barrier& barrier
++) {
++    auto global_offset = global_tensor.layout()(workspace_idx, 0, 0);
++    Tensor global_tile = make_tensor(
++        global_tensor.data() + global_offset,
++        make_layout(shape(smem_layout), stride(global_tensor.layout())));
++    Tensor shared_tile = make_tensor(make_smem_ptr(smem_ptr), smem_layout);
++    auto cta_tma_load = tma_load.get_slice(Int<0>{});
++    cute::copy(
++        tma_load.with(barrier),
++        cta_tma_load.partition_S(global_tile),
++        cta_tma_load.partition_D(shared_tile));
++}
++
+ // ==================== Kernel 2: Recurrence ====================
+ template <
+     class TmaLoadV,
+     class TmaLoadBeta,
++    class TmaLoadWorkspaceLarge,
++    class TmaLoadWorkspaceSmall,
+     class TmaLoadState,
+     class TmaStoreState,
+     class TmaStoreOut,
+@@ -143,6 +166,12 @@ template <
+ __global__ void __launch_bounds__(NumThreads, 2) _flash_kda_fwd_recurrence(
+     CUTE_GRID_CONSTANT TmaLoadV const tma_load_v,
+     CUTE_GRID_CONSTANT TmaLoadBeta const tma_load_beta,
++    CUTE_GRID_CONSTANT TmaLoadWorkspaceLarge const tma_load_ws_kd,
++    CUTE_GRID_CONSTANT TmaLoadWorkspaceLarge const tma_load_ws_qd,
++    CUTE_GRID_CONSTANT TmaLoadWorkspaceLarge const tma_load_ws_kr,
++    CUTE_GRID_CONSTANT TmaLoadWorkspaceSmall const tma_load_ws_gt,
++    CUTE_GRID_CONSTANT TmaLoadWorkspaceSmall const tma_load_ws_inv,
++    CUTE_GRID_CONSTANT TmaLoadWorkspaceSmall const tma_load_ws_mqk,
+     CUTE_GRID_CONSTANT TmaLoadState const tma_load_initial_state,
+     CUTE_GRID_CONSTANT TmaStoreState const tma_store_final_state,
+     CUTE_GRID_CONSTANT TmaStoreOut const tma_store_out,
+@@ -178,6 +207,25 @@ __global__ void __launch_bounds__(NumThreads, 2) _flash_kda_fwd_recurrence(
+     using TMABetaSmemLayout = typename Layouts::TMABetaSmemLayout;
+     using TMAStateSmemLayout = typename Layouts::TMAStateSmemLayout;
+     using SharedStorageT = SharedStorageK2<Layouts, InputStages, OutputStages>;
++    constexpr int kWorkspaceWordsPerRow = 8;
++    constexpr int kLargeWorkspaceRows =
++        (CHUNK * D * int(sizeof(BF16)) / int(sizeof(uint32_t))) /
++        kWorkspaceWordsPerRow;
++    constexpr int kSmallWorkspaceRows =
++        (D * int(sizeof(float)) / int(sizeof(uint32_t))) /
++        kWorkspaceWordsPerRow;
++    static_assert(
++        D * int(sizeof(float)) == CHUNK * CHUNK * int(sizeof(BF16)));
++    using WorkspaceLargeSmemLayout = decltype(make_layout(
++        make_shape(
++            Int<1>{}, Int<kLargeWorkspaceRows>{},
++            Int<kWorkspaceWordsPerRow>{}),
++        LayoutRight{}));
++    using WorkspaceSmallSmemLayout = decltype(make_layout(
++        make_shape(
++            Int<1>{}, Int<kSmallWorkspaceRows>{},
++            Int<kWorkspaceWordsPerRow>{}),
++        LayoutRight{}));
+ 
+     // --- shared memory
+     extern __shared__ __align__(128) unsigned char shared_mem[];
+@@ -188,10 +236,10 @@ __global__ void __launch_bounds__(NumThreads, 2) _flash_kda_fwd_recurrence(
+     constexpr int kComputeThreads = 128;
+     constexpr int kVSlices = D / VD;
+ 
+-    // Transaction bytes: v + beta + k_decayed + q_decayed + k_restored + g_total + INV + Mqk
++    // Transaction bytes: v + beta + six workspace TensorMap loads.
+     constexpr uint32_t kTmaTransactionBytes =
+         uint32_t(cute::cosize_v<VOLayout>) * uint32_t(sizeof(BF16)) +
+-        uint32_t(32) * uint32_t(sizeof(BF16)) +  // beta (bf16, sigmoid fused)
++        uint32_t(32) * uint32_t(sizeof(BF16)) +
+         uint32_t(cute::cosize_v<MMALayout>) * uint32_t(sizeof(BF16)) * 3 +
+         uint32_t(cute::cosize_v<GTotalLayout>) * uint32_t(sizeof(float)) +
+         uint32_t(cute::cosize_v<LMLayout>) * uint32_t(sizeof(BF16)) * 2;
+@@ -338,10 +386,26 @@ __global__ void __launch_bounds__(NumThreads, 2) _flash_kda_fwd_recurrence(
+         __syncthreads();
+     }
+ 
+-    // --- LOAD warp: issue TMA loads for v, beta, and workspace intermediates
++    // --- LOAD warp: issue TensorMap loads for v, beta, and the raw K1
++    // workspace byte images. Unlike SM90_BULK_COPY_G2S, TensorMap loads do not
++    // pull in CUDA 13.3's multi-GiB SM120 bulk-copy syscall runtime.
+     if (warp_role == WarpRole::LOAD_QKG && lane_predicate) {
+         Tensor g_v = tma_load_v.get_tma_tensor(make_shape(H, T_total, D));
+         Tensor g_beta = tma_load_beta.get_tma_tensor(make_shape(H * T_total));
++        auto workspace_large_shape = make_shape(
++            H * total_tiles,
++            Int<kLargeWorkspaceRows>{},
++            Int<kWorkspaceWordsPerRow>{});
++        auto workspace_small_shape = make_shape(
++            H * total_tiles,
++            Int<kSmallWorkspaceRows>{},
++            Int<kWorkspaceWordsPerRow>{});
++        Tensor g_ws_kd = tma_load_ws_kd.get_tma_tensor(workspace_large_shape);
++        Tensor g_ws_qd = tma_load_ws_qd.get_tma_tensor(workspace_large_shape);
++        Tensor g_ws_kr = tma_load_ws_kr.get_tma_tensor(workspace_large_shape);
++        Tensor g_ws_gt = tma_load_ws_gt.get_tma_tensor(workspace_small_shape);
++        Tensor g_ws_inv = tma_load_ws_inv.get_tma_tensor(workspace_small_shape);
++        Tensor g_ws_mqk = tma_load_ws_mqk.get_tma_tensor(workspace_small_shape);
+ 
+         LoadPipelineState load_write = cutlass::make_producer_start_state<LoadPipeline>();
+         auto cta_tma_load_v = tma_load_v.get_slice(Int<0>{});
+@@ -353,26 +417,75 @@ __global__ void __launch_bounds__(NumThreads, 2) _flash_kda_fwd_recurrence(
+             int stage = load_write.index();
+             int ws_idx = head_idx * total_tiles + tile_base + t;
+ 
+-            // TMA load v
+-            auto v_off = g_v.layout()(head_idx, int(bos) + t * CHUNK, v_idx * VD);
+-            Tensor g_v_tile = make_tensor(g_v.data() + v_off,
+-                make_layout(make_shape(Int<1>{}, Int<CHUNK>{}, Int<VD>{}), stride(g_v.layout())));
+-            Tensor s_v_tile = make_tensor(make_smem_ptr(shared_storage.input[stage].v.begin()), TMAVOLayout{});
+-            cute::copy(tma_load_v.with(*tma_barrier),
+-                cta_tma_load_v.partition_S(g_v_tile), cta_tma_load_v.partition_D(s_v_tile));
++            auto v_off = g_v.layout()(
++                head_idx, int(bos) + t * CHUNK, v_idx * VD);
++            Tensor g_v_tile = make_tensor(
++                g_v.data() + v_off,
++                make_layout(
++                    make_shape(Int<1>{}, Int<CHUNK>{}, Int<VD>{}),
++                    stride(g_v.layout())));
++            Tensor s_v_tile = make_tensor(
++                make_smem_ptr(shared_storage.input[stage].v.begin()),
++                TMAVOLayout{});
++            cute::copy(
++                tma_load_v.with(*tma_barrier),
++                cta_tma_load_v.partition_S(g_v_tile),
++                cta_tma_load_v.partition_D(s_v_tile));
+ 
+-            // TMA load beta (1D)
+-            int beta_linear = head_idx * T_total + (int(bos) + t * CHUNK);
++            int beta_linear =
++                head_idx * T_total + (int(bos) + t * CHUNK);
+             int beta_aligned = beta_linear & ~7;
+             auto beta_off = g_beta.layout()(beta_aligned);
+-            Tensor g_beta_tile = make_tensor(g_beta.data() + beta_off, BetaSmemLayout{});
+-            Tensor s_beta_tile = make_tensor(make_smem_ptr(shared_storage.input[stage].beta.begin()), TMABetaSmemLayout{});
+-            cute::copy(tma_load_beta.with(*tma_barrier),
+-                cta_tma_load_beta.partition_S(g_beta_tile), cta_tma_load_beta.partition_D(s_beta_tile));
+-
+-            // K1 stores byte images of its swizzled shared-memory tensors.
+-            // K2 uses the same layouts, so raw bulk copies restore them
+-            // directly without tensor-map coordinate work or repacking.
++            Tensor g_beta_tile = make_tensor(
++                g_beta.data() + beta_off, BetaSmemLayout{});
++            Tensor s_beta_tile = make_tensor(
++                make_smem_ptr(shared_storage.input[stage].beta.begin()),
++                TMABetaSmemLayout{});
++            cute::copy(
++                tma_load_beta.with(*tma_barrier),
++                cta_tma_load_beta.partition_S(g_beta_tile),
++                cta_tma_load_beta.partition_D(s_beta_tile));
++
++#if defined(__CUDA_ARCH__) && (__CUDA_ARCH__ >= 1200)
++            // CUDA 13.3 lowers SM90_BULK_COPY_G2S to the driver-provided
++            // __cuda_syscall_cp_async_bulk_unicast fallback on SM120. Loading
++            // that fallback reserves several GiB per CUDA context. TensorMap
++            // loads preserve the raw workspace byte images without the
++            // syscall. Earlier architectures retain their native bulk-copy
++            // path below.
++            WorkspaceLargeSmemLayout workspace_large_smem_layout;
++            WorkspaceSmallSmemLayout workspace_small_smem_layout;
++            load_workspace_tile(
++                tma_load_ws_kd, g_ws_kd, workspace_large_smem_layout,
++                reinterpret_cast<uint32_t*>(
++                    shared_storage.input[stage].k_decayed.begin()),
++                ws_idx, *tma_barrier);
++            load_workspace_tile(
++                tma_load_ws_qd, g_ws_qd, workspace_large_smem_layout,
++                reinterpret_cast<uint32_t*>(
++                    shared_storage.input[stage].q_decayed.begin()),
++                ws_idx, *tma_barrier);
++            load_workspace_tile(
++                tma_load_ws_kr, g_ws_kr, workspace_large_smem_layout,
++                reinterpret_cast<uint32_t*>(
++                    shared_storage.input[stage].k_restored.begin()),
++                ws_idx, *tma_barrier);
++            load_workspace_tile(
++                tma_load_ws_gt, g_ws_gt, workspace_small_smem_layout,
++                reinterpret_cast<uint32_t*>(
++                    shared_storage.input[stage].g_total.begin()),
++                ws_idx, *tma_barrier);
++            load_workspace_tile(
++                tma_load_ws_inv, g_ws_inv, workspace_small_smem_layout,
++                reinterpret_cast<uint32_t*>(
++                    shared_storage.input[stage].INV.begin()),
++                ws_idx, *tma_barrier);
++            load_workspace_tile(
++                tma_load_ws_mqk, g_ws_mqk, workspace_small_smem_layout,
++                reinterpret_cast<uint32_t*>(
++                    shared_storage.input[stage].Mqk.begin()),
++                ws_idx, *tma_barrier);
++#else
+             cute::SM90_BULK_COPY_G2S::copy(
+                 ws_kd + int64_t(ws_idx) * (CHUNK * D),
+                 reinterpret_cast<uint64_t*>(tma_barrier),
+@@ -403,6 +516,7 @@ __global__ void __launch_bounds__(NumThreads, 2) _flash_kda_fwd_recurrence(
+                 reinterpret_cast<uint64_t*>(tma_barrier),
+                 shared_storage.input[stage].Mqk.begin(),
+                 int32_t(CHUNK * CHUNK * sizeof(BF16)));
++#endif
+ 
+             ++load_write;
+         }
+diff --git a/csrc/smxx/fwd_launch.cu b/csrc/smxx/fwd_launch.cu
+index aef551405ebf2658b821c95225d4d3e67e3abcaa..14ebd82026d76be149bc47d024c069b65a84693a 100644
+--- a/csrc/smxx/fwd_launch.cu
++++ b/csrc/smxx/fwd_launch.cu
+@@ -48,8 +48,8 @@ void launch_fwd(
+     using K2VSplitL = K2Layouts<D, CHUNK, VD>;
+     using WS = WorkspaceSizes<CHUNK, D>;
+ 
+-    // Raw bulk copies make the swizzled shared-memory layout a private ABI
+-    // between K1 and K2. Fail at compile time if either side changes alone.
++    // K1 and K2 exchange raw byte images of these swizzled layouts. Fail at
++    // compile time if either side changes the private workspace ABI alone.
+     static_assert(std::is_same_v<typename K1L::MMALayout,
+                                  typename K2L::MMALayout>);
+     static_assert(std::is_same_v<typename K1L::GTotalLayout,
+@@ -95,6 +95,63 @@ void launch_fwd(
+     BF16*  ws_inv = reinterpret_cast<BF16*>(ws + n_ht * (WS::kKDecayed + WS::kQDecayed + WS::kKRestored + WS::kGTotal));
+     BF16*  ws_mqk = reinterpret_cast<BF16*>(ws + n_ht * (WS::kKDecayed + WS::kQDecayed + WS::kKRestored + WS::kGTotal + WS::kINV));
+ 
++    // Describe each workspace tile as an unswizzled uint32 byte image. CUDA
++    // 13.3 emits native TensorMap loads for SM120, avoiding the multi-GiB
++    // __cuda_syscall_cp_async_bulk_unicast runtime used by raw bulk copies.
++    constexpr int kWorkspaceWordsPerRow = 8;
++    constexpr int kLargeWorkspaceRows =
++        (WS::kKDecayed / int(sizeof(uint32_t))) /
++        kWorkspaceWordsPerRow;
++    constexpr int kSmallWorkspaceRows =
++        (WS::kGTotal / int(sizeof(uint32_t))) /
++        kWorkspaceWordsPerRow;
++    static_assert(WS::kKDecayed == WS::kQDecayed);
++    static_assert(WS::kKDecayed == WS::kKRestored);
++    static_assert(WS::kGTotal == WS::kINV);
++    static_assert(WS::kGTotal == WS::kMqk);
++
++    auto workspace_large_gmem_layout = make_layout(
++        make_shape(
++            n_ht, Int<kLargeWorkspaceRows>{},
++            Int<kWorkspaceWordsPerRow>{}),
++        LayoutRight{});
++    auto workspace_small_gmem_layout = make_layout(
++        make_shape(
++            n_ht, Int<kSmallWorkspaceRows>{},
++            Int<kWorkspaceWordsPerRow>{}),
++        LayoutRight{});
++    using WorkspaceLargeSmemLayout = decltype(make_layout(
++        make_shape(
++            Int<1>{}, Int<kLargeWorkspaceRows>{},
++            Int<kWorkspaceWordsPerRow>{}),
++        LayoutRight{}));
++    using WorkspaceSmallSmemLayout = decltype(make_layout(
++        make_shape(
++            Int<1>{}, Int<kSmallWorkspaceRows>{},
++            Int<kWorkspaceWordsPerRow>{}),
++        LayoutRight{}));
++
++    auto make_workspace_large_tma = [&](void const* ptr) {
++        Tensor tensor = make_tensor(
++            make_gmem_ptr(static_cast<uint32_t const*>(ptr)),
++            workspace_large_gmem_layout);
++        return make_tma_copy(
++            SM90_TMA_LOAD{}, tensor, WorkspaceLargeSmemLayout{});
++    };
++    auto make_workspace_small_tma = [&](void const* ptr) {
++        Tensor tensor = make_tensor(
++            make_gmem_ptr(static_cast<uint32_t const*>(ptr)),
++            workspace_small_gmem_layout);
++        return make_tma_copy(
++            SM90_TMA_LOAD{}, tensor, WorkspaceSmallSmemLayout{});
++    };
++    auto tma_load_ws_kd = make_workspace_large_tma(ws_kd);
++    auto tma_load_ws_qd = make_workspace_large_tma(ws_qd);
++    auto tma_load_ws_kr = make_workspace_large_tma(ws_kr);
++    auto tma_load_ws_gt = make_workspace_small_tma(ws_gt);
++    auto tma_load_ws_inv = make_workspace_small_tma(ws_inv);
++    auto tma_load_ws_mqk = make_workspace_small_tma(ws_mqk);
++
+     // --- TMA descriptors for Kernel 1 inputs
+     auto tma_load_q    = make_tma_copy(SM90_TMA_LOAD{}, m_q, TMAQKLayout{});
+     auto tma_load_k    = make_tma_copy(SM90_TMA_LOAD{}, m_k, TMAQKLayout{});
+@@ -107,8 +164,7 @@ void launch_fwd(
+     Tensor m_dt_bias = make_tensor(make_gmem_ptr(dt_bias_ptr), dt_bias_gmem_layout);
+     auto tma_load_dt_bias = make_tma_copy(SM90_TMA_LOAD{}, m_dt_bias, TMAGTotalSmemLayout{});
+ 
+-    // --- TMA descriptors for Kernel 2 inputs and outputs. Workspace payloads
+-    // use the raw bulk-copy pointers above rather than tensor maps.
++    // --- TMA descriptors for Kernel 2 inputs and outputs.
+     auto tma_load_v     = make_tma_copy(SM90_TMA_LOAD{}, m_v, TMAVOLayout{});
+     auto tma_load_beta2 = make_tma_copy(SM90_TMA_LOAD{}, m_beta, TMABetaSmemLayout{});
+     auto tma_store_out = make_tma_copy(SM90_TMA_STORE{}, m_out, TMAVOLayout{});
+@@ -201,6 +257,8 @@ void launch_fwd(
+             auto kernel2 = _flash_kda_fwd_recurrence<
+                 decltype(tma_load_v_vsplit),
+                 decltype(tma_load_beta2),
++                decltype(tma_load_ws_kd),
++                decltype(tma_load_ws_gt),
+                 decltype(tma_load_initial_state_vsplit),
+                 decltype(tma_store_final_state_vsplit),
+                 decltype(tma_store_out_vsplit),
+@@ -214,6 +272,8 @@ void launch_fwd(
+                 smem_size_k2);
+             kernel2<<<grid_k2, block_k2, smem_size_k2, stream>>>(
+                 tma_load_v_vsplit, tma_load_beta2,
++                tma_load_ws_kd, tma_load_ws_qd, tma_load_ws_kr,
++                tma_load_ws_gt, tma_load_ws_inv, tma_load_ws_mqk,
+                 tma_load_initial_state_vsplit,
+                 tma_store_final_state_vsplit,
+                 tma_store_out_vsplit,
+@@ -228,6 +288,7 @@ void launch_fwd(
+ 
+         auto kernel2 = _flash_kda_fwd_recurrence<
+             decltype(tma_load_v), decltype(tma_load_beta2),
++            decltype(tma_load_ws_kd), decltype(tma_load_ws_gt),
+             decltype(tma_load_initial_state),
+             decltype(tma_store_final_state),
+             decltype(tma_store_out),
+@@ -244,6 +305,8 @@ void launch_fwd(
+ 
+         kernel2<<<grid_k2, block_k2, smem_size_k2, stream>>>(
+             tma_load_v, tma_load_beta2,
++            tma_load_ws_kd, tma_load_ws_qd, tma_load_ws_kr,
++            tma_load_ws_gt, tma_load_ws_inv, tma_load_ws_mqk,
+             tma_load_initial_state,
+             tma_store_final_state,
+             tma_store_out,
+diff --git a/tests/test.sh b/tests/test.sh
+index cd00d6df44f771273ddfd6f1a890e9a0a3924113..8463a37088b4e2e3c569fcf333e4937b1fef2a69 100644
+--- a/tests/test.sh
++++ b/tests/test.sh
+@@ -3,3 +3,4 @@ pip install -e .
+ pip install "flash-linear-attention>=0.5.0" matplotlib pytest
+ python tests/test_fwd.py
+ python -m pytest tests/test_vsplit.py -x -q
++python -m pytest tests/test_sm120_runtime.py -x -q
+diff --git a/tests/test_sm120_runtime.py b/tests/test_sm120_runtime.py
+new file mode 100644
+index 0000000000000000000000000000000000000000..951bf590a46bfcb17062966957533168d7461a4d
+--- /dev/null
++++ b/tests/test_sm120_runtime.py
+@@ -0,0 +1,31 @@
++"""SM120-specific binary contract checks."""
++
++from __future__ import annotations
++
++import shutil
++import subprocess
++
++import pytest
++import torch
++
++
++if not torch.cuda.is_available():
++    pytest.skip("CUDA is required", allow_module_level=True)
++
++import flash_kda
++
++
++def test_sm120_avoids_bulk_copy_syscall_runtime() -> None:
++    if torch.cuda.get_device_capability() != (12, 0):
++        pytest.skip("SM120 is required")
++    cuobjdump = shutil.which("cuobjdump")
++    if cuobjdump is None:
++        pytest.skip("cuobjdump is required")
++
++    symbols = subprocess.run(
++        [cuobjdump, "--dump-elf-symbols", flash_kda._C.__file__],
++        check=True,
++        capture_output=True,
++        text=True,
++    ).stdout
++    assert "__cuda_syscall_cp_async_bulk_unicast" not in symbols
+diff --git a/tests/test_vsplit.py b/tests/test_vsplit.py
+index d6d9febde017d0879f3b08631603aa45a0106576..b763d06af90f5bd8b2d981a106e523b2fb0b8577 100644
+--- a/tests/test_vsplit.py
++++ b/tests/test_vsplit.py
+@@ -110,11 +110,12 @@ def _make_fixed_problem() -> Problem:
+ 
+ 
+ def _make_stage_reuse_problem() -> Problem:
+-    # InputStages=3, so four full chunks are the smallest case that forces a
+-    # circular input stage to be reused.
++    # InputStages=3, so five full chunks exercise two successive circular
++    # stage reuses. A single reuse can miss producer/publication races because
++    # the first three loads fill otherwise untouched stages.
+     return _make_problem(
+         batch=1,
+-        seq_len=64,
++        seq_len=80,
+         cu_seqlens=None,
+         num_sequences=1,
+         seed=404,

--- a/tests/test_flashkda_sm120_release.py
+++ b/tests/test_flashkda_sm120_release.py
@@ -1,0 +1,108 @@
+from __future__ import annotations
+
+import hashlib
+import json
+import os
+import subprocess
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+RELEASE = ROOT / "patches/releases/flashkda-sm120-tensormap-r1/flashkda"
+LOCK = RELEASE / "integration.lock.json"
+PATCH = RELEASE / "integration.patch"
+MANIFEST = ROOT / "manifests/flashkda/kimi-k3-sm120-tensormap.json"
+DOCKERFILE = ROOT / "Dockerfile.kimi-k3-infernal-invocation-cu133-torch213"
+BUILD = ROOT / "build-kimi-k3-infernal-invocation-cu133-torch213.sh"
+RECEIPT = ROOT / "validation/kimi-k3-flashkda-sm120-tensormap-20260830.json"
+
+
+def sha256(path: Path) -> str:
+    return hashlib.sha256(path.read_bytes()).hexdigest()
+
+
+def test_flashkda_source_lock_is_self_consistent() -> None:
+    lock = json.loads(LOCK.read_text())
+    manifest = json.loads(MANIFEST.read_text())
+    receipt = json.loads(RECEIPT.read_text())
+
+    assert lock["schema_version"] == 1
+    assert lock["base"]["repository"] == manifest["repository"]
+    assert lock["base"]["ref"] == manifest["base_ref"]
+    assert lock["base"]["commit"] == manifest["base_commit"]
+    assert lock["base"]["commit"] == receipt["source"]["commit"]
+    assert lock["result"]["tree"] == receipt["source"]["result_tree"]
+    assert lock["result"]["patch_sha256"] == sha256(PATCH)
+    assert lock["result"]["patch_sha256"] == receipt["source"]["patch_sha256"]
+    assert lock["manifest"]["sha256"] == sha256(MANIFEST)
+    assert lock["submodules"] == manifest["submodules"]
+    assert lock["submodules"]["cutlass"]["commit"] == (
+        "5c149f52a436782210263fb2f19b354443a61c6a"
+    )
+    assert manifest["source_patches"] == [
+        {
+            "path": "releases/flashkda-sm120-tensormap-r1/flashkda/integration.patch",
+            "sha256": sha256(PATCH),
+        }
+    ]
+
+
+def test_flashkda_patch_preserves_generic_abi_and_targets_sm120() -> None:
+    patch = PATCH.read_text()
+
+    assert "#if defined(__CUDA_ARCH__) && (__CUDA_ARCH__ >= 1200)" in patch
+    assert "__cuda_syscall_cp_async_bulk_unicast" in patch
+    assert "WorkspaceLargeSmemLayout" in patch
+    assert patch.count("load_workspace_tile(") >= 7
+    assert "seq_len=80" in patch
+    assert 'assert "__cuda_syscall_cp_async_bulk_unicast" not in symbols' in patch
+    assert "-INSTANTIATE_STATE_VARIANTS" not in patch
+    assert "-INSTANTIATE_CHECKPOINT_VARIANTS" not in patch
+
+
+def test_kimi_image_build_composes_and_labels_flashkda() -> None:
+    dockerfile = DOCKERFILE.read_text()
+    build = BUILD.read_text()
+
+    assert "compose_source flashkda /opt/kimi-k3/flashkda" in dockerfile
+    assert "flashkda submodule update --init --recursive" in dockerfile
+    assert "-DFETCHCONTENT_SOURCE_DIR_FLASHKDA=/opt/kimi-k3/flashkda" in dockerfile
+    assert (
+        'local-inference.flashkda.integration.tree="${FLASHKDA_INTEGRATION_TREE}"'
+        in dockerfile
+    )
+    assert 'read_lock flashkda FLASHKDA "${flashkda_composition_root}"' in build
+    assert "-flashkda${FLASHKDA_INTEGRATION_TREE:0:10}" in build
+    assert "__cuda_syscall_cp_async_bulk_unicast" in build
+    assert "assert_label local-inference.flashkda.integration.tree" in build
+    assert "assert_label local-inference.flashkda.cutlass.commit" in build
+
+    environment = os.environ.copy()
+    environment["PRINT_RELEASE_CONFIG"] = "1"
+    output = subprocess.run(
+        [str(BUILD)],
+        cwd=ROOT,
+        env=environment,
+        check=True,
+        capture_output=True,
+        text=True,
+    ).stdout.splitlines()
+    assert "flashkda_ref=dev" in output
+    assert "flashkda_commit=ee0be888cd0e972f9409bf53756f8c38c6652173" in output
+    assert "flashkda_tree=6851531e95decd57c28f166fa6ce8aa381a1aa04" in output
+    assert (
+        "flashkda_patch_sha256="
+        "2119fdd721decd873cdbbbe5263f624e21b8b2e83cede36d9f19e75377895951" in output
+    )
+
+
+def test_receipt_records_the_qualified_memory_envelope() -> None:
+    receipt = json.loads(RECEIPT.read_text())
+
+    assert receipt["root_cause"]["checkpoint_abi_caused_delta"] is False
+    assert receipt["root_cause"]["vsplit_specific"] is False
+    assert receipt["kernel_validation"]["syscall_symbol_present"] is False
+    assert receipt["kernel_validation"]["racecheck_errors"] == 0
+    assert receipt["live_profile"]["max_model_len"] == 320000
+    assert receipt["live_profile"]["kv_cache_bytes_per_rank"] == 1879048192
+    assert receipt["live_profile"]["request_errors"] == 0
+    assert receipt["rejected_profile"]["first_flashkda_request_completed"] is True

--- a/validation/kimi-k3-flashkda-sm120-tensormap-20260830.json
+++ b/validation/kimi-k3-flashkda-sm120-tensormap-20260830.json
@@ -1,0 +1,104 @@
+{
+  "schema_version": 1,
+  "date_utc": "2026-08-29",
+  "source": {
+    "repository": "https://github.com/vllm-project/FlashKDA.git",
+    "ref": "refs/heads/dev",
+    "commit": "ee0be888cd0e972f9409bf53756f8c38c6652173",
+    "base_tree": "0930ae5e073254fd9312351550d6738a2064ba7b",
+    "result_tree": "6851531e95decd57c28f166fa6ce8aa381a1aa04",
+    "patch_sha256": "2119fdd721decd873cdbbbe5263f624e21b8b2e83cede36d9f19e75377895951",
+    "cutlass_commit": "5c149f52a436782210263fb2f19b354443a61c6a"
+  },
+  "build": {
+    "cuda_toolkit": "13.3.73",
+    "pytorch": "2.13.0",
+    "cuda_arch": "sm_120a",
+    "generic_binary_sha256": "5d2466074b29005bc149e9da942e8e33f342af54f031e8055daa9d1daeecbde3",
+    "generic_binary_bytes": 5547024,
+    "production_binary_sha256": "c0b440ab87e6cfec16b23138f95a67d8fe9142836c040a56c41a574dc7d27ed1",
+    "production_image_digest": "sha256:087276f1ec791909e71055d655eeadb3b35c246e46f2be21af9d210aa970a60b"
+  },
+  "root_cause": {
+    "symbol": "__cuda_syscall_cp_async_bulk_unicast",
+    "old_first_call_driver_delta_bytes": 3925868544,
+    "k1_only_driver_delta_bytes": 127926272,
+    "checkpoint_abi_caused_delta": false,
+    "vsplit_specific": false
+  },
+  "kernel_validation": {
+    "syscall_symbol_present": false,
+    "stack_bytes": 0,
+    "local_bytes": 0,
+    "racecheck_errors": 0,
+    "racecheck_warnings": 0,
+    "reference_cases": [
+      {
+        "name": "vsplit",
+        "tokens": 97,
+        "sequences": 1,
+        "checkpoint": true,
+        "max_relative_rmse": 0.005136
+      },
+      {
+        "name": "default",
+        "tokens": 164,
+        "sequences": 8,
+        "checkpoint": true,
+        "max_relative_rmse": 0.004703
+      },
+      {
+        "name": "production_chunk",
+        "tokens": 3080,
+        "sequences": 1,
+        "checkpoint_offset": 3072,
+        "max_relative_rmse": 0.005526
+      }
+    ],
+    "warm_checkpoint_gpu_ms_per_call": 0.1283,
+    "old_bulk_copy_gpu_ms_per_call": 0.1354
+  },
+  "live_profile": {
+    "tensor_parallel_size": 8,
+    "decode_context_parallel_size": 8,
+    "max_model_len": 320000,
+    "kv_cache_bytes_per_rank": 1879048192,
+    "kv_capacity_tokens": 625777,
+    "max_num_batched_tokens": 3080,
+    "max_num_scheduled_tokens": 3080,
+    "normal_output": "pass",
+    "json_schema": "pass",
+    "concurrency_4": "pass",
+    "disconnect_prompt_tokens": 18001,
+    "disconnect_timeout_seconds": 1.2,
+    "first_idle_observation_seconds": 0.08,
+    "immediate_retry_seconds": 1.52,
+    "cold_16k_prompt_tokens": 16104,
+    "cold_16k_seconds": 21.0,
+    "cached_16k_seconds": 6.56,
+    "cold_32k_prompt_tokens": 32092,
+    "cold_32k_seconds": 36.2766,
+    "cold_32k_prompt_tokens_per_second": 884.648,
+    "request_errors": 0,
+    "corrupted_requests": 0,
+    "container_restarts": 0,
+    "container_oom_killed": false
+  },
+  "rejected_profile": {
+    "max_model_len": 372000,
+    "kv_cache_bytes_per_rank": 2147483648,
+    "first_flashkda_request_completed": true,
+    "allocation_warning_request_bytes": 264241152,
+    "allocation_warning_free_bytes": 263585792,
+    "reason": "insufficient rank-0 physical memory margin"
+  },
+  "repository_validation": {
+    "focused_source_lock_tests_passed": 4,
+    "full_python_tests_passed": 35,
+    "shell_syntax": "pass",
+    "ruff_check": "pass",
+    "ruff_format_check": "pass",
+    "docker_build_check": "pass",
+    "patch_result_tree_reproduced": true
+  }
+}


### PR DESCRIPTION
## Problem

The first FlashKDA prefill on RTX PRO 6000 Blackwell reserved about 3.8 GiB
outside PyTorch's allocator. Checkpoint-aware serving then failed with
`cudaErrorMemoryAllocation`; lowering max context and fixed KV memory did not
remove the first-call allocation.

Direct isolation showed that:

- old and checkpoint-aware generic ABI binaries reserved the same amount;
- K1 alone used about 122 MiB;
- K2 alone reproduced the full allocation on both V-split and default paths;
- the K2 SM120 cubin uniquely referenced
  `__cuda_syscall_cp_async_bulk_unicast`.

CUDA 13.3 lowers the six `SM90_BULK_COPY_G2S` workspace restores to this
driver-provided syscall on SM120. Loading its runtime caused the multi-GiB
context reservation.

## Fix

- Compose FlashKDA dev commit
  `ee0be888cd0e972f9409bf53756f8c38c6652173` as a separately locked source
  component, including pinned CUTLASS submodule commit
  `5c149f52a436782210263fb2f19b354443a61c6a`.
- Describe the six separated K1 workspace arrays as raw `uint32` TensorMap
  tiles and load them through K2's existing three-stage TMA barrier on SM120.
- Select the new path at compile time with `__CUDA_ARCH__ >= 1200`, so the
  SM120 cubin cannot contain the syscall call.
- Preserve native bulk copies for SM90/SM100 and preserve every generic
  state/dtype/fixed/varlen/checkpoint ABI instantiation.
- Extend stage-reuse coverage from four chunks to five and add a cubin symbol
  contract test.
- Wire the locked FlashKDA tree into the Kimi CUDA 13.3 image build, cache
  identity, OCI labels, and post-build cubin validation.

This does not duplicate an existing open PR or issue in
`vllm-project/FlashKDA` or `local-inference-lab/blackwell-llm-docker`; both
repositories were searched for SM120, bulk-copy, TensorMap, and syscall work.

## Source identity

- Base tree: `0930ae5e073254fd9312351550d6738a2064ba7b`
- Result tree: `6851531e95decd57c28f166fa6ce8aa381a1aa04`
- Integration patch SHA-256:
  `2119fdd721decd873cdbbbe5263f624e21b8b2e83cede36d9f19e75377895951`
- Generic SM120 binary SHA-256:
  `5d2466074b29005bc149e9da942e8e33f342af54f031e8055daa9d1daeecbde3`

## Verification

Repository checks:

```text
focused source-lock tests: 4 passed
full Python suite: 35 passed
Ruff check + format check: passed
all repository shell scripts: bash -n passed
Dockerfile build check: no warnings
patch apply/result-tree reproduction: passed
```

The Dockerfile check used the qualified local Kimi r5 image as `BASE_IMAGE`
because the historical default base tag is no longer available from the
registry.

GPU checks on CUDA 13.3.73 / PyTorch 2.13 / `sm_120a`:

- generic ABI build passed;
- no `__cuda_syscall`, stack, or local-memory spill in the cubin;
- Compute Sanitizer racecheck: 0 errors, 0 warnings;
- V-split/default, checkpoint off/on, and T=3,080/checkpoint=3,072 matched the
  FP32 recurrent reference at relative RMSE 0.0044-0.0056;
- reusable buffers were bitwise stable;
- warm T=3,080 checkpoint call: 0.1283 ms versus 0.1354 ms before the fix;
- the multi-GiB first-call driver allocation was eliminated.

Live TP8/DCP8 qualification covered normal and JSON-schema output, four
concurrent requests, an 18K disconnect/immediate retry, a 16,104-token cold
prefill and checkpoint replay, and a 32,092-token cold prefill at about 884.6
prompt tokens/s. There were no request errors, corrupted requests, worker
restarts, container OOMs, or CUDA errors.

The active production envelope is 320K context with 1.75 GiB KV/rank
(625,777-token capacity). A 372K/2.0 GiB trial completed its first FlashKDA
request but was rejected because a later 264,241,152-byte allocation had only
263,585,792 bytes free on rank 0.

Full commands, source identities, and machine-readable results are in
`docs/kimi-k3-flashkda-sm120-runtime.md` and
`validation/kimi-k3-flashkda-sm120-tensormap-20260830.json`.

## Compatibility and risk

Risk is medium. Kernel parameter lists gain six TensorMap descriptors on every
architecture, but only SM120 changes workspace transport. SM90/SM100 retain
the previous bulk-copy instructions. The source lock and result tree fail
closed during build, and the image build fails if the packaged SM120 extension
contains the syscall symbol.

Relates to local-inference-lab/rtx6kpro#75.

## AI assistance

AI assistance was used for root-cause isolation, implementation, test design,
runtime qualification, documentation, and PR drafting. The submitting human
must review every changed line and be able to defend the CUDA transaction and
memory-envelope contracts before merge.

Signed-off-by: myshytf <9619163+myshytf@users.noreply.github.com>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added FlashKDA SM120 TensorMap support for Kimi-K3 runtime builds.
  * Replaced the problematic SM120 bulk-copy path with TensorMap workspace loads, while preserving native behavior on SM90 and SM100.
  * Added pinned source manifests, release metadata, and validation records.
* **Documentation**
  * Documented the SM120 runtime issue, resolution, qualification results, and supported memory envelope.
* **Tests**
  * Added release checks for source integrity, build labeling, architecture compatibility, and runtime validation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->