### PR TITLE
feat(ds41): source-locked DSpark release with RAM and SSD Engram

### DIFF
--- a/examples/docker-compose-ds41-jovian-judgement-r36.yml
+++ b/examples/docker-compose-ds41-jovian-judgement-r36.yml
@@ -1,0 +1,48 @@
+name: ds41-jovian-judgement
+
+services:
+  ds41:
+    image: ${DS41_IMAGE:-localinferencelab/vllm:jovian-judgement-community-20260912-r36}
+    container_name: ${DS41_CONTAINER:-ds41-jovian-judgement}
+    entrypoint: ["/usr/local/bin/serve-ds41-jovian.sh"]
+    init: true
+    network_mode: host
+    ipc: host
+    shm_size: 32gb
+    restart: "no"
+    security_opt: ["seccomp=unconfined"]
+    ulimits:
+      memlock: {soft: -1, hard: -1}
+      stack: 67108864
+    environment:
+      MODEL_PATH: /model
+      HOST: 0.0.0.0
+      PORT: ${PORT:-8000}
+      CUDA_DEVICE_ORDER: PCI_BUS_ID
+      TP_SIZE: "4"
+      DCP_SIZE: "1"
+      MAX_MODEL_LEN: ${MAX_MODEL_LEN:-131072}
+      MAX_NUM_SEQS: ${MAX_NUM_SEQS:-4}
+      MAX_NUM_BATCHED_TOKENS: ${MAX_NUM_BATCHED_TOKENS:-4096}
+      GPU_MEMORY_UTILIZATION: ${GPU_MEMORY_UTILIZATION:-0.95}
+      ENGRAM_TABLE_MEMORY: ${ENGRAM_TABLE_MEMORY:-disk}
+      HF_HUB_OFFLINE: "1"
+      TRANSFORMERS_OFFLINE: "1"
+    volumes:
+      - type: bind
+        source: ${DS41_MODEL_DIR:-./models/DeepSeek-V4.1-Flash}
+        target: /model
+        read_only: true
+        bind:
+          create_host_path: false
+      - ds41-cache:/cache
+    deploy:
+      resources:
+        reservations:
+          devices:
+            - driver: nvidia
+              device_ids: ["${GPU0:-0}", "${GPU1:-1}", "${GPU2:-2}", "${GPU3:-3}"]
+              capabilities: [gpu]
+
+volumes:
+  ds41-cache:

--- a/recipes/glm53/install_glm53_source_locked.sh
+++ b/recipes/glm53/install_glm53_source_locked.sh
@@ -27,6 +27,16 @@ verify /flashinfer-wheels/flashinfer_jit_cache-0.6.18+cu133-cp39-abi3-manylinux_
 test "$(cat /flashkda-artifacts/flashkda-base.commit)" = "$(value flashkda.base.commit)"
 test "$(awk '{print $1}' /flashkda-artifacts/flashkda-patch.sha256)" = "$(value flashkda.patch.sha256)"
 
+# B12X disk-backed Engram requires the io_uring library and build headers.
+# Install both inside the source layer; keep the CUDA runtime foundation intact.
+readonly uring_package_version=$(value runtime.liburing.package.version)
+apt-get update
+DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends \
+    "liburing2=${uring_package_version}" "liburing-dev=${uring_package_version}"
+test "$(pkg-config --modversion liburing)" = "$(value runtime.liburing.version)"
+test "$(dpkg-query -W -f='${Version}' liburing-dev)" = "$uring_package_version"
+test "$(dpkg-query -W -f='${Version}' liburing2)" = "$uring_package_version"
+
 for name in vllm b12x lmcache; do
     if [[ $name == lmcache ]]; then destination=/opt/lmcache/source; else destination=/opt/glm53-flash/$name; fi
     bash /build-inputs/install_source_bundle.sh "/source-bundles/$name.bundle" \
@@ -103,6 +113,8 @@ from lmcache.integration.vllm.recurrent_checkpoint_connector import LMCacheRecur
 assert (torch.__version__, torch.version.cuda, torch._C._GLIBCXX_USE_CXX11_ABI) == ("2.13.0", "13.3", True)
 print("LMCache wheel:", metadata.version("lmcache"))
 print("Source imports:", vllm.__file__, b12x.__file__)
+from b12x.loader._native import load as load_checkpoint_helper
+assert load_checkpoint_helper().ABI_VERSION == 1
 assert Path(vllm.__file__).resolve() == Path("/opt/glm53-flash/vllm/vllm/__init__.py")
 assert Path(b12x.__file__).resolve() == Path("/opt/glm53-flash/b12x/b12x/__init__.py")
 schema = str(torch.ops._C.fused_deepseek_v4_qnorm_rope_kv_rope_quant_insert.default._schema)

--- a/recipes/glm53/install_glm53_source_locked.sh
+++ b/recipes/glm53/install_glm53_source_locked.sh
@@ -87,6 +87,7 @@ ln -s /opt/glm53-flash/vllm/vllm /opt/venv/lib/python3.12/site-packages/vllm
 ln -s /opt/glm53-flash/b12x/b12x /opt/venv/lib/python3.12/site-packages/b12x
 install -Dm755 /source-bundles/lmcache-mp-wrapper.sh /usr/local/bin/lmcache-mp-wrapper.sh
 install -Dm755 /build-inputs/serve-ds4-jovian.sh /usr/local/bin/serve-ds4-jovian.sh
+install -Dm755 /build-inputs/serve-ds41-jovian.sh /usr/local/bin/serve-ds41-jovian.sh
 
 install -Dm755 /build-inputs/serve-glm53-flash-nvfp4-dflash2.sh /usr/local/libexec/serve-glm53-flash-nvfp4-dflash2.sh
 install -Dm755 /build-inputs/serve-glm53-flash-nvfp4-dflash2-scheduler-qos.sh /usr/local/bin/serve-glm53-flash-nvfp4-dflash2.sh

--- a/recipes/glm53/prepare_glm53_source_bundles.py
+++ b/recipes/glm53/prepare_glm53_source_bundles.py
@@ -171,6 +171,7 @@ def main() -> None:
         "install_glm53_source_locked.sh",
         "install_vllm_source_version.py",
         "serve-ds4-jovian.sh",
+        "serve-ds41-jovian.sh",
         "Dockerfile.jovian-stable-native",
         "build_jovian_stable_native.py",
         "serve-glm53-flash-nvfp4-dflash2.sh",

--- a/recipes/glm53/prepare_glm53_source_bundles.py
+++ b/recipes/glm53/prepare_glm53_source_bundles.py
@@ -73,6 +73,8 @@ def main() -> None:
         "runtime.base.image": "voipmonitor/vllm@sha256:93ac5228f1cbde2182ca294d8b479259144742af2756a49ff207dd245429bf43",
         "runtime.cuda.version": "13.3",
         "runtime.pytorch.version": "2.13.0",
+        "runtime.liburing.version": "2.5",
+        "runtime.liburing.package.version": "2.5-1build1",
         "runtime.rootfs.layers": "2",
         "runtime.cudagraph.mode": "FULL_AND_PIECEWISE",
         "runtime.moe-backend.default": "b12x",

--- a/recipes/glm53/serve-ds41-jovian.sh
+++ b/recipes/glm53/serve-ds41-jovian.sh
@@ -1,0 +1,54 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Use the source-locked native DS4.1 policy, without inherited GLM kernel tuning.
+for name in ${!VLLM_@}; do
+    case "$name" in
+        VLLM_SOURCE_DIR|VLLM_NCCL_SO_PATH|VLLM_CACHE_ROOT|VLLM_CACHE_DIR) ;;
+        *) unset "$name" ;;
+    esac
+done
+for name in ${!B12X_@}; do
+    case "$name" in
+        B12X_CUTE_COMPILE_CACHE_DIR|B12X_COMPILE_CACHE_DIR) ;;
+        *) unset "$name" ;;
+    esac
+done
+unset NCCL_GRAPH_FILE
+
+export PYTHON_BIN=${PYTHON_BIN:-/opt/venv/bin/python}
+export MODEL_PATH=${MODEL_PATH:-${MODEL:-deepseek-ai/DeepSeek-V4.1-Flash}}
+export HOST=${HOST:-0.0.0.0} PORT=${PORT:-8000}
+export TP_SIZE=${TP_SIZE:-4}
+export MAX_MODEL_LEN=${MAX_MODEL_LEN:-131072}
+export MAX_NUM_SEQS=${MAX_NUM_SEQS:-4}
+export MAX_NUM_BATCHED_TOKENS=${MAX_NUM_BATCHED_TOKENS:-4096}
+export GPU_MEMORY_UTILIZATION=${GPU_MEMORY_UTILIZATION:-0.95}
+export LOAD_FORMAT=${LOAD_FORMAT:-instanttensor}
+export ENGRAM_TABLE_MEMORY=${ENGRAM_TABLE_MEMORY:-disk}
+export VLLM_HOST_IP=127.0.0.1 VLLM_EXECUTE_MODEL_TIMEOUT_SECONDS=900
+export NCCL_IB_DISABLE=${NCCL_IB_DISABLE:-1} NCCL_P2P_LEVEL=${NCCL_P2P_LEVEL:-SYS}
+export NCCL_MIN_NCHANNELS=${NCCL_MIN_NCHANNELS:-16}
+export NCCL_MAX_NCHANNELS=${NCCL_MAX_NCHANNELS:-16}
+export NCCL_BUFFSIZE=${NCCL_BUFFSIZE:-2097152}
+export NCCL_SOCKET_IFNAME=${NCCL_SOCKET_IFNAME:-lo}
+export GLOO_SOCKET_IFNAME=${GLOO_SOCKET_IFNAME:-lo}
+case "$ENGRAM_TABLE_MEMORY" in
+    ram|disk) ;;
+    *) echo 'ENGRAM_TABLE_MEMORY must be ram or disk.' >&2; exit 2 ;;
+esac
+
+generation_args=(--override-generation-config '{"temperature":1.0,"top_p":0.95}')
+for argument in "$@"; do
+    case "${argument//_/-}" in
+        --generation-config|--generation-config=*|--override-generation-config|\
+        --override-generation-config=*|--override-generation-config.*|--config|--config=*)
+            generation_args=() ;;
+    esac
+done
+exec "${VLLM_SOURCE_DIR:-/opt/glm53-flash/vllm}/serve-ds41-flash.sh" \
+    --decode-context-parallel-size "${DCP_SIZE:-1}" \
+    --kv-cache-dtype fp8 --enable-chunked-prefill \
+    --attention-backend B12X \
+    --compilation-config '{"cudagraph_mode":"FULL_AND_PIECEWISE"}' \
+    "${generation_args[@]}" "$@"

--- a/recipes/glm53/source_locked_image_labels.py
+++ b/recipes/glm53/source_locked_image_labels.py
@@ -122,6 +122,11 @@ def image_labels(
         labels[f"local-inference.{name}.branch"] = "image-source"
     if "vllm.version" in lock:
         labels["local-inference.vllm.version"] = lock["vllm.version"]
+    for key in ("version", "package.version"):
+        if f"runtime.liburing.{key}" in lock:
+            labels[f"local-inference.liburing.{key}"] = lock[
+                f"runtime.liburing.{key}"
+            ]
     for key in ("base.commit", "patch.sha256", "extension.sha256"):
         labels[f"local-inference.flashkda.{key}"] = lock[f"flashkda.{key}"]
     if "flashinfer.commit" in lock:

--- a/recipes/glm53/source_locked_image_labels.py
+++ b/recipes/glm53/source_locked_image_labels.py
@@ -62,7 +62,7 @@ def image_labels(
     labels.update(
         {
             "org.opencontainers.image.title": "Jovian Judgement community serving",
-            "org.opencontainers.image.description": "GLM-5.3-Flash, Qwen3.8-Flash-Next and DeepSeek-V4-Flash serving; complete Git sources and model-specific launch profiles",
+            "org.opencontainers.image.description": "GLM-5.3-Flash, Qwen3.8-Flash-Next, DeepSeek-V4-Flash and DeepSeek-V4.1-Flash serving; complete Git sources and model-specific launch profiles",
             "org.opencontainers.image.version": lock["release.version"],
             "org.opencontainers.image.source": "https://github.com/local-inference-lab/blackwell-llm-docker",
             "org.opencontainers.image.revision": lock["vllm.commit"],
@@ -124,9 +124,7 @@ def image_labels(
         labels["local-inference.vllm.version"] = lock["vllm.version"]
     for key in ("version", "package.version"):
         if f"runtime.liburing.{key}" in lock:
-            labels[f"local-inference.liburing.{key}"] = lock[
-                f"runtime.liburing.{key}"
-            ]
+            labels[f"local-inference.liburing.{key}"] = lock[f"runtime.liburing.{key}"]
     for key in ("base.commit", "patch.sha256", "extension.sha256"):
         labels[f"local-inference.flashkda.{key}"] = lock[f"flashkda.{key}"]
     if "flashinfer.commit" in lock:
@@ -153,6 +151,12 @@ def image_labels(
             "vllm.native.extension.sha256"
         ]
         labels["local-inference.ds4.entrypoint"] = "/usr/local/bin/serve-ds4-jovian.sh"
+        labels["local-inference.ds41.entrypoint"] = (
+            "/usr/local/bin/serve-ds41-jovian.sh"
+        )
+        labels["local-inference.ds41.engram-table-memory"] = (
+            "disk; opt-in mapped pinned RAM"
+        )
         labels["local-inference.ds4.target-backends"] = (
             "attention:B12X,moe:B12X-W4A8,linear:DeepGEMM"
         )

--- a/recipes/glm53/tests/test_build_contract.py
+++ b/recipes/glm53/tests/test_build_contract.py
@@ -87,6 +87,15 @@ def test_deployment_moe_backend_is_declared_in_image_and_lock(lock):
     assert "VLLM_DEFAULT_MOE_BACKEND=b12x" in dockerfile
 
 
+def test_disk_engram_dependency_identity_replaces_inherited_version(lock):
+    lock["runtime.liburing.version"] = "2.5"
+    lock["runtime.liburing.package.version"] = "2.5-1build1"
+    inherited = {"local-inference.liburing.version": "unrelated-version"}
+    overrides = labels.image_labels(lock, inherited, "b" * 64)
+    assert overrides["local-inference.liburing.version"] == "2.5"
+    assert overrides["local-inference.liburing.package.version"] == "2.5-1build1"
+
+
 def test_source_repository_labels_use_manifest_not_inferred_ownership(lock):
     lock["vllm.repository"] = "https://github.com/voipmonitor/vllm.git"
     overrides = labels.image_labels(lock, {}, "b" * 64)

--- a/recipes/glm53/tests/test_ds41_launcher.py
+++ b/recipes/glm53/tests/test_ds41_launcher.py
@@ -1,0 +1,95 @@
+"""Native DS4.1 policy isolation and public Engram storage controls."""
+
+import json
+import os
+from pathlib import Path
+import subprocess
+import sys
+
+import pytest
+
+LAUNCHER = Path(__file__).resolve().parents[1] / "serve-ds41-jovian.sh"
+
+
+def launch(tmp_path, overrides=None, arguments=()):
+    native = tmp_path / "serve-ds41-flash.sh"
+    native.write_text(
+        '#!/bin/bash\nexec "$PYTHON_BIN" -c '
+        "'import json,os,sys; print(json.dumps({"
+        '"args":sys.argv[1:],"env":dict(os.environ)}))' + '\' "$@"\n'
+    )
+    native.chmod(0o755)
+    env = {
+        "PATH": os.environ["PATH"],
+        "PYTHON_BIN": sys.executable,
+        "VLLM_SOURCE_DIR": str(tmp_path),
+        **(overrides or {}),
+    }
+    return subprocess.run(
+        ["bash", str(LAUNCHER), *arguments], env=env, text=True, capture_output=True
+    )
+
+
+@pytest.mark.parametrize("memory", [None, "ram", "disk"])
+def test_engram_storage_is_forwarded_without_general_cpu_offload(tmp_path, memory):
+    result = launch(tmp_path, {} if memory is None else {"ENGRAM_TABLE_MEMORY": memory})
+    assert result.returncode == 0, result.stderr
+    payload = json.loads(result.stdout)
+    assert payload["env"]["ENGRAM_TABLE_MEMORY"] == (memory or "disk")
+    assert payload["env"]["HOST"] == "0.0.0.0"
+    assert payload["env"]["MAX_NUM_BATCHED_TOKENS"] == "4096"
+    assert payload["env"]["MODEL_PATH"] == "deepseek-ai/DeepSeek-V4.1-Flash"
+    assert "--cpu-offload-gb" not in payload["args"]
+
+
+def test_invalid_engram_storage_is_rejected(tmp_path):
+    result = launch(tmp_path, {"ENGRAM_TABLE_MEMORY": "ssd"})
+    assert result.returncode == 2
+    assert "ram or disk" in result.stderr
+
+
+def test_glm_tuning_is_removed_but_cache_paths_are_preserved(tmp_path):
+    result = launch(
+        tmp_path,
+        {
+            "VLLM_GLM53_MTP_DRAFT_HEAD": "nvfp4",
+            "B12X_PCIE_ONESHOT_THREADS": "512",
+            "B12X_COMPILE_CACHE_DIR": "/cache/b12x",
+            "VLLM_CACHE_ROOT": "/cache/vllm",
+            "NCCL_GRAPH_FILE": "",
+        },
+    )
+    assert result.returncode == 0, result.stderr
+    env = json.loads(result.stdout)["env"]
+    assert "VLLM_GLM53_MTP_DRAFT_HEAD" not in env
+    assert "B12X_PCIE_ONESHOT_THREADS" not in env
+    assert "NCCL_GRAPH_FILE" not in env
+    assert env["B12X_COMPILE_CACHE_DIR"] == "/cache/b12x"
+    assert env["VLLM_CACHE_ROOT"] == "/cache/vllm"
+
+
+@pytest.mark.parametrize(
+    "arguments",
+    [
+        ("--override-generation-config", '{"top_p":1}'),
+        ('--override-generation-config={"top_p":1}',),
+        ("--generation-config", "auto"),
+    ],
+)
+def test_explicit_sampling_configuration_is_not_duplicated(tmp_path, arguments):
+    result = launch(tmp_path, arguments=arguments)
+    assert result.returncode == 0, result.stderr
+    argv = json.loads(result.stdout)["args"]
+    assert argv[-len(arguments) :] == list(arguments)
+    assert '{"temperature":1.0,"top_p":0.95}' not in argv
+
+
+def test_sampling_defaults_are_explicit(tmp_path):
+    result = launch(tmp_path)
+    assert result.returncode == 0, result.stderr
+    argv = json.loads(result.stdout)["args"]
+    assert argv.count("--override-generation-config") == 1
+    assert json.loads(argv[argv.index("--override-generation-config") + 1]) == {
+        "temperature": 1.0,
+        "top_p": 0.95,
+    }


### PR DESCRIPTION
## Purpose

Package DeepSeek-V4.1-Flash DSpark serving in the source-locked Jovian community
image, with explicit RAM or disk Engram table placement. Preserve the GLM,
Qwen and DeepSeek V4 entrypoints and the two-filesystem-layer build.

## Behavior and compatibility

- Install `/usr/local/bin/serve-ds41-jovian.sh`, delegating to the exact bundled
  vLLM `serve-ds41-flash.sh` with B12X backends and DSpark K7.
- Isolate model-specific GLM tuning; preserve JIT-cache paths and native B12X
  policy. Default TP4/DCP1, 4096 scheduler tokens, max sequences 4, 131072 context,
  full-and-piecewise graphs, temperature 1 and top-p 0.95.
- `ENGRAM_TABLE_MEMORY=disk` uses the disk-backed native table implementation;
  `ram` stages complete tables in pinned mapped host RAM. This is not generic
  CPU model offload and not an LMCache KV tier.
- Include pinned liburing runtime/development packages required by disk tables.
- Ship portable Compose with a read-only checkpoint bind, named JIT volume,
  and explicitly selected GPU devices. No serving-source bind is present.
- Hash the entrypoint into the source lock and publish its path in OCI labels.

## Validation

Status: **implemented**; 200 recipe tests passed, including nine DS4.1 launcher
cases. Bash syntax, Compose rendering, Ruff and `git diff --check` passed.
GPU/registry qualification will be added after the exact image completes.

The vLLM feature is merged in local-inference-lab/vllm#738. The startup seeded
target sampling correction is separately reviewed in
local-inference-lab/vllm#740. B12X is unmodified master at `323107ff` and LMCache
source is retained, not changed by this PR. DS4.1 LMCache is not qualified by
the native serving profile.

AI assistance was used for implementation and validation. Published evidence
is scoped to the tested image and model configuration, not all common-image
entrypoints.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added support for serving DeepSeek-V4.1 Flash with a dedicated launcher and Docker Compose configuration.
  - Added configurable model paths, ports, GPU allocation, inference limits, and Engram storage settings.
  - Added offline Hugging Face operation and persistent model/cache storage.
  - Added validation for required runtime settings and native extension compatibility.
  - Added serving-image metadata for model, runtime, entrypoint, and Engram configuration details.

- **Bug Fixes**
  - Prevented conflicting inherited tuning settings from affecting DS4.1 serving.
  - Avoided duplicate sampling options when explicitly configured.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->